### PR TITLE
Use box-drawing branch characters for match-arm rendering in HTML and text

### DIFF
--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -1807,7 +1807,8 @@ impl Formatter {
   pub fn match_expression(&mut self, node: &MatchExpression) -> String {
     let source = self.expression(&node.source);
     let mut lines = vec![format!("{}?", source)];
-    for arm in &node.arms {
+    for (ix, arm) in node.arms.iter().enumerate() {
+      let branch = if ix + 1 == node.arms.len() { "└" } else { "├" };
       let pattern = self.pattern(&arm.pattern);
       let guard = arm
         .guard
@@ -1815,9 +1816,29 @@ impl Formatter {
         .map(|expr| format!(", {}", self.expression(expr)))
         .unwrap_or_default();
       let expr = self.expression(&arm.expression);
-      lines.push(format!("│ {}{} -> {}", pattern, guard, expr));
+      if self.html {
+        lines.push(format!(
+          "<span class=\"mech-match-arm\"><span class=\"mech-match-branch\">{}</span> <span class=\"mech-match-pattern\">{}{}</span> <span class=\"mech-match-arrow\">-&gt;</span> <span class=\"mech-match-expression\">{}</span></span>",
+          branch, pattern, guard, expr
+        ));
+      } else {
+        lines.push(format!("{} {}{} -> {}", branch, pattern, guard, expr));
+      }
     }
-    lines.join("\n")
+    if self.html {
+      format!(
+        "<span class=\"mech-match-expression\"><span class=\"mech-match-source\">{}?</span>{}</span>",
+        source,
+        lines
+          .iter()
+          .skip(1)
+          .cloned()
+          .collect::<Vec<_>>()
+          .join("")
+      )
+    } else {
+      lines.join("\n")
+    }
   }
 
   pub fn fsm_instance(&mut self, node: &FsmInstance) -> String {


### PR DESCRIPTION
### Motivation
- Match-expression HTML used a plain vertical guard marker instead of the box-drawing branch characters used by functions and FSMs, causing inconsistent output styling.
- The goal is to make match arm prefixes use the same `├`/`└` branch markers and to produce structured HTML that matches the function and FSM formatting conventions.

### Description
- Compute a per-arm branch operator (`"├"` or `"└"`) for `match_expression` arms and use it for non-HTML text output instead of the previous vertical marker.
- Update HTML output for matches to emit structured spans (`mech-match-expression`, `mech-match-source`, `mech-match-arm`, `mech-match-branch`, `mech-match-pattern`, `mech-match-arrow`, `mech-match-expression`) and include the unicode branch characters in the markup.
- Preserve the existing non-HTML formatting semantics while aligning arm prefixes and ensure the match source is wrapped separately from arms in the HTML.
- Changes are implemented in `src/syntax/src/formatter.rs` inside `match_expression` formatting.

### Testing
- Ran `cargo test -p mech-syntax` and all unit tests passed (`5` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7eb5dc6f8832aa2caf32689a0799c)