### PR TITLE
Fix recursive function calls

### DIFF
--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -19,7 +19,7 @@ pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter)
     Expression::Structure(strct) => structure(strct, env, p),
     Expression::Literal(ltrl) => literal(&ltrl, p),
     #[cfg(feature = "functions")]
-    Expression::FunctionCall(fxn_call) => function_call(fxn_call, p),
+    Expression::FunctionCall(fxn_call) => function_call(fxn_call, env, p),
     #[cfg(feature = "set_comprehensions")]
     Expression::SetComprehension(set_comp) => set_comprehension(set_comp, p),
     Expression::MatrixComprehension(matrix_comp) => matrix_comprehension(matrix_comp, p),

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -38,7 +38,11 @@ pub fn function_define(fxn_def: &FunctionDefine, p: &Interpreter) -> MResult<Fun
     Ok(new_fxn)
 }
 
-pub fn function_call(fxn_call: &FunctionCall, p: &Interpreter) -> MResult<Value> {
+pub fn function_call(
+    fxn_call: &FunctionCall,
+    env: Option<&Environment>,
+    p: &Interpreter,
+) -> MResult<Value> {
     let plan = p.plan();
     let functions = p.functions();
     let fxn_name_id = fxn_call.name.hash();
@@ -46,7 +50,7 @@ pub fn function_call(fxn_call: &FunctionCall, p: &Interpreter) -> MResult<Value>
     if let Some(user_fxn) = { functions.borrow().user_functions.get(&fxn_name_id).cloned() } {
         let mut input_arg_values = vec![];
         for (_, arg_expr) in fxn_call.args.iter() {
-            input_arg_values.push(expression(arg_expr, None, p)?);
+            input_arg_values.push(expression(arg_expr, env, p)?);
         }
         return execute_user_function(&user_fxn, &input_arg_values, p);
     }
@@ -66,7 +70,7 @@ pub fn function_call(fxn_call: &FunctionCall, p: &Interpreter) -> MResult<Value>
         Some(fxn_compiler) => {
             let mut input_arg_values = vec![];
             for (_, arg_expr) in fxn_call.args.iter() {
-                input_arg_values.push(expression(arg_expr, None, p)?);
+                input_arg_values.push(expression(arg_expr, env, p)?);
             }
             match fxn_compiler.compile(&input_arg_values) {
                 Ok(new_fxn) => {
@@ -260,11 +264,20 @@ fn coerce_function_output_kind(value: Value, fxn_def: &FunctionDefinition, p: &I
     if fxn_def.output.is_empty() {
         return Ok(value);
     }
-    let Some((_, kind_annotation)) = fxn_def.output.get_index(0) else {
+    let Some((_, output_kind_annotation)) = fxn_def.output.get_index(0) else {
         return Ok(value);
     };
-    let target_kind = kind_annotation.kind.to_value_kind(&p.state.borrow().kinds)?;
+    #[cfg(feature = "kind_annotation")]
+    {
+    let target_kind = kind_annotation(&output_kind_annotation.kind, p)?
+        .to_value_kind(&p.state.borrow().kinds)?;
     Ok(value.convert_to(&target_kind).unwrap_or(value))
+    }
+    #[cfg(not(feature = "kind_annotation"))]
+    {
+        let _ = (output_kind_annotation, p);
+        Ok(value)
+    }
 }
 
 struct FunctionScope {

--- a/src/syntax/src/functions.rs
+++ b/src/syntax/src/functions.rs
@@ -50,9 +50,14 @@ fn function_define_match_arms(
   let (input, _) = transition_operator(input)?;
   let (input, _) = whitespace0(input)?;
   let (input, output_kind) = kind_annotation(input)?;
+  let output_src_range = output_kind
+    .tokens()
+    .first()
+    .map(|token| token.src_range.clone())
+    .unwrap_or_default();
   let output = vec![FunctionArgument {
     name: Identifier {
-      name: Token::new(TokenKind::Identifier, output_kind.src_range.clone(), vec!['_']),
+      name: Token::new(TokenKind::Identifier, output_src_range, vec!['_']),
     },
     kind: output_kind,
   }];


### PR DESCRIPTION
### Motivation
- Allow expressions evaluated as function arguments to see the current environment so functions can close over or reference local variables.
- Support coercing user/function-compiler outputs to a declared output kind when `kind_annotation` is enabled.
- Fix token source range used when creating an anonymous output identifier in function match-arm syntax parsing.

### Description
- Update call sites so `Expression::FunctionCall` forwards the current `env` into `function_call` in `src/interpreter/src/expressions.rs`.
- Change the `function_call` signature to `fn function_call(..., env: Option<&Environment>, p: &Interpreter)` and use the passed `env` when evaluating each argument expression.
- Implement conditional output-kind coercion in `coerce_function_output_kind` to convert the returned `Value` when the `kind_annotation` feature is enabled and otherwise return the value unchanged.
- Compute `output_src_range` from `output_kind.tokens().first()` and use it when building the anonymous output `Identifier` in `src/syntax/src/functions.rs` to ensure correct source-range metadata.

### Testing
- Ran `cargo test` across the workspace and the test suite completed successfully.
- Existing function- and expression-related tests passed with no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29f148698832a93c954cc46f28030)