### PR TITLE
docs: expand enum and atom pattern matching reference

### DIFF
--- a/docs/reference/enum.mec
+++ b/docs/reference/enum.mec
@@ -6,16 +6,16 @@ enum
 1. Syntax
 --------------------------------------------------------------------------------
 
-Enums are defined by declaring a set of named variants, each of which is an atom.
+Enums are defined by declaring a set of atom variants. Variants may be plain tags or carry typed payloads.
 
 ```
-&lt;color&gt; := red | green | blue
+<color> := :red<f64> | :green<f64> | :blue<f64>
 ```
 
 When parsed and rendered, this code will appear as:
 
 ```mech:disabled
-<color> := red | green | blue
+<color> := :red<f64> | :green<f64> | :blue<f64>
 ```
 
 
@@ -31,9 +31,9 @@ The kind of an enum value is the enum kind itself. For example:
 3. Construction
 --------------------------------------------------------------------------------
 
-Enum values are constructed by selecting a variant name, optionally providing a value if the variant carries data.
+Enum values are constructed by selecting a variant atom and, when required, supplying its payload value.
 
 ```mech:ex 3.1
-<color> := red | green | blue
-c<color> := :color/red
+<color> := :red<f64> | :green<f64> | :blue<f64>
+c<color> := :red(300)
 ```

--- a/docs/reference/match.mec
+++ b/docs/reference/match.mec
@@ -77,3 +77,24 @@ max := triple?
   | * -> 0.
 max
 ```
+
+4. Enum variant matching
+-------------------------------------------------------------------------------
+
+Match arms can destructure enum variants directly, including variants that carry values.
+
+```mech:match enum
+<color> := :red<f64> | :green<f64> | :blue<f64>
+my-color<color> := :red(300)
+
+string-color := my-color?
+  | :red(100) -> "dark red"
+  | :red(50) -> "light red"
+  | :red(x), x < 50 -> "pink"
+  | :red(x), x > 100 -> "maroon"
+  | :green(100) -> "dark green"
+  | * -> "unknown".
+string-color
+```
+
+This combines literal variant matches (for example `:red(100)`) with guarded captures (for example `:red(x), x > 100`).

--- a/docs/reference/patterns.mec
+++ b/docs/reference/patterns.mec
@@ -11,8 +11,10 @@ Mech patterns support the same core shapes in every pattern context:
 - `_` wildcard: matches anything and binds nothing.
 - Variable pattern: binds a value (for example `x`).
 - Literal / expression pattern: matches when evaluated pattern equals the candidate value.
+- Atom pattern: matches exact atoms (for example `:ready`).
 - Tuple pattern: positional matching for tuples, e.g. `(head, tail)`.
 - Tuple-struct pattern: state-like tagged tuples, e.g. `ready(x)`.
+- Enum-variant pattern: matches tagged atom variants and optionally destructures payloads, e.g. `:red(x)`.
 - Array pattern: prefix/suffix matching with optional spread capture.
 
 2. Function match arms
@@ -69,6 +71,18 @@ result := value ?
 ```
 
 Guard-like conditions in option arms are pattern expressions that evaluate to `bool` in the arm environment.
+
+You can also match deeply on atom-tagged values:
+
+```mech
+shade := color?
+  | :red(100) -> "dark red"
+  | :red(50) -> "light red"
+  | :red(x) if x < 50 -> "pink"
+  | :red(x) if x > 100 -> "maroon"
+  | :green(100) -> "dark green"
+  | _ -> "unknown".
+```
 
 5. Binding behavior
 -------------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Clarify how enums are represented and matched by documenting atom-tagged variants and payloads so readers can construct and destructure them consistently.
- Surface atom-level and enum-variant pattern forms in the pattern reference to show how deep matching and guarded captures work in option matches, functions, and FSM transitions.

### Description

- Updated `docs/reference/enum.mec` to define enums as atom variants with optional typed payloads and replaced the construction example with `c<color> := :red(300)`.
- Updated `docs/reference/patterns.mec` to add `Atom pattern` and `Enum-variant pattern` entries and included an example that matches deeply on atom-tagged values (e.g. `:red(x) if ...`).
- Added a new `Enum variant matching` section to `docs/reference/match.mec` demonstrating match arms that destructure enum variants, use literal variant matches, guarded captures, and a wildcard fallback.
- The files changed are `docs/reference/enum.mec`, `docs/reference/patterns.mec`, and `docs/reference/match.mec`.

### Testing

- Ran `git diff --check` to verify there are no formatting or patch issues and it completed successfully.
- Created a commit for the documentation updates using `git commit` which succeeded.
- Recorded PR metadata via the `make_pr` helper which executed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d653329498832a931794d305763c81)