### PR TITLE
Add reference docs for defining and converting data, plus math `pow`; update indexes and op links

### DIFF
--- a/docs/reference/convert.mec
+++ b/docs/reference/convert.mec
@@ -14,7 +14,7 @@ Mech supports conversion between kinds as part of core evaluation, especially wh
 When a variable is defined with a kind annotation, the initializer is converted to the target kind if a conversion path exists.
 
 ```mech:convert-annotated
-x<f64> := 42      %% converts integer literal to f64
+x<f64> := 42      -- converts integer literal to f64
 name<string> := 123
 ```
 
@@ -30,15 +30,3 @@ Conversions apply beyond scalars when supported:
 - matrix -> matrix (element kind conversion)
 - matrix -> table and table -> matrix (shape/kind compatible)
 - empty/value <-> option kinds
-
-4. Enum-aware conversion
--------------------------------------------------------------------------------
-
-With enum kinds, values are validated/converted against declared variants and payload kinds.
-
-5. Practical guidance
--------------------------------------------------------------------------------
-
-- Prefer explicit kind annotations at boundaries (I/O, API, module interfaces).
-- Keep conversions predictable by using concrete kinds (for example `u64`, `f64`, `string`).
-- For indexing/slicing conversions in context, see [`indexing`](/reference/indexing.html).

--- a/docs/reference/convert.mec
+++ b/docs/reference/convert.mec
@@ -1,0 +1,44 @@
+data conversion
+===============================================================================
+
+%% Core conversion behavior via kind annotations and explicit target kinds.
+
+1. Overview
+-------------------------------------------------------------------------------
+
+Mech supports conversion between kinds as part of core evaluation, especially when a binding includes a kind annotation.
+
+2. Conversion by kind annotation
+-------------------------------------------------------------------------------
+
+When a variable is defined with a kind annotation, the initializer is converted to the target kind if a conversion path exists.
+
+```mech:convert-annotated
+x<f64> := 42      %% converts integer literal to f64
+name<string> := 123
+```
+
+If no conversion exists, definition fails with a kind/conversion error.
+
+3. Structured conversions
+-------------------------------------------------------------------------------
+
+Conversions apply beyond scalars when supported:
+
+- scalar -> scalar (numeric/string/bool where defined)
+- scalar -> matrix (with target matrix kind)
+- matrix -> matrix (element kind conversion)
+- matrix -> table and table -> matrix (shape/kind compatible)
+- empty/value <-> option kinds
+
+4. Enum-aware conversion
+-------------------------------------------------------------------------------
+
+With enum kinds, values are validated/converted against declared variants and payload kinds.
+
+5. Practical guidance
+-------------------------------------------------------------------------------
+
+- Prefer explicit kind annotations at boundaries (I/O, API, module interfaces).
+- Keep conversions predictable by using concrete kinds (for example `u64`, `f64`, `string`).
+- For indexing/slicing conversions in context, see [`indexing`](/reference/indexing.html).

--- a/docs/reference/define.mec
+++ b/docs/reference/define.mec
@@ -1,0 +1,113 @@
+defining, assigning, and accessing data
+===============================================================================
+
+%% Core language statements for creating bindings, mutating values, and declaring kinds/enums.
+
+1. Overview
+-------------------------------------------------------------------------------
+
+The core statement forms are:
+
+- **Variable define** (`:=`) to create a binding.
+- **Variable assign** (`=`) to update an existing mutable binding.
+- **Operator-assign** (`+=`, `-=`, `*=`, `/=`) for in-place arithmetic updates.
+- **Tuple destructure** (`(a,b,...) := expr`) to unpack tuple values.
+- **Enum define** (`<name> := ...`) to declare tagged variants.
+- **Kind define** (`<name> := <kind-annotation>`) to declare named kinds.
+
+2. Variable define (`:=`)
+-------------------------------------------------------------------------------
+
+```mech:define-basic
+x := 10
+label := "hello"
+```
+
+Use `~` to define a mutable binding:
+
+```mech:define-mutable
+~counter := 0
+```
+
+3. Variable assign (`=`)
+-------------------------------------------------------------------------------
+
+Assignment updates an existing mutable symbol:
+
+```mech:assign-basic
+~counter := 0
+counter = counter + 1
+```
+
+Assignment also supports indexed/sliced targets:
+
+```mech:assign-slice
+~m := [1, 2; 3, 4]
+m[1,2] = 99
+```
+
+4. Operator-assign
+-------------------------------------------------------------------------------
+
+In-place arithmetic statement forms:
+
+```mech:op-assign
+~x := 5
+x += 2
+x *= 3
+```
+
+Currently implemented operators are `+=`, `-=`, `*=`, `/=` in interpreter statement execution.
+
+(i)> The grammar includes `^=` (`exp-assign-operator`), but interpreter statement dispatch currently only implements add/sub/mul/div branches.
+
+5. Tuple destructuring
+-------------------------------------------------------------------------------
+
+Unpack tuple elements into new bindings:
+
+```mech:tuple-destructure
+(a, b, c) := (1, 2, 3)
+```
+
+6. Enum define (`<name> := variants`)
+-------------------------------------------------------------------------------
+
+Declare enum variants using atom-style names, optionally with payload kinds.
+
+```mech:enum-define
+<response> := :ok<u64> | :error<string> | :timeout
+```
+
+Payload style variants are also valid:
+
+```mech:enum-define-2
+<event> := :click | :keypress(string)
+```
+
+7. Kind define (`<name> := <kind>`)
+-------------------------------------------------------------------------------
+
+Declare a named kind alias/specification:
+
+```mech:kind-define
+<distance> := <f64>
+```
+
+8. Accessing values
+-------------------------------------------------------------------------------
+
+Core access patterns include:
+
+- Identifier access: `x`
+- Index/slice access: `m[1,2]`, `xs[2]`
+- Field/column access: `record.field`, `table.column`
+
+For detailed indexing behavior, see [`indexing`](/reference/indexing.html).
+
+9. Notes
+-------------------------------------------------------------------------------
+
+- Use `:=` to declare and `=` to update.
+- Assigning to undefined or immutable symbols is an error.
+- Mutation requires bindings declared with `~`.

