### PR TITLE
Add functions and comprehensions to specification and docs

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -763,9 +763,22 @@ The exception is if either of the operands are scalar, then the scalar is broadc
 ```ebnf
 set := "{"
       , ws0
-      , ?[expression, list-separator]
+      , ?(set-comprehension | [expression, list-separator])
       , ws0
       , "}" ;
+set-comprehension := expression
+      , ws0
+      , "|"
+      , ws0
+      , comprehension-clause
+      , *(ws0, list-separator, ws0, comprehension-clause) ;
+comprehension-clause := comprehension-generator | comprehension-predicate ;
+comprehension-generator := expression
+      , ws0
+      , "<-"
+      , ws0
+      , expression ;
+comprehension-predicate := expression ;
 empty-set := table-start
       , ws0
       , empty
@@ -809,6 +822,16 @@ The kind of a set consists of:
 - Union: Combines two sets, keeping only unique elements.
 - Intersection: Produces a set containing elements common to both sets.
 - Difference: Returns a set containing elements in the first set but not in the second.
+
+(5.2.5) Set Comprehensions
+
+Set comprehensions are declarative set constructors. They use a yielded expression on the left side of `|`, then generator and predicate clauses on the right side.
+
+```mech:ex 5.2.5
+pairs := {(1, 2), (1, 3), (2, 8), (3, 5), (3, 9)}
+user := 1
+{fof | (u, f) <- pairs, (f, fof) <- pairs, u == user}
+```
 
 (5.3) Map
 
@@ -1100,6 +1123,17 @@ factor := (parenthetical-term
 
 A formula is an expression that follows operator precedence rules and consists of arithmetic, logical, comparison, matrix, range, table, and set expressions. Expressions in formulas are evaluated according to their precedence, with higher-precedence operations being evaluated first. Precedence rules are encoded in the structure of the formula grammar.
 
+(6.1.0) Function Calls
+
+```ebnf
+function-call := identifier
+      , "("
+      , ?[expression, list-separator]
+      , ")" ;
+```
+
+Function calls are expressions and can appear anywhere a `factor` is allowed.
+
 (6.1.1) Operator Precedence
 
 Operators in formulas are applied according to the following precedence, from highest to lowest:
@@ -1270,10 +1304,11 @@ swizzle-subscript := "."
 -------------------------------------------------------------------------------
 
 ```ebnf
-statement := variable-define 
-      | variable-assign 
-      | enum-define 
-      | fsm-declare 
+statement := variable-define
+      | variable-assign
+      | enum-define
+      | function-define
+      | fsm-declare
       | kind-define ;
 ```
 
@@ -1361,7 +1396,42 @@ enum-variant-kind := "("
     priority < High | Medium | Low        -- Enum definition for priority levels
 ```
 
-(8.5) Kind Define
+(8.5) Function Define
+
+```ebnf
+function-define := function-signature
+      , new-line
+      , +function-branch
+      , "." ;
+function-signature := identifier
+      , "("
+      , ?[function-argument, list-separator]
+      , ")"
+      , ws0
+      , "->"
+      , ws0
+      , kind-annotation ;
+function-argument := identifier, ?kind-annotation ;
+function-branch := ws0
+      , ("├" | "└")
+      , ws0
+      , (expression | tuple)
+      , ws0
+      , "->"
+      , ws0
+      , expression
+      , ?new-line ;
+```
+
+Functions are declared with a signature and one or more branches. Branches are matched in order and can be recursive.
+
+```mech:ex 8.5
+power(x<u64>, n<u64>) -> <u64>
+  ├ (*, 0u64) -> 1u64
+  └ (x, n) -> x * power(x, n - 1u64).
+```
+
+(8.6) Kind Define
 
 ```ebnf
 kind-define := "<"
@@ -1370,7 +1440,7 @@ kind-define := "<"
       , define-operator
       , kind-annotation ;
 ```
