### PR TITLE
Fix issue #191: allow defining empty variables

### DIFF
--- a/src/interpreter/src/stdlib/convert/scalar.rs
+++ b/src/interpreter/src/stdlib/convert/scalar.rs
@@ -46,6 +46,42 @@ register_descriptor! {
   }
 }
 
+#[derive(Debug)]
+struct ConvertSEmpty {
+  out: Ref<Value>,
+}
+
+impl MechFunctionImpl for ConvertSEmpty {
+  fn solve(&self) { }
+  fn out(&self) -> Value { self.out.borrow().clone() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for ConvertSEmpty {
+  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+    let name = format!("ConvertSEmpty<empty>");
+    compile_nullop!(name, self.out, ctx, FeatureFlag::Builtin(FeatureKind::Convert));
+  }
+}
+register_descriptor! {
+  FunctionDescriptor {
+    name: "ConvertSEmpty<empty>",
+    ptr: |args: FunctionArgs| -> MResult<Box<dyn MechFunction>> {
+      match args {
+        FunctionArgs::Nullary(out) => {
+          let out: Ref<Value> = unsafe { out.as_unchecked() }.clone();
+          Ok(Box::new(ConvertSEmpty { out }))
+        },
+        _ => Err(MechError::new(
+            IncorrectNumberOfArguments { expected: 0, found: args.len() },
+            None
+          ).with_compiler_loc()
+        ),
+      }
+    },
+  }
+}
+
 #[cfg(all(feature = "matrix", feature = "table"))]
 #[derive(Debug)]
 struct ConvertMat2Table<T> {
@@ -175,6 +211,9 @@ macro_rules! impl_conversion_match_arms {
           let val = Ref::new(enm.clone());
           todo!("This isn't finished yet");
           Ok(Box::new(ConvertSEnum{out: val}))
+        }
+        (Value::Empty, Value::Kind(ValueKind::Empty)) => {
+          Ok(Box::new(ConvertSEmpty { out: Ref::new(Value::Empty) }))
         }
         x => Err(MechError::new(
             UnsupportedConversionError{from: x.0.kind(), to: x.1.kind()},

--- a/src/interpreter/src/stdlib/define.rs
+++ b/src/interpreter/src/stdlib/define.rs
@@ -168,6 +168,46 @@ impl_variable_define_fxn!(MechMap);
 #[cfg(feature = "atom")]
 impl_variable_define_fxn!(MechAtom);
 
+#[derive(Debug, Clone)]
+pub struct VariableDefineEmpty {
+  id: u64,
+  name: Ref<String>,
+  mutable: Ref<bool>,
+  var: Ref<Value>,
+}
+impl MechFunctionImpl for VariableDefineEmpty {
+  fn solve(&self) {}
+  fn out(&self) -> Value { self.var.borrow().clone() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for VariableDefineEmpty {
+  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+    let name = "VariableDefineEmpty".to_string();
+    compile_binop!(name, self.var, self.name, self.mutable, ctx, FeatureFlag::Builtin(FeatureKind::VariableDefine) );
+  }
+}
+register_descriptor! {
+  FunctionDescriptor {
+    name: "VariableDefineEmpty",
+    ptr: |args: FunctionArgs| -> MResult<Box<dyn MechFunction>> {
+      match args {
+        FunctionArgs::Binary(var, arg1, arg2) => {
+          let var: Ref<Value> = unsafe { var.as_unchecked() }.clone();
+          let name: Ref<String> = unsafe { arg1.as_unchecked() }.clone();
+          let mutable: Ref<bool> = unsafe { arg2.as_unchecked() }.clone();
+          let id = hash_str(&name.borrow());
+          Ok(Box::new(VariableDefineEmpty { id, name, mutable, var }))
+        }
+        _ => Err(MechError::new(
+          IncorrectNumberOfArguments { expected: 3, found: args.len() },
+          None
+        ).with_compiler_loc()),
+      }
+    },
+  }
+}
+
 #[macro_export]
 macro_rules! impl_variable_define_match_arms {
   ($arg:expr, $value_kind:ty, $feature:expr) => {
@@ -263,6 +303,7 @@ macro_rules! impl_variable_define_match_arms {
 fn impl_var_define_fxn(var: Value, name: Value, mutable: Value, id: u64) -> MResult<Box<dyn MechFunction>> {
   let arg = (var.clone(), name.clone(), mutable.clone(), id);
   match arg {
+    (Value::Empty, name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineEmpty { var: Ref::new(Value::Empty), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     #[cfg(feature = "table")]
     (Value::Table(sink), name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineMechTable{ var: sink.clone(), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     #[cfg(feature = "set")]

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -53,6 +53,8 @@ test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false))
 test_interpreter!(interpret_literal_false, "false", Value::Bool(Ref::new(false)));
 test_interpreter!(interpret_literal_atom, ":A", Value::Atom(Ref::new(MechAtom::new(55450514845822917))));
 test_interpreter!(interpret_literal_empty, "_", Value::Empty);
+test_interpreter!(interpret_variable_define_empty, "em := _", Value::Empty);
+test_interpreter!(interpret_variable_define_typed_empty, "emp<_> := _", Value::Empty);
 test_interpreter!(interpret_literal_complex, "5+4i", Value::C64(Ref::new(C64::new(5.0, 4.0))));
 test_interpreter!(interpret_literal_complex2, "5-4i", Value::C64(Ref::new(C64::new(5.0, -4.0))));
 test_interpreter!(interpret_literal_complex3, "5-4j", Value::C64(Ref::new(C64::new(5.0, -4.0))));


### PR DESCRIPTION
### Motivation
- The interpreter rejected attempts to define empty variables (e.g. `em := _` and `emp<_> := _`) with an `UnhandledFunctionArgumentKind` error. 
- The intent is to treat `Value::Empty` as a valid target for `var/define` and to support conversion paths for empty-to-empty typed definitions. 

### Description
- Add a `VariableDefineEmpty` Mech function and register it so `var/define` accepts `Value::Empty` as the left-hand side. 
- Add a `ConvertSEmpty` conversion path and a `(Value::Empty, Value::Kind(ValueKind::Empty))` match arm to `convert/scalar` so typed empty declarations succeed. 
- Add two interpreter regression tests (`interpret_variable_define_empty` and `interpret_variable_define_typed_empty`) and wire them into the existing test suite. 

### Testing
- Ran the focused interpreter tests `cargo test -q --test interpreter interpret_variable_define_empty -- --exact`, `cargo test -q --test interpreter interpret_variable_define_typed_empty -- --exact`, and `cargo test -q --test interpreter interpret_literal_empty -- --exact`, all of which passed. 
- Verified the three modified files compile and the new tests execute successfully under the interpreter test binary. 
- No failing automated tests were observed for the exercised interpreter cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84224b0c0832a9d9519b75fd3d048)