### PR TITLE
Add kind membership support for ∈ and ∉ operators

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -1225,6 +1225,11 @@ not-element-of := "∉";
 symmetric-difference := "Δ";
 ```
 
+`∈` and `∉` are overloaded:
+
+- set membership: `x ∈ S`, `x ∉ S` where `S` is a set
+- kind membership: `x ∈ <K>`, `x ∉ <K>` where `<K>` is a kind value
+
 (6.8) Range
 
 ```ebnf

--- a/docs/reference/kind.mec
+++ b/docs/reference/kind.mec
@@ -125,7 +125,30 @@ n<[i32]:2,3> := m            -- reshapes to `[i32]:2,3`
 
 Matrices may be reshaped to compatible dimensions using kind annotations.
 
-6. Custom Kinds
+6. Kind Membership (`∈`, `∉`)
+-------------------------------------------------------------------------------
+
+The set membership operators are also defined for kinds:
+
+- `value ∈ <kind>` returns `true` when `value` conforms to `<kind>`
+- `value ∉ <kind>` returns `true` when `value` does not conform to `<kind>`
+
+Examples:
+
+```mech:ex 6.1
+42 ∈ <u64>         -- true
+42 ∉ <string>      -- true
+```
+
+This also applies to enum kinds (including payload variants):
+
+```mech:ex 6.2
+<color> := :red<u64> | :green<u64> | :blue
+:red(300) ∈ <color>   -- true
+:red("300") ∈ <color> -- false
+```
+
+7. Custom Kinds
 -------------------------------------------------------------------------------
 
 Users may define custom kinds as aliases of existing kinds:

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1329,9 +1329,21 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
                 SetProperSuperset {}.compile(&vec![lhs, rhs])?
             }
             #[cfg(feature = "set_element_of")]
