### PR TITLE
Unify interpreter pattern engine for functions, FSMs, and option guards

### DIFF
--- a/docs/reference/index.mec
+++ b/docs/reference/index.mec
@@ -31,6 +31,7 @@ Platform Reference
 (i)> Coming `v0.3`
 
 - [Functions](/reference/functions.html)
+- [Patterns](/reference/patterns.html)
 - [Comprehensions](/reference/comprehensions.html)
 - Error Handling
 - State Machines

--- a/docs/reference/patterns.mec
+++ b/docs/reference/patterns.mec
@@ -1,0 +1,84 @@
+patterns
+================================================================================
+
+%% Patterns are a single matching language shared by functions, state-machine transitions, and option-match guards.
+
+1. Pattern forms
+-------------------------------------------------------------------------------
+
+Mech patterns support the same core shapes in every pattern context:
+
+- `_` wildcard: matches anything and binds nothing.
+- Variable pattern: binds a value (for example `x`).
+- Literal / expression pattern: matches when evaluated pattern equals the candidate value.
+- Tuple pattern: positional matching for tuples, e.g. `(head, tail)`.
+- Tuple-struct pattern: state-like tagged tuples, e.g. `ready(x)`.
+- Array pattern: prefix/suffix matching with optional spread capture.
+
+2. Function match arms
+-------------------------------------------------------------------------------
+
+Function branches are evaluated top-to-bottom. The first arm whose pattern matches call arguments is selected.
+
+```mech
+abs(x) -> <f64>
+  ├ n if n < 0.0 -> -n
+  └ n -> n.
+```
+
+Multiple call arguments are matched with tuple-style structure:
+
+```mech
+max2(a, b) -> <u64>
+  ├ (x, y) if x > y -> x
+  └ (_, y) -> y.
+```
+
+3. State machine transitions
+-------------------------------------------------------------------------------
+
+State-machine arms use the same pattern forms to match the current state value.
+
+```mech
+traffic() -> <atom>
+  @red -> @green
+  @green -> @yellow
+  @yellow -> @red.
+```
+
+Tuple-struct patterns are useful for richer states:
+
+```mech
+connection() -> <atom>
+  connecting(retries) ->
+    | retries < 3 -> connecting(retries + 1)
+    | _ -> failed
+  connected -> connected.
+```
+
+4. Option-match guards
+-------------------------------------------------------------------------------
+
+Option matching also reuses the same pattern syntax. A wildcard arm is required for exhaustiveness.
+
+```mech
+result := value ?
+  | x if x > 10 -> "large"
+  | x -> "small"
+  | _ -> "empty".
+```
+
+Guard-like conditions in option arms are pattern expressions that evaluate to `bool` in the arm environment.
+
+5. Binding behavior
+-------------------------------------------------------------------------------
+
+- Repeated variable names in one pattern require equality with the previous binding.
+- Bound names are available to arm expressions and transition statements.
+- Wildcards never bind.
+- Array spread bindings capture the unmatched middle segment.
+
+6. Shared semantics notes
+-------------------------------------------------------------------------------
+
+All three systems (functions, FSMs, option matches) use one interpreter pattern engine, so tuple/array/tagged-state matching and variable bindings behave consistently across contexts.

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -7,241 +7,265 @@ use std::collections::HashMap;
 pub type Environment = HashMap<u64, Value>;
 
 pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  match &expr {
-    #[cfg(feature = "variables")]
-    Expression::Var(v) => var(v, env, p),
-    #[cfg(feature = "range")]
-    Expression::Range(rng) => range(&rng, env, p),
-    #[cfg(all(feature = "subscript_slice", feature = "access"))]
-    Expression::Slice(slc) => slice(&slc, env, p),
-    #[cfg(feature = "formulas")]
-    Expression::Formula(fctr) => factor(fctr, env, p),
-    Expression::Structure(strct) => structure(strct, env, p),
-    Expression::Literal(ltrl) => literal(&ltrl, p),
-    #[cfg(feature = "functions")]
-    Expression::FunctionCall(fxn_call) => function_call(fxn_call, env, p),
-    #[cfg(feature = "set_comprehensions")]
-    Expression::SetComprehension(set_comp) => set_comprehension(set_comp, p),
-    #[cfg(feature = "matrix_comprehensions")]
-    Expression::MatrixComprehension(matrix_comp) => matrix_comprehension(matrix_comp, p),
-    Expression::OptionMatch(opt_match) => option_match_expression(opt_match, env, p),
-    #[cfg(feature = "state_machines")]
-    Expression::FsmPipe(fsm_pipe) => crate::state_machines::execute_fsm_pipe(fsm_pipe, env, p),
-    x => Err(MechError::new(
-      FeatureNotEnabledError,
-      None
-    ).with_compiler_loc().with_tokens(x.tokens())),
-  }
+    match &expr {
+        #[cfg(feature = "variables")]
+        Expression::Var(v) => var(v, env, p),
+        #[cfg(feature = "range")]
+        Expression::Range(rng) => range(&rng, env, p),
+        #[cfg(all(feature = "subscript_slice", feature = "access"))]
+        Expression::Slice(slc) => slice(&slc, env, p),
+        #[cfg(feature = "formulas")]
+        Expression::Formula(fctr) => factor(fctr, env, p),
+        Expression::Structure(strct) => structure(strct, env, p),
+        Expression::Literal(ltrl) => literal(&ltrl, p),
+        #[cfg(feature = "functions")]
+        Expression::FunctionCall(fxn_call) => function_call(fxn_call, env, p),
+        #[cfg(feature = "set_comprehensions")]
+        Expression::SetComprehension(set_comp) => set_comprehension(set_comp, p),
+        #[cfg(feature = "matrix_comprehensions")]
+        Expression::MatrixComprehension(matrix_comp) => matrix_comprehension(matrix_comp, p),
+        Expression::OptionMatch(opt_match) => option_match_expression(opt_match, env, p),
+        #[cfg(feature = "state_machines")]
+        Expression::FsmPipe(fsm_pipe) => crate::state_machines::execute_fsm_pipe(fsm_pipe, env, p),
+        x => Err(MechError::new(FeatureNotEnabledError, None)
+            .with_compiler_loc()
+            .with_tokens(x.tokens())),
+    }
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
 pub fn pattern_match_value(pattern: &Pattern, value: &Value, env: &mut Environment) -> MResult<()> {
-  match pattern {
-    Pattern::Wildcard => Ok(()),
-    Pattern::Expression(expr) => match expr {
-      Expression::Var(var) => {
-        let id = &var.name.hash();
-        match env.get(id) {
-          Some(existing) if existing == value => Ok(()),
-          Some(existing) => {
-            Err(MechError::new(
-                PatternMatchError {
-                    var: var.name.to_string(),
-                    expected: existing.to_string(),
-                    found: value.to_string(),
+    match pattern {
+        Pattern::Wildcard => Ok(()),
+        Pattern::Expression(expr) => match expr {
+            Expression::Var(var) => {
+                let id = &var.name.hash();
+                match env.get(id) {
+                    Some(existing) if existing == value => Ok(()),
+                    Some(existing) => Err(MechError::new(
+                        PatternMatchError {
+                            var: var.name.to_string(),
+                            expected: existing.to_string(),
+                            found: value.to_string(),
+                        },
+                        None,
+                    )
+                    .with_compiler_loc()),
+                    None => {
+                        env.insert(id.clone(), value.clone());
+                        Ok(())
+                    }
+                }
+            }
+            _ => todo!("Unsupported expression in pattern"),
+        },
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(pat_tuple) => match value {
+            Value::Tuple(values) => {
+                let values_brrw = values.borrow();
+                if pat_tuple.0.len() != values_brrw.elements.len() {
+                    return Err(MechError::new(
+                        ArityMismatchError {
+                            expected: pat_tuple.0.len(),
+                            found: values_brrw.elements.len(),
+                        },
+                        None,
+                    )
+                    .with_compiler_loc());
+                }
+                for (pttrn, val) in pat_tuple.0.iter().zip(values_brrw.elements.iter()) {
+                    pattern_match_value(pttrn, val, env)?;
+                }
+                Ok(())
+            }
+            _ => Err(MechError::new(
+                PatternExpectedTupleError {
+                    found: value.kind(),
                 },
-                None
-            ).with_compiler_loc())
-          }
-          None => {
-            env.insert(id.clone(), value.clone());
-            Ok(())
-          }
+                None,
+            )
+            .with_compiler_loc()),
+        },
+        Pattern::TupleStruct(pat_struct) => {
+            todo!("Implement tuple struct pattern matching")
         }
-      },
-      _ => todo!("Unsupported expression in pattern"),
-    },
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pat_tuple) => {
-      match value {
-        Value::Tuple(values) => {
-          let values_brrw = values.borrow();
-          if pat_tuple.0.len() != values_brrw.elements.len() {
-            return Err(MechError::new(
-              ArityMismatchError{
-                expected: pat_tuple.0.len(),
-                found: values_brrw.elements.len(),
-              },
-              None
-            ).with_compiler_loc());
-          }
-          for (pttrn, val) in pat_tuple.0.iter().zip(values_brrw.elements.iter()) {
-            pattern_match_value(pttrn, val, env)?;
-          }
-          Ok(())
-        }
-        _ => Err(MechError::new(
-          PatternExpectedTupleError{
-            found: value.kind(),
-          },
-          None
-        ).with_compiler_loc()),
-      }
-    },
-    Pattern::TupleStruct(pat_struct) => {
-      todo!("Implement tuple struct pattern matching")
-    },
-    _ => {
-      Err(MechError::new(
-        FeatureNotEnabledError,
-        None
-      ).with_compiler_loc())
-    } 
-  }
+        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
+    }
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
-fn comprehension_environments(qualifiers: &[ComprehensionQualifier], comprehension_id: u64, p: &Interpreter) -> MResult<(Vec<Environment>, Interpreter)> {
-  let mut envs: Vec<Environment> = vec![HashMap::new()];
-  let mut new_p = p.clone();
-  new_p.id = comprehension_id;
-  new_p.clear_plan();
-  for qual in qualifiers {
-    envs = match qual {
-      ComprehensionQualifier::Generator((pttrn, expr)) => {
-        let mut new_envs = Vec::new();
-        for env in &envs {
-          let collection = expression(expr, Some(env), &new_p)?;
-          for elmnt in comprehension_generator_values(&collection)? {
-            let mut new_env = env.clone();
-            if pattern_match_value(pttrn, &elmnt, &mut new_env).is_ok() {
-              new_envs.push(new_env);
+fn comprehension_environments(
+    qualifiers: &[ComprehensionQualifier],
+    comprehension_id: u64,
+    p: &Interpreter,
+) -> MResult<(Vec<Environment>, Interpreter)> {
+    let mut envs: Vec<Environment> = vec![HashMap::new()];
+    let mut new_p = p.clone();
+    new_p.id = comprehension_id;
+    new_p.clear_plan();
+    for qual in qualifiers {
+        envs = match qual {
+            ComprehensionQualifier::Generator((pttrn, expr)) => {
+                let mut new_envs = Vec::new();
+                for env in &envs {
+                    let collection = expression(expr, Some(env), &new_p)?;
+                    for elmnt in comprehension_generator_values(&collection)? {
+                        let mut new_env = env.clone();
+                        if pattern_match_value(pttrn, &elmnt, &mut new_env).is_ok() {
+                            new_envs.push(new_env);
+                        }
+                    }
+                }
+                new_envs
             }
-          }
-        }
-        new_envs
-      }
-      ComprehensionQualifier::Filter(expr) => {
-        envs
-          .into_iter()
-          .filter(|env| {
-            let result = expression(expr, Some(env), &new_p);
-            match result {
-              Ok(Value::Bool(v)) => v.borrow().clone(),
-              Ok(_) => false,
-              Err(_) => false,
-            }
-          })
-          .collect()
-      }
-      ComprehensionQualifier::Let(var_def) => {
-        envs.into_iter()
-            .map(|mut env| -> MResult<_> {
-                let val = expression(&var_def.expression, Some(&env), &new_p)?;
-                env.insert(var_def.var.name.hash(), val);
-                Ok(env)
-            })
-            .collect::<MResult<Vec<_>>>()?
-      }
-    };
-  }
-  Ok((envs, new_p))
+            ComprehensionQualifier::Filter(expr) => envs
+                .into_iter()
+                .filter(|env| {
+                    let result = expression(expr, Some(env), &new_p);
+                    match result {
+                        Ok(Value::Bool(v)) => v.borrow().clone(),
+                        Ok(_) => false,
+                        Err(_) => false,
+                    }
+                })
+                .collect(),
+            ComprehensionQualifier::Let(var_def) => envs
+                .into_iter()
+                .map(|mut env| -> MResult<_> {
+                    let val = expression(&var_def.expression, Some(&env), &new_p)?;
+                    env.insert(var_def.var.name.hash(), val);
+                    Ok(env)
+                })
+                .collect::<MResult<Vec<_>>>()?,
+        };
+    }
+    Ok((envs, new_p))
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
 fn comprehension_generator_values(collection: &Value) -> MResult<Vec<Value>> {
-  match collection {
-    #[cfg(feature = "set")]
-    Value::Set(mset) => Ok(mset.borrow().set.iter().cloned().collect()),
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Ok(matrix.as_vec().into_iter().map(|value| Value::Index(Ref::new(value))).collect()),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Ok(matrix.as_vec().into_iter().map(|value| value.to_value()).collect()),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Ok(matrix.as_vec().into_iter().map(|value| value.to_value()).collect()),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Ok(matrix.as_vec()),
-    Value::MutableReference(reference) => comprehension_generator_values(&reference.borrow()),
-    x => Err(MechError::new(
-      ComprehensionGeneratorError{
-        found: x.kind(),
-      },
-      None
-    ).with_compiler_loc()),
-  }
+    match collection {
+        #[cfg(feature = "set")]
+        Value::Set(mset) => Ok(mset.borrow().set.iter().cloned().collect()),
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Ok(matrix
+            .as_vec()
+            .into_iter()
+            .map(|value| Value::Index(Ref::new(value)))
+            .collect()),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Ok(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Ok(matrix
+            .as_vec()
+            .into_iter()
+            .map(|value| value.to_value())
+            .collect()),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Ok(matrix
+            .as_vec()
+            .into_iter()
+            .map(|value| value.to_value())
+            .collect()),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Ok(matrix.as_vec()),
+        Value::MutableReference(reference) => comprehension_generator_values(&reference.borrow()),
+        x => Err(
+            MechError::new(ComprehensionGeneratorError { found: x.kind() }, None)
+                .with_compiler_loc(),
+        ),
+    }
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
 fn detach_comprehension_value(value: &Value) -> Value {
-  match value {
-    Value::MutableReference(reference) => reference.borrow().clone(),
-    _ => value.clone(),
-  }
+    match value {
+        Value::MutableReference(reference) => reference.borrow().clone(),
+        _ => value.clone(),
+    }
 }
 
 #[cfg(feature = "set_comprehensions")]
 #[derive(Debug)]
 pub struct ValueSetComprehension {
-  pub arguments: Vec<Value>,
-  pub out: Ref<MechSet>,
+    pub arguments: Vec<Value>,
+    pub out: Ref<MechSet>,
 }
 #[cfg(all(feature = "set_comprehensions", feature = "functions"))]
 impl MechFunctionImpl for ValueSetComprehension {
-  fn solve(&self) {
-    let args = self.arguments.iter().map(detach_comprehension_value).collect::<Vec<Value>>();
-    *self.out.borrow_mut() = MechSet::from_vec(args);
-  }
-  fn out(&self) -> Value { Value::Set(self.out.clone()) }
-  fn to_string(&self) -> String { format!("{:#?}", self) }
+    fn solve(&self) {
+        let args = self
+            .arguments
+            .iter()
+            .map(detach_comprehension_value)
+            .collect::<Vec<Value>>();
+        *self.out.borrow_mut() = MechSet::from_vec(args);
+    }
+    fn out(&self) -> Value {
+        Value::Set(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        format!("{:#?}", self)
+    }
 }
 #[cfg(all(feature = "set_comprehensions", feature = "functions"))]
 impl MechFunctionFactory for ValueSetComprehension {
-  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-    match args {
-      FunctionArgs::Nullary(out) => {
-        let out: Ref<MechSet> = unsafe{ out.as_unchecked().clone() };
-        Ok(Box::new(ValueSetComprehension { arguments: Vec::new(), out }))
-      }
-      _ => Err(MechError::new(
-        IncorrectNumberOfArguments { expected: 0, found: args.len() },
-        None
-      ).with_compiler_loc()),
+    fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+        match args {
+            FunctionArgs::Nullary(out) => {
+                let out: Ref<MechSet> = unsafe { out.as_unchecked().clone() };
+                Ok(Box::new(ValueSetComprehension {
+                    arguments: Vec::new(),
+                    out,
+                }))
+            }
+            _ => Err(MechError::new(
+                IncorrectNumberOfArguments {
+                    expected: 0,
+                    found: args.len(),
+                },
+                None,
+            )
+            .with_compiler_loc()),
+        }
     }
-  }
 }
 #[cfg(all(feature = "set_comprehensions", feature = "compiler"))]
 impl MechFunctionCompiler for ValueSetComprehension {
-  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
-    compile_nullop!("set/comprehension", self.out, ctx, FeatureFlag::Builtin(FeatureKind::SetComprehensions));
-  }
+    fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+        compile_nullop!(
+            "set/comprehension",
+            self.out,
+            ctx,
+            FeatureFlag::Builtin(FeatureKind::SetComprehensions)
+        );
+    }
 }
 #[cfg(all(feature = "set_comprehensions", feature = "functions"))]
 register_descriptor! {
@@ -254,15 +278,15 @@ register_descriptor! {
 pub struct SetComprehensionDefine {}
 #[cfg(all(feature = "set_comprehensions", feature = "functions"))]
 impl NativeFunctionCompiler for SetComprehensionDefine {
-  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
-    Ok(Box::new(ValueSetComprehension {
-      arguments: arguments.clone(),
-      out: Ref::new(MechSet::from_vec(arguments.clone())),
-    }))
-  }
+    fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+        Ok(Box::new(ValueSetComprehension {
+            arguments: arguments.clone(),
+            out: Ref::new(MechSet::from_vec(arguments.clone())),
+        }))
+    }
 }
 #[cfg(all(feature = "set_comprehensions", feature = "functions"))]
-register_descriptor!{
+register_descriptor! {
   FunctionCompilerDescriptor {
     name: "set/comprehension",
     ptr: &SetComprehensionDefine{},
@@ -272,42 +296,64 @@ register_descriptor!{
 #[cfg(feature = "matrix_comprehensions")]
 #[derive(Debug)]
 pub struct ValueMatrixComprehension {
-  pub arguments: Vec<Value>,
-  pub out: Ref<Value>,
+    pub arguments: Vec<Value>,
+    pub out: Ref<Value>,
 }
 #[cfg(all(feature = "matrix_comprehensions", feature = "functions"))]
 impl MechFunctionImpl for ValueMatrixComprehension {
-  fn solve(&self) {
-    let args = self.arguments.iter().map(detach_comprehension_value).collect::<Vec<Value>>();
-    let out = if args.is_empty() {
-      Value::MatrixValue(Matrix::from_vec(vec![], 0, 0))
-    } else {
-      let fxn = MatrixHorzCat{}.compile(&args).expect("matrix/comprehension input kinds changed to incompatible values");
-      fxn.solve();
-      fxn.out()
-    };
-    *self.out.borrow_mut() = out;
-  }
-  fn out(&self) -> Value { self.out.borrow().clone() }
-  fn to_string(&self) -> String { format!("{:#?}", self) }
+    fn solve(&self) {
+        let args = self
+            .arguments
+            .iter()
+            .map(detach_comprehension_value)
+            .collect::<Vec<Value>>();
+        let out = if args.is_empty() {
+            Value::MatrixValue(Matrix::from_vec(vec![], 0, 0))
+        } else {
+            let fxn = MatrixHorzCat {}
+                .compile(&args)
+                .expect("matrix/comprehension input kinds changed to incompatible values");
+            fxn.solve();
+            fxn.out()
+        };
+        *self.out.borrow_mut() = out;
+    }
+    fn out(&self) -> Value {
+        self.out.borrow().clone()
+    }
+    fn to_string(&self) -> String {
+        format!("{:#?}", self)
+    }
 }
 #[cfg(all(feature = "matrix_comprehensions", feature = "functions"))]
 impl MechFunctionFactory for ValueMatrixComprehension {
-  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-    match args {
-      FunctionArgs::Nullary(out) => Ok(Box::new(ValueMatrixComprehension { arguments: Vec::new(), out: Ref::new(out) })),
-      _ => Err(MechError::new(
-        IncorrectNumberOfArguments { expected: 0, found: args.len() },
-        None
-      ).with_compiler_loc()),
+    fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+        match args {
+            FunctionArgs::Nullary(out) => Ok(Box::new(ValueMatrixComprehension {
+                arguments: Vec::new(),
+                out: Ref::new(out),
+            })),
+            _ => Err(MechError::new(
+                IncorrectNumberOfArguments {
+                    expected: 0,
+                    found: args.len(),
+                },
+                None,
+            )
+            .with_compiler_loc()),
+        }
     }
-  }
 }
 #[cfg(all(feature = "matrix_comprehensions", feature = "compiler"))]
 impl MechFunctionCompiler for ValueMatrixComprehension {
-  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
-    compile_nullop!("matrix/comprehension", self.out, ctx, FeatureFlag::Builtin(FeatureKind::MatrixComprehensions));
-  }
+    fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+        compile_nullop!(
+            "matrix/comprehension",
+            self.out,
+            ctx,
+            FeatureFlag::Builtin(FeatureKind::MatrixComprehensions)
+        );
+    }
 }
 #[cfg(all(feature = "matrix_comprehensions", feature = "functions"))]
 register_descriptor! {
@@ -320,19 +366,22 @@ register_descriptor! {
 pub struct MatrixComprehensionDefine {}
 #[cfg(all(feature = "matrix_comprehensions", feature = "functions"))]
 impl NativeFunctionCompiler for MatrixComprehensionDefine {
-  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
-    let out = if arguments.is_empty() {
-      Value::MatrixValue(Matrix::from_vec(vec![], 0, 0))
-    } else {
-      let fxn = MatrixHorzCat {}.compile(arguments)?;
-      fxn.solve();
-      fxn.out()
-    };
-    Ok(Box::new(ValueMatrixComprehension { arguments: arguments.clone(), out: Ref::new(out) }))
-  }
+    fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+        let out = if arguments.is_empty() {
+            Value::MatrixValue(Matrix::from_vec(vec![], 0, 0))
+        } else {
+            let fxn = MatrixHorzCat {}.compile(arguments)?;
+            fxn.solve();
+            fxn.out()
+        };
+        Ok(Box::new(ValueMatrixComprehension {
+            arguments: arguments.clone(),
+            out: Ref::new(out),
+        }))
+    }
 }
 #[cfg(all(feature = "matrix_comprehensions", feature = "functions"))]
-register_descriptor!{
+register_descriptor! {
   FunctionCompilerDescriptor {
     name: "matrix/comprehension",
     ptr: &MatrixComprehensionDefine{},
@@ -340,1061 +389,996 @@ register_descriptor!{
 }
 
 #[cfg(feature = "set_comprehensions")]
-pub fn set_comprehension(set_comp: &SetComprehension,p: &Interpreter) -> MResult<Value> {
-  let comprehension_id = hash_str(&format!("{:?}", set_comp));
-  let (envs, new_p) = comprehension_environments(&set_comp.qualifiers, comprehension_id, p)?;
-  let mut values = Vec::new();
-  for env in envs {
-    let val = expression(&set_comp.expression, Some(&env), &new_p)?;
-    values.push(val);
-  }
-  let functions = p.functions();
-  let set_define_id = hash_str("set/comprehension");
-  let set_define = {
-    functions
-      .borrow()
-      .function_compilers
-      .get(&set_define_id)
-      .copied()
-  };
-  match set_define {
-    Some(compiler) => execute_native_function_compiler(compiler, &values, p),
-    None => Err(MechError::new(
-      MissingFunctionError { function_id: set_define_id },
-      None,
-    ).with_compiler_loc()),
-  }
+pub fn set_comprehension(set_comp: &SetComprehension, p: &Interpreter) -> MResult<Value> {
+    let comprehension_id = hash_str(&format!("{:?}", set_comp));
+    let (envs, new_p) = comprehension_environments(&set_comp.qualifiers, comprehension_id, p)?;
+    let mut values = Vec::new();
+    for env in envs {
+        let val = expression(&set_comp.expression, Some(&env), &new_p)?;
+        values.push(val);
+    }
+    let functions = p.functions();
+    let set_define_id = hash_str("set/comprehension");
+    let set_define = {
+        functions
+            .borrow()
+            .function_compilers
+            .get(&set_define_id)
+            .copied()
+    };
+    match set_define {
+        Some(compiler) => execute_native_function_compiler(compiler, &values, p),
+        None => Err(MechError::new(
+            MissingFunctionError {
+                function_id: set_define_id,
+            },
+            None,
+        )
+        .with_compiler_loc()),
+    }
 }
 
 #[cfg(feature = "matrix_comprehensions")]
-pub fn matrix_comprehension(matrix_comp: &MatrixComprehension,p: &Interpreter) -> MResult<Value> {
-  let comprehension_id = hash_str(&format!("{:?}", matrix_comp));
-  let (envs, new_p) = comprehension_environments(&matrix_comp.qualifiers, comprehension_id, p)?;
-  let mut values = Vec::new();
-  for env in envs {
-    values.push(expression(&matrix_comp.expression, Some(&env), &new_p)?);
-  }
-  let functions = p.functions();
-  let horzcat_id = hash_str("matrix/comprehension");
-  let horzcat = {
-    functions
-      .borrow()
-      .function_compilers
-      .get(&horzcat_id)
-      .copied()
-  };
-  match horzcat {
-    Some(compiler) => execute_native_function_compiler(compiler, &values, p),
-    None => Err(MechError::new(
-      MissingFunctionError { function_id: horzcat_id },
-      None,
-    ).with_compiler_loc()),
-  }
+pub fn matrix_comprehension(matrix_comp: &MatrixComprehension, p: &Interpreter) -> MResult<Value> {
+    let comprehension_id = hash_str(&format!("{:?}", matrix_comp));
+    let (envs, new_p) = comprehension_environments(&matrix_comp.qualifiers, comprehension_id, p)?;
+    let mut values = Vec::new();
+    for env in envs {
+        values.push(expression(&matrix_comp.expression, Some(&env), &new_p)?);
+    }
+    let functions = p.functions();
+    let horzcat_id = hash_str("matrix/comprehension");
+    let horzcat = {
+        functions
+            .borrow()
+            .function_compilers
+            .get(&horzcat_id)
+            .copied()
+    };
+    match horzcat {
+        Some(compiler) => execute_native_function_compiler(compiler, &values, p),
+        None => Err(MechError::new(
+            MissingFunctionError {
+                function_id: horzcat_id,
+            },
+            None,
+        )
+        .with_compiler_loc()),
+    }
 }
-
 
 #[cfg(feature = "range")]
 pub fn range(rng: &RangeExpression, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  let plan = p.plan();
-  let start = factor(&rng.start, env, p)?;
-  let terminal = factor(&rng.terminal, env, p)?;
-  let new_fxn = match &rng.increment {
-    Some((_,inc)) => {
-      let step = factor(inc, env, p)?;
-      match &rng.operator {
-        #[cfg(feature = "range_exclusive")]
-        RangeOp::Exclusive => RangeIncrementExclusive{}.compile(&vec![start, step, terminal])?,
-        #[cfg(feature = "range_inclusive")]
-        RangeOp::Inclusive => RangeIncrementInclusive{}.compile(&vec![start, step, terminal])?,
-        x => unreachable!(),
-      }
-    }
-    None => {
-      match &rng.operator {
-        #[cfg(feature = "range_exclusive")]
-        RangeOp::Exclusive => RangeExclusive{}.compile(&vec![start,terminal])?,
-        #[cfg(feature = "range_inclusive")]
-        RangeOp::Inclusive => RangeInclusive{}.compile(&vec![start,terminal])?,
-        x => unreachable!(),
-      }
-    }
-  };
-  let mut plan_brrw = plan.borrow_mut();
-  plan_brrw.push(new_fxn);
-  let step = plan_brrw.last().unwrap();
-  step.solve();
-  let res = step.out();
-  Ok(res)
+    let plan = p.plan();
+    let start = factor(&rng.start, env, p)?;
+    let terminal = factor(&rng.terminal, env, p)?;
+    let new_fxn = match &rng.increment {
+        Some((_, inc)) => {
+            let step = factor(inc, env, p)?;
+            match &rng.operator {
+                #[cfg(feature = "range_exclusive")]
+                RangeOp::Exclusive => {
+                    RangeIncrementExclusive {}.compile(&vec![start, step, terminal])?
+                }
+                #[cfg(feature = "range_inclusive")]
+                RangeOp::Inclusive => {
+                    RangeIncrementInclusive {}.compile(&vec![start, step, terminal])?
+                }
+                x => unreachable!(),
+            }
+        }
+        None => match &rng.operator {
+            #[cfg(feature = "range_exclusive")]
+            RangeOp::Exclusive => RangeExclusive {}.compile(&vec![start, terminal])?,
+            #[cfg(feature = "range_inclusive")]
+            RangeOp::Inclusive => RangeInclusive {}.compile(&vec![start, terminal])?,
+            x => unreachable!(),
+        },
+    };
+    let mut plan_brrw = plan.borrow_mut();
+    plan_brrw.push(new_fxn);
+    let step = plan_brrw.last().unwrap();
+    step.solve();
+    let res = step.out();
+    Ok(res)
 }
 
 #[cfg(all(feature = "subscript_slice", feature = "access"))]
-pub fn slice(slc: &Slice, env: Option<&Environment>,p: &Interpreter) -> MResult<Value> {
-  let id = slc.name.hash();
-  let val: Value = if let Some(env) = env {
-    if let Some(val) = env.get(&id) {
-      val.clone()
-    } else {
-      // fallback to global symbols
-      match p.symbols().borrow().get(id) {
-        Some(val) => Value::MutableReference(val.clone()),
-        None => {
-          return Err(MechError::new(
-            UndefinedVariableError { id },
-            None,
-          )
-          .with_compiler_loc()
-          .with_tokens(slc.tokens()))
+pub fn slice(slc: &Slice, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+    let id = slc.name.hash();
+    let val: Value = if let Some(env) = env {
+        if let Some(val) = env.get(&id) {
+            val.clone()
+        } else {
+            // fallback to global symbols
+            match p.symbols().borrow().get(id) {
+                Some(val) => Value::MutableReference(val.clone()),
+                None => {
+                    return Err(MechError::new(UndefinedVariableError { id }, None)
+                        .with_compiler_loc()
+                        .with_tokens(slc.tokens()));
+                }
+            }
         }
-      }
+    } else {
+        match p.symbols().borrow().get(id) {
+            Some(val) => Value::MutableReference(val.clone()),
+            None => {
+                return Err(MechError::new(UndefinedVariableError { id }, None)
+                    .with_compiler_loc()
+                    .with_tokens(slc.tokens()));
+            }
+        }
+    };
+    let mut v = val;
+    for s in &slc.subscript {
+        v = subscript(s, &v, env, p)?;
     }
-  } else {
-    match p.symbols().borrow().get(id) {
-      Some(val) => Value::MutableReference(val.clone()),
-      None => {
-        return Err(MechError::new(
-          UndefinedVariableError { id },
-          None,
-        )
-        .with_compiler_loc()
-        .with_tokens(slc.tokens()))
-      }
-    }
-  };
-  let mut v = val;
-  for s in &slc.subscript {
-    v = subscript(s, &v, env, p)?;
-  }
-  Ok(v)
+    Ok(v)
 }
 
 #[cfg(feature = "subscript_formula")]
-pub fn subscript_formula(sbscrpt: &Subscript, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  match sbscrpt {
-    Subscript::Formula(fctr) => {
-      factor(fctr, env, p)
+pub fn subscript_formula(
+    sbscrpt: &Subscript,
+    env: Option<&Environment>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    match sbscrpt {
+        Subscript::Formula(fctr) => factor(fctr, env, p),
+        _ => unreachable!(),
     }
-    _ => unreachable!()
-  }
 }
 
 #[cfg(feature = "subscript_formula")]
-pub fn subscript_formula_ix(sbscrpt: &Subscript, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  match sbscrpt {
-    Subscript::Formula(fctr) => {
-      let result = factor(fctr, env, p)?;
-      result.as_index()
+pub fn subscript_formula_ix(
+    sbscrpt: &Subscript,
+    env: Option<&Environment>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    match sbscrpt {
+        Subscript::Formula(fctr) => {
+            let result = factor(fctr, env, p)?;
+            result.as_index()
+        }
+        _ => unreachable!(),
     }
-    _ => unreachable!()
-  }
 }
 
 #[cfg(feature = "subscript_range")]
-pub fn subscript_range(sbscrpt: &Subscript, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  match sbscrpt {
-    Subscript::Range(rng) => {
-      let result = range(rng, env, p)?;
-      match result.as_vecusize() {
-        Ok(v) => Ok(v.to_value()),
-        Err(_) => Err(MechError::new(
-            InvalidIndexKindError { kind: result.kind() },
-            None
-          ).with_compiler_loc().with_tokens(rng.tokens())
-        ),
-      }
+pub fn subscript_range(
+    sbscrpt: &Subscript,
+    env: Option<&Environment>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    match sbscrpt {
+        Subscript::Range(rng) => {
+            let result = range(rng, env, p)?;
+            match result.as_vecusize() {
+                Ok(v) => Ok(v.to_value()),
+                Err(_) => Err(MechError::new(
+                    InvalidIndexKindError {
+                        kind: result.kind(),
+                    },
+                    None,
+                )
+                .with_compiler_loc()
+                .with_tokens(rng.tokens())),
+            }
+        }
+        _ => unreachable!(),
     }
-    _ => unreachable!()
-  }
 }
 
 #[cfg(all(feature = "subscript", feature = "access"))]
-pub fn subscript(sbscrpt: &Subscript, val: &Value, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  let plan = p.plan();
-  match sbscrpt {
-    #[cfg(feature = "table")]
-    Subscript::Dot(x) => {
-      let key = x.hash();
-      let fxn_input: Vec<Value> = vec![val.clone(), Value::Id(key)];
-      let new_fxn = AccessColumn{}.compile(&fxn_input)?;
-      new_fxn.solve();
-      let res = new_fxn.out();
-      plan.borrow_mut().push(new_fxn);
-      return Ok(res);
-    },
-    Subscript::DotInt(x) => {
-      let mut fxn_input = vec![val.clone()];
-      let result = real(&x.clone(), p)?;
-      fxn_input.push(result.as_index()?);
-      match val.deref_kind() {
-        #[cfg(feature = "matrix")]
-        ValueKind::Matrix(..) => {
-          let new_fxn = MatrixAccessScalar{}.compile(&fxn_input)?;
-          new_fxn.solve();
-          let res = new_fxn.out();
-          plan.borrow_mut().push(new_fxn);
-          return Ok(res);
-        },
-        #[cfg(feature = "tuple")]
-        ValueKind::Tuple(..) => {
-          let new_fxn = TupleAccess{}.compile(&fxn_input)?;
-          new_fxn.solve();
-          let res = new_fxn.out();
-          plan.borrow_mut().push(new_fxn);
-          return Ok(res);
-        },
-        /*ValueKind::Record(_) => {
-          let new_fxn = RecordAccessScalar{}.compile(&fxn_input)?;
-          new_fxn.solve();
-          let res = new_fxn.out();
-          plan.borrow_mut().push(new_fxn);
-          return Ok(res);
-        },*/
-        _ => todo!("Implement access for dot int"),
-      }
-    },
-    #[cfg(feature = "swizzle")]
-    Subscript::Swizzle(x) => {
-      let mut keys = x.iter().map(|x| Value::Id(x.hash())).collect::<Vec<Value>>();
-      let mut fxn_input: Vec<Value> = vec![val.clone()];
-      fxn_input.append(&mut keys);
-      let new_fxn = AccessSwizzle{}.compile(&fxn_input)?;
-      new_fxn.solve();
-      let res = new_fxn.out();
-      plan.borrow_mut().push(new_fxn);
-      return Ok(res);
-    },
-    Subscript::Brace(subs) => {
-      let mut fxn_input = vec![val.clone()];
-      match &subs[..] {
-        #[cfg(feature = "subscript_formula")]
-        [Subscript::Formula(ix)] => {
-          let result = subscript_formula(&subs[0], env, p)?;
-          let shape = result.shape();
-          fxn_input.push(result);
-          match shape[..] {
-            [1, 1] => plan.borrow_mut().push(AccessScalar{}.compile(&fxn_input)?),
-            #[cfg(feature = "subscript_range")]
-            [n,1] => plan.borrow_mut().push(AccessRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "subscript_range")]
-            [1,n] => plan.borrow_mut().push(AccessRange{}.compile(&fxn_input)?),
-            _ => todo!(),
-          }
-        },
-        #[cfg(feature = "subscript_range")]
-        [Subscript::Range(ix)] => {
-          let result = subscript_range(&subs[0], env, p)?;
-          fxn_input.push(result);
-          plan.borrow_mut().push(AccessRange{}.compile(&fxn_input)?);
-        },
-        /*[Subscript::All] => {
-          fxn_input.push(Value::IndexAll);
-          #[cfg(feature = "matrix")]
-          plan.borrow_mut().push(MapAccessAll{}.compile(&fxn_input)?);
-        },*/
-        _ => {
-          todo!("Implement brace subscript")
+pub fn subscript(
+    sbscrpt: &Subscript,
+    val: &Value,
+    env: Option<&Environment>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    let plan = p.plan();
+    match sbscrpt {
+        #[cfg(feature = "table")]
+        Subscript::Dot(x) => {
+            let key = x.hash();
+            let fxn_input: Vec<Value> = vec![val.clone(), Value::Id(key)];
+            let new_fxn = AccessColumn {}.compile(&fxn_input)?;
+            new_fxn.solve();
+            let res = new_fxn.out();
+            plan.borrow_mut().push(new_fxn);
+            return Ok(res);
         }
-      }
-      let plan_brrw = plan.borrow();
-      let mut new_fxn = &plan_brrw.last().unwrap();
-      new_fxn.solve();
-      let res = new_fxn.out();
-      return Ok(res);
-    }
-    #[cfg(feature = "subscript_slice")]
-    Subscript::Bracket(subs) => {
-      let mut fxn_input = vec![val.clone()];
-      match &subs[..] {
-        #[cfg(feature = "subscript_formula")]
-        [Subscript::Formula(ix)] => {
-          let result = subscript_formula_ix(&subs[0], env, p)?;
-          let shape = result.shape();
-          fxn_input.push(result);
-          match shape[..] {
-            [1,1] => plan.borrow_mut().push(AccessScalar{}.compile(&fxn_input)?),
-            #[cfg(feature = "subscript_range")]
-            [1,n] => plan.borrow_mut().push(AccessRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "subscript_range")]
-            [n,1] => plan.borrow_mut().push(AccessRange{}.compile(&fxn_input)?),
-            _ => todo!(),
-          }
-        },
-        #[cfg(feature = "subscript_range")]
-        [Subscript::Range(ix)] => {
-          let result = subscript_range(&subs[0], env, p)?;
-          fxn_input.push(result);
-          plan.borrow_mut().push(AccessRange{}.compile(&fxn_input)?);
-        },
-        [Subscript::All] => {
-          fxn_input.push(Value::IndexAll);
-          #[cfg(feature = "matrix")]
-          plan.borrow_mut().push(MatrixAccessAll{}.compile(&fxn_input)?);
-        },
-        [Subscript::All,Subscript::All] => todo!(),
-        #[cfg(feature = "subscript_formula")]
-        [Subscript::Formula(ix1),Subscript::Formula(ix2)] => {
-          let result = subscript_formula_ix(&subs[0], env, p)?;
-          let shape1 = result.shape();
-          fxn_input.push(result);
-          let result = subscript_formula_ix(&subs[1], env, p)?;
-          let shape2 = result.shape();
-          fxn_input.push(result);
-          match ((shape1[0],shape1[1]),(shape2[0],shape2[1])) {
-            #[cfg(feature = "matrix")]
-            ((1,1),(1,1)) => plan.borrow_mut().push(MatrixAccessScalarScalar{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            ((1,1),(m,1)) => plan.borrow_mut().push(MatrixAccessScalarRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            ((n,1),(1,1)) => plan.borrow_mut().push(MatrixAccessRangeScalar{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            ((n,1),(m,1)) => plan.borrow_mut().push(MatrixAccessRangeRange{}.compile(&fxn_input)?),
-            _ => unreachable!(),
-          }
-        },
-        #[cfg(feature = "subscript_range")]
-        [Subscript::Range(ix1),Subscript::Range(ix2)] => {
-          let result = subscript_range(&subs[0], env, p)?;
-          fxn_input.push(result);
-          let result = subscript_range(&subs[1], env, p)?;
-          fxn_input.push(result);
-          #[cfg(feature = "matrix")]
-          plan.borrow_mut().push(MatrixAccessRangeRange{}.compile(&fxn_input)?);
-        },
-        #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
-        [Subscript::All,Subscript::Formula(ix2)] => {
-          fxn_input.push(Value::IndexAll);
-          let result = subscript_formula_ix(&subs[1], env, p)?;
-          let shape = result.shape();
-          fxn_input.push(result);
-          match &shape[..] {
-            #[cfg(feature = "matrix")]
-            [1,1] => plan.borrow_mut().push(MatrixAccessAllScalar{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [1,n] => plan.borrow_mut().push(MatrixAccessAllRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [n,1] => plan.borrow_mut().push(MatrixAccessAllRange{}.compile(&fxn_input)?),
-            _ => todo!(),
-          }
-        },
-        #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
-        [Subscript::Formula(ix1),Subscript::All] => {
-          let result = subscript_formula_ix(&subs[0], env, p)?;
-          let shape = result.shape();
-          fxn_input.push(result);
-          fxn_input.push(Value::IndexAll);
-          match &shape[..] {
-            #[cfg(feature = "matrix")]
-            [1,1] => plan.borrow_mut().push(MatrixAccessScalarAll{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [1,n] => plan.borrow_mut().push(MatrixAccessRangeAll{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [n,1] => plan.borrow_mut().push(MatrixAccessRangeAll{}.compile(&fxn_input)?),
-            _ => todo!(),
-          }
-        },
-        #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
-        [Subscript::Range(ix1),Subscript::Formula(ix2)] => {
-          let result = subscript_range(&subs[0], env, p)?;
-          fxn_input.push(result);
-          let result = subscript_formula_ix(&subs[1], env, p)?;
-          let shape = result.shape();
-          fxn_input.push(result);
-          match &shape[..] {
-            #[cfg(feature = "matrix")]
-            [1,1] => plan.borrow_mut().push(MatrixAccessRangeScalar{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [1,n] => plan.borrow_mut().push(MatrixAccessRangeRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [n,1] => plan.borrow_mut().push(MatrixAccessRangeRange{}.compile(&fxn_input)?),
-            _ => todo!(),
-          }
-        },
-        #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
-        [Subscript::Formula(ix1),Subscript::Range(ix2)] => {
-          let result = subscript_formula_ix(&subs[0], env, p)?;
-          let shape = result.shape();
-          fxn_input.push(result);
-          let result = subscript_range(&subs[1], env, p)?;
-          fxn_input.push(result);
-          match &shape[..] {
-            #[cfg(feature = "matrix")]
-            [1,1] => plan.borrow_mut().push(MatrixAccessScalarRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [1,n] => plan.borrow_mut().push(MatrixAccessRangeRange{}.compile(&fxn_input)?),
-            #[cfg(feature = "matrix")]
-            [n,1] => plan.borrow_mut().push(MatrixAccessRangeRange{}.compile(&fxn_input)?),
-            _ => todo!(),
-          }
-        },
-        #[cfg(feature = "subscript_range")]
-        [Subscript::All,Subscript::Range(ix2)] => {
-          fxn_input.push(Value::IndexAll);
-          let result = subscript_range(&subs[1], env, p)?;
-          fxn_input.push(result);
-          #[cfg(feature = "matrix")]
-          plan.borrow_mut().push(MatrixAccessAllRange{}.compile(&fxn_input)?);
-        },
-        #[cfg(feature = "subscript_range")]
-        [Subscript::Range(ix1),Subscript::All] => {
-          let result = subscript_range(&subs[0], env, p)?;
-          fxn_input.push(result);
-          fxn_input.push(Value::IndexAll);
-          #[cfg(feature = "matrix")]
-          plan.borrow_mut().push(MatrixAccessRangeAll{}.compile(&fxn_input)?);
-        },
+        Subscript::DotInt(x) => {
+            let mut fxn_input = vec![val.clone()];
+            let result = real(&x.clone(), p)?;
+            fxn_input.push(result.as_index()?);
+            match val.deref_kind() {
+                #[cfg(feature = "matrix")]
+                ValueKind::Matrix(..) => {
+                    let new_fxn = MatrixAccessScalar {}.compile(&fxn_input)?;
+                    new_fxn.solve();
+                    let res = new_fxn.out();
+                    plan.borrow_mut().push(new_fxn);
+                    return Ok(res);
+                }
+                #[cfg(feature = "tuple")]
+                ValueKind::Tuple(..) => {
+                    let new_fxn = TupleAccess {}.compile(&fxn_input)?;
+                    new_fxn.solve();
+                    let res = new_fxn.out();
+                    plan.borrow_mut().push(new_fxn);
+                    return Ok(res);
+                }
+                /*ValueKind::Record(_) => {
+                  let new_fxn = RecordAccessScalar{}.compile(&fxn_input)?;
+                  new_fxn.solve();
+                  let res = new_fxn.out();
+                  plan.borrow_mut().push(new_fxn);
+                  return Ok(res);
+                },*/
+                _ => todo!("Implement access for dot int"),
+            }
+        }
+        #[cfg(feature = "swizzle")]
+        Subscript::Swizzle(x) => {
+            let mut keys = x
+                .iter()
+                .map(|x| Value::Id(x.hash()))
+                .collect::<Vec<Value>>();
+            let mut fxn_input: Vec<Value> = vec![val.clone()];
+            fxn_input.append(&mut keys);
+            let new_fxn = AccessSwizzle {}.compile(&fxn_input)?;
+            new_fxn.solve();
+            let res = new_fxn.out();
+            plan.borrow_mut().push(new_fxn);
+            return Ok(res);
+        }
+        Subscript::Brace(subs) => {
+            let mut fxn_input = vec![val.clone()];
+            match &subs[..] {
+                #[cfg(feature = "subscript_formula")]
+                [Subscript::Formula(ix)] => {
+                    let result = subscript_formula(&subs[0], env, p)?;
+                    let shape = result.shape();
+                    fxn_input.push(result);
+                    match shape[..] {
+                        [1, 1] => plan.borrow_mut().push(AccessScalar {}.compile(&fxn_input)?),
+                        #[cfg(feature = "subscript_range")]
+                        [n, 1] => plan.borrow_mut().push(AccessRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "subscript_range")]
+                        [1, n] => plan.borrow_mut().push(AccessRange {}.compile(&fxn_input)?),
+                        _ => todo!(),
+                    }
+                }
+                #[cfg(feature = "subscript_range")]
+                [Subscript::Range(ix)] => {
+                    let result = subscript_range(&subs[0], env, p)?;
+                    fxn_input.push(result);
+                    plan.borrow_mut().push(AccessRange {}.compile(&fxn_input)?);
+                }
+                /*[Subscript::All] => {
+                  fxn_input.push(Value::IndexAll);
+                  #[cfg(feature = "matrix")]
+                  plan.borrow_mut().push(MapAccessAll{}.compile(&fxn_input)?);
+                },*/
+                _ => {
+                    todo!("Implement brace subscript")
+                }
+            }
+            let plan_brrw = plan.borrow();
+            let mut new_fxn = &plan_brrw.last().unwrap();
+            new_fxn.solve();
+            let res = new_fxn.out();
+            return Ok(res);
+        }
+        #[cfg(feature = "subscript_slice")]
+        Subscript::Bracket(subs) => {
+            let mut fxn_input = vec![val.clone()];
+            match &subs[..] {
+                #[cfg(feature = "subscript_formula")]
+                [Subscript::Formula(ix)] => {
+                    let result = subscript_formula_ix(&subs[0], env, p)?;
+                    let shape = result.shape();
+                    fxn_input.push(result);
+                    match shape[..] {
+                        [1, 1] => plan.borrow_mut().push(AccessScalar {}.compile(&fxn_input)?),
+                        #[cfg(feature = "subscript_range")]
+                        [1, n] => plan.borrow_mut().push(AccessRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "subscript_range")]
+                        [n, 1] => plan.borrow_mut().push(AccessRange {}.compile(&fxn_input)?),
+                        _ => todo!(),
+                    }
+                }
+                #[cfg(feature = "subscript_range")]
+                [Subscript::Range(ix)] => {
+                    let result = subscript_range(&subs[0], env, p)?;
+                    fxn_input.push(result);
+                    plan.borrow_mut().push(AccessRange {}.compile(&fxn_input)?);
+                }
+                [Subscript::All] => {
+                    fxn_input.push(Value::IndexAll);
+                    #[cfg(feature = "matrix")]
+                    plan.borrow_mut()
+                        .push(MatrixAccessAll {}.compile(&fxn_input)?);
+                }
+                [Subscript::All, Subscript::All] => todo!(),
+                #[cfg(feature = "subscript_formula")]
+                [Subscript::Formula(ix1), Subscript::Formula(ix2)] => {
+                    let result = subscript_formula_ix(&subs[0], env, p)?;
+                    let shape1 = result.shape();
+                    fxn_input.push(result);
+                    let result = subscript_formula_ix(&subs[1], env, p)?;
+                    let shape2 = result.shape();
+                    fxn_input.push(result);
+                    match ((shape1[0], shape1[1]), (shape2[0], shape2[1])) {
+                        #[cfg(feature = "matrix")]
+                        ((1, 1), (1, 1)) => plan
+                            .borrow_mut()
+                            .push(MatrixAccessScalarScalar {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        ((1, 1), (m, 1)) => plan
+                            .borrow_mut()
+                            .push(MatrixAccessScalarRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        ((n, 1), (1, 1)) => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeScalar {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        ((n, 1), (m, 1)) => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeRange {}.compile(&fxn_input)?),
+                        _ => unreachable!(),
+                    }
+                }
+                #[cfg(feature = "subscript_range")]
+                [Subscript::Range(ix1), Subscript::Range(ix2)] => {
+                    let result = subscript_range(&subs[0], env, p)?;
+                    fxn_input.push(result);
+                    let result = subscript_range(&subs[1], env, p)?;
+                    fxn_input.push(result);
+                    #[cfg(feature = "matrix")]
+                    plan.borrow_mut()
+                        .push(MatrixAccessRangeRange {}.compile(&fxn_input)?);
+                }
+                #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
+                [Subscript::All, Subscript::Formula(ix2)] => {
+                    fxn_input.push(Value::IndexAll);
+                    let result = subscript_formula_ix(&subs[1], env, p)?;
+                    let shape = result.shape();
+                    fxn_input.push(result);
+                    match &shape[..] {
+                        #[cfg(feature = "matrix")]
+                        [1, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessAllScalar {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [1, n] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessAllRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [n, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessAllRange {}.compile(&fxn_input)?),
+                        _ => todo!(),
+                    }
+                }
+                #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
+                [Subscript::Formula(ix1), Subscript::All] => {
+                    let result = subscript_formula_ix(&subs[0], env, p)?;
+                    let shape = result.shape();
+                    fxn_input.push(result);
+                    fxn_input.push(Value::IndexAll);
+                    match &shape[..] {
+                        #[cfg(feature = "matrix")]
+                        [1, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessScalarAll {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [1, n] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeAll {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [n, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeAll {}.compile(&fxn_input)?),
+                        _ => todo!(),
+                    }
+                }
+                #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
+                [Subscript::Range(ix1), Subscript::Formula(ix2)] => {
+                    let result = subscript_range(&subs[0], env, p)?;
+                    fxn_input.push(result);
+                    let result = subscript_formula_ix(&subs[1], env, p)?;
+                    let shape = result.shape();
+                    fxn_input.push(result);
+                    match &shape[..] {
+                        #[cfg(feature = "matrix")]
+                        [1, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeScalar {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [1, n] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [n, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeRange {}.compile(&fxn_input)?),
+                        _ => todo!(),
+                    }
+                }
+                #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
+                [Subscript::Formula(ix1), Subscript::Range(ix2)] => {
+                    let result = subscript_formula_ix(&subs[0], env, p)?;
+                    let shape = result.shape();
+                    fxn_input.push(result);
+                    let result = subscript_range(&subs[1], env, p)?;
+                    fxn_input.push(result);
+                    match &shape[..] {
+                        #[cfg(feature = "matrix")]
+                        [1, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessScalarRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [1, n] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeRange {}.compile(&fxn_input)?),
+                        #[cfg(feature = "matrix")]
+                        [n, 1] => plan
+                            .borrow_mut()
+                            .push(MatrixAccessRangeRange {}.compile(&fxn_input)?),
+                        _ => todo!(),
+                    }
+                }
+                #[cfg(feature = "subscript_range")]
+                [Subscript::All, Subscript::Range(ix2)] => {
+                    fxn_input.push(Value::IndexAll);
+                    let result = subscript_range(&subs[1], env, p)?;
+                    fxn_input.push(result);
+                    #[cfg(feature = "matrix")]
+                    plan.borrow_mut()
+                        .push(MatrixAccessAllRange {}.compile(&fxn_input)?);
+                }
+                #[cfg(feature = "subscript_range")]
+                [Subscript::Range(ix1), Subscript::All] => {
+                    let result = subscript_range(&subs[0], env, p)?;
+                    fxn_input.push(result);
+                    fxn_input.push(Value::IndexAll);
+                    #[cfg(feature = "matrix")]
+                    plan.borrow_mut()
+                        .push(MatrixAccessRangeAll {}.compile(&fxn_input)?);
+                }
+                _ => unreachable!(),
+            };
+            let plan_brrw = plan.borrow();
+            let mut new_fxn = &plan_brrw.last().unwrap();
+            new_fxn.solve();
+            let res = new_fxn.out();
+            return Ok(res);
+        }
         _ => unreachable!(),
-      };
-      let plan_brrw = plan.borrow();
-      let mut new_fxn = &plan_brrw.last().unwrap();
-      new_fxn.solve();
-      let res = new_fxn.out();
-      return Ok(res);
-    },
-    _ => unreachable!(),
-  }
+    }
 }
 
 #[cfg(feature = "symbol_table")]
 pub fn var(v: &Var, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  let maybe_cast_to_kind = |value: Value| -> MResult<Value> {
-    match &v.kind {
-      Some(kind_anntn) => {
-        let target_kind = {
-          let state_brrw = p.state.borrow();
-          kind_annotation(&kind_anntn.kind, p)?.to_value_kind(&state_brrw.kinds)?
-        };
-        let convert_fxn = ConvertKind{}.compile(&vec![value, Value::Kind(target_kind)])?;
-        convert_fxn.solve();
-        let out = convert_fxn.out();
-        p.state.borrow_mut().add_plan_step(convert_fxn);
-        Ok(out)
-      }
-      None => Ok(value),
-    }
-  };
-
-  let id = v.name.hash();
-  match env {
-    Some(env) => {
-      match env.get(&id) {
-        Some(value) => maybe_cast_to_kind(value.clone()),
-        None => {
-          let state_brrw = p.state.borrow();
-          let symbols_brrw = state_brrw.symbol_table.borrow();
-          let symbol_value = symbols_brrw.get(id);
-          drop(symbols_brrw);
-          drop(state_brrw);
-          match symbol_value {
-            Some(value) => maybe_cast_to_kind(Value::MutableReference(value)),
-            None => Err(MechError::new(
-                  UndefinedVariableError { id },
-                  None
-                ).with_compiler_loc().with_tokens(v.tokens())
-              ),
-          }
+    let maybe_cast_to_kind = |value: Value| -> MResult<Value> {
+        match &v.kind {
+            Some(kind_anntn) => {
+                let target_kind = {
+                    let state_brrw = p.state.borrow();
+                    kind_annotation(&kind_anntn.kind, p)?.to_value_kind(&state_brrw.kinds)?
+                };
+                let convert_fxn = ConvertKind {}.compile(&vec![value, Value::Kind(target_kind)])?;
+                convert_fxn.solve();
+                let out = convert_fxn.out();
+                p.state.borrow_mut().add_plan_step(convert_fxn);
+                Ok(out)
+            }
+            None => Ok(value),
         }
-      }
+    };
+
+    let id = v.name.hash();
+    match env {
+        Some(env) => match env.get(&id) {
+            Some(value) => maybe_cast_to_kind(value.clone()),
+            None => {
+                let state_brrw = p.state.borrow();
+                let symbols_brrw = state_brrw.symbol_table.borrow();
+                let symbol_value = symbols_brrw.get(id);
+                drop(symbols_brrw);
+                drop(state_brrw);
+                match symbol_value {
+                    Some(value) => maybe_cast_to_kind(Value::MutableReference(value)),
+                    None => Err(MechError::new(UndefinedVariableError { id }, None)
+                        .with_compiler_loc()
+                        .with_tokens(v.tokens())),
+                }
+            }
+        },
+        None => {
+            let state_brrw = p.state.borrow();
+            let symbols_brrw = state_brrw.symbol_table.borrow();
+            let symbol_value = symbols_brrw.get(id);
+            drop(symbols_brrw);
+            drop(state_brrw);
+            match symbol_value {
+                Some(value) => maybe_cast_to_kind(Value::MutableReference(value)),
+                None => Err(MechError::new(UndefinedVariableError { id }, None)
+                    .with_compiler_loc()
+                    .with_tokens(v.tokens())),
+            }
+        }
     }
-    None => {
-      let state_brrw = p.state.borrow();
-      let symbols_brrw = state_brrw.symbol_table.borrow();
-      let symbol_value = symbols_brrw.get(id);
-      drop(symbols_brrw);
-      drop(state_brrw);
-      match symbol_value {
-        Some(value) => maybe_cast_to_kind(Value::MutableReference(value)),
-        None => Err(MechError::new(
-              UndefinedVariableError { id },
-              None
-            ).with_compiler_loc().with_tokens(v.tokens())
-          ),
-      }
-    }
-  }
 }
 
-pub fn option_match_expression(opt_match: &OptionMatchExpression, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  if !opt_match.arms.iter().any(|arm| matches!(arm.pattern, Pattern::Wildcard)) {
-    return Err(MechError::new(
-      OptionMatchNonExhaustiveError,
-      None,
-    ).with_compiler_loc().with_tokens(opt_match.source.tokens()));
-  }
-  let source = expression(&opt_match.source, env, p)?;
-  let detached_source = match &source {
-    Value::MutableReference(reference) => reference.borrow().clone(),
-    _ => source.clone(),
-  };
-  let mut base_env = env.cloned().unwrap_or_default();
-  if let Expression::Var(var) = &opt_match.source {
-    base_env.insert(var.name.hash(), detached_source.clone());
-  }
-  if option_value_is_empty(&detached_source) {
-    if let Some(arm) = opt_match.arms.iter().find(|arm| matches!(arm.pattern, Pattern::Wildcard)) {
-      return expression(&arm.expression, Some(&base_env), p);
+pub fn option_match_expression(
+    opt_match: &OptionMatchExpression,
+    env: Option<&Environment>,
+    p: &Interpreter,
+) -> MResult<Value> {
+    if !opt_match
+        .arms
+        .iter()
+        .any(|arm| matches!(arm.pattern, Pattern::Wildcard))
+    {
+        return Err(MechError::new(OptionMatchNonExhaustiveError, None)
+            .with_compiler_loc()
+            .with_tokens(opt_match.source.tokens()));
     }
-    return Err(MechError::new(
-      OptionMatchNoArmMatchedError,
-      None,
-    ).with_compiler_loc().with_tokens(opt_match.source.tokens()));
-  }
-
-  for (arm_ix, arm) in opt_match.arms.iter().enumerate() {
-    let mut guard_env = base_env.clone();
-    let matched = match &arm.pattern {
-      Pattern::Wildcard => true,
-      Pattern::Expression(expr) => match expr {
-        Expression::Var(_) => option_pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
-        _ => {
-          let pattern_value = expression(expr, Some(&guard_env), p)?;
-          option_pattern_expression_matches_value(&pattern_value, &detached_source)
-        }
-      },
-      _ => option_pattern_matches_value(&arm.pattern, &detached_source, &mut guard_env, p)?,
+    let source = expression(&opt_match.source, env, p)?;
+    let detached_source = match &source {
+        Value::MutableReference(reference) => reference.borrow().clone(),
+        _ => source.clone(),
     };
-    if matched {
-      let output = expression(&arm.expression, Some(&guard_env), p)?;
-      option_match_validate_arm_kinds(
-        opt_match,
-        arm_ix,
-        &output.kind(),
-        &detached_source,
-        &base_env,
-        p,
-      )?;
-      return Ok(output);
+    let mut base_env = env.cloned().unwrap_or_default();
+    if let Expression::Var(var) = &opt_match.source {
+        base_env.insert(var.name.hash(), detached_source.clone());
     }
-  }
+    if option_value_is_empty(&detached_source) {
+        if let Some(arm) = opt_match
+            .arms
+            .iter()
+            .find(|arm| matches!(arm.pattern, Pattern::Wildcard))
+        {
+            return expression(&arm.expression, Some(&base_env), p);
+        }
+        return Err(MechError::new(OptionMatchNoArmMatchedError, None)
+            .with_compiler_loc()
+            .with_tokens(opt_match.source.tokens()));
+    }
 
-  Err(MechError::new(
-    OptionMatchNoArmMatchedError,
-    None,
-  ).with_compiler_loc().with_tokens(opt_match.source.tokens()))
+    for (arm_ix, arm) in opt_match.arms.iter().enumerate() {
+        let mut guard_env = base_env.clone();
+        let matched = match &arm.pattern {
+            Pattern::Wildcard => true,
+            _ => crate::patterns::pattern_matches_value_with_semantics(
+                &arm.pattern,
+                &detached_source,
+                &mut guard_env,
+                p,
+                crate::patterns::PatternMatchSemantics::OptionGuard,
+            )?,
+        };
+        if matched {
+            let output = expression(&arm.expression, Some(&guard_env), p)?;
+            option_match_validate_arm_kinds(
+                opt_match,
+                arm_ix,
+                &output.kind(),
+                &detached_source,
+                &base_env,
+                p,
+            )?;
+            return Ok(output);
+        }
+    }
+
+    Err(MechError::new(OptionMatchNoArmMatchedError, None)
+        .with_compiler_loc()
+        .with_tokens(opt_match.source.tokens()))
 }
 
 fn option_match_validate_arm_kinds(
-  opt_match: &OptionMatchExpression,
-  matched_arm_ix: usize,
-  matched_kind: &ValueKind,
-  source: &Value,
-  base_env: &Environment,
-  p: &Interpreter,
+    opt_match: &OptionMatchExpression,
+    matched_arm_ix: usize,
+    matched_kind: &ValueKind,
+    source: &Value,
+    base_env: &Environment,
+    p: &Interpreter,
 ) -> MResult<()> {
-  for (ix, arm) in opt_match.arms.iter().enumerate() {
-    if ix == matched_arm_ix {
-      continue;
+    for (ix, arm) in opt_match.arms.iter().enumerate() {
+        if ix == matched_arm_ix {
+            continue;
+        }
+        let mut arm_env = base_env.clone();
+        let applicable = match arm.pattern {
+            Pattern::Wildcard => true,
+            _ => crate::patterns::pattern_matches_value_with_semantics(
+                &arm.pattern,
+                source,
+                &mut arm_env,
+                p,
+                crate::patterns::PatternMatchSemantics::OptionGuard,
+            )?,
+        };
+        if !applicable {
+            continue;
+        }
+        let arm_value = expression(&arm.expression, Some(&arm_env), p)?;
+        let arm_kind = arm_value.kind();
+        if arm_kind != *matched_kind {
+            return Err(MechError::new(
+                OptionMatchArmKindMismatchError {
+                    expected: matched_kind.clone(),
+                    found: arm_kind,
+                },
+                None,
+            )
+            .with_compiler_loc()
+            .with_tokens(arm.expression.tokens()));
+        }
     }
-    let mut arm_env = base_env.clone();
-    let applicable = match arm.pattern {
-      Pattern::Wildcard => true,
-      _ => option_pattern_matches_value(&arm.pattern, source, &mut arm_env, p)?,
-    };
-    if !applicable {
-      continue;
-    }
-    let arm_value = expression(&arm.expression, Some(&arm_env), p)?;
-    let arm_kind = arm_value.kind();
-    if arm_kind != *matched_kind {
-      return Err(MechError::new(
-        OptionMatchArmKindMismatchError {
-          expected: matched_kind.clone(),
-          found: arm_kind,
-        },
-        None,
-      ).with_compiler_loc().with_tokens(arm.expression.tokens()));
-    }
-  }
-  Ok(())
+    Ok(())
 }
 
 fn option_value_is_empty(value: &Value) -> bool {
-  match value {
-    Value::Empty => true,
-    #[cfg(feature = "tuple")]
-    Value::Tuple(tuple) => tuple.borrow().elements.iter().any(|value| option_value_is_empty(value.as_ref())),
-    Value::MutableReference(reference) => option_value_is_empty(&reference.borrow()),
-    _ => false,
-  }
-}
-
-fn option_pattern_matches_value(
-  pattern: &Pattern,
-  value: &Value,
-  env: &mut Environment,
-  p: &Interpreter,
-) -> MResult<bool> {
-  match pattern {
-    Pattern::Wildcard => Ok(true),
-    #[cfg(feature = "functions")]
-    Pattern::Expression(Expression::Var(_)) => crate::functions::pattern_matches_value(pattern, value, env, p),
-    #[cfg(not(feature = "functions"))]
-    Pattern::Expression(Expression::Var(var)) => {
-      let var_id = var.name.hash();
-      let detached = option_detach_value(value);
-      if let Some(existing) = env.get(&var_id) {
-        Ok(existing == &detached)
-      } else {
-        env.insert(var_id, detached);
-        Ok(true)
-      }
+    match value {
+        Value::Empty => true,
+        #[cfg(feature = "tuple")]
+        Value::Tuple(tuple) => tuple
+            .borrow()
+            .elements
+            .iter()
+            .any(|value| option_value_is_empty(value.as_ref())),
+        Value::MutableReference(reference) => option_value_is_empty(&reference.borrow()),
+        _ => false,
     }
-    Pattern::Expression(expr) => {
-      let expected = expression(expr, Some(env), p)?;
-      Ok(option_pattern_expression_matches_value(&expected, &option_detach_value(value)))
-    }
-    #[cfg(feature = "functions")]
-    _ => crate::functions::pattern_matches_value(pattern, value, env, p),
-    #[cfg(not(feature = "functions"))]
-    _ => option_pattern_matches_value_fallback(pattern, value, env, p),
-  }
-}
-
-fn option_detach_value(value: &Value) -> Value {
-  match value {
-    Value::MutableReference(reference) => option_detach_value(&reference.borrow()),
-    _ => value.clone(),
-  }
-}
-
-#[cfg(not(feature = "functions"))]
-fn option_pattern_matches_value_fallback(
-  pattern: &Pattern,
-  value: &Value,
-  env: &mut Environment,
-  p: &Interpreter,
-) -> MResult<bool> {
-  match pattern {
-    Pattern::Wildcard => Ok(true),
-    Pattern::Tuple(pattern_tuple) => match value {
-      #[cfg(feature = "tuple")]
-      Value::Tuple(tuple) => {
-        let tuple_brrw = tuple.borrow();
-        if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-          return Ok(false);
-        }
-        for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-          if !option_pattern_matches_value_fallback(pat, val, env, p)? {
-            return Ok(false);
-          }
-        }
-        Ok(true)
-      }
-      _ => Ok(false),
-    },
-    Pattern::Array(pattern_array) => {
-      let values = match option_matrix_like_values_fallback(value) {
-        Some(values) => values,
-        None => return Ok(false),
-      };
-      if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
-        return Ok(false);
-      }
-      for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
-        if !option_pattern_matches_value_fallback(pat, val, env, p)? {
-          return Ok(false);
-        }
-      }
-      let suffix_start = values.len() - pattern_array.suffix.len();
-      for (pat, val) in pattern_array.suffix.iter().zip(values[suffix_start..].iter()) {
-        if !option_pattern_matches_value_fallback(pat, val, env, p)? {
-          return Ok(false);
-        }
-      }
-      if pattern_array.spread.is_none() && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len() {
-        return Ok(false);
-      }
-      if let Some(spread) = &pattern_array.spread {
-        if let Some(binding) = &spread.binding {
-          let middle = values[pattern_array.prefix.len()..suffix_start].to_vec();
-          #[cfg(feature = "matrix")]
-          let captured = Value::MatrixValue(Matrix::from_vec(
-            middle,
-            1,
-            suffix_start.saturating_sub(pattern_array.prefix.len()),
-          ));
-          #[cfg(not(feature = "matrix"))]
-          let captured = {
-            let _ = middle;
-            return Ok(false);
-          };
-          if !option_pattern_matches_value_fallback(binding, &captured, env, p)? {
-            return Ok(false);
-          }
-        }
-      }
-      Ok(true)
-    }
-    Pattern::Expression(Expression::Var(var)) => {
-      let var_id = var.name.hash();
-      let detached = option_detach_value(value);
-      if let Some(existing) = env.get(&var_id) {
-        Ok(existing == &detached)
-      } else {
-        env.insert(var_id, detached);
-        Ok(true)
-      }
-    }
-    Pattern::Expression(expr) => {
-      let expected = expression(expr, Some(env), p)?;
-      Ok(option_pattern_expression_matches_value(&expected, &option_detach_value(value)))
-    }
-    Pattern::TupleStruct(_) => Ok(false),
-  }
-}
-
-#[cfg(not(feature = "functions"))]
-fn option_matrix_like_values_fallback(value: &Value) -> Option<Vec<Value>> {
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Some(matrix.as_vec().into_iter().map(|value| Value::Index(Ref::new(value))).collect()),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Some(matrix.as_vec().into_iter().map(|value| value.to_value()).collect()),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Some(matrix.as_vec().into_iter().map(|value| value.to_value()).collect()),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Some(matrix.as_vec()),
-    Value::MutableReference(reference) => option_matrix_like_values_fallback(&reference.borrow()),
-    _ => None,
-  }
-}
-
-fn option_pattern_expression_matches_value(pattern_value: &Value, value: &Value) -> bool {
-  #[cfg(feature = "bool")]
-  if let Value::Bool(flag) = pattern_value {
-    return *flag.borrow();
-  }
-  option_values_match(pattern_value, value)
-}
-
-fn option_values_match(expected: &Value, actual: &Value) -> bool {
-  if expected == actual {
-    return true;
-  }
-  #[cfg(all(feature = "u64", feature = "f64"))]
-  {
-    match (expected, actual) {
-      (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-      (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-      _ => {}
-    }
-  }
-  false
 }
 
 #[cfg(feature = "formulas")]
 pub fn factor(fctr: &Factor, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  match fctr {
-    Factor::Term(trm) => {
-      let result = term(trm, env, p)?;
-      Ok(result)
-    },
-    Factor::Parenthetical(paren) => factor(&*paren, env, p),
-    Factor::Expression(expr) => expression(expr, env, p),
-    #[cfg(feature = "math_neg")]
-    Factor::Negate(neg) => {
-      let value = factor(neg, env, p)?;
-      let new_fxn = MathNegate{}.compile(&vec![value])?;
-      new_fxn.solve();
-      let out = new_fxn.out();
-      p.state.borrow_mut().add_plan_step(new_fxn);
-      Ok(out)
-    },
-    #[cfg(feature = "logic_not")]
-    Factor::Not(neg) => {
-      let value = factor(neg, env, p)?;
-      let new_fxn = LogicNot{}.compile(&vec![value])?;
-      new_fxn.solve();
-      let out = new_fxn.out();
-      p.state.borrow_mut().add_plan_step(new_fxn);
-      Ok(out)
-    },
-    #[cfg(feature = "matrix_transpose")]
-    Factor::Transpose(fctr) => {
-      use mech_matrix::MatrixTranspose;
-      let value = factor(fctr, env, p)?;
-      let new_fxn = MatrixTranspose{}.compile(&vec![value])?;
-      new_fxn.solve();
-      let out = new_fxn.out();
-      p.state.borrow_mut().add_plan_step(new_fxn);
-      Ok(out)
+    match fctr {
+        Factor::Term(trm) => {
+            let result = term(trm, env, p)?;
+            Ok(result)
+        }
+        Factor::Parenthetical(paren) => factor(&*paren, env, p),
+        Factor::Expression(expr) => expression(expr, env, p),
+        #[cfg(feature = "math_neg")]
+        Factor::Negate(neg) => {
+            let value = factor(neg, env, p)?;
+            let new_fxn = MathNegate {}.compile(&vec![value])?;
+            new_fxn.solve();
+            let out = new_fxn.out();
+            p.state.borrow_mut().add_plan_step(new_fxn);
+            Ok(out)
+        }
+        #[cfg(feature = "logic_not")]
+        Factor::Not(neg) => {
+            let value = factor(neg, env, p)?;
+            let new_fxn = LogicNot {}.compile(&vec![value])?;
+            new_fxn.solve();
+            let out = new_fxn.out();
+            p.state.borrow_mut().add_plan_step(new_fxn);
+            Ok(out)
+        }
+        #[cfg(feature = "matrix_transpose")]
+        Factor::Transpose(fctr) => {
+            use mech_matrix::MatrixTranspose;
+            let value = factor(fctr, env, p)?;
+            let new_fxn = MatrixTranspose {}.compile(&vec![value])?;
+            new_fxn.solve();
+            let out = new_fxn.out();
+            p.state.borrow_mut().add_plan_step(new_fxn);
+            Ok(out)
+        }
+        _ => todo!(),
     }
-    _ => todo!(),
-  }
 }
 
 #[cfg(feature = "formulas")]
 pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
-  let plan = p.plan();
-  let mut lhs = factor(&trm.lhs, env, p)?;
-  let mut term_plan: Vec<Box<dyn MechFunction>> = vec![];
-  for (op,rhs) in &trm.rhs {
-    let rhs = factor(&rhs, env, p)?;
-    let new_fxn: Box<dyn MechFunction> = match op {
-      // Math
-      FormulaOperator::AddSub(AddSubOp::Add) => {
-        match (&lhs, &rhs) {
-          #[cfg(feature = "string_concat")]
-          (_, value) | (value, _) if value.is_string() => StringConcat{}.compile(&vec![lhs, rhs])?,
-          #[cfg(feature = "math_add")]
-          _ => MathAdd{}.compile(&vec![lhs,rhs])?,
-        }
-      }
-      #[cfg(feature = "math_sub")]
-      FormulaOperator::AddSub(AddSubOp::Sub) => MathSub{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "math_mul")]
-      FormulaOperator::MulDiv(MulDivOp::Mul) => MathMul{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "math_div")]
-      FormulaOperator::MulDiv(MulDivOp::Div) => MathDiv{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "math_mod")]
-      FormulaOperator::MulDiv(MulDivOp::Mod) => MathMod{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "math_pow")]
-      FormulaOperator::Power(PowerOp::Pow) => MathPow{}.compile(&vec![lhs,rhs])?,
+    let plan = p.plan();
+    let mut lhs = factor(&trm.lhs, env, p)?;
+    let mut term_plan: Vec<Box<dyn MechFunction>> = vec![];
+    for (op, rhs) in &trm.rhs {
+        let rhs = factor(&rhs, env, p)?;
+        let new_fxn: Box<dyn MechFunction> = match op {
+            // Math
+            FormulaOperator::AddSub(AddSubOp::Add) => match (&lhs, &rhs) {
+                #[cfg(feature = "string_concat")]
+                (_, value) | (value, _) if value.is_string() => {
+                    StringConcat {}.compile(&vec![lhs, rhs])?
+                }
+                #[cfg(feature = "math_add")]
+                _ => MathAdd {}.compile(&vec![lhs, rhs])?,
+            },
+            #[cfg(feature = "math_sub")]
+            FormulaOperator::AddSub(AddSubOp::Sub) => MathSub {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "math_mul")]
+            FormulaOperator::MulDiv(MulDivOp::Mul) => MathMul {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "math_div")]
+            FormulaOperator::MulDiv(MulDivOp::Div) => MathDiv {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "math_mod")]
+            FormulaOperator::MulDiv(MulDivOp::Mod) => MathMod {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "math_pow")]
+            FormulaOperator::Power(PowerOp::Pow) => MathPow {}.compile(&vec![lhs, rhs])?,
 
-      // Matrix
-      #[cfg(feature = "matrix_matmul")]
-      FormulaOperator::Vec(VecOp::MatMul) => {
-        use mech_matrix::MatrixMatMul;
-        MatrixMatMul{}.compile(&vec![lhs,rhs])?
-      }
-      #[cfg(feature = "matrix_solve")]
-      FormulaOperator::Vec(VecOp::Solve) => MatrixSolve{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "matrix_cross")]
-      FormulaOperator::Vec(VecOp::Cross) => todo!(),
-      #[cfg(feature = "matrix_dot")]
-      FormulaOperator::Vec(VecOp::Dot) => MatrixDot{}.compile(&vec![lhs,rhs])?,
+            // Matrix
+            #[cfg(feature = "matrix_matmul")]
+            FormulaOperator::Vec(VecOp::MatMul) => {
+                use mech_matrix::MatrixMatMul;
+                MatrixMatMul {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "matrix_solve")]
+            FormulaOperator::Vec(VecOp::Solve) => MatrixSolve {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "matrix_cross")]
+            FormulaOperator::Vec(VecOp::Cross) => todo!(),
+            #[cfg(feature = "matrix_dot")]
+            FormulaOperator::Vec(VecOp::Dot) => MatrixDot {}.compile(&vec![lhs, rhs])?,
 
-      // Compare
-      #[cfg(feature = "compare_eq")]
-      FormulaOperator::Comparison(ComparisonOp::Equal) => CompareEqual{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_seq")]
-      FormulaOperator::Comparison(ComparisonOp::StrictEqual) => todo!(), //CompareStrictEqual{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_neq")]
-      FormulaOperator::Comparison(ComparisonOp::NotEqual) => CompareNotEqual{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_sneq")]
-      FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => todo!(), //CompareStrictNotEqual{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_lte")]
-      FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => CompareLessThanEqual{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_gte")]
-      FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => CompareGreaterThanEqual{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_lt")]
-      FormulaOperator::Comparison(ComparisonOp::LessThan) => CompareLessThan{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "compare_gt")]
-      FormulaOperator::Comparison(ComparisonOp::GreaterThan) => CompareGreaterThan{}.compile(&vec![lhs,rhs])?,
+            // Compare
+            #[cfg(feature = "compare_eq")]
+            FormulaOperator::Comparison(ComparisonOp::Equal) => {
+                CompareEqual {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "compare_seq")]
+            FormulaOperator::Comparison(ComparisonOp::StrictEqual) => todo!(), //CompareStrictEqual{}.compile(&vec![lhs,rhs])?,
+            #[cfg(feature = "compare_neq")]
+            FormulaOperator::Comparison(ComparisonOp::NotEqual) => {
+                CompareNotEqual {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "compare_sneq")]
+            FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => todo!(), //CompareStrictNotEqual{}.compile(&vec![lhs,rhs])?,
+            #[cfg(feature = "compare_lte")]
+            FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => {
+                CompareLessThanEqual {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "compare_gte")]
+            FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => {
+                CompareGreaterThanEqual {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "compare_lt")]
+            FormulaOperator::Comparison(ComparisonOp::LessThan) => {
+                CompareLessThan {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "compare_gt")]
+            FormulaOperator::Comparison(ComparisonOp::GreaterThan) => {
+                CompareGreaterThan {}.compile(&vec![lhs, rhs])?
+            }
 
-      // Logic
-      #[cfg(feature = "logic_and")]
-      FormulaOperator::Logic(LogicOp::And) => LogicAnd{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "logic_or")]
-      FormulaOperator::Logic(LogicOp::Or)  => LogicOr{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "logic_not")]
-      FormulaOperator::Logic(LogicOp::Not) => LogicNot{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "logic_xor")]
-      FormulaOperator::Logic(LogicOp::Xor) => LogicXor{}.compile(&vec![lhs,rhs])?,
-      
-      // Table
-      #[cfg(feature = "table")]
-      FormulaOperator::Table(TableOp::InnerJoin) => TableInnerJoin{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "table")]
-      FormulaOperator::Table(TableOp::LeftOuterJoin) => TableLeftOuterJoin{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "table")]
-      FormulaOperator::Table(TableOp::RightOuterJoin) => TableRightOuterJoin{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "table")]
-      FormulaOperator::Table(TableOp::FullOuterJoin) => TableFullOuterJoin{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "table")]
-      FormulaOperator::Table(TableOp::LeftSemiJoin) => TableLeftSemiJoin{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "table")]
-      FormulaOperator::Table(TableOp::LeftAntiJoin) => TableLeftAntiJoin{}.compile(&vec![lhs,rhs])?,
+            // Logic
+            #[cfg(feature = "logic_and")]
+            FormulaOperator::Logic(LogicOp::And) => LogicAnd {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "logic_or")]
+            FormulaOperator::Logic(LogicOp::Or) => LogicOr {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "logic_not")]
+            FormulaOperator::Logic(LogicOp::Not) => LogicNot {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "logic_xor")]
+            FormulaOperator::Logic(LogicOp::Xor) => LogicXor {}.compile(&vec![lhs, rhs])?,
 
-      // Set
-      #[cfg(feature = "set_union")]
-      FormulaOperator::Set(SetOp::Union) => SetUnion{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_intersection")]
-      FormulaOperator::Set(SetOp::Intersection) => SetIntersection{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_difference")]
-      FormulaOperator::Set(SetOp::Difference) => SetDifference{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_symmetric_difference")]
-      FormulaOperator::Set(SetOp::SymmetricDifference) => SetSymmetricDifference{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_complement")]
-      FormulaOperator::Set(SetOp::Complement) => todo!(),
-      #[cfg(feature = "set_subset")]
-      FormulaOperator::Set(SetOp::Subset) => SetSubset{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_superset")]
-      FormulaOperator::Set(SetOp::Superset) => SetSuperset{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_proper_subset")]
-      FormulaOperator::Set(SetOp::ProperSubset) => SetProperSubset{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_proper_superset")]
-      FormulaOperator::Set(SetOp::ProperSuperset) => SetProperSuperset{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_element_of")]
-      FormulaOperator::Set(SetOp::ElementOf) => SetElementOf{}.compile(&vec![lhs,rhs])?,
-      #[cfg(feature = "set_not_element_of")]
-      FormulaOperator::Set(SetOp::NotElementOf) => SetNotElementOf{}.compile(&vec![lhs,rhs])?,
-      x => return Err(MechError::new(
-          UnhandledFormulaOperatorError { operator: x.clone() },
-          None
-        ).with_compiler_loc().with_tokens(trm.tokens())
-      ),
-    };
-    new_fxn.solve();
-    let res = new_fxn.out();
-    term_plan.push(new_fxn);
-    lhs = res;
-  }
-  let mut plan_brrw = plan.borrow_mut();
-  plan_brrw.append(&mut term_plan);
-  return Ok(lhs);
+            // Table
+            #[cfg(feature = "table")]
+            FormulaOperator::Table(TableOp::InnerJoin) => {
+                TableInnerJoin {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "table")]
+            FormulaOperator::Table(TableOp::LeftOuterJoin) => {
+                TableLeftOuterJoin {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "table")]
+            FormulaOperator::Table(TableOp::RightOuterJoin) => {
+                TableRightOuterJoin {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "table")]
+            FormulaOperator::Table(TableOp::FullOuterJoin) => {
+                TableFullOuterJoin {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "table")]
+            FormulaOperator::Table(TableOp::LeftSemiJoin) => {
+                TableLeftSemiJoin {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "table")]
+            FormulaOperator::Table(TableOp::LeftAntiJoin) => {
+                TableLeftAntiJoin {}.compile(&vec![lhs, rhs])?
+            }
+
+            // Set
+            #[cfg(feature = "set_union")]
+            FormulaOperator::Set(SetOp::Union) => SetUnion {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "set_intersection")]
+            FormulaOperator::Set(SetOp::Intersection) => {
+                SetIntersection {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "set_difference")]
+            FormulaOperator::Set(SetOp::Difference) => SetDifference {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "set_symmetric_difference")]
+            FormulaOperator::Set(SetOp::SymmetricDifference) => {
+                SetSymmetricDifference {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "set_complement")]
+            FormulaOperator::Set(SetOp::Complement) => todo!(),
+            #[cfg(feature = "set_subset")]
+            FormulaOperator::Set(SetOp::Subset) => SetSubset {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "set_superset")]
+            FormulaOperator::Set(SetOp::Superset) => SetSuperset {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "set_proper_subset")]
+            FormulaOperator::Set(SetOp::ProperSubset) => {
+                SetProperSubset {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "set_proper_superset")]
+            FormulaOperator::Set(SetOp::ProperSuperset) => {
+                SetProperSuperset {}.compile(&vec![lhs, rhs])?
+            }
+            #[cfg(feature = "set_element_of")]
+            FormulaOperator::Set(SetOp::ElementOf) => SetElementOf {}.compile(&vec![lhs, rhs])?,
+            #[cfg(feature = "set_not_element_of")]
+            FormulaOperator::Set(SetOp::NotElementOf) => {
+                SetNotElementOf {}.compile(&vec![lhs, rhs])?
+            }
+            x => {
+                return Err(MechError::new(
+                    UnhandledFormulaOperatorError {
+                        operator: x.clone(),
+                    },
+                    None,
+                )
+                .with_compiler_loc()
+                .with_tokens(trm.tokens()));
+            }
+        };
+        new_fxn.solve();
+        let res = new_fxn.out();
+        term_plan.push(new_fxn);
+        lhs = res;
+    }
+    let mut plan_brrw = plan.borrow_mut();
+    plan_brrw.append(&mut term_plan);
+    return Ok(lhs);
 }
 
 #[derive(Debug, Clone)]
 pub struct UnhandledFormulaOperatorError {
-  pub operator: FormulaOperator,
+    pub operator: FormulaOperator,
 }
 impl MechErrorKind for UnhandledFormulaOperatorError {
-  fn name(&self) -> &str { "UnhandledFormulaOperator" }
-  fn message(&self) -> String {
-    format!("Unhandled formula operator: {:#?}", self.operator)
-  }
+    fn name(&self) -> &str {
+        "UnhandledFormulaOperator"
+    }
+    fn message(&self) -> String {
+        format!("Unhandled formula operator: {:#?}", self.operator)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct UndefinedVariableError {
-  pub id: u64, 
+    pub id: u64,
 }
 impl MechErrorKind for UndefinedVariableError {
-  fn name(&self) -> &str { "UndefinedVariable" }
+    fn name(&self) -> &str {
+        "UndefinedVariable"
+    }
 
-  fn message(&self) -> String {
-    format!("Undefined variable: {}", self.id)
-  }
+    fn message(&self) -> String {
+        format!("Undefined variable: {}", self.id)
+    }
 }
 #[derive(Debug, Clone)]
 pub struct InvalidIndexKindError {
-  kind: ValueKind,
+    kind: ValueKind,
 }
 impl MechErrorKind for InvalidIndexKindError {
-  fn name(&self) -> &str {
-    "InvalidIndexKind"
-  }
-  fn message(&self) -> String {
-    "Invalid index kind".to_string()
-  }
+    fn name(&self) -> &str {
+        "InvalidIndexKind"
+    }
+    fn message(&self) -> String {
+        "Invalid index kind".to_string()
+    }
 }
 
 #[derive(Debug, Clone)]
-pub struct ComprehensionGeneratorError{
-  found: ValueKind,
+pub struct ComprehensionGeneratorError {
+    found: ValueKind,
 }
 
 impl MechErrorKind for ComprehensionGeneratorError {
-  fn name(&self) -> &str {
-    "ComprehensionGenerator"
-  }
-  fn message(&self) -> String {
-    format!("Comprehension generator must produce a set or matrix, found kind: {:?}", self.found)
-  }
+    fn name(&self) -> &str {
+        "ComprehensionGenerator"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Comprehension generator must produce a set or matrix, found kind: {:?}",
+            self.found
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
-pub struct PatternExpectedTupleError{
-  found: ValueKind,
+pub struct PatternExpectedTupleError {
+    found: ValueKind,
 }
 impl MechErrorKind for PatternExpectedTupleError {
-  fn name(&self) -> &str {
-    "PatternExpectedTuple"
-  }
-  fn message(&self) -> String {
-    format!("Pattern expected a tuple, found kind: {:?}", self.found)
-  }
+    fn name(&self) -> &str {
+        "PatternExpectedTuple"
+    }
+    fn message(&self) -> String {
+        format!("Pattern expected a tuple, found kind: {:?}", self.found)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct ArityMismatchError {
-  expected: usize,
-  found: usize,
+    expected: usize,
+    found: usize,
 }
 impl MechErrorKind for ArityMismatchError {
-  fn name(&self) -> &str {
-    "ArityMismatch"
-  }
-  fn message(&self) -> String {
-    format!("Arity mismatch: expected {}, found {}", self.expected, self.found)
-  }
+    fn name(&self) -> &str {
+        "ArityMismatch"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Arity mismatch: expected {}, found {}",
+            self.expected, self.found
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct PatternMatchError {
-  pub var: String,
-  pub expected: String,
-  pub found: String,
+    pub var: String,
+    pub expected: String,
+    pub found: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct OptionMatchNoArmMatchedError;
 impl MechErrorKind for OptionMatchNoArmMatchedError {
-  fn name(&self) -> &str { "OptionMatchNoArmMatched" }
-  fn message(&self) -> String {
-    format!("No option match arm matched the provided value.")
-  }
+    fn name(&self) -> &str {
+        "OptionMatchNoArmMatched"
+    }
+    fn message(&self) -> String {
+        format!("No option match arm matched the provided value.")
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct OptionMatchArmKindMismatchError {
-  expected: ValueKind,
-  found: ValueKind,
+    expected: ValueKind,
+    found: ValueKind,
 }
 impl MechErrorKind for OptionMatchArmKindMismatchError {
-  fn name(&self) -> &str { "OptionMatchArmKindMismatch" }
-  fn message(&self) -> String {
-    format!(
-      "Option match arm kind mismatch: expected {:?}, found {:?}",
-      self.expected, self.found
-    )
-  }
+    fn name(&self) -> &str {
+        "OptionMatchArmKindMismatch"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Option match arm kind mismatch: expected {:?}, found {:?}",
+            self.expected, self.found
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct OptionMatchNonExhaustiveError;
 impl MechErrorKind for OptionMatchNonExhaustiveError {
-  fn name(&self) -> &str { "OptionMatchNonExhaustive" }
-  fn message(&self) -> String {
-    "Option match must include a wildcard (`*`) arm to handle empty values.".to_string()
-  }
+    fn name(&self) -> &str {
+        "OptionMatchNonExhaustive"
+    }
+    fn message(&self) -> String {
+        "Option match must include a wildcard (`*`) arm to handle empty values.".to_string()
+    }
 }
 
 impl MechErrorKind for PatternMatchError {
-  fn name(&self) -> &str {
-    "PatternMatchError"
-  }
-  fn message(&self) -> String {
-    format!(
-      "Pattern match error for variable '{}': expected value {}, found value {}",
-      self.var, self.expected, self.found
-    )
-  }
+    fn name(&self) -> &str {
+        "PatternMatchError"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Pattern match error for variable '{}': expected value {}, found value {}",
+            self.var, self.expected, self.found
+        )
+    }
 }

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -209,7 +209,12 @@ fn execute_function_match_arms(
 ) -> MResult<Value> {
     for (arm_idx, arm) in fxn_def.code.match_arms.iter().enumerate() {
         let mut env = Environment::new();
-        let matched = pattern_matches_arguments(&arm.pattern, input_arg_values, &mut env, p)?;
+        let matched = crate::patterns::pattern_matches_arguments(
+            &arm.pattern,
+            input_arg_values,
+            &mut env,
+            p,
+        )?;
         trace_println!(p, "{}", {
             let args_summary = summarize_values_with_kinds(input_arg_values);
             let pattern_summary = summarize_pattern(&arm.pattern);
@@ -337,7 +342,11 @@ fn summarize_pattern(pattern: &Pattern) -> String {
         Pattern::Expression(expr) => truncate_for_trace(&format!("{:?}", expr), 72),
         Pattern::Tuple(tuple) => format!("tuple(len={})", tuple.0.len()),
         Pattern::Array(array) => {
-            let spread = if array.spread.is_some() { ",spread" } else { "" };
+            let spread = if array.spread.is_some() {
+                ",spread"
+            } else {
+                ""
+            };
             format!(
                 "array(prefix={}{} ,suffix={})",
                 array.prefix.len(),
@@ -366,239 +375,6 @@ fn truncate_for_trace(text: &str, max_chars: usize) -> String {
 
 fn single_line_trace_text(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn pattern_matches_arguments(
-    pattern: &Pattern,
-    args: &Vec<Value>,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<bool> {
-    if args.len() == 1 {
-        return pattern_matches_value(pattern, &args[0], env, p);
-    }
-    match pattern {
-        Pattern::Tuple(pattern_tuple) => {
-            if pattern_tuple.0.len() != args.len() {
-                return Ok(false);
-            }
-            for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
-                if !pattern_matches_value(pat, arg, env, p)? {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        }
-        _ => Ok(false),
-    }
-}
-
-pub(crate) fn pattern_matches_value(
-    pattern: &Pattern,
-    value: &Value,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<bool> {
-    match pattern {
-        Pattern::Wildcard => Ok(true),
-        Pattern::Tuple(pattern_tuple) => match detach_value(value) {
-            Value::Tuple(tuple) => {
-                let tuple_brrw = tuple.borrow();
-                if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-                    return Ok(false);
-                }
-                for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-                    if !pattern_matches_value(pat, val, env, p)? {
-                        return Ok(false);
-                    }
-                }
-                Ok(true)
-            }
-            _ => Ok(false),
-        },
-        Pattern::Array(pattern_array) => {
-            let detached = detach_value(value);
-            let values = match matrix_like_values(&detached) {
-                Some(values) => values,
-                None => return Ok(false),
-            };
-            if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
-                return Ok(false);
-            }
-
-            for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
-                if !pattern_matches_value(pat, val, env, p)? {
-                    return Ok(false);
-                }
-            }
-
-            let suffix_start = values.len() - pattern_array.suffix.len();
-            for (pat, val) in pattern_array
-                .suffix
-                .iter()
-                .zip(values[suffix_start..].iter())
-            {
-                if !pattern_matches_value(pat, val, env, p)? {
-                    return Ok(false);
-                }
-            }
-
-            if pattern_array.spread.is_none() && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len() {
-                return Ok(false);
-            }
-
-            if let Some(spread) = &pattern_array.spread {
-                if let Some(binding) = &spread.binding {
-                    let middle = values[pattern_array.prefix.len()..suffix_start].to_vec();
-                    #[cfg(feature = "matrix")]
-                    let captured = Value::MatrixValue(Matrix::from_vec(
-                        middle,
-                        1,
-                        suffix_start.saturating_sub(pattern_array.prefix.len()),
-                    ));
-                    #[cfg(not(feature = "matrix"))]
-                    let captured = {
-                        let _ = middle;
-                        return Ok(false);
-                    };
-                    if !pattern_matches_value(binding, &captured, env, p)? {
-                        return Ok(false);
-                    }
-                }
-            }
-
-            Ok(true)
-        }
-        Pattern::Expression(Expression::Var(var)) => {
-            let var_id = var.name.hash();
-            let detached = detach_value(value);
-            if let Some(existing) = env.get(&var_id) {
-                Ok(existing == &detached)
-            } else {
-                env.insert(var_id, detached);
-                Ok(true)
-            }
-        }
-        Pattern::Expression(expr) => {
-            if let Some(var_id) = extract_pattern_variable_id(expr) {
-                let detached = detach_value(value);
-                if let Some(existing) = env.get(&var_id) {
-                    return Ok(existing == &detached);
-                }
-                env.insert(var_id, detached);
-                return Ok(true);
-            }
-            let expected = expression(expr, Some(env), p)?;
-            Ok(values_match(&detach_value(&expected), &detach_value(value)))
-        }
-        Pattern::TupleStruct(pat_struct) => match detach_value(value) {
-            Value::Tuple(tuple) => {
-                let tuple_brrw = tuple.borrow();
-                if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
-                    return Ok(false);
-                }
-                let expected_state = atom(
-                    &Atom {
-                        name: pat_struct.name.clone(),
-                    },
-                    p,
-                );
-                if !values_match(&expected_state, &detach_value(&tuple_brrw.elements[0])) {
-                    return Ok(false);
-                }
-                for (pat, val) in pat_struct
-                    .patterns
-                    .iter()
-                    .zip(tuple_brrw.elements.iter().skip(1))
-                {
-                    if !pattern_matches_value(pat, val, env, p)? {
-                        return Ok(false);
-                    }
-                }
-                Ok(true)
-            }
-            _ => Ok(false),
-        },
-    }
-}
-
-fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
-    match value {
-        #[cfg(feature = "matrix")]
-        Value::MatrixIndex(matrix) => Some(matrix.as_vec().into_iter().map(|value| Value::Index(Ref::new(value))).collect()),
-        #[cfg(all(feature = "matrix", feature = "bool"))]
-        Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u8"))]
-        Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u16"))]
-        Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u32"))]
-        Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u64"))]
-        Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u128"))]
-        Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i8"))]
-        Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i16"))]
-        Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i32"))]
-        Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i64"))]
-        Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i128"))]
-        Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "f32"))]
-        Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "f64"))]
-        Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "string"))]
-        Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "rational"))]
-        Value::MatrixR64(matrix) => Some(matrix.as_vec().into_iter().map(|value| value.to_value()).collect()),
-        #[cfg(all(feature = "matrix", feature = "complex"))]
-        Value::MatrixC64(matrix) => Some(matrix.as_vec().into_iter().map(|value| value.to_value()).collect()),
-        #[cfg(feature = "matrix")]
-        Value::MatrixValue(matrix) => Some(matrix.as_vec()),
-        _ => None,
-    }
-}
-
-fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
-    match expr {
-        Expression::Var(var) => Some(var.name.hash()),
-        Expression::Formula(factor) => match factor {
-            Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
-            Factor::Term(term) if term.rhs.is_empty() => {
-                extract_pattern_variable_id_from_term(&term.lhs)
-            }
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
-    match factor {
-        Factor::Expression(expr) => extract_pattern_variable_id(expr),
-        Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
-        _ => None,
-    }
-}
-
-fn values_match(expected: &Value, actual: &Value) -> bool {
-    if expected == actual {
-        return true;
-    }
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    {
-        match (expected, actual) {
-            (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-            (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-            _ => {}
-        }
-    }
-    false
 }
 
 fn coerce_function_output_kind(

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -596,194 +596,161 @@ impl Interpreter {
     }
 }
 
+// Interpreter Errors
+// ----------------------------------------------------------------------------
+
 #[derive(Debug, Clone)]
 pub struct UnknownInstructionError {
-    pub instr: String,
+  pub instr: String,
 }
 impl MechErrorKind for UnknownInstructionError {
-    fn name(&self) -> &str {
-        "UnknownInstruction"
-    }
+  fn name(&self) -> &str {
+    "UnknownInstruction"
+  }
 
-    fn message(&self) -> String {
-        format!("Unknown instruction: {}", self.instr)
-    }
+  fn message(&self) -> String {
+    format!("Unknown instruction: {}", self.instr)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownVariadicFunctionError {
-    pub fxn_id: u64,
+  pub fxn_id: u64,
 }
 
 impl MechErrorKind for UnknownVariadicFunctionError {
-    fn name(&self) -> &str {
-        "UnknownVariadicFunction"
-    }
-    fn message(&self) -> String {
-        format!("Unknown variadic function ID: {}", self.fxn_id)
-    }
+  fn name(&self) -> &str {
+    "UnknownVariadicFunction"
+  }
+  fn message(&self) -> String {
+    format!("Unknown variadic function ID: {}", self.fxn_id)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownQuadFunctionError {
-    pub fxn_id: u64,
+  pub fxn_id: u64,
 }
 impl MechErrorKind for UnknownQuadFunctionError {
-    fn name(&self) -> &str {
-        "UnknownQuadFunction"
-    }
-    fn message(&self) -> String {
-        format!("Unknown quad function ID: {}", self.fxn_id)
-    }
+  fn name(&self) -> &str {
+    "UnknownQuadFunction"
+  }
+  fn message(&self) -> String {
+    format!("Unknown quad function ID: {}", self.fxn_id)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownTernaryFunctionError {
-    pub fxn_id: u64,
+  pub fxn_id: u64,
 }
 impl MechErrorKind for UnknownTernaryFunctionError {
-    fn name(&self) -> &str {
-        "UnknownTernaryFunction"
-    }
-    fn message(&self) -> String {
-        format!("Unknown ternary function ID: {}", self.fxn_id)
-    }
+  fn name(&self) -> &str {
+    "UnknownTernaryFunction"
+  }
+  fn message(&self) -> String {
+    format!("Unknown ternary function ID: {}", self.fxn_id)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownBinaryFunctionError {
-    pub fxn_id: u64,
+  pub fxn_id: u64,
 }
 impl MechErrorKind for UnknownBinaryFunctionError {
-    fn name(&self) -> &str {
-        "UnknownBinaryFunction"
-    }
-    fn message(&self) -> String {
-        format!("Unknown binary function ID: {}", self.fxn_id)
-    }
+  fn name(&self) -> &str {
+    "UnknownBinaryFunction"
+  }
+  fn message(&self) -> String {
+    format!("Unknown binary function ID: {}", self.fxn_id)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownUnaryFunctionError {
-    pub fxn_id: u64,
+  pub fxn_id: u64,
 }
 impl MechErrorKind for UnknownUnaryFunctionError {
-    fn name(&self) -> &str {
-        "UnknownUnaryFunction"
-    }
-    fn message(&self) -> String {
-        format!("Unknown unary function ID: {}", self.fxn_id)
-    }
+  fn name(&self) -> &str {
+    "UnknownUnaryFunction"
+  }
+  fn message(&self) -> String {
+    format!("Unknown unary function ID: {}", self.fxn_id)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownNullaryFunctionError {
-    pub fxn_id: u64,
+  pub fxn_id: u64,
 }
 impl MechErrorKind for UnknownNullaryFunctionError {
-    fn name(&self) -> &str {
-        "UnknownNullaryFunction"
-    }
-    fn message(&self) -> String {
-        format!("Unknown nullary function ID: {}", self.fxn_id)
-    }
+  fn name(&self) -> &str {
+    "UnknownNullaryFunction"
+  }
+  fn message(&self) -> String {
+    format!("Unknown nullary function ID: {}", self.fxn_id)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct IndexOutOfBoundsError;
 impl MechErrorKind for IndexOutOfBoundsError {
-    fn name(&self) -> &str {
-        "IndexOutOfBounds"
-    }
-    fn message(&self) -> String {
-        "Index out of bounds".to_string()
-    }
+  fn name(&self) -> &str {
+    "IndexOutOfBounds"
+  }
+  fn message(&self) -> String {
+    "Index out of bounds".to_string()
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct OverflowSubtractionError;
 impl MechErrorKind for OverflowSubtractionError {
-    fn name(&self) -> &str {
-        "OverflowSubtraction"
-    }
-    fn message(&self) -> String {
-        "Attempted subtraction overflow".to_string()
-    }
+  fn name(&self) -> &str {
+    "OverflowSubtraction"
+  }
+  fn message(&self) -> String {
+    "Attempted subtraction overflow".to_string()
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnknownPanicError {
-    pub details: String,
+  pub details: String,
 }
 impl MechErrorKind for UnknownPanicError {
-    fn name(&self) -> &str {
-        "UnknownPanic"
-    }
-    fn message(&self) -> String {
-        self.details.clone()
-    }
+  fn name(&self) -> &str {
+    "UnknownPanic"
+  }
+  fn message(&self) -> String {
+    self.details.clone()
+  }
 }
 
 #[derive(Debug, Clone)]
 struct StepIndexOutOfBoundsError {
-    pub step_id: usize,
-    pub plan_length: usize,
+  pub step_id: usize,
+  pub plan_length: usize,
 }
 impl MechErrorKind for StepIndexOutOfBoundsError {
-    fn name(&self) -> &str {
-        "StepIndexOutOfBounds"
-    }
-    fn message(&self) -> String {
-        format!(
-            "Step id {} out of range (plan has {} steps)",
-            self.step_id, self.plan_length
-        )
-    }
+  fn name(&self) -> &str {
+    "StepIndexOutOfBounds"
+  }
+  fn message(&self) -> String {
+    format!(
+      "Step id {} out of range (plan has {} steps)",
+      self.step_id, self.plan_length
+    )
+  }
 }
 
 #[derive(Debug, Clone)]
 struct NoStepsInPlanError;
 impl MechErrorKind for NoStepsInPlanError {
-    fn name(&self) -> &str {
-        "NoStepsInPlan"
-    }
-    fn message(&self) -> String {
-        "Plan contains no steps. This program doesn't do anything.".to_string()
-    }
-}
-
-fn format_duration(d: Duration) -> String {
-    let ns = d.as_nanos();
-    if ns < 1_000 {
-        format!("{}ns", ns)
-    } else if ns < 1_000_000 {
-        format!("{:.2}µs", ns as f64 / 1_000.0)
-    } else if ns < 1_000_000_000 {
-        format!("{:.2}ms", ns as f64 / 1_000_000.0)
-    } else {
-        format!("{:.2}s", ns as f64 / 1_000_000_000.0)
-    }
-}
-
-fn print_histogram(total_durations: &[Duration]) {
-    let max_duration = total_durations
-        .iter()
-        .cloned()
-        .max()
-        .unwrap_or(Duration::ZERO);
-    let max_bar_len = 50; // max characters for the bar
-
-    println!("{:>5}  {:>10}  {}", "#", "Time", "Histogram");
-    println!("-----------------------------------------------");
-
-    for (idx, dur) in total_durations.iter().enumerate() {
-        let bar_len = if max_duration.as_nanos() == 0 {
-            0
-        } else {
-            ((dur.as_nanos() * max_bar_len as u128) / max_duration.as_nanos()) as usize
-        };
-        let bar = std::iter::repeat('░').take(bar_len).collect::<String>();
-
-        println!("{:>5}  {:>10}  {}", idx, format_duration(*dur), bar);
-    }
+  fn name(&self) -> &str {
+    "NoStepsInPlan"
+  }
+  fn message(&self) -> String {
+    "Plan contains no steps. This program doesn't do anything.".to_string()
+  }
 }

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -111,52 +111,52 @@ impl Interpreter {
 
     #[cfg(feature = "pretty_print")]
     pub fn pretty_print(&self) -> String {
-        let mut output = String::new();
-        output.push_str(&format!("Interpreter ID: {}\n", self.id));
-        // print state
-        output.push_str(&self.state.borrow().pretty_print());
+      let mut output = String::new();
+      output.push_str(&format!("Interpreter ID: {}\n", self.id));
+      // print state
+      output.push_str(&self.state.borrow().pretty_print());
 
-        output.push_str("Registers:\n");
-        for (i, reg) in self.registers.iter().enumerate() {
-            output.push_str(&format!("  R{}: {}\n", i, reg));
-        }
-        output.push_str("Constants:\n");
-        for (i, constant) in self.constants.iter().enumerate() {
-            output.push_str(&format!("  C{}: {}\n", i, constant));
-        }
-        output.push_str(&format!("Output Value: {}\n", self.out));
-        output.push_str(&format!(
-            "Number of Sub-Interpreters: {}\n",
-            self.sub_interpreters.borrow().len()
-        ));
-        output.push_str("Output Values:\n");
-        for (key, value) in self.out_values.borrow().iter() {
-            output.push_str(&format!("  {}: {}\n", key, value));
-        }
-        output.push_str(&format!("Code Length: {}\n", self.code.len()));
-        #[cfg(feature = "compiler")]
-        if let Some(context) = &self.context {
-            output.push_str("Context: Exists\n");
-        } else {
-            output.push_str("Context: None\n");
-        }
-        output
+      output.push_str("Registers:\n");
+      for (i, reg) in self.registers.iter().enumerate() {
+        output.push_str(&format!("  R{}: {}\n", i, reg));
+      }
+      output.push_str("Constants:\n");
+      for (i, constant) in self.constants.iter().enumerate() {
+        output.push_str(&format!("  C{}: {}\n", i, constant));
+      }
+      output.push_str(&format!("Output Value: {}\n", self.out));
+      output.push_str(&format!(
+        "Number of Sub-Interpreters: {}\n",
+        self.sub_interpreters.borrow().len()
+      ));
+      output.push_str("Output Values:\n");
+      for (key, value) in self.out_values.borrow().iter() {
+        output.push_str(&format!("  {}: {}\n", key, value));
+      }
+      output.push_str(&format!("Code Length: {}\n", self.code.len()));
+      #[cfg(feature = "compiler")]
+      if let Some(context) = &self.context {
+        output.push_str("Context: Exists\n");
+      } else {
+        output.push_str("Context: None\n");
+      }
+      output
     }
 
     pub fn clear(&mut self) {
-        let id = self.id;
-        *self = Interpreter::new(id);
+      let id = self.id;
+      *self = Interpreter::new(id);
     }
 
     pub fn set_trace_enabled(&mut self, enabled: bool) {
-        #[cfg(feature = "trace")]
-        {
-            self.trace = enabled;
-        }
-        #[cfg(not(feature = "trace"))]
-        {
-            let _ = enabled;
-        }
+      #[cfg(feature = "trace")]
+      {
+        self.trace = enabled;
+      }
+      #[cfg(not(feature = "trace"))]
+      {
+        let _ = enabled;
+      }
     }
 
     #[cfg(feature = "trace")]

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -11,28 +11,29 @@ use std::time::Instant;
 // ----------------------------------------------------------------------------
 
 pub struct Interpreter {
-    pub id: u64,
-    pub profile: bool,
-    #[cfg(feature = "trace")]
-    pub trace: bool,
-    #[cfg(feature = "trace")]
-    pub trace_to_stdout: bool,
-    #[cfg(feature = "trace")]
-    pub trace_events: Ref<Vec<TraceEvent>>,
-    ip: usize, // instruction pointer
-    pub state: Ref<ProgramState>,
-    #[cfg(feature = "functions")]
-    pub stack: Vec<Frame>,
-    registers: Vec<Value>,
-    constants: Vec<Value>,
-    #[cfg(feature = "compiler")]
-    pub context: Option<CompileCtx>,
-    pub code: Vec<MechSourceCode>,
-    pub out: Value,
-    pub out_values: Ref<HashMap<u64, Value>>,
-    #[cfg(feature = "state_machines")]
-    pub user_state_machines: Ref<HashMap<u64, FsmImplementation>>,
-    pub sub_interpreters: Ref<HashMap<u64, Box<Interpreter>>>,
+  pub id: u64,
+  pub profile: bool,
+  pub max_steps: usize,
+  #[cfg(feature = "trace")]
+  pub trace: bool,
+  #[cfg(feature = "trace")]
+  pub trace_to_stdout: bool,
+  #[cfg(feature = "trace")]
+  pub trace_events: Ref<Vec<TraceEvent>>,
+  ip: usize, // instruction pointer
+  pub state: Ref<ProgramState>,
+  #[cfg(feature = "functions")]
+  pub stack: Vec<Frame>,
+  registers: Vec<Value>,
+  constants: Vec<Value>,
+  #[cfg(feature = "compiler")]
+  pub context: Option<CompileCtx>,
+  pub code: Vec<MechSourceCode>,
+  pub out: Value,
+  pub out_values: Ref<HashMap<u64, Value>>,
+  #[cfg(feature = "state_machines")]
+  pub user_state_machines: Ref<HashMap<u64, FsmImplementation>>,
+  pub sub_interpreters: Ref<HashMap<u64, Box<Interpreter>>>,
 }
 
 impl Clone for Interpreter {
@@ -41,6 +42,7 @@ impl Clone for Interpreter {
             id: self.id,
             ip: self.ip,
             profile: false,
+            max_steps: self.max_steps,
             #[cfg(feature = "trace")]
             trace: self.trace,
             #[cfg(feature = "trace")]
@@ -74,6 +76,7 @@ impl Interpreter {
             id,
             ip: 0,
             profile: false,
+            max_steps: 10_00000, // Default maximum steps
             #[cfg(feature = "trace")]
             trace: false,
             #[cfg(feature = "trace")]

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -375,225 +375,205 @@ impl Interpreter {
         })?
     }
 
-    #[cfg(feature = "program")]
-    pub fn run_program(&mut self, program: &ParsedProgram) -> MResult<Value> {
-        // Reset the instruction pointer
-        self.ip = 0;
-        // Resize the registers and constant table
-        self.registers = vec![Value::Empty; program.header.reg_count as usize];
-        self.constants = vec![Value::Empty; program.const_entries.len()];
-        // Load the constants
-        self.constants = program.decode_const_entries()?;
-        // Load the symbol table
-        {
-            let mut state_brrw = self.state.borrow_mut();
-            let mut symbol_table = state_brrw.symbol_table.borrow_mut();
-            for (id, reg) in program.symbols.iter() {
-                let constant = self.constants[*reg as usize].clone();
-                self.out = constant.clone();
-                let mutable = program.mutable_symbols.contains(id);
-                symbol_table.insert(*id, constant, mutable);
-            }
-        }
-        // Load the instructions
-        {
-            let state_brrw = self.state.borrow();
-            let functions_table = state_brrw.functions.borrow();
-            while self.ip < program.instrs.len() {
-                let instr = &program.instrs[self.ip];
-                match instr {
-                    DecodedInstr::ConstLoad { dst, const_id } => {
-                        let value = self.constants[*const_id as usize].clone();
-                        self.registers[*dst as usize] = value;
-                    }
-                    DecodedInstr::NullOp { fxn_id, dst } => {
-                        match functions_table.functions.get(fxn_id) {
-                            Some(fxn_factory) => {
-                                let out = &self.registers[*dst as usize];
-                                let fxn = fxn_factory(FunctionArgs::Nullary(out.clone()))?;
-                                self.out = fxn.out().clone();
-                                state_brrw.add_plan_step(fxn);
-                            }
-                            None => {
-                                return Err(MechError::new(
-                                    UnknownNullaryFunctionError { fxn_id: *fxn_id },
-                                    None,
-                                )
-                                .with_compiler_loc());
-                            }
-                        }
-                    }
-                    DecodedInstr::UnOp { fxn_id, dst, src } => {
-                        match functions_table.functions.get(fxn_id) {
-                            Some(fxn_factory) => {
-                                let src = &self.registers[*src as usize];
-                                let out = &self.registers[*dst as usize];
-                                let fxn =
-                                    fxn_factory(FunctionArgs::Unary(out.clone(), src.clone()))?;
-                                self.out = fxn.out().clone();
-                                state_brrw.add_plan_step(fxn);
-                            }
-                            None => {
-                                return Err(MechError::new(
-                                    UnknownUnaryFunctionError { fxn_id: *fxn_id },
-                                    None,
-                                )
-                                .with_compiler_loc());
-                            }
-                        }
-                    }
-                    DecodedInstr::BinOp {
-                        fxn_id,
-                        dst,
-                        lhs,
-                        rhs,
-                    } => match functions_table.functions.get(fxn_id) {
-                        Some(fxn_factory) => {
-                            let lhs = &self.registers[*lhs as usize];
-                            let rhs = &self.registers[*rhs as usize];
-                            let out = &self.registers[*dst as usize];
-                            let fxn = fxn_factory(FunctionArgs::Binary(
-                                out.clone(),
-                                lhs.clone(),
-                                rhs.clone(),
-                            ))?;
-                            self.out = fxn.out().clone();
-                            state_brrw.add_plan_step(fxn);
-                        }
-                        None => {
-                            return Err(MechError::new(
-                                UnknownBinaryFunctionError { fxn_id: *fxn_id },
-                                None,
-                            )
-                            .with_compiler_loc());
-                        }
-                    },
-                    DecodedInstr::TernOp {
-                        fxn_id,
-                        dst,
-                        a,
-                        b,
-                        c,
-                    } => match functions_table.functions.get(fxn_id) {
-                        Some(fxn_factory) => {
-                            let arg1 = &self.registers[*a as usize];
-                            let arg2 = &self.registers[*b as usize];
-                            let arg3 = &self.registers[*c as usize];
-                            let out = &self.registers[*dst as usize];
-                            let fxn = fxn_factory(FunctionArgs::Ternary(
-                                out.clone(),
-                                arg1.clone(),
-                                arg2.clone(),
-                                arg3.clone(),
-                            ))?;
-                            self.out = fxn.out().clone();
-                            state_brrw.add_plan_step(fxn);
-                        }
-                        None => {
-                            return Err(MechError::new(
-                                UnknownTernaryFunctionError { fxn_id: *fxn_id },
-                                None,
-                            )
-                            .with_compiler_loc());
-                        }
-                    },
-                    DecodedInstr::QuadOp {
-                        fxn_id,
-                        dst,
-                        a,
-                        b,
-                        c,
-                        d,
-                    } => match functions_table.functions.get(fxn_id) {
-                        Some(fxn_factory) => {
-                            let arg1 = &self.registers[*a as usize];
-                            let arg2 = &self.registers[*b as usize];
-                            let arg3 = &self.registers[*c as usize];
-                            let arg4 = &self.registers[*d as usize];
-                            let out = &self.registers[*dst as usize];
-                            let fxn = fxn_factory(FunctionArgs::Quaternary(
-                                out.clone(),
-                                arg1.clone(),
-                                arg2.clone(),
-                                arg3.clone(),
-                                arg4.clone(),
-                            ))?;
-                            self.out = fxn.out().clone();
-                            state_brrw.add_plan_step(fxn);
-                        }
-                        None => {
-                            return Err(MechError::new(
-                                UnknownQuadFunctionError { fxn_id: *fxn_id },
-                                None,
-                            )
-                            .with_compiler_loc());
-                        }
-                    },
-                    DecodedInstr::VarArg { fxn_id, dst, args } => {
-                        match functions_table.functions.get(fxn_id) {
-                            Some(fxn_factory) => {
-                                let arg_values: Vec<Value> = args
-                                    .iter()
-                                    .map(|r| self.registers[*r as usize].clone())
-                                    .collect();
-                                let out = &self.registers[*dst as usize];
-                                let fxn =
-                                    fxn_factory(FunctionArgs::Variadic(out.clone(), arg_values))?;
-                                self.out = fxn.out().clone();
-                                state_brrw.add_plan_step(fxn);
-                            }
-                            None => {
-                                return Err(MechError::new(
-                                    UnknownVariadicFunctionError { fxn_id: *fxn_id },
-                                    None,
-                                )
-                                .with_compiler_loc());
-                            }
-                        }
-                    }
-                    DecodedInstr::Ret { src } => {
-                        todo!();
-                    }
-                    x => {
-                        return Err(MechError::new(
-                            UnknownInstructionError {
-                                instr: format!("{:?}", x),
-                            },
-                            None,
-                        )
-                        .with_compiler_loc());
-                    }
-                }
-                self.ip += 1;
-            }
-        }
-        // Load the dictionary
-        {
-            let mut state_brrw = self.state.borrow_mut();
-            let mut symbol_table = state_brrw.symbol_table.borrow_mut();
-            for (id, name) in &program.dictionary {
-                symbol_table
-                    .dictionary
-                    .borrow_mut()
-                    .insert(*id, name.clone());
-                state_brrw.dictionary.borrow_mut().insert(*id, name.clone());
-            }
-        }
-        Ok(self.out.clone())
+  #[cfg(feature = "program")]
+  pub fn run_program(&mut self, program: &ParsedProgram) -> MResult<Value> {
+    // Reset the instruction pointer
+    self.ip = 0;
+    // Resize the registers and constant table
+    self.registers = vec![Value::Empty; program.header.reg_count as usize];
+    self.constants = vec![Value::Empty; program.const_entries.len()];
+    // Load the constants
+    self.constants = program.decode_const_entries()?;
+    // Load the symbol table
+    {
+      let mut state_brrw = self.state.borrow_mut();
+      let mut symbol_table = state_brrw.symbol_table.borrow_mut();
+      for (id, reg) in program.symbols.iter() {
+        let constant = self.constants[*reg as usize].clone();
+        self.out = constant.clone();
+        let mutable = program.mutable_symbols.contains(id);
+        symbol_table.insert(*id, constant, mutable);
+      }
     }
+    // Load the instructions
+    {
+      let state_brrw = self.state.borrow();
+      let functions_table = state_brrw.functions.borrow();
+      while self.ip < program.instrs.len() {
+        let instr = &program.instrs[self.ip];
+        match instr {
+          DecodedInstr::ConstLoad { dst, const_id } => {
+            let value = self.constants[*const_id as usize].clone();
+            self.registers[*dst as usize] = value;
+          }
+          DecodedInstr::NullOp { fxn_id, dst } => {
+            match functions_table.functions.get(fxn_id) {
+              Some(fxn_factory) => {
+                let out = &self.registers[*dst as usize];
+                let fxn = fxn_factory(FunctionArgs::Nullary(out.clone()))?;
+                self.out = fxn.out().clone();
+                state_brrw.add_plan_step(fxn);
+              }
+              None => {
+                return Err(MechError::new(
+                  UnknownNullaryFunctionError { fxn_id: *fxn_id },
+                  None,
+                )
+                .with_compiler_loc());
+              }
+            }
+          }
+          DecodedInstr::UnOp { fxn_id, dst, src } => {
+            match functions_table.functions.get(fxn_id) {
+              Some(fxn_factory) => {
+                let src = &self.registers[*src as usize];
+                let out = &self.registers[*dst as usize];
+                let fxn =
+                    fxn_factory(FunctionArgs::Unary(out.clone(), src.clone()))?;
+                self.out = fxn.out().clone();
+                state_brrw.add_plan_step(fxn);
+              }
+              None => {
+                return Err(MechError::new(
+                  UnknownUnaryFunctionError { fxn_id: *fxn_id },
+                  None,
+                )
+                .with_compiler_loc());
+              }
+            }
+          }
+          DecodedInstr::BinOp { fxn_id, dst, lhs, rhs } => 
+          match functions_table.functions.get(fxn_id) {
+            Some(fxn_factory) => {
+              let lhs = &self.registers[*lhs as usize];
+              let rhs = &self.registers[*rhs as usize];
+              let out = &self.registers[*dst as usize];
+              let fxn = fxn_factory(FunctionArgs::Binary(out.clone(),lhs.clone(),rhs.clone()))?;
+              self.out = fxn.out().clone();
+              state_brrw.add_plan_step(fxn);
+            }
+            None => {
+              return Err(MechError::new(
+                UnknownBinaryFunctionError { fxn_id: *fxn_id },
+                None,
+              )
+              .with_compiler_loc());
+            }
+          },
+          DecodedInstr::TernOp {fxn_id,dst,a,b,c} => 
+          match functions_table.functions.get(fxn_id) {
+            Some(fxn_factory) => {
+              let arg1 = &self.registers[*a as usize];
+              let arg2 = &self.registers[*b as usize];
+              let arg3 = &self.registers[*c as usize];
+              let out = &self.registers[*dst as usize];
+              let fxn = fxn_factory(FunctionArgs::Ternary(
+                out.clone(),
+                arg1.clone(),
+                arg2.clone(),
+                arg3.clone(),
+              ))?;
+              self.out = fxn.out().clone();
+              state_brrw.add_plan_step(fxn);
+            }
+            None => {
+              return Err(MechError::new(
+                UnknownTernaryFunctionError { fxn_id: *fxn_id },
+                None,
+              )
+              .with_compiler_loc());
+            }
+          },
+          DecodedInstr::QuadOp {fxn_id,dst,a,b,c,d } => 
+            match functions_table.functions.get(fxn_id) {
+              Some(fxn_factory) => {
+                let arg1 = &self.registers[*a as usize];
+                let arg2 = &self.registers[*b as usize];
+                let arg3 = &self.registers[*c as usize];
+                let arg4 = &self.registers[*d as usize];
+                let out = &self.registers[*dst as usize];
+                let fxn = fxn_factory(FunctionArgs::Quaternary(
+                    out.clone(),
+                    arg1.clone(),
+                    arg2.clone(),
+                    arg3.clone(),
+                    arg4.clone(),
+                ))?;
+                self.out = fxn.out().clone();
+                state_brrw.add_plan_step(fxn);
+              }
+              None => {
+                return Err(MechError::new(
+                  UnknownQuadFunctionError { fxn_id: *fxn_id },
+                  None,
+                )
+                .with_compiler_loc());
+              }
+          },
+          DecodedInstr::VarArg { fxn_id, dst, args } => {
+            match functions_table.functions.get(fxn_id) {
+              Some(fxn_factory) => {
+                let arg_values: Vec<Value> = args
+                  .iter()
+                  .map(|r| self.registers[*r as usize].clone())
+                  .collect();
+                let out = &self.registers[*dst as usize];
+                let fxn = fxn_factory(FunctionArgs::Variadic(out.clone(), arg_values))?;
+                self.out = fxn.out().clone();
+                state_brrw.add_plan_step(fxn);
+              }
+              None => {
+                return Err(MechError::new(
+                  UnknownVariadicFunctionError { fxn_id: *fxn_id },
+                  None,
+                )
+                .with_compiler_loc());
+              }
+            }
+          }
+          DecodedInstr::Ret { src } => {
+            todo!();
+          }
+          x => {
+            return Err(MechError::new(
+              UnknownInstructionError {
+                instr: format!("{:?}", x),
+              },
+              None,
+            )
+            .with_compiler_loc());
+          }
+        }
+        self.ip += 1;
+      }
+    }
+    // Load the dictionary
+    {
+      let mut state_brrw = self.state.borrow_mut();
+      let mut symbol_table = state_brrw.symbol_table.borrow_mut();
+      for (id, name) in &program.dictionary {
+        symbol_table
+            .dictionary
+            .borrow_mut()
+            .insert(*id, name.clone());
+        state_brrw.dictionary.borrow_mut().insert(*id, name.clone());
+      }
+    }
+    Ok(self.out.clone())
+  }
 
-    #[cfg(feature = "compiler")]
-    pub fn compile(&mut self) -> MResult<Vec<u8>> {
-        let state_brrw = self.state.borrow();
-        let mut plan_brrw = state_brrw.plan.borrow_mut();
-        let mut ctx = CompileCtx::new();
-        for step in plan_brrw.iter() {
-            step.compile(&mut ctx)?;
-        }
-        let bytes = ctx.compile()?;
-        self.context = Some(ctx);
-        Ok(bytes)
+  #[cfg(feature = "compiler")]
+  pub fn compile(&mut self) -> MResult<Vec<u8>> {
+    let state_brrw = self.state.borrow();
+    let mut plan_brrw = state_brrw.plan.borrow_mut();
+    let mut ctx = CompileCtx::new();
+    for step in plan_brrw.iter() {
+        step.compile(&mut ctx)?;
     }
+    let bytes = ctx.compile()?;
+    self.context = Some(ctx);
+    Ok(bytes)
+  }
 }
 
 // Interpreter Errors

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -23,7 +23,7 @@ macro_rules! trace_println {
 #[cfg(not(feature = "trace"))]
 #[macro_export]
 macro_rules! trace_println {
-    ($interpreter:expr, $($arg:tt)*) => {};
+  ($interpreter:expr, $($arg:tt)*) => {};
 }
 
 #[cfg(feature = "functions")]
@@ -155,48 +155,84 @@ pub use mech_set::*;
 pub use mech_stats::*;
 
 pub fn load_stdkinds(kinds: &mut KindTable) {
-    #[cfg(feature = "u8")]
-    kinds.insert(hash_str("u8"), ValueKind::U8);
-    #[cfg(feature = "u16")]
-    kinds.insert(hash_str("u16"), ValueKind::U16);
-    #[cfg(feature = "u32")]
-    kinds.insert(hash_str("u32"), ValueKind::U32);
-    #[cfg(feature = "u64")]
-    kinds.insert(hash_str("u64"), ValueKind::U64);
-    #[cfg(feature = "u128")]
-    kinds.insert(hash_str("u128"), ValueKind::U128);
-    #[cfg(feature = "i8")]
-    kinds.insert(hash_str("i8"), ValueKind::I8);
-    #[cfg(feature = "i16")]
-    kinds.insert(hash_str("i16"), ValueKind::I16);
-    #[cfg(feature = "i32")]
-    kinds.insert(hash_str("i32"), ValueKind::I32);
-    #[cfg(feature = "i64")]
-    kinds.insert(hash_str("i64"), ValueKind::I64);
-    #[cfg(feature = "i128")]
-    kinds.insert(hash_str("i128"), ValueKind::I128);
-    #[cfg(feature = "f32")]
-    kinds.insert(hash_str("f32"), ValueKind::F32);
-    #[cfg(feature = "f64")]
-    kinds.insert(hash_str("f64"), ValueKind::F64);
-    #[cfg(feature = "c64")]
-    kinds.insert(hash_str("c64"), ValueKind::C64);
-    #[cfg(feature = "r64")]
-    kinds.insert(hash_str("r64"), ValueKind::R64);
-    #[cfg(feature = "string")]
-    kinds.insert(hash_str("string"), ValueKind::String);
-    #[cfg(feature = "bool")]
-    kinds.insert(hash_str("bool"), ValueKind::Bool);
+  #[cfg(feature = "u8")]
+  kinds.insert(hash_str("u8"), ValueKind::U8);
+  #[cfg(feature = "u16")]
+  kinds.insert(hash_str("u16"), ValueKind::U16);
+  #[cfg(feature = "u32")]
+  kinds.insert(hash_str("u32"), ValueKind::U32);
+  #[cfg(feature = "u64")]
+  kinds.insert(hash_str("u64"), ValueKind::U64);
+  #[cfg(feature = "u128")]
+  kinds.insert(hash_str("u128"), ValueKind::U128);
+  #[cfg(feature = "i8")]
+  kinds.insert(hash_str("i8"), ValueKind::I8);
+  #[cfg(feature = "i16")]
+  kinds.insert(hash_str("i16"), ValueKind::I16);
+  #[cfg(feature = "i32")]
+  kinds.insert(hash_str("i32"), ValueKind::I32);
+  #[cfg(feature = "i64")]
+  kinds.insert(hash_str("i64"), ValueKind::I64);
+  #[cfg(feature = "i128")]
+  kinds.insert(hash_str("i128"), ValueKind::I128);
+  #[cfg(feature = "f32")]
+  kinds.insert(hash_str("f32"), ValueKind::F32);
+  #[cfg(feature = "f64")]
+  kinds.insert(hash_str("f64"), ValueKind::F64);
+  #[cfg(feature = "c64")]
+  kinds.insert(hash_str("c64"), ValueKind::C64);
+  #[cfg(feature = "r64")]
+  kinds.insert(hash_str("r64"), ValueKind::R64);
+  #[cfg(feature = "string")]
+  kinds.insert(hash_str("string"), ValueKind::String);
+  #[cfg(feature = "bool")]
+  kinds.insert(hash_str("bool"), ValueKind::Bool);
 }
 
 #[cfg(feature = "functions")]
 pub fn load_stdlib(fxns: &mut Functions) {
-    for fxn_desc in inventory::iter::<FunctionDescriptor> {
-        fxns.insert_function(fxn_desc.clone());
-    }
+  for fxn_desc in inventory::iter::<FunctionDescriptor> {
+    fxns.insert_function(fxn_desc.clone());
+  }
 
-    for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
-        fxns.function_compilers
-            .insert(hash_str(fxn_comp.name), fxn_comp.ptr);
-    }
+  for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
+    fxns.function_compilers
+      .insert(hash_str(fxn_comp.name), fxn_comp.ptr);
+  }
+}
+
+fn format_duration(d: Duration) -> String {
+  let ns = d.as_nanos();
+  if ns < 1_000 {
+    format!("{}ns", ns)
+  } else if ns < 1_000_000 {
+    format!("{:.2}µs", ns as f64 / 1_000.0)
+  } else if ns < 1_000_000_000 {
+    format!("{:.2}ms", ns as f64 / 1_000_000.0)
+  } else {
+    format!("{:.2}s", ns as f64 / 1_000_000_000.0)
+  }
+}
+
+fn print_histogram(total_durations: &[Duration]) {
+  let max_duration = total_durations
+    .iter()
+    .cloned()
+    .max()
+    .unwrap_or(Duration::ZERO);
+  let max_bar_len = 50; // max characters for the bar
+
+  println!("{:>5}  {:>10}  {}", "#", "Time", "Histogram");
+  println!("-----------------------------------------------");
+
+  for (idx, dur) in total_durations.iter().enumerate() {
+    let bar_len = if max_duration.as_nanos() == 0 {
+        0
+    } else {
+        ((dur.as_nanos() * max_bar_len as u128) / max_duration.as_nanos()) as usize
+    };
+    let bar = std::iter::repeat('░').take(bar_len).collect::<String>();
+
+    println!("{:>5}  {:>10}  {}", idx, format_duration(*dur), bar);
+  }
 }

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -93,6 +93,7 @@ use indexmap::map::IndexMap;
 use indexmap::set::IndexSet;
 #[cfg(feature = "matrix")]
 use na::DMatrix;
+use std::time::Duration;
 
 pub mod expressions;
 #[cfg(feature = "functions")]

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -102,6 +102,7 @@ pub mod functions;
 pub mod interpreter;
 pub mod literals;
 pub mod mechdown;
+pub mod patterns;
 #[cfg(feature = "state_machines")]
 pub mod state_machines;
 pub mod statements;
@@ -119,6 +120,7 @@ pub use crate::functions::*;
 pub use crate::interpreter::*;
 pub use crate::literals::*;
 pub use crate::mechdown::*;
+pub use crate::patterns::*;
 #[cfg(feature = "state_machines")]
 pub use crate::state_machines::*;
 pub use crate::statements::*;

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -3,12 +3,23 @@ use crate::*;
 // Patterns
 // ----------------------------------------------------------------------------
 
+// Implements pattern matching. Handles matching runtime Values against 
+// Pattern AST nodes, binding variables into an Environment. 
+ 
+// Supports destructuring of tuples, arrays/matrices, and tagged tuple-structs, 
+// and reconstructing values from patterns.
+
+// Used by functinos, state machines, and option guards.
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PatternMatchSemantics {
-    Standard,
-    OptionGuard,
+  Standard,     // Standard semantics: pattern expressions are evaluated once and compared to the value.
+  OptionGuard,  // Option guard semantics: pattern expressions are evaluated for each value and must evaluate to true for all to match.
 }
 
+// Entry point for multi-argument dispatch. When a function is called with 
+// multiple arguments, this wraps them as if they were a tuple and delegates 
+// to pattern_matches_value.
 pub fn pattern_matches_arguments(pattern: &Pattern, args: &Vec<Value>, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
   if args.len() == 1 {
     return pattern_matches_value(pattern, &args[0], env, p);
@@ -33,6 +44,13 @@ pub fn pattern_matches_value(pattern: &Pattern, value: &Value, env: &mut Environ
   pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
 }
 
+// Takes a semantics mode. Dispatches on pattern kind:
+// Wildcard - always succeeds, binds nothing.
+// - Tuple - recursively matches element-wise against a Value::Tuple, requiring equal arity.
+// - Array - matches prefix and suffix element-wise against any matrix-like value, with optional spread binding (...) for the middle slice.
+// - Expression(Var()) - if the variable is already in the environment, checks equality (used for repeated variable patterns).
+// - Expression(other) - attempts to extract a variable id from more complex expression wrappers (parentheticals, single-term formulas) and handles them like Var.
+// - TupleStruct - matches a tagged tuple
 pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter, semantics: PatternMatchSemantics) -> MResult<bool> {
   let detached_value = deep_detach_value(value);
   match pattern {
@@ -96,10 +114,6 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
             1,
             suffix_start.saturating_sub(pattern_array.prefix.len()),
           ));
-          let captured = {
-            let _ = middle;
-            return Ok(false);
-          };
           if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
           {
             return Ok(false);
@@ -165,6 +179,10 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
   }
 }
 
+
+// Collects all variable ids introduced by a pattern (via 
+// collect_pattern_variable_ids) and removes them from the environment. Used 
+// to undo bindings when a pattern arm fails or needs to be retried.
 pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
   let mut ids = Vec::new();
   collect_pattern_variable_ids(pattern, &mut ids);
@@ -173,6 +191,8 @@ pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
   }
 }
 
+
+// Reconstructs a Value from a pattern using the current environment. This is the inverse of matching. used to extract or re-emit bound values.
 pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
   match pattern {
     Pattern::Wildcard => Ok(Value::Empty),
@@ -219,6 +239,9 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
   }
 }
 
+// Mutable reference unwrapper. Recursively follows Value::MutableReference 
+// chains until it reaches a plain value, then clones it. Ensures the pattern 
+// matcher always works on an owned, non-reference value.
 fn deep_detach_value(value: &Value) -> Value {
   match value {
     Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
@@ -226,6 +249,10 @@ fn deep_detach_value(value: &Value) -> Value {
   }
 }
 
+// Variable id harvester. Recursively walks a pattern and pushes the hashed ids 
+// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples, 
+// arrays (including spread bindings), and tuple-structs. Used by 
+// clear_pattern_bindings.
 fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
   match pattern {
     Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
@@ -259,6 +286,7 @@ fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
   }
 }
 
+// Used by the Array pattern arm to get a uniform element list regardless of the matrix's concrete numeric type.
 fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
   match value {
     #[cfg(feature = "matrix")]
@@ -339,6 +367,7 @@ fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
   }
 }
 
+// TODO: This needs to be expanded to handle all types.
 fn values_match(expected: &Value, actual: &Value) -> bool {
   if expected == actual {
     return true;

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,425 +1,364 @@
 use crate::*;
 
+// Patterns
+// ----------------------------------------------------------------------------
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PatternMatchSemantics {
     Standard,
     OptionGuard,
 }
 
-pub fn pattern_matches_arguments(
-    pattern: &Pattern,
-    args: &Vec<Value>,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<bool> {
-    if args.len() == 1 {
-        return pattern_matches_value(pattern, &args[0], env, p);
+pub fn pattern_matches_arguments(pattern: &Pattern, args: &Vec<Value>, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
+  if args.len() == 1 {
+    return pattern_matches_value(pattern, &args[0], env, p);
+  }
+  match pattern {
+    Pattern::Tuple(pattern_tuple) => {
+      if pattern_tuple.0.len() != args.len() {
+        return Ok(false);
+      }
+      for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
+        if !pattern_matches_value(pat, arg, env, p)? {
+          return Ok(false);
+        }
+      }
+      Ok(true)
     }
-    match pattern {
-        Pattern::Tuple(pattern_tuple) => {
-            if pattern_tuple.0.len() != args.len() {
-                return Ok(false);
+    _ => Ok(false),
+  }
+}
+
+pub fn pattern_matches_value(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
+  pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
+}
+
+pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter, semantics: PatternMatchSemantics) -> MResult<bool> {
+  let detached_value = deep_detach_value(value);
+  match pattern {
+    Pattern::Wildcard => Ok(true),
+    #[cfg(feature = "tuple")]
+    Pattern::Tuple(pattern_tuple) => {
+      match detached_value {
+        Value::Tuple(tuple) => {
+          let tuple_brrw = tuple.borrow();
+          if pattern_tuple.0.len() != tuple_brrw.elements.len() {
+            return Ok(false);
+          }
+          for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
+            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+              return Ok(false);
             }
-            for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
-                if !pattern_matches_value(pat, arg, env, p)? {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
+          }
+          Ok(true)
         }
         _ => Ok(false),
+      }
+      let _ = pattern_tuple;
+      let _ = detached_value;
+      Ok(false)
     }
-}
-
-pub fn pattern_matches_value(
-    pattern: &Pattern,
-    value: &Value,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<bool> {
-    pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
-}
-
-pub fn pattern_matches_value_with_semantics(
-    pattern: &Pattern,
-    value: &Value,
-    env: &mut Environment,
-    p: &Interpreter,
-    semantics: PatternMatchSemantics,
-) -> MResult<bool> {
-    let detached_value = deep_detach_value(value);
-    match pattern {
-        Pattern::Wildcard => Ok(true),
-        Pattern::Tuple(pattern_tuple) => {
-            #[cfg(feature = "tuple")]
-            {
-                match detached_value {
-                    Value::Tuple(tuple) => {
-                        let tuple_brrw = tuple.borrow();
-                        if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-                            return Ok(false);
-                        }
-                        for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-                            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-                                return Ok(false);
-                            }
-                        }
-                        Ok(true)
-                    }
-                    _ => Ok(false),
-                }
-            }
-            #[cfg(not(feature = "tuple"))]
-            {
-                let _ = pattern_tuple;
-                let _ = detached_value;
-                Ok(false)
-            }
+    #[cfg(feature = "matrix")]
+    Pattern::Array(pattern_array) => {
+      let values = match matrix_like_values(&detached_value) {
+        Some(values) => values,
+        None => return Ok(false),
+      };
+      if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
+        return Ok(false);
+      }
+      for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
+        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+          return Ok(false);
         }
-        Pattern::Array(pattern_array) => {
-            let values = match matrix_like_values(&detached_value) {
-                Some(values) => values,
-                None => return Ok(false),
-            };
-            if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
-                return Ok(false);
-            }
-
-            for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
-                if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-                    return Ok(false);
-                }
-            }
-
-            let suffix_start = values.len() - pattern_array.suffix.len();
-            for (pat, val) in pattern_array
-                .suffix
-                .iter()
-                .zip(values[suffix_start..].iter())
-            {
-                if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-                    return Ok(false);
-                }
-            }
-
-            if pattern_array.spread.is_none()
-                && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len()
-            {
-                return Ok(false);
-            }
-
-            if let Some(spread) = &pattern_array.spread {
-                if let Some(binding) = &spread.binding {
-                    let middle = values[pattern_array.prefix.len()..suffix_start].to_vec();
-                    #[cfg(feature = "matrix")]
-                    let captured = Value::MatrixValue(Matrix::from_vec(
-                        middle,
-                        1,
-                        suffix_start.saturating_sub(pattern_array.prefix.len()),
-                    ));
-                    #[cfg(not(feature = "matrix"))]
-                    let captured = {
-                        let _ = middle;
-                        return Ok(false);
-                    };
-                    if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
-                    {
-                        return Ok(false);
-                    }
-                }
-            }
-
-            Ok(true)
+      }
+      let suffix_start = values.len() - pattern_array.suffix.len();
+      for (pat, val) in pattern_array
+          .suffix
+          .iter()
+          .zip(values[suffix_start..].iter())
+      {
+        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+          return Ok(false);
         }
-        Pattern::Expression(Expression::Var(var)) => {
-            let var_id = var.name.hash();
-            if let Some(existing) = env.get(&var_id) {
-                Ok(existing == &detached_value)
-            } else {
-                env.insert(var_id, detached_value);
-                Ok(true)
-            }
+      }
+
+      // If there's no spread, the number of values must match exactly. 
+      // If there is a spread, there can be any number of values in the middle.
+      if pattern_array.spread.is_none() && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len()
+      {
+        return Ok(false);
+      }
+      if let Some(spread) = &pattern_array.spread {
+        if let Some(binding) = &spread.binding {
+          let middle = values[pattern_array.prefix.len()..suffix_start].to_vec();
+          #[cfg(feature = "matrix")]
+          let captured = Value::MatrixValue(Matrix::from_vec(
+            middle,
+            1,
+            suffix_start.saturating_sub(pattern_array.prefix.len()),
+          ));
+          let captured = {
+            let _ = middle;
+            return Ok(false);
+          };
+          if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
+          {
+            return Ok(false);
+          }
         }
-        Pattern::Expression(expr) => {
-            if let Some(var_id) = extract_pattern_variable_id(expr) {
-                if let Some(existing) = env.get(&var_id) {
-                    return Ok(existing == &detached_value);
-                }
-                env.insert(var_id, detached_value);
-                return Ok(true);
-            }
-            let expected = expression(expr, Some(env), p)?;
-            if semantics == PatternMatchSemantics::OptionGuard {
-                #[cfg(feature = "bool")]
-                if let Value::Bool(flag) = &expected {
-                    return Ok(*flag.borrow());
-                }
-            }
-            Ok(values_match(&deep_detach_value(&expected), &detached_value))
-        }
-        Pattern::TupleStruct(pat_struct) => {
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            {
-                match detached_value {
-                    Value::Tuple(tuple) => {
-                        let tuple_brrw = tuple.borrow();
-                        if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
-                            return Ok(false);
-                        }
-                        let expected_state = atom(
-                            &Atom {
-                                name: pat_struct.name.clone(),
-                            },
-                            p,
-                        );
-                        if !values_match(
-                            &expected_state,
-                            &deep_detach_value(&tuple_brrw.elements[0]),
-                        ) {
-                            return Ok(false);
-                        }
-                        for (pat, val) in pat_struct
-                            .patterns
-                            .iter()
-                            .zip(tuple_brrw.elements.iter().skip(1))
-                        {
-                            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-                                return Ok(false);
-                            }
-                        }
-                        Ok(true)
-                    }
-                    _ => Ok(false),
-                }
-            }
-            #[cfg(not(all(feature = "tuple", feature = "atom")))]
-            {
-                let _ = pat_struct;
-                let _ = detached_value;
-                let _ = p;
-                Ok(false)
-            }
-        }
+      }
+      Ok(true)
     }
+    Pattern::Expression(Expression::Var(var)) => {
+      let var_id = var.name.hash();
+      if let Some(existing) = env.get(&var_id) {
+        Ok(existing == &detached_value)
+      } else {
+        env.insert(var_id, detached_value);
+        Ok(true)
+      }
+    }
+    Pattern::Expression(expr) => {
+      if let Some(var_id) = extract_pattern_variable_id(expr) {
+        if let Some(existing) = env.get(&var_id) {
+          return Ok(existing == &detached_value);
+        }
+        env.insert(var_id, detached_value);
+        return Ok(true);
+      }
+      let expected = expression(expr, Some(env), p)?;
+      if semantics == PatternMatchSemantics::OptionGuard {
+        #[cfg(feature = "bool")]
+        if let Value::Bool(flag) = &expected {
+          return Ok(*flag.borrow());
+        }
+      }
+      Ok(values_match(&deep_detach_value(&expected), &detached_value))
+    }
+    #[cfg(all(feature = "tuple", feature = "atom"))]
+    Pattern::TupleStruct(pat_struct) => {
+      match detached_value {
+        Value::Tuple(tuple) => {
+          let tuple_brrw = tuple.borrow();
+          if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
+            return Ok(false);
+          }
+          let expected_state = atom(&Atom {name: pat_struct.name.clone(),},p,
+          );
+          if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
+            return Ok(false);
+          }
+          for (pat, val) in pat_struct
+              .patterns
+              .iter()
+              .zip(tuple_brrw.elements.iter().skip(1))
+          {
+            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+              return Ok(false);
+            }
+          }
+          Ok(true)
+        }
+        _ => Ok(false),
+      }
+      Ok(false)
+    } 
+  }
 }
 
 pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
     let mut ids = Vec::new();
     collect_pattern_variable_ids(pattern, &mut ids);
     for var_id in ids {
-        env.remove(&var_id);
+      env.remove(&var_id);
     }
 }
 
 pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
-    match pattern {
-        Pattern::Wildcard => Ok(Value::Empty),
-        Pattern::Expression(expr) => expression(expr, Some(env), p),
-        Pattern::Tuple(pattern_tuple) => {
-            #[cfg(feature = "tuple")]
-            {
-                let mut values = Vec::with_capacity(pattern_tuple.0.len());
-                for inner in &pattern_tuple.0 {
-                    values.push(pattern_to_value(inner, env, p)?);
-                }
-                Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
-            }
-            #[cfg(not(feature = "tuple"))]
-            {
-                let _ = pattern_tuple;
-                Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
-            }
-        }
-        Pattern::Array(array) => {
-            let mut values = Vec::new();
-            for inner in &array.prefix {
-                values.push(pattern_to_value(inner, env, p)?);
-            }
-            if let Some(spread) = &array.spread {
-                if let Some(binding) = &spread.binding {
-                    let bound = pattern_to_value(binding, env, p)?;
-                    #[cfg(feature = "matrix")]
-                    match bound {
-                        Value::MatrixValue(matrix) => values.extend(matrix.as_vec()),
-                        other => values.push(other),
-                    }
-                    #[cfg(not(feature = "matrix"))]
-                    {
-                        values.push(bound);
-                    }
-                }
-            }
-            for inner in &array.suffix {
-                values.push(pattern_to_value(inner, env, p)?);
-            }
-            #[cfg(feature = "matrix")]
-            {
-                Ok(Value::MatrixValue(Matrix::from_vec(
-                    values.clone(),
-                    1,
-                    values.len(),
-                )))
-            }
-            #[cfg(not(feature = "matrix"))]
-            {
-                let _ = values;
-                Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
-            }
-        }
-        Pattern::TupleStruct(pattern_tuple_struct) => {
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            {
-                let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
-                values.push(atom(
-                    &Atom {
-                        name: pattern_tuple_struct.name.clone(),
-                    },
-                    p,
-                ));
-                for inner in &pattern_tuple_struct.patterns {
-                    values.push(pattern_to_value(inner, env, p)?);
-                }
-                Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
-            }
-            #[cfg(not(all(feature = "tuple", feature = "atom")))]
-            {
-                let _ = pattern_tuple_struct;
-                Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
-            }
-        }
+  match pattern {
+    Pattern::Wildcard => Ok(Value::Empty),
+    Pattern::Expression(expr) => expression(expr, Some(env), p),
+    #[cfg(not(feature = "tuple"))]
+    Pattern::Tuple(pattern_tuple) => {
+      let mut values = Vec::with_capacity(pattern_tuple.0.len());
+      for inner in &pattern_tuple.0 {
+        values.push(pattern_to_value(inner, env, p)?);
+      }
+      Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
+      let _ = pattern_tuple;
+      Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
     }
+    #[cfg(feature = "matrix")]
+    Pattern::Array(array) => {
+      let mut values = Vec::new();
+      for inner in &array.prefix {
+        values.push(pattern_to_value(inner, env, p)?);
+      }
+      if let Some(spread) = &array.spread {
+        if let Some(binding) = &spread.binding {
+          let bound = pattern_to_value(binding, env, p)?;
+          match bound {
+            Value::MatrixValue(matrix) => values.extend(matrix.as_vec()),
+            other => values.push(other),
+          }
+          values.push(bound);
+        }
+      }
+      for inner in &array.suffix {
+        values.push(pattern_to_value(inner, env, p)?);
+      }
+      Ok(Value::MatrixValue(Matrix::from_vec(values.clone(), 1, values.len())))
+      let _ = values;
+      Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+    }
+    #[cfg(all(feature = "tuple", feature = "atom"))]
+    Pattern::TupleStruct(pattern_tuple_struct) => {
+      let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
+      values.push(atom(&Atom {name: pattern_tuple_struct.name.clone()}, p));
+      for inner in &pattern_tuple_struct.patterns {
+        values.push(pattern_to_value(inner, env, p)?);
+      }
+      Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
+      let _ = pattern_tuple_struct;
+      Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+    }
+    _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
+  }
 }
 
 fn deep_detach_value(value: &Value) -> Value {
-    match value {
-        Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
-        _ => value.clone(),
-    }
+  match value {
+    Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
+    _ => value.clone(),
+  }
 }
 
 fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
-    match pattern {
-        Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
-        Pattern::Tuple(tuple) => {
-            for item in &tuple.0 {
-                collect_pattern_variable_ids(item, ids);
-            }
-        }
-        Pattern::Array(array) => {
-            for item in &array.prefix {
-                collect_pattern_variable_ids(item, ids);
-            }
-            if let Some(spread) = &array.spread {
-                if let Some(binding) = &spread.binding {
-                    collect_pattern_variable_ids(binding, ids);
-                }
-            }
-            for item in &array.suffix {
-                collect_pattern_variable_ids(item, ids);
-            }
-        }
-        Pattern::TupleStruct(tuple_struct) => {
-            for item in &tuple_struct.patterns {
-                collect_pattern_variable_ids(item, ids);
-            }
-        }
-        _ => {}
+  match pattern {
+    Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
+    #[cfg(feature = "tuple")]
+    Pattern::Tuple(tuple) => {
+      for item in &tuple.0 {
+        collect_pattern_variable_ids(item, ids);
+      }
     }
+    #[cfg(feature = "matrix")]
+    Pattern::Array(array) => {
+      for item in &array.prefix {
+        collect_pattern_variable_ids(item, ids);
+      }
+      if let Some(spread) = &array.spread {
+        if let Some(binding) = &spread.binding {
+          collect_pattern_variable_ids(binding, ids);
+        }
+      }
+      for item in &array.suffix {
+        collect_pattern_variable_ids(item, ids);
+      }
+    }
+    #[cfg(all(feature = "tuple", feature = "atom"))]
+    Pattern::TupleStruct(tuple_struct) => {
+      for item in &tuple_struct.patterns {
+        collect_pattern_variable_ids(item, ids);
+      }
+    }
+    _ => {}
+  }
 }
 
 fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
-    match value {
-        #[cfg(feature = "matrix")]
-        Value::MatrixIndex(matrix) => Some(
-            matrix
-                .as_vec()
-                .into_iter()
-                .map(|value| Value::Index(Ref::new(value)))
-                .collect(),
-        ),
-        #[cfg(all(feature = "matrix", feature = "bool"))]
-        Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u8"))]
-        Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u16"))]
-        Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u32"))]
-        Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u64"))]
-        Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "u128"))]
-        Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i8"))]
-        Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i16"))]
-        Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i32"))]
-        Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i64"))]
-        Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "i128"))]
-        Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "f32"))]
-        Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "f64"))]
-        Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "string"))]
-        Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-        #[cfg(all(feature = "matrix", feature = "rational"))]
-        Value::MatrixR64(matrix) => Some(
-            matrix
-                .as_vec()
-                .into_iter()
-                .map(|value| value.to_value())
-                .collect(),
-        ),
-        #[cfg(all(feature = "matrix", feature = "complex"))]
-        Value::MatrixC64(matrix) => Some(
-            matrix
-                .as_vec()
-                .into_iter()
-                .map(|value| value.to_value())
-                .collect(),
-        ),
-        #[cfg(feature = "matrix")]
-        Value::MatrixValue(matrix) => Some(matrix.as_vec()),
-        _ => None,
-    }
+  match value {
+    #[cfg(feature = "matrix")]
+    Value::MatrixIndex(matrix) => Some(
+      matrix
+          .as_vec()
+          .into_iter()
+          .map(|value| Value::Index(Ref::new(value)))
+          .collect(),
+    ),
+    #[cfg(all(feature = "matrix", feature = "bool"))]
+    Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "u8"))]
+    Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "u16"))]
+    Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "u32"))]
+    Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "u64"))]
+    Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "u128"))]
+    Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "i8"))]
+    Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "i16"))]
+    Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "i32"))]
+    Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "i64"))]
+    Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "i128"))]
+    Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "f32"))]
+    Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "string"))]
+    Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+    #[cfg(all(feature = "matrix", feature = "rational"))]
+    Value::MatrixR64(matrix) => Some(
+      matrix
+          .as_vec()
+          .into_iter()
+          .map(|value| value.to_value())
+          .collect(),
+    ),
+    #[cfg(all(feature = "matrix", feature = "complex"))]
+    Value::MatrixC64(matrix) => Some(
+      matrix
+          .as_vec()
+          .into_iter()
+          .map(|value| value.to_value())
+          .collect(),
+    ),
+    #[cfg(feature = "matrix")]
+    Value::MatrixValue(matrix) => Some(matrix.as_vec()),
+    _ => None,
+  }
 }
 
 fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
-    match expr {
-        Expression::Var(var) => Some(var.name.hash()),
-        Expression::Formula(factor) => match factor {
-            Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
-            Factor::Term(term) if term.rhs.is_empty() => {
-                extract_pattern_variable_id_from_term(&term.lhs)
-            }
-            _ => None,
-        },
-        _ => None,
-    }
+  match expr {
+    Expression::Var(var) => Some(var.name.hash()),
+    Expression::Formula(factor) => match factor {
+      Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
+      Factor::Term(term) if term.rhs.is_empty() => extract_pattern_variable_id_from_term(&term.lhs),
+      _ => None,
+    },
+    _ => None,
+  }
 }
 
 fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
-    match factor {
-        Factor::Expression(expr) => extract_pattern_variable_id(expr),
-        Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
-        _ => None,
-    }
+  match factor {
+    Factor::Expression(expr) => extract_pattern_variable_id(expr),
+    Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
+    _ => None,
+  }
 }
 
 fn values_match(expected: &Value, actual: &Value) -> bool {
-    if expected == actual {
-        return true;
+  if expected == actual {
+    return true;
+  }
+  {
+    match (expected, actual) {
+      #[cfg(all(feature = "u64", feature = "f64"))]
+      (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
+      #[cfg(all(feature = "u64", feature = "f64"))]
+      (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
+      _ => {}
     }
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    {
-        match (expected, actual) {
-            (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-            (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-            _ => {}
-        }
-    }
-    false
+  }
+  false
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -174,7 +174,8 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
         _ => return Ok(false),
       }
       return Ok(false);
-    } 
+    }
+    x => Err(MechError::new(FeatureNotEnabledError, Some(format!("Pattern not enabled: {:?}", x))).with_compiler_loc().with_tokens(x.tokens())), 
   }
 }
 
@@ -196,7 +197,7 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
   match pattern {
     Pattern::Wildcard => Ok(Value::Empty),
     Pattern::Expression(expr) => expression(expr, Some(env), p),
-    #[cfg(not(feature = "tuple"))]
+    #[cfg(feature = "tuple")]
     Pattern::Tuple(pattern_tuple) => {
       let mut values = Vec::with_capacity(pattern_tuple.0.len());
       for inner in &pattern_tuple.0 {

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -166,11 +166,11 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
 }
 
 pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
-    let mut ids = Vec::new();
-    collect_pattern_variable_ids(pattern, &mut ids);
-    for var_id in ids {
-      env.remove(&var_id);
-    }
+  let mut ids = Vec::new();
+  collect_pattern_variable_ids(pattern, &mut ids);
+  for var_id in ids {
+    env.remove(&var_id);
+  }
 }
 
 pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
@@ -343,14 +343,12 @@ fn values_match(expected: &Value, actual: &Value) -> bool {
   if expected == actual {
     return true;
   }
-  {
-    match (expected, actual) {
-      #[cfg(all(feature = "u64", feature = "f64"))]
-      (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-      #[cfg(all(feature = "u64", feature = "f64"))]
-      (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-      _ => {}
-    }
+  match (expected, actual) {
+    #[cfg(all(feature = "u64", feature = "f64"))]
+    (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
+    #[cfg(all(feature = "u64", feature = "f64"))]
+    (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
+    _ => {}
   }
   false
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,0 +1,377 @@
+use crate::*;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PatternMatchSemantics {
+    Standard,
+    OptionGuard,
+}
+
+pub fn pattern_matches_arguments(
+    pattern: &Pattern,
+    args: &Vec<Value>,
+    env: &mut Environment,
+    p: &Interpreter,
+) -> MResult<bool> {
+    if args.len() == 1 {
+        return pattern_matches_value(pattern, &args[0], env, p);
+    }
+    match pattern {
+        Pattern::Tuple(pattern_tuple) => {
+            if pattern_tuple.0.len() != args.len() {
+                return Ok(false);
+            }
+            for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
+                if !pattern_matches_value(pat, arg, env, p)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+pub fn pattern_matches_value(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    p: &Interpreter,
+) -> MResult<bool> {
+    pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
+}
+
+pub fn pattern_matches_value_with_semantics(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    p: &Interpreter,
+    semantics: PatternMatchSemantics,
+) -> MResult<bool> {
+    let detached_value = deep_detach_value(value);
+    match pattern {
+        Pattern::Wildcard => Ok(true),
+        Pattern::Tuple(pattern_tuple) => match detached_value {
+            Value::Tuple(tuple) => {
+                let tuple_brrw = tuple.borrow();
+                if pattern_tuple.0.len() != tuple_brrw.elements.len() {
+                    return Ok(false);
+                }
+                for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
+                    if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+        Pattern::Array(pattern_array) => {
+            let values = match matrix_like_values(&detached_value) {
+                Some(values) => values,
+                None => return Ok(false),
+            };
+            if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
+                return Ok(false);
+            }
+
+            for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
+                if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+                    return Ok(false);
+                }
+            }
+
+            let suffix_start = values.len() - pattern_array.suffix.len();
+            for (pat, val) in pattern_array
+                .suffix
+                .iter()
+                .zip(values[suffix_start..].iter())
+            {
+                if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+                    return Ok(false);
+                }
+            }
+
+            if pattern_array.spread.is_none()
+                && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len()
+            {
+                return Ok(false);
+            }
+
+            if let Some(spread) = &pattern_array.spread {
+                if let Some(binding) = &spread.binding {
+                    let middle = values[pattern_array.prefix.len()..suffix_start].to_vec();
+                    #[cfg(feature = "matrix")]
+                    let captured = Value::MatrixValue(Matrix::from_vec(
+                        middle,
+                        1,
+                        suffix_start.saturating_sub(pattern_array.prefix.len()),
+                    ));
+                    #[cfg(not(feature = "matrix"))]
+                    let captured = {
+                        let _ = middle;
+                        return Ok(false);
+                    };
+                    if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
+                    {
+                        return Ok(false);
+                    }
+                }
+            }
+
+            Ok(true)
+        }
+        Pattern::Expression(Expression::Var(var)) => {
+            let var_id = var.name.hash();
+            if let Some(existing) = env.get(&var_id) {
+                Ok(existing == &detached_value)
+            } else {
+                env.insert(var_id, detached_value);
+                Ok(true)
+            }
+        }
+        Pattern::Expression(expr) => {
+            if let Some(var_id) = extract_pattern_variable_id(expr) {
+                if let Some(existing) = env.get(&var_id) {
+                    return Ok(existing == &detached_value);
+                }
+                env.insert(var_id, detached_value);
+                return Ok(true);
+            }
+            let expected = expression(expr, Some(env), p)?;
+            if semantics == PatternMatchSemantics::OptionGuard {
+                #[cfg(feature = "bool")]
+                if let Value::Bool(flag) = &expected {
+                    return Ok(*flag.borrow());
+                }
+            }
+            Ok(values_match(&deep_detach_value(&expected), &detached_value))
+        }
+        Pattern::TupleStruct(pat_struct) => match detached_value {
+            Value::Tuple(tuple) => {
+                let tuple_brrw = tuple.borrow();
+                if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
+                    return Ok(false);
+                }
+                let expected_state = atom(
+                    &Atom {
+                        name: pat_struct.name.clone(),
+                    },
+                    p,
+                );
+                if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
+                    return Ok(false);
+                }
+                for (pat, val) in pat_struct
+                    .patterns
+                    .iter()
+                    .zip(tuple_brrw.elements.iter().skip(1))
+                {
+                    if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+    }
+}
+
+pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
+    let mut ids = Vec::new();
+    collect_pattern_variable_ids(pattern, &mut ids);
+    for var_id in ids {
+        env.remove(&var_id);
+    }
+}
+
+pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
+    match pattern {
+        Pattern::Wildcard => Ok(Value::Empty),
+        Pattern::Expression(expr) => expression(expr, Some(env), p),
+        Pattern::Tuple(pattern_tuple) => {
+            let mut values = Vec::with_capacity(pattern_tuple.0.len());
+            for inner in &pattern_tuple.0 {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
+        }
+        Pattern::Array(array) => {
+            let mut values = Vec::new();
+            for inner in &array.prefix {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    match pattern_to_value(binding, env, p)? {
+                        Value::MatrixValue(matrix) => values.extend(matrix.as_vec()),
+                        other => values.push(other),
+                    }
+                }
+            }
+            for inner in &array.suffix {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            #[cfg(feature = "matrix")]
+            {
+                Ok(Value::MatrixValue(Matrix::from_vec(
+                    values.clone(),
+                    1,
+                    values.len(),
+                )))
+            }
+            #[cfg(not(feature = "matrix"))]
+            {
+                let _ = values;
+                Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+            }
+        }
+        Pattern::TupleStruct(pattern_tuple_struct) => {
+            let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
+            values.push(atom(
+                &Atom {
+                    name: pattern_tuple_struct.name.clone(),
+                },
+                p,
+            ));
+            for inner in &pattern_tuple_struct.patterns {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
+        }
+    }
+}
+
+fn deep_detach_value(value: &Value) -> Value {
+    match value {
+        Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
+        _ => detach_value(value),
+    }
+}
+
+fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
+    match pattern {
+        Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
+        Pattern::Tuple(tuple) => {
+            for item in &tuple.0 {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        Pattern::Array(array) => {
+            for item in &array.prefix {
+                collect_pattern_variable_ids(item, ids);
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    collect_pattern_variable_ids(binding, ids);
+                }
+            }
+            for item in &array.suffix {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        Pattern::TupleStruct(tuple_struct) => {
+            for item in &tuple_struct.patterns {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| Value::Index(Ref::new(value)))
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Some(matrix.as_vec()),
+        _ => None,
+    }
+}
+
+fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
+    match expr {
+        Expression::Var(var) => Some(var.name.hash()),
+        Expression::Formula(factor) => match factor {
+            Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
+            Factor::Term(term) if term.rhs.is_empty() => {
+                extract_pattern_variable_id_from_term(&term.lhs)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
+    match factor {
+        Factor::Expression(expr) => extract_pattern_variable_id(expr),
+        Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
+        _ => None,
+    }
+}
+
+fn values_match(expected: &Value, actual: &Value) -> bool {
+    if expected == actual {
+        return true;
+    }
+    #[cfg(all(feature = "u64", feature = "f64"))]
+    {
+        match (expected, actual) {
+            (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
+            (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
+            _ => {}
+        }
+    }
+    false
+}

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -50,21 +50,32 @@ pub fn pattern_matches_value_with_semantics(
     let detached_value = deep_detach_value(value);
     match pattern {
         Pattern::Wildcard => Ok(true),
-        Pattern::Tuple(pattern_tuple) => match detached_value {
-            Value::Tuple(tuple) => {
-                let tuple_brrw = tuple.borrow();
-                if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-                    return Ok(false);
-                }
-                for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-                    if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-                        return Ok(false);
+        Pattern::Tuple(pattern_tuple) => {
+            #[cfg(feature = "tuple")]
+            {
+                match detached_value {
+                    Value::Tuple(tuple) => {
+                        let tuple_brrw = tuple.borrow();
+                        if pattern_tuple.0.len() != tuple_brrw.elements.len() {
+                            return Ok(false);
+                        }
+                        for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
+                            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+                                return Ok(false);
+                            }
+                        }
+                        Ok(true)
                     }
+                    _ => Ok(false),
                 }
-                Ok(true)
             }
-            _ => Ok(false),
-        },
+            #[cfg(not(feature = "tuple"))]
+            {
+                let _ = pattern_tuple;
+                let _ = detached_value;
+                Ok(false)
+            }
+        }
         Pattern::Array(pattern_array) => {
             let values = match matrix_like_values(&detached_value) {
                 Some(values) => values,
@@ -146,34 +157,49 @@ pub fn pattern_matches_value_with_semantics(
             }
             Ok(values_match(&deep_detach_value(&expected), &detached_value))
         }
-        Pattern::TupleStruct(pat_struct) => match detached_value {
-            Value::Tuple(tuple) => {
-                let tuple_brrw = tuple.borrow();
-                if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
-                    return Ok(false);
-                }
-                let expected_state = atom(
-                    &Atom {
-                        name: pat_struct.name.clone(),
-                    },
-                    p,
-                );
-                if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
-                    return Ok(false);
-                }
-                for (pat, val) in pat_struct
-                    .patterns
-                    .iter()
-                    .zip(tuple_brrw.elements.iter().skip(1))
-                {
-                    if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-                        return Ok(false);
+        Pattern::TupleStruct(pat_struct) => {
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            {
+                match detached_value {
+                    Value::Tuple(tuple) => {
+                        let tuple_brrw = tuple.borrow();
+                        if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
+                            return Ok(false);
+                        }
+                        let expected_state = atom(
+                            &Atom {
+                                name: pat_struct.name.clone(),
+                            },
+                            p,
+                        );
+                        if !values_match(
+                            &expected_state,
+                            &deep_detach_value(&tuple_brrw.elements[0]),
+                        ) {
+                            return Ok(false);
+                        }
+                        for (pat, val) in pat_struct
+                            .patterns
+                            .iter()
+                            .zip(tuple_brrw.elements.iter().skip(1))
+                        {
+                            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
+                                return Ok(false);
+                            }
+                        }
+                        Ok(true)
                     }
+                    _ => Ok(false),
                 }
-                Ok(true)
             }
-            _ => Ok(false),
-        },
+            #[cfg(not(all(feature = "tuple", feature = "atom")))]
+            {
+                let _ = pat_struct;
+                let _ = detached_value;
+                let _ = p;
+                Ok(false)
+            }
+        }
     }
 }
 
@@ -190,11 +216,19 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
         Pattern::Wildcard => Ok(Value::Empty),
         Pattern::Expression(expr) => expression(expr, Some(env), p),
         Pattern::Tuple(pattern_tuple) => {
-            let mut values = Vec::with_capacity(pattern_tuple.0.len());
-            for inner in &pattern_tuple.0 {
-                values.push(pattern_to_value(inner, env, p)?);
+            #[cfg(feature = "tuple")]
+            {
+                let mut values = Vec::with_capacity(pattern_tuple.0.len());
+                for inner in &pattern_tuple.0 {
+                    values.push(pattern_to_value(inner, env, p)?);
+                }
+                Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
             }
-            Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
+            #[cfg(not(feature = "tuple"))]
+            {
+                let _ = pattern_tuple;
+                Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+            }
         }
         Pattern::Array(array) => {
             let mut values = Vec::new();
@@ -203,9 +237,15 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
             }
             if let Some(spread) = &array.spread {
                 if let Some(binding) = &spread.binding {
-                    match pattern_to_value(binding, env, p)? {
+                    let bound = pattern_to_value(binding, env, p)?;
+                    #[cfg(feature = "matrix")]
+                    match bound {
                         Value::MatrixValue(matrix) => values.extend(matrix.as_vec()),
                         other => values.push(other),
+                    }
+                    #[cfg(not(feature = "matrix"))]
+                    {
+                        values.push(bound);
                     }
                 }
             }
@@ -227,17 +267,25 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
             }
         }
         Pattern::TupleStruct(pattern_tuple_struct) => {
-            let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
-            values.push(atom(
-                &Atom {
-                    name: pattern_tuple_struct.name.clone(),
-                },
-                p,
-            ));
-            for inner in &pattern_tuple_struct.patterns {
-                values.push(pattern_to_value(inner, env, p)?);
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            {
+                let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
+                values.push(atom(
+                    &Atom {
+                        name: pattern_tuple_struct.name.clone(),
+                    },
+                    p,
+                ));
+                for inner in &pattern_tuple_struct.patterns {
+                    values.push(pattern_to_value(inner, env, p)?);
+                }
+                Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
             }
-            Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
+            #[cfg(not(all(feature = "tuple", feature = "atom")))]
+            {
+                let _ = pattern_tuple_struct;
+                Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+            }
         }
     }
 }
@@ -245,7 +293,7 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
 fn deep_detach_value(value: &Value) -> Value {
     match value {
         Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
-        _ => detach_value(value),
+        _ => value.clone(),
     }
 }
 

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -50,13 +50,11 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
               return Ok(false);
             }
           }
-          Ok(true)
+          return Ok(true);
         }
-        _ => Ok(false),
+        _ => {return Ok(false);},
       }
-      let _ = pattern_tuple;
-      let _ = detached_value;
-      Ok(false)
+      return Ok(false);
     }
     #[cfg(feature = "matrix")]
     Pattern::Array(pattern_array) => {
@@ -158,11 +156,11 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
               return Ok(false);
             }
           }
-          Ok(true)
+          return Ok(true);
         }
-        _ => Ok(false),
+        _ => return Ok(false),
       }
-      Ok(false)
+      return Ok(false);
     } 
   }
 }
@@ -185,9 +183,7 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
       for inner in &pattern_tuple.0 {
         values.push(pattern_to_value(inner, env, p)?);
       }
-      Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
-      let _ = pattern_tuple;
-      Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
     }
     #[cfg(feature = "matrix")]
     Pattern::Array(array) => {
@@ -199,18 +195,16 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
         if let Some(binding) = &spread.binding {
           let bound = pattern_to_value(binding, env, p)?;
           match bound {
-            Value::MatrixValue(matrix) => values.extend(matrix.as_vec()),
-            other => values.push(other),
+            Value::MatrixValue(ref matrix) => values.extend(matrix.as_vec()),
+            ref other => values.push(other.clone()),
           }
-          values.push(bound);
+          values.push(bound.clone());
         }
       }
       for inner in &array.suffix {
         values.push(pattern_to_value(inner, env, p)?);
       }
-      Ok(Value::MatrixValue(Matrix::from_vec(values.clone(), 1, values.len())))
-      let _ = values;
-      Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+      return Ok(Value::MatrixValue(Matrix::from_vec(values.clone(), 1, values.len())));
     }
     #[cfg(all(feature = "tuple", feature = "atom"))]
     Pattern::TupleStruct(pattern_tuple_struct) => {
@@ -219,9 +213,7 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
       for inner in &pattern_tuple_struct.patterns {
         values.push(pattern_to_value(inner, env, p)?);
       }
-      Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
-      let _ = pattern_tuple_struct;
-      Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc())
+      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
     }
     _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
   }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -156,8 +156,7 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
           if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
             return Ok(false);
           }
