### PR TITLE
Fix #191: allow empty variable definitions

### DIFF
--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -243,7 +243,8 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
     let mut state_brrw = &mut p.state.borrow_mut();
     let target_knd = knd.to_value_kind(&mut state_brrw.kinds)?;
     // Do kind checking
-    match (&result, &target_knd) {
+    if result.kind() != target_knd {
+      match (&result, &target_knd) {
       // Atom is a variant of an enum
       #[cfg(all(feature = "atom", feature = "enum"))]
       (Value::Atom(atom_variant), ValueKind::Enum(enum_id, target_enum_variant_name)) => {
@@ -350,13 +351,14 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
       }
       // Kind isn't checked
       x => {
-        let convert_fxn = ConvertKind{}.compile(&vec![result.clone(), Value::Kind(target_knd)])?;
+        let convert_fxn = ConvertKind{}.compile(&vec![result.clone(), Value::Kind(target_knd.clone())])?;
         convert_fxn.solve();
         let converted_result = convert_fxn.out();
         state_brrw.add_plan_step(convert_fxn);
         result = converted_result;
       },
-    };
+      };
+    }
     // Save symbol to interpreter
     let val_ref = state_brrw.save_symbol(var_id, var_name.clone(), result.clone(), var_def.mutable);
     // Add variable define step to plan

--- a/src/interpreter/src/stdlib/define.rs
+++ b/src/interpreter/src/stdlib/define.rs
@@ -60,6 +60,19 @@ where
   fn out(&self) -> Value {self.var.to_value()}
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
+
+#[derive(Debug, Clone)]
+pub struct VariableDefineEmpty {
+  id: u64,
+  name: Ref<String>,
+  mutable: Ref<bool>,
+}
+
+impl MechFunctionImpl for VariableDefineEmpty {
+  fn solve(&self) {}
+  fn out(&self) -> Value { Value::Empty }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
 #[cfg(feature = "compiler")]
 impl<T, MatA> MechFunctionCompiler for VariableDefineMatrix<T, MatA> 
 where
@@ -263,6 +276,7 @@ macro_rules! impl_variable_define_match_arms {
 fn impl_var_define_fxn(var: Value, name: Value, mutable: Value, id: u64) -> MResult<Box<dyn MechFunction>> {
   let arg = (var.clone(), name.clone(), mutable.clone(), id);
   match arg {
+    (Value::Empty, name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineEmpty{ name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     #[cfg(feature = "table")]
     (Value::Table(sink), name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineMechTable{ var: sink.clone(), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     #[cfg(feature = "set")]


### PR DESCRIPTION
### Motivation
- Defining a variable to `Empty` (e.g. `x := _`) produced an `UnhandledFunctionArgumentKind3` error because `var/define` had no handler for `Value::Empty`.
- Kind-annotation code could run no-op conversions (e.g. `Empty -> Empty`) which invoked conversion machinery unnecessarily.

### Description
- Add a new mech function `VariableDefineEmpty` (struct + `MechFunctionImpl`) that returns `Value::Empty` for empty variable definitions in `src/interpreter/src/stdlib/define.rs`.
- Route `Value::Empty` to the new handler by matching it first in `impl_var_define_fxn` in `src/interpreter/src/stdlib/define.rs`.
- In `variable_define` (in `src/interpreter/src/statements.rs`) only perform kind conversion when `result.kind() != target_knd`, avoiding no-op conversions and ensuring `ConvertKind` is called with a cloned `target_knd` when needed.
- Files changed: `src/interpreter/src/stdlib/define.rs` and `src/interpreter/src/statements.rs`.

### Testing
- Ran `cargo test -q`, which could not complete in this environment because the workspace requires `rustc 1.96` while the runner has `rustc 1.92.0`, so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c75bc7d0a4832a8c76937d31428075)