### PR TITLE
Allow unsized-target matrix conversions and enforce function input kind annotations

### DIFF
--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -969,7 +969,11 @@ impl Value {
     match (self, other) {
     (Value::Empty, ValueKind::Option(_)) => Some(Value::Empty),
     (value, ValueKind::Option(inner)) => value.convert_to(inner.as_ref()),
-    (value, ValueKind::Matrix(_, target_shape)) if target_shape.is_empty() && value.is_matrix() => Some(value.clone()),
+    (value, ValueKind::Matrix(_, target_shape))
+      if target_shape.is_empty() && matches!(value.kind(), ValueKind::Matrix(_, _)) =>
+    {
+      Some(value.clone())
+    },
     // ==== Unsigned widening and narrowing ====
     #[cfg(all(feature = "u8", feature = "u16"))]
     (Value::U8(v), ValueKind::U16) => Some(Value::U16(Ref::new((*v.borrow()) as u16))),

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -275,7 +275,9 @@ impl ValueKind {
       (U8, Index) | (U16, Index) | (U32, Index) | (U64, Index) | (U128, Index) |
       (I8, Index) | (I16, Index) | (I32, Index) | (I64, Index) | (I128, Index) => true,
 
-      // Matrix: element type convertible and shape matches
+      // Matrix: element type convertible and shape matches.
+      // An empty target shape (`[]`) is treated as a wildcard shape.
+      (Matrix(a, _ashape), Matrix(b, bshape)) if bshape.is_empty() && a.as_ref().is_convertible_to(b.as_ref()) => true,
       (Matrix(a, ashape), Matrix(b, bshape)) if ashape.into_iter().product::<usize>() == bshape.into_iter().product::<usize>() && a.as_ref().is_convertible_to(b.as_ref()) => true,
 
       // Option conversions
@@ -967,6 +969,7 @@ impl Value {
     match (self, other) {
     (Value::Empty, ValueKind::Option(_)) => Some(Value::Empty),
     (value, ValueKind::Option(inner)) => value.convert_to(inner.as_ref()),
+    (value, ValueKind::Matrix(_, target_shape)) if target_shape.is_empty() && value.is_matrix() => Some(value.clone()),
     // ==== Unsigned widening and narrowing ====
     #[cfg(all(feature = "u8", feature = "u16"))]
     (Value::U8(v), ValueKind::U16) => Some(Value::U16(Ref::new((*v.borrow()) as u16))),

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -444,7 +444,7 @@ fn bind_function_inputs(
     p: &Interpreter,
 ) -> MResult<()> {
     let scoped_state = p.state.borrow();
-    for ((arg_id, _), input_value) in fxn_def.input.iter().zip(input_arg_values.iter()) {
+    for ((arg_id, input_kind_annotation), input_value) in fxn_def.input.iter().zip(input_arg_values.iter()) {
         let arg_name = fxn_def
             .code
             .input
@@ -452,7 +452,32 @@ fn bind_function_inputs(
             .find(|arg| arg.name.hash() == *arg_id)
             .map(|arg| arg.name.to_string())
             .unwrap_or_else(|| arg_id.to_string());
-        scoped_state.save_symbol(*arg_id, arg_name, detach_value(input_value), false);
+        let bound_value = {
+            #[cfg(feature = "kind_annotation")]
+            {
+                let target_kind = kind_annotation(&input_kind_annotation.kind, p)?
+                    .to_value_kind(&p.state.borrow().kinds)?;
+                let detached_input = detach_value(input_value);
+                detached_input.clone().convert_to(&target_kind).ok_or_else(|| {
+                    MechError::new(
+                        FunctionInputTypeMismatchError {
+                            function_name: fxn_def.name.clone(),
+                            argument_name: arg_name.clone(),
+                            expected: target_kind.clone(),
+                            found: detached_input.kind(),
+                        },
+                        None,
+                    )
+                    .with_compiler_loc()
+                    .with_tokens(input_kind_annotation.tokens())
+                })?
+            }
+            #[cfg(not(feature = "kind_annotation"))]
+            {
+                detach_value(input_value)
+            }
+        };
+        scoped_state.save_symbol(*arg_id, arg_name, bound_value, false);
     }
     Ok(())
 }
@@ -517,6 +542,27 @@ impl MechErrorKind for FunctionOutputUndefinedError {
         format!(
             "Function output {} was declared but never defined",
             self.output_id
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionInputTypeMismatchError {
+    pub function_name: String,
+    pub argument_name: String,
+    pub expected: ValueKind,
+    pub found: ValueKind,
+}
+
+impl MechErrorKind for FunctionInputTypeMismatchError {
+    fn name(&self) -> &str {
+        "FunctionInputTypeMismatch"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Function '{}' argument '{}' expected {}, found {}",
+            self.function_name, self.argument_name, self.expected, self.found
         )
     }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -996,6 +996,15 @@ test_interpreter!(interpret_convert_rational_to_string,r#"x<string>:=1/2"#, Valu
 test_interpreter!(interpret_convert_f64_to_string2,r#"x<string>:=123"#, Value::String(Ref::new(String::from("123"))));
 
 test_interpreter!(interpret_convert_f64_to_rational_to_string,r#"x<string> := 0.5<r64>"#,Value::String(Ref::new(String::from("1/2"))));
+test_interpreter!(interpret_convert_matrix_to_optional_unsized_matrix, r#"x<[u64]?> := [1u64 2u64 3u64]; x[1]"#, Value::U64(Ref::new(1u64)));
+test_interpreter!(interpret_user_function_input_annotation_optional_promotion, r#"
+x := [1u64 2u64 3u64]
+head(x<[u64]?>) -> <u64?>
+  | [] -> _
+  | [h ...] -> h
+  | _ -> _.
+head(x)
+"#, Value::U64(Ref::new(1u64)));
 
 test_interpreter!(interpret_matrix_power_and_addition,"~μ := [1 2 3]; K := [0.1 0.2 0.3; 0.4 0.5 0.6; 0.7 0.8 0.9]; Ẑ := [0.01; 0.02; 0.03]; μ = μ + (K ** Ẑ)'", Value::MatrixF64(Matrix::from_vec(vec![1.014, 2.032, 3.05], 1, 3)));
 test_interpreter!(interpret_assign_scalar_no_space, "~z:=10;z=20", Value::F64(Ref::new(20.0)));


### PR DESCRIPTION
### Motivation

- Allow matrix conversions where the target shape is unspecified (treated as a wildcard) and respect user-provided function input kind annotations at call time.
- Provide clearer error reporting when an argument fails to convert to the annotated kind.

### Description

- Treat a `Matrix` target kind with an empty shape (`[]`) as a wildcard shape in `ValueKind::is_convertible_to` so any source matrix with a convertible element type can convert to it. 
- Permit converting any matrix value to a `Matrix` kind whose `target_shape` is empty in `Value::convert_to` by short-circuiting when the target shape is unsized. 
- Enhance `bind_function_inputs` to consider function input kind annotations (behind the `kind_annotation` feature), convert detached argument values to the annotated `ValueKind`, and return a typed `FunctionInputTypeMismatchError` when conversion fails. 
- Add the `FunctionInputTypeMismatchError` error kind to report function name, argument name, expected kind, and found kind. 
- Add interpreter tests exercising unsized optional matrix promotion and function input annotation behavior and adjust test ordering in `tests/interpreter.rs`.

### Testing

- Ran the interpreter test suite (`tests/interpreter.rs`) including the new tests `interpret_convert_matrix_to_optional_unsized_matrix` and `interpret_user_function_input_annotation_optional_promotion`, and they passed. 
- Ran the project unit tests (`cargo test`) and they passed with the current feature combinations enabled locally. 
- No automated tests failed during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d556e96c7c832a800572047a844a68)