### PR TITLE
docs: expand v0.2 Data Model (define & convert) and fix typos

### DIFF
--- a/docs/index.mec
+++ b/docs/index.mec
@@ -24,14 +24,14 @@ Mech Documentation
     - [`string`](/reference/string.html) - sequence of UTF-8 characters representing text
 - Data Structures
     - [`map`](/reference/map.html) - stores key-value pairs for fast lookups
-    - [`matrix`](/reference/matrix.html) - 2D array of homogenous values arranged in rows and columns
+    - [`matrix`](/reference/matrix.html) - 2D array of homogeneous values arranged in rows and columns
     - [`record`](/reference/record.html) - groups related fields, usually for representing structured data
     - [`set`](/reference/set.html) - unordered collection of unique values
     - [`table`](/reference/table.html) - collection of heterogeneous data organized into rows and columns
     - [`tuple`](/reference/tuple.html) - fixed-size, ordered grouping of heterogeneous values
 - Statements and Expressions
-    - [Defining, Assigning, and Accessing Data](/reference/define.html) `todo` - create data and change it
-    - [Data Conversion](/reference/convert.html) `todo` - convert data from one kind to another
+    - [Defining, Assigning, and Accessing Data](/reference/define.html) - define, update, and read values
+    - [Data Conversion](/reference/convert.html) - convert values between compatible kinds
     - [Expression Broadcasting](/reference/broadcasting.html) - apply operations over data structures
     - [Indexing](/reference/indexing.html) - access elements within data structures
 

--- a/docs/reference/convert.mec
+++ b/docs/reference/convert.mec
@@ -1,0 +1,62 @@
+Data Conversion
+===============================================================================
+
+%% Mech supports explicit and annotation-driven conversion between compatible kinds.
+
+1. Why Convert Data?
+-------------------------------------------------------------------------------
+
+Conversion is useful when:
+
+- Interfacing with APIs or tables that require specific kinds.
+- Reducing storage size (for example, `f64` to `u8`).
+- Preparing data for numeric or logical operations.
+
+2. Conversion with Kind Annotations
+-------------------------------------------------------------------------------
+
+Apply a kind annotation to request conversion.
+
+```mech:ex 1
+x := [1 2 3]
+y<[u8]> := x
+```
+
+In this example, `x` is inferred as a numeric matrix (commonly `f64`), and `y` is converted to `u8`.
+
+3. Scalar Conversion
+-------------------------------------------------------------------------------
+
+Scalars can be converted similarly:
+
+```mech:ex 2
+n := 42
+n_u16<u16> := n
+ratio := 3.14
+ratio_f32<f32> := ratio
+```
+
+4. Conversion Rules and Safety
+-------------------------------------------------------------------------------
+
+- Conversions must be defined between source and target kinds.
+- Some numeric conversions can lose precision.
+- Overflowing conversions may fail depending on target range.
+- Structural conversion requires compatible shapes.
+
+```mech:disabled
+big := 999
+small<u8> := big   -- may fail or truncate depending on conversion semantics
+```
+
+5. Converting Structured Data
+-------------------------------------------------------------------------------
+
+You can convert elements in vectors/matrices by annotating the result kind:
+
+```mech:disabled
+A := [1.2 2.7 3.1]
+B<[u8]:1,3> := A
+```
+
+For operations that combine conversion with math, see [`broadcasting`](/reference/broadcasting.html).

--- a/docs/reference/data.mec
+++ b/docs/reference/data.mec
@@ -90,7 +90,7 @@ The kind of a kind is itself, and `kind`. For example, the kind {{<i32>}} has th
   <kind>
 ```
 
-for more, see [`kind`](/reference/kind.html).
+For more, see [`kind`](/reference/kind.html).
 
 (1.5) Empty
 
@@ -117,7 +117,7 @@ Data structures in Mech are used to organize and manipulate collections of data.
 | Data Structure                     | Description                                                       |
 |-----------------------------------:|-------------------------------------------------------------------|
 | [`map`](/reference/map.html)       | stores key-value pairs for fast lookups.                          |
-| [`matrix`](/reference/matrix.html) | 2D array of homogenous values arranged in rows and columns.       |
+| [`matrix`](/reference/matrix.html) | 2D array of homogeneous values arranged in rows and columns.       |
 | [`record`](/reference/record.html) | groups related fields, usually for representing structured data.  |
 | [`set`](/reference/set.html)       | unordered collection of unique values                             |
 | [`table`](/reference/table.html)   | collection of heterogeneous data organized into rows and columns. |
@@ -136,7 +136,7 @@ For example, the kind of a signed 32-bit integer is represented as: {{<i32>}}. T
 
 (3.1.2) Kind Annotations
 
-Kind annotations are a tag that you can apply to values and expressions to specify their type explicitly. Syntatically they are specified with a form called a "kirby", which encases the kind in angle brackets:
+Kind annotations are a tag that you can apply to values and expressions to specify their type explicitly. Syntactically they are specified with a form called a "kirby", which encases the kind in angle brackets:
 
 ```mech:disabled
   <u8>    -- An unsigned 8-bit integer
