### PR TITLE
Try operand type conversions in binary operator compiler and add u64 default-literal tests

### DIFF
--- a/src/core/src/stdlib.rs
+++ b/src/core/src/stdlib.rs
@@ -1110,11 +1110,23 @@ macro_rules! impl_mech_binop_fxn {
               (Value::MutableReference(lhs),Value::MutableReference(rhs)) => {$gen_fxn(lhs.borrow().clone(), rhs.borrow().clone())}
               (lhs_value,Value::MutableReference(rhs)) => { $gen_fxn(lhs_value.clone(), rhs.borrow().clone())}
               (Value::MutableReference(lhs),rhs_value) => { $gen_fxn(lhs.borrow().clone(), rhs_value.clone()) }
-              (lhs, rhs) => Err(MechError::new(
+            (lhs, rhs) => {
+              if let Some(rhs_converted) = rhs.convert_to(&lhs.kind()) {
+                if let Ok(fxn) = $gen_fxn(lhs.clone(), rhs_converted) {
+                  return Ok(fxn);
+                }
+              }
+              if let Some(lhs_converted) = lhs.convert_to(&rhs.kind()) {
+                if let Ok(fxn) = $gen_fxn(lhs_converted, rhs.clone()) {
+                  return Ok(fxn);
+                }
+              }
+              Err(MechError::new(
                   UnhandledFunctionArgumentKind2 { arg: (lhs.kind(), rhs.kind()), fxn_name: stringify!($fxn_name).to_string() },
                   None
                 ).with_compiler_loc()
-              ),            
+              )
+            },            
             }
           }
         }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -201,9 +201,15 @@ test_interpreter!(interpret_formula_math_add_u64, "2<u64> + 2<u64>", Value::U64(
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_formula_math_sub_u64, "2<u64> - 2<u64>", Value::U64(Ref::new(0)));
 #[cfg(feature = "u64")]
+test_interpreter!(interpret_formula_math_sub_u64_with_default_literal_rhs, "2<u64> - 1", Value::U64(Ref::new(1)));
+#[cfg(feature = "u64")]
 test_interpreter!(interpret_formula_math_div_u64, "2<u64> / 2<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_formula_math_mul_u64, "2<u64> * 2<u64>", Value::U64(Ref::new(4)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_formula_compare_gt_u64_with_default_literal_rhs, "2<u64> > 1", Value::Bool(Ref::new(true)));
+#[cfg(feature = "u64")]
+test_interpreter!(interpret_formula_compare_gt_u64_with_default_literal_lhs, "2 > 1<u64>", Value::Bool(Ref::new(true)));
 // u128
 #[cfg(feature = "u128")]
 test_interpreter!(interpret_formula_math_add_u128, "2<u128> + 2<u128>", Value::U128(Ref::new(4)));


### PR DESCRIPTION
### Motivation
- Improve binary operator compilation robustness by allowing implicit conversions between operand kinds when a direct handler is not found.
- Cover conversion behavior for `u64` arithmetic and comparisons with default literal operands via unit tests.

### Description
- Updated the `impl_mech_binop_fxn` macro to attempt `rhs.convert_to(&lhs.kind())` and `lhs.convert_to(&rhs.kind())` and call the generator if conversion succeeds before returning an `UnhandledFunctionArgumentKind2` error.
- Preserved existing `MutableReference` handling branches and only fall back to conversions for other argument kinds.
- Added interpreter tests in `tests/interpreter.rs` for `interpret_formula_math_sub_u64_with_default_literal_rhs`, `interpret_formula_compare_gt_u64_with_default_literal_rhs`, and `interpret_formula_compare_gt_u64_with_default_literal_lhs`.

### Testing
- Ran the unit test suite with `cargo test` including the interpreter tests and the run succeeded.
- The new interpreter tests for `u64` default-literal interactions were executed and passed.
- Existing numeric-type interpreter tests were re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb5e58d24832a995d794b5dcd3699)