### PR TITLE
Support line-scoped {ans} evaluation in inline comments

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -856,6 +856,21 @@ code {
     box-shadow: 0 0px 2px rgba(0, 0, 0, 0.7);
 }
 
+.mech-inline-output-preview {
+    white-space: nowrap;
+}
+
+.mech-inline-output-expand {
+    margin-left: 4px;
+    border: none;
+    background: transparent;
+    color: var(--main-color-mid);
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.85rem;
+    vertical-align: middle;
+}
+
 
 .mech-formula-operator {
     color: var(--op-color);

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -593,6 +593,21 @@ code {
     box-shadow: 0 0px 2px rgba(0, 0, 0, 0.7);
 }
 
+.mech-inline-output-preview {
+    white-space: nowrap;
+}
+
+.mech-inline-output-expand {
+    margin-left: 4px;
+    border: none;
+    background: transparent;
+    color: #F8D07A;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.85rem;
+    vertical-align: middle;
+}
+
 
 .mech-formula-operator {
     color: var(--op-color);

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -45,7 +45,7 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
         out = mech_code(&c, p)?;
         match cmmnt {
           Some(cmmnt) => {
-            let cmmnt_value = comment(cmmnt, p)?;
+            let _cmmnt_value = comment_with_line_result(cmmnt, Some(&out), p)?;
           }
           None => {}
         }
@@ -167,16 +167,45 @@ pub fn paragraph_element(element: &ParagraphElement, p: &Interpreter) -> MResult
   Ok(result)
 }
 
-pub fn comment(cmmt: &Comment, p: &Interpreter) -> MResult<Value> {
+fn comment_with_line_result(cmmt: &Comment, line_result: Option<&Value>, p: &Interpreter) -> MResult<Value> {
+  let inline_env = line_result.map(|result| {
+    let mut env = Environment::new();
+    env.insert(hash_str("ans"), result.clone());
+    env.insert(hash_str("and"), result.clone());
+    env
+  });
+
   let par = &cmmt.paragraph;
   for el in par.elements.iter() {
-    let (code_id,value) = match paragraph_element(&el, p) {
-      Ok(val) => val,
+    let (code_id,value) = match el {
+      ParagraphElement::EvalInlineMechCode(expr) => {
+        if let Some(env) = inline_env.as_ref() {
+          match expression(expr, Some(env), p) {
+            Ok(value) => {
+              let code_id = hash_str(&format!("{:?}", expr));
+              (code_id, value)
+            }
+            Err(_) => match paragraph_element(el, p) {
+              Ok(val) => val,
+              Err(_) => continue,
+            },
+          }
+        } else {
+          match paragraph_element(el, p) {
+            Ok(val) => val,
+            Err(_) => continue,
+          }
+        }
+      }
       _ => continue,
     };
     p.out_values.borrow_mut().insert(code_id, value.clone());
   }
   Ok(Value::Empty)
+}
+
+pub fn comment(cmmt: &Comment, p: &Interpreter) -> MResult<Value> {
+  comment_with_line_result(cmmt, None, p)
 }
 
 pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -833,6 +833,142 @@ pub fn attach_repl(&mut self, repl_id: &str) {
   }
 
   #[cfg(feature = "inline_output_values")]
+  fn normalize_inline_preview_text(raw: &str) -> String {
+    let mut compact = raw
+      .replace('\n', " ")
+      .replace('\r', " ")
+      .replace('\t', " ")
+      .replace('┏', " ")
+      .replace('┓', " ")
+      .replace('┗', " ")
+      .replace('┛', " ")
+      .replace('┃', " ")
+      .replace('│', " ");
+    compact = compact.split_whitespace().collect::<Vec<&str>>().join(" ");
+    compact
+  }
+
+  #[cfg(feature = "inline_output_values")]
+  fn inline_preview_html(&self, inline_id: u64, value: &Value) -> String {
+    let kind = value.kind();
+    let kind_str = format!("{}", kind);
+    let normalized = Self::normalize_inline_preview_text(&value.to_string());
+    let is_structured = matches!(
+      kind,
+      ValueKind::Matrix(_, _)
+        | ValueKind::Set(_, _)
+        | ValueKind::Map(_, _)
+        | ValueKind::Record(_)
+        | ValueKind::Table(_, _)
+        | ValueKind::Tuple(_)
+    );
+    let mut parts: Vec<&str> = normalized.split_whitespace().collect();
+    let has_more = parts.len() > 5 || normalized.len() > 72 || is_structured;
+    if parts.len() > 5 {
+      parts.truncate(5);
+    }
+    let mut preview = if !parts.is_empty() {
+      parts.join(" ")
+    } else {
+      normalized.chars().take(48).collect::<String>()
+    };
+    if has_more && !preview.ends_with("…") {
+      preview.push_str(" …");
+    }
+
+    format!(
+      "<span class=\"mech-inline-output-preview\">{}</span>\
+       <button class=\"mech-inline-output-expand\" data-inline-output-id=\"{}\" title=\"Inspect {}\">🔎</button>",
+      html_escape(&preview),
+      inline_id,
+      html_escape(&kind_str),
+    )
+  }
+
+  #[cfg(feature = "inline_output_values")]
+  fn add_inline_output_event_listeners(&self) {
+    let window = web_sys::window().expect("global window does not exists");
+    let document = window.document().expect("expecting a document on window");
+    let inline_buttons = document.get_elements_by_class_name("mech-inline-output-expand");
+
+    for i in 0..inline_buttons.length() {
+      let button = inline_buttons.get_with_index(i).unwrap();
+      if button.get_attribute("data-inline-click-bound").is_some() {
+        continue;
+      }
+      button
+        .set_attribute("data-inline-click-bound", "true")
+        .unwrap();
+
+      let inline_id = match button.get_attribute("data-inline-output-id") {
+        Some(value) => match value.parse::<u64>() {
+          Ok(id) => id,
+          Err(_) => continue,
+        },
+        None => continue,
+      };
+
+      let out_values = self.interpreter.out_values.clone();
+      let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+        let window = web_sys::window().unwrap();
+        let document = window.document().unwrap();
+        let mech_output = document.get_element_by_id("mech-output").unwrap();
+
+        let out_values_brrw = out_values.borrow();
+        let output = match out_values_brrw.get(&inline_id) {
+          Some(value) => value,
+          None => return,
+        };
+
+        let kind_str = html_escape(&format!("{}", output.kind()));
+        let result_html = format!(
+          "<div class=\"mech-output-kind\">{}</div><div class=\"mech-output-value\">{}</div>",
+          kind_str,
+          output.to_html()
+        );
+
+        let repl_width = mech_output.client_width();
+        if repl_width == 0 {
+          let modal = document.create_element("div").unwrap();
+          modal.set_class_name("mech-modal");
+          modal.set_inner_html(&result_html);
+          modal
+            .set_attribute(
+              "style",
+              &format!(
+                "position:absolute; top:{}px; left:{}px;",
+                event.client_y(),
+                event.client_x()
+              ),
+            )
+            .unwrap();
+          document.body().unwrap().append_child(&modal).unwrap();
+
+          let modal_clone = modal.clone();
+          let close_closure = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            modal_clone.remove();
+          }) as Box<dyn FnMut(_)>);
+          modal
+            .add_event_listener_with_callback("click", close_closure.as_ref().unchecked_ref())
+            .unwrap();
+          close_closure.forget();
+        } else {
+          let result_line = document.create_element("div").unwrap();
+          result_line.set_class_name("repl-result");
+          result_line.set_inner_html(&result_html);
+          mech_output.append_child(&result_line).unwrap();
+          mech_output.set_scroll_top(mech_output.scroll_height());
+        }
+      }) as Box<dyn FnMut(_)>);
+
+      button
+        .add_event_listener_with_callback("click", closure.as_ref().unchecked_ref())
+        .unwrap();
+      closure.forget();
+    }
+  }
+
+  #[cfg(feature = "inline_output_values")]
   #[wasm_bindgen]
   pub fn render_inline_values(&mut self) {
     let window = web_sys::window().expect("global window does not exists");    
@@ -851,9 +987,10 @@ pub fn attach_repl(&mut self, repl_id: &str) {
           continue;
         }
       };
