### PR TITLE
Handle FSM nodes in formatter mech_code paths

### DIFF
--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -454,8 +454,8 @@ impl Formatter {
       let c = match code {
         MechCode::Comment(cmnt) => self.comment(cmnt),
         MechCode::Expression(expr) => self.expression(expr),
-        //MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
-        //MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
+        MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
+        MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FunctionDefine(func_def) => self.function_define(func_def),
         MechCode::Statement(stmt) => self.statement(stmt),
         x => format!("{{{:?}}}", x)
@@ -1168,8 +1168,8 @@ impl Formatter {
       let c = match code {
         MechCode::Comment(cmnt) => self.comment(cmnt),
         MechCode::Expression(expr) => self.expression(expr),
-        //MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
-        //MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
+        MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
+        MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FunctionDefine(func_def) => self.function_define(func_def),
         MechCode::Statement(stmt) => self.statement(stmt),
         x => todo!("Unhandled MechCode: {:#?}", x),


### PR DESCRIPTION
### Motivation
- Prevent a runtime panic when formatting FSM specifications/implementations and ensure FSM code is rendered by the formatter instead of falling through to the `todo!` path.

### Description
- Enable handling of `MechCode::FsmSpecification` and `MechCode::FsmImplementation` in both `fenced_mech_code` and `mech_code` match arms so FSM nodes are formatted via `fsm_specification`/`fsm_implementation` helper methods.

### Testing
- Ran `cargo test -p mech-syntax --quiet` and the test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf1564c84832a8e272574e5d0adeb)