### PR TITLE
Fix #178: detach variable references on definition for matrix copies

### DIFF
--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -357,20 +357,29 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
         result = converted_result;
       },
     };
+    let detached_result = detach_variable_value(&result);
     // Save symbol to interpreter
-    let val_ref = state_brrw.save_symbol(var_id, var_name.clone(), result.clone(), var_def.mutable);
+    let val_ref = state_brrw.save_symbol(var_id, var_name.clone(), detached_result.clone(), var_def.mutable);
     // Add variable define step to plan
-    let var_def_fxn = VarDefine{}.compile(&vec![result.clone(), Value::String(Ref::new(var_name.clone())), Value::Bool(Ref::new(var_def.mutable))])?;
+    let var_def_fxn = VarDefine{}.compile(&vec![detached_result.clone(), Value::String(Ref::new(var_name.clone())), Value::Bool(Ref::new(var_def.mutable))])?;
     state_brrw.add_plan_step(var_def_fxn);
-    return Ok(result);
+    return Ok(detached_result);
   } 
   let mut state_brrw = p.state.borrow_mut();
+  let detached_result = detach_variable_value(&result);
   // Save symbol to interpreter
-  let val_ref = state_brrw.save_symbol(var_id,var_name.clone(),result.clone(),var_def.mutable);
+  let val_ref = state_brrw.save_symbol(var_id,var_name.clone(),detached_result.clone(),var_def.mutable);
   // Add variable define step to plan
-  let var_def_fxn = VarDefine{}.compile(&vec![result.clone(), Value::String(Ref::new(var_name.clone())), Value::Bool(Ref::new(var_def.mutable))])?;
+  let var_def_fxn = VarDefine{}.compile(&vec![detached_result.clone(), Value::String(Ref::new(var_name.clone())), Value::Bool(Ref::new(var_def.mutable))])?;
   state_brrw.add_plan_step(var_def_fxn);
-  return Ok(result);
+  return Ok(detached_result);
+}
+
+fn detach_variable_value(value: &Value) -> Value {
+  match value {
+    Value::MutableReference(reference) => detach_variable_value(&reference.borrow()),
+    _ => value.clone(),
+  }
 }
 
 macro_rules! op_assign {

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -111,6 +111,8 @@ test_interpreter!(interpret_matrix_lt_rational, "[1/2 3/4] < [3/4 1/2]", Value::
 test_interpreter!(interpret_matrix_lt_complex, "[1+2i 3+4i] < [2+3i 4+5i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_lte_rational, "[1/2 3/4] <= [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_lte_complex, "[1+2i 3+4i] <= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_assignment_copy_index, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b[2,3]", Value::F64(Ref::new(6.0)));
+test_interpreter!(interpret_matrix_assignment_copy_eq, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b == a", Value::MatrixBool(Matrix::from_vec(vec![true, true, true, true, true, true, true, true, true], 3, 3)));
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_kind_annotation, "1<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]


### PR DESCRIPTION
### Motivation
- Variable definitions could store a `MutableReference` wrapper instead of the underlying value, causing indexing and comparison operations on aliases (e.g. `b := a`) to fail (issue #178). 
- The intent is to ensure variable definitions store concrete values so subsequent operations behave as if a true copy was created.

### Description
- Update `variable_define` in `src/interpreter/src/statements.rs` to detach `MutableReference` values before saving them to the symbol table and before adding the `VarDefine` plan step by introducing `detach_variable_value`. 
- Replace uses of the original `result` with the detached value when calling `save_symbol` and `VarDefine{}.compile(...)`, and return the detached value from `variable_define`. 
- Add two regression tests in `tests/interpreter.rs`: `interpret_matrix_assignment_copy_index` to validate indexing after `b := a`, and `interpret_matrix_assignment_copy_eq` to validate equality comparisons after `b := a`.

### Testing
- Ran `cargo test -q interpret_matrix_assignment_copy --test interpreter` and it passed (`2 passed; 0 failed`).
- Ran `cargo test -q interpret_matrix_eq --test interpreter` and it passed (`2 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6c85ac60832a8e83578d594418c5)