### PR TITLE
Add automatic broadcasting for scalar user functions on matrices

### DIFF
--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -152,6 +152,11 @@ fn execute_user_function(
         .with_tokens(fxn_def.code.name.tokens()));
     }
 
+    #[cfg(feature = "matrix")]
+    if let Some(result) = try_broadcast_user_function(fxn_def, input_arg_values, p)? {
+        return Ok(result);
+    }
+
     trace_println!(
         p,
         "{}",
@@ -199,6 +204,78 @@ fn execute_user_function(
             );
             Err(err)
         }
+    }
+}
+
+#[cfg(feature = "matrix")]
+fn try_broadcast_user_function(
+    fxn_def: &FunctionDefinition,
+    input_arg_values: &Vec<Value>,
+    p: &Interpreter,
+) -> MResult<Option<Value>> {
+    if input_arg_values.len() != 1 || fxn_def.code.output.len() != 1 || fxn_def.code.input.len() != 1 {
+        return Ok(None);
+    }
+
+    let source = detach_value(&input_arg_values[0]);
+    if !source.is_matrix() {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "kind_annotation")]
+    let (input_kind, output_kind) = {
+        let input_kind = kind_annotation(&fxn_def.code.input[0].kind.kind, p)?
+            .to_value_kind(&p.state.borrow().kinds)?;
+        let output_kind = kind_annotation(&fxn_def.code.output[0].kind.kind, p)?
+            .to_value_kind(&p.state.borrow().kinds)?;
+        (input_kind, output_kind)
+    };
+
+    #[cfg(not(feature = "kind_annotation"))]
+    let (input_kind, output_kind) = {
+        return Ok(None);
+    };
+
+    if input_kind != output_kind || matches!(input_kind, ValueKind::Matrix(_, _)) {
+        return Ok(None);
+    }
+
+    let Some(elements) = crate::patterns::matrix_like_values(&source) else {
+        return Ok(None);
+    };
+
+    let mut outputs = Vec::with_capacity(elements.len());
+    for element in elements {
+        outputs.push(execute_user_function(fxn_def, &vec![element], p)?);
+    }
+
+    let shape = source.shape();
+    Ok(Some(build_typed_matrix_from_values(
+        &output_kind,
+        outputs,
+        shape[0],
+        shape[1],
+    )))
+}
+
+#[cfg(feature = "matrix")]
+fn build_typed_matrix_from_values(
+    output_kind: &ValueKind,
+    outputs: Vec<Value>,
+    rows: usize,
+    cols: usize,
+) -> Value {
+    match output_kind {
+        #[cfg(feature = "f64")]
+        ValueKind::F64 => Value::MatrixF64(f64::to_matrix(
+            outputs
+                .into_iter()
+                .map(|value| value.as_f64().expect("Expected f64 output").borrow().clone())
+                .collect::<Vec<f64>>(),
+            rows,
+            cols,
+        )),
+        _ => Value::MatrixValue(Value::to_matrix(outputs, rows, cols)),
     }
 }
 

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -287,7 +287,7 @@ fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
 }
 
 // Used by the Array pattern arm to get a uniform element list regardless of the matrix's concrete numeric type.
-fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
+pub(crate) fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
   match value {
     #[cfg(feature = "matrix")]
     Value::MatrixIndex(matrix) => Some(

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -722,6 +722,9 @@ test_interpreter!(interpret_function_call_native_vector, "math/sin([1.570796327 
 test_interpreter!(interpret_function_call_native, r#"math/sin(1.5707963267948966)"#, Value::F64(Ref::new(1.0)));
 test_interpreter!(interpret_function_call_native_cos, r#"math/cos(0.0)"#, Value::F64(Ref::new(1.0)));
 test_interpreter!(interpret_function_call_native_vector2, "math/cos([0.0 0.0])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
+test_interpreter!(interpret_user_function_scalar_auto_broadcast, r#"add-one(x<f64>) -> <f64>
+  | * -> x + 1.
+add-one([1 2 3])"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
 
 test_interpreter!(interpret_set_value,"~x := 1.23; x = 4.56;", Value::F64(Ref::new(4.56)));
 test_interpreter!(interpret_set_value_row_vector,"~x := [6,2]; x[1] = 4;", Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2)));


### PR DESCRIPTION
### Motivation

- Allow user-defined functions that operate on scalars to be called with matrix arguments by automatically broadcasting the scalar function over each element and returning a matrix of results.

### Description

- Detect 1-arg/1-output user functions and, when called with a matrix, run a broadcast path implemented in `try_broadcast_user_function` inside `src/interpreter/src/functions.rs` that evaluates the user function element-wise and reconstructs a matrix result preserving the original shape.
- Reuse the pattern-matching helper by exposing `matrix_like_values` as `pub(crate)` in `src/interpreter/src/patterns.rs` so broadcasting can iterate matrix elements uniformly across different concrete matrix types.
- Reconstruct typed matrix outputs with `build_typed_matrix_from_values`, with a fast-path specialization for `f64` matrices to produce `Value::MatrixF64` instead of a generic `MatrixValue`.
- Add a unit test in `tests/interpreter.rs` (`interpret_user_function_scalar_auto_broadcast`) covering the example `add-one(x<f64>) -> <f64> | * -> x + 1.` called with `[1 2 3]` expecting `[2 3 4]`.

### Testing

- Ran `cargo test -q interpret_user_function_scalar_auto_broadcast --test interpreter` and it passed.
- Ran `cargo test -q interpret_function_call_native_vector --test interpreter` to ensure existing native vector-call behavior was unaffected and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d58feb9bdc832a8a217ea420efc27f)