### PR TITLE
Fix unicode slicing panic in parser error snippet extraction

### DIFF
--- a/src/syntax/src/lib.rs
+++ b/src/syntax/src/lib.rs
@@ -730,20 +730,36 @@ fn extract_snippet(lines: &[&str], range: &SourceRange) -> String {
   let mut out = String::new();
 
   for row in range.start.row..=range.end.row {
-    if let Some(line) = lines.get(row) {
-      let start = if row == range.start.row { range.start.col } else { 0 };
-      let end   = if row == range.end.row   { range.end.col } else { line.len() };
+    if let Some(row_index) = row.checked_sub(1) {
+      if let Some(line) = lines.get(row_index) {
+        let start_col = if row == range.start.row { range.start.col } else { 1 };
+        let end_col = if row == range.end.row {
+          range.end.col
+        } else {
+          line.chars().count() + 1
+        };
 
-      let end = end.min(line.len());
-
-      if start <= end {
-        out.push_str(&line[start..end]);
+        out.push_str(&slice_by_char_cols(line, start_col, end_col));
+        out.push('\n');
       }
-      out.push('\n');
     }
   }
 
   out
+}
+
+fn slice_by_char_cols(line: &str, start_col: usize, end_col: usize) -> String {
+  let start_idx = start_col.saturating_sub(1);
+  let end_idx = end_col.saturating_sub(1);
+
+  if start_idx >= end_idx {
+    return String::new();
+  }
+
+  line.chars()
+    .skip(start_idx)
+    .take(end_idx - start_idx)
+    .collect()
 }
 
 fn indent(s: &str) -> String {
@@ -751,6 +767,27 @@ fn indent(s: &str) -> String {
     .map(|line| format!("  {}", line))
     .collect::<Vec<_>>()
     .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn extract_snippet_handles_unicode_boundaries() {
+    let line = "  :Reverse([], acc, swaps) → :Pass(acc, [], 0)";
+    let lines = vec![line];
+    let range = SourceRange {
+      start: SourceLocation { row: 1, col: 1 },
+      end: SourceLocation {
+        row: 1,
+        col: line.chars().count() + 1,
+      },
+    };
+
+    let snippet = extract_snippet(&lines, &range);
+    assert_eq!(snippet, format!("{line}\n"));
+  }
 }
 
 /// Try a list of parsers in order, tracking successes, failures, and errors.


### PR DESCRIPTION
### Motivation
- Parser error reporting could panic when extracting diagnostic snippets that contain multi-byte Unicode graphemes (e.g. `→`) because the code used byte-indexed slicing on Rust `&str` values.
- Source row/column lookups needed to align with the one-based `SourceLocation` rows used elsewhere to avoid off-by-one accesses into `lines`.

### Description
- Replaced byte-index slicing in `extract_snippet` with Unicode-safe character-column slicing using a new helper `slice_by_char_cols` to avoid slicing on invalid UTF-8 boundaries (file: `src/syntax/src/lib.rs`).
- Adjusted row lookup to use `row.checked_sub(1)` so the parser's 1-based `SourceLocation` indexes map correctly to the `lines` vector.
- Added a regression unit test `extract_snippet_handles_unicode_boundaries` that verifies snippet extraction for a line containing the `→` character.

### Testing
- Ran `cargo test -p mech-syntax --lib --quiet`, which executed the syntax tests and passed: `6 passed; 0 failed`.
- The new unit test `extract_snippet_handles_unicode_boundaries` is included in the test suite and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f7d1800c832abf3852d0bbc333e8)