-          let expected_state = atom(&Atom {name: pat_struct.name.clone(),},p,
-          );
+          let expected_state = atom(&Atom {name: pat_struct.name.clone(),},p);
           if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
             return Ok(false);
           }

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -261,7 +261,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
   }
   Err(MechError::new(
     FsmExceededTransitionLimitError {
-      max_transitions: max_steps,
+      max_transitions: p.max_steps,
     },
     None,
   )

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -2,407 +2,402 @@ use crate::tracing::{
     format_fsm_trace, summarize_guard_condition, summarize_pattern, summarize_value,
 };
 use crate::*;
+use crate::patterns::*;
 use std::collections::HashSet;
 
 // Finite State Machines
 // ----------------------------------------------------------------------------
 
+// Review: how does this fail?
 pub fn register_fsm_implementation(fsm: &FsmImplementation, p: &Interpreter) -> MResult<()> {
-    let fsm_id = fsm.name.hash();
-    p.user_state_machines
-        .borrow_mut()
-        .insert(fsm_id, fsm.clone());
-    p.state
-        .borrow()
-        .dictionary
-        .borrow_mut()
-        .insert(fsm_id, fsm.name.to_string());
-    Ok(())
+  let fsm_id = fsm.name.hash();
+  p.user_state_machines
+    .borrow_mut()
+    .insert(fsm_id, fsm.clone());
+  p.state
+    .borrow()
+    .dictionary
+    .borrow_mut()
+    .insert(fsm_id, fsm.name.to_string());
+  Ok(())
 }
 
-pub fn execute_fsm_pipe(
-    fsm_pipe: &FsmPipe,
-    env: Option<&Environment>,
-    p: &Interpreter,
-) -> MResult<Value> {
-    let fsm_id = fsm_pipe.start.name.hash();
-    let fsm = {
-        let fsms = p.user_state_machines.borrow();
-        fsms.get(&fsm_id).cloned()
-    }
-    .ok_or_else(|| {
-        MechError::new(
-            MissingFunctionError {
-                function_id: fsm_id,
-            },
-            None,
-        )
-        .with_compiler_loc()
-        .with_tokens(fsm_pipe.start.tokens())
-    })?;
+pub fn execute_fsm_pipe(fsm_pipe: &FsmPipe, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let fsm_id = fsm_pipe.start.name.hash();
+  let fsm = {
+    let fsms = p.user_state_machines.borrow();
+    fsms.get(&fsm_id).cloned()
+  }
+  .ok_or_else(|| {
+    MechError::new(
+      MissingFsmError {
+        fsm_id,
+      },
+      None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fsm_pipe.start.tokens())
+  })?;
 
-    let mut call_env = Environment::new();
-    let mut args = Vec::new();
-    if let Some(start_args) = &fsm_pipe.start.args {
-        for (_, arg_expr) in start_args {
-            args.push(expression(arg_expr, env, p)?);
-        }
+  let mut call_env = Environment::new();
+  let mut args = Vec::new();
+  if let Some(start_args) = &fsm_pipe.start.args {
+    for (_, arg_expr) in start_args {
+      args.push(expression(arg_expr, env, p)?);
     }
-    if fsm.input.len() != args.len() {
+  }
+  if fsm.input.len() != args.len() {
+    return Err(MechError::new(
+      IncorrectNumberOfArguments {
+        expected: fsm.input.len(),
+        found: args.len(),
+      },
+      None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fsm_pipe.start.tokens()));
+  }
+  for (arg_decl, arg_value) in fsm.input.iter().zip(args.iter()) {
+    #[cfg(feature = "kind_annotation")]
+    if let Some(kind_annotation_node) = &arg_decl.kind {
+      let expected_kind = kind_annotation(&kind_annotation_node.kind, p)?
+          .to_value_kind(&p.state.borrow().kinds)?;
+      let actual_kind = arg_value.kind();
+      if actual_kind != expected_kind {
         return Err(MechError::new(
-            IncorrectNumberOfArguments {
-                expected: fsm.input.len(),
-                found: args.len(),
-            },
-            None,
+          FsmArgumentKindMismatchError {
+            argument: arg_decl.name.to_string(),
+            expected_kind,
+            actual_kind,
+          },
+          None,
         )
         .with_compiler_loc()
         .with_tokens(fsm_pipe.start.tokens()));
-    }
-    for (arg_decl, arg_value) in fsm.input.iter().zip(args.iter()) {
-        #[cfg(feature = "kind_annotation")]
-        if let Some(kind_annotation_node) = &arg_decl.kind {
-            let expected_kind = kind_annotation(&kind_annotation_node.kind, p)?
-                .to_value_kind(&p.state.borrow().kinds)?;
-            let actual_kind = arg_value.kind();
-            if actual_kind != expected_kind {
-                return Err(MechError::new(
-                    FsmArgumentKindMismatchError {
-                        argument: arg_decl.name.to_string(),
-                        expected_kind,
-                        actual_kind,
-                    },
-                    None,
-                )
-                .with_compiler_loc()
-                .with_tokens(fsm_pipe.start.tokens()));
-            }
         }
-        call_env.insert(arg_decl.name.hash(), detach_value(arg_value));
-    }
-    let mut state = crate::patterns::pattern_to_value(&fsm.start, &call_env, p)?;
-    validate_fsm_state_coverage(&fsm, fsm_pipe)?;
-    execute_fsm_pipe_impl(&fsm, &mut state, &mut call_env, p)
+      }
+      call_env.insert(arg_decl.name.hash(), detach_value(arg_value));
+  }
+  let mut state = crate::patterns::pattern_to_value(&fsm.start, &call_env, p)?;
+  validate_fsm_state_coverage(&fsm, fsm_pipe)?;
+  execute_fsm_pipe_impl(&fsm, &mut state, &mut call_env, p)
 }
 
-fn execute_fsm_pipe_impl(
-    fsm: &FsmImplementation,
-    state: &mut Value,
-    call_env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<Value> {
+fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &mut Environment, p: &Interpreter) -> MResult<Value> {
+  trace_println!(
+    p,
+    "{}",
+    format_fsm_trace(
+      "start",
+      format!(
+        "name={} state={}",
+        fsm.name.to_string(),
+        summarize_value(state)
+      )
+    )
+  );
+  for step in 0..p.max_steps {
     trace_println!(
         p,
         "{}",
         format_fsm_trace(
-            "start",
-            format!(
-                "name={} state={}",
-                fsm.name.to_string(),
-                summarize_value(state)
-            )
+            "step",
+            format!("{step:>4} state={}", summarize_value(state))
         )
     );
-    let max_steps = 10_000usize; // TODO This must be a parameter
-    for step in 0..max_steps {
-        trace_println!(
-            p,
-            "{}",
-            format_fsm_trace(
-                "step",
-                format!("{step:>4} state={}", summarize_value(state))
-            )
-        );
-        let mut transitioned = false;
-        for (arm_idx, arm) in fsm.arms.iter().enumerate() {
-            match arm {
-                FsmArm::Transition(pattern, transitions) => {
-                    let mut arm_env = call_env.clone();
-                    crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
-                    let matched =
-                        crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
-                    trace_println!(
-                        p,
-                        "{}",
-                        format_fsm_trace(
-                            "arm",
-                            format!(
-                                "[{arm_idx}] check transition pattern={} {}",
-                                summarize_pattern(pattern),
-                                if matched { "✓" } else { "✗" }
-                            )
-                        )
-                    );
-                    if matched {
-                        let previous_state = summarize_value(state);
-                        let out = apply_transitions(transitions, state, &mut arm_env, p)?;
-                        *call_env = arm_env;
-                        if let Some(value) = out {
-                            trace_println!(
-                                p,
-                                "{}",
-                                format_fsm_trace(
-                                    "output",
-                                    format!("value={}", summarize_value(&value))
-                                )
-                            );
-                            return Ok(value);
-                        }
-                        trace_println!(
-                            p,
-                            "{}",
-                            format_fsm_trace(
-                                "transition",
-                                format!(
-                                    "arm[{arm_idx}] {} -> {}",
-                                    previous_state,
-                                    summarize_value(state)
-                                )
-                            )
-                        );
-                        transitioned = true;
-                        break;
-                    }
-                }
-                FsmArm::Guard(pattern, guards) => {
-                    let mut arm_env = call_env.clone();
-                    crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
-                    let pattern_matched =
-                        crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
-                    trace_println!(
-                        p,
-                        "{}",
-                        format_fsm_trace(
-                            "arm",
-                            format!(
-                                "[{arm_idx}] check guard pattern={} {}",
-                                summarize_pattern(pattern),
-                                if pattern_matched { "✓" } else { "✗" }
-                            )
-                        )
-                    );
-                    if !pattern_matched {
-                        continue;
-                    }
-                    for (guard_idx, guard) in guards.iter().enumerate() {
-                        let guard_passes = match &guard.condition {
-                            Pattern::Wildcard => true,
-                            _ => {
-                                let cond = crate::patterns::pattern_to_value(
-                                    &guard.condition,
-                                    &arm_env,
-                                    p,
-                                )?;
-                                match cond {
-                                    Value::Bool(x) => *x.borrow(),
-                                    other => {
-                                        return Err(MechError::new(
-                                            FsmGuardConditionKindMismatchError {
-                                                arm_index: arm_idx,
-                                                guard_index: guard_idx,
-                                                actual_kind: other.kind(),
-                                            },
-                                            None,
-                                        )
-                                        .with_compiler_loc());
-                                    }
-                                }
-                            }
-                        };
-                        trace_println!(
-                            p,
-                            "{}",
-                            format_fsm_trace(
-                                "guard",
-                                format!(
-                                    "arm[{arm_idx}] check guard[{guard_idx}] condition={} {}",
-                                    summarize_guard_condition(&guard.condition),
-                                    if guard_passes { "✓" } else { "✗" }
-                                )
-                            )
-                        );
-                        if !guard_passes {
-                            continue;
-                        }
-                        let previous_state = summarize_value(state);
-                        let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
-                        *call_env = arm_env;
-                        if let Some(value) = out {
-                            trace_println!(
-                                p,
-                                "{}",
-                                format_fsm_trace(
-                                    "output",
-                                    format!("value={}", summarize_value(&value))
-                                )
-                            );
-                            return Ok(value);
-                        }
-                        trace_println!(
-                            p,
-                            "{}",
-                            format_fsm_trace(
-                                "transition",
-                                format!(
-                                    "arm[{arm_idx}] {} -> {}",
-                                    previous_state,
-                                    summarize_value(state)
-                                )
-                            )
-                        );
-                        transitioned = true;
-                        break;
-                    }
-                    if transitioned {
-                        break;
-                    }
-                }
-            }
-        }
-        if !transitioned {
+    let mut transitioned = false;
+    for (arm_idx, arm) in fsm.arms.iter().enumerate() {
+      match arm {
+        FsmArm::Transition(pattern, transitions) => {
+            let mut arm_env = call_env.clone();
+            crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
+            let matched =
+                crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
             trace_println!(
                 p,
                 "{}",
-                format_fsm_trace("halt", format!("state={}", summarize_value(state)))
+                format_fsm_trace(
+                    "arm",
+                    format!(
+                        "[{arm_idx}] check transition pattern={} {}",
+                        summarize_pattern(pattern),
+                        if matched { "✓" } else { "✗" }
+                    )
+                )
             );
-            return Ok(state.clone());
+            if matched {
+                let previous_state = summarize_value(state);
+                let out = apply_transitions(transitions, state, &mut arm_env, p)?;
+                *call_env = arm_env;
+                if let Some(value) = out {
+                    trace_println!(
+                        p,
+                        "{}",
+                        format_fsm_trace(
+                            "output",
+                            format!("value={}", summarize_value(&value))
+                        )
+                    );
+                    return Ok(value);
+                }
+                trace_println!(
+                    p,
+                    "{}",
+                    format_fsm_trace(
+                        "transition",
+                        format!(
+                            "arm[{arm_idx}] {} -> {}",
+                            previous_state,
+                            summarize_value(state)
+                        )
+                    )
+                );
+                transitioned = true;
+                break;
+            }
         }
+        FsmArm::Guard(pattern, guards) => {
+          let mut arm_env = call_env.clone();
+          crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
+          let pattern_matched = crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          trace_println!(
+              p,
+              "{}",
+              format_fsm_trace(
+                  "arm",
+                  format!(
+                      "[{arm_idx}] check guard pattern={} {}",
+                      summarize_pattern(pattern),
+                      if pattern_matched { "✓" } else { "✗" }
+                  )
+              )
+          );
+          if !pattern_matched {
+              continue;
+          }
+          for (guard_idx, guard) in guards.iter().enumerate() {
+              let guard_passes = match &guard.condition {
+                  Pattern::Wildcard => true,
+                  _ => {
+                      let cond = crate::patterns::pattern_to_value(
+                          &guard.condition,
+                          &arm_env,
+                          p,
+                      )?;
+                      match cond {
+                          Value::Bool(x) => *x.borrow(),
+                          other => {
+                              return Err(MechError::new(
+                                  FsmGuardConditionKindMismatchError {
+                                      arm_index: arm_idx,
+                                      guard_index: guard_idx,
+                                      actual_kind: other.kind(),
+                                  },
+                                  None,
+                              )
+                              .with_compiler_loc());
+                          }
+                      }
+                  }
+              };
+              trace_println!(
+                  p,
+                  "{}",
+                  format_fsm_trace(
+                      "guard",
+                      format!(
+                          "arm[{arm_idx}] check guard[{guard_idx}] condition={} {}",
+                          summarize_guard_condition(&guard.condition),
+                          if guard_passes { "✓" } else { "✗" }
+                      )
+                  )
+              );
+              if !guard_passes {
+                  continue;
+              }
+              let previous_state = summarize_value(state);
+              let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
+              *call_env = arm_env;
+              if let Some(value) = out {
+                  trace_println!(
+                      p,
+                      "{}",
+                      format_fsm_trace(
+                          "output",
+                          format!("value={}", summarize_value(&value))
+                      )
+                  );
+                  return Ok(value);
+              }
+              trace_println!(
+                  p,
+                  "{}",
+                  format_fsm_trace(
+                      "transition",
+                      format!(
+                          "arm[{arm_idx}] {} -> {}",
+                          previous_state,
+                          summarize_value(state)
+                      )
+                  )
+              );
+              transitioned = true;
+              break;
+          }
+          if transitioned {
+              break;
+          }
+        }
+      }
     }
-    Err(MechError::new(
-        FsmExceededTransitionLimitError {
-            max_transitions: max_steps,
-        },
-        None,
-    )
-    .with_compiler_loc())
+    if !transitioned {
+      trace_println!(
+        p,
+        "{}",
+        format_fsm_trace("halt", format!("state={}", summarize_value(state)))
+      );
+      return Ok(state.clone());
+    }
+  }
+  Err(MechError::new(
+    FsmExceededTransitionLimitError {
+      max_transitions: max_steps,
+    },
+    None,
+  )
+  .with_compiler_loc())
 }
 
 fn validate_fsm_state_coverage(fsm: &FsmImplementation, fsm_pipe: &FsmPipe) -> MResult<()> {
-    let state_names: HashSet<String> = fsm
-        .arms
-        .iter()
-        .filter_map(|arm| {
-            let pattern = match arm {
-                FsmArm::Guard(pattern, _) | FsmArm::Transition(pattern, _) => pattern,
-            };
-            state_name_from_pattern(pattern)
-        })
-        .collect();
-    if state_names.is_empty() {
-        return Ok(());
-    }
+  let state_names: HashSet<String> = fsm
+    .arms
+    .iter()
+    .filter_map(|arm| {
+      let pattern = match arm {
+        FsmArm::Guard(pattern, _) | FsmArm::Transition(pattern, _) => pattern,
+      };
+      state_name_from_pattern(pattern)
+    })
+    .collect();
+  if state_names.is_empty() {
+    return Ok(());
+  }
 
-    let start_state = state_name_from_pattern(&fsm.start).ok_or_else(|| {
-        MechError::new(
-            FsmUndefinedStateError {
-                fsm_name: fsm.name.to_string(),
-                state_name: summarize_pattern(&fsm.start),
-            },
-            None,
-        )
-        .with_compiler_loc()
-        .with_tokens(fsm_pipe.start.tokens())
-    })?;
-    if !state_names.contains(&start_state) {
-        return Err(MechError::new(
-            FsmUndefinedStateError {
-                fsm_name: fsm.name.to_string(),
-                state_name: start_state,
-            },
-            None,
-        )
-        .with_compiler_loc()
-        .with_tokens(fsm_pipe.start.tokens()));
-    }
+  let start_state = state_name_from_pattern(&fsm.start).ok_or_else(|| {
+    MechError::new(
+      FsmUndefinedStateError {
+        fsm_name: fsm.name.to_string(),
+        state_name: summarize_pattern(&fsm.start),
+      },
+      None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fsm_pipe.start.tokens())
+  })?;
+  if !state_names.contains(&start_state) {
+    return Err(MechError::new(
+      FsmUndefinedStateError {
+        fsm_name: fsm.name.to_string(),
+        state_name: start_state,
+      },
+      None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fsm_pipe.start.tokens()));
+  }
 
-    for arm in &fsm.arms {
-        let transitions = match arm {
-            FsmArm::Transition(_, transitions) => transitions.as_slice(),
-            FsmArm::Guard(_, guards) => {
-                for guard in guards {
-                    for transition in &guard.transitions {
-                        validate_transition_target_state(transition, fsm, &state_names, fsm_pipe)?;
-                    }
-                }
-                &[]
-            }
-        };
-        for transition in transitions {
-            validate_transition_target_state(transition, fsm, &state_names, fsm_pipe)?;
+  for arm in &fsm.arms {
+    let transitions = match arm {
+      FsmArm::Transition(_, transitions) => transitions.as_slice(),
+      FsmArm::Guard(_, guards) => {
+        for guard in guards {
+          for transition in &guard.transitions {
+              validate_transition_target_state(transition, fsm, &state_names, fsm_pipe)?;
+          }
         }
+        &[]
+      }
+    };
+    for transition in transitions {
+      validate_transition_target_state(transition, fsm, &state_names, fsm_pipe)?;
     }
-    Ok(())
+  }
+  Ok(())
 }
 
-fn validate_transition_target_state(
-    transition: &Transition,
-    fsm: &FsmImplementation,
-    state_names: &HashSet<String>,
-    fsm_pipe: &FsmPipe,
-) -> MResult<()> {
-    let target = match transition {
-        Transition::Next(pattern) | Transition::Async(pattern) => state_name_from_pattern(pattern),
-        _ => None,
-    };
-    if let Some(state_name) = target {
-        if !state_names.contains(&state_name) {
-            return Err(MechError::new(
-                FsmUndefinedStateError {
-                    fsm_name: fsm.name.to_string(),
-                    state_name,
-                },
-                None,
-            )
-            .with_compiler_loc()
-            .with_tokens(fsm_pipe.start.tokens()));
-        }
+fn validate_transition_target_state(transition: &Transition, fsm: &FsmImplementation, state_names: &HashSet<String>, fsm_pipe: &FsmPipe) -> MResult<()> {
+  let target = match transition {
+    Transition::Next(pattern) | Transition::Async(pattern) => state_name_from_pattern(pattern),
+    _ => None,
+  };
+  if let Some(state_name) = target {
+    if !state_names.contains(&state_name) {
+      return Err(MechError::new(
+        FsmUndefinedStateError {
+          fsm_name: fsm.name.to_string(),
+          state_name,
+        },
+        None,
+      )
+      .with_compiler_loc()
+      .with_tokens(fsm_pipe.start.tokens()));
     }
-    Ok(())
+  }
+  Ok(())
 }
 
 fn state_name_from_pattern(pattern: &Pattern) -> Option<String> {
-    match pattern {
-        Pattern::TupleStruct(tuple_struct) => Some(tuple_struct.name.to_string()),
-        Pattern::Expression(Expression::Literal(Literal::Atom(atom))) => {
-            Some(atom.name.to_string())
-        }
-        _ => None,
+  match pattern {
+    Pattern::TupleStruct(tuple_struct) => Some(tuple_struct.name.to_string()),
+    Pattern::Expression(Expression::Literal(Literal::Atom(atom))) => {
+      Some(atom.name.to_string())
     }
+    _ => None,
+  }
 }
 
-fn apply_transitions(
-    transitions: &[Transition],
-    state: &mut Value,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<Option<Value>> {
-    for transition in transitions {
-        match transition {
-            Transition::Next(next_pattern) | Transition::Async(next_pattern) => {
-                *state = crate::patterns::pattern_to_value(next_pattern, env, p)?;
-            }
-            Transition::Output(output_pattern) => {
-                return Ok(Some(crate::patterns::pattern_to_value(
-                    output_pattern,
-                    env,
-                    p,
-                )?));
-            }
-            Transition::Statement(stmt) => {
-                statement(stmt, Some(env), p)?;
-            }
-            Transition::CodeBlock(code) => {
-                for (line, _) in code {
-                    mech_code(line, p)?;
-                }
-            }
+fn apply_transitions(transitions: &[Transition], state: &mut Value, env: &mut Environment, p: &Interpreter) -> MResult<Option<Value>> {
+  for transition in transitions {
+    match transition {
+      Transition::Next(next_pattern) | Transition::Async(next_pattern) => {
+        *state = crate::patterns::pattern_to_value(next_pattern, env, p)?;
+      }
+      Transition::Output(output_pattern) => {
+        return Ok(Some(crate::patterns::pattern_to_value(
+          output_pattern,
+          env,
+          p,
+        )?));
+      }
+      Transition::Statement(stmt) => {
+        statement(stmt, Some(env), p)?;
+      }
+      Transition::CodeBlock(code) => {
+        for (line, _) in code {
+          mech_code(line, p)?;
         }
+      }
     }
-    Ok(None)
+  }
+  Ok(None)
 }
 
 // FSM Errors
 // ----------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct MissingFsmError {
+  pub fsm_id: u64,
+}
+
+impl MechErrorKind for MissingFsmError {
+  fn name(&self) -> &str {
+    "MissingFsm"
+  }
+  fn message(&self) -> String {
+    format!("FSM with id {} not found", self.fsm_id)
+  }
+}
 
 #[derive(Debug, Clone)]
 pub struct FsmUndefinedStateError {

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -80,7 +80,7 @@ pub fn execute_fsm_pipe(
         }
         call_env.insert(arg_decl.name.hash(), detach_value(arg_value));
     }
-    let mut state = pattern_to_value(&fsm.start, &call_env, p)?;
+    let mut state = crate::patterns::pattern_to_value(&fsm.start, &call_env, p)?;
     validate_fsm_state_coverage(&fsm, fsm_pipe)?;
     execute_fsm_pipe_impl(&fsm, &mut state, &mut call_env, p)
 }
@@ -118,8 +118,9 @@ fn execute_fsm_pipe_impl(
             match arm {
                 FsmArm::Transition(pattern, transitions) => {
                     let mut arm_env = call_env.clone();
-                    clear_pattern_bindings(pattern, &mut arm_env);
-                    let matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+                    crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
+                    let matched =
+                        crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
                     trace_println!(
                         p,
                         "{}",
@@ -165,8 +166,9 @@ fn execute_fsm_pipe_impl(
                 }
                 FsmArm::Guard(pattern, guards) => {
                     let mut arm_env = call_env.clone();
-                    clear_pattern_bindings(pattern, &mut arm_env);
-                    let pattern_matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+                    crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
+                    let pattern_matched =
+                        crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
                     trace_println!(
                         p,
                         "{}",
@@ -186,7 +188,11 @@ fn execute_fsm_pipe_impl(
                         let guard_passes = match &guard.condition {
                             Pattern::Wildcard => true,
                             _ => {
-                                let cond = pattern_to_value(&guard.condition, &arm_env, p)?;
+                                let cond = crate::patterns::pattern_to_value(
+                                    &guard.condition,
+                                    &arm_env,
+                                    p,
+                                )?;
                                 match cond {
                                     Value::Bool(x) => *x.borrow(),
                                     other => {
@@ -198,7 +204,7 @@ fn execute_fsm_pipe_impl(
                                             },
                                             None,
                                         )
-                                        .with_compiler_loc())
+                                        .with_compiler_loc());
                                     }
                                 }
                             }
@@ -357,46 +363,10 @@ fn validate_transition_target_state(
 fn state_name_from_pattern(pattern: &Pattern) -> Option<String> {
     match pattern {
         Pattern::TupleStruct(tuple_struct) => Some(tuple_struct.name.to_string()),
-        Pattern::Expression(Expression::Literal(Literal::Atom(atom))) => Some(atom.name.to_string()),
+        Pattern::Expression(Expression::Literal(Literal::Atom(atom))) => {
+            Some(atom.name.to_string())
+        }
         _ => None,
-    }
-}
-
-fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
-    let mut ids = Vec::new();
-    collect_pattern_variable_ids(pattern, &mut ids);
-    for var_id in ids {
-        env.remove(&var_id);
-    }
-}
-
-fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
-    match pattern {
-        Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
-        Pattern::Tuple(tuple) => {
-            for item in &tuple.0 {
-                collect_pattern_variable_ids(item, ids);
-            }
-        }
-        Pattern::Array(array) => {
-            for item in &array.prefix {
-                collect_pattern_variable_ids(item, ids);
-            }
-            if let Some(spread) = &array.spread {
-                if let Some(binding) = &spread.binding {
-                    collect_pattern_variable_ids(binding, ids);
-                }
-            }
-            for item in &array.suffix {
-                collect_pattern_variable_ids(item, ids);
-            }
-        }
-        Pattern::TupleStruct(tuple_struct) => {
-            for item in &tuple_struct.patterns {
-                collect_pattern_variable_ids(item, ids);
-            }
-        }
-        _ => {}
     }
 }
 
@@ -409,10 +379,14 @@ fn apply_transitions(
     for transition in transitions {
         match transition {
             Transition::Next(next_pattern) | Transition::Async(next_pattern) => {
-                *state = pattern_to_value(next_pattern, env, p)?;
+                *state = crate::patterns::pattern_to_value(next_pattern, env, p)?;
             }
             Transition::Output(output_pattern) => {
-                return Ok(Some(pattern_to_value(output_pattern, env, p)?));
+                return Ok(Some(crate::patterns::pattern_to_value(
+                    output_pattern,
+                    env,
+                    p,
+                )?));
             }
             Transition::Statement(stmt) => {
                 statement(stmt, Some(env), p)?;
@@ -425,63 +399,6 @@ fn apply_transitions(
         }
     }
     Ok(None)
-}
-
-fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
-    match pattern {
-        Pattern::Wildcard => Ok(Value::Empty),
-        Pattern::Expression(expr) => expression(expr, Some(env), p),
-        Pattern::Tuple(pattern_tuple) => {
-            let mut values = Vec::with_capacity(pattern_tuple.0.len());
-            for inner in &pattern_tuple.0 {
-                values.push(pattern_to_value(inner, env, p)?);
-            }
-            Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
-        }
-        Pattern::Array(array) => {
-            let mut values = Vec::new();
-            for inner in &array.prefix {
-                values.push(pattern_to_value(inner, env, p)?);
-            }
-            if let Some(spread) = &array.spread {
-                if let Some(binding) = &spread.binding {
-                    match pattern_to_value(binding, env, p)? {
-                        Value::MatrixValue(matrix) => values.extend(matrix.as_vec()),
-                        other => values.push(other),
-                    }
-                }
-            }
-            for inner in &array.suffix {
-                values.push(pattern_to_value(inner, env, p)?);
-            }
-            #[cfg(feature = "matrix")]
-            {
-                Ok(Value::MatrixValue(Matrix::from_vec(values.clone(), 1, values.len())))
-            }
-            #[cfg(not(feature = "matrix"))]
-            {
-                let _ = values;
-                Err(MechError::new(
-                    FeatureNotEnabledError,
-                    None,
-                )
-                .with_compiler_loc())
-            }
-        }
-        Pattern::TupleStruct(pattern_tuple_struct) => {
-            let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
-            values.push(atom(
-                &Atom {
-                    name: pattern_tuple_struct.name.clone(),
-                },
-                p,
-            ));
-            for inner in &pattern_tuple_struct.patterns {
-                values.push(pattern_to_value(inner, env, p)?);
-            }
-            Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))))
-        }
-    }
 }
 
 // FSM Errors
@@ -526,7 +443,6 @@ impl MechErrorKind for FsmGuardConditionKindMismatchError {
         )
     }
 }
-
 
 #[derive(Debug, Clone)]
 pub struct FsmExceededTransitionLimitError {

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -78,7 +78,7 @@ pub fn execute_fsm_pipe(fsm_pipe: &FsmPipe, env: Option<&Environment>, p: &Inter
       }
       call_env.insert(arg_decl.name.hash(), detach_value(arg_value));
   }
-  let mut state = crate::patterns::pattern_to_value(&fsm.start, &call_env, p)?;
+  let mut state = pattern_to_value(&fsm.start, &call_env, p)?;
   validate_fsm_state_coverage(&fsm, fsm_pipe)?;
   execute_fsm_pipe_impl(&fsm, &mut state, &mut call_env, p)
 }
@@ -96,156 +96,152 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       )
     )
   );
+  // Step through the FSM, applying transitions until we hit a terminal state (no applicable transitions) or exceed the step limit.
   for step in 0..p.max_steps {
     trace_println!(
-        p,
-        "{}",
-        format_fsm_trace(
-            "step",
-            format!("{step:>4} state={}", summarize_value(state))
-        )
+      p,
+      "{}",
+      format_fsm_trace(
+        "step",
+        format!("{step:>4} state={}", summarize_value(state))
+      )
     );
     let mut transitioned = false;
     for (arm_idx, arm) in fsm.arms.iter().enumerate() {
       match arm {
         FsmArm::Transition(pattern, transitions) => {
-            let mut arm_env = call_env.clone();
-            crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
-            let matched =
-                crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
-            trace_println!(
+          let mut arm_env = call_env.clone();
+          clear_pattern_bindings(pattern, &mut arm_env);
+          let matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          trace_println!(
+            p,
+            "{}",
+            format_fsm_trace(
+              "arm",
+              format!(
+                "[{arm_idx}] check transition pattern={} {}",
+                summarize_pattern(pattern),
+                if matched { "✓" } else { "✗" }
+              )
+            )
+          );
+          if matched {
+            let previous_state = summarize_value(state);
+            let out = apply_transitions(transitions, state, &mut arm_env, p)?;
+            *call_env = arm_env;
+            if let Some(value) = out {
+              trace_println!(
                 p,
                 "{}",
                 format_fsm_trace(
-                    "arm",
-                    format!(
-                        "[{arm_idx}] check transition pattern={} {}",
-                        summarize_pattern(pattern),
-                        if matched { "✓" } else { "✗" }
-                    )
+                  "output",
+                  format!("value={}", summarize_value(&value))
                 )
-            );
-            if matched {
-                let previous_state = summarize_value(state);
-                let out = apply_transitions(transitions, state, &mut arm_env, p)?;
-                *call_env = arm_env;
-                if let Some(value) = out {
-                    trace_println!(
-                        p,
-                        "{}",
-                        format_fsm_trace(
-                            "output",
-                            format!("value={}", summarize_value(&value))
-                        )
-                    );
-                    return Ok(value);
-                }
-                trace_println!(
-                    p,
-                    "{}",
-                    format_fsm_trace(
-                        "transition",
-                        format!(
-                            "arm[{arm_idx}] {} -> {}",
-                            previous_state,
-                            summarize_value(state)
-                        )
-                    )
-                );
-                transitioned = true;
-                break;
+              );
+              return Ok(value);
             }
-        }
-        FsmArm::Guard(pattern, guards) => {
-          let mut arm_env = call_env.clone();
-          crate::patterns::clear_pattern_bindings(pattern, &mut arm_env);
-          let pattern_matched = crate::patterns::pattern_matches_value(pattern, state, &mut arm_env, p)?;
-          trace_println!(
+            trace_println!(
               p,
               "{}",
               format_fsm_trace(
-                  "arm",
-                  format!(
-                      "[{arm_idx}] check guard pattern={} {}",
-                      summarize_pattern(pattern),
-                      if pattern_matched { "✓" } else { "✗" }
-                  )
+                "transition",
+                format!(
+                  "arm[{arm_idx}] {} -> {}",
+                  previous_state,
+                  summarize_value(state)
+                )
               )
+            );
+            transitioned = true;
+            break;
+          }
+        }
+        FsmArm::Guard(pattern, guards) => {
+          let mut arm_env = call_env.clone();
+          clear_pattern_bindings(pattern, &mut arm_env);
+          let pattern_matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          trace_println!(
+            p,
+            "{}",
+            format_fsm_trace(
+              "arm",
+              format!(
+                "[{arm_idx}] check guard pattern={} {}",
+                summarize_pattern(pattern),
+                if pattern_matched { "✓" } else { "✗" }
+              )
+            )
           );
           if !pattern_matched {
-              continue;
+            continue;
           }
           for (guard_idx, guard) in guards.iter().enumerate() {
-              let guard_passes = match &guard.condition {
-                  Pattern::Wildcard => true,
-                  _ => {
-                      let cond = crate::patterns::pattern_to_value(
-                          &guard.condition,
-                          &arm_env,
-                          p,
-                      )?;
-                      match cond {
-                          Value::Bool(x) => *x.borrow(),
-                          other => {
-                              return Err(MechError::new(
-                                  FsmGuardConditionKindMismatchError {
-                                      arm_index: arm_idx,
-                                      guard_index: guard_idx,
-                                      actual_kind: other.kind(),
-                                  },
-                                  None,
-                              )
-                              .with_compiler_loc());
-                          }
-                      }
+            let guard_passes = match &guard.condition {
+              Pattern::Wildcard => true,
+              _ => {
+                let cond = pattern_to_value(&guard.condition,&arm_env,p)?;
+                match cond {
+                  Value::Bool(x) => *x.borrow(),
+                  other => {
+                    return Err(MechError::new(
+                      FsmGuardConditionKindMismatchError {
+                        arm_index: arm_idx,
+                        guard_index: guard_idx,
+                        actual_kind: other.kind(),
+                      },
+                      None,
+                    )
+                    .with_compiler_loc());
                   }
-              };
-              trace_println!(
-                  p,
-                  "{}",
-                  format_fsm_trace(
-                      "guard",
-                      format!(
-                          "arm[{arm_idx}] check guard[{guard_idx}] condition={} {}",
-                          summarize_guard_condition(&guard.condition),
-                          if guard_passes { "✓" } else { "✗" }
-                      )
-                  )
-              );
-              if !guard_passes {
-                  continue;
+                }
               }
-              let previous_state = summarize_value(state);
-              let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
-              *call_env = arm_env;
-              if let Some(value) = out {
-                  trace_println!(
-                      p,
-                      "{}",
-                      format_fsm_trace(
-                          "output",
-                          format!("value={}", summarize_value(&value))
-                      )
-                  );
-                  return Ok(value);
-              }
+            };
+            trace_println!(
+              p,
+              "{}",
+              format_fsm_trace(
+                "guard",
+                format!(
+                  "arm[{arm_idx}] check guard[{guard_idx}] condition={} {}",
+                  summarize_guard_condition(&guard.condition),
+                  if guard_passes { "✓" } else { "✗" }
+                )
+              )
+            );
+            if !guard_passes {
+              continue;
+            }
+            let previous_state = summarize_value(state);
+            let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
+            *call_env = arm_env;
+            if let Some(value) = out {
               trace_println!(
-                  p,
-                  "{}",
-                  format_fsm_trace(
-                      "transition",
-                      format!(
-                          "arm[{arm_idx}] {} -> {}",
-                          previous_state,
-                          summarize_value(state)
-                      )
-                  )
+                p,
+                "{}",
+                format_fsm_trace(
+                  "output",
+                  format!("value={}", summarize_value(&value))
+                )
               );
-              transitioned = true;
-              break;
+              return Ok(value);
+            }
+            trace_println!(
+              p,
+              "{}",
+              format_fsm_trace(
+                "transition",
+                format!(
+                  "arm[{arm_idx}] {} -> {}",
+                  previous_state,
+                  summarize_value(state)
+                )
+              )
+            );
+            transitioned = true;
+            break;
           }
           if transitioned {
-              break;
+            break;
           }
         }
       }
@@ -360,10 +356,10 @@ fn apply_transitions(transitions: &[Transition], state: &mut Value, env: &mut En
   for transition in transitions {
     match transition {
       Transition::Next(next_pattern) | Transition::Async(next_pattern) => {
-        *state = crate::patterns::pattern_to_value(next_pattern, env, p)?;
+        *state = pattern_to_value(next_pattern, env, p)?;
       }
       Transition::Output(output_pattern) => {
-        return Ok(Some(crate::patterns::pattern_to_value(
+        return Ok(Some(pattern_to_value(
           output_pattern,
           env,
           p,

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -406,79 +406,79 @@ fn apply_transitions(
 
 #[derive(Debug, Clone)]
 pub struct FsmUndefinedStateError {
-    pub fsm_name: String,
-    pub state_name: String,
+  pub fsm_name: String,
+  pub state_name: String,
 }
 
 impl MechErrorKind for FsmUndefinedStateError {
-    fn name(&self) -> &str {
-        "FsmUndefinedState"
-    }
-    fn message(&self) -> String {
-        format!(
-            "FSM '{}' references undefined state '{}'",
-            self.fsm_name, self.state_name
-        )
-    }
+  fn name(&self) -> &str {
+    "FsmUndefinedState"
+  }
+  fn message(&self) -> String {
+    format!(
+      "FSM '{}' references undefined state '{}'",
+      self.fsm_name, self.state_name
+    )
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct FsmGuardConditionKindMismatchError {
-    pub arm_index: usize,
-    pub guard_index: usize,
-    pub actual_kind: ValueKind,
+  pub arm_index: usize,
+  pub guard_index: usize,
+  pub actual_kind: ValueKind,
 }
 
 impl MechErrorKind for FsmGuardConditionKindMismatchError {
-    fn name(&self) -> &str {
-        "FsmGuardConditionKindMismatch"
-    }
+  fn name(&self) -> &str {
+    "FsmGuardConditionKindMismatch"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "FSM guard condition arm[{}] guard[{}] must evaluate to Bool, got '{}'",
-            self.arm_index,
-            self.guard_index,
-            self.actual_kind.to_string(),
-        )
-    }
+  fn message(&self) -> String {
+    format!(
+      "FSM guard condition arm[{}] guard[{}] must evaluate to Bool, got '{}'",
+      self.arm_index,
+      self.guard_index,
+      self.actual_kind.to_string(),
+    )
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct FsmExceededTransitionLimitError {
-    pub max_transitions: usize,
+  pub max_transitions: usize,
 }
 
 impl MechErrorKind for FsmExceededTransitionLimitError {
-    fn name(&self) -> &str {
-        "FsmExceededTransitionLimit"
-    }
+  fn name(&self) -> &str {
+    "FsmExceededTransitionLimit"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "FSM exceeded maximum transition limit of {} steps",
-            self.max_transitions
-        )
-    }
+  fn message(&self) -> String {
+    format!(
+      "FSM exceeded maximum transition limit of {} steps",
+      self.max_transitions
+    )
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct FsmArgumentKindMismatchError {
-    pub argument: String,
-    pub expected_kind: ValueKind,
-    pub actual_kind: ValueKind,
+  pub argument: String,
+  pub expected_kind: ValueKind,
+  pub actual_kind: ValueKind,
 }
 
 impl MechErrorKind for FsmArgumentKindMismatchError {
-    fn name(&self) -> &str {
-        "FsmArgumentKindMismatch"
-    }
-    fn message(&self) -> String {
-        format!(
-            "FSM argument '{}' expected kind '{}' but received '{}'",
-            self.argument,
-            self.expected_kind.to_string(),
-            self.actual_kind.to_string()
-        )
-    }
+  fn name(&self) -> &str {
+    "FsmArgumentKindMismatch"
+  }
+  fn message(&self) -> String {
+    format!(
+      "FSM argument '{}' expected kind '{}' but received '{}'",
+      self.argument,
+      self.expected_kind.to_string(),
+      self.actual_kind.to_string()
+    )
+  }
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated pattern logic that lived separately in functions, FSMs, and option-match guards to ensure consistent matching and binding behavior across interpreter subsystems.
- Allow option-match guard expressions to reuse the same matcher while preserving guard-specific boolean semantics.
- Make pattern functionality easier to maintain by centralizing conversion of patterns into runtime `Value`s and variable-binding cleanup.

### Description
- Added a new module `src/interpreter/src/patterns.rs` that implements `PatternMatchSemantics` and central functions including `pattern_matches_arguments`, `pattern_matches_value_with_semantics`, `pattern_matches_value`, `pattern_to_value`, and `clear_pattern_bindings` along with supporting helpers for detach/collecting ids and matrix-like handling.
- Updated function match-arm evaluation to call the shared matcher (`crate::patterns::pattern_matches_arguments`) and kept the original tracing/arm-selection logic intact.
- Updated FSM execution to use `crate::patterns::pattern_to_value`, `crate::patterns::clear_pattern_bindings`, and `crate::patterns::pattern_matches_value`, and moved `apply_transitions` to call the shared conversion for next/output patterns.
- Updated option-match evaluation to use the shared matcher in `OptionGuard` mode (so guard expressions evaluate to `bool` when appropriate) and reused the matcher for arm-kind validation.
- Exported the new `patterns` module from the interpreter `lib.rs` and added documentation `docs/reference/patterns.mec`, also linked the new reference from `docs/reference/index.mec`.

### Testing
- Ran `rustfmt` on the modified interpreter files (`src/interpreter/src/patterns.rs`, `src/interpreter/src/functions.rs`, `src/interpreter/src/state_machines.rs`, `src/interpreter/src/expressions.rs`, `src/interpreter/src/lib.rs`) and formatting succeeded for those files.
- Performed `cargo check -p mech-interpreter` which completed successfully.
- Performed `cargo check -p mech-interpreter --features state_machines,functions` which completed successfully.
- `cargo fmt` across the repository failed due to unrelated trailing-whitespace issues in `src/wasm/*` files (these failures are external to the changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4360d30c0832ab873860bc8643abd)