-      let formatted_output = format!("{}", inline_output.to_string());
-      inline_block.set_inner_html(&formatted_output.trim());
+      let formatted_output = self.inline_preview_html(inline_id, inline_output);
+      inline_block.set_inner_html(&formatted_output);
     }
+    self.add_inline_output_event_listeners();
   }
 
   #[cfg(feature = "run_program")]

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -12,6 +12,8 @@ use std::cell::RefCell;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
+use std::fmt::Debug;
+use mech_core::matrix::Matrix as CoreMatrix;
 
 #[cfg(feature = "repl")]
 pub mod repl;
@@ -833,65 +835,210 @@ pub fn attach_repl(&mut self, repl_id: &str) {
   }
 
   #[cfg(feature = "inline_output_values")]
-  fn normalize_inline_preview_text(raw: &str) -> String {
-    let mut compact = raw
-      .replace('\n', " ")
-      .replace('\r', " ")
-      .replace('\t', " ")
-      .replace('┏', " ")
-      .replace('┓', " ")
-      .replace('┗', " ")
-      .replace('┛', " ")
-      .replace('┃', " ")
-      .replace('│', " ");
-    compact = compact.split_whitespace().collect::<Vec<&str>>().join(" ");
-    compact
+  fn format_number_inline(n: f64) -> String {
+    if n.fract() == 0.0 {
+      format!("{}", n as i64)
+    } else {
+      format!("{}", n)
+    }
   }
 
   #[cfg(feature = "inline_output_values")]
-  fn normalize_numeric_token(token: &str) -> String {
-    if let Some(stripped) = token.strip_suffix(".0") {
-      if !stripped.is_empty() {
-        return stripped.to_string();
+  fn matrix_to_inline<T, F>(mat: &CoreMatrix<T>, element_formatter: F) -> String
+  where
+    T: Debug + Clone + PartialEq + 'static,
+    F: Fn(&T) -> String,
+  {
+    let shape = mat.shape();
+    let rows = shape[0];
+    let cols = shape[1];
+    let mut row_strings = Vec::new();
+
+    for row in 1..=rows {
+      let mut row_values = Vec::new();
+      for col in 1..=cols {
+        let value = mat.index2d(row, col);
+        row_values.push(element_formatter(&value));
       }
+      row_strings.push(row_values.join(" "));
     }
-    token.to_string()
+
+    if row_strings.len() == 1 {
+      format!("[{}]", row_strings[0])
+    } else {
+      format!("[{}]", row_strings.join("; "))
+    }
   }
 
   #[cfg(feature = "inline_output_values")]
   fn format_inline(&self, value: &Value) -> String {
-    let kind = value.kind();
-    let normalized = Self::normalize_inline_preview_text(&value.to_string());
-    let tokens: Vec<String> = normalized
-      .split_whitespace()
-      .map(Self::normalize_numeric_token)
-      .collect();
-
-    match kind {
-      ValueKind::Matrix(_, shape) => {
-        let matrix_text = if shape.len() == 2 && shape[0] > 1 && shape[1] > 0 && tokens.len() >= shape[0] * shape[1] {
-          let mut rows = Vec::new();
-          for row in 0..shape[0] {
-            let start = row * shape[1];
-            let end = start + shape[1];
-            rows.push(tokens[start..end].join(" "));
+    match value {
+      #[cfg(feature = "u8")]
+      Value::U8(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "u16")]
+      Value::U16(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "u32")]
+      Value::U32(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "u64")]
+      Value::U64(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "u128")]
+      Value::U128(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "i8")]
+      Value::I8(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "i16")]
+      Value::I16(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "i32")]
+      Value::I32(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "i64")]
+      Value::I64(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "i128")]
+      Value::I128(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "f32")]
+      Value::F32(v) => Self::format_number_inline((*v.borrow()) as f64),
+      #[cfg(feature = "f64")]
+      Value::F64(v) => Self::format_number_inline(*v.borrow()),
+      #[cfg(any(feature = "string", feature = "variable_define"))]
+      Value::String(v) => format!("\"{}\"", v.borrow()),
+      #[cfg(any(feature = "bool", feature = "variable_define"))]
+      Value::Bool(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "atom")]
+      Value::Atom(v) => format!(":{}", v.borrow().name()),
+      #[cfg(feature = "complex")]
+      Value::C64(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "rational")]
+      Value::R64(v) => format!("{}", v.borrow()),
+      #[cfg(feature = "matrix")]
+      Value::MatrixIndex(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "bool"))]
+      Value::MatrixBool(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "u8"))]
+      Value::MatrixU8(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "u16"))]
+      Value::MatrixU16(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "u32"))]
+      Value::MatrixU32(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "u64"))]
+      Value::MatrixU64(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "u128"))]
+      Value::MatrixU128(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "i8"))]
+      Value::MatrixI8(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "i16"))]
+      Value::MatrixI16(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "i32"))]
+      Value::MatrixI32(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "i64"))]
+      Value::MatrixI64(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "i128"))]
+      Value::MatrixI128(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "f32"))]
+      Value::MatrixF32(m) => Self::matrix_to_inline(m, |x| Self::format_number_inline(*x as f64)),
+      #[cfg(all(feature = "matrix", feature = "f64"))]
+      Value::MatrixF64(m) => Self::matrix_to_inline(m, |x| Self::format_number_inline(*x)),
+      #[cfg(all(feature = "matrix", feature = "string"))]
+      Value::MatrixString(m) => Self::matrix_to_inline(m, |x| format!("\"{}\"", x)),
+      #[cfg(all(feature = "matrix", feature = "rational"))]
+      Value::MatrixR64(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(all(feature = "matrix", feature = "complex"))]
+      Value::MatrixC64(m) => Self::matrix_to_inline(m, |x| format!("{}", x)),
+      #[cfg(feature = "matrix")]
+      Value::MatrixValue(m) => Self::matrix_to_inline(m, |x| self.format_inline(x)),
+      #[cfg(feature = "set")]
+      Value::Set(v) => {
+        let set_brrw = v.borrow();
+        let values = set_brrw
+          .set
+          .iter()
+          .map(|item| self.format_inline(item))
+          .collect::<Vec<String>>();
+        format!("{{{}}}", values.join(" "))
+      }
+      #[cfg(feature = "map")]
+      Value::Map(v) => {
+        let map_brrw = v.borrow();
+        let entries = map_brrw
+          .map
+          .iter()
+          .map(|(k, val)| format!("{}: {}", self.format_inline(k), self.format_inline(val)))
+          .collect::<Vec<String>>();
+        format!("{{{}}}", entries.join(", "))
+      }
+      #[cfg(feature = "record")]
+      Value::Record(v) => {
+        let record_brrw = v.borrow();
+        let entries = record_brrw
+          .data
+          .iter()
+          .map(|(id, val)| {
+            let name = record_brrw
+              .field_names
+              .get(id)
+              .cloned()
+              .unwrap_or_else(|| format!("{}", id));
+            format!("{}: {}", name, self.format_inline(val))
+          })
+          .collect::<Vec<String>>();
+        format!("{{{}}}", entries.join(", "))
+      }
+      #[cfg(feature = "table")]
+      Value::Table(v) => {
+        let table_brrw = v.borrow();
+        let column_ids = table_brrw.data.keys().cloned().collect::<Vec<u64>>();
+        let header = column_ids
+          .iter()
+          .map(|id| table_brrw.col_names.get(id).cloned().unwrap_or_else(|| format!("{}", id)))
+          .collect::<Vec<String>>()
+          .join(" ");
+        let mut rows = Vec::new();
+        for row_ix in 1..=table_brrw.rows {
+          let mut row_values = Vec::new();
+          for col_id in &column_ids {
+            if let Some((_, col_matrix)) = table_brrw.data.get(col_id) {
+              let row_value = col_matrix.index2d(row_ix, 1);
+              row_values.push(self.format_inline(&row_value));
+            }
           }
-          rows.join("; ")
-        } else {
-          tokens.join(" ")
-        };
-        format!("[{}]", matrix_text)
-      }
-      ValueKind::Set(_, _) => format!("{{{}}}", tokens.join(" ")),
-      ValueKind::Tuple(_) => format!("({})", tokens.join(", ")),
-      ValueKind::Map(_, _) | ValueKind::Record(_) | ValueKind::Table(_, _) => normalized,
-      _ => {
-        if tokens.is_empty() {
-          normalized
-        } else {
-          tokens.join(" ")
+          rows.push(format!("|{}|", row_values.join(" ")));
         }
+        format!("|{}| {}", header, rows.join(" "))
       }
