### PR TITLE
Fix matrix assignment via variable definition (`b := a`)

### DIFF
--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -237,6 +237,12 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
     }
   }
   let mut result = expression(&var_def.expression, None, p)?;
+  // Variable definitions should capture the current value, not a mutable reference wrapper.
+  // This prevents nested `MutableReference` values when defining from another symbol
+  // (e.g. `b := a`), which can break operations like indexing and equality on `b`.
+  if let Value::MutableReference(value_ref) = &result {
+    result = value_ref.borrow().clone();
+  }
   #[cfg(all(feature = "kind_annotation", feature = "convert"))]
   if let Some(knd_anntn) =  &var_def.var.kind {
     let knd = kind_annotation(&knd_anntn.kind,p)?;

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -100,6 +100,8 @@ test_interpreter!(interpret_matrix_lt_rational, "[1/2 3/4] < [3/4 1/2]", Value::
 test_interpreter!(interpret_matrix_lt_complex, "[1+2i 3+4i] < [2+3i 4+5i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_lte_rational, "[1/2 3/4] <= [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_lte_complex, "[1+2i 3+4i] <= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_assignment_copy_eq, "a := [1 2; 3 4]; b := a; b == a", Value::MatrixBool(Matrix::from_vec(vec![true, true, true, true], 2, 2)));
+test_interpreter!(interpret_matrix_assignment_copy_index, "a := [1 2; 3 4]; b := a; b[2,1]", Value::F64(Ref::new(3.0)));
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_kind_annotation, "1<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]


### PR DESCRIPTION
### Motivation
- Variable definitions that assign from another symbol were storing a `MutableReference` wrapper instead of the referenced value, causing nested references that break operations like matrix indexing and equality.

### Description
- Unwrap `Value::MutableReference` in `variable_define` so a definition like `b := a` captures the current value instead of a nested mutable reference (change in `src/interpreter/src/statements.rs`).
- Add two regression tests in `tests/interpreter.rs`: `interpret_matrix_assignment_copy_eq` to check `b == a` and `interpret_matrix_assignment_copy_index` to check `b[2,1]`.

### Testing
- Attempted to run `cargo test -q tests:: -- --nocapture` but execution was blocked by a toolchain mismatch (workspace requires `rustc 1.96` while the environment has `rustc 1.92`).
- Ran `cargo fmt --all -- --check` which reported repository-wide formatting differences not introduced by this change, so no formatting changes were applied in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c710cb20c8832ab793d207b5fc1382)