### PR TITLE
Implement user-defined functions: definition, calling, scoping, and tests

### DIFF
--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -21,6 +21,7 @@ use std::fmt;
 pub type FunctionsRef = Ref<Functions>;
 pub type FunctionTable = HashMap<u64, fn(FunctionArgs) -> MResult<Box<dyn MechFunction>>>;
 pub type FunctionCompilerTable = HashMap<u64, &'static dyn NativeFunctionCompiler>;
+pub type UserFunctionTable = HashMap<u64, FunctionDefinition>;
 
 #[derive(Clone,Debug)]
 pub enum FunctionArgs {
@@ -107,14 +108,16 @@ pub trait NativeFunctionCompiler {
 pub struct Functions {
   pub functions: FunctionTable,
   pub function_compilers: FunctionCompilerTable,
+  pub user_functions: UserFunctionTable,
   pub dictionary: Ref<Dictionary>,
 }
 
 impl Functions {
   pub fn new() -> Self {
     Self {
-      functions: HashMap::new(), 
-      function_compilers: HashMap::new(), 
+      functions: HashMap::new(),
+      function_compilers: HashMap::new(),
+      user_functions: HashMap::new(),
       dictionary: Ref::new(Dictionary::new()),
     }
   }
@@ -131,6 +134,7 @@ impl Functions {
     output.push_str("\nFunctions:\n");
     // print number of functions loaded:
     output.push_str(&format!("Total Functions: {}\n", self.functions.len()));
+    output.push_str(&format!("User Functions: {}\n", self.user_functions.len()));
     //for (id, fxn_ptr) in &self.functions {
     //  let dict_brrw = self.dictionary.borrow();
     //  let name = dict_brrw.get(id).unwrap();
@@ -160,7 +164,7 @@ impl fmt::Debug for FunctionDefinition {
       return fmt::Display::fmt(&self.pretty_print(), f);
       fmt::Display::fmt(&"".to_string(), f)
     } else {
-      write!(f, "FunctionDefinition {{ id: {}, name: {}, input: {:?}, output: {:?}, symbols: {:?} }}", 
+      write!(f, "FunctionDefinition {{ id: {}, name: {}, input: {:?}, output: {:?}, symbols: {:?} }}",
       self.id, self.name, self.input, self.output, self.symbols.borrow())
     }
   }
@@ -176,8 +180,8 @@ impl PrettyPrint for FunctionDefinition {
     for step in self.plan.borrow().iter() {
       plan_str = format!("{}  - {}\n",plan_str,step.to_string());
     }
-    let data = vec!["📥 Input", &input_str, 
-                    "📤 Output", &output_str, 
+    let data = vec!["📥 Input", &input_str,
+                    "📤 Output", &output_str,
                     "🔣 Symbols",   &symbols_str,
                     "📋 Plan", &plan_str];
     let mut table = tabled::Table::new(data);
@@ -227,7 +231,7 @@ impl MechFunctionImpl for UserFunction {
     self.fxn.solve();
   }
   fn out(&self) -> Value {
-    Value::MutableReference(self.fxn.out.clone())
+    self.fxn.out.borrow().clone()
   }
   fn to_string(&self) -> String { format!("UserFxn::{:?}", self.fxn.name) }
 }

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -800,6 +800,14 @@ pub struct FunctionDefine {
   pub input: Vec<FunctionArgument>,
   pub output: Vec<FunctionArgument>,
   pub statements: Vec<Statement>,
+  pub match_arms: Vec<FunctionMatchArm>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct FunctionMatchArm {
+  pub pattern: Pattern,
+  pub expression: Expression,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -4,83 +4,237 @@ use crate::*;
 // ----------------------------------------------------------------------------
 
 pub fn function_define(fxn_def: &FunctionDefine, p: &Interpreter) -> MResult<FunctionDefinition> {
-  /*let fxn_name_id = fxn_def.name.hash();
-  let mut new_fxn = FunctionDefinition::new(fxn_name_id,fxn_def.name.to_string(), fxn_def.clone());
-  for input_arg in &fxn_def.input {
-    let arg_id = input_arg.name.hash();
-    new_fxn.input.insert(arg_id,input_arg.kind.clone());
-    let in_arg = Value::F64(Ref::new(F64::new(0.0)));
-    new_fxn.symbols.borrow_mut().insert(arg_id, in_arg, false);
-  }
-  let output_arg_ids = fxn_def.output.iter().map(|output_arg| {
-    let arg_id = output_arg.name.hash();
-    new_fxn.output.insert(arg_id,output_arg.kind.clone());
-    arg_id
-  }).collect::<Vec<u64>>();
-  
-  for stmnt in &fxn_def.statements {
-    let result = statement(stmnt, new_fxn.plan.clone(), new_fxn.symbols.clone(), functions.clone());
-  }    
-  // get the output cell
-  {
-    let symbol_brrw = new_fxn.symbols.borrow();
-    for arg_id in output_arg_ids {
-      match symbol_brrw.get(arg_id) {
-        Some(cell) => new_fxn.out = cell.clone(),
-        None => { return Err(MechError{file: file!().to_string(), tokens: fxn_def.output.iter().flat_map(|a| a.tokens()).collect(), msg: "".to_string(), id: line!(), kind: MechErrorKind::OutputUndefinedInFunctionBody(arg_id)});} 
-      }
+    let fxn_name_id = fxn_def.name.hash();
+    let mut new_fxn =
+        FunctionDefinition::new(fxn_name_id, fxn_def.name.to_string(), fxn_def.clone());
+
+    for input_arg in &fxn_def.input {
+        new_fxn
+            .input
+            .insert(input_arg.name.hash(), input_arg.kind.clone());
     }
-  }
-  Ok(new_fxn)*/
-  todo!("Function define needs to be redone!");
+
+    for output_arg in &fxn_def.output {
+        new_fxn
+            .output
+            .insert(output_arg.name.hash(), output_arg.kind.clone());
+    }
+
+    let functions = p.functions();
+    let mut functions_brrw = functions.borrow_mut();
+    functions_brrw
+        .user_functions
+        .insert(fxn_name_id, new_fxn.clone());
+    functions_brrw
+        .dictionary
+        .borrow_mut()
+        .insert(fxn_name_id, fxn_def.name.to_string());
+    p.state
+        .borrow()
+        .dictionary
+        .borrow_mut()
+        .insert(fxn_name_id, fxn_def.name.to_string());
+
+    Ok(new_fxn)
 }
 
 pub fn function_call(fxn_call: &FunctionCall, p: &Interpreter) -> MResult<Value> {
-  let plan = p.plan();
-  let functions = p.functions();
-  let fxn_name_id = fxn_call.name.hash();
-  let fxns_brrw = functions.borrow();
-  match fxns_brrw.functions.get(&fxn_name_id) {
-    Some(fxn) => {
-      todo!();
-    }
-    None => { 
-      match fxns_brrw.function_compilers.get(&fxn_name_id) {
-        Some(fxn_compiler) => {
-          let mut input_arg_values = vec![];
-          for (arg_name, arg_expr) in fxn_call.args.iter() {
-            let result = expression(&arg_expr, None, p)?;
-            input_arg_values.push(result);
-          }
-          match fxn_compiler.compile(&input_arg_values) {
-            Ok(new_fxn) => {
-              let mut plan_brrw = plan.borrow_mut();
-              new_fxn.solve();
-              let result = new_fxn.out();
-              plan_brrw.push(new_fxn);
-              return Ok(result)
-            }
-            Err(x) => {return Err(x);}
-          }
+    let plan = p.plan();
+    let functions = p.functions();
+    let fxn_name_id = fxn_call.name.hash();
+
+    if let Some(user_fxn) = { functions.borrow().user_functions.get(&fxn_name_id).cloned() } {
+        let mut input_arg_values = vec![];
+        for (_, arg_expr) in fxn_call.args.iter() {
+            input_arg_values.push(expression(arg_expr, None, p)?);
         }
-        None => {return Err(MechError::new(
-            MissingFunctionError{ function_id: fxn_name_id },
-            None
-          ).with_compiler_loc().with_tokens(fxn_call.name.tokens())
-        );}
-      }
+        return execute_user_function(&user_fxn, &input_arg_values, p);
     }
-  }   
-  unreachable!()
+
+    if { functions.borrow().functions.contains_key(&fxn_name_id) } {
+        todo!();
+    }
+
+    let fxn_compiler = {
+        functions
+            .borrow()
+            .function_compilers
+            .get(&fxn_name_id)
+            .copied()
+    };
+    match fxn_compiler {
+        Some(fxn_compiler) => {
+            let mut input_arg_values = vec![];
+            for (_, arg_expr) in fxn_call.args.iter() {
+                input_arg_values.push(expression(arg_expr, None, p)?);
+            }
+            match fxn_compiler.compile(&input_arg_values) {
+                Ok(new_fxn) => {
+                    let mut plan_brrw = plan.borrow_mut();
+                    new_fxn.solve();
+                    let result = new_fxn.out();
+                    plan_brrw.push(new_fxn);
+                    Ok(result)
+                }
+                Err(err) => Err(err),
+            }
+        }
+        None => Err(MechError::new(
+            MissingFunctionError {
+                function_id: fxn_name_id,
+            },
+            None,
+        )
+        .with_compiler_loc()
+        .with_tokens(fxn_call.name.tokens())),
+    }
+}
+
+fn execute_user_function(
+    fxn_def: &FunctionDefinition,
+    input_arg_values: &Vec<Value>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    if input_arg_values.len() != fxn_def.input.len() {
+        return Err(MechError::new(
+            IncorrectNumberOfArguments {
+                expected: fxn_def.input.len(),
+                found: input_arg_values.len(),
+            },
+            None,
+        )
+        .with_compiler_loc()
+        .with_tokens(fxn_def.code.name.tokens()));
+    }
+
+    let scope = FunctionScope::enter(p);
+    bind_function_inputs(fxn_def, input_arg_values, p)?;
+
+    for statement_node in &fxn_def.code.statements {
+        statement(statement_node, None, p)?;
+    }
+
+    let output = collect_function_output(p, fxn_def);
+    drop(scope);
+    output
+}
+
+struct FunctionScope {
+    state: Ref<ProgramState>,
+    previous_symbols: SymbolTableRef,
+    previous_plan: Plan,
+    previous_environment: Option<SymbolTableRef>,
+}
+
+impl FunctionScope {
+    fn enter(p: &Interpreter) -> Self {
+        let state = p.state.clone();
+        let mut state_brrw = state.borrow_mut();
+        let mut local_symbols = SymbolTable::new();
+        local_symbols.dictionary = state_brrw.dictionary.clone();
+        let local_symbols = Ref::new(local_symbols);
+        let previous_symbols = std::mem::replace(&mut state_brrw.symbol_table, local_symbols);
+        let previous_plan = std::mem::replace(&mut state_brrw.plan, Plan::new());
+        let previous_environment = state_brrw.environment.take();
+        drop(state_brrw);
+
+        Self {
+            state,
+            previous_symbols,
+            previous_plan,
+            previous_environment,
+        }
+    }
+}
+
+impl Drop for FunctionScope {
+    fn drop(&mut self) {
+        let mut state_brrw = self.state.borrow_mut();
+        state_brrw.symbol_table = self.previous_symbols.clone();
+        state_brrw.plan = self.previous_plan.clone();
+        state_brrw.environment = self.previous_environment.clone();
+    }
+}
+
+fn bind_function_inputs(
+    fxn_def: &FunctionDefinition,
+    input_arg_values: &Vec<Value>,
+    p: &Interpreter,
+) -> MResult<()> {
+    let scoped_state = p.state.borrow();
+    for ((arg_id, _), input_value) in fxn_def.input.iter().zip(input_arg_values.iter()) {
+        let arg_name = fxn_def
+            .code
+            .input
+            .iter()
+            .find(|arg| arg.name.hash() == *arg_id)
+            .map(|arg| arg.name.to_string())
+            .unwrap_or_else(|| arg_id.to_string());
+        scoped_state.save_symbol(*arg_id, arg_name, detach_value(input_value), false);
+    }
+    Ok(())
+}
+
+fn collect_function_output(p: &Interpreter, fxn_def: &FunctionDefinition) -> MResult<Value> {
+    let symbols = p.symbols();
+    let symbols_brrw = symbols.borrow();
+    let mut outputs = vec![];
+
+    for output_arg in &fxn_def.code.output {
+        let output_id = output_arg.name.hash();
+        match symbols_brrw.get(output_id) {
+            Some(cell) => outputs.push(detach_value(&cell.borrow())),
+            None => {
+                return Err(
+                    MechError::new(FunctionOutputUndefinedError { output_id }, None)
+                        .with_compiler_loc()
+                        .with_tokens(output_arg.tokens()),
+                );
+            }
+        }
+    }
+
+    Ok(match outputs.len() {
+        0 => Value::Empty,
+        1 => outputs.remove(0),
+        _ => Value::Tuple(Ref::new(MechTuple::from_vec(outputs))),
+    })
+}
+
+fn detach_value(value: &Value) -> Value {
+    match value {
+        Value::MutableReference(reference) => detach_value(&reference.borrow()),
+        _ => value.clone(),
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct MissingFunctionError {
-  pub function_id: u64,
+    pub function_id: u64,
 }
+
 impl MechErrorKind for MissingFunctionError {
-  fn name(&self) -> &str { "MissingFunction" }
-  fn message(&self) -> String {
-    format!("Function with id {} not found", self.function_id)
-  }
+    fn name(&self) -> &str {
+        "MissingFunction"
+    }
+    fn message(&self) -> String {
+        format!("Function with id {} not found", self.function_id)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionOutputUndefinedError {
+    pub output_id: u64,
+}
+
+impl MechErrorKind for FunctionOutputUndefinedError {
+    fn name(&self) -> &str {
+        "FunctionOutputUndefined"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Function output {} was declared but never defined",
+            self.output_id
+        )
+    }
 }

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -110,6 +110,12 @@ fn execute_user_function(
     let scope = FunctionScope::enter(p);
     bind_function_inputs(fxn_def, input_arg_values, p)?;
 
+    if !fxn_def.code.match_arms.is_empty() {
+        let output = execute_function_match_arms(fxn_def, input_arg_values, p);
+        drop(scope);
+        return output;
+    }
+
     for statement_node in &fxn_def.code.statements {
         statement(statement_node, None, p)?;
     }
@@ -117,6 +123,109 @@ fn execute_user_function(
     let output = collect_function_output(p, fxn_def);
     drop(scope);
     output
+}
+
+fn execute_function_match_arms(
+    fxn_def: &FunctionDefinition,
+    input_arg_values: &Vec<Value>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    for arm in &fxn_def.code.match_arms {
+        let mut env = Environment::new();
+        if pattern_matches_arguments(&arm.pattern, input_arg_values, &mut env, p)? {
+            let out = expression(&arm.expression, Some(&env), p)?;
+            return Ok(detach_value(&out));
+        }
+    }
+    Err(MechError::new(
+        FunctionOutputUndefinedError {
+            output_id: fxn_def.id,
+        },
+        None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fxn_def.code.name.tokens()))
+}
+
+fn pattern_matches_arguments(
+    pattern: &Pattern,
+    args: &Vec<Value>,
+    env: &mut Environment,
+    p: &Interpreter,
+) -> MResult<bool> {
+    if args.len() == 1 {
+        return pattern_matches_value(pattern, &args[0], env, p);
+    }
+    match pattern {
+        Pattern::Tuple(pattern_tuple) => {
+            if pattern_tuple.0.len() != args.len() {
+                return Ok(false);
+            }
+            for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
+                if !pattern_matches_value(pat, arg, env, p)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn pattern_matches_value(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    p: &Interpreter,
+) -> MResult<bool> {
+    match pattern {
+        Pattern::Wildcard => Ok(true),
+        Pattern::Tuple(pattern_tuple) => match detach_value(value) {
+            Value::Tuple(tuple) => {
+                let tuple_brrw = tuple.borrow();
+                if pattern_tuple.0.len() != tuple_brrw.elements.len() {
+                    return Ok(false);
+                }
+                for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
+                    if !pattern_matches_value(pat, val, env, p)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+        Pattern::Expression(Expression::Var(var)) => {
+            let var_id = var.name.hash();
+            let detached = detach_value(value);
+            if let Some(existing) = env.get(&var_id) {
+                Ok(existing == &detached)
+            } else {
+                env.insert(var_id, detached);
+                Ok(true)
+            }
+        }
+        Pattern::Expression(expr) => {
+            let expected = expression(expr, Some(env), p)?;
+            Ok(values_match(&detach_value(&expected), &detach_value(value)))
+        }
+        Pattern::TupleStruct(_) => Ok(false),
+    }
+}
+
+fn values_match(expected: &Value, actual: &Value) -> bool {
+    if expected == actual {
+        return true;
+    }
+    #[cfg(all(feature = "u64", feature = "f64"))]
+    {
+        match (expected, actual) {
+            (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
+            (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
+            _ => {}
+        }
+    }
+    false
 }
 
 struct FunctionScope {

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -134,7 +134,7 @@ fn execute_function_match_arms(
         let mut env = Environment::new();
         if pattern_matches_arguments(&arm.pattern, input_arg_values, &mut env, p)? {
             let out = expression(&arm.expression, Some(&env), p)?;
-            return Ok(detach_value(&out));
+            return coerce_function_output_kind(detach_value(&out), fxn_def, p);
         }
     }
     Err(MechError::new(
@@ -206,10 +206,38 @@ fn pattern_matches_value(
             }
         }
         Pattern::Expression(expr) => {
+            if let Some(var_id) = extract_pattern_variable_id(expr) {
+                let detached = detach_value(value);
+                if let Some(existing) = env.get(&var_id) {
+                    return Ok(existing == &detached);
+                }
+                env.insert(var_id, detached);
+                return Ok(true);
+            }
             let expected = expression(expr, Some(env), p)?;
             Ok(values_match(&detach_value(&expected), &detach_value(value)))
         }
         Pattern::TupleStruct(_) => Ok(false),
+    }
+}
+
+fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
+    match expr {
+        Expression::Var(var) => Some(var.name.hash()),
+        Expression::Formula(factor) => match factor {
+            Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
+            Factor::Term(term) if term.rhs.is_empty() => extract_pattern_variable_id_from_term(&term.lhs),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
+    match factor {
+        Factor::Expression(expr) => extract_pattern_variable_id(expr),
+        Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
+        _ => None,
     }
 }
 
@@ -226,6 +254,17 @@ fn values_match(expected: &Value, actual: &Value) -> bool {
         }
     }
     false
+}
+
+fn coerce_function_output_kind(value: Value, fxn_def: &FunctionDefinition, p: &Interpreter) -> MResult<Value> {
+    if fxn_def.output.is_empty() {
+        return Ok(value);
+    }
+    let Some((_, kind_annotation)) = fxn_def.output.get_index(0) else {
+        return Ok(value);
+    };
+    let target_kind = kind_annotation.kind.to_value_kind(&p.state.borrow().kinds)?;
+    Ok(value.convert_to(&target_kind).unwrap_or(value))
 }
 
 struct FunctionScope {

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -187,12 +187,8 @@ pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
     //MechCode::FsmImplementation(_) => todo!(),
     #[cfg(feature = "functions")]
     MechCode::FunctionDefine(fxn_def) => {
-      todo!();
-      /*
-      let usr_fxn = function_define(&fxn_def, p)?;
-      p.state.borrow_mut().insert_function(usr_fxn);
+      function_define(&fxn_def, p)?;
       Ok(Value::Empty)
-      */
     },
     MechCode::Comment(cmmt) => comment(&cmmt, p),
     x => Err(MechError::new(
@@ -202,4 +198,3 @@ pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
     ),
   }
 }
-  

--- a/src/syntax/src/functions.rs
+++ b/src/syntax/src/functions.rs
@@ -49,14 +49,20 @@ fn function_define_match_arms(
 ) -> ParseResult<FunctionDefine> {
   let (input, _) = transition_operator(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, _output_kind) = kind_annotation(input)?;
+  let (input, output_kind) = kind_annotation(input)?;
+  let output = vec![FunctionArgument {
+    name: Identifier {
+      name: Token::new(TokenKind::Identifier, output_kind.src_range.clone(), vec!['_']),
+    },
+    kind: output_kind,
+  }];
   let (input, _) = many1(alt((whitespace1, statement_separator)))(input)?;
   let (input, match_arms) = many1(function_match_arm)(input)?;
   let (input, _) = opt(period)(input)?;
   Ok((input, FunctionDefine {
     name,
     input: input_args,
-    output: vec![],
+    output,
     statements: vec![],
     match_arms,
   }))

--- a/src/syntax/src/functions.rs
+++ b/src/syntax/src/functions.rs
@@ -22,13 +22,60 @@ pub fn function_define(input: ParseString) -> ParseResult<FunctionDefine> {
   let ((input, input_args)) = separated_list0(list_separator, function_arg)(input)?;
   let ((input, _)) = right_parenthesis(input)?;
   let ((input, _)) = whitespace0(input)?;
+  match function_define_match_arms(input.clone(), name.clone(), input_args.clone()) {
+    Ok((input, fxn_def)) => Ok((input, fxn_def)),
+    Err(_) => function_define_statements(input, name, input_args),
+  }
+}
+
+fn function_define_statements(
+  input: ParseString,
+  name: Identifier,
+  input_args: Vec<FunctionArgument>,
+) -> ParseResult<FunctionDefine> {
   let ((input, _)) = equal(input)?;
   let ((input, _)) = whitespace0(input)?;
   let ((input, output)) = alt((function_out_args,function_out_arg))(input)?;
   let ((input, _)) = define_operator(input)?;
   let ((input, statements)) = separated_list1(alt((whitespace1,statement_separator)), statement)(input)?;
   let ((input, _)) = period(input)?;
-  Ok((input,FunctionDefine{name,input: input_args,output,statements}))
+  Ok((input,FunctionDefine{name,input: input_args,output,statements,match_arms: vec![]}))
+}
+
+fn function_define_match_arms(
+  input: ParseString,
+  name: Identifier,
+  input_args: Vec<FunctionArgument>,
+) -> ParseResult<FunctionDefine> {
+  let (input, _) = transition_operator(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, _output_kind) = kind_annotation(input)?;
+  let (input, _) = many1(alt((whitespace1, statement_separator)))(input)?;
+  let (input, match_arms) = many1(function_match_arm)(input)?;
+  let (input, _) = opt(period)(input)?;
+  Ok((input, FunctionDefine {
+    name,
+    input: input_args,
+    output: vec![],
+    statements: vec![],
+    match_arms,
+  }))
+}
+
+fn function_match_arm(input: ParseString) -> ParseResult<FunctionMatchArm> {
+  let (input, _) = whitespace0(input)?;
+  let (input, _) = alt((box_t_left, box_bl, bar))(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, pattern) = crate::state_machines::pattern(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, _) = transition_operator(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, expr) = expression(input)?;
+  let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
+  Ok((input, FunctionMatchArm {
+    pattern,
+    expression: expr,
+  }))
 }
 
 // function_out_args := "(", list1(list_separator, function_arg), ")" ;

--- a/src/syntax/src/parser.rs
+++ b/src/syntax/src/parser.rs
@@ -324,7 +324,7 @@ pub fn mech_code_alt(input: ParseString) -> ParseResult<MechCode> {
   let parsers: Vec<(&str, Box<dyn Fn(ParseString) -> ParseResult<MechCode>>)> = vec![
     // ("fsm_specification", Box::new(|i| fsm_specification(i).map(|(i, v)| (i, MechCode::FsmSpecification(v))))),
     // ("fsm_implementation", Box::new(|i| fsm_implementation(i).map(|(i, v)| (i, MechCode::FsmImplementation(v))))),
-    // ("function_define", Box::new(|i| function_define(i).map(|(i, v)| (i, MechCode::FunctionDefine(v))))),
+    ("function_define", Box::new(|i| function_define(i).map(|(i, v)| (i, MechCode::FunctionDefine(v))))),
     ("statement",   Box::new(|i| statement(i).map(|(i, v)| (i, MechCode::Statement(v))))),
     ("expression",  Box::new(|i| expression(i).map(|(i, v)| (i, MechCode::Expression(v))))),
     ("comment",     Box::new(|i| comment(i).map(|(i, v)| (i, MechCode::Comment(v))))),

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -492,6 +492,38 @@ z := 10 + x.
 foo(x<f64>) = z<f64> :=
 z := bar(x).
 foo(10)"#, Value::F64(Ref::new(20.0)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_function_recursive_max,r#"max(x<u64>, y<u64>) -> <u64>
+  ├ (0, y) -> y
+  ├ (x, 0) -> x
+  └ (x, y) -> max(x - 1<u64>, y - 1<u64>) + 1<u64>.
+max(4<u64>, 7<u64>)"#, Value::U64(Ref::new(7)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_function_recursive_is_zero,r#"is-zero(x<u64>) -> <bool>
+  ├ 0 -> true
+  └ * -> false.
+is-zero(0<u64>)"#, Value::Bool(Ref::new(true)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_function_recursive_factorial_tree,r#"factorial(x<u64>) -> <u64>
+  ├ 0 -> 1
+  └ n -> n * factorial(n - 1<u64>).
+factorial(5<u64>)"#, Value::U64(Ref::new(120)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_function_recursive_factorial_bar,r#"factorial(x<u64>) -> <u64>
+  | 0 -> 1
+  | n -> n * factorial(n - 1<u64>).
+factorial(6<u64>)"#, Value::U64(Ref::new(720)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_function_recursive_fib,r#"fib(x<u64>) -> <u64>
+  ├ 0 -> 0
+  ├ 1 -> 1
+  └ n -> fib(n - 1<u64>) + fib(n - 2<u64>).
+fib(10<u64>)"#, Value::U64(Ref::new(55)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_function_recursive_power,r#"power(x<u64>, y<u64>) -> <u64>
+  ├ (*, 0) -> 1
+  └ (x, y) -> x * power(x, y - 1<u64>).
+power(2<u64>, 10<u64>)"#, Value::U64(Ref::new(1024)));
 test_interpreter!(interpret_function_call_native_vector, "math/sin([1.570796327 1.570796327])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
 test_interpreter!(interpret_function_call_native, r#"math/sin(1.5707963267948966)"#, Value::F64(Ref::new(1.0)));
 test_interpreter!(interpret_function_call_native_cos, r#"math/cos(0.0)"#, Value::F64(Ref::new(1.0)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -476,8 +476,8 @@ test_interpreter!(interpret_map_assign, r#"~m := {"a": 10, "b": 20}; m{"b"} = 42
 test_interpreter!(interpret_map_assign2, r#"~m := {"a": 10, "b": 20}; m{"c"} = 42; m{"c"}"#, Value::F64(Ref::new(42.0)));
 test_interpreter!(interpret_set_rational, r#"{1/2, 3/4}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::R64(Ref::new(R64::new(1, 2))), Value::R64(Ref::new(R64::new(3, 4)))]))));
 
-/*test_interpreter!(interpret_function_define,r#"foo(x<f64>) = z<f64> :=
-z := 10 + x. 
+test_interpreter!(interpret_function_define,r#"foo(x<f64>) = z<f64> :=
+z := 10 + x.
 foo(10)"#, Value::F64(Ref::new(20.0)));
 test_interpreter!(interpret_function_define_2_args,r#"foo(x<f64>, y<f64>) = z<f64> :=
 z := x + y.
@@ -486,7 +486,12 @@ test_interpreter!(interpret_function_define_statements,r#"foo(x<f64>, y<f64>) = 
     a := 1 + x
     b := y + 1
     z := a + b.
-foo(10,20)"#, Value::F64(Ref::new(32.0)));*/
+foo(10,20)"#, Value::F64(Ref::new(32.0)));
+test_interpreter!(interpret_function_define_nested_call,r#"bar(x<f64>) = z<f64> :=
+z := 10 + x.
+foo(x<f64>) = z<f64> :=
+z := bar(x).
+foo(10)"#, Value::F64(Ref::new(20.0)));
 test_interpreter!(interpret_function_call_native_vector, "math/sin([1.570796327 1.570796327])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
 test_interpreter!(interpret_function_call_native, r#"math/sin(1.5707963267948966)"#, Value::F64(Ref::new(1.0)));
 test_interpreter!(interpret_function_call_native_cos, r#"math/cos(0.0)"#, Value::F64(Ref::new(1.0)));


### PR DESCRIPTION
### Motivation

- Reintroduce and implement user-defined function support that was previously TODO'd so functions can be defined in source, registered, and executed at runtime.  
- Provide correct scoping for function execution so function-local symbols and plans do not leak into the global interpreter state.  
- Expose user function info in the functions registry and in the pretty printer for better diagnostics.  

### Description

- Added a `UserFunctionTable` and `user_functions` field to `Functions`, and updated `pretty_print` to show the number of user functions.  
- Implemented `function_define` to construct a `FunctionDefinition`, insert it into `functions.user_functions` and the dictionaries, and return the definition.  
- Implemented `function_call` to dispatch to user functions (via `execute_user_function`) as well as existing native/compiler paths, and added `execute_user_function`, `bind_function_inputs`, `collect_function_output`, and `detach_value` helpers.  
- Introduced `FunctionScope` RAII to swap in a local `SymbolTable`/`Plan`/`environment` for the duration of a function and restore previous state on drop, and updated `UserFunction::out()` to return a detached/cloned output value.  
- Updated `mech_code` to actually call `function_define` for `MechCode::FunctionDefine` and enabled the `function_define` branch in the parser.  
- Re-enabled and extended interpreter tests for function define/call behavior in `tests/interpreter.rs` (including a nested call test).  

### Testing

- Ran the interpreter-focused tests (`cargo test --test interpreter`) which include the newly re-enabled function definition and call tests.  
- The updated interpreter tests that exercise `function_define` and `function_call` passed locally.  
- Ran the full test suite (`cargo test`) and no regressions were observed in the repository tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c14fc3e48321a6a50244e2880576)