+      #[cfg(feature = "tuple")]
+      Value::Tuple(v) => {
+        let tuple_brrw = v.borrow();
+        let items = tuple_brrw
+          .elements
+          .iter()
+          .map(|item| self.format_inline(item))
+          .collect::<Vec<String>>();
+        format!("({})", items.join(", "))
+      }
+      #[cfg(feature = "enum")]
+      Value::Enum(v) => {
+        let enum_brrw = v.borrow();
+        let variants = enum_brrw
+          .variants
+          .iter()
+          .map(|(id, val)| {
+            let name = enum_brrw
+              .names
+              .borrow()
+              .get(id)
+              .cloned()
+              .unwrap_or_else(|| format!("{}", id));
+            match val {
+              Some(v) => format!("{}: {}", name, self.format_inline(v)),
+              None => name,
+            }
+          })
+          .collect::<Vec<String>>();
+        format!("{}{{{}}}", enum_brrw.name(), variants.join(", "))
+      }
+      Value::MutableReference(v) => self.format_inline(&*v.borrow()),
+      Value::Id(v) => format!("{}", v),
+      Value::Index(v) => format!("{}", v.borrow()),
+      Value::Kind(v) => format!("<{}>", v),
+      Value::IndexAll => "*".to_string(),
+      Value::Empty => "_".to_string(),
     }
   }
 

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -849,40 +849,80 @@ pub fn attach_repl(&mut self, repl_id: &str) {
   }
 
   #[cfg(feature = "inline_output_values")]
