### PR TITLE
Canonicalize atom identities, accept qualified/bare atom syntax, add enum/tagged-union design doc and tests

### DIFF
--- a/docs/atom-enum-tagged-union.md
+++ b/docs/atom-enum-tagged-union.md
@@ -1,0 +1,254 @@
+# Mech: Atom, Enum, and Tagged Union System — Implementation Sketch
+
+## Overview
+
+This document defines a unified design for atoms, enum constraints, and tagged unions in Mech.
+The core idea is:
+
+- **Atom** is the primitive.
+- **Enum declarations** constrain which atoms are valid in a context.
+- **Tagged unions** are enums whose variants may carry typed payloads.
+
+This model supports clear type checking, pattern matching, and synthesis-phase workflows.
+
+## 1. Primitives
+
+### 1.1 Atoms
+
+An atom is a globally unique symbolic constant. Its name is its value.
+
+```mech
+:red
+:ok
+:idle
+:done
+```
+
+Properties:
+
+- Atoms are interned globally. `:red` is always the same value everywhere.
+- Atoms are not owned by any type. Types constrain atoms, but do not namespace them.
+- Atoms are compared by identity.
+- Atoms are valid standalone values with type `atom` when unconstrained.
+
+Structured atoms (atoms with payloads):
+
+```mech
+:ok(123)
+:error("something went wrong")
+:some(3.14)
+```
+
+A structured atom is a `(tag, payload)` pair where the tag is an atom and payload is any Mech value.
+Before applying a type constraint, `:ok(123)` is inferred as an existential shape:
+
+- `∃T. :ok(T)` (with literal inference giving `T = i64` here)
+
+Constraints later resolve this existential during type checking.
+
+## 2. Enum Declarations
+
+An enum is a named **constraint** over a set of atoms (or structured atoms). It does not namespace variants.
+
+### 2.1 Simple Enums
+
+```mech
+<color> := :red | :green | :blue
+<direction> := :north | :south | :east | :west
+<status> := :pending | :active | :done
+```
+
+Semantics:
+
+- `<color>` means “value must be one of these atoms.”
+- Atoms still exist globally.
+- Multiple enums can share atoms.
+
+### 2.2 Typed Variable Declaration
+
+```mech
+foo<color> := :red
+```
+
+Type checking:
+
+- Validate membership of `:red` in `<color>`.
+- Reject if atom is not in the enum’s variant set.
+
+### 2.3 Compiler Membership Predicate
+
+Internal type-checking helper:
+
+```text
+member(atom, enum_decl) -> bool
+```
+
+Behavior:
+
+1. Check tag membership against enum variants.
+2. If structured, validate payload type against declared payload schema.
+
+## 3. Tagged Unions
+
+A tagged union is an enum where variants may carry typed payloads.
+
+### 3.1 Declaration
+
+```mech
+<result> := :ok(<i64>) | :error(<string>)
+<option> := :some(<f64>) | :none
+<tree>   := :leaf(<i64>) | :branch(<tree>, <tree>)
+```
+
+Semantics:
+
+- Variants are either bare atoms or structured atoms with typed payloads.
+- Payload type may be primitive, enum, record, etc.
+- Recursive declarations are permitted.
+
+### 3.2 Construction
+
+```mech
+bar<result> := :ok(123)
+baz<result> := :error("not found")
+nothing<option> := :none
+```
+
+Compiler behavior:
+
+1. Check tag exists in target type.
+2. If payload is expected, unify provided payload type.
+3. Emit type error on unknown tag or failed unification.
+
+### 3.3 Untyped Construction
+
+```mech
+x := :ok(123)
+```
+
+Without annotation, this remains weakly typed and unresolved until constrained.
+A useful internal representation:
+
+- `∃T. { tag: :ok, payload: T }` with current inference `T = i64`.
+
+If later assigned to a typed position, validate retroactively.
+
+## 4. Pattern Matching
+
+### 4.1 Basic Match
+
+```mech
+color-string := foo?
+  | :red   -> "Red"
+  | :green -> "Green"
+  | :blue  -> "Blue".
+```
+
+Rules:
+
+- Match subject must have resolved enum/union type.
+- Arms must be legal members for the subject type.
+- Exhaustiveness required unless wildcard `_` appears.
+
+### 4.2 Structured Match
+
+```mech
+message := bar?
+  | :ok(n)    -> n + 1
+  | :error(e) -> 0.
+```
+
+Bound variables inherit payload types from declaration (`n: i64`, `e: string` for `<result>`).
+
+### 4.3 Partial Match (Non-Exhaustive)
+
+If variants are missing and `_` absent:
+
+- permissive mode: warning
+- strict mode: error
+
+### 4.4 Nested Match
+
+```mech
+<wrapped> := :some(<result>) | :none
+
+x<wrapped> := :some(:ok(42))
+
+result := x?
+  | :some(:ok(n))    -> n
+  | :some(:error(e)) -> -1
+  | :none            -> 0.
+```
+
+Nested structured atoms are matched recursively, with type constraints resolved layer-by-layer.
+
+## 5. Namespace Collision and Resolution
+
+### 5.1 Global Atoms, Local Constraints
+
+Atoms are global; enums constrain usage contexts.
+
+### 5.2 Type-Context Resolution
+
+In typed positions, context selects the relevant enum membership check.
+
+```mech
+foo<color>  := :red
+bar<status> := :red
+```
+
+### 5.3 Ambiguous Untyped Atom
+
+```mech
+x := :red
+```
+
+If `:red` appears in multiple enums and no type context exists, emit ambiguity error and require annotation:
+
+```mech
+x<color> := :red
+```
+
+### 5.4 Explicit Qualification (Escape Hatch)
+
+```mech
+:color/red
+:status/red
+```
+
+Qualification is contextual syntax sugar only. It does not change atom identity.
+
+## 6. Suggested Compiler Data Model
+
+A straightforward representation for semantic analysis:
+
+```text
+AtomId        := interned symbol id
+TypeId        := canonical type reference
+
+VariantSpec   := { tag: AtomId, payload: Option<TypeExpr> }
+EnumDecl      := { name: TypeId, variants: Vec<VariantSpec> }
+AtomValue     := { tag: AtomId, payload: Option<ValueId> }
+```
+
+Type checks:
+
+- `check_atom_against_enum(value, enum_decl)`
+- `check_match_exhaustive(subject_enum, seen_tags, has_wildcard)`
+- `infer_pattern_bindings(pattern, variant_spec)`
+
+## 7. Implementation Phases
+
+1. **Parser**: ensure syntax support for structured atoms and typed variants.
+2. **Type declarations**: store enum variant specs (tag + optional payload type).
+3. **Checker**: implement membership and payload unification.
+4. **Match checker**: validate legal patterns and exhaustiveness.
+5. **Inference**: carry unresolved structured atom forms until constrained.
+6. **Diagnostics**: ambiguity errors and strict/permissive non-exhaustive behavior.
+
+## 8. Compatibility and Migration Notes
+
+- Existing atom-only usage remains valid.
+- Existing enums map naturally to constraint-only interpretation.
+- Tagged-union behavior is additive when payloads are introduced.
+- Explicit qualification can be optional and only needed for ambiguous untyped contexts.

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1,5 +1,7 @@
 use crate::*;
 use std::collections::HashMap;
