### PR TITLE
Fix FSM pattern rebinding across transitions

### DIFF
--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -1,6 +1,4 @@
 use crate::*;
-use std::collections::HashSet;
-
 #[cfg(feature = "state_machines")]
 pub fn register_fsm_implementation(fsm: &FsmImplementation, p: &Interpreter) -> MResult<()> {
     let fsm_id = fsm.name.hash();
@@ -53,8 +51,6 @@ pub fn execute_fsm_pipe(
     for (arg_name, arg_value) in fsm.input.iter().zip(args.iter()) {
         call_env.insert(arg_name.hash(), detach_value(arg_value));
     }
-    let input_binding_ids: HashSet<u64> = fsm.input.iter().map(|arg| arg.hash()).collect();
-
     let mut state = pattern_to_value(&fsm.start, &call_env, p)?;
     let max_steps = 10_000usize;
     for _ in 0..max_steps {
@@ -63,7 +59,7 @@ pub fn execute_fsm_pipe(
             match arm {
                 FsmArm::Transition(pattern, transitions) => {
                     let mut arm_env = call_env.clone();
-                    clear_pattern_bindings(pattern, &input_binding_ids, &mut arm_env);
+                    clear_pattern_bindings(pattern, &mut arm_env);
                     if pattern_matches_value(pattern, &state, &mut arm_env, p)? {
                         let out = apply_transitions(transitions, &mut state, &mut arm_env, p)?;
                         call_env = arm_env;
@@ -76,7 +72,7 @@ pub fn execute_fsm_pipe(
                 }
                 FsmArm::Guard(pattern, guards) => {
                     let mut arm_env = call_env.clone();
-                    clear_pattern_bindings(pattern, &input_binding_ids, &mut arm_env);
+                    clear_pattern_bindings(pattern, &mut arm_env);
                     if !pattern_matches_value(pattern, &state, &mut arm_env, p)? {
                         continue;
                     }
@@ -120,17 +116,11 @@ pub fn execute_fsm_pipe(
 }
 
 #[cfg(feature = "state_machines")]
-fn clear_pattern_bindings(
-    pattern: &Pattern,
-    input_binding_ids: &HashSet<u64>,
-    env: &mut Environment,
-) {
+fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
     let mut ids = Vec::new();
     collect_pattern_variable_ids(pattern, &mut ids);
     for var_id in ids {
-        if input_binding_ids.contains(&var_id) {
-            env.remove(&var_id);
-        }
+        env.remove(&var_id);
     }
 }
 

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -52,7 +52,7 @@ pub fn execute_fsm_pipe(
         call_env.insert(arg_name.hash(), detach_value(arg_value));
     }
     let mut state = pattern_to_value(&fsm.start, &call_env, p)?;
-    let max_steps = 10_000usize;
+    let max_steps = 10_000usize; // TODO This must be a parameter
     for _ in 0..max_steps {
         let mut transitioned = false;
         for arm in &fsm.arms {

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -53,14 +53,11 @@ test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false))
 test_interpreter!(interpret_literal_false, "false", Value::Bool(Ref::new(false)));
 test_interpreter!(interpret_literal_atom, ":A", Value::Atom(Ref::new(MechAtom::new(55450514845822917))));
 test_interpreter!(interpret_literal_empty, "_", Value::Empty);
-#[test]
-fn interpret_fsm_tuple_struct_states() {
-  let s = "#Counter(x) -> :Count(x)\n:Count(v)\n  ├ v > 0 -> :Done(v)\n  └ * -> :Done(1)\n:Done(v) => v.\n#Counter(0)";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let result = intrp.interpret(&tree).unwrap();
-  assert_eq!(result, Value::F64(Ref::new(1.0)));
-}
+test_interpreter!(
+  interpret_fsm_tuple_struct_states,
+  "#Counter(x) -> :Count(x)\n:Count(v)\n  ├ v > 0 -> :Done(v)\n  └ * -> :Done(1)\n:Done(v) => v.\n#Counter(0)",
+  Value::F64(Ref::new(1.0))
+);
 
 test_interpreter!(
   interpret_fsm_counter_example_with_kinds,
@@ -68,18 +65,11 @@ test_interpreter!(
   Value::F64(Ref::new(0.0))
 );
 
-#[test]
-fn interpret_fsm_fibonacci_reaches_done_state() {
-  let s = "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0, 1)\n  :Compute(n, a, b)\n    ├ n > 0 -> :Compute(n - 1, b, a + b)\n    └ n == 0 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10)";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let result = intrp.interpret(&tree).unwrap();
-  match result {
-    Value::U64(n) => assert_eq!(*n.borrow(), 55),
-    Value::F64(n) => assert_eq!(*n.borrow(), 55.0),
-    _ => panic!("expected numeric fibonacci output"),
-  }
-}
+test_interpreter!(
+  interpret_fsm_fibonacci_reaches_done_state,
+  "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0, 1)\n  :Compute(n, a, b)\n    ├ n > 0 -> :Compute(n - 1, b, a + b)\n    └ n == 0 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10)",
+  Value::F64(Ref::new(55.0))
+);
 test_interpreter!(interpret_variable_define_empty, "em := _", Value::Empty);
 #[cfg(feature = "u8")]
 test_interpreter!(interpret_variable_define_kind_literal, "x := <u8>;", Value::Kind(ValueKind::U8));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -53,20 +53,15 @@ test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false))
 test_interpreter!(interpret_literal_false, "false", Value::Bool(Ref::new(false)));
 test_interpreter!(interpret_literal_atom, ":A", Value::Atom(Ref::new(MechAtom::new(55450514845822917))));
 test_interpreter!(interpret_literal_empty, "_", Value::Empty);
-test_interpreter!(
-  interpret_fsm_tuple_struct_states,
-  "#Counter(x) -> :Count(x)\n:Count(v)\n  ├ v > 0 -> :Done(v)\n  └ * -> :Done(1)\n:Done(v) => v.\n#Counter(0)",
-  Value::F64(Ref::new(1.0))
-);
 
 test_interpreter!(
-  interpret_fsm_counter_example_with_kinds,
+  interpret_fsm_counter_example,
   "#Counter(n<u64>) => <u64>\n  ├ :Count(n<u64>)\n  └ :Done(n<u64>).\n\n#Counter(n<u64>) -> :Count(n)\n  :Count(n)\n    ├ n > 0 -> :Count(n - 1)\n    └ n == 0 -> :Done(0)\n  :Done(n) => n.\n\n#Counter(5)",
   Value::F64(Ref::new(0.0))
 );
 
 test_interpreter!(
-  interpret_fsm_fibonacci_reaches_done_state,
+  interpret_fsm_fibonacci,
   "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0, 1)\n  :Compute(n, a, b)\n    ├ n > 0 -> :Compute(n - 1, b, a + b)\n    └ n == 0 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10)",
   Value::F64(Ref::new(55.0))
 );

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -59,18 +59,7 @@ fn interpret_fsm_tuple_struct_states() {
   let tree = parser::parse(s).unwrap();
   let mut intrp = Interpreter::new(0);
   let result = intrp.interpret(&tree).unwrap();
-  match result {
-    Value::Tuple(tpl) => {
-      let tpl_brrw = tpl.borrow();
-      assert_eq!(tpl_brrw.elements.len(), 2);
-      match &*tpl_brrw.elements[0] {
-        Value::Atom(atm) => assert_eq!(atm.borrow().id(), hash_str("Done")),
-        _ => panic!("expected tuple state atom"),
-      }
-      assert_eq!(*tpl_brrw.elements[1], Value::F64(Ref::new(1.0)));
-    }
-    _ => panic!("expected tuple state output"),
-  }
+  assert_eq!(result, Value::F64(Ref::new(1.0)));
 }
 
 test_interpreter!(
@@ -78,6 +67,19 @@ test_interpreter!(
   "#Counter(n<u64>) => <u64>\n  ├ :Count(n<u64>)\n  └ :Done(n<u64>).\n\n#Counter(n<u64>) -> :Count(n)\n  :Count(n)\n    ├ n > 0 -> :Count(n - 1)\n    └ n == 0 -> :Done(0)\n  :Done(n) => n.\n\n#Counter(5)",
   Value::F64(Ref::new(0.0))
 );
+
+#[test]
+fn interpret_fsm_fibonacci_reaches_done_state() {
+  let s = "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0, 1)\n  :Compute(n, a, b)\n    ├ n > 0 -> :Compute(n - 1, b, a + b)\n    └ n == 0 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10)";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let result = intrp.interpret(&tree).unwrap();
+  match result {
+    Value::U64(n) => assert_eq!(*n.borrow(), 55),
+    Value::F64(n) => assert_eq!(*n.borrow(), 55.0),
+    _ => panic!("expected numeric fibonacci output"),
+  }
+}
 test_interpreter!(interpret_variable_define_empty, "em := _", Value::Empty);
 #[cfg(feature = "u8")]
 test_interpreter!(interpret_variable_define_kind_literal, "x := <u8>;", Value::Kind(ValueKind::U8));


### PR DESCRIPTION
### Motivation
- FSM transitions could retain stale pattern variable bindings across arm evaluations, causing subsequent pattern matches to fail and long-running FSMs (e.g. Fibonacci) to get stuck after the first step. 
- The intent is to ensure tuple-struct state variables and other pattern-bound names are allowed to rebind on each transition attempt so the machine can progress to completion.

### Description
- Change `clear_pattern_bindings` to unconditionally remove all variable ids collected from the pattern instead of only removing ids that overlap with original input argument ids, and update calls accordingly in `src/interpreter/src/state_machines.rs`.
- Remove the now-unnecessary `HashSet` of input binding ids used for selective clearing. 
- Update `tests/interpreter.rs` to assert the final emitted value for an earlier tuple-struct state test and add a regression test `interpret_fsm_fibonacci_reaches_done_state` that runs the supplied Fibonacci FSM and accepts either `u64` or `f64` numeric result.
- Files changed: `src/interpreter/src/state_machines.rs` and `tests/interpreter.rs`.

### Testing
- Ran `cargo test -q --test interpreter interpret_fsm_tuple_struct_states` and it passed. 
- Ran `cargo test -q --test interpreter interpret_fsm_counter_example_with_kinds` and it passed. 
- Ran `cargo test -q --test interpreter interpret_fsm_fibonacci_reaches_done_state` (regression test for the Fibonacci example) and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf7cac4e0832a81a5064d2bcdc965)