### PR TITLE
Fix issue #191: support defining empty variables

### DIFF
--- a/src/interpreter/src/stdlib/convert/scalar.rs
+++ b/src/interpreter/src/stdlib/convert/scalar.rs
@@ -46,6 +46,44 @@ register_descriptor! {
   }
 }
 
+#[derive(Debug)]
+struct ConvertSEmpty {
+  out: Ref<Value>,
+}
+impl MechFunctionFactory for ConvertSEmpty {
+  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+    match args {
+      FunctionArgs::Unary(out, _) => {
+        let out: Ref<Value> = unsafe { out.as_unchecked() }.clone();
+        Ok(Box::new(Self { out }))
+      },
+      _ => Err(MechError::new(
+          IncorrectNumberOfArguments { expected: 1, found: args.len() },
+          None
+        ).with_compiler_loc()
+      ),
+    }
+  }
+}
+impl MechFunctionImpl for ConvertSEmpty {
+  fn solve(&self) {}
+  fn out(&self) -> Value { self.out.borrow().clone() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for ConvertSEmpty {
+  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+    let name = "ConvertSEmpty<empty>".to_string();
+    compile_nullop!(name, self.out, ctx, FeatureFlag::Builtin(FeatureKind::Convert));
+  }
+}
+register_descriptor! {
+  FunctionDescriptor {
+    name: "ConvertSEmpty<empty>",
+    ptr: ConvertSEmpty::new,
+  }
+}
+
 #[cfg(all(feature = "matrix", feature = "table"))]
 #[derive(Debug)]
 struct ConvertMat2Table<T> {
@@ -260,6 +298,7 @@ where
 
 fn impl_conversion_fxn(source_value: Value, target_kind: Value) -> MResult<Box<dyn MechFunction>>  {
   match (&source_value, &target_kind) {
+    (Value::Empty, Value::Kind(ValueKind::Empty)) => {return Ok(Box::new(ConvertSEmpty{ out: Ref::new(Value::Empty) }));}
     #[cfg(all(feature = "rational", feature = "f64"))]
     (Value::R64(r), Value::Kind(ValueKind::F64)) => {return Ok(Box::new(ConvertScalarToScalar{arg: r.clone(),out: Ref::new(f64::default()),}));}
     #[cfg(all(feature = "matrix", feature = "table", feature = "string"))]

--- a/src/interpreter/src/stdlib/define.rs
+++ b/src/interpreter/src/stdlib/define.rs
@@ -168,6 +168,50 @@ impl_variable_define_fxn!(MechMap);
 #[cfg(feature = "atom")]
 impl_variable_define_fxn!(MechAtom);
 
+#[derive(Debug, Clone)]
+pub struct VariableDefineEmpty {
+  id: u64,
+  name: Ref<String>,
+  mutable: Ref<bool>,
+  out: Ref<Value>,
+}
+impl MechFunctionFactory for VariableDefineEmpty {
+  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+    match args {
+      FunctionArgs::Binary(out, arg1, arg2) => {
+        let out: Ref<Value> = unsafe { out.as_unchecked() }.clone();
+        let name: Ref<String> = unsafe { arg1.as_unchecked() }.clone();
+        let mutable: Ref<bool> = unsafe { arg2.as_unchecked() }.clone();
+        let id = hash_str(&name.borrow());
+        Ok(Box::new(Self { id, name, mutable, out }))
+      },
+      _ => Err(MechError::new(
+          IncorrectNumberOfArguments { expected: 3, found: args.len() },
+          None
+        ).with_compiler_loc()
+      ),
+    }
+  }
+}
+impl MechFunctionImpl for VariableDefineEmpty {
+  fn solve(&self) {}
+  fn out(&self) -> Value { self.out.borrow().clone() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for VariableDefineEmpty {
+  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+    let name = "VariableDefineEmpty".to_string();
+    compile_nullop!(name, self.out, ctx, FeatureFlag::Builtin(FeatureKind::VariableDefine));
+  }
+}
+inventory::submit! {
+  FunctionDescriptor {
+    name: "VariableDefineEmpty",
+    ptr: VariableDefineEmpty::new,
+  }
+}
+
 #[macro_export]
 macro_rules! impl_variable_define_match_arms {
   ($arg:expr, $value_kind:ty, $feature:expr) => {
@@ -263,6 +307,7 @@ macro_rules! impl_variable_define_match_arms {
 fn impl_var_define_fxn(var: Value, name: Value, mutable: Value, id: u64) -> MResult<Box<dyn MechFunction>> {
   let arg = (var.clone(), name.clone(), mutable.clone(), id);
   match arg {
+    (Value::Empty, name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineEmpty{ name: name.as_string()?, mutable: mutable.as_bool()?, id, out: Ref::new(Value::Empty) } ))),
     #[cfg(feature = "table")]
     (Value::Table(sink), name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineMechTable{ var: sink.clone(), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     #[cfg(feature = "set")]

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -53,6 +53,8 @@ test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false))
 test_interpreter!(interpret_literal_false, "false", Value::Bool(Ref::new(false)));
 test_interpreter!(interpret_literal_atom, ":A", Value::Atom(Ref::new(MechAtom::new(55450514845822917))));
 test_interpreter!(interpret_literal_empty, "_", Value::Empty);
+test_interpreter!(interpret_define_empty_variable, "em := _", Value::Empty);
+test_interpreter!(interpret_define_typed_empty_variable, "emp<_> := _", Value::Empty);
 test_interpreter!(interpret_literal_complex, "5+4i", Value::C64(Ref::new(C64::new(5.0, 4.0))));
 test_interpreter!(interpret_literal_complex2, "5-4i", Value::C64(Ref::new(C64::new(5.0, -4.0))));
 test_interpreter!(interpret_literal_complex3, "5-4j", Value::C64(Ref::new(C64::new(5.0, -4.0))));


### PR DESCRIPTION
### Motivation
- The interpreter produced `UnhandledFunctionArgumentKind3` when attempting to define empty variables (e.g. `em := _` or `emp<_> := _`), so variable definition and conversion paths need explicit handling for `Empty` values.

### Description
- Add `VariableDefineEmpty` implementation with `MechFunctionFactory`, `MechFunctionImpl`, `MechFunctionCompiler`, and inventory registration to handle `var/define` when the LHS is `Value::Empty` and preserve the output reference.
- Wire `impl_var_define_fxn` to return `VariableDefineEmpty` for `(Value::Empty, ...)` before other match arms so untyped empty definitions succeed.
- Add `ConvertSEmpty` and an `impl_conversion_fxn` match arm for `(Value::Empty, ValueKind::Empty)` so typed empty definitions like `emp<_> := _` convert properly at compile/run time.
- Add two interpreter regression tests (`interpret_define_empty_variable` and `interpret_define_typed_empty_variable`) and small test harness updates to validate both untyped and typed empty definitions.

### Testing
- Ran `cargo test interpret_define -- --nocapture`, which executed the interpreter tests and reported: `4 passed; 0 failed` (the two new tests passed along with existing define tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c75f180fdc832ab8af57d00991f955)