### PR TITLE
Add Mechdown include syntax (`{{path}}`) with recursive expansion

### DIFF
--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -534,6 +534,7 @@ pub enum SectionElement {
   Float((Box<SectionElement>, FloatDirection)),
   Footnote(Footnote),
   Grammar(Grammar),
+  Include(Token),
   Image(Image),
   List(MDList),
   MechCode(Vec<(MechCode,Option<Comment>)>),
@@ -623,6 +624,7 @@ impl SectionElement {
         }
         tokens
       }
+      SectionElement::Include(path) => vec![path.clone()],
       SectionElement::List(list) => match list {
       MDList::Unordered(items) => {
         let mut tokens = vec![];

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -39,6 +39,7 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
     SectionElement::Equation(x) => x.hash(&mut hasher),
     SectionElement::Abstract(x) => x.hash(&mut hasher),
     SectionElement::Diagram(x) => x.hash(&mut hasher),
+    SectionElement::Include(x) => x.hash(&mut hasher),
     SectionElement::MechCode(code) => {
       for (c,cmmnt) in code {
         out = mech_code(&c, p)?;

--- a/src/mechfs.rs
+++ b/src/mechfs.rs
@@ -454,6 +454,78 @@ impl MechSources {
     }
   }
 
+  fn extract_include_path(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !(trimmed.starts_with("{{") && trimmed.ends_with("}}")) {
+      return None;
+    }
+    let path = trimmed
+      .trim_start_matches("{{")
+      .trim_end_matches("}}")
+      .trim()
+      .to_string();
+    if path.ends_with(".mec") || path.ends_with(".md") || path.ends_with(".html") || path.ends_with(".htm") {
+      Some(path)
+    } else {
+      None
+    }
+  }
+
+  fn expand_mechdown_includes(
+    &self,
+    source: &str,
+    current_file: &Path,
+    visited: &mut std::collections::HashSet<PathBuf>,
+  ) -> MResult<String> {
+    let mut expanded = String::new();
+
+    for line in source.lines() {
+      if let Some(include_path) = Self::extract_include_path(line) {
+        let include_candidate = current_file
+          .parent()
+          .unwrap_or_else(|| Path::new("."))
+          .join(&include_path);
+
+        if include_candidate.exists() {
+          let include_canonical = include_candidate.canonicalize().map_err(|err| {
+            MechError2::new(
+              FileOpenFailed {
+                file_path: include_candidate.to_string_lossy().to_string(),
+                source: err.to_string(),
+              },
+              None,
+            ).with_compiler_loc()
+          })?;
+
+          if visited.contains(&include_canonical) {
+            continue;
+          }
+
+          visited.insert(include_canonical.clone());
+          match read_mech_source_file(&include_canonical)? {
+            MechSourceCode::String(include_source) => {
+              let include_expanded = self.expand_mechdown_includes(&include_source, &include_canonical, visited)?;
+              expanded.push_str(&include_expanded);
+              if !include_expanded.ends_with('\n') {
+                expanded.push('\n');
+              }
+            }
+            _ => {
+              expanded.push_str(line);
+              expanded.push('\n');
+            }
+          }
+          continue;
+        }
+      }
+
+      expanded.push_str(line);
+      expanded.push('\n');
+    }
+
+    Ok(expanded)
+  }
+
   pub fn add_source(&mut self, src_str: &str, src_root: &str) -> MResult<MechSourceCode> {
     use MechSourceCode::*;
     let src_path = std::path::Path::new(src_str);
@@ -480,6 +552,16 @@ impl MechSources {
         Ok(MechSourceCode::Image(extension, img_bytes))
       } 
       Ok(src) => {
+        let src = match src {
+          MechSourceCode::String(source_text) => {
+            let mut visited = std::collections::HashSet::new();
+            visited.insert(canonical_path.clone());
+            let expanded = self.expand_mechdown_includes(&source_text, &canonical_path, &mut visited)?;
+            MechSourceCode::String(expanded)
+          }
+          other => other,
+        };
+
         let (tree_sc, html_sc) = self.to_tree_and_html(&src)?;
         let file_id = hash_str(&canonical_path.display().to_string());
 

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -688,6 +688,10 @@ impl Formatter {
     }
   }
 
+  pub fn include(&mut self, node: &Token) -> String {
+    format!("{{{{{}}}}}", node.to_string())
+  }
+
   pub fn section_element(&mut self, node: &SectionElement) -> String {
     match node {
       SectionElement::Abstract(n) => self.abstract_el(n),
@@ -707,6 +711,7 @@ impl Formatter {
       SectionElement::Float((n,f)) => self.float(n,f),
       SectionElement::Footnote(n) => self.footnote(n),
       SectionElement::Grammar(n) => self.grammar(n),
+      SectionElement::Include(n) => self.include(n),
       SectionElement::Image(n) => self.image(n),
       SectionElement::List(n) => self.list(n),
       SectionElement::MechCode(n) => self.mech_code(n),

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -825,6 +825,33 @@ pub fn equation(input: ParseString) -> ParseResult<Token> {
   Ok((input, eqn))
 }
 
+// include-document := "{{", +text, "}}" ;
+pub fn include_document(input: ParseString) -> ParseResult<Token> {
+  let (input, _) = left_brace(input)?;
+  let (input, _) = left_brace(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, path_tokens) = many1(tuple((is_not(right_brace), text)))(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, _) = right_brace(input)?;
+  let (input, _) = right_brace(input)?;
+
+  let mut path_tokens = path_tokens.into_iter().map(|(_, tkn)| tkn).collect::<Vec<Token>>();
+  let mut path = Token::merge_tokens(&mut path_tokens).unwrap_or_default();
+  path.kind = TokenKind::Text;
+
+  let include_path = path.to_string().trim().to_string();
+  let valid_extension = include_path.ends_with(".mec")
+    || include_path.ends_with(".md")
+    || include_path.ends_with(".html")
+    || include_path.ends_with(".htm");
+
+  if !valid_extension {
+    return Err(nom::Err::Error(ParseError::new(input, "Expected include path like {{foo.mec}}")));
+  }
+
+  Ok((input, path))
+}
+
 // citation := "[", (identifier | number), "]", ":", ws0, paragraph, ws0, ?("(", +text, ")") ;
 pub fn citation(input: ParseString) -> ParseResult<Citation> {
   let (input, _) = left_bracket(input)?;
@@ -878,6 +905,7 @@ pub fn section_element(input: ParseString) -> ParseResult<SectionElement> {
     ("citation",        Box::new(|i| citation(i).map(|(i, c)| (i, SectionElement::Citation(c))))),
     ("abstract",        Box::new(abstract_el)),
     ("img",             Box::new(|i| img(i).map(|(i, img)| (i, SectionElement::Image(img))))),
+    ("include",         Box::new(|i| include_document(i).map(|(i, p)| (i, SectionElement::Include(p))))),
     ("equation",        Box::new(|i| equation(i).map(|(i, e)| (i, SectionElement::Equation(e))))),
     ("table",           Box::new(|i| mechdown_table(i).map(|(i, t)| (i, SectionElement::Table(t))))),
     ("float",           Box::new(|i| float(i).map(|(i, f)| (i, SectionElement::Float(f))))),


### PR DESCRIPTION
### Motivation
- Provide LaTeX-like document inclusion so one Mechdown document can embed another as its own section using `{{foo.mec}}`.
- Make includes a first-class section element so they are parsed, formatted and carried through the interpreter/formatter pipeline consistently.

### Description
- Add a parser for include markers: `pub fn include_document` recognizes `{{...}}` and returns a `Token`, and is wired into section parsing so `{{file.mec}}` becomes a `SectionElement::Include` (`src/syntax/src/mechdown.rs`).
- Extend the AST with `SectionElement::Include(Token)` and ensure token extraction supports it so includes propagate through the tree (`src/core/src/nodes.rs`).
- Add formatter support `Formatter::include` and map `SectionElement::Include` to it so includes render back as `{{path}}` (`src/syntax/src/formatter.rs`).
- Teach the interpreter to accept `Include` elements (hashing/recognition) so include nodes do not break runtime section handling (`src/interpreter/src/mechdown.rs`).
- Implement recursive include expansion when loading file-backed sources by adding `extract_include_path` and `expand_mechdown_includes` and integrating them into `MechSources::add_source`; includes are resolved relative to the including file, cycles are prevented with a `visited` set, and non-string or missing includes are left in-place (non-fatal) (`src/mechfs.rs`).

### Testing
- Ran `rustfmt` on the modified files which completed successfully for the patched files (`rustfmt` on modified sources succeeded). 
- Ran `cargo fmt` which surfaced pre-existing trailing-whitespace failures in unrelated `src/wasm/*` files and therefore did not fully complete. 
- Attempted `cargo test -p mech-syntax` but automated tests were blocked by an environment toolchain mismatch (installed `rustc 1.92.0`, workspace requires `rustc >= 1.96`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3037f8b108321b7676ffc1298ad26)