### PR TITLE
Add --trace CLI flag for function and state-arm execution tracing

### DIFF
--- a/docs/getting-started/build-and-run.mec
+++ b/docs/getting-started/build-and-run.mec
@@ -34,6 +34,7 @@ If you run the Mech command without any files or subcommands, it will start the 
 | `-d`, `--debug`       | Prints debug information.                        |
 | `-r`, `--repl`        | Starts the Mech Read-Eval-Print Loop (REPL).     |
 | `-t`, `--time`        | Measures execution time of the program.          |
+| `--trace`             | Prints runtime trace output for function calls, selected state-machine arms, and step results. |
 | `-e`, `--tree`        | Prints the parse tree of the Mech program.       |
 
 (1.5) Examples
@@ -42,6 +43,7 @@ If you run the Mech command without any files or subcommands, it will start the 
 mech file1.mec file2.mec dir1
 mech -d -e file.mec
 mech -t file.mec
+mech --trace file.mec
 mech -r file.mec
 ```
 

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -202,7 +202,11 @@ async fn main() -> Result<(), MechError> {
         .short('t')
         .long("time")
         .help("Measure how long the programs takes to execute.")
-        .action(ArgAction::SetTrue))       
+        .action(ArgAction::SetTrue))
+    .arg(Arg::new("trace")
+        .long("trace")
+        .help("Print trace output for state-machine arms and function calls")
+        .action(ArgAction::SetTrue))
     .arg(Arg::new("repl")
         .short('r')
         .long("repl")
@@ -214,6 +218,7 @@ async fn main() -> Result<(), MechError> {
   let tree_flag = matches.get_flag("tree");
   let mut repl_flag = matches.get_flag("repl");
   let time_flag = matches.get_flag("time");
+  let trace_flag = matches.get_flag("trace");
 
   let shim_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/shim.html".to_string();
   let stylesheet_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css".to_string();
@@ -312,7 +317,7 @@ async fn main() -> Result<(), MechError> {
     let uuid = generate_uuid();
     let mut intrp = Interpreter::new(uuid);
 
-    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag); 
+    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag); 
 
     let bytecode = intrp.compile()?;
 
@@ -532,7 +537,7 @@ async fn main() -> Result<(), MechError> {
       }
     }
 
-    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag); 
+    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag); 
     if !repl_flag {
       match &result {
         Ok(r) => {

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -51,6 +51,13 @@ pub fn function_call(
         for (_, arg_expr) in fxn_call.args.iter() {
             input_arg_values.push(expression(arg_expr, env, p)?);
         }
+        if p.trace {
+            println!(
+                "[trace] call user function {}({})",
+                fxn_call.name.to_string(),
+                format_trace_args(&input_arg_values)
+            );
+        }
         return execute_user_function(&user_fxn, &input_arg_values, p);
     }
 
@@ -70,6 +77,13 @@ pub fn function_call(
             let mut input_arg_values = vec![];
             for (_, arg_expr) in fxn_call.args.iter() {
                 input_arg_values.push(expression(arg_expr, env, p)?);
+            }
+            if p.trace {
+                println!(
+                    "[trace] call native function {}({})",
+                    fxn_call.name.to_string(),
+                    format_trace_args(&input_arg_values)
+                );
             }
             execute_native_function_compiler(fxn_compiler, &input_arg_values, p)
         }
@@ -91,10 +105,26 @@ pub fn execute_native_function_compiler(
 ) -> MResult<Value> {
     let plan = p.plan();
     match fxn_compiler.compile(input_arg_values) {
-        Ok(new_fxn) => {
+        Ok(mut new_fxn) => {
+            if p.trace {
+                let arm_name = new_fxn
+                    .to_string()
+                    .lines()
+                    .next()
+                    .unwrap_or("<unknown-arm>")
+                    .to_string();
+                println!(
+                    "[trace] state arm selected: {} | args=[{}]",
+                    arm_name,
+                    format_trace_args(input_arg_values)
+                );
+            }
             let mut plan_brrw = plan.borrow_mut();
             new_fxn.solve();
             let result = new_fxn.out();
+            if p.trace {
+                println!("[trace] state arm result: {}", result);
+            }
             plan_brrw.push(new_fxn);
             Ok(result)
         }
@@ -144,7 +174,13 @@ fn execute_function_match_arms(
 ) -> MResult<Value> {
     for arm in &fxn_def.code.match_arms {
         let mut env = Environment::new();
+        if p.trace {
+            println!("[trace] testing user arm pattern: {:?}", arm.pattern);
+        }
         if pattern_matches_arguments(&arm.pattern, input_arg_values, &mut env, p)? {
+            if p.trace {
+                println!("[trace] matched user arm pattern: {:?}", arm.pattern);
+            }
             let out = expression(&arm.expression, Some(&env), p)?;
             return coerce_function_output_kind(detach_value(&out), fxn_def, p);
         }
@@ -157,6 +193,14 @@ fn execute_function_match_arms(
     )
     .with_compiler_loc()
     .with_tokens(fxn_def.code.name.tokens()))
+}
+
+fn format_trace_args(values: &Vec<Value>) -> String {
+    values
+        .iter()
+        .map(|value| format!("{}", value))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn pattern_matches_arguments(

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 pub struct Interpreter {
   pub id: u64,
   pub profile: bool,
+  pub trace: bool,
   ip: usize,  // instruction pointer
   pub state: Ref<ProgramState>,
   #[cfg(feature = "functions")]
@@ -33,6 +34,7 @@ impl Clone for Interpreter {
       id: self.id,
       ip: self.ip,
       profile: false,
+      trace: self.trace,
       state: Ref::new(self.state.borrow().clone()),
       #[cfg(feature = "functions")]
       stack: self.stack.clone(),
@@ -58,6 +60,7 @@ impl Interpreter {
       id,
       ip: 0,
       profile: false,
+      trace: false,
       state: Ref::new(state),
       #[cfg(feature = "functions")]
       stack: Vec::new(),
@@ -199,8 +202,20 @@ impl Interpreter {
         return Ok(plan_brrw[len - 1].out().clone());
       } else {
         for _ in 0..step_count {
-          for fxn in plan_brrw.iter_mut() {
+          for (idx, fxn) in plan_brrw.iter_mut().enumerate() {
+            if self.trace {
+              let fxn_header = fxn
+                .to_string()
+                .lines()
+                .next()
+                .unwrap_or("<unknown-step>")
+                .to_string();
+              println!("[trace] step[{idx}] -> {fxn_header}");
+            }
             fxn.solve();
+            if self.trace {
+              println!("[trace] step[{idx}] out = {}", fxn.out());
+            }
           }
         }
         return Ok(plan_brrw[len - 1].out().clone());

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -155,7 +155,7 @@ impl MechRepl {
         for source in paths {
           mechfs.watch_source(&source)?;
         }
-        match run_mech_code(&mut intrp, &mechfs, false,false,false) {
+        match run_mech_code(&mut intrp, &mechfs, false,false,false,false) {
           Ok(r) => {
             #[cfg(feature = "pretty_print")]
             let out = r.pretty_print();
@@ -170,7 +170,7 @@ impl MechRepl {
         for (_,src) in code {
           mechfs.add_code(&src)?;
         }
-        match run_mech_code(&mut intrp, &mechfs, false,false,false)  {
+        match run_mech_code(&mut intrp, &mechfs, false,false,false,false)  {
           Ok(r) => { 
             #[cfg(feature = "pretty_print")]
             let out = r.pretty_print();

--- a/src/run.rs
+++ b/src/run.rs
@@ -35,7 +35,8 @@ macro_rules! print_plan {
 }
 
 
-pub fn run_mech_code(intrp: &mut Interpreter, code: &MechFileSystem, tree_flag: bool, debug_flag: bool, time_flag: bool) -> MResult<Value> {
+pub fn run_mech_code(intrp: &mut Interpreter, code: &MechFileSystem, tree_flag: bool, debug_flag: bool, time_flag: bool, trace_flag: bool) -> MResult<Value> {
+  intrp.trace = trace_flag;
   let sources = code.sources();
   let sources = sources.read().unwrap();
   for (file,source) in sources.sources_iter() {


### PR DESCRIPTION
### Motivation
- Provide a runtime tracing mode to observe state-machine arm execution and function calls with argument and return values to aid debugging and understanding program execution.
- Trace output should be opt-in via a CLI flag and controlled on the interpreter so both batch and REPL flows can enable it.

### Description
- Add a new CLI option `--trace` and read it in `src/bin/mech.rs` as `trace_flag`, threading it into `run_mech_code` calls so the runtime can enable tracing via `intrp.trace`.
- Extend `Interpreter` with a `trace: bool` field (initialized and cloned appropriately) and emit per-plan-step traces showing the step index, the function/arm header, and the step output when `trace` is enabled in `src/interpreter/src/interpreter.rs`.
- Emit trace logs for function activity in `src/interpreter/src/functions.rs`, including evaluated argument lists for user/native calls, testing/matching of user function match-arms, and reporting the selected native state-arm name and its result; add a helper `format_trace_args` to render arg lists.
- Update `run_mech_code` signature (`src/run.rs`) to accept the `trace_flag` and set `intrp.trace`, and update REPL call sites (`src/repl.rs`) to pass the new parameter (REPL currently calls with `false`).

### Testing
- Ran `cargo check -q` to validate compilation after changes; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb7d6fcc4832a8b97a544275fbe62)