### PR TITLE
Unwrap option-like enums in match-arm comparisons

### DIFF
--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -254,18 +254,57 @@ fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
 }
 
 fn values_match(expected: &Value, actual: &Value) -> bool {
+    fn unwrap_option_like(value: &Value) -> Value {
+        match value {
+            Value::Enum(enum_value) => {
+                let enum_brrw = enum_value.borrow();
+                if enum_brrw.variants.len() == 1 {
+                    if let Some(inner) = &enum_brrw.variants[0].1 {
+                        return unwrap_option_like(inner);
+                    }
+                }
+                value.clone()
+            }
+            _ => value.clone(),
+        }
+    }
+
+    let expected = unwrap_option_like(expected);
+    let actual = unwrap_option_like(actual);
+
     if expected == actual {
         return true;
     }
     #[cfg(all(feature = "u64", feature = "f64"))]
     {
-        match (expected, actual) {
+        match (&expected, &actual) {
             (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
             (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
             _ => {}
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "u64")]
+    #[test]
+    fn values_match_option_like_enum_payload() {
+        let mut names = Dictionary::default();
+        names.insert(1, "Option".to_string());
+        names.insert(2, "Some".to_string());
+
+        let wrapped_zero = Value::Enum(Ref::new(MechEnum {
+            id: 1,
+            variants: vec![(2, Some(Value::U64(Ref::new(0))))],
+            names: Ref::new(names),
+        }));
+
+        assert!(values_match(&Value::U64(Ref::new(0)), &wrapped_zero));
+    }
 }
 
 fn coerce_function_output_kind(value: Value, fxn_def: &FunctionDefinition, p: &Interpreter) -> MResult<Value> {


### PR DESCRIPTION
### Motivation
- Pattern matching was failing when matching against option-like enum wrappers (single-variant enums containing a payload) because comparisons were being performed against the enum wrapper rather than the inner payload.

### Description
- In `values_match` (in `src/interpreter/src/functions.rs`) added a local helper `unwrap_option_like` that unwraps option-like `Value::Enum` values with a single variant and an inner payload before comparing values.
- Normalization (unwrapping) is applied to both sides prior to the existing equality checks, and the existing numeric compatibility branch (e.g. `u64`/`f64`) was preserved by applying it after unwrapping.
- Added a unit test that constructs an option-like enum wrapping `0<u64>` and asserts that `values_match(&Value::U64(0), &wrapped_enum)` returns true.

### Testing
- Ran the new unit test with `cargo test -p mech-interpreter values_match_option_like_enum_payload -- --nocapture` and it passed.
- No other automated test changes were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ab1faa28832a8113832ac3c992a0)