### PR TITLE
Allow function match arms without explicit patterns

### DIFF
--- a/src/syntax/src/functions.rs
+++ b/src/syntax/src/functions.rs
@@ -149,28 +149,3 @@ pub fn call_arg(input: ParseString) -> ParseResult<(Option<Identifier>,Expressio
   let (input, expr) = expression(input)?;
   Ok((input, (None, expr)))
 }
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn parse_function_define_match_arm_without_pattern() {
-    let source = "add-one(x<f64>) -> <f64>\n  | x + 1.";
-    let graphemes = crate::graphemes::init_source(source);
-    let input = ParseString::new(&graphemes);
-    let (_, parsed) = function_define(input).expect("function with shorthand match arm should parse");
-    assert_eq!(parsed.match_arms.len(), 1);
-    assert_eq!(parsed.match_arms[0].pattern, Pattern::Wildcard);
-  }
-
-  #[test]
-  fn parse_function_define_match_arms_mixed() {
-    let source = "score(x<f64>, weight<f64>, bias<f64>) -> <f64>\n  | x + 1\n  | * -> 0.";
-    let graphemes = crate::graphemes::init_source(source);
-    let input = ParseString::new(&graphemes);
-    let (_, parsed) = function_define(input).expect("mixed function match arms should parse");
-    assert_eq!(parsed.match_arms.len(), 2);
-    assert_eq!(parsed.match_arms[0].pattern, Pattern::Wildcard);
-  }
-}

--- a/src/syntax/src/functions.rs
+++ b/src/syntax/src/functions.rs
@@ -77,14 +77,23 @@ fn function_match_arm(input: ParseString) -> ParseResult<FunctionMatchArm> {
   let (input, _) = whitespace0(input)?;
   let (input, _) = alt((box_t_left, box_bl, bar))(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, pattern) = crate::patterns::pattern(input)?;
-  let (input, _) = whitespace0(input)?;
-  let (input, _) = transition_operator(input)?;
-  let (input, _) = whitespace0(input)?;
+  if let Ok((input, pattern)) = crate::patterns::pattern(input.clone()) {
+    if let Ok((input, _)) = whitespace0(input) {
+      if let Ok((input, _)) = transition_operator(input) {
+        let (input, _) = whitespace0(input)?;
+        let (input, expr) = expression(input)?;
+        let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
+        return Ok((input, FunctionMatchArm {
+          pattern,
+          expression: expr,
+        }));
+      }
+    }
+  }
   let (input, expr) = expression(input)?;
   let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
   Ok((input, FunctionMatchArm {
-    pattern,
+    pattern: Pattern::Wildcard,
     expression: expr,
   }))
 }
@@ -139,4 +148,29 @@ pub fn call_arg_with_binding(input: ParseString) -> ParseResult<(Option<Identifi
 pub fn call_arg(input: ParseString) -> ParseResult<(Option<Identifier>,Expression)> {
   let (input, expr) = expression(input)?;
   Ok((input, (None, expr)))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_function_define_match_arm_without_pattern() {
+    let source = "add-one(x<f64>) -> <f64>\n  | x + 1.";
+    let graphemes = crate::graphemes::init_source(source);
+    let input = ParseString::new(&graphemes);
+    let (_, parsed) = function_define(input).expect("function with shorthand match arm should parse");
+    assert_eq!(parsed.match_arms.len(), 1);
+    assert_eq!(parsed.match_arms[0].pattern, Pattern::Wildcard);
+  }
+
+  #[test]
+  fn parse_function_define_match_arms_mixed() {
+    let source = "score(x<f64>, weight<f64>, bias<f64>) -> <f64>\n  | x + 1\n  | * -> 0.";
+    let graphemes = crate::graphemes::init_source(source);
+    let input = ParseString::new(&graphemes);
+    let (_, parsed) = function_define(input).expect("mixed function match arms should parse");
+    assert_eq!(parsed.match_arms.len(), 2);
+    assert_eq!(parsed.match_arms[0].pattern, Pattern::Wildcard);
+  }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -172,6 +172,11 @@ test_interpreter!(
 );
 
 test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) -> x | * -> 0u64.; y + 0u64", Value::U64(Ref::new(9)));
+test_interpreter!(
+  interpret_function_shorthand_match_arm_broadcasts_over_matrix_input,
+  "add-one(x<f64>) -> <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
+  Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
+);
 test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) -> <u64>\n  | [x ...] -> x\n  | * -> 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
 test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x ... y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
 #[test]


### PR DESCRIPTION
### Motivation
- Reduce boilerplate by permitting function match-arms to omit an explicit `pattern ->` and instead write `| expression` as a shorthand.

### Description
- Update `function_match_arm` in `src/syntax/src/functions.rs` to try parsing a full `pattern -> expression` and fall back to treating a bare `| expression` as `Pattern::Wildcard` when the `->` is absent.
- Add parser unit tests in `src/syntax/src/functions.rs` that cover a shorthand-only arm and a mixed shorthand + explicit pattern case.
- Preserve existing `| pattern -> expression` parsing semantics while mapping the new shorthand to the wildcard pattern internally.

### Testing
- Ran `cargo test -p mech-syntax parse_function_define_match_arm`, which executed the two new tests and passed.
- Ran `cargo test -p mech-syntax`, which ran the package test suite (9 tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5bde77bac832aaa41da9516633303)