-            FormulaOperator::Set(SetOp::ElementOf) => SetElementOf {}.compile(&vec![lhs, rhs])?,
+            FormulaOperator::Set(SetOp::ElementOf) => {
+                #[cfg(feature = "kind_annotation")]
+                if let Value::Kind(kind) = &rhs {
+                    lhs = Value::Bool(Ref::new(value_in_kind(&lhs, kind, p)));
+                    continue;
+                }
+                SetElementOf {}.compile(&vec![lhs, rhs])?
+            }
             #[cfg(feature = "set_not_element_of")]
             FormulaOperator::Set(SetOp::NotElementOf) => {
+                #[cfg(feature = "kind_annotation")]
+                if let Value::Kind(kind) = &rhs {
+                    lhs = Value::Bool(Ref::new(!value_in_kind(&lhs, kind, p)));
+                    continue;
+                }
                 SetNotElementOf {}.compile(&vec![lhs, rhs])?
             }
             x => {
@@ -1353,6 +1365,64 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
     let mut plan_brrw = plan.borrow_mut();
     plan_brrw.append(&mut term_plan);
     return Ok(lhs);
+}
+
+#[cfg(all(feature = "kind_annotation", feature = "enum", feature = "atom"))]
+fn enum_value_matches_kind(value: &Value, enum_id: u64, state: &ProgramState) -> bool {
+    let enum_def = match state.enums.get(&enum_id) {
+        Some(enm) => enm,
+        None => return false,
+    };
+    match value {
+        Value::Atom(atom) => {
+            let variant_id = atom.borrow().id();
+            enum_def
+                .variants
+                .iter()
+                .any(|(known_variant, payload_kind)| *known_variant == variant_id && payload_kind.is_none())
+        }
+        #[cfg(feature = "tuple")]
+        Value::Tuple(tuple_val) => {
+            let tuple_brrw = tuple_val.borrow();
+            if tuple_brrw.elements.len() != 2 {
+                return false;
+            }
+            let tag = match tuple_brrw.elements[0].as_ref() {
+                Value::Atom(atom) => atom.borrow().id(),
+                _ => return false,
+            };
+            let payload = tuple_brrw.elements[1].as_ref();
+            let (_, declared_payload_kind) = match enum_def
+                .variants
+                .iter()
+                .find(|(known_variant, _)| *known_variant == tag)
+            {
+                Some(entry) => entry,
+                None => return false,
+            };
+            match declared_payload_kind {
+                Some(Value::Kind(expected_kind)) => match expected_kind {
+                    ValueKind::Enum(inner_enum_id, _) => {
+                        enum_value_matches_kind(payload, *inner_enum_id, state)
+                    }
+                    _ => payload.kind() == expected_kind.clone() || payload.convert_to(expected_kind).is_some(),
+                },
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+#[cfg(feature = "kind_annotation")]
+fn value_in_kind(value: &Value, kind: &ValueKind, p: &Interpreter) -> bool {
+    let detached = detach_value(value);
+    #[cfg(all(feature = "enum", feature = "atom"))]
+    if let ValueKind::Enum(enum_id, _) = kind {
+        let state_brrw = p.state.borrow();
+        return enum_value_matches_kind(&detached, *enum_id, &state_brrw);
+    }
+    detached.convert_to(kind).is_some()
 }
 
 #[derive(Debug, Clone)]

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1119,6 +1119,14 @@ test_interpreter!(interpret_table_record_mutation, r#"~T:=|x<f64> y<bool>|1.2 tr
 //test_interpreter!("interpret_table_record_mutation_fail", r#"T := | x<f64>  y<bool> |  1.2     true   |  1.3     false  |;~r := T{1};r.x = 42;T.x[1]"#, Value::F64(Ref::new(1.2)));
 
 test_interpreter!(interpret_define_custom_enum, r#"<color>:=:red|:green|:blue; x<color>:=:red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
+test_interpreter!(interpret_kind_membership_enum_payload, r#"
+<color> := :red<u64> | :green<u64> | :blue
+:red(300) ∈ <color>
+"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_kind_not_membership_enum_payload, r#"
+<color> := :red<u64> | :green<u64> | :blue
+:red("300") ∉ <color>
+"#, Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_tagged_union_nested_match, r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none


### PR DESCRIPTION
### Motivation
- Allow `∈` / `∉` to be used not only for set membership but also to test whether a value conforms to a kind (`value ∈ <kind>`), including enum kinds with payloads.
- Provide interpreter-level handling so kind membership short-circuits to a boolean result rather than invoking set membership machinery when RHS is a kind.

### Description
- Overload handling of `SetOp::ElementOf` and `SetOp::NotElementOf` in `term()` so when RHS is `Value::Kind(...)` the interpreter directly returns a `Bool` using `value_in_kind`, otherwise the existing set functions (`SetElementOf` / `SetNotElementOf`) are used.
- Add `value_in_kind` helper (in `src/interpreter/src/expressions.rs`) which detaches values before attempting conversions and handles `ValueKind::Enum` specially by delegating to `enum_value_matches_kind` for enum payload validation (including nested enum payloads and tuple-struct variants).
- Ensure enum checks work for both atom and tagged tuple syntax, and use `detach_value` so mutable references are handled correctly.
- Add interpreter tests in `tests/interpreter.rs` for enum-kind membership and non-membership (payload matches and mismatches).
- Update documentation: add a "Kind Membership (`∈`, `∉`)" section to `docs/reference/kind.mec` and note the overload in `docs/design/specification.mec`.

### Testing
- Ran `cargo test --test interpreter interpret_kind_` which executed the kind-related interpreter tests and the new kind-membership tests; result: OK (13 tests passed).
- Ran `cargo test --test interpreter interpret_set_` which executed the set-related interpreter tests to ensure set semantics were unchanged; result: OK (55 tests passed).
- Targeted single-test runs were used during development to reproduce and fix a failing case, after which the full targeted test groups above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b392ea58832aa6f9fd93ffea9c8e)