+#[cfg(feature = "enum")]
+use std::collections::HashSet;
 
 // Expressions
 // ----------------------------------------------------------------------------
@@ -918,20 +920,34 @@ pub fn match_expression(
     env: Option<&Environment>,
     p: &Interpreter,
 ) -> MResult<Value> {
-    if !match_expr
-        .arms
-        .iter()
-        .any(|arm| matches!(arm.pattern, Pattern::Wildcard))
-    {
-        return Err(MechError::new(MatchNonExhaustiveError, None)
-            .with_compiler_loc()
-            .with_tokens(match_expr.source.tokens()));
-    }
     let source = expression(&match_expr.source, env, p)?;
     let detached_source = match &source {
         Value::MutableReference(reference) => reference.borrow().clone(),
         _ => source.clone(),
     };
+    if !match_expr
+        .arms
+        .iter()
+        .any(|arm| matches!(arm.pattern, Pattern::Wildcard))
+    {
+        #[cfg(feature = "enum")]
+        if let Some((enum_name, missing_patterns)) =
+            infer_missing_enum_match_patterns(match_expr, &detached_source, p)
+        {
+            return Err(MechError::new(
+                MatchNonExhaustiveVariantsError {
+                    enum_name,
+                    missing_patterns,
+                },
+                None,
+            )
+            .with_compiler_loc()
+            .with_tokens(match_expr.source.tokens()));
+        }
+        return Err(MechError::new(MatchNonExhaustiveError, None)
+            .with_compiler_loc()
+            .with_tokens(match_expr.source.tokens()));
+    }
     let mut base_env = env.cloned().unwrap_or_default();
     if let Expression::Var(var) = &match_expr.source {
         base_env.insert(var.name.hash(), detached_source.clone());
@@ -985,6 +1001,83 @@ pub fn match_expression(
     Err(MechError::new(MatchNoArmMatchedError, None)
         .with_compiler_loc()
         .with_tokens(match_expr.source.tokens()))
+}
+
+#[cfg(feature = "enum")]
+fn infer_missing_enum_match_patterns(
+    match_expr: &MatchExpression,
+    source: &Value,
+    p: &Interpreter,
+) -> Option<(String, Vec<String>)> {
+    let source_tag = match source {
+        Value::Atom(atom) => Some(atom.borrow().id()),
+        #[cfg(feature = "tuple")]
+        Value::Tuple(tuple_val) => {
+            let tuple_brrw = tuple_val.borrow();
+            match tuple_brrw.elements.first() {
+                Some(tag) => match tag.as_ref() {
+                    Value::Atom(atom) => Some(atom.borrow().id()),
+                    _ => None,
+                },
+                None => None,
+            }
+        }
+        _ => None,
+    }?;
+
+    let mut arm_tags: HashSet<u64> = HashSet::new();
+    for arm in &match_expr.arms {
+        match &arm.pattern {
+            Pattern::Expression(Expression::Literal(Literal::Atom(atom))) => {
+                arm_tags.insert(atom.name.hash());
+            }
+            #[cfg(feature = "atom")]
+            Pattern::TupleStruct(pattern_tuple_struct) => {
+                arm_tags.insert(pattern_tuple_struct.name.hash());
+            }
+            _ => {}
+        }
+    }
+    if arm_tags.is_empty() {
+        return None;
+    }
+
+    let state_brrw = p.state.borrow();
+    let candidates: Vec<&MechEnum> = state_brrw
+        .enums
+        .values()
+        .filter(|enm| {
+            let variant_ids: HashSet<u64> = enm.variants.iter().map(|(id, _)| *id).collect();
+            variant_ids.contains(&source_tag) && arm_tags.is_subset(&variant_ids)
+        })
+        .collect();
+    if candidates.len() != 1 {
+        return None;
+    }
+    let enum_def = candidates[0];
+    let variant_ids: HashSet<u64> = enum_def.variants.iter().map(|(id, _)| *id).collect();
+    let missing_ids: Vec<u64> = variant_ids.difference(&arm_tags).copied().collect();
+    if missing_ids.is_empty() {
+        return None;
+    }
+    let names_brrw = enum_def.names.borrow();
+    let missing_patterns = enum_def
+        .variants
+        .iter()
+        .filter(|(id, _)| missing_ids.contains(id))
+        .map(|(id, payload_kind)| {
+            let variant_name = names_brrw
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| id.to_string());
+            if payload_kind.is_some() {
+                format!(":{}(...)", variant_name)
+            } else {
+                format!(":{}", variant_name)
+            }
+        })
+        .collect::<Vec<String>>();
+    Some((enum_def.name(), missing_patterns))
 }
 
 fn match_validate_arm_kinds(
@@ -1391,6 +1484,24 @@ impl MechErrorKind for MatchNonExhaustiveError {
     }
     fn message(&self) -> String {
         "Match expression must include a wildcard (`*`) arm.".to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchNonExhaustiveVariantsError {
+    pub enum_name: String,
+    pub missing_patterns: Vec<String>,
+}
+impl MechErrorKind for MatchNonExhaustiveVariantsError {
+    fn name(&self) -> &str {
+        "MatchNonExhaustive"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Match over enum '{}' is non-exhaustive. Missing patterns: {}. Add the missing patterns or add a wildcard (`*`) arm.",
+            self.enum_name,
+            self.missing_patterns.join(", ")
+        )
     }
 }
 

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -1,4 +1,6 @@
 use crate::*;
+#[cfg(all(feature = "kind_annotation", feature = "enum"))]
+use std::collections::HashSet;
 
 // Functions
 // ----------------------------------------------------------------------------
@@ -284,6 +286,49 @@ fn execute_function_match_arms(
     input_arg_values: &Vec<Value>,
     p: &Interpreter,
 ) -> MResult<Value> {
+    #[cfg(all(feature = "kind_annotation", feature = "enum"))]
+    {
+        let has_wildcard = fxn_def
+            .code
+            .match_arms
+            .iter()
+            .any(|arm| matches!(arm.pattern, Pattern::Wildcard));
+        if !has_wildcard && fxn_def.input.len() == 1 {
+            if let Some((_, kind_annotation_node)) = fxn_def.input.iter().next() {
+                let input_kind = kind_annotation(&kind_annotation_node.kind, p)?
+                    .to_value_kind(&p.state.borrow().kinds)?;
+                if let ValueKind::Enum(enum_id, _) = input_kind {
+                    let state_brrw = p.state.borrow();
+                    if let Some(enum_def) = state_brrw.enums.get(&enum_id) {
+                        let mut covered_variants: HashSet<u64> = HashSet::new();
+                        for arm in &fxn_def.code.match_arms {
+                            match &arm.pattern {
+                                #[cfg(feature = "atom")]
+                                Pattern::TupleStruct(tuple_struct) => {
+                                    covered_variants.insert(tuple_struct.name.hash());
+                                }
+                                Pattern::Expression(expr) => {
+                                    if let Expression::Literal(Literal::Atom(atom)) = expr {
+                                        covered_variants.insert(atom.name.hash());
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        let all_covered = enum_def
+                            .variants
+                            .iter()
+                            .all(|(variant_id, _)| covered_variants.contains(variant_id));
+                        if !all_covered {
+                            return Err(MechError::new(MatchNonExhaustiveError, None)
+                                .with_compiler_loc()
+                                .with_tokens(fxn_def.code.name.tokens()));
+                        }
+                    }
+                }
+            }
+        }
+    }
     for (arm_idx, arm) in fxn_def.code.match_arms.iter().enumerate() {
         let mut env = Environment::new();
         let matched = crate::patterns::pattern_matches_arguments(

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -535,6 +535,40 @@ fn bind_function_inputs(
                 let target_kind = kind_annotation(&input_kind_annotation.kind, p)?
                     .to_value_kind(&p.state.borrow().kinds)?;
                 let detached_input = detach_value(input_value);
+                #[cfg(all(feature = "enum", feature = "atom"))]
+                if let ValueKind::Enum(enum_id, _) = &target_kind {
+                    let state_brrw = p.state.borrow();
+                    if enum_value_matches(detached_input.clone(), *enum_id, &state_brrw) {
+                        detached_input.clone()
+                    } else {
+                        return Err(MechError::new(
+                            FunctionInputTypeMismatchError {
+                                function_name: fxn_def.name.clone(),
+                                argument_name: arg_name.clone(),
+                                expected: target_kind.clone(),
+                                found: detached_input.kind(),
+                            },
+                            None,
+                        )
+                        .with_compiler_loc()
+                        .with_tokens(input_kind_annotation.tokens()));
+                    }
+                } else {
+                    detached_input.clone().convert_to(&target_kind).ok_or_else(|| {
+                        MechError::new(
+                            FunctionInputTypeMismatchError {
+                                function_name: fxn_def.name.clone(),
+                                argument_name: arg_name.clone(),
+                                expected: target_kind.clone(),
+                                found: detached_input.kind(),
+                            },
+                            None,
+                        )
+                        .with_compiler_loc()
+                        .with_tokens(input_kind_annotation.tokens())
+                    })?
+                }
+                #[cfg(not(all(feature = "enum", feature = "atom")))]
                 detached_input.clone().convert_to(&target_kind).ok_or_else(|| {
                     MechError::new(
                         FunctionInputTypeMismatchError {
@@ -557,6 +591,50 @@ fn bind_function_inputs(
         scoped_state.save_symbol(*arg_id, arg_name, bound_value, false);
     }
     Ok(())
+}
+
+#[cfg(all(feature = "enum", feature = "atom"))]
+fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool {
+    let enum_def = match state.enums.get(&enum_id) {
+        Some(enm) => enm,
+        None => return false,
+    };
+    match value {
+        Value::Atom(atom) => {
+            let variant_id = atom.borrow().id();
+            enum_def
+                .variants
+                .iter()
+                .any(|(known_variant, payload_kind)| *known_variant == variant_id && payload_kind.is_none())
+        }
+        #[cfg(feature = "tuple")]
+        Value::Tuple(tuple_val) => {
+            let tuple_brrw = tuple_val.borrow();
+            if tuple_brrw.elements.len() != 2 {
+                return false;
+            }
+            let tag = match tuple_brrw.elements[0].as_ref() {
+                Value::Atom(atom) => atom.borrow().id(),
+                _ => return false,
+            };
+            let payload = tuple_brrw.elements[1].as_ref().clone();
+            let (_, declared_payload_kind) = match enum_def.variants.iter().find(|(known_variant, _)| *known_variant == tag) {
+                Some(entry) => entry,
+                None => return false,
+            };
+            match declared_payload_kind {
+                Some(Value::Kind(expected_kind)) => match expected_kind {
+                    ValueKind::Enum(inner_enum_id, _) => enum_value_matches(payload, *inner_enum_id, state),
+                    _ => {
+                        payload.kind() == expected_kind.clone()
+                            || payload.convert_to(expected_kind).is_some()
+                    }
+                },
+                _ => false,
+            }
+        }
+        _ => false,
+    }
 }
 
 fn collect_function_output(p: &Interpreter, fxn_def: &FunctionDefinition) -> MResult<Value> {

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -320,7 +320,31 @@ fn execute_function_match_arms(
                             .iter()
                             .all(|(variant_id, _)| covered_variants.contains(variant_id));
                         if !all_covered {
-                            return Err(MechError::new(MatchNonExhaustiveError, None)
+                            let missing_patterns = enum_def
+                                .variants
+                                .iter()
+                                .filter(|(variant_id, _)| !covered_variants.contains(variant_id))
+                                .map(|(variant_id, payload_kind)| {
+                                    let variant_name = enum_def
+                                        .names
+                                        .borrow()
+                                        .get(variant_id)
+                                        .cloned()
+                                        .unwrap_or_else(|| variant_id.to_string());
+                                    if payload_kind.is_some() {
+                                        format!(":{}(...)", variant_name)
+                                    } else {
+                                        format!(":{}", variant_name)
+                                    }
+                                })
+                                .collect::<Vec<String>>();
+                            return Err(MechError::new(
+                                FunctionMatchNonExhaustiveError {
+                                    function_name: fxn_def.name.clone(),
+                                    missing_patterns,
+                                },
+                                None,
+                            )
                                 .with_compiler_loc()
                                 .with_tokens(fxn_def.code.name.tokens()));
                         }
@@ -752,6 +776,26 @@ pub struct FunctionInputTypeMismatchError {
     pub argument_name: String,
     pub expected: ValueKind,
     pub found: ValueKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionMatchNonExhaustiveError {
+    pub function_name: String,
+    pub missing_patterns: Vec<String>,
+}
+
+impl MechErrorKind for FunctionMatchNonExhaustiveError {
+    fn name(&self) -> &str {
+        "FunctionMatchNonExhaustive"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Function '{}' has non-exhaustive match arms. Missing patterns: {}. Add the missing patterns or add a wildcard (`*`) arm.",
+            self.function_name,
+            self.missing_patterns.join(", ")
+        )
+    }
 }
 
 impl MechErrorKind for FunctionInputTypeMismatchError {

--- a/src/interpreter/src/literals.rs
+++ b/src/interpreter/src/literals.rs
@@ -142,22 +142,12 @@ pub fn typed_literal(ltrl: &Literal, knd_attn: &KindAnnotation, p: &Interpreter)
 
 #[cfg(feature = "atom")]
 pub fn atom(atm: &Atom, p: &Interpreter) -> Value {
-  let full_name = atm.name.to_string();
-  let canonical_name = full_name
-    .rsplit_once('/')
-    .map(|(_, variant)| variant.to_string())
-    .unwrap_or_else(|| full_name.clone());
-  let id = hash_str(&canonical_name);
+  let id = atm.name.hash();
   let state = p.state.borrow();
   let dictionary = state.dictionary.clone();
   {
     let mut dictionary_brrw = dictionary.borrow_mut();
-    dictionary_brrw.insert(id, canonical_name);
-    // Keep the originally parsed representation available in the dictionary
-    // for diagnostics and tooling, while preserving canonical atom identity.
-    if full_name.contains('/') {
-      dictionary_brrw.insert(hash_str(&full_name), full_name);
-    }
+    dictionary_brrw.insert(id, atm.name.to_string());
   }
   Value::Atom(Ref::new(MechAtom((id, dictionary))))
 }

--- a/src/interpreter/src/literals.rs
+++ b/src/interpreter/src/literals.rs
@@ -142,12 +142,22 @@ pub fn typed_literal(ltrl: &Literal, knd_attn: &KindAnnotation, p: &Interpreter)
 
 #[cfg(feature = "atom")]
 pub fn atom(atm: &Atom, p: &Interpreter) -> Value {
-  let id = atm.name.hash();
+  let full_name = atm.name.to_string();
+  let canonical_name = full_name
+    .rsplit_once('/')
+    .map(|(_, variant)| variant.to_string())
+    .unwrap_or_else(|| full_name.clone());
+  let id = hash_str(&canonical_name);
   let state = p.state.borrow();
   let dictionary = state.dictionary.clone();
   {
     let mut dictionary_brrw = dictionary.borrow_mut();
-    dictionary_brrw.insert(id, atm.name.to_string());
+    dictionary_brrw.insert(id, canonical_name);
+    // Keep the originally parsed representation available in the dictionary
+    // for diagnostics and tooling, while preserving canonical atom identity.
+    if full_name.contains('/') {
+      dictionary_brrw.insert(hash_str(&full_name), full_name);
+    }
   }
   Value::Atom(Ref::new(MechAtom((id, dictionary))))
 }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -195,7 +195,21 @@ pub fn variable_assign(var_assgn: &VariableAssign, env: Option<&Environment>, p:
 #[cfg(feature = "enum")]
 pub fn enum_define(enm_def: &EnumDefine, p: &Interpreter) -> MResult<()> {
   let id = enm_def.name.hash();
-  let variants = enm_def.variants.iter().map(|v| (v.name.hash(),None)).collect::<Vec<(u64, Option<Value>)>>();
+  let mut variants: Vec<(u64, Option<Value>)> = Vec::new();
+  {
+    let mut state_brrw = p.state.borrow_mut();
+    for v in &enm_def.variants {
+      let payload = match &v.value {
+        Some(kind_annotation_node) => {
+          let knd = kind_annotation(&kind_annotation_node.kind, p)?;
+          let vk = knd.to_value_kind(&mut state_brrw.kinds)?;
+          Some(Value::Kind(vk))
+        }
+        None => None,
+      };
+      variants.push((v.name.hash(), payload));
+    }
+  }
   let state = &p.state;
   let mut state_brrw = state.borrow_mut();
   let dictionary = state_brrw.dictionary.clone();
@@ -224,6 +238,48 @@ pub fn kind_define(knd_def: &KindDefine, p: &Interpreter) -> MResult<Value> {
   Ok(Value::Kind(value_kind))
 }
 
+#[cfg(all(feature = "enum", feature = "atom"))]
+fn value_matches_enum_variant(value: &Value, enum_id: u64, state: &ProgramState) -> bool {
+  let my_enum = match state.enums.get(&enum_id) {
+    Some(enm) => enm,
+    None => return false,
+  };
+  match value {
+    Value::Atom(atom_variant) => {
+      let variant_id = atom_variant.borrow().id();
+      my_enum.variants.iter().any(|(known_variant, payload_kind)| *known_variant == variant_id && payload_kind.is_none())
+    }
+    #[cfg(feature = "tuple")]
+    Value::Tuple(tuple_val) => {
+      let tuple_brrw = tuple_val.borrow();
+      if tuple_brrw.elements.len() != 2 {
+        return false;
+      }
+      let variant_atom = match tuple_brrw.elements[0].as_ref() {
+        Value::Atom(atom) => atom.borrow(),
+        _ => return false,
+      };
+      let variant_id = variant_atom.id();
+      let payload = tuple_brrw.elements[1].as_ref();
+      let (_, declared_payload_kind) = match my_enum.variants.iter().find(|(known_variant, _)| *known_variant == variant_id) {
+        Some(v) => v,
+        None => return false,
+      };
+      match declared_payload_kind {
+        Some(Value::Kind(expected_kind)) => match expected_kind {
+          ValueKind::Enum(inner_enum_id, _) => value_matches_enum_variant(payload, *inner_enum_id, state),
+          _ => {
+            payload.kind() == expected_kind.clone() ||
+            ConvertKind{}.compile(&vec![payload.clone(), Value::Kind(expected_kind.clone())]).is_ok()
+          }
+        },
+        _ => false,
+      }
+    }
+    _ => false,
+  }
+}
+
 #[cfg(feature = "variable_define")]
 pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Value> {
   let var_id = var_def.var.name.hash();
@@ -248,25 +304,20 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
       // Atom is a variant of an enum
       #[cfg(all(feature = "atom", feature = "enum"))]
       (Value::Atom(atom_variant), ValueKind::Enum(enum_id, target_enum_variant_name)) => {
-        let atom_variant_brrw = atom_variant.borrow();
-        let enums = &state_brrw.enums;
-        let my_enum = match enums.get(enum_id) {
-          Some(my_enum) => my_enum,
-          None => todo!(),
-        };
-        let atom_name = atom_variant_brrw.name();
-        // Resolve to canonical global atom id by variant name.
-        // Qualified forms like :color/red and bare forms like :red map to the
-        // same atom identity (`red`).
-        let enum_variant_name = atom_name
-          .rsplit_once('/')
-          .map(|(_, variant_name)| variant_name.to_string())
-          .unwrap_or(atom_name.clone());
-        let variant_id = hash_str(&enum_variant_name);
-        // Given atom isn't a variant of the enum.
-        if !my_enum.variants.iter().any(|(known_enum_variant, inner_value)| variant_id == *known_enum_variant) {
+        let atom_name = atom_variant.borrow().name();
+        if !value_matches_enum_variant(&result, *enum_id, &*state_brrw) {
           return Err(MechError::new(
             UnableToConvertAtomToEnumVariantError { atom_name: atom_name.clone(), target_enum_variant_name: target_enum_variant_name.clone() },
+            None
+          ).with_compiler_loc().with_tokens(var_def.expression.tokens()));
+        }
+      }
+      #[cfg(all(feature = "tuple", feature = "atom", feature = "enum"))]
+      (Value::Tuple(tuple_val), ValueKind::Enum(enum_id, target_enum_variant_name)) => {
+        let atom_name = format!("{:?}", tuple_val);
+        if !value_matches_enum_variant(&result, *enum_id, &*state_brrw) {
+          return Err(MechError::new(
+            UnableToConvertAtomToEnumVariantError { atom_name, target_enum_variant_name: target_enum_variant_name.clone() },
             None
           ).with_compiler_loc().with_tokens(var_def.expression.tokens()));
         }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -254,26 +254,16 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
           Some(my_enum) => my_enum,
           None => todo!(),
         };
-        let dictionary = state_brrw.dictionary.clone();
-        let atom_id = atom_variant_brrw.id();
         let atom_name = atom_variant_brrw.name();
-        // split the enum name at the '/' to get the variant name
-        let enum_variant_name = if let Some((enum_name, variant_name)) = atom_name.split_once('/') {
-          if enum_name != target_enum_variant_name {
-            return Err(MechError::new(
-              UnableToConvertAtomToEnumVariantError { atom_name: atom_name.clone(), target_enum_variant_name: target_enum_variant_name.to_string() },
-              None
-            ).with_compiler_loc().with_tokens(var_def.expression.tokens()));
-          }
-          variant_name.to_string()
-        } else {
-          return Err(MechError::new(
-            UnableToConvertAtomToEnumVariantError { atom_name: atom_name.clone(), target_enum_variant_name: target_enum_variant_name.clone() },
-            None
-          ).with_compiler_loc().with_tokens(var_def.expression.tokens()));
-        };
+        // Resolve to canonical global atom id by variant name.
+        // Qualified forms like :color/red and bare forms like :red map to the
+        // same atom identity (`red`).
+        let enum_variant_name = atom_name
+          .rsplit_once('/')
+          .map(|(_, variant_name)| variant_name.to_string())
+          .unwrap_or(atom_name.clone());
         let variant_id = hash_str(&enum_variant_name);
-        // Given atom isn't a variant of the enum
+        // Given atom isn't a variant of the enum.
         if !my_enum.variants.iter().any(|(known_enum_variant, inner_value)| variant_id == *known_enum_variant) {
           return Err(MechError::new(
             UnableToConvertAtomToEnumVariantError { atom_name: atom_name.clone(), target_enum_variant_name: target_enum_variant_name.clone() },

--- a/src/interpreter/src/structures.rs
+++ b/src/interpreter/src/structures.rs
@@ -15,8 +15,8 @@ pub fn structure(strct: &Structure, env: Option<&Environment>, p: &Interpreter) 
     Structure::Table(x) => table(&x, env, p),
     #[cfg(feature = "tuple")]
     Structure::Tuple(x) => tuple(&x, env, p),
-    #[cfg(feature = "tuple_struct")]
-    Structure::TupleStruct(x) => todo!(),
+    #[cfg(all(feature = "tuple", feature = "atom"))]
+    Structure::TupleStruct(x) => tuple_struct(&x, env, p),
     #[cfg(feature = "set")]
     Structure::Set(x) => set(&x, env, p),
     #[cfg(feature = "map")]
@@ -34,6 +34,16 @@ pub fn tuple(tpl: &Tuple, env: Option<&Environment>, p: &Interpreter) -> MResult
   }
   let mech_tuple = Ref::new(MechTuple{elements});
   Ok(Value::Tuple(mech_tuple))
+}
+
+#[cfg(all(feature = "tuple", feature = "atom"))]
+pub fn tuple_struct(tpl: &TupleStruct, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let mut elements = vec![];
+  let atom_value = atom(&Atom { name: tpl.name.clone() }, p);
+  elements.push(Box::new(atom_value));
+  let payload = expression(&tpl.value, env, p)?;
+  elements.push(Box::new(payload));
+  Ok(Value::Tuple(Ref::new(MechTuple { elements })))
 }
 
 #[cfg(feature = "map")]

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -176,9 +176,10 @@ pub fn enum_define(input: ParseString) -> ParseResult<EnumDefine> {
   Ok((input, EnumDefine{name, variants}))
 }
 
-// enum-variant := grave?, identifier, enum-variant-kind? ;
+// enum-variant := grave?, colon?, identifier, enum-variant-kind? ;
 pub fn enum_variant(input: ParseString) -> ParseResult<EnumVariant> {
   let (input, _) = opt(grave)(input)?;
+  let (input, _) = opt(colon)(input)?;
   let (input, name) = identifier(input)?;
   let (input, value) = opt(enum_variant_kind)(input)?;
   Ok((input, EnumVariant{name, value}))

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -181,7 +181,7 @@ pub fn enum_variant(input: ParseString) -> ParseResult<EnumVariant> {
   let (input, _) = opt(grave)(input)?;
   let (input, _) = opt(colon)(input)?;
   let (input, name) = identifier(input)?;
-  let (input, value) = opt(enum_variant_kind)(input)?;
+  let (input, value) = opt(alt((enum_variant_kind, enum_variant_inline_kind)))(input)?;
   Ok((input, EnumVariant{name, value}))
 }
 
@@ -191,6 +191,12 @@ pub fn enum_variant_kind(input: ParseString) -> ParseResult<KindAnnotation> {
   let (input, annotation) = kind_annotation(input)?;
   let (input, _) = right_parenthesis(input)?;
   Ok((input, annotation))
+}
+
+// enum-variant-inline-kind := kind-annotation ;
+// Allows compact tagged-union syntax like `:ok<u64>`.
+pub fn enum_variant_inline_kind(input: ParseString) -> ParseResult<KindAnnotation> {
+  kind_annotation(input)
 }
 
 // kind-define := "<", identifier, ">", define-operator, kind-annotation ;

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -436,7 +436,7 @@ pub fn tuple(input: ParseString) -> ParseResult<Tuple> {
 
 // tuple-struct = atom, "(", expression, ")" ;
 pub fn tuple_struct(input: ParseString) -> ParseResult<TupleStruct> {
-  let (input, _) = grave(input)?;
+  let (input, _) = colon(input)?;
   let (input, name) = identifier(input)?;
   let (input, _) = left_parenthesis(input)?;
   let (input, _) = whitespace0(input)?;

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1069,9 +1069,18 @@ test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [
 test_interpreter!(interpret_table_record_mutation, r#"~T:=|x<f64> y<bool>|1.2 true|1.3 false|;~r:=T[1];r.x=42;T.x[1]"#, Value::F64(Ref::new(42.0)));
 //test_interpreter!("interpret_table_record_mutation_fail", r#"T := | x<f64>  y<bool> |  1.2     true   |  1.3     false  |;~r := T{1};r.x = 42;T.x[1]"#, Value::F64(Ref::new(1.2)));
 
-test_interpreter!(interpret_define_custom_enum, r#"<color>:=red|green|blue; x<color>:=:color/red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
-test_interpreter!(interpret_define_custom_enum_with_colon_variants, r#"<color>:=:red|:green|:blue; x<color>:=:red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
-test_interpreter!(interpret_qualified_and_bare_atom_have_same_identity, r#"a := :color/red; b := :red; a == b"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_define_custom_enum, r#"<color>:=:red|:green|:blue; x<color>:=:red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
+test_interpreter!(interpret_tagged_union_nested_match, r#"
+<result> := :ok<u64> | :err<string>
+<option> := :some<result> | :none
+x<option> := :some(:ok(42u64))
+result := x?
+  | :some(:ok(n))  -> n
+  | :some(:err(e)) -> 0u64
+  | :none          -> 0u64
+  | *              -> 0u64.
+result + 0u64
+"#, Value::U64(Ref::new(42u64)));
 test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
 test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));
 test_interpreter!(interpret_string_concatenation_var, r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#, Value::String(Ref::new("Hello, Alice!".to_string())));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1121,7 +1121,11 @@ unwrap(x)
 "#;
   let tree = parser::parse(s).unwrap();
   let mut intrp = Interpreter::new(0);
-  assert!(intrp.interpret(&tree).is_err());
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("FunctionMatchNonExhaustive"));
+  assert!(msg.contains(":none"));
+  assert!(msg.contains("wildcard"));
 }
 test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
 test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1094,6 +1094,18 @@ result := x?
   | *              -> 0u64.
 result + 0u64
 "#, Value::U64(Ref::new(42u64)));
+test_interpreter!(interpret_tagged_union_function_input_enum_kind, r#"
+<result> := :ok<u64> | :err<string>
+<option> := :some<result> | :none
+x<option> := :some(:err("this sucks"))
+
+unwrap(x<option>) -> <u64>
+  | :some(:ok(n))  -> n
+  | :some(:err(e)) -> 0u64
+  | :none          -> 0u64.
+
+unwrap(x)
+"#, Value::U64(Ref::new(0u64)));
 test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
 test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));
 test_interpreter!(interpret_string_concatenation_var, r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#, Value::String(Ref::new("Hello, Alice!".to_string())));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1069,7 +1069,9 @@ test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [
 test_interpreter!(interpret_table_record_mutation, r#"~T:=|x<f64> y<bool>|1.2 true|1.3 false|;~r:=T[1];r.x=42;T.x[1]"#, Value::F64(Ref::new(42.0)));
 //test_interpreter!("interpret_table_record_mutation_fail", r#"T := | x<f64>  y<bool> |  1.2     true   |  1.3     false  |;~r := T{1};r.x = 42;T.x[1]"#, Value::F64(Ref::new(1.2)));
 
-test_interpreter!(interpret_define_custom_enum, r#"<color>:=red|green|blue; x<color>:=:color/red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("color/red")))));
+test_interpreter!(interpret_define_custom_enum, r#"<color>:=red|green|blue; x<color>:=:color/red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
+test_interpreter!(interpret_define_custom_enum_with_colon_variants, r#"<color>:=:red|:green|:blue; x<color>:=:red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
+test_interpreter!(interpret_qualified_and_bare_atom_have_same_identity, r#"a := :color/red; b := :red; a == b"#, Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
 test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));
 test_interpreter!(interpret_string_concatenation_var, r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#, Value::String(Ref::new("Hello, Alice!".to_string())));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -150,6 +150,42 @@ fn interpret_option_match_requires_wildcard_arm() {
   assert!(intrp.interpret(&tree).is_err());
 }
 
+#[test]
+fn interpret_enum_match_reports_missing_variants_color() {
+  let s = r#"
+<color> := :red | :green | :blue
+my-color<color> := :red
+string-color := my-color?
+  | :red   -> "red"
+  | :green -> "green".
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("MatchNonExhaustive"));
+  assert!(msg.contains(":blue"));
+  assert!(msg.contains("wildcard"));
+}
+
+#[test]
+fn interpret_enum_match_reports_missing_variants_generalized() {
+  let s = r#"
+<door> := :open | :closed | :locked
+state<door> := :open
+label := state?
+  | :open   -> "open"
+  | :closed -> "closed".
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("MatchNonExhaustive"));
+  assert!(msg.contains(":locked"));
+  assert!(msg.contains("wildcard"));
+}
+
 #[cfg(feature = "u64")]
 test_interpreter!(
   interpret_match_array_pattern_head,

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -172,6 +172,19 @@ test_interpreter!(
 );
 
 test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) -> x | * -> 0u64.; y + 0u64", Value::U64(Ref::new(9)));
+#[test]
+fn interpret_tagged_union_match_requires_exhaustive_arms() {
+  let s = r#"
+<result> := :ok<u64> | :err<string>
+<option> := :some<result> | :none
+x<option> := :some(:ok(42u64))
+result := x?
+  | :some(:ok(n)) -> n.
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
+}
 test_interpreter!(
   interpret_function_shorthand_match_arm_broadcasts_over_matrix_input,
   "add-one(x<f64>) -> <f64>\n  | x + 1.\n\nadd-one([1 2 3])",

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1106,6 +1106,23 @@ unwrap(x<option>) -> <u64>
 
 unwrap(x)
 "#, Value::U64(Ref::new(0u64)));
+#[test]
+fn interpret_tagged_union_function_match_requires_exhaustive_arms() {
+  let s = r#"
+<result> := :ok<u64> | :err<string>
+<option> := :some<result> | :none
+x<option> := :some(:err("this sucks"))
+
+unwrap(x<option>) -> <u64>
+  | :some(:ok(n))  -> n
+  | :some(:err(e)) -> 0u64.
+
+unwrap(x)
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
+}
 test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
 test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));
 test_interpreter!(interpret_string_concatenation_var, r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#, Value::String(Ref::new("Hello, Alice!".to_string())));


### PR DESCRIPTION
### Motivation

- Unify atom identity so qualified forms like `:color/red` and bare forms like `:red` share the same canonical identity and simplify enum membership checks.
- Extend parser support for variants with leading colons and document the design for atoms, enums, and tagged unions.
- Add tests to assert canonicalization behavior and to prevent regressions in atom/enum handling.

### Description

- Update `atom` in `src/interpreter/src/literals.rs` to compute a canonical atom id from the variant name (strip optional qualification before hashing), store both canonical and full parsed names in the dictionary, and return the canonical `Value::Atom` identity via `hash_str`.
- Change enum membership checking in `src/interpreter/src/statements.rs` to resolve incoming atom names by extracting the variant (using `rsplit_once('/')`) and comparing hashed variant ids against the enum's variants.
- Modify parser `src/syntax/src/statements.rs` to accept an optional leading colon for enum variants so variants like `:red` parse cleanly.
- Add comprehensive design documentation in `docs/atom-enum-tagged-union.md` describing atoms, enums, tagged unions, pattern matching, and a suggested compiler data model.
- Update and add interpreter tests in `tests/interpreter.rs` to expect canonical hashing of variants and to verify that qualified and bare atoms have the same identity.

### Testing

- Ran the project test suite (including `tests/interpreter.rs`) after changes; the interpreter tests covering atom equality, enum definition, and the new canonicalization/qualification cases passed.
- Verified newly added tests `interpret_define_custom_enum_with_colon_variants` and `interpret_qualified_and_bare_atom_have_same_identity` succeed in asserting the intended behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5ccc7b5f4832abe6dcedfdd048aed)