### PR TITLE
Add GitHub Actions CI workflow equivalent to GitLab pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  cargo:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
+
+      - name: Build and test
+        run: |
+          cargo clean
+          cargo build --bin mech
+          cargo build --no-default-features
+          cargo test interpret --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"
+          cargo test bytecode --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"


### PR DESCRIPTION
### Motivation
- Enable running the same cargo build and test script on GitHub infrastructure by mirroring the existing root GitLab job so CI behavior is consistent across providers.

### Description
- Add `./github/workflows/ci.yml` which installs `nightly-2026-03-03` and runs `cargo clean`, `cargo build --bin mech`, `cargo build --no-default-features`, `cargo test interpret --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"`, and `cargo test bytecode --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"`, matching the commands in `.gitlab-ci.yml`.

### Testing
- No automated tests were executed locally; the new GitHub Actions workflow will run the same automated cargo build and test steps on GitHub Actions as defined in `.gitlab-ci.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83d54abfc832a87b98882104b13a6)