### PR TITLE
Fix #207: allow adding real scalars to complex values

### DIFF
--- a/machines/math/src/ops/add.rs
+++ b/machines/math/src/ops/add.rs
@@ -78,6 +78,21 @@ macro_rules! add_scalar_rhs_op {
 impl_math_fxns!(Add);
 
 fn impl_add_fxn(lhs_value: Value, rhs_value: Value) -> MResult<Box<dyn MechFunction>> {
+  #[cfg(feature = "c64")]
+  match (&lhs_value, &rhs_value) {
+    (Value::C64(lhs), rhs) if !matches!(rhs, Value::C64(_)) => {
+      if let Ok(rhs_c64) = rhs.as_c64() {
+        return impl_add_fxn(Value::C64(lhs.clone()), Value::C64(rhs_c64));
+      }
+    }
+    (lhs, Value::C64(rhs)) if !matches!(lhs, Value::C64(_)) => {
+      if let Ok(lhs_c64) = lhs.as_c64() {
+        return impl_add_fxn(Value::C64(lhs_c64), Value::C64(rhs.clone()));
+      }
+    }
+    _ => {}
+  }
+
   impl_binop_match_arms!(
     Add,
     register_fxn_descriptor_inner,

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -139,6 +139,8 @@ test_interpreter!(interpret_formulat_math_sub_rational, "1/10 - 2/10 - 3/10", Va
 test_interpreter!(interpret_formula_math_mul_rational, "1/10 * 2/10 * 3/10", Value::R64(Ref::new(R64::new(3, 500))));
 test_interpreter!(interpret_formula_math_div_rational, "1/10 / 2/10 / 3/10", Value::R64(Ref::new(R64::new(5, 3))));
 test_interpreter!(interpret_formula_math_add_complex, "1+2i + 3+4i", Value::C64(Ref::new(C64::new(4.0, 6.0))));
+test_interpreter!(interpret_formula_math_add_complex_real_rhs, "4i + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
+test_interpreter!(interpret_formula_math_add_complex_real_lhs, "1 + 4i", Value::C64(Ref::new(C64::new(1.0, 4.0))));
 test_interpreter!(interpret_formula_math_sub_complex, "1+2i - 3+4i", Value::C64(Ref::new(C64::new(-2.0, -2.0))));
 test_interpreter!(interpret_formula_math_mul_complex, "1+2i * 3+4i", Value::C64(Ref::new(C64::new(-5.0, 10.0))));
 test_interpreter!(interpret_formula_math_div_complex, "1+2i / 3+4i", Value::C64(Ref::new(C64::new(0.44, 0.08))));


### PR DESCRIPTION
### Motivation
- Addresses issue #207 where expressions like `4i + 1` and `1 + 4i` produced `UnhandledFunctionArgumentKind2` because the `MathAdd` dispatch did not normalize mixed complex/real scalar operands to a common complex type.

### Description
- In `machines/math/src/ops/add.rs` the `impl_add_fxn` now detects a `C64` operand and attempts to convert the other operand with `as_c64()` and recurse so the implementation selection always sees `C64 + C64` when possible.
- This normalization ensures the existing `impl_binop_match_arms!` logic selects the complex addition code path instead of erroring on mixed kinds.
- Added two interpreter regression tests in `tests/interpreter.rs` for both operand orders: `4i + 1` and `1 + 4i`.

### Testing
- `CARGO_TARGET_DIR=/tmp/mech-target cargo check -p mech-math` completed successfully.
- `CARGO_TARGET_DIR=/tmp/mech-target cargo test --test interpreter interpret_formula_math_add_complex_real_rhs` passed (test result: ok).
- `CARGO_TARGET_DIR=/tmp/mech-target cargo test --test interpreter interpret_formula_math_add_complex_real_lhs` passed (test result: ok).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd5754308832a800e72cf0828b40a)