### PR TITLE
Add optional title byline (AST, parser, formatter, docs)

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -1426,7 +1426,15 @@ title := +text
       , new-line
       , +"="
       , *(space|tab)
+      , ?byline
       , ws0 ;
+byline := *new-line
+       , *(space|tab)
+       , paragraph
+       , new-line
+       , +"="
+       , *(space|tab)
+       , new-line ;
 paragraph-element := +(¬define-operator, text) ;
 paragraph := paragraph-starter, *paragraph-element ;
 subtitle := +digit-token
@@ -1461,6 +1469,9 @@ There are 6 levels of titles: the document title, section titles, and two levels
 
 ```
 Title
+========
+
+v0.3.1-beta
 ========
 
 1. Section Title

--- a/docs/mechdown/title.mec
+++ b/docs/mechdown/title.mec
@@ -14,6 +14,7 @@ Mechdown supports hierarchical titles:
 -------------------------------------------------------------------------------
 
 - Use one document title per file.
+- Optionally include one byline directly under the title (for example a version string).
 - Keep section numbering sequential.
 - Keep subsection numbering aligned with the parent section.
 - Prefer short, descriptive titles so generated navigation remains readable.
@@ -23,6 +24,9 @@ Mechdown supports hierarchical titles:
 
 ```mech
 Mechdown Title Guide
+===============================================================================
+
+v0.3.1-beta
 ===============================================================================
 
 1. Section Title

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -305,6 +305,7 @@ fn pretty_print(&self) -> String {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Title {
   pub text: Token,
+  pub byline: Option<Paragraph>,
 }
 
 impl Title {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -164,9 +164,20 @@ impl Formatter {
 
   pub fn title(&mut self, node: &Title) -> String {
     if self.html {
-      format!("<h1 class=\"mech-program-title\">{}</h1>",node.to_string())
+      let byline = match &node.byline {
+        Some(byline) => format!("<h2 class=\"mech-program-byline\">{}</h2>", byline.to_string()),
+        None => "".to_string(),
+      };
+      format!("<h1 class=\"mech-program-title\">{}</h1>{}",node.to_string(), byline)
     } else {
-      format!("{}\n===============================================================================\n",node.to_string()) 
+      match &node.byline {
+        Some(byline) => format!(
+          "{}\n===============================================================================\n{}\n===============================================================================\n",
+          node.to_string(),
+          byline.to_string()
+        ),
+        None => format!("{}\n===============================================================================\n",node.to_string()),
+      }
     }
   }
 

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -24,18 +24,31 @@ use crate::*;
 // Mechdown
 // ============================================================================
 
-// title := +text, new-line, +equal, *(space|tab), *whitespace ;
+// title := +text, new-line, +equal, *(space|tab), ?byline, *whitespace ;
 pub fn title(input: ParseString) -> ParseResult<Title> {
   let (input, mut text) = many1(text)(input)?;
   let (input, _) = new_line(input)?;
   let (input, _) = many1(equal)(input)?;
   let (input, _) = many0(space_tab)(input)?;
   let (input, _) = new_line(input)?;
+  let (input, byline) = opt(byline)(input)?;
   let (input, _) = many0(space_tab)(input)?;
   let (input, _) = whitespace0(input)?;
   let mut title = Token::merge_tokens(&mut text).unwrap();
   title.kind = TokenKind::Title;
-  Ok((input, Title{text: title}))
+  Ok((input, Title{text: title, byline}))
+}
+
+// byline := *new-line, *(space|tab), paragraph, new-line, +equal, *(space|tab), new-line ;
+pub fn byline(input: ParseString) -> ParseResult<Paragraph> {
+  let (input, _) = many0(new_line)(input)?;
+  let (input, _) = many0(space_tab)(input)?;
+  let (input, byline) = paragraph(input)?;
+  let (input, _) = new_line(input)?;
+  let (input, _) = many1(equal)(input)?;
+  let (input, _) = many0(space_tab)(input)?;
+  let (input, _) = new_line(input)?;
+  Ok((input, byline))
 }
 
 pub struct MarkdownTableHeader {


### PR DESCRIPTION
### Motivation

- Introduce an optional byline immediately under the document title (examples use version strings) so documents can carry a short metadata line displayed under the title and included in rendered output.
- Update documentation and the specification to formally describe the `byline` production and its placement beneath the title.

### Description

- Add an optional `byline: Option<Paragraph>` field to the `Title` struct in `src/core/src/nodes.rs` to represent a title byline in the AST.
- Extend the parser in `src/syntax/src/mechdown.rs` by changing `title` to accept an optional `byline` and adding a new `byline` parser that returns a `Paragraph` node.
- Update the output formatter in `src/syntax/src/formatter.rs` to render the byline for both HTML (as an `<h2>` with class `mech-program-byline`) and plain-text output (as a second underlined block), and preserve existing behavior when no byline is present.
- Update documentation and spec examples in `docs/design/specification.mec` and `docs/mechdown/title.mec` to document the optional byline and show example usage.

### Testing

- Ran the project test suite with `cargo test` across the workspace and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83c30f6f8832a8284d24008566cad)