-(8.5.1) Examples
+(8.6.1) Examples
 
 ```
     userKind < Person > :< string | int -- Kind definition with annotation

--- a/docs/index.mec
+++ b/docs/index.mec
@@ -40,13 +40,25 @@ v0.3.1-beta
 
 (2.2) Program Model
 
-- [Functions](#) `todo`
-- [Error Handling](#) `todo`
-- [Comprehensions](#) `todo`
-- [State Machines](#) `todo`
-- [Synthesis and Generation](#) `todo`
-- [Tests](#) `todo`
-- [Programs](#) `todo`
+- [Functions](/reference/functions.html)
+- Error Handling `todo`
+- [Comprehensions](/reference/comprehensions.html)
+- State Machines `todo`
+- Synthesis and Generation `todo`
+- Tests `todo`
+- Programs `todo`
+
+(2.2.1) Functions
+
+Functions are branch-based and use pattern matching over inputs.
+
+See: [Functions Reference](/reference/functions.html)
+
+(2.2.2) Comprehensions
+
+Comprehensions construct sets from generators and predicates in a concise declarative form.
+
+See: [Comprehensions Reference](/reference/comprehensions.html)
 
 (2.3) System Model
 

--- a/docs/reference/comprehensions.mec
+++ b/docs/reference/comprehensions.mec
@@ -1,0 +1,97 @@
+comprehensions
+================================================================================
+
+%% A `comprehension` builds a set from generators and predicates. It is useful for concise construction, filtering, and relational joins over data.
+
+***
+
+1. Syntax
+-------------------------------------------------------------------------------
+
+A set comprehension has the form:
+
+```mech:disabled
+{yield-expression | clause-1, clause-2, ..., clause-n}
+```
+
+Common clause forms:
+
+- Generator: `pattern <- source`
+- Predicate: `condition`
+
+2. Semantics
+-------------------------------------------------------------------------------
+
+- Generators introduce variables and iterate values from a source collection.
+- Predicates filter candidate bindings.
+- Later clauses can use variables introduced by earlier clauses.
+- Reused variables across generators naturally express join-like relationships.
+- The result is a set, so duplicates are removed.
+
+3. Basic Examples
+-------------------------------------------------------------------------------
+
+(3.1) Squares
+
+```mech:ex 3.1
+A := {1,2,3,4,5}
+{x*x | x <- A}
+```
+
+(3.2) Filtering Evens
+
+```mech:ex 3.2
+A := {1,2,3,4,5,6,7,8,9,10}
+{x | x <- A, x % 2 == 0}
+```
+
+(3.3) Set Intersection Pattern
+
+```mech:ex 3.3
+A := {1,2,3,4,5,6,7,8,9,10}
+B := {2,3,5,7,11,13}
+{x | x <- A, x <- B}
+```
+
+4. Matrix-Oriented Index Sets
+-------------------------------------------------------------------------------
+
+Comprehensions are often used to generate index sets for matrix-style work.
+
+(4.1) EYE Indices
+
+```mech:ex 4.1
+n := 4
+EYE := {(i,j) | i <- 1..=n, j <- 1..=n, i == j}
+```
+
+(4.2) Triangular Indices
+
+```mech:ex 4.2
+n := 5
+upper-tri-ix := {(i,j) | i <- 1..=n, j <- 1..=n, i <= j}
+lower-tri-ix := {(i,j) | i <- 1..=n, j <- 1..=n, i >= j}
+strict-upper-tri-ix := {(i,j) | i <- 1..=n, j <- 1..=n, i < j}
+```
+
+5. Relational-Style Comprehensions
+-------------------------------------------------------------------------------
+
+(5.1) Friends of Friends
+
+```mech:ex 5.1
+pairs := {(1, 2), (1, 3), (2, 8), (3, 5), (3, 9)}
+user := 1
+{fof | (u, f) <- pairs, (f, fof) <- pairs, u == user}
+```
+
+(5.2) Pythagorean Triples
+
+```mech:ex 5.2
+limit := 30
+{(a,b,c) |
+  a <- 1..=limit,
+  b <- a..=limit,
+  c <- b..=limit,
+  a*a + b*b == c*c}
+```

--- a/docs/reference/functions.mec
+++ b/docs/reference/functions.mec
@@ -1,0 +1,110 @@
+functions
+================================================================================
+
+%% A `function` maps input values to output values. In Mech, functions are branch-based and support pattern matching, recursion, and kind annotations.
+
+***
+
+1. Syntax
+-------------------------------------------------------------------------------
+
+Functions are defined with a signature, one or more branches, and a trailing `.`.
+
+```mech:disabled
+name(arg1<kind1>, arg2<kind2>, ...) -> <return-kind>
+  ├ pattern-1 -> expression-1
+  ├ pattern-2 -> expression-2
+  └ pattern-n -> expression-n.
+```
+
+A function call uses regular call syntax:
+
+```mech:disabled
+name(value1, value2)
+```
+
+2. Semantics
+-------------------------------------------------------------------------------
+
+- Branches are matched from top to bottom.
+- The first matching branch is selected.
+- Function bodies are expressions.
+- Functions can call themselves recursively.
+- Calls are expressions, so they can be nested in formulas and broadcast over vectors/matrices.
+
+3. Defining Functions
+-------------------------------------------------------------------------------
+
+(3.1) Simple Branching
+
+```mech:ex 3.1
+choose(op<kind>, x<f64>, y<f64>) -> <f64>
+  ├ (#add, x, y) -> x + y
+  ├ (#sub, x, y) -> x - y
+  ├ (#mul, x, y) -> x * y
+  └ (#div, x, y) -> x / y.
+
+[choose(#add, 3.0, 2.0)
+ choose(#sub, 3.0, 2.0)
+ choose(#mul, 3.0, 2.0)
+ choose(#div, 3.0, 2.0)]
+```
+
+(3.2) Recursive Power
+
+```mech:ex 3.2
+power(x<u64>, n<u64>) -> <u64>
+  ├ (*, 0u64) -> 1u64
+  └ (x, n) -> x * power(x, n - 1u64).
+
+power(2u64, 8u64)
+```
+
+(3.3) Recursive Factorial
+
+```mech:ex 3.3
+factorial(n<u64>) -> <u64>
+  ├ 0u64 -> 1u64
+  └ n -> n * factorial(n - 1u64).
+
+factorial(10u64)
+```
+
+(3.4) Recursive Fibonacci
+
+```mech:ex 3.4
+fib(n<u64>) -> <u64>
+  ├ 0u64 -> 0u64
+  ├ 1u64 -> 1u64
+  └ n -> fib(n - 1u64) + fib(n - 2u64).
+
+fib(10u64)
+```
+
+4. Calling Functions
+-------------------------------------------------------------------------------
+
+Function calls can be used directly in larger expressions:
+
+```mech:ex 4.1
+power(2u64, 5u64) + factorial(4u64)
+```
+
+Function calls can also broadcast over vectors:
+
+```mech:ex 4.2
+fib(n<u64>) -> <u64>
+  ├ 0u64 -> 0u64
+  ├ 1u64 -> 1u64
+  └ n -> fib(n - 1u64) + fib(n - 2u64).
+
+xs := 0u64..=10u64
+fib(xs)
+```
+
+5. Notes
+-------------------------------------------------------------------------------
+
+- Prefer explicit base cases in recursive definitions.
+- Use kind annotations on public function interfaces for clarity.
+- Keep branch patterns specific to avoid accidental broad matches.

--- a/docs/reference/index.mec
+++ b/docs/reference/index.mec
@@ -29,8 +29,8 @@ Platform Reference
 
 (i)> Coming `v0.3`
 
-- Functions
-- Comprehensions
+- [Functions](/reference/functions.html)
+- [Comprehensions](/reference/comprehensions.html)
 - Error Handling
 - State Machines
 - SynthAssign


### PR DESCRIPTION
### Motivation

- Introduce first-class support for branch-based `function` declarations and set comprehensions in the language specification.  
- Provide concrete reference documentation for `functions` and `comprehensions` to guide users and examples.  
- Update top-level indexes to expose the new reference pages and cross-link to the specification changes.

### Description

- Extend `docs/design/specification.mec` with grammar and prose for `set-comprehension`, comprehension clauses, `function-call`, and `function-define` including examples and semantics.  
- Add new reference pages `docs/reference/comprehensions.mec` and `docs/reference/functions.mec` which document syntax, semantics, examples, and usage patterns for comprehensions and branch-based functions.  
- Update `docs/index.mec` and `docs/reference/index.mec` to surface links to the new `Functions` and `Comprehensions` references and add brief descriptive notes.  
- Clean up minor formatting and section numbering in the specification and examples to integrate the new constructs into existing operator precedence and statement grammar.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf4cc160c832ab01f1deb4c001b12)