### PR TITLE
Fix #179: infer compact Mechdown table literals and detach Ids on variable define

### DIFF
--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -102,6 +102,9 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
     },
     SectionElement::Footnote(x) => x.hash(&mut hasher),
     SectionElement::Paragraph(x) => {
+      if let Some(table_value) = inline_table_paragraph_to_value(x)? {
+        return Ok(table_value);
+      }
       for el in x.elements.iter() {
         let (code_id,value) = match paragraph_element(&el, p) {
           Ok(val) => val,
@@ -112,6 +115,9 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
     },
     SectionElement::Grammar(x) => x.hash(&mut hasher),
     SectionElement::Table(x) => {
+      if let Ok(table_value) = markdown_table_to_value(x) {
+        return Ok(table_value);
+      }
       for row in &x.rows {
         for cell in row {
           for el in &cell.elements {
@@ -197,4 +203,90 @@ pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
       ).with_compiler_loc().with_tokens(x.tokens())
     ),
   }
+}
+
+fn markdown_table_to_value(table: &MarkdownTable) -> MResult<Value> {
+  let mut headers: Vec<String> = table.header.iter().map(|header| header.to_string().trim().to_string()).collect();
+  let rows: Vec<Vec<String>> = table.rows.iter().map(|row| {
+    row.iter().map(|column| column.to_string().trim().to_string()).collect()
+  }).collect();
+
+  if headers.is_empty() && rows.len() == 1 && !rows[0].is_empty() {
+    headers = vec![rows[0][0].clone()];
+    let compact_records: Vec<_> = rows[0]
+      .iter()
+      .skip(1)
+      .map(|value_text| MechRecord::new(vec![(headers[0].as_str(), parse_markdown_table_value(value_text))]))
+      .collect();
+    let compact_table = MechTable::from_records(compact_records)?;
+    return Ok(Value::Table(Ref::new(compact_table)));
+  }
+
+  if headers.is_empty() {
+    return Err(MechError::new(
+      GenericError { msg: "Markdown table is missing a header row.".to_string() },
+      None,
+    ));
+  }
+
+  let mut records = Vec::with_capacity(rows.len());
+  for row in &rows {
+    if row.len() != headers.len() {
+      return Err(MechError::new(
+        GenericError { msg: "Markdown table row has a different number of columns than the header.".to_string() },
+        None,
+      ));
+    }
+
+    let mut fields = Vec::with_capacity(row.len());
+    for (text, header) in row.iter().zip(headers.iter()) {
+      let value = parse_markdown_table_value(text);
+      fields.push((header.as_str(), value));
+    }
+    records.push(MechRecord::new(fields));
+  }
+
+  let table = MechTable::from_records(records)?;
+  Ok(Value::Table(Ref::new(table)))
+}
+
+fn parse_markdown_table_value(text: &str) -> Value {
+  if text.eq_ignore_ascii_case("true") || text == "✓" {
+    return Value::Bool(Ref::new(true));
+  }
+  if text.eq_ignore_ascii_case("false") || text == "✗" {
+    return Value::Bool(Ref::new(false));
+  }
+  if let Ok(value) = text.parse::<f64>() {
+    return Value::F64(Ref::new(value));
+  }
+  Value::String(Ref::new(text.to_string()))
+}
+
+fn inline_table_paragraph_to_value(paragraph: &Paragraph) -> MResult<Option<Value>> {
+  let text = paragraph.to_string();
+  let trimmed = text.trim();
+  if !(trimmed.starts_with('|') && trimmed.ends_with('|')) {
+    return Ok(None);
+  }
+
+  let cells: Vec<String> = trimmed
+    .split('|')
+    .map(|cell| cell.trim())
+    .filter(|cell| !cell.is_empty())
+    .map(|cell| cell.to_string())
+    .collect();
+
+  if cells.len() < 2 {
+    return Ok(None);
+  }
+
+  let header = vec![cells[0].clone()];
+  let mut records = Vec::with_capacity(cells.len() - 1);
+  for value_text in cells.iter().skip(1) {
+    records.push(MechRecord::new(vec![(header[0].as_str(), parse_markdown_table_value(value_text))]));
+  }
+
+  let table = MechTable::from_records(records)?;
+  Ok(Some(Value::Table(Ref::new(table))))
 }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -357,7 +357,7 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
         result = converted_result;
       },
     };
-    let detached_result = detach_variable_value(&result);
+    let detached_result = detach_variable_value(&result, state_brrw);
     // Save symbol to interpreter
     let val_ref = state_brrw.save_symbol(var_id, var_name.clone(), detached_result.clone(), var_def.mutable);
     // Add variable define step to plan
@@ -366,7 +366,7 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
     return Ok(detached_result);
   } 
   let mut state_brrw = p.state.borrow_mut();
-  let detached_result = detach_variable_value(&result);
+  let detached_result = detach_variable_value(&result, &state_brrw);
   // Save symbol to interpreter
   let val_ref = state_brrw.save_symbol(var_id,var_name.clone(),detached_result.clone(),var_def.mutable);
   // Add variable define step to plan
@@ -375,9 +375,16 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
   return Ok(detached_result);
 }
 
-fn detach_variable_value(value: &Value) -> Value {
+fn detach_variable_value(value: &Value, state: &ProgramState) -> Value {
   match value {
-    Value::MutableReference(reference) => detach_variable_value(&reference.borrow()),
+    Value::MutableReference(reference) => detach_variable_value(&reference.borrow(), state),
+    Value::Id(id) => {
+      if let Some(symbol) = state.get_env_symbol(*id).or_else(|| state.get_symbol(*id)) {
+        detach_variable_value(&symbol.borrow(), state)
+      } else {
+        value.clone()
+      }
+    }
     _ => value.clone(),
   }
 }


### PR DESCRIPTION
### Motivation
- Mechdown table-like content was always hashed to `Value::Id` instead of being reconstructed as runtime `Value::Table`, which broke inline/compact table literals like `| y | true | false |`.
- Variable definitions could store unresolved `Value::Id` or `MutableReference` wrappers, causing incorrect values to be saved/returned in some flows (notably copy/assignment scenarios).

### Description
- Add table-value reconstruction in `src/interpreter/src/mechdown.rs` by implementing `markdown_table_to_value`, `inline_table_paragraph_to_value`, and `parse_markdown_table_value`, and wire them into `section_element` so markdown tables and inline pipe-paragraphs can produce `Value::Table` at runtime.  The compact single-row form (first cell = column name, remaining cells = values) is supported. 
- Implement cell value inference for booleans and numeric literals with string fallback via `parse_markdown_table_value` (recognizes `true`/`false`/`✓`/`✗` and numeric parses).
- Update `variable_define` in `src/interpreter/src/statements.rs` to detach stored/returned values using a new `detach_variable_value(value, state)` helper that recursively resolves `Value::MutableReference` and `Value::Id` by looking up symbols in the `ProgramState` so definitions save/return concrete values instead of raw ids.

### Testing
- Ran `cargo test -q --test interpreter table_column_inference`, which initially reproduced the failure and then passed after fixes. (automated)
- Ran targeted interpreter tests for matrix copy behavior with `cargo test -q --test interpreter interpret_matrix_assignment_copy`, which passed. (automated)
- Ran the full interpreter test suite `cargo test --test interpreter`, and all `495` tests passed locally. (automated)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca72e0b788832a827651657db8b287)