### PR TITLE
Allow homogeneous matrix assignment to `[*]` kind (fix #185)

### DIFF
--- a/src/interpreter/src/stdlib/convert/mat_to_mat.rs
+++ b/src/interpreter/src/stdlib/convert/mat_to_mat.rs
@@ -275,6 +275,18 @@ macro_rules! impl_conversion_mat_to_mat_fxn {
       paste::paste! {
         match (source_value.clone(), target_kind.clone()) {
           $(
+            #[cfg(all(feature = "matrix", feature = $src_string))]
+            (Value::[<Matrix $src:camel>](v), ValueKind::Matrix(target_kind, dims)) if matches!(target_kind.as_ref(), ValueKind::Any) => {
+              if dims.is_empty() {
+                create_convert_mat_to_mat::<$src, $src>(v, &shape)
+              } else if ((shape[0] == dims[0]) && (shape[1] == dims[1])) {
+                create_convert_mat_to_mat::<$src, $src>(v, &dims)
+              } else if shape[0] * shape[1] == dims[0] * dims[1] {
+                create_reshape_mat_to_mat::<$src, $src>(v, &dims)
+              } else {
+                Err(MechError::new(UnsupportedConversionError{from: source_value.kind(), to: target_kind.as_ref().clone()}, None).with_compiler_loc())
+              }
+            }
             $(
               #[cfg(all(feature = "matrix", feature = $src_string, feature = $dst_string))]
               (Value::[<Matrix $src:camel>](v), ValueKind::Matrix(target_kind, dims)) if matches!(target_kind.as_ref(), ValueKind::[<$dst:camel>]) => {

--- a/src/interpreter/src/stdlib/convert/mod.rs
+++ b/src/interpreter/src/stdlib/convert/mod.rs
@@ -464,6 +464,13 @@ impl LosslessInto<f64> for R64 {
     }
   }
 }
+
+#[cfg(feature = "rational")]
+impl LosslessInto<R64> for R64 {
+  fn lossless_into(self) -> R64 {
+    self
+  }
+}
 #[cfg(all(feature = "rational", feature = "f64"))]
 impl LosslessInto<R64> for f64 {
   fn lossless_into(self) -> R64 {
@@ -482,6 +489,13 @@ impl LosslessInto<R64> for f32 {
 impl LosslessInto<String> for C64 {
   fn lossless_into(self) -> String {
     self.pretty_print()
+  }
+}
+
+#[cfg(feature = "complex")]
+impl LosslessInto<C64> for C64 {
+  fn lossless_into(self) -> C64 {
+    self
   }
 }
 

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -242,6 +242,7 @@ test_interpreter!(interpret_kind_convert_twice, "x<u64> := 1; y<i8> := x", Value
 test_interpreter!(interpret_kind_convert_float, "x<f32> := 123;", Value::F32(Ref::new(123.0)));
 test_interpreter!(interpret_kind_convert_rational, "x<r64> := 1 / 2; y<f64> := x", Value::F64(Ref::new(0.5)));
 test_interpreter!(interpret_kind_convert_rational2, "x<f64> := 1/2; y<r64> := x", Value::R64(Ref::new(R64::new(1, 2))));
+test_interpreter!(interpret_kind_convert_mat_to_any, "x := [2 3 4]; y<[*]> := x", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
 
 test_interpreter!(interpret_kind_define, "<foo> := <f64>; x<foo> := 123", Value::F64(Ref::new(123.0)));
 test_interpreter!(interpret_formula_math_neg, "-1", Value::F64(Ref::new(-1.0)));


### PR DESCRIPTION
### Motivation
- Assigning a homogeneous matrix into a target annotated as `Matrix(Any, ...)` produced `UnsupportedConversion` and prevented `y<[*]> := x` style assignments. 
- The intent is to accept homogeneous source matrices for `Any`-typed matrix targets while preserving existing shape/reshape compatibility rules.

### Description
- Add a match arm in `impl_conversion_mat_to_mat_fxn` (in `src/interpreter/src/stdlib/convert/mat_to_mat.rs`) to handle `ValueKind::Any` targets by performing identity conversions or reshapes for the source scalar type. 
- Provide identity `LosslessInto` implementations for `R64` and `C64` in `src/interpreter/src/stdlib/convert/mod.rs` so conversions to `Any` compile for rational and complex scalar kinds. 
- Add a regression test `interpret_kind_convert_mat_to_any` in `tests/interpreter.rs` that covers `x := [2 3 4]; y<[*]> := x` and verifies the resulting `MatrixF64` value. 

### Testing
- Ran `cargo test interpret_kind_convert_mat_to_any --test interpreter` which compiled and executed the test, resulting in `ok` (1 passed; 0 failed). 
- The change resolves the compile errors encountered when converting homogeneous `R64`/`C64` matrices to `Any`-typed targets by adding the required identity `LosslessInto` impls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c842b00584832a946524ef7be69dfc)