### PR TITLE
Support kind-annotated variables and table->matrix conversion; add interpreter test

### DIFF
--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -754,43 +754,58 @@ pub fn subscript(sbscrpt: &Subscript, val: &Value, env: Option<&Environment>, p:
 
 #[cfg(feature = "symbol_table")]
 pub fn var(v: &Var, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  let state_brrw = p.state.borrow();
-  let symbols_brrw = state_brrw.symbol_table.borrow();
+  let maybe_cast_to_kind = |value: Value| -> MResult<Value> {
+    match &v.kind {
+      Some(kind_anntn) => {
+        let target_kind = {
+          let state_brrw = p.state.borrow();
+          kind_annotation(&kind_anntn.kind, p)?.to_value_kind(&state_brrw.kinds)?
+        };
+        let convert_fxn = ConvertKind{}.compile(&vec![value, Value::Kind(target_kind)])?;
+        convert_fxn.solve();
+        let out = convert_fxn.out();
+        p.state.borrow_mut().add_plan_step(convert_fxn);
+        Ok(out)
+      }
+      None => Ok(value),
+    }
+  };
+
   let id = v.name.hash();
   match env {
     Some(env) => {
       match env.get(&id) {
-        Some(value) => {
-          return Ok(value.clone())
-        }
+        Some(value) => maybe_cast_to_kind(value.clone()),
         None => {
-          match symbols_brrw.get(id) {
-            Some(value) => {
-              return Ok(Value::MutableReference(value.clone()))
-            }
-            None => {
-              return Err(MechError::new(
+          let state_brrw = p.state.borrow();
+          let symbols_brrw = state_brrw.symbol_table.borrow();
+          let symbol_value = symbols_brrw.get(id);
+          drop(symbols_brrw);
+          drop(state_brrw);
+          match symbol_value {
+            Some(value) => maybe_cast_to_kind(Value::MutableReference(value)),
+            None => Err(MechError::new(
                   UndefinedVariableError { id },
                   None
                 ).with_compiler_loc().with_tokens(v.tokens())
-              )
-            }
+              ),
           }
         }
       }
     }
     None => {
-      match symbols_brrw.get(id) {
-        Some(value) => {
-          return Ok(Value::MutableReference(value.clone()))
-        }
-        None => {
-          return Err(MechError::new(
+      let state_brrw = p.state.borrow();
+      let symbols_brrw = state_brrw.symbol_table.borrow();
+      let symbol_value = symbols_brrw.get(id);
+      drop(symbols_brrw);
+      drop(state_brrw);
+      match symbol_value {
+        Some(value) => maybe_cast_to_kind(Value::MutableReference(value)),
+        None => Err(MechError::new(
               UndefinedVariableError { id },
               None
             ).with_compiler_loc().with_tokens(v.tokens())
-          )
-        }
+          ),
       }
     }
   }

--- a/src/interpreter/src/stdlib/convert/scalar.rs
+++ b/src/interpreter/src/stdlib/convert/scalar.rs
@@ -434,6 +434,43 @@ fn impl_conversion_fxn(source_value: Value, target_kind: Value) -> MResult<Box<d
       let out = MechTable::from_kind(ValueKind::Table(resolved_tbl, out_rows))?;
       return Ok(Box::new(ConvertMat2Table::<bool>{arg: mat.clone(), out: Ref::new(out)}));
     }
+    #[cfg(all(feature = "matrix", feature = "table"))]
+    (Value::Table(table), Value::Kind(ValueKind::Matrix(target_kind, dims))) => {
+      let table = table.borrow();
+      let rows = table.rows();
+      let cols = table.cols();
+
+      if !dims.is_empty() {
+        let dim_count = dims.iter().product::<usize>();
+        if dim_count != rows * cols {
+          return Err(MechError::new(
+            ConvertIncorrectNumberOfColumnsError { from: rows * cols, to: dim_count },
+            None,
+          ).with_compiler_loc());
+        }
+      }
+
+      let mut elements = Vec::with_capacity(rows * cols);
+      for (_column_id, (_kind, column_values)) in table.data.iter() {
+        elements.extend(column_values.as_vec());
+      }
+
+      if target_kind.as_ref() != &ValueKind::Any {
+        return Err(MechError::new(
+          UnhandledFunctionArgumentKind2 {
+            arg: (
+              source_value.kind(),
+              ValueKind::Matrix(target_kind.clone(), dims.clone()),
+            ),
+            fxn_name: "convert/scalar".to_string(),
+          },
+          None,
+        ).with_compiler_loc());
+      }
+
+      let matrix = Value::MatrixValue(Matrix::from_vec(elements, rows, cols));
+      return Ok(Box::new(ConvertSEmpty { out: Ref::new(matrix) }));
+    }
     _ =>(),
   }
   impl_conversion_match_arms!(

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -168,6 +168,20 @@ test_interpreter!(interpret_matrix_lte_rational, "[1/2 3/4] <= [1/2 3/4]", Value
 test_interpreter!(interpret_matrix_lte_complex, "[1+2i 3+4i] <= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_assignment_copy_index, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b[2,3]", Value::F64(Ref::new(6.0)));
 test_interpreter!(interpret_matrix_assignment_copy_eq, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b == a", Value::MatrixBool(Matrix::from_vec(vec![true, true, true, true, true, true, true, true, true], 3, 3)));
+test_interpreter!(
+  interpret_table_wildcard_access_returns_matrix,
+  "b := |a<f64> b<f64>| 1 2 | 3 4|; b<[*]>",
+  Value::MatrixValue(Matrix::from_vec(
+    vec![
+      Value::F64(Ref::new(1.0)),
+      Value::F64(Ref::new(3.0)),
+      Value::F64(Ref::new(2.0)),
+      Value::F64(Ref::new(4.0)),
+    ],
+    2,
+    2
+  ))
+);
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_kind_annotation, "1<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]


### PR DESCRIPTION
### Motivation
- Allow variables with kind annotations to be automatically converted to the annotated kind when looked up. 
- Enable converting a `Table` value into a `Matrix` in the scalar conversion utility, including validation of requested matrix dimensions. 
- Add a regression test that verifies wildcard/table access returns a matrix when appropriate.

### Description
- Updated the variable lookup function `var` to apply an on-demand cast when the `Var` has a `kind` annotation by compiling and executing `ConvertKind` and appending the conversion step to the interpreter plan. 
- Refactored symbol table lookup in `var` to reduce borrow lifetimes by capturing `symbol_value` then dropping borrows before further processing. 
- Added conversion branch in `stdlib/convert/scalar.rs` to handle `(Value::Table, Value::Kind(ValueKind::Matrix(...)))`, validating dimension/product consistency, flattening table columns into a contiguous element vector, rejecting non-`Any` target kinds, and returning a `Matrix`-wrapped `Value`. 
- Added `interpret_table_wildcard_access_returns_matrix` test to `tests/interpreter.rs` to assert that wildcard access on a typed table returns a `MatrixValue`. 

### Testing
- Ran the interpreter test suite with `cargo test --tests` and the modified tests, including `interpret_table_wildcard_access_returns_matrix`, all completed successfully. 
- Existing interpreter tests in `tests/interpreter.rs` were also executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd8593794832a97d558e8d71ae3f9)