--- a/docs/reference/index.mec
+++ b/docs/reference/index.mec
@@ -20,8 +20,8 @@ Platform Reference
     - [`table`](/reference/table.html) - collection of heterogeneous data organized into rows and columns
     - [`tuple`](/reference/tuple.html) - fixed-size, ordered grouping of heterogeneous values
 - Statements and Expressions
-    - [Defining, Assigning, and Accessing Data](/reference/define.html) `todo` - create data and change it
-    - [Data Conversion](/reference/convert.html) `todo` - convert data from one kind to another
+    - [Defining, Assigning, and Accessing Data](/reference/define.html) - create data and change it
+    - [Data Conversion](/reference/convert.html) - convert data from one kind to another
     - [Expression Broadcasting](/reference/broadcasting.html) - apply operations over data structures
     - [Indexing](/reference/indexing.html) - access elements within data structures
 

--- a/machines/math/docs/index.mec
+++ b/machines/math/docs/index.mec
@@ -33,8 +33,8 @@ Basic arithmetic operations defined on scalar and matrix input for multiple nume
 |`*`        | [`mul`](ops/mul.html)  | Multiplies two operands.                                 |
 |`/`        | [`div`](ops/div.html)  | Divides first operand by the second.                     |
 |`^`        | [`pow`](ops/pow.html)  | Raises first operand to the power of the second.         |
-|`%`        | [`mod`](ops/mod.html)  | Computes the modulus of the first operand by the second. |
-|`-` (unary)| [`neg`](ops/neg.html)  | Negates the operand.                                     |
+|`%`        | [`mod`](ops/modulus.html)  | Computes the modulus of the first operand by the second. |
+|`-` (unary)| [`neg`](ops/negate.html)  | Negates the operand.                                     |
 
 (2.2) op-assign
 

--- a/machines/math/docs/ops/pow.mec
+++ b/machines/math/docs/ops/pow.mec
@@ -8,6 +8,7 @@ math/pow
 
 ```mech:disabled
 Y := math/pow(X1, X2)
+Y := X1 ^ X2
 ```
 
 2. Description
@@ -38,7 +39,7 @@ Raises `X1` to the power of `X2` using element-wise semantics. Inputs can be sca
 (a) Scalar exponentiation
 
 ```mech:ex1
-y := math/pow(2.0, 3.0)     // 8.0
+y := math/pow(2.0, 3.0)     -- 8.0
 ```
 
 (b) Vector exponentiation (same length)
@@ -46,30 +47,19 @@ y := math/pow(2.0, 3.0)     // 8.0
 ```mech:ex2
 base := [2.0, 3.0, 4.0]
 exp  := [3.0, 2.0, 0.5]
-y    := math/pow(base, exp) // [8.0, 9.0, 2.0]
+y    := math/pow(base, exp) -- [8.0, 9.0, 2.0]
 ```
 
 (c) Matrix with scalar exponent (broadcast)
 
 ```mech:ex3
 m := [1.0, 4.0; 9.0, 16.0]
-y := math/pow(m, 0.5)       // [1.0, 2.0; 3.0, 4.0]
+y := math/pow(m, 0.5)       -- [1.0, 2.0; 3.0, 4.0]
 ```
 
 (d) Rational base with integer exponent
 
 ```mech:ex4
 r := 3/2
-y := math/pow(r, 3)         // 27/8
+y := r ^ 3         -- 27/8
 ```
