### PR TITLE
Add optional types and guarded unwrap expressions (`?`)

### DIFF
--- a/docs/reference/data.mec
+++ b/docs/reference/data.mec
@@ -17,6 +17,7 @@ Data in Mech is represented using one of the following primitive data types:
 | [`atom`](/reference/atom.html)     | Represents symbolic constants.                   |
 | [`kind`](/reference/kind.html)     | Represents types or categories of values.        |
 | [`empty`](/reference/empty.html)   | Represents an empty value or placeholder.        |
+| [`option`](/reference/option.html) | Represents either an empty value or a value.     |
 
 (1.1) Number
 
@@ -108,6 +109,40 @@ y<_> := _     -- An empty value of kind `_`
 ```
 
 For more, see [`empty`](/reference/empty.html).
+
+(1.6) Option
+
+Represents a value that may either be present (`Some`) or absent (`None`/empty).
+
+(1.6.1) Kind
+
+Option kinds are written with a `?` suffix:
+
+```mech:disabled
+<u64?>
+<string?>
+<([u8],bool)?>
+```
+
+(1.6.2) Examples
+
+```mech:disabled
+x<u64?> := 123u64
+y<u64?> := _
+```
+
+(1.6.3) Unwrapping with guards
+
+Use `?` followed by guarded arms to branch on `None`/`Some` values:
+
+```mech:disabled
+foo := x?
+  │ x > 3u64 -> x
+  │ x == 3u64 -> 0u64
+  └ * -> 0u64.
+```
+
+The wildcard arm `*` acts as the fallback branch.
 
 2. Data Structures
 -------------------------------------------------------------------------------

--- a/docs/reference/index.mec
+++ b/docs/reference/index.mec
@@ -10,6 +10,7 @@ Platform Reference
     - [`empty`](/reference/empty.html) - represents an absence of value
     - [`kind`](/reference/kind.html) - a category of values
     - [`number`](/reference/number.html) - numeric values, including integers and floating-point numbers
+    - [`option`](/reference/option.html) - optional values that may be empty or present
     - [`string`](/reference/string.html) - sequence of UTF-8 characters representing text
 - Data Structures
     - [`map`](/reference/map.html) - stores key-value pairs for fast lookups

--- a/docs/reference/option.mec
+++ b/docs/reference/option.mec
@@ -1,0 +1,42 @@
+option
+===============================================================================
+
+%% An `option` value represents either an empty value (`_`) or a value of an inner kind. Use `?` on kinds to indicate optionality.
+
+1. Kind Syntax
+-------------------------------------------------------------------------------
+
+```mech:disabled
+<u64?>
+<string?>
+<([u64],bool)?>
+```
+
+2. Construction
+-------------------------------------------------------------------------------
+
+```mech:disabled
+x<u64?> := 123u64
+y<u64?> := _
+```
+
+3. Guarded Unwrap
+-------------------------------------------------------------------------------
+
+Use postfix `?` on an expression to unwrap through guarded arms. Arms use the same box-drawing guard style as functions/state machines.
+
+```mech:disabled
+foo := x?
+  │ x > 3u64 -> x
+  │ x == 3u64 -> 0u64
+  └ * -> 0u64.
+```
+
+Tuple patterns are supported:
+
+```mech:disabled
+(x2,y2) := (x,y)?
+  │ (x,y) -> (x,y)
+  └ * -> (0u64,0u64).
+```
+

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -812,6 +812,13 @@ pub struct FunctionMatchArm {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct OptionMatchArm {
+  pub pattern: Pattern,
+  pub expression: Expression,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct FunctionArgument {
   pub name: Identifier,
   pub kind: KindAnnotation,
@@ -1633,6 +1640,7 @@ pub enum Expression {
   FunctionCall(FunctionCall),
   FsmPipe(FsmPipe),
   Literal(Literal),
+  OptionMatch(Box<OptionMatchExpression>),
   Range(Box<RangeExpression>),
   Slice(Slice),
   Structure(Structure),
@@ -1648,6 +1656,7 @@ impl Expression {
       Expression::Literal(ltrl) => ltrl.tokens(),
       Expression::Structure(strct) => strct.tokens(),
       Expression::Formula(fctr) => fctr.tokens(),
+      Expression::OptionMatch(opt_match) => opt_match.tokens(),
       Expression::Range(range) => range.tokens(),
       Expression::Slice(slice) => slice.tokens(),
       Expression::SetComprehension(sc) => sc.tokens(),
@@ -1655,6 +1664,24 @@ impl Expression {
       Expression::MatrixComprehension(mc) => mc.tokens(),
       _ => todo!(),
     }
+  }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct OptionMatchExpression {
+  pub source: Expression,
+  pub arms: Vec<OptionMatchArm>,
+}
+
+impl OptionMatchExpression {
+  pub fn tokens(&self) -> Vec<Token> {
+    let mut tokens = self.source.tokens();
+    for arm in &self.arms {
+      tokens.append(&mut arm.pattern.tokens());
+      tokens.append(&mut arm.expression.tokens());
+    }
+    tokens
   }
 }
 

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -279,6 +279,8 @@ impl ValueKind {
       (Matrix(a, ashape), Matrix(b, bshape)) if ashape.into_iter().product::<usize>() == bshape.into_iter().product::<usize>() && a.as_ref().is_convertible_to(b.as_ref()) => true,
 
       // Option conversions
+      (x, Option(b)) if x.is_convertible_to(b.as_ref()) => true,
+      (Empty, Option(_)) => true,
       (Option(a), Option(b)) if a.as_ref().is_convertible_to(b.as_ref()) => true,
 
       // Reference conversions
@@ -963,6 +965,8 @@ impl Value {
     }
 
     match (self, other) {
+    (Value::Empty, ValueKind::Option(_)) => Some(Value::Empty),
+    (value, ValueKind::Option(inner)) => value.convert_to(inner.as_ref()),
     // ==== Unsigned widening and narrowing ====
     #[cfg(all(feature = "u8", feature = "u16"))]
     (Value::U8(v), ValueKind::U16) => Some(Value::U16(Ref::new((*v.borrow()) as u16))),

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -837,13 +837,24 @@ pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&E
     let matched = match &arm.pattern {
       Pattern::Wildcard => true,
       Pattern::Expression(expr) => match expr {
-        Expression::Var(_) => crate::functions::pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
-        _ => match expression(expr, Some(&guard_env), p)? {
-          Value::Bool(flag) => *flag.borrow(),
-          _ => false,
-        },
+        Expression::Var(_) => option_pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
+        _ => {
+          let cond_value = expression(expr, Some(&guard_env), p)?;
+          #[cfg(feature = "bool")]
+          {
+            match cond_value {
+              Value::Bool(flag) => *flag.borrow(),
+              _ => false,
+            }
+          }
+          #[cfg(not(feature = "bool"))]
+          {
+            let _ = cond_value;
+            false
+          }
+        }
       },
-      _ => crate::functions::pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
+      _ => option_pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
     };
     if matched {
       return expression(&arm.expression, Some(&guard_env), p);
@@ -863,6 +874,47 @@ fn option_value_is_empty(value: &Value) -> bool {
     Value::Tuple(tuple) => tuple.borrow().elements.iter().any(|value| option_value_is_empty(value.as_ref())),
     Value::MutableReference(reference) => option_value_is_empty(&reference.borrow()),
     _ => false,
+  }
+}
+
+fn option_pattern_matches_value(
+  pattern: &Pattern,
+  value: &Value,
+  env: &mut Environment,
+  p: &Interpreter,
+) -> MResult<bool> {
+  match pattern {
+    Pattern::Wildcard => Ok(true),
+    Pattern::Tuple(pattern_tuple) => match value {
+      #[cfg(feature = "tuple")]
+      Value::Tuple(tuple) => {
+        let tuple_brrw = tuple.borrow();
+        if pattern_tuple.0.len() != tuple_brrw.elements.len() {
+          return Ok(false);
+        }
+        for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
+          if !option_pattern_matches_value(pat, val, env, p)? {
+            return Ok(false);
+          }
+        }
+        Ok(true)
+      }
+      _ => Ok(false),
+    },
+    Pattern::Expression(Expression::Var(var)) => {
+      let var_id = var.name.hash();
+      if let Some(existing) = env.get(&var_id) {
+        Ok(existing == value)
+      } else {
+        env.insert(var_id, value.clone());
+        Ok(true)
+      }
+    }
+    Pattern::Expression(expr) => {
+      let expected = expression(expr, Some(env), p)?;
+      Ok(expected == *value)
+    }
+    Pattern::TupleStruct(_) => Ok(false),
   }
 }
 

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -813,6 +813,12 @@ pub fn var(v: &Var, env: Option<&Environment>, p: &Interpreter) -> MResult<Value
 }
 
 pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  if !opt_match.arms.iter().any(|arm| matches!(arm.pattern, Pattern::Wildcard)) {
+    return Err(MechError::new(
+      OptionMatchNonExhaustiveError,
+      None,
+    ).with_compiler_loc().with_tokens(opt_match.source.tokens()));
+  }
   let source = expression(&opt_match.source, env, p)?;
   let detached_source = match &source {
     Value::MutableReference(reference) => reference.borrow().clone(),
@@ -1229,6 +1235,15 @@ impl MechErrorKind for OptionMatchArmKindMismatchError {
       "Option match arm kind mismatch: expected {:?}, found {:?}",
       self.expected, self.found
     )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct OptionMatchNonExhaustiveError;
+impl MechErrorKind for OptionMatchNonExhaustiveError {
+  fn name(&self) -> &str { "OptionMatchNonExhaustive" }
+  fn message(&self) -> String {
+    "Option match must include a wildcard (`*`) arm to handle empty values.".to_string()
   }
 }
 

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -832,7 +832,7 @@ pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&E
     ).with_compiler_loc().with_tokens(opt_match.source.tokens()));
   }
 
-  for arm in &opt_match.arms {
+  for (arm_ix, arm) in opt_match.arms.iter().enumerate() {
     let mut guard_env = base_env.clone();
     let matched = match &arm.pattern {
       Pattern::Wildcard => true,
@@ -857,7 +857,16 @@ pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&E
       _ => option_pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
     };
     if matched {
-      return expression(&arm.expression, Some(&guard_env), p);
+      let output = expression(&arm.expression, Some(&guard_env), p)?;
+      option_match_validate_arm_kinds(
+        opt_match,
+        arm_ix,
+        &output.kind(),
+        &detached_source,
+        &base_env,
+        p,
+      )?;
+      return Ok(output);
     }
   }
 
@@ -865,6 +874,41 @@ pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&E
     OptionMatchNoArmMatchedError,
     None,
   ).with_compiler_loc().with_tokens(opt_match.source.tokens()))
+}
+
+fn option_match_validate_arm_kinds(
+  opt_match: &OptionMatchExpression,
+  matched_arm_ix: usize,
+  matched_kind: &ValueKind,
+  source: &Value,
+  base_env: &Environment,
+  p: &Interpreter,
+) -> MResult<()> {
+  for (ix, arm) in opt_match.arms.iter().enumerate() {
+    if ix == matched_arm_ix {
+      continue;
+    }
+    let mut arm_env = base_env.clone();
+    let applicable = match arm.pattern {
+      Pattern::Wildcard => true,
+      _ => option_pattern_matches_value(&arm.pattern, source, &mut arm_env, p)?,
+    };
+    if !applicable {
+      continue;
+    }
+    let arm_value = expression(&arm.expression, Some(&arm_env), p)?;
+    let arm_kind = arm_value.kind();
+    if arm_kind != *matched_kind {
+      return Err(MechError::new(
+        OptionMatchArmKindMismatchError {
+          expected: matched_kind.clone(),
+          found: arm_kind,
+        },
+        None,
+      ).with_compiler_loc().with_tokens(arm.expression.tokens()));
+    }
+  }
+  Ok(())
 }
 
 fn option_value_is_empty(value: &Value) -> bool {
@@ -1170,6 +1214,21 @@ impl MechErrorKind for OptionMatchNoArmMatchedError {
   fn name(&self) -> &str { "OptionMatchNoArmMatched" }
   fn message(&self) -> String {
     format!("No option match arm matched the provided value.")
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct OptionMatchArmKindMismatchError {
+  expected: ValueKind,
+  found: ValueKind,
+}
+impl MechErrorKind for OptionMatchArmKindMismatchError {
+  fn name(&self) -> &str { "OptionMatchArmKindMismatch" }
+  fn message(&self) -> String {
+    format!(
+      "Option match arm kind mismatch: expected {:?}, found {:?}",
+      self.expected, self.found
+    )
   }
 }
 

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -24,6 +24,7 @@ pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter)
     Expression::SetComprehension(set_comp) => set_comprehension(set_comp, p),
     #[cfg(feature = "matrix_comprehensions")]
     Expression::MatrixComprehension(matrix_comp) => matrix_comprehension(matrix_comp, p),
+    Expression::OptionMatch(opt_match) => option_match_expression(opt_match, env, p),
     #[cfg(feature = "state_machines")]
     Expression::FsmPipe(fsm_pipe) => crate::state_machines::execute_fsm_pipe(fsm_pipe, env, p),
     x => Err(MechError::new(
@@ -811,6 +812,60 @@ pub fn var(v: &Var, env: Option<&Environment>, p: &Interpreter) -> MResult<Value
   }
 }
 
+pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let source = expression(&opt_match.source, env, p)?;
+  let detached_source = match &source {
+    Value::MutableReference(reference) => reference.borrow().clone(),
+    _ => source.clone(),
+  };
+  let mut base_env = env.cloned().unwrap_or_default();
+  if let Expression::Var(var) = &opt_match.source {
+    base_env.insert(var.name.hash(), detached_source.clone());
+  }
+  if option_value_is_empty(&detached_source) {
+    if let Some(arm) = opt_match.arms.iter().find(|arm| matches!(arm.pattern, Pattern::Wildcard)) {
+      return expression(&arm.expression, Some(&base_env), p);
+    }
+    return Err(MechError::new(
+      OptionMatchNoArmMatchedError,
+      None,
+    ).with_compiler_loc().with_tokens(opt_match.source.tokens()));
+  }
+
+  for arm in &opt_match.arms {
+    let mut guard_env = base_env.clone();
+    let matched = match &arm.pattern {
+      Pattern::Wildcard => true,
+      Pattern::Expression(expr) => match expr {
+        Expression::Var(_) => crate::functions::pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
+        _ => match expression(expr, Some(&guard_env), p)? {
+          Value::Bool(flag) => *flag.borrow(),
+          _ => false,
+        },
+      },
+      _ => crate::functions::pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
+    };
+    if matched {
+      return expression(&arm.expression, Some(&guard_env), p);
+    }
+  }
+
+  Err(MechError::new(
+    OptionMatchNoArmMatchedError,
+    None,
+  ).with_compiler_loc().with_tokens(opt_match.source.tokens()))
+}
+
+fn option_value_is_empty(value: &Value) -> bool {
+  match value {
+    Value::Empty => true,
+    #[cfg(feature = "tuple")]
+    Value::Tuple(tuple) => tuple.borrow().elements.iter().any(|value| option_value_is_empty(value.as_ref())),
+    Value::MutableReference(reference) => option_value_is_empty(&reference.borrow()),
+    _ => false,
+  }
+}
+
 #[cfg(feature = "formulas")]
 pub fn factor(fctr: &Factor, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
   match fctr {
@@ -1055,6 +1110,15 @@ pub struct PatternMatchError {
   pub var: String,
   pub expected: String,
   pub found: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct OptionMatchNoArmMatchedError;
+impl MechErrorKind for OptionMatchNoArmMatchedError {
+  fn name(&self) -> &str { "OptionMatchNoArmMatched" }
+  fn message(&self) -> String {
+    format!("No option match arm matched the provided value.")
+  }
 }
 
 impl MechErrorKind for PatternMatchError {

--- a/src/interpreter/src/stdlib/convert/scalar.rs
+++ b/src/interpreter/src/stdlib/convert/scalar.rs
@@ -300,6 +300,19 @@ macro_rules! impl_conversion_match_arms {
         (Value::Empty, Value::Kind(ValueKind::Empty)) => {
           Ok(Box::new(ConvertSEmpty { out: Ref::new(Value::Empty) }))
         }
+        (value, Value::Kind(ValueKind::Option(inner_kind))) => {
+          let converted = if value == Value::Empty {
+            Value::Empty
+          } else {
+            value
+              .convert_to(inner_kind.as_ref())
+              .ok_or_else(|| MechError::new(
+                UnsupportedConversionError { from: value.kind(), to: ValueKind::Option(inner_kind.clone()) },
+                None,
+              ).with_compiler_loc())?
+          };
+          Ok(Box::new(ConvertSEmpty { out: Ref::new(converted) }))
+        }
         x => Err(MechError::new(
             UnsupportedConversionError{from: x.0.kind(), to: x.1.kind()},
             None,

--- a/src/syntax/src/expressions.rs
+++ b/src/syntax/src/expressions.rs
@@ -51,18 +51,48 @@ pub fn expression(input: ParseString) -> ParseResult<Expression> {
         Ok((input, mc)) => (input, Expression::MatrixComprehension(Box::new(mc))),
         Err(_) => match range_expression(input.clone()) {
           Ok((input, rng)) => (input, Expression::Range(Box::new(rng))),
-          Err(_) => match formula(input.clone()) {
-            Ok((input, Factor::Expression(expr))) => (input, *expr),
-            Ok((input, fctr)) => (input, Expression::Formula(fctr)),
-            Err(err) => {
-              return Err(err);
+          Err(_) => match option_match_expression(input.clone()) {
+            Ok((input, expr)) => (input, Expression::OptionMatch(Box::new(expr))),
+            Err(_) => match formula(input.clone()) {
+              Ok((input, Factor::Expression(expr))) => (input, *expr),
+              Ok((input, fctr)) => (input, Expression::Formula(fctr)),
+              Err(err) => {
+                return Err(err);
+              }
             }
-          }
+          },
         }
       }
     }
   };
   Ok((input, expr))
+}
+
+// option-match-expression := expression, "?", whitespace*, option-match-arm+, period? ;
+pub fn option_match_expression(input: ParseString) -> ParseResult<OptionMatchExpression> {
+  let (input, source) = factor(input)?;
+  let source = match source {
+    Factor::Expression(expr) => *expr,
+    fctr => Expression::Formula(fctr),
+  };
+  let (input, _) = question(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, arms) = many1(option_match_arm)(input)?;
+  let (input, _) = opt(period)(input)?;
+  Ok((input, OptionMatchExpression { source, arms }))
+}
+
+// option-match-arm := guard-operator, pattern, transition-operator, expression, statement-separator? ;
+pub fn option_match_arm(input: ParseString) -> ParseResult<OptionMatchArm> {
+  let (input, _) = crate::state_machines::guard_operator(input)?;
+  let (input, pattern) = crate::state_machines::pattern(input)?;
+  let (input, _) = transition_operator(input)?;
+  let (input, expr) = expression(input)?;
+  let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
+  Ok((input, OptionMatchArm {
+    pattern,
+    expression: expr,
+  }))
 }
 
 // formula := l1 ;

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -1775,6 +1775,7 @@ impl Formatter {
       Expression::Range(range) => self.range_expression(range),
       Expression::SetComprehension(set_comp) => self.set_comprehension(set_comp),
       Expression::MatrixComprehension(matrix_comp) => self.matrix_comprehension(matrix_comp),
+      Expression::OptionMatch(opt_match) => self.option_match_expression(opt_match),
       Expression::FsmPipe(fsm_pipe) => self.fsm_pipe(fsm_pipe),
       x => todo!("Unhandled Expression: {:#?}", x),
     };
@@ -1783,6 +1784,17 @@ impl Formatter {
     } else {
       format!("{}", e)
     }
+  }
+
+  pub fn option_match_expression(&mut self, node: &OptionMatchExpression) -> String {
+    let source = self.expression(&node.source);
+    let mut lines = vec![format!("{}?", source)];
+    for arm in &node.arms {
+      let pattern = self.pattern(&arm.pattern);
+      let expr = self.expression(&arm.expression);
+      lines.push(format!("│ {} -> {}", pattern, expr));
+    }
+    lines.join("\n")
   }
 
   pub fn fsm_instance(&mut self, node: &FsmInstance) -> String {

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -106,6 +106,30 @@ fn interpret_variable_define_undefined_kind_literal_error() {
   assert!(intrp.interpret(&tree).is_err());
 }
 test_interpreter!(interpret_variable_define_typed_empty, "emp<_> := _", Value::Empty);
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_variable_define_typed_option_some,
+  "x<u64?> := 123u64",
+  Value::U64(Ref::new(123))
+);
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_variable_define_typed_option_none,
+  "x<u64?> := _",
+  Value::Empty
+);
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_option_match_scalar_some,
+  "x<u64?> := 4u64; x? | x > 3u64 -> x | * -> 0u64.",
+  Value::U64(Ref::new(4))
+);
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_option_match_tuple_destructure,
+  "x<u64?> := 2u64; y<u64?> := _; (x2,y2) := (x,y)? | (x,y) -> (x,y) | * -> (0u64,0u64).; x2 + y2",
+  Value::U64(Ref::new(0))
+);
 #[test]
 fn interpret_variable_define_typed_set_from_range_matrix() {
   let s = "input<{f64}> := 1..=5";

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -137,6 +137,14 @@ fn interpret_option_match_rejects_mismatched_arm_kinds() {
   let mut intrp = Interpreter::new(0);
   assert!(intrp.interpret(&tree).is_err());
 }
+
+#[test]
+fn interpret_option_match_requires_wildcard_arm() {
+  let s = "foo<u64?> := 1234\n\nbar := foo?\n  | 0 -> 9.\n\nbar";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
+}
 #[test]
 fn interpret_variable_define_typed_set_from_range_matrix() {
   let s = "input<{f64}> := 1..=5";

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -131,6 +131,13 @@ test_interpreter!(
   Value::U64(Ref::new(0))
 );
 #[test]
+fn interpret_option_match_rejects_mismatched_arm_kinds() {
+  let s = "foo<f64?> := 1234\n\nbar := foo?\n  | x -> \"One Two Three\"\n  | * -> 12.\n\nbar";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
+}
+#[test]
 fn interpret_variable_define_typed_set_from_range_matrix() {
   let s = "input<{f64}> := 1..=5";
   let tree = parser::parse(s).unwrap();


### PR DESCRIPTION
### Motivation
- Introduce a first-class optional type/kind so values can be `None` (`_`) or `Some(value)` and provide a convenient guarded-unwrap syntax for handling both cases. 
- Allow guarded arms using the existing box-drawing guard syntax (same style as state machines/functions) and support tuple patterns for destructuring option payloads.
- Ensure kind-checking and conversions understand `T?` kinds (accepting `_` as empty or a value convertible to `T`).

### Description
- AST & parser: added `OptionMatchExpression` and `OptionMatchArm` nodes and parser rules `option_match_expression` / `option_match_arm` so `expr?` with guarded arms (e.g. `x? │ x > 3 -> x │ * -> 0.`) can be parsed, including tuple patterns; integrated into `expression` parsing path. (`src/core/src/nodes.rs`, `src/syntax/src/expressions.rs`) 
- Interpreter: implemented `option_match_expression` evaluation that binds the source into the guard environment, evaluates boolean guards or structural pattern matches, supports wildcard fallback, and treats tuples containing empties as empty for fallback propagation. (`src/interpreter/src/expressions.rs`) 
- Kinds & conversion: extended `ValueKind::is_convertible_to` and `Value::convert_to` so `Option` kinds accept `_` and convertible values; added conversion handling for `Option` targets in the scalar conversion logic. (`src/core/src/value.rs`, `src/interpreter/src/stdlib/convert/scalar.rs`) 
- Formatting & docs: formatter renders option-unwrap guard blocks with box-drawing guards; documentation pages added/updated to describe `option` kind and guarded-unwrapping examples. (`src/syntax/src/formatter.rs`, `docs/reference/option.mec`, `docs/reference/data.mec`, `docs/reference/index.mec`) 
- Tests: added interpreter tests for typed optional assignments, guarded scalar unwrap, and tuple-destructuring with option unwrap. (`tests/interpreter.rs`) 

### Testing
- Ran the interpreter unit tests focusing on the new option features with `cargo test --test interpreter interpret_option_match_` and `cargo test --test interpreter interpret_variable_define_typed_option_`; both test groups passed after fixes. 
- Iteratively built and ran failing cases during development and resolved them (conversion/boxing and environment binding); final automated tests for the added cases succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d023981ff8832aa72cf449720c94bc)