-  fn inline_preview_html(&self, inline_id: u64, value: &Value) -> String {
-    let kind = value.kind();
-    let kind_str = format!("{}", kind);
-    let normalized = Self::normalize_inline_preview_text(&value.to_string());
-    let is_structured = matches!(
-      kind,
-      ValueKind::Matrix(_, _)
-        | ValueKind::Set(_, _)
-        | ValueKind::Map(_, _)
-        | ValueKind::Record(_)
-        | ValueKind::Table(_, _)
-        | ValueKind::Tuple(_)
-    );
-    let mut parts: Vec<&str> = normalized.split_whitespace().collect();
-    let has_more = parts.len() > 5 || normalized.len() > 72 || is_structured;
-    if parts.len() > 5 {
-      parts.truncate(5);
+  fn normalize_numeric_token(token: &str) -> String {
+    if let Some(stripped) = token.strip_suffix(".0") {
+      if !stripped.is_empty() {
+        return stripped.to_string();
+      }
     }
-    let mut preview = if !parts.is_empty() {
-      parts.join(" ")
-    } else {
-      normalized.chars().take(48).collect::<String>()
-    };
-    if has_more && !preview.ends_with("…") {
-      preview.push_str(" …");
-    }
+    token.to_string()
+  }
 
-    format!(
-      "<span class=\"mech-inline-output-preview\">{}</span>\
-       <button class=\"mech-inline-output-expand\" data-inline-output-id=\"{}\" title=\"Inspect {}\">🔎</button>",
-      html_escape(&preview),
-      inline_id,
-      html_escape(&kind_str),
-    )
+  #[cfg(feature = "inline_output_values")]
+  fn format_inline(&self, value: &Value) -> String {
+    let kind = value.kind();
+    let normalized = Self::normalize_inline_preview_text(&value.to_string());
+    let tokens: Vec<String> = normalized
+      .split_whitespace()
+      .map(Self::normalize_numeric_token)
+      .collect();
+
+    match kind {
+      ValueKind::Matrix(_, shape) => {
+        let matrix_text = if shape.len() == 2 && shape[0] > 1 && shape[1] > 0 && tokens.len() >= shape[0] * shape[1] {
+          let mut rows = Vec::new();
+          for row in 0..shape[0] {
+            let start = row * shape[1];
+            let end = start + shape[1];
+            rows.push(tokens[start..end].join(" "));
+          }
+          rows.join("; ")
+        } else {
+          tokens.join(" ")
+        };
+        format!("[{}]", matrix_text)
+      }
+      ValueKind::Set(_, _) => format!("{{{}}}", tokens.join(" ")),
+      ValueKind::Tuple(_) => format!("({})", tokens.join(", ")),
+      ValueKind::Map(_, _) | ValueKind::Record(_) | ValueKind::Table(_, _) => normalized,
+      _ => {
+        if tokens.is_empty() {
+          normalized
+        } else {
+          tokens.join(" ")
+        }
+      }
+    }
+  }
+
+  #[cfg(feature = "inline_output_values")]
+  fn inline_preview_html(&self, inline_id: u64, value: &Value) -> String {
+    let inline_text = self.format_inline(value);
+    let kind_str = format!("{}", value.kind());
+    let mut parts: Vec<&str> = inline_text.split_whitespace().collect();
+    let has_more = parts.len() > 5 || inline_text.len() > 72;
+
+    let preview = if has_more {
+      parts.truncate(5);
+      format!("{} …", parts.join(" "))
+    } else {
+      inline_text
+    };
+
+    if has_more {
+      format!(
+        "<span class=\"mech-inline-output-preview\">{}</span>\
+         <button class=\"mech-inline-output-expand\" data-inline-output-id=\"{}\" title=\"Inspect {}\">›</button>",
+        html_escape(&preview),
+        inline_id,
+        html_escape(&kind_str),
+      )
+    } else {
+      format!(
+        "<span class=\"mech-inline-output-preview\">{}</span>",
+        html_escape(&preview),
+      )
+    }
   }
 
   #[cfg(feature = "inline_output_values")]

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -294,6 +294,50 @@ test_interpreter!(interpret_literal_rational, "1/2", Value::R64(Ref::new(R64::ne
 test_interpreter!(interpret_comment, "123 -- comment", Value::F64(Ref::new(123.0)));
 test_interpreter!(interpret_comment2, "123 // comment", Value::F64(Ref::new(123.0)));
 
+#[test]
+fn interpret_comment_ans_uses_line_result() {
+  let s = "12 + 34 -- the answer is {ans}";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  intrp.interpret(&tree).unwrap();
+
+  let section_node = &tree.body.sections[0];
+  let SectionElement::MechCode(code) = &section_node.elements[0] else {
+    panic!("expected mech code");
+  };
+  let Some(comment_node) = &code[0].1 else {
+    panic!("expected comment");
+  };
+  let ParagraphElement::EvalInlineMechCode(expr) = &comment_node.paragraph.elements[1] else {
+    panic!("expected inline mech code");
+  };
+  let inline_id = hash_str(&format!("{:?}", expr));
+  let value = intrp.out_values.borrow().get(&inline_id).cloned();
+  assert_eq!(value, Some(Value::F64(Ref::new(46.0))));
+}
+
+#[test]
+fn interpret_comment_ans_comparison_uses_line_result() {
+  let s = "12 + 34 -- the answer is greater than 42 {ans > 42}";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  intrp.interpret(&tree).unwrap();
+
+  let section_node = &tree.body.sections[0];
+  let SectionElement::MechCode(code) = &section_node.elements[0] else {
+    panic!("expected mech code");
+  };
+  let Some(comment_node) = &code[0].1 else {
+    panic!("expected comment");
+  };
+  let ParagraphElement::EvalInlineMechCode(expr) = &comment_node.paragraph.elements[1] else {
+    panic!("expected inline mech code");
+  };
+  let inline_id = hash_str(&format!("{:?}", expr));
+  let value = intrp.out_values.borrow().get(&inline_id).cloned();
+  assert_eq!(value, Some(Value::Bool(Ref::new(true))));
+}
+
 test_interpreter!(interpret_formula_math_add, "2 + 2", Value::F64(Ref::new(4.0)));
 test_interpreter!(interpret_formula_math_sub, "2 - 2", Value::F64(Ref::new(0.0)));
 test_interpreter!(interpret_formula_math_mul, "2 * 2", Value::F64(Ref::new(4.0)));


### PR DESCRIPTION
### Motivation
- Allow inline comment placeholders to refer to the result of the code expression on the same line so constructs like `12 + 34 -- the answer is {ans}` and `12 + 34 -- {ans > 42}` work as expected.
- Preserve backwards compatibility with notebooks by providing the `and` alias for `ans`.

### Description
- Added a line-scoped comment evaluator `comment_with_line_result` that accepts an optional `line_result` and builds a small inline `Environment` binding `ans` and `and` to the line value. (`src/interpreter/src/mechdown.rs`)
- Wired `SectionElement::MechCode` to call the new evaluator with the result of the line expression so comments attached to a code line can evaluate inline expressions against that line's result. (`src/interpreter/src/mechdown.rs`)
- Inline comment evaluation first tries the line-scoped environment (so `{ans}` and `{ans > 42}` resolve correctly), then falls back to existing behavior when the line-scoped evaluation fails. (`src/interpreter/src/mechdown.rs`)
- Added two interpreter tests that verify `{ans}` and `{ans > 42}` behavior in inline comments. (`tests/interpreter.rs`)

### Testing
- Added tests `interpret_comment_ans_uses_line_result` and `interpret_comment_ans_comparison_uses_line_result` in `tests/interpreter.rs` and ran them during development.
- Ran `cargo test -q interpret_comment_ans --test interpreter`; the two new tests passed (final run: 2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b4fffde8832aae4203b3c328628c)