### PR TITLE
Docs: Enumerations — allow inline payload kinds, update EBNF and examples

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -1383,18 +1383,33 @@ enum-define := "<"
       , define-operator
       , [enum-variant, enum-separator];
 enum-variant := ?grave
+      , ?colon
       , identifier
-      , ?enum-variant-kind ;
+      , ?(enum-variant-kind | enum-variant-inline-kind) ;
 enum-variant-kind := "("
       , kind-annotation
       , ")" ;
+enum-variant-inline-kind := kind-annotation ;
 ```
 (8.4.1) Examples
 
+```mech:disabled
+<status> := active | inactive | pending
+<response> := ok<u64> | error<string> | timeout
+
+state<status> := :status/active
+reply<response> := :ok(200)
+
+status-code<u64> := reply?
+  | :ok(code) -> code
+  | :error(message) -> 500
+  | :timeout -> 408
+  | * -> 500.
 ```
-    status < Active | Inactive | Pending  -- Enum definition with variants
-    priority < High | Medium | Low        -- Enum definition for priority levels
-```
+
+Enum variant identifiers follow normal identifier rules. Underscores are not
+valid in identifiers, so names such as `not_found` are rejected; use kebab-case
+instead (for example `not-found`).
 
 (8.5) Function Define
 

--- a/docs/reference/kind.mec
+++ b/docs/reference/kind.mec
@@ -178,3 +178,47 @@ example2<color> := :color/yellow   -- Error, yellow not in enum
 ~~~
 
 Enums are kinds and participate in all kind-based reasoning.
+
+(8.2) Variants with payload kinds
+
+Enum variants may optionally carry data. Payload kinds can be written either
+inline (`ok<u64>`) or with parentheses (`ok(<u64>)`):
+
+~~~mech:ex 8.2
+<response> := ok<u64> | error<string> | timeout
+
+r1<response> := :ok(200)
+r2<response> := :error("Not Found")
+r3<response> := :timeout
+~~~
+
+In this enum:
+
+- `ok` requires a `u64` payload
+- `error` requires a `string` payload
+- `timeout` carries no payload
+
+Assignments with the wrong payload kind are rejected:
+
+~~~mech:disabled
+rbad<response> := :ok("200")   -- Error: expected u64 payload
+~~~
+
+(8.3) Enum kinds in pattern matching
+
+Enums participate in pattern matching like other kinds, including payload
+destructuring:
+
+~~~mech:ex 8.3
+<response> := ok<u64> | error<string> | timeout
+r<response> := :error("Not Found")
+
+status-code<u64> := r?
+  | :ok(code) -> code
+  | :error(msg) -> 500
+  | :timeout -> 408
+  | * -> 500.
+~~~
+
+When matching enum kinds, arms should be exhaustive (cover every variant or use
+`*`). Non-exhaustive matches are reported as errors.


### PR DESCRIPTION
### Motivation

- Clarify and extend the enum grammar to support inline payload kinds and improve examples for readers.
- Document how enum variants with payloads interact with pattern matching and kind checking.

### Description

- Updated `enum-define` EBNF to accept an optional `?colon` before identifiers and to allow `enum-variant-inline-kind` in addition to parenthesized kinds.  
- Replaced old examples with concrete `mech:disabled` snippets showing inline payload syntaxes like `ok<u64>` and pattern-matching usage.  
- Added a note that enum variant identifiers follow normal identifier rules and that underscores are not valid, recommending kebab-case instead.  
- Extended `docs/reference/kind.mec` to describe payload kinds, destructuring in pattern matches, and the requirement for exhaustive match arms.

### Testing

- Built the documentation with `make docs` to validate formatting and links, and the build completed successfully.  
- Ran the markdown/documentation linter with `make lint-docs`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64348756c832a8220cf72d6d1580f)