@@ -175,7 +175,7 @@ Kinds start from one of the primitive data types:
 | Signed integers   | {{<i8>}}, {{<i16>}}, {{<i32>}}, {{<i64>}}, {{<i128>}}  |
 | Unsigned integers | {{<u8>}}, {{<u16>}}, {{<u32>}}, {{<u64>}}, {{<u128>}}  |
 | Floating-point    | {{<f32>}}, {{<f64>}}                                   |
-| Rational          | {{<r64>}}                                              |  
+| Rational          | {{<r64>}}                                              |
 | Complex           | {{<c64>}}                                              |
 | String            | {{<string>}}                                           |
 | Boolean           | {{<bool>}}                                             |

--- a/docs/reference/define.mec
+++ b/docs/reference/define.mec
@@ -1,0 +1,76 @@
+Defining, Assigning, and Accessing Data
+===============================================================================
+
+%% This section covers the core forms used to create values, update values, and read values from data structures.
+
+1. Defining Data
+-------------------------------------------------------------------------------
+
+Use `:=` to define new data. The interpreter infers the resulting kind when possible.
+
+```mech:ex 1
+x := 42
+name := "Mika"
+flags := [true false true]
+```
+
+You can also define structured values:
+
+```mech:ex 2
+point := (3, 4)
+config := {mode: :fast retries: 3}
+```
+
+2. Assigning and Re-assigning Data
+-------------------------------------------------------------------------------
+
+Use assignment to update existing bindings and data locations.
+
+```mech:ex 3
+count := 0
+count = count + 1
+```
+
+For structured data, assignment can target slices or fields.
+
+```mech:disabled
+A := [1 2 3
+      4 5 6]
+A[2,3] = 9
+
+person := {name: "Alice" age: 30}
+person.age = 31
+```
+
+3. Kind-Constrained Definitions
+-------------------------------------------------------------------------------
+
+Annotate data with a kind to enforce shape/type expectations.
+
+```mech:ex 4
+id<u32> := 7
+scores<[f64]:1,3> := [9.5 8.0 10.0]
+```
+
+If a value does not match the annotation, Mech raises a kind mismatch error.
+
+4. Accessing Data
+-------------------------------------------------------------------------------
+
+Common access patterns include:
+
+- Name access: `x`
+- Index access: `A[2,3]`
+- Field access: `record.field`
+- Column access: `table.column`
+
+```mech:disabled
+A := [10 20 30
+      40 50 60]
+first_row := A[1,:]
+
+user := {name: "Rin" role: :admin}
+role := user.role
+```
+
+For full indexing details, see [`indexing`](/reference/indexing.html).

--- a/docs/reference/index.mec
+++ b/docs/reference/index.mec
@@ -13,14 +13,14 @@ Platform Reference
     - [`string`](/reference/string.html) - sequence of UTF-8 characters representing text
 - Data Structures
     - [`map`](/reference/map.html) - stores key-value pairs for fast lookups
-    - [`matrix`](/reference/matrix.html) - 2D array of homogenous values arranged in rows and columns
+    - [`matrix`](/reference/matrix.html) - 2D array of homogeneous values arranged in rows and columns
     - [`record`](/reference/record.html) - groups related fields, usually for representing structured data
     - [`set`](/reference/set.html) - unordered collection of unique values
     - [`table`](/reference/table.html) - collection of heterogeneous data organized into rows and columns
     - [`tuple`](/reference/tuple.html) - fixed-size, ordered grouping of heterogeneous values
 - Statements and Expressions
-    - [Defining, Assigning, and Accessing Data](/reference/define.html) `todo` - create data and change it
-    - [Data Conversion](/reference/convert.html) `todo` - convert data from one kind to another
+    - [Defining, Assigning, and Accessing Data](/reference/define.html) - define, update, and read values
+    - [Data Conversion](/reference/convert.html) - convert values between compatible kinds
     - [Expression Broadcasting](/reference/broadcasting.html) - apply operations over data structures
     - [Indexing](/reference/indexing.html) - access elements within data structures
 


### PR DESCRIPTION
### Motivation

- Clarify and complete the v0.2 Data Model documentation by replacing `todo` placeholders with concrete reference material for defining/assigning data and for data conversion.
- Provide concise, example-driven guidance for the least-attended sections so readers can create, update, and convert values with clear expectations about kinds and safety.

### Description

- Added `docs/reference/define.mec` to document value creation (`:=`), assignment, kind-constrained definitions, and common access patterns with examples.
- Added `docs/reference/convert.mec` to document annotation-driven conversion, scalar and structured conversion examples, and conversion safety rules.
- Updated `docs/reference/index.mec` and `docs/index.mec` to remove `todo` placeholders and to point to the new `define` and `convert` reference pages.
- Fixed wording and typos in `docs/reference/data.mec`, including `homogenous` → `homogeneous` and `Syntatically` → `Syntactically`.

### Testing

- Ran `git diff --check` to detect whitespace/patch issues and the check completed with no errors.
- Searched for remaining `todo` markers with `rg -n "todo" docs/reference/index.mec docs/index.mec` and confirmed the v0.2 Data Model statements no longer contain `todo` entries.
- Verified repository status with `git status --short` and ensured the documentation-only changes are staged/committed locally without build or formatting failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c472d64314832ab87d3d96ee324216)