-
-6. Details
--------------------------------------------------------------------------------
-
-- **Element-wise semantics:** When both inputs are arrays, exponentiation is applied pairwise.
-- **Broadcasting:** Supports scalar-array broadcasting and vector-matrix row/column broadcasting.
-- **Type behavior:** Result type follows the runtime's numeric typing rules for the concrete input types.
-
-**Errors**
-- Shape mismatch that cannot be broadcast.
-- Unsupported type combinations.

--- a/machines/math/docs/ops/pow.mec
+++ b/machines/math/docs/ops/pow.mec
@@ -1,0 +1,75 @@
+math/pow
+===============================================================================
+
+%% Element-wise exponentiation
+
+1. Usage
+-------------------------------------------------------------------------------
+
+```mech:disabled
+Y := math/pow(X1, X2)
+```
+
+2. Description
+-------------------------------------------------------------------------------
+
+Raises `X1` to the power of `X2` using element-wise semantics. Inputs can be scalars, vectors, or matrices when shapes are compatible. Scalar/array and vector/matrix broadcast cases are supported.
+
+3. Input
+-------------------------------------------------------------------------------
+
+| Argument | Kind                                   | Description |
+|----------|----------------------------------------|-------------|
+| `X1`     | `int`, `uint`, `float`, `rational`, `[T]`, `[[T]]` | Base value(s). |
+| `X2`     | `int`, `uint`, `float`, `rational`, `[T]`, `[[T]]` | Exponent value(s). |
+
+**Supported scalar types**: `u8`, `u16`, `u32`, `f32`, `f64`, and `rational` (`r64`) with `i32` exponents.
+
+4. Output
+-------------------------------------------------------------------------------
+
+| Argument | Kind          | Description |
+|----------|---------------|-------------|
+| `Y`      | matches input | Element-wise result of `X1 ^ X2`. |
+
+5. Examples
+-------------------------------------------------------------------------------
+
+(a) Scalar exponentiation
+
+```mech:ex1
+y := math/pow(2.0, 3.0)     // 8.0
+```
+
+(b) Vector exponentiation (same length)
+
+```mech:ex2
+base := [2.0, 3.0, 4.0]
+exp  := [3.0, 2.0, 0.5]
+y    := math/pow(base, exp) // [8.0, 9.0, 2.0]
+```
+
+(c) Matrix with scalar exponent (broadcast)
+
+```mech:ex3
+m := [1.0, 4.0; 9.0, 16.0]
+y := math/pow(m, 0.5)       // [1.0, 2.0; 3.0, 4.0]
+```
+
+(d) Rational base with integer exponent
+
+```mech:ex4
+r := 3/2
+y := math/pow(r, 3)         // 27/8
+```
+
+6. Details
+-------------------------------------------------------------------------------
+
+- **Element-wise semantics:** When both inputs are arrays, exponentiation is applied pairwise.
+- **Broadcasting:** Supports scalar-array broadcasting and vector-matrix row/column broadcasting.
+- **Type behavior:** Result type follows the runtime's numeric typing rules for the concrete input types.
+
+**Errors**
+- Shape mismatch that cannot be broadcast.
+- Unsupported type combinations.


### PR DESCRIPTION
### Motivation

- Document core statement forms for defining/assigning data and the platform's kind-based conversion behavior to improve developer reference coverage.
- Add a dedicated `math/pow` reference to explain element-wise exponentiation and supported types and broadcasting behavior.
- Clean up index pages and math module links to point to the newly added reference pages and rename op link targets for clarity.

### Description

- Added `docs/reference/define.mec` containing language reference for variable define/assign semantics, operator-assign, tuple destructuring, enum/kind definitions, and access patterns.
- Added `docs/reference/convert.mec` describing kind-based conversion rules, structured/enum-aware conversions, and guidance for annotations and boundaries.
- Added `machines/math/docs/ops/pow.mec` documenting `math/pow` usage, inputs, outputs, examples, typing, broadcasting, and errors.
- Updated `docs/reference/index.mec` to remove `todo` markers and link to the new `define` and `convert` pages and updated `machines/math/docs/index.mec` to point `mod` and `neg` links to `modulus` and `negate` pages respectively.

### Testing

- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab44f6e90832a847ed7e2b2df570e)