### PR TITLE
Add tail-call elimination to user functions and expand interpreter tests

### DIFF
--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -161,91 +161,91 @@ pub fn execute_native_function_compiler(
 }
 
 fn execute_user_function(
-    fxn_def: &FunctionDefinition,
-    input_arg_values: &Vec<Value>,
-    p: &Interpreter,
+  fxn_def: &FunctionDefinition,
+  input_arg_values: &Vec<Value>,
+  p: &Interpreter,
 ) -> MResult<Value> {
-    if input_arg_values.len() != fxn_def.input.len() {
-        return Err(MechError::new(
-            IncorrectNumberOfArguments {
-                expected: fxn_def.input.len(),
-                found: input_arg_values.len(),
-            },
-            None,
-        )
-        .with_compiler_loc()
-        .with_tokens(fxn_def.code.name.tokens()));
-    }
+  if input_arg_values.len() != fxn_def.input.len() {
+    return Err(MechError::new(
+      IncorrectNumberOfArguments {
+        expected: fxn_def.input.len(),
+        found: input_arg_values.len(),
+      },
+      None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fxn_def.code.name.tokens()));
+  }
 
-    #[cfg(feature = "matrix")]
-    if let Some(result) = try_broadcast_user_function(fxn_def, input_arg_values, p)? {
-        return Ok(result);
-    }
+  #[cfg(feature = "matrix")]
+  if let Some(result) = try_broadcast_user_function(fxn_def, input_arg_values, p)? {
+    return Ok(result);
+  }
 
-    trace_println!(
+  trace_println!(
+    p,
+    "{}",
+    format_trace(
+      "fn",
+      format!(
+        "enter {}({})",
+        fxn_def.name,
+        format_trace_args(input_arg_values)
+      ),
+    )
+  );
+
+  let output = if !fxn_def.code.match_arms.is_empty() {
+    let mut current_args: Vec<Value> = input_arg_values.clone();
+    loop {
+      let scope = FunctionScope::enter(p);
+      bind_function_inputs(fxn_def, &current_args, p)?;
+      let step: FunctionCallStep = execute_function_match_arms(fxn_def, &current_args, p)?;
+      drop(scope);
+      match step {
+        FunctionCallStep::Return(value) => break Ok(value),
+        FunctionCallStep::TailCall(next_args) => {
+          current_args = next_args;
+        }
+      }
+    }
+  } else {
+    let scope = FunctionScope::enter(p);
+    bind_function_inputs(fxn_def, input_arg_values, p)?;
+    for statement_node in &fxn_def.code.statements {
+      statement(statement_node, None, p)?;
+    }
+    let result = collect_function_output(p, fxn_def);
+    drop(scope);
+    result
+  };
+
+  match output {
+    Ok(value) => {
+      trace_println!(
         p,
         "{}",
         format_trace(
-            "fn",
-            format!(
-                "enter {}({})",
-                fxn_def.name,
-                format_trace_args(input_arg_values)
-            ),
+          "fn",
+          format!("exit  {} => {}", fxn_def.name, summarize_value(&value))
         )
-    );
-
-    let output = if !fxn_def.code.match_arms.is_empty() {
-        let mut current_args = input_arg_values.clone();
-        loop {
-            let scope = FunctionScope::enter(p);
-            bind_function_inputs(fxn_def, &current_args, p)?;
-            let step = execute_function_match_arms(fxn_def, &current_args, p)?;
-            drop(scope);
-            match step {
-                FunctionCallStep::Return(value) => break Ok(value),
-                FunctionCallStep::TailCall(next_args) => {
-                    current_args = next_args;
-                }
-            }
-        }
-    } else {
-        let scope = FunctionScope::enter(p);
-        bind_function_inputs(fxn_def, input_arg_values, p)?;
-        for statement_node in &fxn_def.code.statements {
-            statement(statement_node, None, p)?;
-        }
-        let result = collect_function_output(p, fxn_def);
-        drop(scope);
-        result
-    };
-
-    match output {
-        Ok(value) => {
-            trace_println!(
-                p,
-                "{}",
-                format_trace(
-                    "fn",
-                    format!("exit  {} => {}", fxn_def.name, summarize_value(&value))
-                )
-            );
-            Ok(value)
-        }
-        Err(err) => {
-            trace_println!(
-                p,
-                "{}",
-                format_trace("fn", format!("fail  {} => {:?}", fxn_def.name, err))
-            );
-            Err(err)
-        }
+      );
+      Ok(value)
     }
+    Err(err) => {
+      trace_println!(
+        p,
+        "{}",
+        format_trace("fn", format!("fail  {} => {:?}", fxn_def.name, err))
+      );
+      Err(err)
+    }
+  }
 }
 
 enum FunctionCallStep {
-    Return(Value),
-    TailCall(Vec<Value>),
+  Return(Value),
+  TailCall(Vec<Value>),
 }
 
 #[cfg(feature = "matrix")]
@@ -401,70 +401,70 @@ fn execute_function_match_arms(
             }
         }
     }
-    for (arm_idx, arm) in fxn_def.code.match_arms.iter().enumerate() {
-        let mut env = Environment::new();
-        let matched = crate::patterns::pattern_matches_arguments(
-            &arm.pattern,
-            input_arg_values,
-            &mut env,
-            p,
-        )?;
-        trace_println!(p, "{}", {
-            let args_summary = summarize_values_with_kinds(input_arg_values);
-            let pattern_summary = summarize_pattern(&arm.pattern);
-            let marker = if matched { "✓" } else { "X" };
-            format_trace(
-                "match",
-                format!(
-                    "arm[{arm_idx}] test pattern={pattern_summary} args=[{args_summary}] {marker}"
-                ),
-            )
-        });
-        if matched {
-            if let Expression::FunctionCall(fxn_call) = &arm.expression {
-                if fxn_call.name.hash() == fxn_def.code.name.hash() {
-                    let mut tail_args = Vec::with_capacity(fxn_call.args.len());
-                    for (_, arg_expr) in fxn_call.args.iter() {
-                        tail_args.push(expression(arg_expr, Some(&env), p)?);
-                    }
-                    if tail_args.len() == fxn_def.input.len() {
-                        trace_println!(
-                            p,
-                            "{}",
-                            format_trace(
-                                "match",
-                                format!("arm[{arm_idx}] tail-call {}", fxn_def.name)
-                            )
-                        );
-                        return Ok(FunctionCallStep::TailCall(tail_args));
-                    }
-                }
-            }
-            let out = expression(&arm.expression, Some(&env), p)?;
-            let coerced = coerce_function_output_kind(detach_value(&out), fxn_def, p)?;
+  for (arm_idx, arm) in fxn_def.code.match_arms.iter().enumerate() {
+    let mut env = Environment::new();
+    let matched = crate::patterns::pattern_matches_arguments(
+      &arm.pattern,
+      input_arg_values,
+      &mut env,
+      p,
+    )?;
+    trace_println!(p, "{}", {
+      let args_summary = summarize_values_with_kinds(input_arg_values);
+      let pattern_summary = summarize_pattern(&arm.pattern);
+      let marker = if matched { "✓" } else { "X" };
+      format_trace(
+        "match",
+        format!(
+          "arm[{arm_idx}] test pattern={pattern_summary} args=[{args_summary}] {marker}"
+        ),
+      )
+    });
+    if matched {
+      if let Expression::FunctionCall(fxn_call) = &arm.expression {
+        if fxn_call.name.hash() == fxn_def.code.name.hash() {
+          let mut tail_args = Vec::with_capacity(fxn_call.args.len());
+          for (_, arg_expr) in fxn_call.args.iter() {
+            tail_args.push(expression(arg_expr, Some(&env), p)?);
+          }
+          if tail_args.len() == fxn_def.input.len() {
             trace_println!(
-                p,
-                "{}",
-                format_trace(
-                    "match",
-                    format!(
-                        "arm[{arm_idx}] out  value={} kind={}",
-                        summarize_value(&coerced),
-                        coerced.kind().to_string()
-                    )
-                )
+              p,
+              "{}",
+              format_trace(
+                "match",
+                format!("arm[{arm_idx}] tail-call {}", fxn_def.name)
+              )
             );
-            return Ok(FunctionCallStep::Return(coerced));
+            return Ok(FunctionCallStep::TailCall(tail_args));
+          }
         }
+      }
+      let out = expression(&arm.expression, Some(&env), p)?;
+      let coerced = coerce_function_output_kind(detach_value(&out), fxn_def, p)?;
+      trace_println!(
+        p,
+        "{}",
+        format_trace(
+          "match",
+          format!(
+            "arm[{arm_idx}] out  value={} kind={}",
+            summarize_value(&coerced),
+            coerced.kind().to_string()
+          )
+        )
+      );
+      return Ok(FunctionCallStep::Return(coerced));
     }
-    Err(MechError::new(
-        FunctionOutputUndefinedError {
-            output_id: fxn_def.id,
-        },
-        None,
-    )
-    .with_compiler_loc()
-    .with_tokens(fxn_def.code.name.tokens()))
+  }
+  Err(MechError::new(
+    FunctionOutputUndefinedError {
+      output_id: fxn_def.id,
+    },
+    None,
+  )
+  .with_compiler_loc()
+  .with_tokens(fxn_def.code.name.tokens()))
 }
 
 fn format_trace(scope: &str, message: String) -> String {

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -1,4 +1,11 @@
 use crate::*;
+use crate::tracing::{
+  format_trace,
+  format_trace_args,
+  summarize_function_pattern,
+  summarize_function_value,
+  summarize_values_with_kinds,
+};
 #[cfg(all(feature = "kind_annotation", feature = "enum"))]
 use std::collections::HashSet;
 
@@ -151,7 +158,7 @@ pub fn execute_native_function_compiler(
             trace_println!(
                 p,
                 "{}",
-                format_trace("arm", format!("result {}", summarize_value(&result)))
+                format_trace("arm", format!("result {}", summarize_function_value(&result)))
             );
             plan_brrw.push(new_fxn);
             Ok(result)
@@ -227,7 +234,7 @@ fn execute_user_function(
         "{}",
         format_trace(
           "fn",
-          format!("exit  {} => {}", fxn_def.name, summarize_value(&value))
+          format!("exit  {} => {}", fxn_def.name, summarize_function_value(&value))
         )
       );
       Ok(value)
@@ -411,7 +418,7 @@ fn execute_function_match_arms(
     )?;
     trace_println!(p, "{}", {
       let args_summary = summarize_values_with_kinds(input_arg_values);
-      let pattern_summary = summarize_pattern(&arm.pattern);
+      let pattern_summary = summarize_function_pattern(&arm.pattern);
       let marker = if matched { "✓" } else { "X" };
       format_trace(
         "match",
@@ -449,7 +456,7 @@ fn execute_function_match_arms(
           "match",
           format!(
             "arm[{arm_idx}] out  value={} kind={}",
-            summarize_value(&coerced),
+            summarize_function_value(&coerced),
             coerced.kind().to_string()
           )
         )
@@ -465,129 +472,6 @@ fn execute_function_match_arms(
   )
   .with_compiler_loc()
   .with_tokens(fxn_def.code.name.tokens()))
-}
-
-fn format_trace(scope: &str, message: String) -> String {
-    format!("[trace][{scope}] {message}")
-}
-
-fn format_trace_args(values: &Vec<Value>) -> String {
-    values
-        .iter()
-        .map(summarize_value)
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-fn summarize_value(value: &Value) -> String {
-    const MAX_TRACE_CHARS: usize = 96;
-    let rendered = single_line_trace_text(&summarize_value_compact(value, 0));
-    truncate_for_trace(&rendered, MAX_TRACE_CHARS)
-}
-
-fn summarize_value_compact(value: &Value, depth: usize) -> String {
-    if depth > 2 {
-        return format!("{}(..)", value.kind().to_string());
-    }
-    match value {
-        #[cfg(feature = "u64")]
-        Value::U64(x) => format!("u64(@{:04x}:{})", short_addr(x.addr()), *x.borrow()),
-        #[cfg(feature = "i64")]
-        Value::I64(x) => format!("i64(@{:04x}:{})", short_addr(x.addr()), *x.borrow()),
-        #[cfg(feature = "f64")]
-        Value::F64(x) => format!("f64(@{:04x}:{})", short_addr(x.addr()), *x.borrow()),
-        #[cfg(feature = "bool")]
-        Value::Bool(x) => format!("bool(@{:04x}:{})", short_addr(x.addr()), *x.borrow()),
-        #[cfg(feature = "string")]
-        Value::String(x) => format!("str(@{:04x}:\"{}\")", short_addr(x.addr()), x.borrow()),
-        #[cfg(feature = "atom")]
-        Value::Atom(x) => format!("{}(@{:04x})", x.borrow().to_string(), short_addr(x.addr())),
-        #[cfg(feature = "tuple")]
-        Value::Tuple(tuple_ref) => summarize_tuple_value(tuple_ref, depth),
-        _ => format!(
-            "{}({})",
-            value.kind().to_string(),
-            truncate_for_trace(&single_line_trace_text(&format!("{:?}", value)), 48)
-        ),
-    }
-}
-
-#[cfg(feature = "tuple")]
-fn summarize_tuple_value(tuple_ref: &Ref<MechTuple>, depth: usize) -> String {
-    let tuple = tuple_ref.borrow();
-    let mut parts = Vec::new();
-    for element in tuple.elements.iter().take(3) {
-        parts.push(summarize_value_compact(element, depth + 1));
-    }
-    if tuple.elements.len() > 3 {
-        parts.push("…".to_string());
-    }
-    format!(
-        "tuple(@{:04x}; len={}; [{}])",
-        short_addr(tuple_ref.addr()),
-        tuple.elements.len(),
-        parts.join(", ")
-    )
-}
-
-fn short_addr(addr: usize) -> u16 {
-    (addr & 0xffff) as u16
-}
-
-fn summarize_values_with_kinds(values: &Vec<Value>) -> String {
-    values
-        .iter()
-        .enumerate()
-        .map(|(idx, value)| {
-            format!(
-                "#{idx}={} :{}",
-                summarize_value(value),
-                value.kind().to_string()
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-fn summarize_pattern(pattern: &Pattern) -> String {
-    match pattern {
-        Pattern::Wildcard => "_".to_string(),
-        Pattern::Expression(expr) => truncate_for_trace(&format!("{:?}", expr), 72),
-        Pattern::Tuple(tuple) => format!("tuple(len={})", tuple.0.len()),
-        Pattern::Array(array) => {
-            let spread = if array.spread.is_some() {
-                ",spread"
-            } else {
-                ""
-            };
-            format!(
-                "array(prefix={}{} ,suffix={})",
-                array.prefix.len(),
-                spread,
-                array.suffix.len()
-            )
-        }
-        Pattern::TupleStruct(tuple_struct) => {
-            format!(
-                "{}(len={})",
-                tuple_struct.name.to_string(),
-                tuple_struct.patterns.len()
-            )
-        }
-    }
-}
-
-fn truncate_for_trace(text: &str, max_chars: usize) -> String {
-    if text.chars().count() <= max_chars {
-        return text.to_string();
-    }
-    let mut truncated = text.chars().take(max_chars).collect::<String>();
-    truncated.push('…');
-    truncated
-}
-
-fn single_line_trace_text(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 // Kind coercion for function outputs, used in match arms when the output kind is annotated.

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -9,23 +9,23 @@ use crate::*;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum FrameState {
-  Running,
-  Suspended,
-  Completed,
+    Running,
+    Suspended,
+    Completed,
 }
 
 #[derive(Clone)]
 pub struct Frame {
-  plan: Plan,
-  ip: usize,               // next instruction
-  locals: SymbolTableRef,  // for subroutine variables
-  out: Option<Value>,      // optional coroutine return
-  state: FrameState,       // Running, Suspended, Completed
+    plan: Plan,
+    ip: usize,              // next instruction
+    locals: SymbolTableRef, // for subroutine variables
+    out: Option<Value>,     // optional coroutine return
+    state: FrameState,      // Running, Suspended, Completed
 }
 
 #[derive(Clone)]
 pub struct Stack {
-  frames: Vec<Frame>,
+    frames: Vec<Frame>,
 }
 
 pub fn function_define(fxn_def: &FunctionDefine, p: &Interpreter) -> MResult<FunctionDefinition> {
@@ -195,19 +195,30 @@ fn execute_user_function(
         )
     );
 
-    let scope = FunctionScope::enter(p);
-    bind_function_inputs(fxn_def, input_arg_values, p)?;
-
     let output = if !fxn_def.code.match_arms.is_empty() {
-        execute_function_match_arms(fxn_def, input_arg_values, p)
+        let mut current_args = input_arg_values.clone();
+        loop {
+            let scope = FunctionScope::enter(p);
+            bind_function_inputs(fxn_def, &current_args, p)?;
+            let step = execute_function_match_arms(fxn_def, &current_args, p)?;
+            drop(scope);
+            match step {
+                FunctionCallStep::Return(value) => break Ok(value),
+                FunctionCallStep::TailCall(next_args) => {
+                    current_args = next_args;
+                }
+            }
+        }
     } else {
+        let scope = FunctionScope::enter(p);
+        bind_function_inputs(fxn_def, input_arg_values, p)?;
         for statement_node in &fxn_def.code.statements {
             statement(statement_node, None, p)?;
         }
-        collect_function_output(p, fxn_def)
+        let result = collect_function_output(p, fxn_def);
+        drop(scope);
+        result
     };
-
-    drop(scope);
 
     match output {
         Ok(value) => {
@@ -232,13 +243,21 @@ fn execute_user_function(
     }
 }
 
+enum FunctionCallStep {
+    Return(Value),
+    TailCall(Vec<Value>),
+}
+
 #[cfg(feature = "matrix")]
 fn try_broadcast_user_function(
     fxn_def: &FunctionDefinition,
     input_arg_values: &Vec<Value>,
     p: &Interpreter,
 ) -> MResult<Option<Value>> {
-    if input_arg_values.len() != 1 || fxn_def.code.output.len() != 1 || fxn_def.code.input.len() != 1 {
+    if input_arg_values.len() != 1
+        || fxn_def.code.output.len() != 1
+        || fxn_def.code.input.len() != 1
+    {
         return Ok(None);
     }
 
@@ -295,7 +314,13 @@ fn build_typed_matrix_from_values(
         ValueKind::F64 => Value::MatrixF64(f64::to_matrix(
             outputs
                 .into_iter()
-                .map(|value| value.as_f64().expect("Expected f64 output").borrow().clone())
+                .map(|value| {
+                    value
+                        .as_f64()
+                        .expect("Expected f64 output")
+                        .borrow()
+                        .clone()
+                })
                 .collect::<Vec<f64>>(),
             rows,
             cols,
@@ -308,7 +333,7 @@ fn execute_function_match_arms(
     fxn_def: &FunctionDefinition,
     input_arg_values: &Vec<Value>,
     p: &Interpreter,
-) -> MResult<Value> {
+) -> MResult<FunctionCallStep> {
     #[cfg(all(feature = "kind_annotation", feature = "enum"))]
     {
         let has_wildcard = fxn_def
@@ -368,8 +393,8 @@ fn execute_function_match_arms(
                                 },
                                 None,
                             )
-                                .with_compiler_loc()
-                                .with_tokens(fxn_def.code.name.tokens()));
+                            .with_compiler_loc()
+                            .with_tokens(fxn_def.code.name.tokens()));
                         }
                     }
                 }
@@ -396,6 +421,25 @@ fn execute_function_match_arms(
             )
         });
         if matched {
+            if let Expression::FunctionCall(fxn_call) = &arm.expression {
+                if fxn_call.name.hash() == fxn_def.code.name.hash() {
+                    let mut tail_args = Vec::with_capacity(fxn_call.args.len());
+                    for (_, arg_expr) in fxn_call.args.iter() {
+                        tail_args.push(expression(arg_expr, Some(&env), p)?);
+                    }
+                    if tail_args.len() == fxn_def.input.len() {
+                        trace_println!(
+                            p,
+                            "{}",
+                            format_trace(
+                                "match",
+                                format!("arm[{arm_idx}] tail-call {}", fxn_def.name)
+                            )
+                        );
+                        return Ok(FunctionCallStep::TailCall(tail_args));
+                    }
+                }
+            }
             let out = expression(&arm.expression, Some(&env), p)?;
             let coerced = coerce_function_output_kind(detach_value(&out), fxn_def, p)?;
             trace_println!(
@@ -410,7 +454,7 @@ fn execute_function_match_arms(
                     )
                 )
             );
-            return Ok(coerced);
+            return Ok(FunctionCallStep::Return(coerced));
         }
     }
     Err(MechError::new(
@@ -546,19 +590,23 @@ fn single_line_trace_text(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-// Kind coercion for function outputs, used in match arms when the output kind is annotated. 
+// Kind coercion for function outputs, used in match arms when the output kind is annotated.
 // If the function output has no kind annotation, or if coercion fails, returns the original value.
 #[cfg(feature = "kind_annotation")]
-fn coerce_function_output_kind( value: Value, fxn_def: &FunctionDefinition, p: &Interpreter) -> MResult<Value> {
-  if fxn_def.output.is_empty() {
-    return Ok(value);
-  }
-  let Some((_, output_kind_annotation)) = fxn_def.output.get_index(0) else {
-    return Ok(value);
-  };
-  let target_kind = kind_annotation(&output_kind_annotation.kind, p)?
-    .to_value_kind(&p.state.borrow().kinds)?;
-  return Ok(value.convert_to(&target_kind).unwrap_or(value))
+fn coerce_function_output_kind(
+    value: Value,
+    fxn_def: &FunctionDefinition,
+    p: &Interpreter,
+) -> MResult<Value> {
+    if fxn_def.output.is_empty() {
+        return Ok(value);
+    }
+    let Some((_, output_kind_annotation)) = fxn_def.output.get_index(0) else {
+        return Ok(value);
+    };
+    let target_kind =
+        kind_annotation(&output_kind_annotation.kind, p)?.to_value_kind(&p.state.borrow().kinds)?;
+    return Ok(value.convert_to(&target_kind).unwrap_or(value));
 }
 
 struct FunctionScope {
@@ -604,7 +652,9 @@ fn bind_function_inputs(
     p: &Interpreter,
 ) -> MResult<()> {
     let scoped_state = p.state.borrow();
-    for ((arg_id, input_kind_annotation), input_value) in fxn_def.input.iter().zip(input_arg_values.iter()) {
+    for ((arg_id, input_kind_annotation), input_value) in
+        fxn_def.input.iter().zip(input_arg_values.iter())
+    {
         let arg_name = fxn_def
             .code
             .input
@@ -637,7 +687,28 @@ fn bind_function_inputs(
                         .with_tokens(input_kind_annotation.tokens()));
                     }
                 } else {
-                    detached_input.clone().convert_to(&target_kind).ok_or_else(|| {
+                    detached_input
+                        .clone()
+                        .convert_to(&target_kind)
+                        .ok_or_else(|| {
+                            MechError::new(
+                                FunctionInputTypeMismatchError {
+                                    function_name: fxn_def.name.clone(),
+                                    argument_name: arg_name.clone(),
+                                    expected: target_kind.clone(),
+                                    found: detached_input.kind(),
+                                },
+                                None,
+                            )
+                            .with_compiler_loc()
+                            .with_tokens(input_kind_annotation.tokens())
+                        })?
+                }
+                #[cfg(not(all(feature = "enum", feature = "atom")))]
+                detached_input
+                    .clone()
+                    .convert_to(&target_kind)
+                    .ok_or_else(|| {
                         MechError::new(
                             FunctionInputTypeMismatchError {
                                 function_name: fxn_def.name.clone(),
@@ -650,21 +721,6 @@ fn bind_function_inputs(
                         .with_compiler_loc()
                         .with_tokens(input_kind_annotation.tokens())
                     })?
-                }
-                #[cfg(not(all(feature = "enum", feature = "atom")))]
-                detached_input.clone().convert_to(&target_kind).ok_or_else(|| {
-                    MechError::new(
-                        FunctionInputTypeMismatchError {
-                            function_name: fxn_def.name.clone(),
-                            argument_name: arg_name.clone(),
-                            expected: target_kind.clone(),
-                            found: detached_input.kind(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()
-                    .with_tokens(input_kind_annotation.tokens())
-                })?
             }
             #[cfg(not(feature = "kind_annotation"))]
             {
@@ -688,7 +744,9 @@ fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool 
             enum_def
                 .variants
                 .iter()
-                .any(|(known_variant, payload_kind)| *known_variant == variant_id && payload_kind.is_none())
+                .any(|(known_variant, payload_kind)| {
+                    *known_variant == variant_id && payload_kind.is_none()
+                })
         }
         #[cfg(feature = "tuple")]
         Value::Tuple(tuple_val) => {
@@ -701,13 +759,19 @@ fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool 
                 _ => return false,
             };
             let payload = tuple_brrw.elements[1].as_ref().clone();
-            let (_, declared_payload_kind) = match enum_def.variants.iter().find(|(known_variant, _)| *known_variant == tag) {
+            let (_, declared_payload_kind) = match enum_def
+                .variants
+                .iter()
+                .find(|(known_variant, _)| *known_variant == tag)
+            {
                 Some(entry) => entry,
                 None => return false,
             };
             match declared_payload_kind {
                 Some(Value::Kind(expected_kind)) => match expected_kind {
-                    ValueKind::Enum(inner_enum_id, _) => enum_value_matches(payload, *inner_enum_id, state),
+                    ValueKind::Enum(inner_enum_id, _) => {
+                        enum_value_matches(payload, *inner_enum_id, state)
+                    }
                     _ => {
                         payload.kind() == expected_kind.clone()
                             || payload.convert_to(expected_kind).is_some()

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -8,170 +8,195 @@ use crate::tracing::{
 };
 #[cfg(all(feature = "kind_annotation", feature = "enum"))]
 use std::collections::HashSet;
+use crate::*;
 
 // Functions
-// ----------------------------------------------------------------------------
+// ============================================================================
 
-use crate::*;
+
+// Frames
+// ----------------------------------------------------------------------------
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum FrameState {
-    Running,
-    Suspended,
-    Completed,
+  Running,
+  Suspended,
+  Completed,
 }
 
+// One activation record on the call stack. Every user-function invocation gets
+// its own Frame so locals and the instruction pointer don't bleed across calls.
 #[derive(Clone)]
 pub struct Frame {
-    plan: Plan,
-    ip: usize,              // next instruction
-    locals: SymbolTableRef, // for subroutine variables
-    out: Option<Value>,     // optional coroutine return
-    state: FrameState,      // Running, Suspended, Completed
+  plan: Plan,
+  ip: usize,              // index of the next instruction to execute
+  locals: SymbolTableRef, // variables local to this invocation
+  out: Option<Value>,     // value yielded by a coroutine, if any
+  state: FrameState,      // Running / Suspended / Completed
 }
 
+// The call stack is a simple growable list of frames; the last entry is current.
 #[derive(Clone)]
 pub struct Stack {
-    frames: Vec<Frame>,
+  frames: Vec<Frame>,
 }
 
+// Registers a user-written function so it can be called by name later.
+// Hashes the name to a u64 id used as the lookup key throughout the runtime.
 pub fn function_define(fxn_def: &FunctionDefine, p: &Interpreter) -> MResult<FunctionDefinition> {
-    let fxn_name_id = fxn_def.name.hash();
-    let mut new_fxn =
-        FunctionDefinition::new(fxn_name_id, fxn_def.name.to_string(), fxn_def.clone());
+  let fxn_name_id = fxn_def.name.hash();
+  let mut new_fxn = FunctionDefinition::new(fxn_name_id, fxn_def.name.to_string(), fxn_def.clone());
 
-    for input_arg in &fxn_def.input {
-        new_fxn
-            .input
-            .insert(input_arg.name.hash(), input_arg.kind.clone());
-    }
+  // Record declared input arguments and their kind annotations.
+  for input_arg in &fxn_def.input {
+    new_fxn
+      .input
+      .insert(input_arg.name.hash(), input_arg.kind.clone());
+  }
 
-    for output_arg in &fxn_def.output {
-        new_fxn
-            .output
-            .insert(output_arg.name.hash(), output_arg.kind.clone());
-    }
+  // Record declared output arguments and their kind annotations.
+  for output_arg in &fxn_def.output {
+    new_fxn
+      .output
+      .insert(output_arg.name.hash(), output_arg.kind.clone());
+  }
 
-    let functions = p.functions();
-    let mut functions_brrw = functions.borrow_mut();
-    functions_brrw
-        .user_functions
-        .insert(fxn_name_id, new_fxn.clone());
-    functions_brrw
-        .dictionary
-        .borrow_mut()
-        .insert(fxn_name_id, fxn_def.name.to_string());
-    p.state
-        .borrow()
-        .dictionary
-        .borrow_mut()
-        .insert(fxn_name_id, fxn_def.name.to_string());
+  // Store the definition and register the human-readable name string in both
+  // dictionaries so error messages and debug output can print it.
+  let functions = p.functions();
+  let mut functions_brrw = functions.borrow_mut();
+  functions_brrw
+    .user_functions
+    .insert(fxn_name_id, new_fxn.clone());
+  functions_brrw
+    .dictionary
+    .borrow_mut()
+    .insert(fxn_name_id, fxn_def.name.to_string());
+  p.state
+    .borrow()
+    .dictionary
+    .borrow_mut()
+    .insert(fxn_name_id, fxn_def.name.to_string());
 
-    Ok(new_fxn)
+  Ok(new_fxn)
 }
 
-pub fn function_call(
-    fxn_call: &FunctionCall,
-    env: Option<&Environment>,
-    p: &Interpreter,
-) -> MResult<Value> {
-    let functions = p.functions();
-    let fxn_name_id = fxn_call.name.hash();
+// Calls
+// ----------------------------------------------------------------------------
 
-    if let Some(user_fxn) = { functions.borrow().user_functions.get(&fxn_name_id).cloned() } {
-        let mut input_arg_values = vec![];
-        for (_, arg_expr) in fxn_call.args.iter() {
-            input_arg_values.push(expression(arg_expr, env, p)?);
-        }
-        return execute_user_function(&user_fxn, &input_arg_values, p);
+// Dispatches a function call to whichever implementation is available:
+// user-defined functions first, then built-in functions, then native compiled
+// functions. Returns an error if the name is not found in any registry.
+pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let functions = p.functions();
+  let fxn_name_id = fxn_call.name.hash();
+
+  // User-defined function: evaluate arguments then run the interpreted body.
+  if let Some(user_fxn) = { functions.borrow().user_functions.get(&fxn_name_id).cloned() } {
+    let mut input_arg_values = vec![];
+    for (_, arg_expr) in fxn_call.args.iter() {
+      input_arg_values.push(expression(arg_expr, env, p)?);
     }
+    return execute_user_function(&user_fxn, &input_arg_values, p);
+  }
 
-    if { functions.borrow().functions.contains_key(&fxn_name_id) } {
-        todo!();
-    }
+  // Pre-compiled built-in functions.
+  if { functions.borrow().functions.contains_key(&fxn_name_id) } {
+    todo!();
+  }
 
-    let fxn_compiler = {
-        functions
-            .borrow()
-            .function_compilers
-            .get(&fxn_name_id)
-            .copied()
-    };
-    match fxn_compiler {
-        Some(fxn_compiler) => {
-            let mut input_arg_values = vec![];
-            for (_, arg_expr) in fxn_call.args.iter() {
-                input_arg_values.push(expression(arg_expr, env, p)?);
-            }
-            trace_println!(
-                p,
-                "{}",
-                format_trace(
-                    "fn",
-                    format!(
-                        "native {}({})",
-                        fxn_call.name.to_string(),
-                        format_trace_args(&input_arg_values)
-                    ),
-                )
-            );
-            execute_native_function_compiler(fxn_compiler, &input_arg_values, p)
-        }
-        None => Err(MechError::new(
-            MissingFunctionError {
-                function_id: fxn_name_id,
-            },
-            None,
+  // Native function compiler: the compiler picks a concrete implementation
+  // based on the runtime argument types, then we execute it immediately.
+  let fxn_compiler = {
+    functions
+      .borrow()
+      .function_compilers
+      .get(&fxn_name_id)
+      .copied()
+  };
+  match fxn_compiler {
+    Some(fxn_compiler) => {
+      let mut input_arg_values = vec![];
+      for (_, arg_expr) in fxn_call.args.iter() {
+        input_arg_values.push(expression(arg_expr, env, p)?);
+      }
+      trace_println!(
+        p,
+        "{}",
+        format_trace(
+          "fn",
+          format!(
+            "native {}({})",
+            fxn_call.name.to_string(),
+            format_trace_args(&input_arg_values)
+          ),
         )
-        .with_compiler_loc()
-        .with_tokens(fxn_call.name.tokens())),
+      );
+      execute_native_function_compiler(fxn_compiler, &input_arg_values, p)
     }
+    // No implementation found under this name at all.
+    None => Err(MechError::new(
+      MissingFunctionError {
+        function_id: fxn_name_id,
+      },
+      None,
+    )
+    .with_compiler_loc()
+    .with_tokens(fxn_call.name.tokens())),
+  }
 }
 
+// Asks a native function compiler to select the right concrete implementation
+// for the given argument types, runs it once to produce an initial value, then
+// pushes it onto the reactive plan so it re-runs when its inputs change.
 pub fn execute_native_function_compiler(
-    fxn_compiler: &'static dyn NativeFunctionCompiler,
-    input_arg_values: &Vec<Value>,
-    p: &Interpreter,
+  fxn_compiler: &'static dyn NativeFunctionCompiler,
+  input_arg_values: &Vec<Value>,
+  p: &Interpreter,
 ) -> MResult<Value> {
-    let plan = p.plan();
-    match fxn_compiler.compile(input_arg_values) {
-        Ok(mut new_fxn) => {
-            trace_println!(
-                p,
-                "{}",
-                format_trace(
-                    "arm",
-                    format!(
-                        "selected {} args=[{}]",
-                        new_fxn
-                            .to_string()
-                            .lines()
-                            .next()
-                            .unwrap_or("<unknown-arm>"),
-                        format_trace_args(input_arg_values)
-                    ),
-                )
-            );
-            let mut plan_brrw = plan.borrow_mut();
-            new_fxn.solve();
-            let result = new_fxn.out();
-            trace_println!(
-                p,
-                "{}",
-                format_trace("arm", format!("result {}", summarize_function_value(&result)))
-            );
-            plan_brrw.push(new_fxn);
-            Ok(result)
-        }
-        Err(err) => Err(err),
+  let plan = p.plan();
+  match fxn_compiler.compile(input_arg_values) {
+    Ok(mut new_fxn) => {
+      trace_println!(
+        p,
+        "{}",
+        format_trace(
+          "arm",
+          format!(
+            "selected {} args=[{}]",
+            new_fxn
+              .to_string()
+              .lines()
+              .next()
+              .unwrap_or("<unknown-arm>"),
+            format_trace_args(input_arg_values)
+          ),
+        )
+      );
+      let mut plan_brrw = plan.borrow_mut();
+      new_fxn.solve();                   // run the function once to initialise its output
+      let result = new_fxn.out();
+      trace_println!(
+        p,
+        "{}",
+        format_trace("arm", format!("result {}", summarize_function_value(&result)))
+      );
+      plan_brrw.push(new_fxn);          // keep it in the plan for reactive re-evaluation
+      Ok(result)
     }
+    Err(err) => Err(err),
+  }
 }
 
+// Executes a user-defined function. Handles argument count validation,
+// optional matrix broadcasting, match-arm dispatch, and plain statement bodies.
+// Logs entry/exit (or failure) via the trace machinery.
 fn execute_user_function(
   fxn_def: &FunctionDefinition,
   input_arg_values: &Vec<Value>,
   p: &Interpreter,
 ) -> MResult<Value> {
+  // Reject calls with the wrong number of arguments before doing anything else.
   if input_arg_values.len() != fxn_def.input.len() {
     return Err(MechError::new(
       IncorrectNumberOfArguments {
@@ -184,6 +209,8 @@ fn execute_user_function(
     .with_tokens(fxn_def.code.name.tokens()));
   }
 
+  // If the function takes a single matrix argument and the element kind matches
+  // the output kind, broadcast element-wise instead of running the body once.
   #[cfg(feature = "matrix")]
   if let Some(result) = try_broadcast_user_function(fxn_def, input_arg_values, p)? {
     return Ok(result);
@@ -202,7 +229,11 @@ fn execute_user_function(
     )
   );
 
+  // Choose execution strategy: match-arm body vs. plain statement body.
   let output = if !fxn_def.code.match_arms.is_empty() {
+    // Match-arm body: loop to support tail-call optimisation. Each iteration
+    // opens a fresh scope, binds the current arguments, runs the arms, then
+    // either returns the result or loops with a new argument set.
     let mut current_args: Vec<Value> = input_arg_values.clone();
     loop {
       let scope = FunctionScope::enter(p);
@@ -211,12 +242,15 @@ fn execute_user_function(
       drop(scope);
       match step {
         FunctionCallStep::Return(value) => break Ok(value),
+        // Tail call: swap in the new args and go around again without growing
+        // the Rust call stack.
         FunctionCallStep::TailCall(next_args) => {
           current_args = next_args;
         }
       }
     }
   } else {
+    // Plain statement body: run statements in order, then collect named outputs.
     let scope = FunctionScope::enter(p);
     bind_function_inputs(fxn_def, input_arg_values, p)?;
     for statement_node in &fxn_def.code.statements {
@@ -250,164 +284,191 @@ fn execute_user_function(
   }
 }
 
+// The outcome of executing one match arm. Either we have a final value, or
+// we identified a tail call and carry its new arguments for the next iteration.
 enum FunctionCallStep {
   Return(Value),
   TailCall(Vec<Value>),
 }
 
+// If the function is single-input / single-output with matching scalar kinds,
+// and the actual argument is a matrix, run the function on each element and
+// reassemble the result into a matrix of the same shape.
+// Returns None if any condition for broadcasting isn't met, so the caller can
+// fall through to normal execution.
 #[cfg(feature = "matrix")]
 fn try_broadcast_user_function(
-    fxn_def: &FunctionDefinition,
-    input_arg_values: &Vec<Value>,
-    p: &Interpreter,
+  fxn_def: &FunctionDefinition,
+  input_arg_values: &Vec<Value>,
+  p: &Interpreter,
 ) -> MResult<Option<Value>> {
-    if input_arg_values.len() != 1
-        || fxn_def.code.output.len() != 1
-        || fxn_def.code.input.len() != 1
-    {
-        return Ok(None);
-    }
+  if input_arg_values.len() != 1
+    || fxn_def.code.output.len() != 1
+    || fxn_def.code.input.len() != 1
+  {
+    return Ok(None);
+  }
 
-    let source = detach_value(&input_arg_values[0]);
-    if !source.is_matrix() {
-        return Ok(None);
-    }
+  let source = detach_value(&input_arg_values[0]);
+  if !source.is_matrix() {
+    return Ok(None);
+  }
 
-    #[cfg(feature = "kind_annotation")]
-    let (input_kind, output_kind) = {
-        let input_kind = kind_annotation(&fxn_def.code.input[0].kind.kind, p)?
-            .to_value_kind(&p.state.borrow().kinds)?;
-        let output_kind = kind_annotation(&fxn_def.code.output[0].kind.kind, p)?
-            .to_value_kind(&p.state.borrow().kinds)?;
-        (input_kind, output_kind)
-    };
+  // Resolve the declared input and output kinds from their annotations.
+  // Without kind_annotation feature we can't know the element type, so bail.
+  #[cfg(feature = "kind_annotation")]
+  let (input_kind, output_kind) = {
+    let input_kind = kind_annotation(&fxn_def.code.input[0].kind.kind, p)?
+      .to_value_kind(&p.state.borrow().kinds)?;
+    let output_kind = kind_annotation(&fxn_def.code.output[0].kind.kind, p)?
+      .to_value_kind(&p.state.borrow().kinds)?;
+    (input_kind, output_kind)
+  };
 
-    #[cfg(not(feature = "kind_annotation"))]
-    let (input_kind, output_kind) = {
-        return Ok(None);
-    };
+  #[cfg(not(feature = "kind_annotation"))]
+  let (input_kind, output_kind) = {
+    return Ok(None);
+  };
 
-    if input_kind != output_kind || matches!(input_kind, ValueKind::Matrix(_, _)) {
-        return Ok(None);
-    }
+  // Only broadcast when input and output kinds are the same scalar kind.
+  // If the input is already a matrix kind, don't recurse.
+  if input_kind != output_kind || matches!(input_kind, ValueKind::Matrix(_, _)) {
+    return Ok(None);
+  }
 
-    let Some(elements) = crate::patterns::matrix_like_values(&source) else {
-        return Ok(None);
-    };
+  let Some(elements) = crate::patterns::matrix_like_values(&source) else {
+    return Ok(None);
+  };
 
-    let mut outputs = Vec::with_capacity(elements.len());
-    for element in elements {
-        outputs.push(execute_user_function(fxn_def, &vec![element], p)?);
-    }
+  // Apply the function element-wise, then reassemble into the original shape.
+  let mut outputs = Vec::with_capacity(elements.len());
+  for element in elements {
+    outputs.push(execute_user_function(fxn_def, &vec![element], p)?);
+  }
 
-    let shape = source.shape();
-    Ok(Some(build_typed_matrix_from_values(
-        &output_kind,
-        outputs,
-        shape[0],
-        shape[1],
-    )))
+  let shape = source.shape();
+  Ok(Some(build_typed_matrix_from_values(
+    &output_kind,
+    outputs,
+    shape[0],
+    shape[1],
+  )))
 }
 
+// Assembles a list of scalar Values into a typed matrix.
+// TODO add more types
 #[cfg(feature = "matrix")]
 fn build_typed_matrix_from_values(
-    output_kind: &ValueKind,
-    outputs: Vec<Value>,
-    rows: usize,
-    cols: usize,
+  output_kind: &ValueKind,
+  outputs: Vec<Value>,
+  rows: usize,
+  cols: usize,
 ) -> Value {
-    match output_kind {
-        #[cfg(feature = "f64")]
-        ValueKind::F64 => Value::MatrixF64(f64::to_matrix(
-            outputs
-                .into_iter()
-                .map(|value| {
-                    value
-                        .as_f64()
-                        .expect("Expected f64 output")
-                        .borrow()
-                        .clone()
-                })
-                .collect::<Vec<f64>>(),
-            rows,
-            cols,
-        )),
-        _ => Value::MatrixValue(Value::to_matrix(outputs, rows, cols)),
-    }
+  match output_kind {
+    #[cfg(feature = "f64")]
+    ValueKind::F64 => Value::MatrixF64(f64::to_matrix(
+      outputs
+        .into_iter()
+        .map(|value| {
+          value
+            .as_f64()
+            .expect("Expected f64 output")
+            .borrow()
+            .clone()
+        })
+        .collect::<Vec<f64>>(),
+      rows,
+      cols,
+    )),
+    _ => Value::MatrixValue(Value::to_matrix(outputs, rows, cols)),
+  }
 }
 
+// Tries each match arm in order against the current arguments. Handles:
+//   - enum exhaustiveness checking (kind_annotation + enum features)
+//   - tail-call detection (arm body is a recursive call with same arity)
+//   - output kind coercion
+// Returns an error if no arm matched.
 fn execute_function_match_arms(
-    fxn_def: &FunctionDefinition,
-    input_arg_values: &Vec<Value>,
-    p: &Interpreter,
+  fxn_def: &FunctionDefinition,
+  input_arg_values: &Vec<Value>,
+  p: &Interpreter,
 ) -> MResult<FunctionCallStep> {
-    #[cfg(all(feature = "kind_annotation", feature = "enum"))]
-    {
-        let has_wildcard = fxn_def
-            .code
-            .match_arms
-            .iter()
-            .any(|arm| matches!(arm.pattern, Pattern::Wildcard));
-        if !has_wildcard && fxn_def.input.len() == 1 {
-            if let Some((_, kind_annotation_node)) = fxn_def.input.iter().next() {
-                let input_kind = kind_annotation(&kind_annotation_node.kind, p)?
-                    .to_value_kind(&p.state.borrow().kinds)?;
-                if let ValueKind::Enum(enum_id, _) = input_kind {
-                    let state_brrw = p.state.borrow();
-                    if let Some(enum_def) = state_brrw.enums.get(&enum_id) {
-                        let mut covered_variants: HashSet<u64> = HashSet::new();
-                        for arm in &fxn_def.code.match_arms {
-                            match &arm.pattern {
-                                #[cfg(feature = "atom")]
-                                Pattern::TupleStruct(tuple_struct) => {
-                                    covered_variants.insert(tuple_struct.name.hash());
-                                }
-                                Pattern::Expression(expr) => {
-                                    if let Expression::Literal(Literal::Atom(atom)) = expr {
-                                        covered_variants.insert(atom.name.hash());
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                        let all_covered = enum_def
-                            .variants
-                            .iter()
-                            .all(|(variant_id, _)| covered_variants.contains(variant_id));
-                        if !all_covered {
-                            let missing_patterns = enum_def
-                                .variants
-                                .iter()
-                                .filter(|(variant_id, _)| !covered_variants.contains(variant_id))
-                                .map(|(variant_id, payload_kind)| {
-                                    let variant_name = enum_def
-                                        .names
-                                        .borrow()
-                                        .get(variant_id)
-                                        .cloned()
-                                        .unwrap_or_else(|| variant_id.to_string());
-                                    if payload_kind.is_some() {
-                                        format!(":{}(...)", variant_name)
-                                    } else {
-                                        format!(":{}", variant_name)
-                                    }
-                                })
-                                .collect::<Vec<String>>();
-                            return Err(MechError::new(
-                                FunctionMatchNonExhaustiveError {
-                                    function_name: fxn_def.name.clone(),
-                                    missing_patterns,
-                                },
-                                None,
-                            )
-                            .with_compiler_loc()
-                            .with_tokens(fxn_def.code.name.tokens()));
-                        }
-                    }
+
+  // Exhaustiveness check: when the single input is an enum type and there is
+  // no wildcard arm, every variant must be covered or we report which ones
+  // are missing before even attempting to run.
+  #[cfg(all(feature = "kind_annotation", feature = "enum"))]
+  {
+    let has_wildcard = fxn_def
+      .code
+      .match_arms
+      .iter()
+      .any(|arm| matches!(arm.pattern, Pattern::Wildcard));
+    if !has_wildcard && fxn_def.input.len() == 1 {
+      if let Some((_, kind_annotation_node)) = fxn_def.input.iter().next() {
+        let input_kind = kind_annotation(&kind_annotation_node.kind, p)?
+          .to_value_kind(&p.state.borrow().kinds)?;
+        if let ValueKind::Enum(enum_id, _) = input_kind {
+          let state_brrw = p.state.borrow();
+          if let Some(enum_def) = state_brrw.enums.get(&enum_id) {
+            // Collect every variant name that appears in the written arms.
+            let mut covered_variants: HashSet<u64> = HashSet::new();
+            for arm in &fxn_def.code.match_arms {
+              match &arm.pattern {
+                #[cfg(feature = "atom")]
+                Pattern::TupleStruct(tuple_struct) => {
+                  covered_variants.insert(tuple_struct.name.hash());
                 }
+                Pattern::Expression(expr) => {
+                  if let Expression::Literal(Literal::Atom(atom)) = expr {
+                    covered_variants.insert(atom.name.hash());
+                  }
+                }
+                _ => {}
+              }
             }
+            let all_covered = enum_def
+              .variants
+              .iter()
+              .all(|(variant_id, _)| covered_variants.contains(variant_id));
+            if !all_covered {
+              // Build a readable list of the missing variant patterns.
+              let missing_patterns = enum_def
+                .variants
+                .iter()
+                .filter(|(variant_id, _)| !covered_variants.contains(variant_id))
+                .map(|(variant_id, payload_kind)| {
+                  let variant_name = enum_def
+                    .names
+                    .borrow()
+                    .get(variant_id)
+                    .cloned()
+                    .unwrap_or_else(|| variant_id.to_string());
+                  if payload_kind.is_some() {
+                    format!(":{}(...)", variant_name)
+                  } else {
+                    format!(":{}", variant_name)
+                  }
+                })
+                .collect::<Vec<String>>();
+              return Err(MechError::new(
+                FunctionMatchNonExhaustiveError {
+                  function_name: fxn_def.name.clone(),
+                  missing_patterns,
+                },
+                None,
+              )
+              .with_compiler_loc()
+              .with_tokens(fxn_def.code.name.tokens()));
+            }
+          }
         }
+      }
     }
+  }
+
+  // Try each arm in source order; the first one whose pattern matches wins.
   for (arm_idx, arm) in fxn_def.code.match_arms.iter().enumerate() {
     let mut env = Environment::new();
     let matched = crate::patterns::pattern_matches_arguments(
@@ -428,6 +489,8 @@ fn execute_function_match_arms(
       )
     });
     if matched {
+      // Tail-call optimisation: if the arm body is a direct recursive call
+      // with the same arity, return new arguments instead of recursing.
       if let Expression::FunctionCall(fxn_call) = &arm.expression {
         if fxn_call.name.hash() == fxn_def.code.name.hash() {
           let mut tail_args = Vec::with_capacity(fxn_call.args.len());
@@ -447,6 +510,7 @@ fn execute_function_match_arms(
           }
         }
       }
+      // Normal arm: evaluate the expression and coerce to the declared output kind.
       let out = expression(&arm.expression, Some(&env), p)?;
       let coerced = coerce_function_output_kind(detach_value(&out), fxn_def, p)?;
       trace_println!(
@@ -464,6 +528,7 @@ fn execute_function_match_arms(
       return Ok(FunctionCallStep::Return(coerced));
     }
   }
+  // No arm matched — this is a runtime error; the function has no defined output.
   Err(MechError::new(
     FunctionOutputUndefinedError {
       output_id: fxn_def.id,
@@ -474,301 +539,342 @@ fn execute_function_match_arms(
   .with_tokens(fxn_def.code.name.tokens()))
 }
 
-// Kind coercion for function outputs, used in match arms when the output kind is annotated.
-// If the function output has no kind annotation, or if coercion fails, returns the original value.
+// Coerces a match-arm result to the function's declared output kind.
+// If no output annotation exists, or conversion fails, the value is returned as-is.
 #[cfg(feature = "kind_annotation")]
 fn coerce_function_output_kind(
-    value: Value,
-    fxn_def: &FunctionDefinition,
-    p: &Interpreter,
+  value: Value,
+  fxn_def: &FunctionDefinition,
+  p: &Interpreter,
 ) -> MResult<Value> {
-    if fxn_def.output.is_empty() {
-        return Ok(value);
-    }
-    let Some((_, output_kind_annotation)) = fxn_def.output.get_index(0) else {
-        return Ok(value);
-    };
-    let target_kind =
-        kind_annotation(&output_kind_annotation.kind, p)?.to_value_kind(&p.state.borrow().kinds)?;
-    return Ok(value.convert_to(&target_kind).unwrap_or(value));
+  if fxn_def.output.is_empty() {
+    return Ok(value);
+  }
+  let Some((_, output_kind_annotation)) = fxn_def.output.get_index(0) else {
+    return Ok(value);
+  };
+  let target_kind =
+    kind_annotation(&output_kind_annotation.kind, p)?.to_value_kind(&p.state.borrow().kinds)?;
+  return Ok(value.convert_to(&target_kind).unwrap_or(value));
 }
 
+// RAII guard that swaps in a fresh symbol table and plan for the duration of a
+// function call, then restores the previous ones on drop. This is what gives
+// each function its own local variable namespace.
 struct FunctionScope {
-    state: Ref<ProgramState>,
-    previous_symbols: SymbolTableRef,
-    previous_plan: Plan,
-    previous_environment: Option<SymbolTableRef>,
+  state: Ref<ProgramState>,
+  previous_symbols: SymbolTableRef,
+  previous_plan: Plan,
+  previous_environment: Option<SymbolTableRef>,
 }
 
 impl FunctionScope {
-    fn enter(p: &Interpreter) -> Self {
-        let state = p.state.clone();
-        let mut state_brrw = state.borrow_mut();
-        let mut local_symbols = SymbolTable::new();
-        local_symbols.dictionary = state_brrw.dictionary.clone();
-        let local_symbols = Ref::new(local_symbols);
-        let previous_symbols = std::mem::replace(&mut state_brrw.symbol_table, local_symbols);
-        let previous_plan = std::mem::replace(&mut state_brrw.plan, Plan::new());
-        let previous_environment = state_brrw.environment.take();
-        drop(state_brrw);
+  fn enter(p: &Interpreter) -> Self {
+    let state = p.state.clone();
+    let mut state_brrw = state.borrow_mut();
+    // A new symbol table that shares the global name dictionary so that
+    // lookups by hash still resolve to human-readable names.
+    let mut local_symbols = SymbolTable::new();
+    local_symbols.dictionary = state_brrw.dictionary.clone();
+    let local_symbols = Ref::new(local_symbols);
+    let previous_symbols = std::mem::replace(&mut state_brrw.symbol_table, local_symbols);
+    let previous_plan = std::mem::replace(&mut state_brrw.plan, Plan::new());
+    let previous_environment = state_brrw.environment.take();
+    drop(state_brrw);
 
-        Self {
-            state,
-            previous_symbols,
-            previous_plan,
-            previous_environment,
-        }
+    Self {
+      state,
+      previous_symbols,
+      previous_plan,
+      previous_environment,
     }
+  }
 }
 
+// Restore the caller's symbol table, plan, and environment when the scope ends.
 impl Drop for FunctionScope {
-    fn drop(&mut self) {
-        let mut state_brrw = self.state.borrow_mut();
-        state_brrw.symbol_table = self.previous_symbols.clone();
-        state_brrw.plan = self.previous_plan.clone();
-        state_brrw.environment = self.previous_environment.clone();
-    }
+  fn drop(&mut self) {
+    let mut state_brrw = self.state.borrow_mut();
+    state_brrw.symbol_table = self.previous_symbols.clone();
+    state_brrw.plan = self.previous_plan.clone();
+    state_brrw.environment = self.previous_environment.clone();
+  }
 }
 
+// Function Definitions
+// ----------------------------------------------------------------------------
+
+// Binds each argument value to the corresponding local variable name.
+// With kind_annotation: validates and coerces argument types, including
+// special handling for enum types where coercion rules differ.
 fn bind_function_inputs(
-    fxn_def: &FunctionDefinition,
-    input_arg_values: &Vec<Value>,
-    p: &Interpreter,
+  fxn_def: &FunctionDefinition,
+  input_arg_values: &Vec<Value>,
+  p: &Interpreter,
 ) -> MResult<()> {
-    let scoped_state = p.state.borrow();
-    for ((arg_id, input_kind_annotation), input_value) in
-        fxn_def.input.iter().zip(input_arg_values.iter())
-    {
-        let arg_name = fxn_def
-            .code
-            .input
-            .iter()
-            .find(|arg| arg.name.hash() == *arg_id)
-            .map(|arg| arg.name.to_string())
-            .unwrap_or_else(|| arg_id.to_string());
-        let bound_value = {
-            #[cfg(feature = "kind_annotation")]
-            {
-                let target_kind = kind_annotation(&input_kind_annotation.kind, p)?
-                    .to_value_kind(&p.state.borrow().kinds)?;
-                let detached_input = detach_value(input_value);
-                #[cfg(all(feature = "enum", feature = "atom"))]
-                if let ValueKind::Enum(enum_id, _) = &target_kind {
-                    let state_brrw = p.state.borrow();
-                    if enum_value_matches(detached_input.clone(), *enum_id, &state_brrw) {
-                        detached_input.clone()
-                    } else {
-                        return Err(MechError::new(
-                            FunctionInputTypeMismatchError {
-                                function_name: fxn_def.name.clone(),
-                                argument_name: arg_name.clone(),
-                                expected: target_kind.clone(),
-                                found: detached_input.kind(),
-                            },
-                            None,
-                        )
-                        .with_compiler_loc()
-                        .with_tokens(input_kind_annotation.tokens()));
-                    }
-                } else {
-                    detached_input
-                        .clone()
-                        .convert_to(&target_kind)
-                        .ok_or_else(|| {
-                            MechError::new(
-                                FunctionInputTypeMismatchError {
-                                    function_name: fxn_def.name.clone(),
-                                    argument_name: arg_name.clone(),
-                                    expected: target_kind.clone(),
-                                    found: detached_input.kind(),
-                                },
-                                None,
-                            )
-                            .with_compiler_loc()
-                            .with_tokens(input_kind_annotation.tokens())
-                        })?
-                }
-                #[cfg(not(all(feature = "enum", feature = "atom")))]
-                detached_input
-                    .clone()
-                    .convert_to(&target_kind)
-                    .ok_or_else(|| {
-                        MechError::new(
-                            FunctionInputTypeMismatchError {
-                                function_name: fxn_def.name.clone(),
-                                argument_name: arg_name.clone(),
-                                expected: target_kind.clone(),
-                                found: detached_input.kind(),
-                            },
-                            None,
-                        )
-                        .with_compiler_loc()
-                        .with_tokens(input_kind_annotation.tokens())
-                    })?
-            }
-            #[cfg(not(feature = "kind_annotation"))]
-            {
-                detach_value(input_value)
-            }
-        };
-        scoped_state.save_symbol(*arg_id, arg_name, bound_value, false);
-    }
-    Ok(())
+  let scoped_state = p.state.borrow();
+  for ((arg_id, input_kind_annotation), input_value) in
+    fxn_def.input.iter().zip(input_arg_values.iter())
+  {
+    // Look up the human-readable argument name for error messages.
+    let arg_name = fxn_def
+      .code
+      .input
+      .iter()
+      .find(|arg| arg.name.hash() == *arg_id)
+      .map(|arg| arg.name.to_string())
+      .unwrap_or_else(|| arg_id.to_string());
+
+    let bound_value = {
+      #[cfg(feature = "kind_annotation")]
+      {
+        let target_kind = kind_annotation(&input_kind_annotation.kind, p)?
+          .to_value_kind(&p.state.borrow().kinds)?;
+        let detached_input = detach_value(input_value);
+
+        // Enum arguments are checked for membership rather than converted,
+        // because coercion semantics don't apply across enum variants.
+        #[cfg(all(feature = "enum", feature = "atom"))]
+        if let ValueKind::Enum(enum_id, _) = &target_kind {
+          let state_brrw = p.state.borrow();
+          if enum_value_matches(detached_input.clone(), *enum_id, &state_brrw) {
+            detached_input.clone()
+          } else {
+            return Err(MechError::new(
+              FunctionInputTypeMismatchError {
+                function_name: fxn_def.name.clone(),
+                argument_name: arg_name.clone(),
+                expected: target_kind.clone(),
+                found: detached_input.kind(),
+              },
+              None,
+            )
+            .with_compiler_loc()
+            .with_tokens(input_kind_annotation.tokens()));
+          }
+        } else {
+          // Non-enum: attempt type conversion; error if it can't be done.
+          detached_input
+            .clone()
+            .convert_to(&target_kind)
+            .ok_or_else(|| {
+              MechError::new(
+                FunctionInputTypeMismatchError {
+                  function_name: fxn_def.name.clone(),
+                  argument_name: arg_name.clone(),
+                  expected: target_kind.clone(),
+                  found: detached_input.kind(),
+                },
+                None,
+              )
+              .with_compiler_loc()
+              .with_tokens(input_kind_annotation.tokens())
+            })?
+        }
+        #[cfg(not(all(feature = "enum", feature = "atom")))]
+        detached_input
+          .clone()
+          .convert_to(&target_kind)
+          .ok_or_else(|| {
+            MechError::new(
+              FunctionInputTypeMismatchError {
+                function_name: fxn_def.name.clone(),
+                argument_name: arg_name.clone(),
+                expected: target_kind.clone(),
+                found: detached_input.kind(),
+              },
+              None,
+            )
+            .with_compiler_loc()
+            .with_tokens(input_kind_annotation.tokens())
+          })?
+      }
+      // Without kind_annotation: accept the value as-is, just detach any reference.
+      #[cfg(not(feature = "kind_annotation"))]
+      {
+        detach_value(input_value)
+      }
+    };
+    scoped_state.save_symbol(*arg_id, arg_name, bound_value, false);
+  }
+  Ok(())
 }
 
+// Returns true if `value` is a valid member of the enum identified by `enum_id`.
+// Handles bare atom variants and tuple-struct variants (atom tag + payload).
 #[cfg(all(feature = "enum", feature = "atom"))]
 fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool {
-    let enum_def = match state.enums.get(&enum_id) {
-        Some(enm) => enm,
+  let enum_def = match state.enums.get(&enum_id) {
+    Some(enm) => enm,
+    None => return false,
+  };
+  match value {
+    // Bare atom: check that the atom's id is a known payload-less variant.
+    Value::Atom(atom) => {
+      let variant_id = atom.borrow().id();
+      enum_def
+        .variants
+        .iter()
+        .any(|(known_variant, payload_kind)| {
+          *known_variant == variant_id && payload_kind.is_none()
+        })
+    }
+    // Tuple-struct variant: a 2-element tuple of (atom-tag, payload).
+    // The tag must match a known variant and the payload must satisfy the
+    // declared payload kind, recursing for nested enums.
+    #[cfg(feature = "tuple")]
+    Value::Tuple(tuple_val) => {
+      let tuple_brrw = tuple_val.borrow();
+      if tuple_brrw.elements.len() != 2 {
+        return false;
+      }
+      let tag = match tuple_brrw.elements[0].as_ref() {
+        Value::Atom(atom) => atom.borrow().id(),
+        _ => return false,
+      };
+      let payload = tuple_brrw.elements[1].as_ref().clone();
+      let (_, declared_payload_kind) = match enum_def
+        .variants
+        .iter()
+        .find(|(known_variant, _)| *known_variant == tag)
+      {
+        Some(entry) => entry,
         None => return false,
-    };
-    match value {
-        Value::Atom(atom) => {
-            let variant_id = atom.borrow().id();
-            enum_def
-                .variants
-                .iter()
-                .any(|(known_variant, payload_kind)| {
-                    *known_variant == variant_id && payload_kind.is_none()
-                })
-        }
-        #[cfg(feature = "tuple")]
-        Value::Tuple(tuple_val) => {
-            let tuple_brrw = tuple_val.borrow();
-            if tuple_brrw.elements.len() != 2 {
-                return false;
-            }
-            let tag = match tuple_brrw.elements[0].as_ref() {
-                Value::Atom(atom) => atom.borrow().id(),
-                _ => return false,
-            };
-            let payload = tuple_brrw.elements[1].as_ref().clone();
-            let (_, declared_payload_kind) = match enum_def
-                .variants
-                .iter()
-                .find(|(known_variant, _)| *known_variant == tag)
-            {
-                Some(entry) => entry,
-                None => return false,
-            };
-            match declared_payload_kind {
-                Some(Value::Kind(expected_kind)) => match expected_kind {
-                    ValueKind::Enum(inner_enum_id, _) => {
-                        enum_value_matches(payload, *inner_enum_id, state)
-                    }
-                    _ => {
-                        payload.kind() == expected_kind.clone()
-                            || payload.convert_to(expected_kind).is_some()
-                    }
-                },
-                _ => false,
-            }
-        }
+      };
+      match declared_payload_kind {
+        Some(Value::Kind(expected_kind)) => match expected_kind {
+          // Nested enum payload: recurse.
+          ValueKind::Enum(inner_enum_id, _) => {
+            enum_value_matches(payload, *inner_enum_id, state)
+          }
+          // Scalar payload: accept exact match or a convertible value.
+          _ => {
+            payload.kind() == expected_kind.clone()
+              || payload.convert_to(expected_kind).is_some()
+          }
+        },
         _ => false,
+      }
     }
+    _ => false,
+  }
 }
 
+// Reads each declared output variable out of the local symbol table and
+// returns them as a single Value. Multiple outputs are wrapped in a Tuple;
+// a single output is returned directly; zero outputs return Empty.
 fn collect_function_output(p: &Interpreter, fxn_def: &FunctionDefinition) -> MResult<Value> {
-    let symbols = p.symbols();
-    let symbols_brrw = symbols.borrow();
-    let mut outputs = vec![];
+  let symbols = p.symbols();
+  let symbols_brrw = symbols.borrow();
+  let mut outputs = vec![];
 
-    for output_arg in &fxn_def.code.output {
-        let output_id = output_arg.name.hash();
-        match symbols_brrw.get(output_id) {
-            Some(cell) => outputs.push(detach_value(&cell.borrow())),
-            None => {
-                return Err(
-                    MechError::new(FunctionOutputUndefinedError { output_id }, None)
-                        .with_compiler_loc()
-                        .with_tokens(output_arg.tokens()),
-                );
-            }
-        }
+  for output_arg in &fxn_def.code.output {
+    let output_id = output_arg.name.hash();
+    match symbols_brrw.get(output_id) {
+      Some(cell) => outputs.push(detach_value(&cell.borrow())),
+      None => {
+        return Err(
+          MechError::new(FunctionOutputUndefinedError { output_id }, None)
+            .with_compiler_loc()
+            .with_tokens(output_arg.tokens()),
+        );
+      }
     }
+  }
 
-    Ok(match outputs.len() {
-        0 => Value::Empty,
-        1 => outputs.remove(0),
-        _ => Value::Tuple(Ref::new(MechTuple::from_vec(outputs))),
-    })
+  Ok(match outputs.len() {
+    0 => Value::Empty,
+    1 => outputs.remove(0),
+    _ => Value::Tuple(Ref::new(MechTuple::from_vec(outputs))),
+  })
 }
 
+// Peels off any MutableReference wrappers to get to the underlying value.
+// Used before storing arguments or returning results so callers always see
+// plain owned values, not live references into other cells.
 pub(crate) fn detach_value(value: &Value) -> Value {
-    match value {
-        Value::MutableReference(reference) => detach_value(&reference.borrow()),
-        _ => value.clone(),
-    }
+  match value {
+    Value::MutableReference(reference) => detach_value(&reference.borrow()),
+    _ => value.clone(),
+  }
 }
 
+// Function Errors
+// ----------------------------------------------------------------------------
+
+// The called function name doesn't exist in any registry.
 #[derive(Debug, Clone)]
 pub struct MissingFunctionError {
-    pub function_id: u64,
+  pub function_id: u64,
 }
 
 impl MechErrorKind for MissingFunctionError {
-    fn name(&self) -> &str {
-        "MissingFunction"
-    }
-    fn message(&self) -> String {
-        format!("Function with id {} not found", self.function_id)
-    }
+  fn name(&self) -> &str {
+    "MissingFunction"
+  }
+  fn message(&self) -> String {
+    format!("Function with id {} not found", self.function_id)
+  }
 }
 
+// A function's output variable was declared but never assigned during execution.
 #[derive(Debug, Clone)]
 pub struct FunctionOutputUndefinedError {
-    pub output_id: u64,
+  pub output_id: u64,
 }
 
 impl MechErrorKind for FunctionOutputUndefinedError {
-    fn name(&self) -> &str {
-        "FunctionOutputUndefined"
-    }
-    fn message(&self) -> String {
-        format!(
-            "Function output {} was declared but never defined",
-            self.output_id
-        )
-    }
+  fn name(&self) -> &str {
+    "FunctionOutputUndefined"
+  }
+  fn message(&self) -> String {
+    format!(
+      "Function output {} was declared but never defined",
+      self.output_id
+    )
+  }
 }
 
-#[derive(Debug, Clone)]
-pub struct FunctionInputTypeMismatchError {
-    pub function_name: String,
-    pub argument_name: String,
-    pub expected: ValueKind,
-    pub found: ValueKind,
-}
-
+// A match-arm function doesn't cover every variant of its enum input type.
 #[derive(Debug, Clone)]
 pub struct FunctionMatchNonExhaustiveError {
-    pub function_name: String,
-    pub missing_patterns: Vec<String>,
+  pub function_name: String,
+  pub missing_patterns: Vec<String>,
 }
 
 impl MechErrorKind for FunctionMatchNonExhaustiveError {
-    fn name(&self) -> &str {
-        "FunctionMatchNonExhaustive"
-    }
+  fn name(&self) -> &str {
+    "FunctionMatchNonExhaustive"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "Function '{}' has non-exhaustive match arms. Missing patterns: {}. Add the missing patterns or add a wildcard (`*`) arm.",
-            self.function_name,
-            self.missing_patterns.join(", ")
-        )
-    }
+  fn message(&self) -> String {
+    format!(
+      "Function '{}' has non-exhaustive match arms. Missing patterns: {}. Add the missing patterns or add a wildcard (`*`) arm.",
+      self.function_name,
+      self.missing_patterns.join(", ")
+    )
+  }
+}
+
+// A value passed to a function argument didn't match the declared kind and
+// couldn't be coerced to it.
+#[derive(Debug, Clone)]
+pub struct FunctionInputTypeMismatchError {
+  pub function_name: String,
+  pub argument_name: String,
+  pub expected: ValueKind,
+  pub found: ValueKind,
 }
 
 impl MechErrorKind for FunctionInputTypeMismatchError {
-    fn name(&self) -> &str {
-        "FunctionInputTypeMismatch"
-    }
+  fn name(&self) -> &str {
+    "FunctionInputTypeMismatch"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "Function '{}' argument '{}' expected {}, found {}",
-            self.function_name, self.argument_name, self.expected, self.found
-        )
-    }
+  fn message(&self) -> String {
+    format!(
+      "Function '{}' argument '{}' expected {}, found {}",
+      self.function_name, self.argument_name, self.expected, self.found
+    )
+  }
 }

--- a/src/interpreter/src/tracing.rs
+++ b/src/interpreter/src/tracing.rs
@@ -189,7 +189,7 @@ pub(crate) fn summarize_function_pattern(pattern: &Pattern) -> String {
 }
 
 fn trace_truncate(text: &str, max_chars: usize) -> String {
-  let text = single_line_trace_text(text);
+  let text = trace_single_line_text(text);
   if text.chars().count() <= max_chars {
     return text;
   }
@@ -205,7 +205,7 @@ fn trace_single_line_text(text: &str) -> String {
 #[cfg(feature = "state_machines")]
 pub fn summarize_value(value: &Value) -> String {
     const MAX_TRACE_CHARS: usize = 1000;
-    let rendered = single_line_trace_text(&summarize_value_compact(value, 0));
+    let rendered = trace_single_line_text(&summarize_value_compact(value, 0));
     truncate_for_trace(&rendered, MAX_TRACE_CHARS)
 }
 
@@ -232,7 +232,7 @@ fn summarize_value_compact(value: &Value, depth: usize) -> String {
         _ => format!(
             "{}({})",
             value.kind().to_string(),
-            truncate_for_trace(&single_line_trace_text(&format!("{:?}", value)), 48)
+            truncate_for_trace(&trace_single_line_text(&format!("{:?}", value)), 48)
         ),
     }
 }
@@ -401,11 +401,6 @@ fn truncate_for_trace(text: &str, max_chars: usize) -> String {
 #[cfg(feature = "state_machines")]
 pub fn format_fsm_trace(label: &str, message: String) -> String {
     format!("[trace][fsm][{label:>6}] {message}")
-}
-
-#[cfg(feature = "state_machines")]
-fn single_line_trace_text(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 #[cfg(all(feature = "state_machines", feature = "trace"))]

--- a/src/interpreter/src/tracing.rs
+++ b/src/interpreter/src/tracing.rs
@@ -84,6 +84,124 @@ fn push_json_string(out: &mut String, value: &str) {
     out.push('"');
 }
 
+pub(crate) fn format_trace(scope: &str, message: String) -> String {
+  format!("[trace][{scope}] {message}")
+}
+
+pub(crate) fn format_trace_args(values: &Vec<Value>) -> String {
+  values
+    .iter()
+    .map(summarize_function_value)
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
+pub(crate) fn summarize_function_value(value: &Value) -> String {
+  const MAX_TRACE_CHARS: usize = 96;
+  let rendered = trace_single_line_text(&summarize_function_value_compact(value, 0));
+  trace_truncate(&rendered, MAX_TRACE_CHARS)
+}
+
+fn summarize_function_value_compact(value: &Value, depth: usize) -> String {
+  if depth > 2 {
+    return format!("{}(..)", value.kind().to_string());
+  }
+  match value {
+    #[cfg(feature = "u64")]
+    Value::U64(x) => format!("u64(@{:04x}:{})", trace_short_addr(x.addr()), *x.borrow()),
+    #[cfg(feature = "i64")]
+    Value::I64(x) => format!("i64(@{:04x}:{})", trace_short_addr(x.addr()), *x.borrow()),
+    #[cfg(feature = "f64")]
+    Value::F64(x) => format!("f64(@{:04x}:{})", trace_short_addr(x.addr()), *x.borrow()),
+    #[cfg(feature = "bool")]
+    Value::Bool(x) => format!("bool(@{:04x}:{})", trace_short_addr(x.addr()), *x.borrow()),
+    #[cfg(feature = "string")]
+    Value::String(x) => format!("str(@{:04x}:\"{}\")", trace_short_addr(x.addr()), x.borrow()),
+    #[cfg(feature = "atom")]
+    Value::Atom(x) => format!("{}(@{:04x})", x.borrow().to_string(), trace_short_addr(x.addr())),
+    #[cfg(feature = "tuple")]
+    Value::Tuple(tuple_ref) => summarize_function_tuple_value(tuple_ref, depth),
+    _ => format!(
+      "{}({})",
+      value.kind().to_string(),
+      trace_truncate(&trace_single_line_text(&format!("{:?}", value)), 48)
+    ),
+  }
+}
+
+#[cfg(feature = "tuple")]
+fn summarize_function_tuple_value(tuple_ref: &Ref<MechTuple>, depth: usize) -> String {
+  let tuple = tuple_ref.borrow();
+  let mut parts = Vec::new();
+  for element in tuple.elements.iter().take(3) {
+    parts.push(summarize_function_value_compact(element, depth + 1));
+  }
+  if tuple.elements.len() > 3 {
+    parts.push("…".to_string());
+  }
+  format!(
+    "tuple(@{:04x}; len={}; [{}])",
+    trace_short_addr(tuple_ref.addr()),
+    tuple.elements.len(),
+    parts.join(", ")
+  )
+}
+
+fn trace_short_addr(addr: usize) -> u16 {
+  (addr & 0xffff) as u16
+}
+
+pub(crate) fn summarize_values_with_kinds(values: &Vec<Value>) -> String {
+  values
+    .iter()
+    .enumerate()
+    .map(|(idx, value)| {
+      format!(
+        "#{idx}={} :{}",
+        summarize_function_value(value),
+        value.kind().to_string()
+      )
+    })
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
+pub(crate) fn summarize_function_pattern(pattern: &Pattern) -> String {
+  match pattern {
+    Pattern::Wildcard => "_".to_string(),
+    Pattern::Expression(expr) => trace_truncate(&format!("{:?}", expr), 72),
+    Pattern::Tuple(tuple) => format!("tuple(len={})", tuple.0.len()),
+    Pattern::Array(array) => {
+      let spread = if array.spread.is_some() { ",spread" } else { "" };
+      format!(
+        "array(prefix={}{} ,suffix={})",
+        array.prefix.len(),
+        spread,
+        array.suffix.len()
+      )
+    }
+    Pattern::TupleStruct(tuple_struct) => format!(
+      "tuple-struct(name={},len={})",
+      tuple_struct.name.to_string(),
+      tuple_struct.patterns.len()
+    ),
+  }
+}
+
+fn trace_truncate(text: &str, max_chars: usize) -> String {
+  let text = single_line_trace_text(text);
+  if text.chars().count() <= max_chars {
+    return text;
+  }
+  let mut truncated = text.chars().take(max_chars).collect::<String>();
+  truncated.push('…');
+  truncated
+}
+
+fn trace_single_line_text(text: &str) -> String {
+  text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 #[cfg(feature = "state_machines")]
 pub fn summarize_value(value: &Value) -> String {
     const MAX_TRACE_CHARS: usize = 1000;

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -792,6 +792,15 @@ test_interpreter!(interpret_function_recursive_fib,r#"fib(x<u64>) => <u64>
   └ n => fib(n - 1<u64>) + fib(n - 2<u64>).
 fib(10<u64>)"#, Value::U64(Ref::new(55)));
 #[cfg(feature = "u64")]
+test_interpreter!(interpret_function_tail_recursive_fib,r#"fib(n<u64>) => <u64>
+  └ n => fib-acc(n, 0<u64>, 1<u64>).
+
+fib-acc(n<u64>, a<u64>, b<u64>) => <u64>
+  ├ (0<u64>, a, *) => a
+  └ (n, a, b) => fib-acc(n - 1<u64>, b, a + b).
+
+fib(50<u64>)"#, Value::U64(Ref::new(12586269025)));
+#[cfg(feature = "u64")]
 test_interpreter!(interpret_function_tail_recursive_countdown,r#"countdown(n<u64>) => <u64>
   └ n => countdown-acc(n, 0<u64>).
 

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1,311 +1,236 @@
 #![allow(warnings)]
-extern crate mech_core;
 extern crate mech_syntax;
+extern crate mech_core;
 extern crate nalgebra as na;
-use indexmap::set::IndexSet;
-use mech_core::matrix::Matrix;
-use mech_core::*;
-use mech_interpreter::*;
-use mech_syntax::*;
 use std::cell::RefCell;
 use std::rc::Rc;
+use mech_core::matrix::Matrix;
+use mech_syntax::*;
+use mech_core::*;
+use mech_interpreter::*;
+use indexmap::set::IndexSet;
 
 /// Compare interpreter output to expected value
 macro_rules! test_interpreter {
-    ($func:ident, $input:tt, $expected:expr) => {
-        #[test]
-        fn $func() {
-            let s = $input;
-            match parser::parse(&s) {
-                Ok(tree) => {
-                    let mut intrp = Interpreter::new(0);
-                    let result = intrp.interpret(&tree).unwrap();
-                    assert_eq!(result, $expected);
-                }
-                Err(err) => {
-                    panic!("{:?}", err);
-                }
-            }
-        }
-    };
+  ($func:ident, $input:tt, $expected:expr) => (
+    #[test]
+    fn $func() {
+      let s = $input;
+      match parser::parse(&s) {
+          Ok(tree) => { 
+            let mut intrp = Interpreter::new(0);
+            let result = intrp.interpret(&tree).unwrap();
+            assert_eq!(result, $expected);
+          },
+          Err(err) => {panic!("{:?}", err);}
+      }   
+    }
+  )
 }
 
 /////////////////////////////////////////////////////////////////////////////////
 
-test_interpreter!(
-    interpret_literal_integer,
-    "123",
-    Value::F64(Ref::new(123.0))
-);
+test_interpreter!(interpret_literal_integer, "123", Value::F64(Ref::new(123.0)));
 test_interpreter!(interpret_literal_sci, "1.23e2", Value::F64(Ref::new(123.0)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_formula_literal_suffix,
-    "100u8",
-    Value::U8(Ref::new(100))
-);
+test_interpreter!(interpret_formula_literal_suffix, "100u8", Value::U8(Ref::new(100)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_literal_bin,
-    "0b10101",
-    Value::I64(Ref::new(0b10101))
-);
+test_interpreter!(interpret_literal_bin, "0b10101", Value::I64(Ref::new(0b10101)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_literal_hex,
-    "0x123abc",
-    Value::I64(Ref::new(0x123abc))
-);
+test_interpreter!(interpret_literal_hex, "0x123abc", Value::I64(Ref::new(0x123abc)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_literal_oct,
-    "0o1234",
-    Value::I64(Ref::new(0o1234))
-);
+test_interpreter!(interpret_literal_oct, "0o1234", Value::I64(Ref::new(0o1234)));
 #[cfg(feature = "i64")]
 test_interpreter!(interpret_literal_dec, "0d1234", Value::I64(Ref::new(1234)));
 test_interpreter!(interpret_literal_float, "1.23", Value::F64(Ref::new(1.23)));
-test_interpreter!(
-    interpret_literal_string,
-    r#""Hello""#,
-    Value::String(Ref::new("Hello".to_string()))
-);
-test_interpreter!(
-    interpret_literal_string_empty,
-    r#""""#,
-    Value::String(Ref::new("".to_string()))
-);
-test_interpreter!(
-    interpret_literal_string_multiline,
-    r#""Hello 
- World""#,
-    Value::String(Ref::new("Hello \n World".to_string()))
-);
+test_interpreter!(interpret_literal_string, r#""Hello""#, Value::String(Ref::new("Hello".to_string())));
+test_interpreter!(interpret_literal_string_empty, r#""""#, Value::String(Ref::new("".to_string())));
+test_interpreter!(interpret_literal_string_multiline, r#""Hello 
+ World""#, Value::String(Ref::new("Hello \n World".to_string())));
 test_interpreter!(interpret_literal_true, "true", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_literal_true2, "✓ ", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false)));
-test_interpreter!(
-    interpret_literal_false,
-    "false",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_literal_atom,
-    ":A",
-    Value::Atom(Ref::new(MechAtom::new(55450514845822917)))
-);
+test_interpreter!(interpret_literal_false, "false", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_literal_atom, ":A", Value::Atom(Ref::new(MechAtom::new(55450514845822917))));
 test_interpreter!(interpret_literal_empty, "_", Value::Empty);
 
 test_interpreter!(
-    interpret_fsm_counter_accepts_typed_input,
-    "#Counter(n<u64>) => <u64>\n  ├ :Count(n<u64>)\n  └ :Done(n<u64>).\n\n#Counter(n<u64>) -> :Count(n)\n  :Count(n)\n    ├ n > 0u64 -> :Count(n - 1u64)\n    └ n == 0u64 -> :Done(0u64)\n  :Done(n) => n.\n\n#Counter(5u64)",
-    Value::U64(Ref::new(0))
+  interpret_fsm_counter_accepts_typed_input,
+  "#Counter(n<u64>) => <u64>\n  ├ :Count(n<u64>)\n  └ :Done(n<u64>).\n\n#Counter(n<u64>) -> :Count(n)\n  :Count(n)\n    ├ n > 0u64 -> :Count(n - 1u64)\n    └ n == 0u64 -> :Done(0u64)\n  :Done(n) => n.\n\n#Counter(5u64)",
+  Value::U64(Ref::new(0))
 );
 
 test_interpreter!(
-    interpret_fsm_fibonacci_accepts_typed_input,
-    "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0u64, 1u64)\n  :Compute(n, a, b)\n    ├ n > 0u64 -> :Compute(n - 1u64, b, a + b)\n    └ n == 0u64 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10u64)",
-    Value::U64(Ref::new(55))
+  interpret_fsm_fibonacci_accepts_typed_input,
+  "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0u64, 1u64)\n  :Compute(n, a, b)\n    ├ n > 0u64 -> :Compute(n - 1u64, b, a + b)\n    └ n == 0u64 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10u64)",
+  Value::U64(Ref::new(55))
 );
 
 #[test]
 fn interpret_fsm_fails_when_transition_targets_undefined_state() {
-    let s = "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  └ :Open(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Open(n) => n.\n\n#Door(1u64)";
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    assert!(intrp.interpret(&tree).is_err());
+  let s = "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  └ :Open(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Open(n) => n.\n\n#Door(1u64)";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
 }
 
 test_interpreter!(
-    interpret_fsm_accepts_when_all_states_are_implemented,
-    "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  ├ :Open(n<u64>)\n  └ :Locked(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Locked(n) -> :Open(n)\n  :Open(n) => n.\n\n#Door(1u64)",
-    Value::U64(Ref::new(1))
+  interpret_fsm_accepts_when_all_states_are_implemented,
+  "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  ├ :Open(n<u64>)\n  └ :Locked(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Locked(n) -> :Open(n)\n  :Open(n) => n.\n\n#Door(1u64)",
+  Value::U64(Ref::new(1))
 );
 test_interpreter!(interpret_variable_define_empty, "em := _", Value::Empty);
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_variable_define_kind_literal,
-    "x := <u8>;",
-    Value::Kind(ValueKind::U8)
-);
+test_interpreter!(interpret_variable_define_kind_literal, "x := <u8>;", Value::Kind(ValueKind::U8));
 #[test]
 fn interpret_variable_define_undefined_kind_literal_error() {
-    let s = "x := <foo>;";
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    assert!(intrp.interpret(&tree).is_err());
+  let s = "x := <foo>;";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
 }
+test_interpreter!(interpret_variable_define_typed_empty, "emp<_> := _", Value::Empty);
+#[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_variable_define_typed_empty,
-    "emp<_> := _",
-    Value::Empty
+  interpret_variable_define_typed_option_some,
+  "x<u64?> := 123u64",
+  Value::U64(Ref::new(123))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_variable_define_typed_option_some,
-    "x<u64?> := 123u64",
-    Value::U64(Ref::new(123))
+  interpret_variable_define_typed_option_none,
+  "x<u64?> := _",
+  Value::Empty
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_variable_define_typed_option_none,
-    "x<u64?> := _",
-    Value::Empty
+  interpret_option_match_scalar_some,
+  "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
+  Value::U64(Ref::new(4))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_option_match_scalar_some,
-    "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
-    Value::U64(Ref::new(4))
+  interpret_option_match_literal_pattern_matches_inner_value,
+  "foo<u64?> := 0\n\nfoo?\n  | 0 => 9\n  | * => 10.",
+  Value::F64(Ref::new(9.0))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_option_match_literal_pattern_matches_inner_value,
-    "foo<u64?> := 0\n\nfoo?\n  | 0 => 9\n  | * => 10.",
-    Value::F64(Ref::new(9.0))
-);
-#[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_option_match_tuple_destructure,
-    "x<u64?> := 2u64; y<u64?> := _; (x2,y2) := (x,y)? | (x,y) => (x,y) | * => (0u64,0u64).; x2 + y2",
-    Value::U64(Ref::new(0))
+  interpret_option_match_tuple_destructure,
+  "x<u64?> := 2u64; y<u64?> := _; (x2,y2) := (x,y)? | (x,y) => (x,y) | * => (0u64,0u64).; x2 + y2",
+  Value::U64(Ref::new(0))
 );
 test_interpreter!(
-    interpret_match_allows_unreachable_wildcard_with_different_kind,
-    "foo<f64?> := 1234\n\nbar := foo?\n  | x => \"One Two Three\"\n  | * => 12.\n\nbar + \"\"",
-    Value::String(Ref::new("One Two Three".to_string()))
+  interpret_match_allows_unreachable_wildcard_with_different_kind,
+  "foo<f64?> := 1234\n\nbar := foo?\n  | x => \"One Two Three\"\n  | * => 12.\n\nbar + \"\"",
+  Value::String(Ref::new("One Two Three".to_string()))
 );
 
 #[test]
 fn interpret_option_match_requires_wildcard_arm() {
-    let s = "foo<u64?> := 1234\n\nbar := foo?\n  | 0 => 9.\n\nbar";
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    assert!(intrp.interpret(&tree).is_err());
+  let s = "foo<u64?> := 1234\n\nbar := foo?\n  | 0 => 9.\n\nbar";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
 }
 
 #[test]
 fn interpret_enum_match_reports_missing_variants_color() {
-    let s = r#"
+  let s = r#"
 <color> := :red | :green | :blue
 my-color<color> := :red
 string-color := my-color?
   | :red   => "red"
   | :green => "green".
 "#;
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    let err = intrp.interpret(&tree).unwrap_err();
-    let msg = format!("{:?}", err);
-    assert!(msg.contains("MatchNonExhaustive"));
-    assert!(msg.contains(":blue"));
-    assert!(msg.contains("wildcard"));
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("MatchNonExhaustive"));
+  assert!(msg.contains(":blue"));
+  assert!(msg.contains("wildcard"));
 }
 
 #[test]
 fn interpret_enum_match_reports_missing_variants_generalized() {
-    let s = r#"
+  let s = r#"
 <door> := :open | :closed | :locked
 state<door> := :open
 label := state?
   | :open   => "open"
   | :closed => "closed".
 "#;
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    let err = intrp.interpret(&tree).unwrap_err();
-    let msg = format!("{:?}", err);
-    assert!(msg.contains("MatchNonExhaustive"));
-    assert!(msg.contains(":locked"));
-    assert!(msg.contains("wildcard"));
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("MatchNonExhaustive"));
+  assert!(msg.contains(":locked"));
+  assert!(msg.contains("wildcard"));
 }
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_match_array_pattern_head,
-    "xs := [10u64 20u64 30u64]; y := xs? | [x ...] => x | * => 0u64.; y + 0u64",
-    Value::U64(Ref::new(10))
+  interpret_match_array_pattern_head,
+  "xs := [10u64 20u64 30u64]; y := xs? | [x ...] => x | * => 0u64.; y + 0u64",
+  Value::U64(Ref::new(10))
 );
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_match_array_pattern_last,
-    "xs := [10u64 20u64 30u64]; y := xs? | [... x] => x | * => 0u64.; y + 0u64",
-    Value::U64(Ref::new(30))
+  interpret_match_array_pattern_last,
+  "xs := [10u64 20u64 30u64]; y := xs? | [... x] => x | * => 0u64.; y + 0u64",
+  Value::U64(Ref::new(30))
+);
+
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_match_array_pattern_rest_binding,
+  "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest? | [r ...] => r | * => 0u64. | * => 0u64.; y + 0u64",
+  Value::U64(Ref::new(30))
 );
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_match_array_pattern_rest_binding,
-    "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest? | [r ...] => r | * => 0u64. | * => 0u64.; y + 0u64",
-    Value::U64(Ref::new(30))
+  interpret_match_array_pattern_rest_binding_returns_matrix,
+  "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest | * => [0u64].; z := y? | [h ... t] => h + t | * => 0u64.; z + 0u64",
+  Value::U64(Ref::new(70))
 );
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-    interpret_match_array_pattern_rest_binding_returns_matrix,
-    "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest | * => [0u64].; z := y? | [h ... t] => h + t | * => 0u64.; z + 0u64",
-    Value::U64(Ref::new(70))
+  interpret_match_tuple_pattern_with_guards,
+  "foo := (1u64, 2u64, 3u64)\n\nmax<u64> := foo?\n  | (a, b, c), a > b && a > c => a\n  | (a, b, c), b > a && b > c => b\n  | (a, b, c), c > a && c > b => c\n  | * => 0u64.\n\nmax + 0u64",
+  Value::U64(Ref::new(3))
 );
 
-#[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_match_tuple_pattern_with_guards,
-    "foo := (1u64, 2u64, 3u64)\n\nmax<u64> := foo?\n  | (a, b, c), a > b && a > c => a\n  | (a, b, c), b > a && b > c => b\n  | (a, b, c), c > a && c > b => c\n  | * => 0u64.\n\nmax + 0u64",
-    Value::U64(Ref::new(3))
-);
-
-test_interpreter!(
-    interpret_option_match_tuple_struct_pattern,
-    "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64",
-    Value::U64(Ref::new(9))
-);
+test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64", Value::U64(Ref::new(9)));
 #[test]
 fn interpret_tagged_union_match_requires_exhaustive_arms() {
-    let s = r#"
+  let s = r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:ok(42u64))
 result := x?
   | :some(:ok(n)) => n.
 "#;
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    assert!(intrp.interpret(&tree).is_err());
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  assert!(intrp.interpret(&tree).is_err());
 }
 test_interpreter!(
-    interpret_function_shorthand_match_arm_broadcasts_over_matrix_input,
-    "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
+  interpret_function_shorthand_match_arm_broadcasts_over_matrix_input,
+  "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
+  Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
 );
-test_interpreter!(
-    interpret_function_array_pattern_arms,
-    "head(xs<[u64]:1,3>) => <u64>\n  | [x ...] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64",
-    Value::U64(Ref::new(10))
-);
-test_interpreter!(
-    interpret_fsm_array_pattern_state_arguments,
-    "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x ... y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)",
-    Value::U64(Ref::new(4))
-);
-test_interpreter!(
-    interpret_fsm_accepts_unsized_vector_input,
-    "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])",
-    Value::U64(Ref::new(5))
-);
-test_interpreter!(
-    interpret_fsm_array_spread_reconstruction_keeps_scalar_guards,
-    "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a | tail])\n    └ * -> :Done(0u64)\n  :Pass([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])",
-    Value::U64(Ref::new(0))
-);
-test_interpreter!(
-    interpret_fsm_bubble_sort_returns_typed_u64_matrix,
-    "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a | tail], [b | acc], swaps + 1u64)\n    └ *     -> :Pass([b | tail], [a | acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x | acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x | acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])",
-    Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4))
-);
-test_interpreter!(
-    interpret_fsm_bubble_sort_assigns_matrix_value,
-    "#bubble-sort(arr<[u64]>) => <[u64]>
+test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) => <u64>\n  | [x ...] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
+test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x ... y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
+test_interpreter!(interpret_fsm_accepts_unsized_vector_input, "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(5)));
+test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a | tail])\n    └ * -> :Done(0u64)\n  :Pass([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
+test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a | tail], [b | acc], swaps + 1u64)\n    └ *     -> :Pass([b | tail], [a | acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x | acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x | acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
+test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>
   ├ :Start(arr<[u64]>)
   ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)
   ├ :Next(arr<[u64]>, swaps<u64>)
@@ -326,360 +251,125 @@ test_interpreter!(
   :Done(arr) ⇒ arr.
 
 x := [5u64 3u64 8u64 1u64]
-y := #bubble-sort(x)",
-    Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4))
-);
+y := #bubble-sort(x)", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 #[test]
 fn interpret_variable_define_typed_set_from_range_matrix() {
-    let s = "input<{f64}> := 1..=5";
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    let result = intrp.interpret(&tree).unwrap();
-    match result {
-        Value::Set(mset) => {
-            let mset = mset.borrow();
-            assert_eq!(mset.set.len(), 5);
-            for value in [1.0, 2.0, 3.0, 4.0, 5.0] {
-                assert!(mset.set.contains(&Value::F64(Ref::new(value))));
-            }
-        }
-        _ => panic!("Expected set output"),
+  let s = "input<{f64}> := 1..=5";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let result = intrp.interpret(&tree).unwrap();
+  match result {
+    Value::Set(mset) => {
+      let mset = mset.borrow();
+      assert_eq!(mset.set.len(), 5);
+      for value in [1.0, 2.0, 3.0, 4.0, 5.0] {
+        assert!(mset.set.contains(&Value::F64(Ref::new(value))));
+      }
     }
+    _ => panic!("Expected set output"),
+  }
 }
 #[test]
 fn interpret_variable_define_typed_set_from_matrix() {
-    let s = "input<{f64}> := [1 2; 3 4; 5 6]";
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    let result = intrp.interpret(&tree).unwrap();
-    match result {
-        Value::Set(mset) => {
-            let mset = mset.borrow();
-            assert_eq!(mset.set.len(), 6);
-            for value in [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] {
-                assert!(mset.set.contains(&Value::F64(Ref::new(value))));
-            }
-        }
-        _ => panic!("Expected set output"),
+  let s = "input<{f64}> := [1 2; 3 4; 5 6]";
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let result = intrp.interpret(&tree).unwrap();
+  match result {
+    Value::Set(mset) => {
+      let mset = mset.borrow();
+      assert_eq!(mset.set.len(), 6);
+      for value in [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] {
+        assert!(mset.set.contains(&Value::F64(Ref::new(value))));
+      }
     }
+    _ => panic!("Expected set output"),
+  }
 }
-test_interpreter!(
-    interpret_literal_complex,
-    "5+4i",
-    Value::C64(Ref::new(C64::new(5.0, 4.0)))
-);
-test_interpreter!(
-    interpret_literal_complex2,
-    "5-4i",
-    Value::C64(Ref::new(C64::new(5.0, -4.0)))
-);
-test_interpreter!(
-    interpret_literal_complex3,
-    "5-4j",
-    Value::C64(Ref::new(C64::new(5.0, -4.0)))
-);
-test_interpreter!(
-    interpret_literal_rational,
-    "1/2",
-    Value::R64(Ref::new(R64::new(1, 2)))
-);
+test_interpreter!(interpret_literal_complex, "5+4i", Value::C64(Ref::new(C64::new(5.0, 4.0))));
+test_interpreter!(interpret_literal_complex2, "5-4i", Value::C64(Ref::new(C64::new(5.0, -4.0))));
+test_interpreter!(interpret_literal_complex3, "5-4j", Value::C64(Ref::new(C64::new(5.0, -4.0))));
+test_interpreter!(interpret_literal_rational, "1/2", Value::R64(Ref::new(R64::new(1, 2))));
 
-test_interpreter!(
-    interpret_comment,
-    "123 -- comment",
-    Value::F64(Ref::new(123.0))
-);
-test_interpreter!(
-    interpret_comment2,
-    "123 // comment",
-    Value::F64(Ref::new(123.0))
-);
+test_interpreter!(interpret_comment, "123 -- comment", Value::F64(Ref::new(123.0)));
+test_interpreter!(interpret_comment2, "123 // comment", Value::F64(Ref::new(123.0)));
 
-test_interpreter!(
-    interpret_formula_math_add,
-    "2 + 2",
-    Value::F64(Ref::new(4.0))
-);
-test_interpreter!(
-    interpret_formula_math_sub,
-    "2 - 2",
-    Value::F64(Ref::new(0.0))
-);
-test_interpreter!(
-    interpret_formula_math_mul,
-    "2 * 2",
-    Value::F64(Ref::new(4.0))
-);
-test_interpreter!(
-    interpret_formula_math_div,
-    "2 / 2",
-    Value::F64(Ref::new(1.0))
-);
-test_interpreter!(
-    interpret_formula_precedence_mul_before_compare,
-    "1 * 2 > 1 * 1",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_precedence_add_before_compare,
-    "1 + 2 > 1",
-    Value::Bool(Ref::new(true))
-);
+test_interpreter!(interpret_formula_math_add, "2 + 2", Value::F64(Ref::new(4.0)));
+test_interpreter!(interpret_formula_math_sub, "2 - 2", Value::F64(Ref::new(0.0)));
+test_interpreter!(interpret_formula_math_mul, "2 * 2", Value::F64(Ref::new(4.0)));
+test_interpreter!(interpret_formula_math_div, "2 / 2", Value::F64(Ref::new(1.0)));
+test_interpreter!(interpret_formula_precedence_mul_before_compare, "1 * 2 > 1 * 1", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_precedence_add_before_compare, "1 + 2 > 1", Value::Bool(Ref::new(true)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_formula_math_pow,
-    "2<u8> ^ 2<u8>",
-    Value::U8(Ref::new(4))
-);
-test_interpreter!(
-    interpret_formula_math_pow_f64,
-    "2.0 ^ 2.0",
-    Value::F64(Ref::new(4.0))
-);
-test_interpreter!(
-    interpret_formulat_math_add_rational,
-    "1/10 + 2/10 + 3/10",
-    Value::R64(Ref::new(R64::new(6, 10)))
-);
-test_interpreter!(
-    interpret_formulat_math_sub_rational,
-    "1/10 - 2/10 - 3/10",
-    Value::R64(Ref::new(R64::new(-4, 10)))
-);
-test_interpreter!(
-    interpret_formula_math_mul_rational,
-    "1/10 * 2/10 * 3/10",
-    Value::R64(Ref::new(R64::new(3, 500)))
-);
-test_interpreter!(
-    interpret_formula_math_div_rational,
-    "1/10 / 2/10 / 3/10",
-    Value::R64(Ref::new(R64::new(5, 3)))
-);
-test_interpreter!(
-    interpret_formula_math_add_complex,
-    "1+2i + 3+4i",
-    Value::C64(Ref::new(C64::new(4.0, 6.0)))
-);
-test_interpreter!(
-    interpret_formula_math_add_complex_real_rhs,
-    "4i + 1",
-    Value::C64(Ref::new(C64::new(1.0, 4.0)))
-);
-test_interpreter!(
-    interpret_formula_math_add_complex_real_lhs,
-    "1 + 4i",
-    Value::C64(Ref::new(C64::new(1.0, 4.0)))
-);
-test_interpreter!(
-    interpret_variable_define_complex_real_sum,
-    "y := 4i + 1",
-    Value::C64(Ref::new(C64::new(1.0, 4.0)))
-);
-test_interpreter!(
-    interpret_variable_add_complex_real,
-    "z := 4i; z + 1",
-    Value::C64(Ref::new(C64::new(1.0, 4.0)))
-);
-test_interpreter!(
-    interpret_formula_math_sub_complex,
-    "1+2i - 3+4i",
-    Value::C64(Ref::new(C64::new(-2.0, -2.0)))
-);
-test_interpreter!(
-    interpret_formula_math_mul_complex,
-    "1+2i * 3+4i",
-    Value::C64(Ref::new(C64::new(-5.0, 10.0)))
-);
-test_interpreter!(
-    interpret_formula_math_div_complex,
-    "1+2i / 3+4i",
-    Value::C64(Ref::new(C64::new(0.44, 0.08)))
-);
+test_interpreter!(interpret_formula_math_pow, "2<u8> ^ 2<u8>", Value::U8(Ref::new(4)));
+test_interpreter!(interpret_formula_math_pow_f64, "2.0 ^ 2.0", Value::F64(Ref::new(4.0)));
+test_interpreter!(interpret_formulat_math_add_rational, "1/10 + 2/10 + 3/10", Value::R64(Ref::new(R64::new(6, 10))));
+test_interpreter!(interpret_formulat_math_sub_rational, "1/10 - 2/10 - 3/10", Value::R64(Ref::new(R64::new(-4, 10))));
+test_interpreter!(interpret_formula_math_mul_rational, "1/10 * 2/10 * 3/10", Value::R64(Ref::new(R64::new(3, 500))));
+test_interpreter!(interpret_formula_math_div_rational, "1/10 / 2/10 / 3/10", Value::R64(Ref::new(R64::new(5, 3))));
+test_interpreter!(interpret_formula_math_add_complex, "1+2i + 3+4i", Value::C64(Ref::new(C64::new(4.0, 6.0))));
+test_interpreter!(interpret_formula_math_add_complex_real_rhs, "4i + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
+test_interpreter!(interpret_formula_math_add_complex_real_lhs, "1 + 4i", Value::C64(Ref::new(C64::new(1.0, 4.0))));
+test_interpreter!(interpret_variable_define_complex_real_sum, "y := 4i + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
+test_interpreter!(interpret_variable_add_complex_real, "z := 4i; z + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
+test_interpreter!(interpret_formula_math_sub_complex, "1+2i - 3+4i", Value::C64(Ref::new(C64::new(-2.0, -2.0))));
+test_interpreter!(interpret_formula_math_mul_complex, "1+2i * 3+4i", Value::C64(Ref::new(C64::new(-5.0, 10.0))));
+test_interpreter!(interpret_formula_math_div_complex, "1+2i / 3+4i", Value::C64(Ref::new(C64::new(0.44, 0.08))));
 
-test_interpreter!(
-    interpret_matrix_rational,
-    "[1/2 3/4]",
-    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 2), R64::new(3, 4)], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_complex,
-    "[1+2i 3+4i]",
-    Value::MatrixC64(Matrix::from_vec(
-        vec![C64::new(1.0, 2.0), C64::new(3.0, 4.0)],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_add_rational,
-    "[1/2 3/4] + [1/4 1/2]",
-    Value::MatrixR64(Matrix::from_vec(vec![R64::new(3, 4), R64::new(5, 4)], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_add_complex,
-    "[1+2i 3+4i] + [5+6i 7+8i]",
-    Value::MatrixC64(Matrix::from_vec(
-        vec![C64::new(6.0, 8.0), C64::new(10.0, 12.0)],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_sub_rational,
-    "[1/2 3/4] - [1/4 1/2]",
-    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 4), R64::new(1, 4)], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_sub_complex,
-    "[1+2i 3+4i] - [5+6i 7+8i]",
-    Value::MatrixC64(Matrix::from_vec(
-        vec![C64::new(-4.0, -4.0), C64::new(-4.0, -4.0)],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_mul_rational,
-    "[1/2 3/4] * [1/4 1/2]",
-    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 8), R64::new(3, 8)], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_mul_complex,
-    "[1+2i 3+4i] * [5+6i 7+8i]",
-    Value::MatrixC64(Matrix::from_vec(
-        vec![C64::new(-7.0, 16.0), C64::new(-11.0, 52.0)],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_div_rational,
-    "[1/2 3/4] / [1/4 1/2]",
-    Value::MatrixR64(Matrix::from_vec(vec![R64::new(2, 1), R64::new(3, 2)], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_div_complex,
-    "[1+2i 3+4i] / [5+6i 7+8i]",
-    Value::MatrixC64(Matrix::from_vec(
-        vec![
-            C64::new(0.2786885245901639, 0.06557377049180328),
-            C64::new(0.4690265486725664, 0.035398230088495575)
-        ],
-        1,
-        2
-    ))
-);
+test_interpreter!(interpret_matrix_rational, "[1/2 3/4]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 2), R64::new(3, 4)], 1, 2)));
+test_interpreter!(interpret_matrix_complex, "[1+2i 3+4i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(1.0, 2.0), C64::new(3.0, 4.0)], 1, 2)));
+test_interpreter!(interpret_matrix_add_rational, "[1/2 3/4] + [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(3, 4), R64::new(5, 4)], 1, 2)));
+test_interpreter!(interpret_matrix_add_complex, "[1+2i 3+4i] + [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(6.0, 8.0), C64::new(10.0, 12.0)], 1, 2)));
+test_interpreter!(interpret_matrix_sub_rational, "[1/2 3/4] - [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 4), R64::new(1, 4)], 1, 2)));
+test_interpreter!(interpret_matrix_sub_complex, "[1+2i 3+4i] - [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(-4.0, -4.0), C64::new(-4.0, -4.0)], 1, 2)));
+test_interpreter!(interpret_matrix_mul_rational, "[1/2 3/4] * [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 8), R64::new(3, 8)], 1, 2)));
+test_interpreter!(interpret_matrix_mul_complex, "[1+2i 3+4i] * [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(-7.0, 16.0), C64::new(-11.0, 52.0)], 1, 2)));
+test_interpreter!(interpret_matrix_div_rational, "[1/2 3/4] / [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(2, 1), R64::new(3, 2)], 1, 2)));
+test_interpreter!(interpret_matrix_div_complex, "[1+2i 3+4i] / [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(0.2786885245901639, 0.06557377049180328), C64::new(0.4690265486725664, 0.035398230088495575)], 1, 2)));
 
+test_interpreter!(interpret_matrix_eq_rational, "[1/2 3/4] == [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_eq_complex, "[1+2i 3+4i] == [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_neq_rational, "[1/2 3/4] != [1/2 3/5]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
+test_interpreter!(interpret_matrix_neq_complex, "[1+2i 3+4i] != [1+2i 3+5i]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
+test_interpreter!(interpret_matrix_gt_rational, "[1/2 3/4] > [1/4 1/2]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_gt_complex, "[1+2i 3+4i] > [1+1i 3+3i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_gte_rational, "[1/2 3/4] >= [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_gte_complex, "[1+2i 3+4i] >= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_lt_rational, "[1/2 3/4] < [3/4 1/2]", Value::MatrixBool(Matrix::from_vec(vec![true, false], 1, 2)));
+test_interpreter!(interpret_matrix_lt_complex, "[1+2i 3+4i] < [2+3i 4+5i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_lte_rational, "[1/2 3/4] <= [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_lte_complex, "[1+2i 3+4i] <= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_assignment_copy_index, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b[2,3]", Value::F64(Ref::new(6.0)));
+test_interpreter!(interpret_matrix_assignment_copy_eq, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b == a", Value::MatrixBool(Matrix::from_vec(vec![true, true, true, true, true, true, true, true, true], 3, 3)));
 test_interpreter!(
-    interpret_matrix_eq_rational,
-    "[1/2 3/4] == [1/2 3/4]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_eq_complex,
-    "[1+2i 3+4i] == [1+2i 3+4i]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_neq_rational,
-    "[1/2 3/4] != [1/2 3/5]",
-    Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_neq_complex,
-    "[1+2i 3+4i] != [1+2i 3+5i]",
-    Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_gt_rational,
-    "[1/2 3/4] > [1/4 1/2]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_gt_complex,
-    "[1+2i 3+4i] > [1+1i 3+3i]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_gte_rational,
-    "[1/2 3/4] >= [1/2 3/4]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_gte_complex,
-    "[1+2i 3+4i] >= [1+2i 3+4i]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_lt_rational,
-    "[1/2 3/4] < [3/4 1/2]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, false], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_lt_complex,
-    "[1+2i 3+4i] < [2+3i 4+5i]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_lte_rational,
-    "[1/2 3/4] <= [1/2 3/4]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_lte_complex,
-    "[1+2i 3+4i] <= [1+2i 3+4i]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_assignment_copy_index,
-    "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b[2,3]",
-    Value::F64(Ref::new(6.0))
-);
-test_interpreter!(
-    interpret_matrix_assignment_copy_eq,
-    "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b == a",
-    Value::MatrixBool(Matrix::from_vec(
-        vec![true, true, true, true, true, true, true, true, true],
-        3,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_table_wildcard_access_returns_matrix,
-    "b := |a<f64> b<f64>| 1 2 | 3 4|; b<[*]>",
-    Value::MatrixValue(Matrix::from_vec(
-        vec![
-            Value::F64(Ref::new(1.0)),
-            Value::F64(Ref::new(3.0)),
-            Value::F64(Ref::new(2.0)),
-            Value::F64(Ref::new(4.0)),
-        ],
-        2,
-        2
-    ))
+  interpret_table_wildcard_access_returns_matrix,
+  "b := |a<f64> b<f64>| 1 2 | 3 4|; b<[*]>",
+  Value::MatrixValue(Matrix::from_vec(
+    vec![
+      Value::F64(Ref::new(1.0)),
+      Value::F64(Ref::new(3.0)),
+      Value::F64(Ref::new(2.0)),
+      Value::F64(Ref::new(4.0)),
+    ],
+    2,
+    2
+  ))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_kind_annotation, "1<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_kind_annotation_math,
-    "1<u64> + 1<u64>",
-    Value::U64(Ref::new(2))
-);
+test_interpreter!(interpret_kind_annotation_math, "1<u64> + 1<u64>", Value::U64(Ref::new(2)));
 #[cfg(feature = "f64")]
 test_interpreter!(
-    interpret_nested_kind_matrix_literal,
-    "<<[f64]:3>>",
-    Value::Kind(ValueKind::Kind(Box::new(ValueKind::Matrix(
-        Box::new(ValueKind::F64),
-        vec![3]
-    ))))
+  interpret_nested_kind_matrix_literal,
+  "<<[f64]:3>>",
+  Value::Kind(ValueKind::Kind(Box::new(ValueKind::Matrix(Box::new(ValueKind::F64), vec![3]))))
 );
 
 // New tests overflow - unsigned
 // test_interpreter!(interpret_kind_math_overflow_u64, "18446744073709551615<u64> + 1<u64>", Value::U64(Ref::new(0)));
 // test_interpreter!(interpret_kind_math_overflow_u128, "340282366920938463463374607431768211455<u128> + 1<u128>", Value::U128(Ref::new(0)));
+
 
 // New tests overflow - unsigned
 // test_interpreter!(interpret_kind_math_overflow_u64, "18446744073709551615<u64> + 1<u64>", Value::U64(Ref::new(0)));
@@ -698,960 +388,288 @@ test_interpreter!(
 // New tests nominal with type def - unsigned
 //u8
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_formula_math_add_u8,
-    "2<u8> + 2<u8>",
-    Value::U8(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_u8, "2<u8> + 2<u8>", Value::U8(Ref::new(4)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_formula_math_sub_u8,
-    "2<u8> - 2<u8>",
-    Value::U8(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_u8, "2<u8> - 2<u8>", Value::U8(Ref::new(0)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_formula_math_div_u8,
-    "2<u8> / 2<u8>",
-    Value::U8(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_u8, "2<u8> / 2<u8>", Value::U8(Ref::new(1)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_formula_math_mul_u8,
-    "2<u8> * 2<u8>",
-    Value::U8(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_u8, "2<u8> * 2<u8>", Value::U8(Ref::new(4)));
 // u16
 #[cfg(feature = "u16")]
-test_interpreter!(
-    interpret_formula_math_add_u16,
-    "2<u16> + 2<u16>",
-    Value::U16(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_u16, "2<u16> + 2<u16>", Value::U16(Ref::new(4)));
 #[cfg(feature = "u16")]
-test_interpreter!(
-    interpret_formula_math_sub_u16,
-    "2<u16> - 2<u16>",
-    Value::U16(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_u16, "2<u16> - 2<u16>", Value::U16(Ref::new(0)));
 #[cfg(feature = "u16")]
-test_interpreter!(
-    interpret_formula_math_div_u16,
-    "2<u16> / 2<u16>",
-    Value::U16(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_u16, "2<u16> / 2<u16>", Value::U16(Ref::new(1)));
 #[cfg(feature = "u16")]
-test_interpreter!(
-    interpret_formula_math_mul_u16,
-    "2<u16> * 2<u16>",
-    Value::U16(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_u16, "2<u16> * 2<u16>", Value::U16(Ref::new(4)));
 // u32
 #[cfg(feature = "u32")]
-test_interpreter!(
-    interpret_formula_math_add_u32,
-    "2<u32> + 2<u32>",
-    Value::U32(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_u32, "2<u32> + 2<u32>", Value::U32(Ref::new(4)));
 #[cfg(feature = "u32")]
-test_interpreter!(
-    interpret_formula_math_sub_u32,
-    "2<u32> - 2<u32>",
-    Value::U32(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_u32, "2<u32> - 2<u32>", Value::U32(Ref::new(0)));
 #[cfg(feature = "u32")]
-test_interpreter!(
-    interpret_formula_math_div_u32,
-    "2<u32> / 2<u32>",
-    Value::U32(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_u32, "2<u32> / 2<u32>", Value::U32(Ref::new(1)));
 #[cfg(feature = "u32")]
-test_interpreter!(
-    interpret_formula_math_mul_u32,
-    "2<u32> * 2<u32>",
-    Value::U32(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_u32, "2<u32> * 2<u32>", Value::U32(Ref::new(4)));
 // u64
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_math_add_u64,
-    "2<u64> + 2<u64>",
-    Value::U64(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_u64, "2<u64> + 2<u64>", Value::U64(Ref::new(4)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_math_sub_u64,
-    "2<u64> - 2<u64>",
-    Value::U64(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_u64, "2<u64> - 2<u64>", Value::U64(Ref::new(0)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_math_sub_u64_with_default_literal_rhs,
-    "2<u64> - 1",
-    Value::U64(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_sub_u64_with_default_literal_rhs, "2<u64> - 1", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_math_div_u64,
-    "2<u64> / 2<u64>",
-    Value::U64(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_u64, "2<u64> / 2<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_math_mul_u64,
-    "2<u64> * 2<u64>",
-    Value::U64(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_u64, "2<u64> * 2<u64>", Value::U64(Ref::new(4)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_compare_gt_u64_with_default_literal_rhs,
-    "2<u64> > 1",
-    Value::Bool(Ref::new(true))
-);
+test_interpreter!(interpret_formula_compare_gt_u64_with_default_literal_rhs, "2<u64> > 1", Value::Bool(Ref::new(true)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_formula_compare_gt_u64_with_default_literal_lhs,
-    "2 > 1<u64>",
-    Value::Bool(Ref::new(true))
-);
+test_interpreter!(interpret_formula_compare_gt_u64_with_default_literal_lhs, "2 > 1<u64>", Value::Bool(Ref::new(true)));
 // u128
 #[cfg(feature = "u128")]
-test_interpreter!(
-    interpret_formula_math_add_u128,
-    "2<u128> + 2<u128>",
-    Value::U128(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_u128, "2<u128> + 2<u128>", Value::U128(Ref::new(4)));
 #[cfg(feature = "u128")]
-test_interpreter!(
-    interpret_formula_math_sub_u128,
-    "2<u128> - 2<u128>",
-    Value::U128(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_u128, "2<u128> - 2<u128>", Value::U128(Ref::new(0)));
 #[cfg(feature = "u128")]
-test_interpreter!(
-    interpret_formula_math_div_u128,
-    "2<u128> / 2<u128>",
-    Value::U128(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_u128, "2<u128> / 2<u128>", Value::U128(Ref::new(1)));
 #[cfg(feature = "u128")]
-test_interpreter!(
-    interpret_formula_math_mul_u128,
-    "2<u128> * 2<u128>",
-    Value::U128(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_u128, "2<u128> * 2<u128>", Value::U128(Ref::new(4)));
 
 // New tests nominal with type def - signed
 //i8
 #[cfg(feature = "i8")]
-test_interpreter!(
-    interpret_formula_math_add_i8,
-    "2<i8> + 2<i8>",
-    Value::I8(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_i8, "2<i8> + 2<i8>", Value::I8(Ref::new(4)));
 #[cfg(feature = "i8")]
-test_interpreter!(
-    interpret_formula_math_sub_i8,
-    "2<i8> - 2<i8>",
-    Value::I8(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_i8, "2<i8> - 2<i8>", Value::I8(Ref::new(0)));
 #[cfg(feature = "i8")]
-test_interpreter!(
-    interpret_formula_math_div_i8,
-    "2<i8> / 2<i8>",
-    Value::I8(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_i8, "2<i8> / 2<i8>", Value::I8(Ref::new(1)));
 #[cfg(feature = "i8")]
-test_interpreter!(
-    interpret_formula_math_mul_i8,
-    "2<i8> * 2<i8>",
-    Value::I8(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_i8, "2<i8> * 2<i8>", Value::I8(Ref::new(4)));
 // i16
 #[cfg(feature = "i16")]
-test_interpreter!(
-    interpret_formula_math_add_i16,
-    "2<i16> + 2<i16>",
-    Value::I16(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_i16, "2<i16> + 2<i16>", Value::I16(Ref::new(4)));
 #[cfg(feature = "i16")]
-test_interpreter!(
-    interpret_formula_math_sub_i16,
-    "2<i16> - 2<i16>",
-    Value::I16(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_i16, "2<i16> - 2<i16>", Value::I16(Ref::new(0)));
 #[cfg(feature = "i16")]
-test_interpreter!(
-    interpret_formula_math_div_i16,
-    "2<i16> / 2<i16>",
-    Value::I16(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_i16, "2<i16> / 2<i16>", Value::I16(Ref::new(1)));
 #[cfg(feature = "i16")]
-test_interpreter!(
-    interpret_formula_math_mul_i16,
-    "2<i16> * 2<i16>",
-    Value::I16(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_i16, "2<i16> * 2<i16>", Value::I16(Ref::new(4)));
 // i32
 #[cfg(feature = "i32")]
-test_interpreter!(
-    interpret_formula_math_add_i32,
-    "2<i32> + 2<i32>",
-    Value::I32(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_i32, "2<i32> + 2<i32>", Value::I32(Ref::new(4)));
 #[cfg(feature = "i32")]
-test_interpreter!(
-    interpret_formula_math_sub_i32,
-    "2<i32> - 2<i32>",
-    Value::I32(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_i32, "2<i32> - 2<i32>", Value::I32(Ref::new(0)));
 #[cfg(feature = "i32")]
-test_interpreter!(
-    interpret_formula_math_div_i32,
-    "2<i32> / 2<i32>",
-    Value::I32(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_i32, "2<i32> / 2<i32>", Value::I32(Ref::new(1)));
 #[cfg(feature = "i32")]
-test_interpreter!(
-    interpret_formula_math_mul_i32,
-    "2<i32> * 2<i32>",
-    Value::I32(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_i32, "2<i32> * 2<i32>", Value::I32(Ref::new(4)));
 // i64
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_formula_math_add_i64,
-    "2<i64> + 2<i64>",
-    Value::I64(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_i64, "2<i64> + 2<i64>", Value::I64(Ref::new(4)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_formula_math_sub_i64,
-    "2<i64> - 2<i64>",
-    Value::I64(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_i64, "2<i64> - 2<i64>", Value::I64(Ref::new(0)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_formula_math_div_i64,
-    "2<i64> / 2<i64>",
-    Value::I64(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_i64, "2<i64> / 2<i64>", Value::I64(Ref::new(1)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_formula_math_mul_i64,
-    "2<i64> * 2<i64>",
-    Value::I64(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_i64, "2<i64> * 2<i64>", Value::I64(Ref::new(4)));
 // i128
 #[cfg(feature = "i128")]
-test_interpreter!(
-    interpret_formula_math_add_i128,
-    "2<i128> + 2<i128>",
-    Value::I128(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_add_i128, "2<i128> + 2<i128>", Value::I128(Ref::new(4)));
 #[cfg(feature = "i128")]
-test_interpreter!(
-    interpret_formula_math_sub_i128,
-    "2<i128> - 2<i128>",
-    Value::I128(Ref::new(0))
-);
+test_interpreter!(interpret_formula_math_sub_i128, "2<i128> - 2<i128>", Value::I128(Ref::new(0)));
 #[cfg(feature = "i128")]
-test_interpreter!(
-    interpret_formula_math_div_i128,
-    "2<i128> / 2<i128>",
-    Value::I128(Ref::new(1))
-);
+test_interpreter!(interpret_formula_math_div_i128, "2<i128> / 2<i128>", Value::I128(Ref::new(1)));
 #[cfg(feature = "i128")]
-test_interpreter!(
-    interpret_formula_math_mul_i128,
-    "2<i128> * 2<i128>",
-    Value::I128(Ref::new(4))
-);
+test_interpreter!(interpret_formula_math_mul_i128, "2<i128> * 2<i128>", Value::I128(Ref::new(4)));
 
 // New tests for nominal with type def - floats
 // f32
 #[cfg(feature = "f32")]
-test_interpreter!(
-    interpret_formula_math_add_f32,
-    "2.0<f32> + 2.0<f32>",
-    Value::F32(Ref::new(4.0))
-);
+test_interpreter!(interpret_formula_math_add_f32, "2.0<f32> + 2.0<f32>", Value::F32(Ref::new(4.0)));
 #[cfg(feature = "f32")]
-test_interpreter!(
-    interpret_formula_math_sub_f32,
-    "2.0<f32> - 2.0<f32>",
-    Value::F32(Ref::new(0.0))
-);
+test_interpreter!(interpret_formula_math_sub_f32, "2.0<f32> - 2.0<f32>", Value::F32(Ref::new(0.0)));
 #[cfg(feature = "f32")]
-test_interpreter!(
-    interpret_formula_math_div_f32,
-    "2.0<f32> / 2.0<f32>",
-    Value::F32(Ref::new(1.0))
-);
+test_interpreter!(interpret_formula_math_div_f32, "2.0<f32> / 2.0<f32>", Value::F32(Ref::new(1.0)));
 #[cfg(feature = "f32")]
-test_interpreter!(
-    interpret_formula_math_mul_f32,
-    "2.0<f32> * 2.0<f32>",
-    Value::F32(Ref::new(4.0))
-);
+test_interpreter!(interpret_formula_math_mul_f32, "2.0<f32> * 2.0<f32>", Value::F32(Ref::new(4.0)));
 //f64
-test_interpreter!(
-    interpret_formula_math_add_f64,
-    "2.0<f64> + 2.0<f64>",
-    Value::F64(Ref::new(4.0))
-);
-test_interpreter!(
-    interpret_formula_math_sub_f64,
-    "2.0<f64> - 2.0<f64>",
-    Value::F64(Ref::new(0.0))
-);
-test_interpreter!(
-    interpret_formula_math_div_f64,
-    "2.0<f64> / 2.0<f64>",
-    Value::F64(Ref::new(1.0))
-);
-test_interpreter!(
-    interpret_formula_math_mul_f64,
-    "2.0<f64> * 2.0<f64>",
-    Value::F64(Ref::new(4.0))
-);
+test_interpreter!(interpret_formula_math_add_f64, "2.0<f64> + 2.0<f64>", Value::F64(Ref::new(4.0)));
+test_interpreter!(interpret_formula_math_sub_f64, "2.0<f64> - 2.0<f64>", Value::F64(Ref::new(0.0)));
+test_interpreter!(interpret_formula_math_div_f64, "2.0<f64> / 2.0<f64>", Value::F64(Ref::new(1.0)));
+test_interpreter!(interpret_formula_math_mul_f64, "2.0<f64> * 2.0<f64>", Value::F64(Ref::new(4.0)));
 
 #[cfg(feature = "u16")]
-test_interpreter!(
-    interpret_kind_math_no_overflow,
-    "255<u16> + 1<u16>",
-    Value::U16(Ref::new(256))
-);
+test_interpreter!(interpret_kind_math_no_overflow, "255<u16> + 1<u16>", Value::U16(Ref::new(256)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_kind_matrix_row3,
-    "[1<u8> 2<u8> 3<u8>]",
-    Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3))
-);
+test_interpreter!(interpret_kind_matrix_row3, "[1<u8> 2<u8> 3<u8>]", Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_kind_lhs_define,
-    "x<u64> := 1",
-    Value::U64(Ref::new(1))
-);
+test_interpreter!(interpret_kind_lhs_define, "x<u64> := 1", Value::U64(Ref::new(1)));
 #[cfg(all(feature = "u64", feature = "i8"))]
-test_interpreter!(
-    interpret_kind_convert_twice,
-    "x<u64> := 1; y<i8> := x",
-    Value::I8(Ref::new(1))
-);
+test_interpreter!(interpret_kind_convert_twice, "x<u64> := 1; y<i8> := x", Value::I8(Ref::new(1)));
 #[cfg(feature = "f32")]
-test_interpreter!(
-    interpret_kind_convert_float,
-    "x<f32> := 123;",
-    Value::F32(Ref::new(123.0))
-);
-test_interpreter!(
-    interpret_kind_convert_rational,
-    "x<r64> := 1 / 2; y<f64> := x",
-    Value::F64(Ref::new(0.5))
-);
-test_interpreter!(
-    interpret_kind_convert_rational2,
-    "x<f64> := 1/2; y<r64> := x",
-    Value::R64(Ref::new(R64::new(1, 2)))
-);
-test_interpreter!(
-    interpret_kind_convert_mat_to_any,
-    "x := [2 3 4]; y<[*]> := x",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
-);
+test_interpreter!(interpret_kind_convert_float, "x<f32> := 123;", Value::F32(Ref::new(123.0)));
+test_interpreter!(interpret_kind_convert_rational, "x<r64> := 1 / 2; y<f64> := x", Value::F64(Ref::new(0.5)));
+test_interpreter!(interpret_kind_convert_rational2, "x<f64> := 1/2; y<r64> := x", Value::R64(Ref::new(R64::new(1, 2))));
+test_interpreter!(interpret_kind_convert_mat_to_any, "x := [2 3 4]; y<[*]> := x", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
 
-test_interpreter!(
-    interpret_kind_define,
-    "<foo> := <f64>; x<foo> := 123",
-    Value::F64(Ref::new(123.0))
-);
+test_interpreter!(interpret_kind_define, "<foo> := <f64>; x<foo> := 123", Value::F64(Ref::new(123.0)));
 test_interpreter!(interpret_formula_math_neg, "-1", Value::F64(Ref::new(-1.0)));
-test_interpreter!(
-    interpret_formula_math_multiple_terms,
-    "1 + 2 + 3",
-    Value::F64(Ref::new(6.0))
-);
-test_interpreter!(
-    interpret_formula_comparison_bool,
-    "true == false",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_formula_comparison_bool2,
-    "true == true",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_comparison_eq,
-    "10 == 11",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_formula_comparison_string_eq,
-    r#"["a" "b"] == ["a" "b"]"#,
-    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
-);
-test_interpreter!(
-    interpret_formula_comparison_string_neq,
-    r#"["a" "b"] != ["a" "c"]"#,
-    Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2))
-);
-test_interpreter!(
-    interpret_formula_comparison_neq,
-    "10 != 11",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_comparison_neq_bool,
-    "false != true",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_comparison_gt,
-    "10 > 11",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_formula_comparison_lt,
-    "10 < 11",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_comparison_gte,
-    "10 >= 10",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_comparison_lte,
-    "10 <= 10",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_comparison_gt_vec,
-    "[1 8; 10 5] > [7 2; 4 11]",
-    Value::MatrixBool(Matrix::from_vec(vec![false, true, true, false], 2, 2))
-);
-test_interpreter!(
-    interpret_formula_comparison_lt_vec,
-    "[1 8 10 5] < [7 2 4 11]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, false, false, true], 1, 4))
-);
-test_interpreter!(
-    interpret_formula_unicode,
-    "😃:=1;🤦🏼‍♂️:=2;y̆és:=🤦🏼‍♂️ + 😃",
-    Value::F64(Ref::new(3.0))
-);
-test_interpreter!(
-    interpret_formula_logic_and,
-    "true && true",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_logic_and_vec,
-    "[true false] && [false false]",
-    Value::MatrixBool(Matrix::from_vec(vec![false, false], 1, 2))
-);
-test_interpreter!(
-    interpret_formula_logic_and2,
-    "true && false",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_formula_logic_or_vec,
-    "[true false true] || [false false true]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3))
-);
-test_interpreter!(
-    interpret_formula_logic_or,
-    "true || false",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_logic_or2,
-    "false || false",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_formula_logic_xor_vec,
-    "[true false false true] ⊕ [true true false true]",
-    Value::MatrixBool(Matrix::from_vec(vec![false, true, false, false], 1, 4))
-);
-test_interpreter!(
-    interpret_formula_logic_not,
-    "!false",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_formula_logic_not_vec,
-    "![false true false]",
-    Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3))
-);
-test_interpreter!(
-    interpret_formula_logic_not_vec1,
-    "![false]",
-    Value::MatrixBool(Matrix::from_vec(vec![true], 1, 1))
-);
+test_interpreter!(interpret_formula_math_multiple_terms, "1 + 2 + 3", Value::F64(Ref::new(6.0)));
+test_interpreter!(interpret_formula_comparison_bool, "true == false", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_formula_comparison_bool2, "true == true", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_comparison_eq, "10 == 11", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_formula_comparison_string_eq, r#"["a" "b"] == ["a" "b"]"#, Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_formula_comparison_string_neq, r#"["a" "b"] != ["a" "c"]"#, Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
+test_interpreter!(interpret_formula_comparison_neq, "10 != 11", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_comparison_neq_bool, "false != true", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_comparison_gt, "10 > 11", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_formula_comparison_lt, "10 < 11", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_comparison_gte, "10 >= 10", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_comparison_lte, "10 <= 10", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_comparison_gt_vec, "[1 8; 10 5] > [7 2; 4 11]", Value::MatrixBool(Matrix::from_vec(vec![false, true, true, false], 2, 2)));
+test_interpreter!(interpret_formula_comparison_lt_vec, "[1 8 10 5] < [7 2 4 11]", Value::MatrixBool(Matrix::from_vec(vec![true, false, false, true], 1, 4)));
+test_interpreter!(interpret_formula_unicode, "😃:=1;🤦🏼‍♂️:=2;y̆és:=🤦🏼‍♂️ + 😃", Value::F64(Ref::new(3.0)));
+test_interpreter!(interpret_formula_logic_and, "true && true", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_logic_and_vec, "[true false] && [false false]", Value::MatrixBool(Matrix::from_vec(vec![false, false], 1, 2)));
+test_interpreter!(interpret_formula_logic_and2, "true && false", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_formula_logic_or_vec, "[true false true] || [false false true]", Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3)));
+test_interpreter!(interpret_formula_logic_or, "true || false", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_logic_or2, "false || false", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_formula_logic_xor_vec, "[true false false true] ⊕ [true true false true]", Value::MatrixBool(Matrix::from_vec(vec![false, true, false, false], 1, 4)));
+test_interpreter!(interpret_formula_logic_not, "!false", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_formula_logic_not_vec, "![false true false]", Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3)));
+test_interpreter!(interpret_formula_logic_not_vec1, "![false]", Value::MatrixBool(Matrix::from_vec(vec![true], 1, 1)));
 
-test_interpreter!(
-    interpret_statement_variable_define,
-    "x := 123",
-    Value::F64(Ref::new(123.0))
-);
+test_interpreter!(interpret_statement_variable_define, "x := 123", Value::F64(Ref::new(123.0)));
 
-test_interpreter!(
-    interpret_reference_bool,
-    "x := false; y := true; x && y",
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_reference_bool2,
-    "x := false; x && true",
-    Value::Bool(Ref::new(false))
-);
+test_interpreter!(interpret_reference_bool, "x := false; y := true; x && y", Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_reference_bool2, "x := false; x && true", Value::Bool(Ref::new(false)));
 
-test_interpreter!(
-    interpret_variable_recall,
-    "a := 1; b := 2; a",
-    Value::MutableReference(Ref::new(Value::F64(Ref::new(1.0))))
-);
+test_interpreter!(interpret_variable_recall, "a := 1; b := 2; a", Value::MutableReference(Ref::new(Value::F64(Ref::new(1.0)))));
 
-test_interpreter!(
-    interpret_matrix_range_exclusive,
-    "1..4",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_range_exclusive_step,
-    "1..4..13",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0], 1, 3))
-);
+test_interpreter!(interpret_matrix_range_exclusive, "1..4", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
+test_interpreter!(interpret_matrix_range_exclusive_step, "1..4..13", Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0], 1, 3)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_matrix_range_exclusive_u8,
-    "1<u8>..4<u8>",
-    Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_range_inclusive,
-    "1..=4",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_matrix_range_inclusive_step,
-    "1..4..=13",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0, 13.0], 1, 4))
-);
+test_interpreter!(interpret_matrix_range_exclusive_u8, "1<u8>..4<u8>", Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3)));
+test_interpreter!(interpret_matrix_range_inclusive, "1..=4", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
+test_interpreter!(interpret_matrix_range_inclusive_step, "1..4..=13", Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0, 13.0], 1, 4)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_matrix_range_inclusive_u8,
-    "1<u8>..=4<u8>",
-    Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3, 4], 1, 4))
-);
-test_interpreter!(
-    interpret_matrix_empty,
-    "[]",
-    Value::MatrixValue(Matrix::from_vec(vec![], 0, 0))
-);
-test_interpreter!(
-    interpret_matrix_row3,
-    "[1 2 3]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_mat1,
-    "[123]",
-    Value::MatrixF64(Matrix::from_vec(vec![123.0], 1, 1))
-);
-test_interpreter!(
-    interpret_matrix_row3_float,
-    "[1.2 2.3 3.4]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.2, 2.3, 3.4], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_mat2,
-    "[1 2; 3 4]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_transpose,
-    "[1 2; 3 4]'",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 2, 2))
-);
+test_interpreter!(interpret_matrix_range_inclusive_u8, "1<u8>..=4<u8>", Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3, 4], 1, 4)));
+test_interpreter!(interpret_matrix_empty, "[]", Value::MatrixValue(Matrix::from_vec(vec![], 0, 0)));
+test_interpreter!(interpret_matrix_row3, "[1 2 3]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
+test_interpreter!(interpret_matrix_mat1, "[123]", Value::MatrixF64(Matrix::from_vec(vec![123.0], 1, 1)));
+test_interpreter!(interpret_matrix_row3_float, "[1.2 2.3 3.4]", Value::MatrixF64(Matrix::from_vec(vec![1.2, 2.3, 3.4], 1, 3)));
+test_interpreter!(interpret_matrix_mat2, "[1 2; 3 4]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
+test_interpreter!(interpret_matrix_transpose, "[1 2; 3 4]'", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 2, 2)));
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_matrix_transpose_u8,
-    "[1<u8> 2<u8> 3<u8>]'",
-    Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 3, 1))
-);
-test_interpreter!(
-    interpret_matrix_transpose_float,
-    "[1.0 2.0 3.0; 4.0 5.0 6.0]'",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2))
-);
+test_interpreter!(interpret_matrix_transpose_u8, "[1<u8> 2<u8> 3<u8>]'", Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 3, 1)));
+test_interpreter!(interpret_matrix_transpose_float, "[1.0 2.0 3.0; 4.0 5.0 6.0]'", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_matrix_transpose_vector,
-    "x := | x<i64> | 1 | 3 | 5 |; x.x'",
-    Value::MatrixI64(Matrix::from_vec(vec![1i64, 3, 5], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_add_v2s,
-    "[1;2] + 3",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 2, 1))
-);
+test_interpreter!(interpret_matrix_transpose_vector, "x := | x<i64> | 1 | 3 | 5 |; x.x'", Value::MatrixI64(Matrix::from_vec(vec![1i64, 3, 5], 1, 3)));
+test_interpreter!(interpret_matrix_add_v2s, "[1;2] + 3", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 2, 1)));
 
-test_interpreter!(
-    interpret_matrix_mat2_f64,
-    "[1.1 2.2; 3.3 4.4]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.1, 3.3, 2.2, 4.4], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_negate,
-    "-[1 2; 3 4]",
-    Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_negate_float,
-    "-[1.0 2.0; 3.0 4.0]",
-    Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_negate_mat1,
-    "-[1]",
-    Value::MatrixF64(Matrix::from_vec(vec![-1.0], 1, 1))
-);
+test_interpreter!(interpret_matrix_mat2_f64, "[1.1 2.2; 3.3 4.4]", Value::MatrixF64(Matrix::from_vec(vec![1.1, 3.3, 2.2, 4.4], 2, 2)));
+test_interpreter!(interpret_matrix_negate, "-[1 2; 3 4]", Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2)));
+test_interpreter!(interpret_matrix_negate_float, "-[1.0 2.0; 3.0 4.0]", Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2)));
+test_interpreter!(interpret_matrix_negate_mat1, "-[1]", Value::MatrixF64(Matrix::from_vec(vec![-1.0], 1, 1)));
 
-test_interpreter!(
-    interpret_matrix_row3_add,
-    "[1 2 3] + [4 5 6]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_row3_mul_scalar,
-    "[1 2 3] * 3",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_row3_mul_scalar2,
-    "3 * [1 2 3]",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_row3_add_float,
-    "[1.0 2.0 3.0] + [4.0 5.0 6.0]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_row3_sub,
-    "[1 2 3] - [4 5 6]",
-    Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_row3_sub_float,
-    "[1.0 2.0 3.0] - [4.0 5.0 6.0]",
-    Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_row3_add_ref,
-    "a := [1 2 3]; b := [4 5 6]; c := a + b",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrix_dynamic_add,
-    "[1 2 3 4; 5 6 7 8] + [1 2 3 4; 5 6 7 8]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![2.0, 10.0, 4.0, 12.0, 6.0, 14.0, 8.0, 16.0],
-        2,
-        4
-    ))
-);
-test_interpreter!(
-    interpret_matrix_dynamic_div,
-    "[2 4 6 8] / [2 2 2 2]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_matrix_gt,
-    "x := [66.0 2.0 3.0; 66.0 5.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x > y",
-    Value::MatrixBool(Matrix::from_vec(
-        vec![true, true, false, false, false, true],
-        2,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_matrix_lt,
-    "x := [66.0 2.0 3.0; 66.0 4.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x < y",
-    Value::MatrixBool(Matrix::from_vec(
-        vec![false, false, false, true, false, false],
-        2,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_matrix_lt_int,
-    "x := [66 2 3; 66 4 66]; y := [1 2 3; 4 5 6]; x < y",
-    Value::MatrixBool(Matrix::from_vec(
-        vec![false, false, false, true, false, false],
-        2,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_matrix_add_m2v2,
-    "[1 1; 2 2] + [1;2]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_add_v2m2,
-    "[1;2] + [1 1; 2 2]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_add_r2m2,
-    "[1 2] + [1 1; 1 1]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_add_m2r2,
-    "[1 1; 1 1] + [1 2]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2))
-);
+test_interpreter!(interpret_matrix_row3_add, "[1 2 3] + [4 5 6]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3)));
+test_interpreter!(interpret_matrix_row3_mul_scalar, "[1 2 3] * 3", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3)));
+test_interpreter!(interpret_matrix_row3_mul_scalar2, "3 * [1 2 3]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3)));
+test_interpreter!(interpret_matrix_row3_add_float, "[1.0 2.0 3.0] + [4.0 5.0 6.0]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3)));
+test_interpreter!(interpret_matrix_row3_sub, "[1 2 3] - [4 5 6]", Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3)));
+test_interpreter!(interpret_matrix_row3_sub_float, "[1.0 2.0 3.0] - [4.0 5.0 6.0]", Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3)));
+test_interpreter!(interpret_matrix_row3_add_ref, "a := [1 2 3]; b := [4 5 6]; c := a + b", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3)));
+test_interpreter!(interpret_matrix_dynamic_add, "[1 2 3 4; 5 6 7 8] + [1 2 3 4; 5 6 7 8]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 10.0, 4.0, 12.0, 6.0, 14.0, 8.0, 16.0], 2, 4)));
+test_interpreter!(interpret_matrix_dynamic_div, "[2 4 6 8] / [2 2 2 2]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
+test_interpreter!(interpret_matrix_gt, "x := [66.0 2.0 3.0; 66.0 5.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x > y", Value::MatrixBool(Matrix::from_vec(vec![true, true, false, false, false, true], 2, 3)));
+test_interpreter!(interpret_matrix_lt, "x := [66.0 2.0 3.0; 66.0 4.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x < y", Value::MatrixBool(Matrix::from_vec(vec![false, false, false, true, false, false], 2, 3)));
+test_interpreter!(interpret_matrix_lt_int, "x := [66 2 3; 66 4 66]; y := [1 2 3; 4 5 6]; x < y", Value::MatrixBool(Matrix::from_vec(vec![false, false, false, true, false, false], 2, 3)));
+test_interpreter!(interpret_matrix_add_m2v2, "[1 1; 2 2] + [1;2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2)));
+test_interpreter!(interpret_matrix_add_v2m2, "[1;2] + [1 1; 2 2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2)));
+test_interpreter!(interpret_matrix_add_r2m2, "[1 2] + [1 1; 1 1]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2)));
+test_interpreter!(interpret_matrix_add_m2r2, "[1 1; 1 1] + [1 2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2)));
 
-test_interpreter!(
-    interpret_matrix_dot,
-    "[1 2 3] · [4 5 6]",
-    Value::F64(Ref::new(32.0))
-);
-test_interpreter!(
-    interpret_matrix_matmul_mat1,
-    "[2] ** [10]",
-    Value::MatrixF64(Matrix::from_vec(vec![20.0], 1, 1))
-);
-test_interpreter!(
-    interpret_matrix_matmul_mat2_ref,
-    "a := [1 2; 3 4]; b := [4 5; 6 7]; c := a ** b",
-    Value::MatrixF64(Matrix::from_vec(vec![16.0, 36.0, 19.0, 43.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrixmatmul_mat2x3_ref,
-    "a := [1.0 2.0 3.0; 4.0 5.0 6.0]; b := [4.0 5.0; 6.0 7.0; 8.0 9.0]; c := a ** b",
-    Value::MatrixF64(Matrix::from_vec(vec![40.0, 94.0, 46.0, 109.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrixmatmul_r3m3,
-    "a := [1.0 2.0 3.0]; b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; c := a ** b",
-    Value::MatrixF64(Matrix::from_vec(vec![48.0, 54.0, 60.0], 1, 3))
-);
-test_interpreter!(
-    interpret_matrixmatmul_m3v3,
-    "b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; a := [1.0 2.0 3.0]'; c := b ** a",
-    Value::MatrixF64(Matrix::from_vec(vec![32.0, 50.0, 68.0], 3, 1))
-);
-test_interpreter!(
-    interpret_matrix_string,
-    r#"["Hello" "World"]"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec!["Hello".to_string(), "World".to_string()],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_string_access,
-    r#"x:=["Hello" "World"];x[2]"#,
-    Value::String(Ref::new("World".to_string()))
-);
-test_interpreter!(
-    interpret_matrix_string_assign,
-    r#"~x:=["Hello" "World"];x[1]="Foo";[x[1] x[2]]"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec!["Foo".to_string(), "World".to_string()],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_string_assign_logical,
-    r#"~x := ["Hello", "World", "!"]; x[[true false true]] = "Foo";"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec!["Foo".to_string(), "World".to_string(), "Foo".to_string()],
-        1,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_table_string_access,
-    r#"x:=|x<string> y<string> | "a" "b" | "c" "d" |; x.y"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec!["b".to_string(), "d".to_string()],
-        2,
-        1
-    ))
-);
-test_interpreter!(
-    interpret_matrix_define_ref,
-    r#"x:=123;y<[f64]:1,4>:=x;"#,
-    Value::MatrixF64(Matrix::from_vec(vec![123.0; 4], 1, 4))
-);
+test_interpreter!(interpret_matrix_dot, "[1 2 3] · [4 5 6]", Value::F64(Ref::new(32.0)));
+test_interpreter!(interpret_matrix_matmul_mat1, "[2] ** [10]", Value::MatrixF64(Matrix::from_vec(vec![20.0], 1, 1)));
+test_interpreter!(interpret_matrix_matmul_mat2_ref, "a := [1 2; 3 4]; b := [4 5; 6 7]; c := a ** b", Value::MatrixF64(Matrix::from_vec(vec![16.0, 36.0, 19.0, 43.0], 2, 2)));
+test_interpreter!(interpret_matrixmatmul_mat2x3_ref, "a := [1.0 2.0 3.0; 4.0 5.0 6.0]; b := [4.0 5.0; 6.0 7.0; 8.0 9.0]; c := a ** b", Value::MatrixF64(Matrix::from_vec(vec![40.0, 94.0, 46.0, 109.0], 2, 2)));
+test_interpreter!(interpret_matrixmatmul_r3m3, "a := [1.0 2.0 3.0]; b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; c := a ** b", Value::MatrixF64(Matrix::from_vec(vec![48.0, 54.0, 60.0], 1, 3)));
+test_interpreter!(interpret_matrixmatmul_m3v3, "b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; a := [1.0 2.0 3.0]'; c := b ** a", Value::MatrixF64(Matrix::from_vec(vec![32.0, 50.0, 68.0], 3, 1)));
+test_interpreter!(interpret_matrix_string, r#"["Hello" "World"]"#, Value::MatrixString(Matrix::from_vec(vec!["Hello".to_string(), "World".to_string()], 1, 2)));
+test_interpreter!(interpret_matrix_string_access, r#"x:=["Hello" "World"];x[2]"#, Value::String(Ref::new("World".to_string())));
+test_interpreter!(interpret_matrix_string_assign, r#"~x:=["Hello" "World"];x[1]="Foo";[x[1] x[2]]"#, Value::MatrixString(Matrix::from_vec(vec!["Foo".to_string(), "World".to_string()], 1, 2)));
+test_interpreter!(interpret_matrix_string_assign_logical, r#"~x := ["Hello", "World", "!"]; x[[true false true]] = "Foo";"#, Value::MatrixString(Matrix::from_vec(vec!["Foo".to_string(), "World".to_string(), "Foo".to_string()], 1, 3)));
+test_interpreter!(interpret_table_string_access, r#"x:=|x<string> y<string> | "a" "b" | "c" "d" |; x.y"#, Value::MatrixString(Matrix::from_vec(vec!["b".to_string(), "d".to_string()], 2, 1)));
+test_interpreter!(interpret_matrix_define_ref, r#"x:=123;y<[f64]:1,4>:=x;"#, Value::MatrixF64(Matrix::from_vec(vec![123.0; 4], 1, 4)));
 #[cfg(all(feature = "f64", feature = "u8"))]
-test_interpreter!(
-    interpret_matrix_define_convert,
-    r#"y<[f64]:1,3> := 123<u8>;"#,
-    Value::MatrixF64(Matrix::from_vec(vec![123.0; 3], 1, 3))
-);
+test_interpreter!(interpret_matrix_define_convert, r#"y<[f64]:1,3> := 123<u8>;"#, Value::MatrixF64(Matrix::from_vec(vec![123.0; 3], 1, 3)));
 #[cfg(all(feature = "u64", feature = "u8"))]
-test_interpreter!(
-    interpret_matrix_define_convert_matrix,
-    r#"x := [1 2 3];y<[u64]> := x;z<[u8]> := y;"#,
-    Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 1, 3))
-);
+test_interpreter!(interpret_matrix_define_convert_matrix, r#"x := [1 2 3];y<[u64]> := x;z<[u8]> := y;"#, Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 1, 3)));
 
-// 2x2 Nominal Operations
-test_interpreter!(
-    interpret_matrix_add_2x2,
-    "[1 2; 3 4] + [5 6; 7 8]",
-    Value::MatrixF64(Matrix::from_vec(vec![6.0, 10.0, 8.0, 12.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_sub_2x2,
-    "[1 2; 3 4] - [5 6; 7 8]",
-    Value::MatrixF64(Matrix::from_vec(vec![-4.0, -4.0, -4.0, -4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_mul_2x2,
-    "[1 2; 3 4] * [5 6; 7 8]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 21.0, 12.0, 32.0], 2, 2))
-);
-test_interpreter!(
-    interpret_matrix_div_2x2,
-    "[20 30; 40 50] / [2 3; 4 5]",
-    Value::MatrixF64(Matrix::from_vec(vec![10.0, 10.0, 10.0, 10.0], 2, 2))
-);
+// 2x2 Nominal Operations 
+test_interpreter!(interpret_matrix_add_2x2, "[1 2; 3 4] + [5 6; 7 8]", Value::MatrixF64(Matrix::from_vec(vec![6.0, 10.0, 8.0, 12.0], 2, 2)));
+test_interpreter!(interpret_matrix_sub_2x2, "[1 2; 3 4] - [5 6; 7 8]", Value::MatrixF64(Matrix::from_vec(vec![-4.0, -4.0, -4.0, -4.0], 2, 2)));
+test_interpreter!(interpret_matrix_mul_2x2, "[1 2; 3 4] * [5 6; 7 8]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 21.0, 12.0, 32.0], 2, 2)));
+test_interpreter!(interpret_matrix_div_2x2, "[20 30; 40 50] / [2 3; 4 5]", Value::MatrixF64(Matrix::from_vec(vec![10.0, 10.0, 10.0, 10.0], 2, 2)));
 
 // 3x3 Nominal Operations
-test_interpreter!(
-    interpret_matrix_add_3x3,
-    "[1 2 3; 4 5 6; 7 8 9] + [9 8 7; 6 5 4; 3 2 1]",
-    Value::MatrixF64(Matrix::from_vec(vec![10.0; 9], 3, 3))
-);
-test_interpreter!(
-    interpret_matrix_mul_3x3,
-    "[1 2 3; 4 5 6; 7 8 9] * [9 8 7; 6 5 4; 3 2 1]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![9.0, 24.0, 21.0, 16.0, 25.0, 16.0, 21.0, 24.0, 9.0],
-        3,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_matrix_div_3x3,
-    "[10 20 30; 40 50 60; 70 80 90] / [10 10 10; 10 10 10; 10 10 10]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0],
-        3,
-        3
-    ))
-);
+test_interpreter!(interpret_matrix_add_3x3, "[1 2 3; 4 5 6; 7 8 9] + [9 8 7; 6 5 4; 3 2 1]", Value::MatrixF64(Matrix::from_vec(vec![10.0; 9], 3, 3)));
+test_interpreter!(interpret_matrix_mul_3x3, "[1 2 3; 4 5 6; 7 8 9] * [9 8 7; 6 5 4; 3 2 1]", Value::MatrixF64(Matrix::from_vec(vec![9.0, 24.0, 21.0, 16.0, 25.0, 16.0, 21.0, 24.0, 9.0], 3, 3)));
+test_interpreter!(interpret_matrix_div_3x3, "[10 20 30; 40 50 60; 70 80 90] / [10 10 10; 10 10 10; 10 10 10]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0], 3, 3)));
+
 
 // 4x4 Nominal Operations
-test_interpreter!(
-    interpret_matrix_add_4x4,
-    "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] + [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![
-            18.0, 26.0, 34.0, 42.0, 20.0, 28.0, 36.0, 44.0, 22.0, 30.0, 38.0, 46.0, 24.0, 32.0,
-            40.0, 48.0
-        ],
-        4,
-        4
-    ))
-);
+test_interpreter!(interpret_matrix_add_4x4, 
+          "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] + [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]", 
+          Value::MatrixF64(Matrix::from_vec(vec![18.0, 26.0, 34.0, 42.0, 
+                              20.0, 28.0, 36.0, 44.0, 
+                              22.0, 30.0, 38.0, 46.0, 
+                              24.0, 32.0, 40.0, 48.0], 4, 4)));
 
-test_interpreter!(
-    interpret_matrix_sub_4x4,
-    "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] - [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![
-            -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0,
-            -16.0, -16.0, -16.0, -16.0
-        ],
-        4,
-        4
-    ))
-);
+test_interpreter!(interpret_matrix_sub_4x4, 
+          "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] - [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]", 
+          Value::MatrixF64(Matrix::from_vec(vec![-16.0, -16.0, -16.0, -16.0, 
+                              -16.0, -16.0, -16.0, -16.0, 
+                              -16.0, -16.0, -16.0, -16.0, 
+                              -16.0, -16.0, -16.0, -16.0], 4, 4)));
 
-test_interpreter!(
-    interpret_matrix_mul_4x4,
-    "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] * [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![
-            17.0, 105.0, 225.0, 377.0, 36.0, 132.0, 260.0, 420.0, 57.0, 161.0, 297.0, 465.0, 80.0,
-            192.0, 336.0, 512.0
-        ],
-        4,
-        4
-    ))
-);
+test_interpreter!(interpret_matrix_mul_4x4, 
+          "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] * [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]", 
+          Value::MatrixF64(Matrix::from_vec(vec![17.0, 105.0, 225.0, 377.0, 
+                              36.0, 132.0, 260.0, 420.0, 
+                              57.0, 161.0, 297.0, 465.0, 
+                              80.0, 192.0, 336.0, 512.0], 4, 4)));
 
-test_interpreter!(
-    interpret_matrix_div_4x4,
-    "[2 3 4 5; 6 7 8 9; 10 11 12 13; 14 15 16 17] / [2 2 2 2; 3 3 3 3; 4 4 4 4; 5 5 5 5]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![
-            1.0,
-            2.0,
-            2.5,
-            2.8,
-            1.5,
-            2.3333333333333335,
-            2.75,
-            3.0,
-            2.0,
-            2.6666666666666665,
-            3.0,
-            3.2,
-            2.5,
-            3.0,
-            3.25,
-            3.4
-        ],
-        4,
-        4
-    ))
-);
+test_interpreter!(interpret_matrix_div_4x4, 
+          "[2 3 4 5; 6 7 8 9; 10 11 12 13; 14 15 16 17] / [2 2 2 2; 3 3 3 3; 4 4 4 4; 5 5 5 5]", 
+          Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 2.5, 2.8, 
+                              1.5, 2.3333333333333335, 2.75, 3.0, 
+                              2.0, 2.6666666666666665, 3.0, 3.2, 
+                              2.5, 3.0, 3.25, 3.4], 4, 4)));
 
 // 2x3 Nominal Operations
-test_interpreter!(
-    interpret_matrix_sub_2x3,
-    "[1 2 3; 4 5 6] - [7 8 9; 10 11 12]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![-6.0, -6.0, -6.0, -6.0, -6.0, -6.0],
-        2,
-        3
-    ))
-);
+test_interpreter!(interpret_matrix_sub_2x3, "[1 2 3; 4 5 6] - [7 8 9; 10 11 12]", 
+          Value::MatrixF64(Matrix::from_vec(vec![-6.0, -6.0, -6.0, 
+                              -6.0, -6.0, -6.0], 2, 3)));
 
 // 3x2 Nominal Operations
-test_interpreter!(
-    interpret_matrix_sub_3x2,
-    "[1 2; 3 4; 5 6] - [7 8; 9 10; 11 12]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![-6.0, -6.0, -6.0, -6.0, -6.0, -6.0],
-        3,
-        2
-    ))
-);
+test_interpreter!(interpret_matrix_sub_3x2, "[1 2; 3 4; 5 6] - [7 8; 9 10; 11 12]", 
+          Value::MatrixF64(Matrix::from_vec(vec![-6.0, -6.0, 
+                              -6.0, -6.0, 
+                              -6.0, -6.0], 3, 2)));
 
 // u8 2x2 Underflow/Overflow
 /*test_interpreter!(interpret_matrix_underflow_2x2_u8_sub,
   "[1 2; 3 4] - [5 6; 7 8]",
-  Ref::new(Matrix2::from_vec(vec![254u8, 255u8, 253u8, 254u8])).to_value()
+  Ref::new(Matrix2::from_vec(vec![254u8, 255u8, 253u8, 254u8])).to_value() 
 );*/
 /*test_interpreter!(interpret_matrix_overflow_2x2_u8_add,
   "[250 251; 252 253] + [10 11; 12 13]",
-  Ref::new(Matrix2::from_vec(vec![4u8, 6u8, 8u8, 10u8])).to_value()
+  Ref::new(Matrix2::from_vec(vec![4u8, 6u8, 8u8, 10u8])).to_value() 
 );*/
 
 // u8 3x3 Underflow/Overflow
@@ -1664,1221 +682,311 @@ test_interpreter!(
   Ref::new(Matrix3::from_vec(vec![4u8, 6u8, 8u8, 10u8, 11u8, 12u8, 16u8, 18u8, 20u8])).to_value()
 );*/
 
-test_interpreter!(
-    interpret_tuple,
-    "(1,true)",
-    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::Bool(Ref::new(true))
-    ])))
-);
-test_interpreter!(
-    interpret_tuple_nested,
-    r#"(1,("Hello",false))"#,
-    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::Tuple(Ref::new(MechTuple::from_vec(vec![
-            Value::String(Ref::new("Hello".to_string())),
-            Value::Bool(Ref::new(false))
-        ])))
-    ])))
-);
-test_interpreter!(
-    interpret_tuple_access,
-    r#"q := (10, "b", true); r := (q.3, q.2, q.1)"#,
-    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
-        Value::Bool(Ref::new(true)),
-        Value::String(Ref::new("b".to_string())),
-        Value::F64(Ref::new(10.0))
-    ])))
-);
-test_interpreter!(
-    interpret_tuple_destructure,
-    r#"a := (10, 11, 12); (x,y,z) := a; x + y + z"#,
-    Value::F64(Ref::new(33.0))
-);
-test_interpreter!(
-    interpret_tuple_assign,
-    r#"~t := (1,2); t.1 = 10; t.1 + t.2"#,
-    Value::F64(Ref::new(12.0))
-);
+test_interpreter!(interpret_tuple, "(1,true)", Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::F64(Ref::new(1.0)), Value::Bool(Ref::new(true))]))));
+test_interpreter!(interpret_tuple_nested, r#"(1,("Hello",false))"#, Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::F64(Ref::new(1.0)), Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::String(Ref::new("Hello".to_string())), Value::Bool(Ref::new(false))])))]))));
+test_interpreter!(interpret_tuple_access, r#"q := (10, "b", true); r := (q.3, q.2, q.1)"#, Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::Bool(Ref::new(true)), Value::String(Ref::new("b".to_string())), Value::F64(Ref::new(10.0))]))));
+test_interpreter!(interpret_tuple_destructure, r#"a := (10, 11, 12); (x,y,z) := a; x + y + z"#, Value::F64(Ref::new(33.0)));
+test_interpreter!(interpret_tuple_assign, r#"~t := (1,2); t.1 = 10; t.1 + t.2"#, Value::F64(Ref::new(12.0)));
 
-test_interpreter!(
-    interpret_slice,
-    "a := [1,2,3]; a[2]",
-    Value::F64(Ref::new(2.0))
-);
-test_interpreter!(
-    interpret_slice_v,
-    "a := [1,2,3]'; a[2]",
-    Value::F64(Ref::new(2.0))
-);
-test_interpreter!(
-    interpret_slice_2d,
-    "a := [1,2;3,4]; a[1,2]",
-    Value::F64(Ref::new(2.0))
-);
-test_interpreter!(
-    interpret_slice_f64,
-    "a := [1.0,2.0,3.0]; a[2]",
-    Value::F64(Ref::new(2.0))
-);
-test_interpreter!(
-    interpret_slice_2d_f64,
-    "a := [1,2;3,4]; a[2,1]",
-    Value::F64(Ref::new(3.0))
-);
-test_interpreter!(
-    interpret_slice_range_2d,
-    "x := [1 2 3; 4 5 6; 7 8 9]; x[2..=3, 2..=3]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 8.0, 6.0, 9.0], 2, 2))
-);
-test_interpreter!(
-    interpret_slice_sclar_range,
-    "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[2,ix]",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 6.0], 1, 2))
-);
-test_interpreter!(
-    interpret_slice_range_scalar,
-    "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[ix,2]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 8.0], 2, 1))
-);
-test_interpreter!(
-    interpret_slice_all,
-    "x := [1 2; 4 5]; x[:]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 4, 1))
-);
-test_interpreter!(
-    interpret_slice_all_2d,
-    "x := [1 2; 4 5]; x[:,2]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 5.0], 2, 1))
-);
-test_interpreter!(
-    interpret_slice_all_2d_row,
-    "x := [1 2; 4 5]; x[2,:]",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2))
-);
-test_interpreter!(
-    interpret_slice_all_2d_row2,
-    "x := [1 2 3 4 5; 6 7 8 9 10]; x[1,:]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5))
-);
-test_interpreter!(
-    interpret_slice_all_range,
-    "x := [1 2 3 4; 5 6 7 8]; x[:,1..=2]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 2.0, 6.0], 2, 2))
-);
-test_interpreter!(
-    interpret_slice_range_all,
-    "x := [1 2 3; 4 5 6; 7 8 9]; x[1..=2,:]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3))
-);
-test_interpreter!(
-    interpret_slice_range_dupe,
-    "x := [1 2 3; 4 5 6; 7 8 9]; x[[1 1],:]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0], 2, 3))
-);
-test_interpreter!(
-    interpret_slice_all_reshape,
-    "x := [1 2 3; 4 5 6; 7 8 9]; y := x[:,[1,1]]; y[:]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 1.0, 4.0, 7.0], 6, 1))
-);
-test_interpreter!(
-    interpret_slice_ix_ref,
-    "x := [94 53 13]; y := [3 3]; x[y]",
-    Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1))
-);
-test_interpreter!(
-    interpret_slice_ix_ref2,
-    "x := [94 53 13]; y := [3; 3]; x[y]",
-    Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1))
-);
-test_interpreter!(
-    interpret_slice_ix_ref3,
-    "x := [94 53 13]; y := 3; x[y]",
-    Value::F64(Ref::new(13.0))
-);
-test_interpreter!(
-    interpret_slice_logical_ix,
-    "x := [94 53 13]; ix := [false true true]; x[ix]",
-    Value::MatrixF64(Matrix::from_vec(vec![53.0, 13.0], 2, 1))
-);
-test_interpreter!(
-    interpret_slice_row,
-    "x := [94 53 13; 4 5 6; 7 8 9]; x[2,1..3]",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2))
-);
-test_interpreter!(
-    interpret_slice_col,
-    "x := [94 53 13; 4 5 6; 7 8 9]; x[1..3,2]",
-    Value::MatrixF64(Matrix::from_vec(vec![53.0, 5.0], 2, 1))
-);
-test_interpreter!(
-    interpret_slice_dynamic,
-    "x := 1..10; y := x'; ix := 1..5; y[ix]'",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_slice_all_bool,
-    "ix := [false, false, true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[:,ix]",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 3, 1))
-);
-test_interpreter!(
-    interpret_slice_ix_bool,
-    "ix := [false, false, true]; x := [1 2 3; 4 5 6; 7 8 9]; x[[1,2,3,3],ix]",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0, 9.0], 4, 1))
-);
-test_interpreter!(
-    interpret_slice_bool_bool,
-    "ix := [true, false, true]; x := [1 2 3; 4 5 6;7 8 9]; x[ix,ix]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 7.0, 3.0, 9.0], 2, 2))
-);
-test_interpreter!(
-    interpret_slice_ix_bool_v,
-    "ix1 := [false, false, true]; ix2 := [1,2,3,3]; x := [1 2 3; 4 5 6; 7 8 9]; x[ix1',ix2']",
-    Value::MatrixF64(Matrix::from_vec(vec![7.0, 8.0, 9.0, 9.0], 1, 4))
-);
+test_interpreter!(interpret_slice, "a := [1,2,3]; a[2]", Value::F64(Ref::new(2.0)));
+test_interpreter!(interpret_slice_v, "a := [1,2,3]'; a[2]", Value::F64(Ref::new(2.0)));
+test_interpreter!(interpret_slice_2d, "a := [1,2;3,4]; a[1,2]", Value::F64(Ref::new(2.0)));
+test_interpreter!(interpret_slice_f64, "a := [1.0,2.0,3.0]; a[2]", Value::F64(Ref::new(2.0)));
+test_interpreter!(interpret_slice_2d_f64, "a := [1,2;3,4]; a[2,1]", Value::F64(Ref::new(3.0)));
+test_interpreter!(interpret_slice_range_2d, "x := [1 2 3; 4 5 6; 7 8 9]; x[2..=3, 2..=3]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 8.0, 6.0, 9.0], 2, 2)));
+test_interpreter!(interpret_slice_sclar_range, "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[2,ix]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 6.0], 1, 2)));
+test_interpreter!(interpret_slice_range_scalar, "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[ix,2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 8.0], 2, 1)));
+test_interpreter!(interpret_slice_all, "x := [1 2; 4 5]; x[:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 4, 1)));
+test_interpreter!(interpret_slice_all_2d, "x := [1 2; 4 5]; x[:,2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 5.0], 2, 1)));
+test_interpreter!(interpret_slice_all_2d_row, "x := [1 2; 4 5]; x[2,:]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2)));
+test_interpreter!(interpret_slice_all_2d_row2, "x := [1 2 3 4 5; 6 7 8 9 10]; x[1,:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5)));
+test_interpreter!(interpret_slice_all_range, "x := [1 2 3 4; 5 6 7 8]; x[:,1..=2]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 2.0, 6.0], 2, 2)));
+test_interpreter!(interpret_slice_range_all, "x := [1 2 3; 4 5 6; 7 8 9]; x[1..=2,:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3)));
+test_interpreter!(interpret_slice_range_dupe, "x := [1 2 3; 4 5 6; 7 8 9]; x[[1 1],:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0], 2, 3)));
+test_interpreter!(interpret_slice_all_reshape, "x := [1 2 3; 4 5 6; 7 8 9]; y := x[:,[1,1]]; y[:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 1.0, 4.0, 7.0], 6, 1)));
+test_interpreter!(interpret_slice_ix_ref, "x := [94 53 13]; y := [3 3]; x[y]", Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1)));
+test_interpreter!(interpret_slice_ix_ref2, "x := [94 53 13]; y := [3; 3]; x[y]", Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1)));
+test_interpreter!(interpret_slice_ix_ref3, "x := [94 53 13]; y := 3; x[y]", Value::F64(Ref::new(13.0)));
+test_interpreter!(interpret_slice_logical_ix, "x := [94 53 13]; ix := [false true true]; x[ix]", Value::MatrixF64(Matrix::from_vec(vec![53.0, 13.0], 2, 1)));
+test_interpreter!(interpret_slice_row, "x := [94 53 13; 4 5 6; 7 8 9]; x[2,1..3]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2)));
+test_interpreter!(interpret_slice_col, "x := [94 53 13; 4 5 6; 7 8 9]; x[1..3,2]", Value::MatrixF64(Matrix::from_vec(vec![53.0, 5.0], 2, 1)));
+test_interpreter!(interpret_slice_dynamic, "x := 1..10; y := x'; ix := 1..5; y[ix]'", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
+test_interpreter!(interpret_slice_all_bool, "ix := [false, false, true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[:,ix]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 3, 1)));
+test_interpreter!(interpret_slice_ix_bool, "ix := [false, false, true]; x := [1 2 3; 4 5 6; 7 8 9]; x[[1,2,3,3],ix]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0, 9.0], 4, 1)));
+test_interpreter!(interpret_slice_bool_bool, "ix := [true, false, true]; x := [1 2 3; 4 5 6;7 8 9]; x[ix,ix]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 7.0, 3.0, 9.0], 2, 2)));
+test_interpreter!(interpret_slice_ix_bool_v, "ix1 := [false, false, true]; ix2 := [1,2,3,3]; x := [1 2 3; 4 5 6; 7 8 9]; x[ix1',ix2']", Value::MatrixF64(Matrix::from_vec(vec![7.0, 8.0, 9.0, 9.0], 1, 4)));
 
-test_interpreter!(
-    interpret_swizzle_record,
-    "x := {x: 1, y: 2, z: 3}; x.y,z,z",
-    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
-        Value::F64(Ref::new(2.0)),
-        Value::F64(Ref::new(3.0)),
-        Value::F64(Ref::new(3.0))
-    ])))
-);
+
+test_interpreter!(interpret_swizzle_record, "x := {x: 1, y: 2, z: 3}; x.y,z,z", Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::F64(Ref::new(2.0)),Value::F64(Ref::new(3.0)),Value::F64(Ref::new(3.0))]))));
 //test_interpreter!(interpret_swizzle_table, "x := | x<i64> y<u8>| 1 2 | 4 5 |; x.x,x,y", Value::Tuple(MechTuple::from_vec(vec![Matrix::Vector2(Ref::new(Vector2::from_vec(vec![Value::I64(Ref::new(1)),Value::I64(Ref::new(4))]))).to_value(),Matrix::Vector2(Ref::new(Vector2::from_vec(vec![Value::I64(Ref::new(1)),Value::I64(Ref::new(4))]))).to_value(),Matrix::Vector2(Ref::new(Vector2::from_vec(vec![Value::U8(Ref::new(2)),Value::U8(Ref::new(5))]))).to_value()])));
 
-test_interpreter!(
-    interpret_dot_record,
-    "x := {x: 1, y: 2, z: 3}; x.x",
-    Value::F64(Ref::new(1.0))
-);
+test_interpreter!(interpret_dot_record, "x := {x: 1, y: 2, z: 3}; x.x", Value::F64(Ref::new(1.0)));
 
-test_interpreter!(
-    interpret_dot_int_matrix,
-    "x := [1,2,3]; x.1",
-    Value::F64(Ref::new(1.0))
-);
+test_interpreter!(interpret_dot_int_matrix, "x := [1,2,3]; x.1", Value::F64(Ref::new(1.0)));
 #[cfg(all(feature = "i64", feature = "u8"))]
-test_interpreter!(
-    interpret_dot_index_table,
-    "x :=  | x<i64> y<u8>| 1 2 | 4 5|; x.x",
-    Value::MatrixI64(Matrix::from_vec(vec![1, 4], 2, 1))
-);
+test_interpreter!(interpret_dot_index_table, "x :=  | x<i64> y<u8>| 1 2 | 4 5|; x.x", Value::MatrixI64(Matrix::from_vec(vec![1, 4], 2, 1)));
 #[cfg(all(feature = "i64", feature = "u8"))]
-test_interpreter!(
-    interpret_dot_index_table2,
-    "x := | x<i64> y<u8>| 1 2 | 4 5|; x.y",
-    Value::MatrixU8(Matrix::from_vec(vec![2, 5], 2, 1))
-);
+test_interpreter!(interpret_dot_index_table2, "x := | x<i64> y<u8>| 1 2 | 4 5|; x.y", Value::MatrixU8(Matrix::from_vec(vec![2, 5], 2, 1)));
 #[cfg(feature = "i64")]
-test_interpreter!(
-    interpret_dot_index_table3,
-    "x := | x<i64> y<bool>| 1 true | 4 false | 3 true|; x.y",
-    Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 3, 1))
-);
+test_interpreter!(interpret_dot_index_table3, "x := | x<i64> y<bool>| 1 true | 4 false | 3 true|; x.y", Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 3, 1)));
 #[cfg(all(feature = "i64", feature = "u8"))]
-test_interpreter!(
-    interpret_dot_index_table4,
-    "x := | x<i64> y<u8>| 1 2| 3 4| 5 6| 7 8 |; x.x",
-    Value::MatrixI64(Matrix::from_vec(vec![1, 3, 5, 7], 4, 1))
-);
+test_interpreter!(interpret_dot_index_table4, "x := | x<i64> y<u8>| 1 2| 3 4| 5 6| 7 8 |; x.x", Value::MatrixI64(Matrix::from_vec(vec![1, 3, 5, 7], 4, 1)));
 #[cfg(all(feature = "i64", feature = "i8"))]
-test_interpreter!(
-    interpret_dot_index_table5,
-    "x := | x<i64> y<i8>| 1 2| 3 4| 5 6| 7 8 |; x.y",
-    Value::MatrixI8(Matrix::from_vec(vec![2, 4, 6, 8], 4, 1))
-);
+test_interpreter!(interpret_dot_index_table5, "x := | x<i64> y<i8>| 1 2| 3 4| 5 6| 7 8 |; x.y", Value::MatrixI8(Matrix::from_vec(vec![2, 4, 6, 8], 4, 1)));
 #[cfg(all(feature = "u32", feature = "f32", feature = "i8"))]
-test_interpreter!(
-    interpret_dot_index_table6,
-    "x := | x<u32> y<f32> z<i8>|1 2 3|4 5 6|; x.y",
-    Value::MatrixF32(Matrix::from_vec(vec![2.0, 5.0], 2, 1))
-);
+test_interpreter!(interpret_dot_index_table6, "x := | x<u32> y<f32> z<i8>|1 2 3|4 5 6|; x.y", Value::MatrixF32(Matrix::from_vec(vec![2.0, 5.0], 2, 1)));
 
-test_interpreter!(
-    interpret_set_empty,
-    "{_}",
-    Value::Set(Ref::new(MechSet::from_vec(vec![])))
-);
-test_interpreter!(
-    interpret_set_empty2,
-    "{}",
-    Value::Set(Ref::new(MechSet::from_vec(vec![])))
-);
-test_interpreter!(
-    interpret_set,
-    "{1,2,3}",
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::F64(Ref::new(2.0)),
-        Value::F64(Ref::new(3.0))
-    ])))
-);
-test_interpreter!(
-    interpret_record,
-    r#"{a: 1, b: "Hello"}"#,
-    Value::Record(Ref::new(MechRecord::from_vec(vec![
-        (
-            (55170961230981453, "a".to_string()),
-            Value::F64(Ref::new(1.0))
-        ),
-        (
-            (44311847522083591, "b".to_string()),
-            Value::String(Ref::new("Hello".to_string()))
-        )
-    ])))
-);
-test_interpreter!(
-    interpret_define_custom_record,
-    r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#,
-    Value::Record(Ref::new(MechRecord::from_vec(vec![
-        (
-            (55170961230981453, "a".to_string()),
-            Value::F64(Ref::new(1.0))
-        ),
-        (
-            (44311847522083591, "b".to_string()),
-            Value::F64(Ref::new(2.0))
-        )
-    ])))
-);
-test_interpreter!(
-    interpret_record_field_access,
-    r#"a := {x: 1,  y: 2}; a.y"#,
-    Value::F64(Ref::new(2.0))
-);
-test_interpreter!(
-    interpret_map,
-    r#"{"a": 1, "b": 2}"#,
-    Value::Map(Ref::new(MechMap::from_vec(vec![
-        (
-            Value::String(Ref::new("a".to_string())),
-            Value::F64(Ref::new(1.0))
-        ),
-        (
-            Value::String(Ref::new("b".to_string())),
-            Value::F64(Ref::new(2.0))
-        )
-    ])))
-);
-test_interpreter!(
-    interpret_map_access,
-    r#"m := {"a": 10, "b": 20}; m{"b"}"#,
-    Value::F64(Ref::new(20.0))
-);
-test_interpreter!(
-    interpret_map_assign,
-    r#"~m := {"a": 10, "b": 20}; m{"b"} = 42; m{"b"}"#,
-    Value::F64(Ref::new(42.0))
-);
-test_interpreter!(
-    interpret_map_assign2,
-    r#"~m := {"a": 10, "b": 20}; m{"c"} = 42; m{"c"}"#,
-    Value::F64(Ref::new(42.0))
-);
-test_interpreter!(
-    interpret_set_rational,
-    r#"{1/2, 3/4}"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::R64(Ref::new(R64::new(1, 2))),
-        Value::R64(Ref::new(R64::new(3, 4)))
-    ])))
-);
+test_interpreter!(interpret_set_empty,"{_}", Value::Set(Ref::new(MechSet::from_vec(vec![]))));
+test_interpreter!(interpret_set_empty2,"{}", Value::Set(Ref::new(MechSet::from_vec(vec![]))));
+test_interpreter!(interpret_set, "{1,2,3}", Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
+test_interpreter!(interpret_record,r#"{a: 1, b: "Hello"}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::String(Ref::new("Hello".to_string())))]))));
+test_interpreter!(interpret_define_custom_record, r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::F64(Ref::new(2.0)))]))));
+test_interpreter!(interpret_record_field_access,r#"a := {x: 1,  y: 2}; a.y"#, Value::F64(Ref::new(2.0)));
+test_interpreter!(interpret_map, r#"{"a": 1, "b": 2}"#, Value::Map(Ref::new(MechMap::from_vec(vec![(Value::String(Ref::new("a".to_string())),Value::F64(Ref::new(1.0))), (Value::String(Ref::new("b".to_string())),Value::F64(Ref::new(2.0)))]))));
+test_interpreter!(interpret_map_access, r#"m := {"a": 10, "b": 20}; m{"b"}"#, Value::F64(Ref::new(20.0)));
+test_interpreter!(interpret_map_assign, r#"~m := {"a": 10, "b": 20}; m{"b"} = 42; m{"b"}"#, Value::F64(Ref::new(42.0)));
+test_interpreter!(interpret_map_assign2, r#"~m := {"a": 10, "b": 20}; m{"c"} = 42; m{"c"}"#, Value::F64(Ref::new(42.0)));
+test_interpreter!(interpret_set_rational, r#"{1/2, 3/4}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::R64(Ref::new(R64::new(1, 2))), Value::R64(Ref::new(R64::new(3, 4)))]))));
 
-test_interpreter!(
-    interpret_function_define,
-    r#"foo(x<f64>) = z<f64> :=
+test_interpreter!(interpret_function_define,r#"foo(x<f64>) = z<f64> :=
 z := 10 + x.
-foo(10)"#,
-    Value::F64(Ref::new(20.0))
-);
-test_interpreter!(
-    interpret_function_define_2_args,
-    r#"foo(x<f64>, y<f64>) = z<f64> :=
+foo(10)"#, Value::F64(Ref::new(20.0)));
+test_interpreter!(interpret_function_define_2_args,r#"foo(x<f64>, y<f64>) = z<f64> :=
 z := x + y.
-foo(10,20)"#,
-    Value::F64(Ref::new(30.0))
-);
-test_interpreter!(
-    interpret_function_define_statements,
-    r#"foo(x<f64>, y<f64>) = z<f64> :=
+foo(10,20)"#, Value::F64(Ref::new(30.0)));
+test_interpreter!(interpret_function_define_statements,r#"foo(x<f64>, y<f64>) = z<f64> :=
     a := 1 + x
     b := y + 1
     z := a + b.
-foo(10,20)"#,
-    Value::F64(Ref::new(32.0))
-);
-test_interpreter!(
-    interpret_function_define_nested_call,
-    r#"bar(x<f64>) = z<f64> :=
+foo(10,20)"#, Value::F64(Ref::new(32.0)));
+test_interpreter!(interpret_function_define_nested_call,r#"bar(x<f64>) = z<f64> :=
 z := 10 + x.
 foo(x<f64>) = z<f64> :=
 z := bar(x).
-foo(10)"#,
-    Value::F64(Ref::new(20.0))
-);
+foo(10)"#, Value::F64(Ref::new(20.0)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_recursive_max,
-    r#"max(x<u64>, y<u64>) => <u64>
+test_interpreter!(interpret_function_recursive_max,r#"max(x<u64>, y<u64>) => <u64>
   ├ (0, y) => y
   ├ (x, 0) => x
   └ (x, y) => max(x - 1<u64>, y - 1<u64>) + 1<u64>.
-max(4<u64>, 7<u64>)"#,
-    Value::U64(Ref::new(7))
-);
+max(4<u64>, 7<u64>)"#, Value::U64(Ref::new(7)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_recursive_is_zero,
-    r#"is-zero(x<u64>) => <bool>
+test_interpreter!(interpret_function_recursive_is_zero,r#"is-zero(x<u64>) => <bool>
   ├ 0 => true
   └ * => false.
-is-zero(0<u64>)"#,
-    Value::Bool(Ref::new(true))
-);
+is-zero(0<u64>)"#, Value::Bool(Ref::new(true)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_recursive_factorial_tree,
-    r#"factorial(x<u64>) => <u64>
+test_interpreter!(interpret_function_recursive_factorial_tree,r#"factorial(x<u64>) => <u64>
   ├ 0 => 1
   └ n => n * factorial(n - 1<u64>).
-factorial(5<u64>)"#,
-    Value::U64(Ref::new(120))
-);
+factorial(5<u64>)"#, Value::U64(Ref::new(120)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_recursive_factorial_bar,
-    r#"factorial(x<u64>) => <u64>
+test_interpreter!(interpret_function_recursive_factorial_bar,r#"factorial(x<u64>) => <u64>
   | 0 => 1
   | n => n * factorial(n - 1<u64>).
-factorial(6<u64>)"#,
-    Value::U64(Ref::new(720))
-);
+factorial(6<u64>)"#, Value::U64(Ref::new(720)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_recursive_fib,
-    r#"fib(x<u64>) => <u64>
+test_interpreter!(interpret_function_recursive_fib,r#"fib(x<u64>) => <u64>
   ├ 0 => 0
   ├ 1 => 1
   └ n => fib(n - 1<u64>) + fib(n - 2<u64>).
-fib(10<u64>)"#,
-    Value::U64(Ref::new(55))
-);
+fib(10<u64>)"#, Value::U64(Ref::new(55)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_tail_recursive_countdown,
-    r#"countdown(n<u64>) => <u64>
+test_interpreter!(interpret_function_tail_recursive_countdown,r#"countdown(n<u64>) => <u64>
   └ n => countdown-acc(n, 0<u64>).
 
 countdown-acc(n<u64>, acc<u64>) => <u64>
   ├ (0<u64>, acc) => acc
   └ (n, acc) => countdown-acc(n - 1<u64>, acc + 1<u64>).
 
-countdown(50000<u64>)"#,
-    Value::U64(Ref::new(50000))
-);
+countdown(50000<u64>)"#, Value::U64(Ref::new(50000)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_function_recursive_power,
-    r#"power(x<u64>, y<u64>) => <u64>
+test_interpreter!(interpret_function_recursive_power,r#"power(x<u64>, y<u64>) => <u64>
   ├ (*, 0) => 1
   └ (x, y) => x * power(x, y - 1<u64>).
-power(2<u64>, 10<u64>)"#,
-    Value::U64(Ref::new(1024))
-);
-test_interpreter!(
-    interpret_function_call_native_vector,
-    "math/sin([1.570796327 1.570796327])",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2))
-);
-test_interpreter!(
-    interpret_function_call_native,
-    r#"math/sin(1.5707963267948966)"#,
-    Value::F64(Ref::new(1.0))
-);
-test_interpreter!(
-    interpret_function_call_native_cos,
-    r#"math/cos(0.0)"#,
-    Value::F64(Ref::new(1.0))
-);
-test_interpreter!(
-    interpret_function_call_native_vector2,
-    "math/cos([0.0 0.0])",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2))
-);
-test_interpreter!(
-    interpret_user_function_scalar_auto_broadcast,
-    r#"add-one(x<f64>) => <f64>
+power(2<u64>, 10<u64>)"#, Value::U64(Ref::new(1024)));
+test_interpreter!(interpret_function_call_native_vector, "math/sin([1.570796327 1.570796327])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
+test_interpreter!(interpret_function_call_native, r#"math/sin(1.5707963267948966)"#, Value::F64(Ref::new(1.0)));
+test_interpreter!(interpret_function_call_native_cos, r#"math/cos(0.0)"#, Value::F64(Ref::new(1.0)));
+test_interpreter!(interpret_function_call_native_vector2, "math/cos([0.0 0.0])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
+test_interpreter!(interpret_user_function_scalar_auto_broadcast, r#"add-one(x<f64>) => <f64>
   | * => x + 1.
-add-one([1 2 3])"#,
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
-);
+add-one([1 2 3])"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
 
-test_interpreter!(
-    interpret_set_value,
-    "~x := 1.23; x = 4.56;",
-    Value::F64(Ref::new(4.56))
-);
-test_interpreter!(
-    interpret_set_value_row_vector,
-    "~x := [6,2]; x[1] = 4;",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2))
-);
-test_interpreter!(
-    interpret_set_value_col_vector,
-    "~x := [false false true true]'; x[1] = true; x[1]",
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_value_scalar_scalar,
-    "~x := [1 2; 3 4]; x[2,2] = 42; x[2,2];",
-    Value::F64(Ref::new(42.0))
-);
-test_interpreter!(
-    interpret_set_value_all,
-    "~x := [1 2; 3 4]; x[:] = 42; x[1] + x[2] + x[3] + x[4]; ",
-    Value::F64(Ref::new(168.0))
-);
-test_interpreter!(
-    interpret_set_value_all_scalar,
-    "~x := [1 2; 3 4]; x[:,1] = 42; x[1] + x[2] + x[3] + x[4]",
-    Value::F64(Ref::new(90.0))
-);
-test_interpreter!(
-    interpret_set_value_scalar_all,
-    "~x := [1 2; 3 4]; x[1,:] = 42; x[1] + x[3];",
-    Value::F64(Ref::new(84.0))
-);
-test_interpreter!(
-    interpret_set_value_slice,
-    "~x := [1 2 3 4]; x[[1 3]] = 42; x[1] + x[2] + x[3] + x[4];",
-    Value::F64(Ref::new(90.0))
-);
-test_interpreter!(
-    interpret_set_value_scalar_slice,
-    "~x := [1 2 3; 4 5 6; 7 8 9]; x[1,[1,3]] = 42; x[1] + x[7];",
-    Value::F64(Ref::new(84.0))
-);
-test_interpreter!(
-    interpret_set_value_slice_slice,
-    "~x := [1 2 3; 5 6 7; 9 10 11]; x[1..3,1..3] = 42; x[1] + x[2] + x[4] + x[5]",
-    Value::F64(Ref::new(168.0))
-);
-test_interpreter!(
-    interpret_set_value_all_slice,
-    "~x := [1 2 3; 5 6 7]; x[:,1..3] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]",
-    Value::F64(Ref::new(178.0))
-);
-test_interpreter!(
-    interpret_set_value_all_slice_vec,
-    "~x := [1;6]; x = [4;5]; x[1] + x[2];",
-    Value::F64(Ref::new(9.0))
-);
-test_interpreter!(
-    interpret_set_value_slice_all,
-    "~x := [1 2 3; 5 6 7]'; x[1..3,:] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]",
-    Value::F64(Ref::new(178.0))
-);
-test_interpreter!(
-    interpret_set_value_slice_vec,
-    "~x := [1 2 3 4]; x[1..=3] = [10 20 30]; x[1] + x[2] + x[3] + x[4]",
-    Value::F64(Ref::new(64.0))
-);
+test_interpreter!(interpret_set_value,"~x := 1.23; x = 4.56;", Value::F64(Ref::new(4.56)));
+test_interpreter!(interpret_set_value_row_vector,"~x := [6,2]; x[1] = 4;", Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2)));
+test_interpreter!(interpret_set_value_col_vector,"~x := [false false true true]'; x[1] = true; x[1]", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_value_scalar_scalar,"~x := [1 2; 3 4]; x[2,2] = 42; x[2,2];", Value::F64(Ref::new(42.0)));
+test_interpreter!(interpret_set_value_all,"~x := [1 2; 3 4]; x[:] = 42; x[1] + x[2] + x[3] + x[4]; ", Value::F64(Ref::new(168.0)));
+test_interpreter!(interpret_set_value_all_scalar,"~x := [1 2; 3 4]; x[:,1] = 42; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(90.0)));
+test_interpreter!(interpret_set_value_scalar_all,"~x := [1 2; 3 4]; x[1,:] = 42; x[1] + x[3];", Value::F64(Ref::new(84.0)));
+test_interpreter!(interpret_set_value_slice,"~x := [1 2 3 4]; x[[1 3]] = 42; x[1] + x[2] + x[3] + x[4];", Value::F64(Ref::new(90.0)));
+test_interpreter!(interpret_set_value_scalar_slice,"~x := [1 2 3; 4 5 6; 7 8 9]; x[1,[1,3]] = 42; x[1] + x[7];", Value::F64(Ref::new(84.0)));
+test_interpreter!(interpret_set_value_slice_slice,"~x := [1 2 3; 5 6 7; 9 10 11]; x[1..3,1..3] = 42; x[1] + x[2] + x[4] + x[5]", Value::F64(Ref::new(168.0)));
+test_interpreter!(interpret_set_value_all_slice,"~x := [1 2 3; 5 6 7]; x[:,1..3] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]", Value::F64(Ref::new(178.0)));
+test_interpreter!(interpret_set_value_all_slice_vec,"~x := [1;6]; x = [4;5]; x[1] + x[2];", Value::F64(Ref::new(9.0)));
+test_interpreter!(interpret_set_value_slice_all,"~x := [1 2 3; 5 6 7]'; x[1..3,:] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]", Value::F64(Ref::new(178.0)));
+test_interpreter!(interpret_set_value_slice_vec,"~x := [1 2 3 4]; x[1..=3] = [10 20 30]; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(64.0)));
 
-test_interpreter!(
-    interpret_set_record_field,
-    "~x := {a: 1, b: true}; x.a = 2; x.a;",
-    Value::F64(Ref::new(2.0))
-);
-test_interpreter!(
-    interpret_set_record_field2,
-    "~x := {a: 1, b: true}; x.b = false; x.b;",
-    Value::Bool(Ref::new(false))
-);
+test_interpreter!(interpret_set_record_field,"~x := {a: 1, b: true}; x.a = 2; x.a;", Value::F64(Ref::new(2.0)));
+test_interpreter!(interpret_set_record_field2,"~x := {a: 1, b: true}; x.b = false; x.b;", Value::Bool(Ref::new(false)));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_set_record_field3,
-    "~x := {a: 1<u64>, b: true}; x.a = 2<u64>; x.a;",
-    Value::U64(Ref::new(2))
-);
+test_interpreter!(interpret_set_record_field3,"~x := {a: 1<u64>, b: true}; x.a = 2<u64>; x.a;", Value::U64(Ref::new(2)));
 
-test_interpreter!(
-    interpret_set_table_col,
-    "~x := | x<f64> y<f64> | 1 2 | 3 4 |; x.x = [42;46]; y := x.x; y[1] + y[2]",
-    Value::F64(Ref::new(88.0))
-);
-test_interpreter!(
-    interpret_set_table_col2,
-    "~x := | x<f64> y<f64> | 1 2 | 3 4 | 5 6 | 7 8 |; x.x = [42;46;47;48]; y := x.x; y[1] + y[2] + y[3] + y[4];",
-    Value::F64(Ref::new(183.0))
-);
-test_interpreter!(
-    interpret_set_table_col_string,
-    r#"~x := | x<string> | "a" | "b" |; x.x = ["c";"d"]; x.x"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec!["c".to_string(), "d".to_string()],
-        2,
-        1
-    ))
-);
+test_interpreter!(interpret_set_table_col,"~x := | x<f64> y<f64> | 1 2 | 3 4 |; x.x = [42;46]; y := x.x; y[1] + y[2]", Value::F64(Ref::new(88.0)));
+test_interpreter!(interpret_set_table_col2,"~x := | x<f64> y<f64> | 1 2 | 3 4 | 5 6 | 7 8 |; x.x = [42;46;47;48]; y := x.x; y[1] + y[2] + y[3] + y[4];", Value::F64(Ref::new(183.0)));
+test_interpreter!(interpret_set_table_col_string,r#"~x := | x<string> | "a" | "b" |; x.x = ["c";"d"]; x.x"#, Value::MatrixString(Matrix::from_vec(vec!["c".to_string(), "d".to_string()], 2, 1)));
 
-test_interpreter!(
-    interpret_set_logical,
-    "~x := [1 2 3]; ix := [true false true]; x[ix] = 4; x[1] + x[2] + x[3];",
-    Value::F64(Ref::new(10.0))
-);
-test_interpreter!(
-    interpret_set_logical2,
-    "~x := [1 2 3 4]; ix := [true false true true]; x[ix] = 5; x[1] + x[2] + x[3] + x[4];",
-    Value::F64(Ref::new(17.0))
-);
-test_interpreter!(
-    interpret_set_logical_scalar,
-    "~x := [1 2 3]; x[4 > 3] = 5; x[1] + x[2] + x[3]",
-    Value::F64(Ref::new(15.0))
-);
+test_interpreter!(interpret_set_logical,"~x := [1 2 3]; ix := [true false true]; x[ix] = 4; x[1] + x[2] + x[3];", Value::F64(Ref::new(10.0)));
+test_interpreter!(interpret_set_logical2,"~x := [1 2 3 4]; ix := [true false true true]; x[ix] = 5; x[1] + x[2] + x[3] + x[4];", Value::F64(Ref::new(17.0)));
+test_interpreter!(interpret_set_logical_scalar,"~x := [1 2 3]; x[4 > 3] = 5; x[1] + x[2] + x[3]", Value::F64(Ref::new(15.0)));
 
-test_interpreter!(
-    interpret_set_logical_vector_scalar_bool,
-    "~x := [1 2; 4 5]; x[[true false], 2] = 42; x[1] + x[2] + x[3] + x[4];",
-    Value::F64(Ref::new(52.0))
-);
-test_interpreter!(
-    interpret_set_logical_scalar_vector_bool,
-    "~x := [1 2; 4 5]; x[2,[false true]] = 42; x[1] + x[2] + x[3] + x[4]",
-    Value::F64(Ref::new(49.0))
-);
-test_interpreter!(
-    interpret_set_logical_vector_vector_bool,
-    "~x := [1 2; 4 5]; x[[true false],[false true]] = 42;",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 42.0, 5.0], 2, 2))
-);
+test_interpreter!(interpret_set_logical_vector_scalar_bool,"~x := [1 2; 4 5]; x[[true false], 2] = 42; x[1] + x[2] + x[3] + x[4];", Value::F64(Ref::new(52.0)));
+test_interpreter!(interpret_set_logical_scalar_vector_bool,"~x := [1 2; 4 5]; x[2,[false true]] = 42; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(49.0)));
+test_interpreter!(interpret_set_logical_vector_vector_bool,"~x := [1 2; 4 5]; x[[true false],[false true]] = 42;", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 42.0, 5.0], 2, 2)));
 
-test_interpreter!(
-    interpret_set_logical_all_vector_bool,
-    "~x := [1 2; 4 5]; x[:,[1 2]] = 42; x[1] + x[2] + x[3] + x[4]",
-    Value::F64(Ref::new(168.0))
-);
+test_interpreter!(interpret_set_logical_all_vector_bool,"~x := [1 2; 4 5]; x[:,[1 2]] = 42; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(168.0)));
 
-test_interpreter!(
-    interpret_horzcat,
-    "x := [1 2]; y := [x 3]; y[1] + y[2] + y[3]",
-    Value::F64(Ref::new(6.0))
-);
-test_interpreter!(
-    interpret_horzcat_r2m1,
-    "x := [1 2]; z := [3]; y := [x z]; y[1] + y[2] + y[3]",
-    Value::F64(Ref::new(6.0))
-);
-test_interpreter!(
-    interpret_horzcat_m1r2,
-    "x := [1 2]; z := [3]; y := [z x]; y[1] + y[2] + y[3]",
-    Value::F64(Ref::new(6.0))
-);
-test_interpreter!(
-    interpret_horzcat_sr2,
-    "x := [1 2]; y := [3 x]; y[1] + y[2] + y[3]",
-    Value::F64(Ref::new(6.0))
-);
+test_interpreter!(interpret_horzcat,"x := [1 2]; y := [x 3]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
+test_interpreter!(interpret_horzcat_r2m1,"x := [1 2]; z := [3]; y := [x z]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
+test_interpreter!(interpret_horzcat_m1r2,"x := [1 2]; z := [3]; y := [z x]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
+test_interpreter!(interpret_horzcat_sr2,"x := [1 2]; y := [3 x]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
 
-test_interpreter!(
-    interpret_horzcat_r2s,
-    "x := [1 2]; y := [x 3];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_m1,
-    "x := [1]; y := [x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0], 1, 1))
-);
-test_interpreter!(
-    interpret_horzcat_r2,
-    "x := [1 2]; y := [x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2))
-);
+test_interpreter!(interpret_horzcat_r2s,"x := [1 2]; y := [x 3];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
+test_interpreter!(interpret_horzcat_m1,"x := [1]; y := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0], 1, 1)));
+test_interpreter!(interpret_horzcat_r2,"x := [1 2]; y := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2)));
 
-test_interpreter!(
-    interpret_horzcat_sm1,
-    "x := [2]; y := [1 x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2))
-);
-test_interpreter!(
-    interpret_horzcat_m1s,
-    "x := [2]; y := [x 1]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0], 1, 2))
-);
-test_interpreter!(
-    interpret_horzcat_m1m1,
-    "x := [2]; y := [x x]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0], 1, 2))
-);
+test_interpreter!(interpret_horzcat_sm1,"x := [2]; y := [1 x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2)));
+test_interpreter!(interpret_horzcat_m1s,"x := [2]; y := [x 1]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0], 1, 2)));
+test_interpreter!(interpret_horzcat_m1m1,"x := [2]; y := [x x]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0], 1, 2)));
 
-test_interpreter!(
-    interpret_horzcat_sr3,
-    "x := [1 2 3]; y := [1 x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r3s,
-    "x := [1 2 3]; y := [x 1]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r2r2,
-    "x := [1 2]; y := [x x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1r3,
-    "x := [1 2 3]; z := [1]; y := [z x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r3m1,
-    "x := [1 2 3]; z := [1]; y := [x z]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
-);
+test_interpreter!(interpret_horzcat_sr3,"x := [1 2 3]; y := [1 x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r3s,"x := [1 2 3]; y := [x 1]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r2r2,"x := [1 2]; y := [x x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1r3,"x := [1 2 3]; z := [1]; y := [z x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r3m1,"x := [1 2 3]; z := [1]; y := [x z]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
 
-test_interpreter!(
-    interpret_horzcat_ssm1,
-    "x := [3]; y := [1 2 x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_sm1s,
-    "x := [3]; y := [1 x 2]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_m1ss,
-    "x := [3]; y := [x 1 2]",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 1.0, 2.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_m1m1m1,
-    "x := [3]; y := [x x x]",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 3.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_sm1m1,
-    "x := [3]; z:= [2]; y := [1 z x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_m1sm1,
-    "x := [3]; z:= [2]; y := [z 1 x]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0, 3.0], 1, 3))
-);
-test_interpreter!(
-    interpret_horzcat_m1m1s,
-    "x := [3]; z:= [2]; y := [z x 1]",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0], 1, 3))
-);
+test_interpreter!(interpret_horzcat_ssm1,"x := [3]; y := [1 2 x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
+test_interpreter!(interpret_horzcat_sm1s,"x := [3]; y := [1 x 2]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0], 1, 3)));
+test_interpreter!(interpret_horzcat_m1ss,"x := [3]; y := [x 1 2]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 1.0, 2.0], 1, 3)));
+test_interpreter!(interpret_horzcat_m1m1m1,"x := [3]; y := [x x x]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 3.0, 3.0], 1, 3)));
+test_interpreter!(interpret_horzcat_sm1m1,"x := [3]; z:= [2]; y := [1 z x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
+test_interpreter!(interpret_horzcat_m1sm1,"x := [3]; z:= [2]; y := [z 1 x]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0, 3.0], 1, 3)));
+test_interpreter!(interpret_horzcat_m1m1s,"x := [3]; z:= [2]; y := [z x 1]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0], 1, 3)));
 
-test_interpreter!(
-    interpret_horzcat_m1m1r2,
-    "x := [1]; y:= [2 3]; z := [x x y];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1r2m1,
-    "x := [1]; y:= [2 3]; z := [x y x];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r2m1m1,
-    "x := [1]; y:= [2 3]; z := [y x x];",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
-);
+test_interpreter!(interpret_horzcat_m1m1r2,"x := [1]; y:= [2 3]; z := [x x y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1r2m1,"x := [1]; y:= [2 3]; z := [x y x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r2m1m1,"x := [1]; y:= [2 3]; z := [y x x];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
 
-test_interpreter!(
-    interpret_horzcat_ssr2,
-    "y:= [2 3]; z := [1 1 y];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_sr2s,
-    "y:= [2 3]; z := [1 y 1];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r2ss,
-    "y:= [2 3]; z := [y 1 1];",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
-);
+test_interpreter!(interpret_horzcat_ssr2,"y:= [2 3]; z := [1 1 y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_sr2s,"y:= [2 3]; z := [1 y 1];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r2ss,"y:= [2 3]; z := [y 1 1];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
 
-test_interpreter!(
-    interpret_horzcat_sm1r2,
-    "x := [1]; y:= [2 3]; z := [1 x y];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1sr2,
-    "x := [1]; y:= [2 3]; z := [x 1 y];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_sr2m1,
-    "x := [1]; y:= [2 3]; z := [1 y x];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1r2s,
-    "x := [1]; y:= [2 3]; z := [x y 1];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r2sm1,
-    "x := [1]; y:= [2 3]; z := [y 1 x];",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_r2m1s,
-    "x := [1]; y:= [2 3]; z := [y x 1];",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
-);
+test_interpreter!(interpret_horzcat_sm1r2,"x := [1]; y:= [2 3]; z := [1 x y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1sr2, "x := [1]; y:= [2 3]; z := [x 1 y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_sr2m1, "x := [1]; y:= [2 3]; z := [1 y x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1r2s, "x := [1]; y:= [2 3]; z := [x y 1];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r2sm1, "x := [1]; y:= [2 3]; z := [y 1 x];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_r2m1s, "x := [1]; y:= [2 3]; z := [y x 1];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
 
-test_interpreter!(
-    interpret_horzcat_sssm1,
-    "x := [4]; y := [1 2 3 x];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1sss,
-    "x := [4]; y := [x 1 2 3];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_sm1ss,
-    "x := [4]; y := [1 x 2 3];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_ssm1s,
-    "x := [4]; y := [1 2 x 3];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 4.0, 3.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_sm1sm1,
-    "x := [4]; z := [5]; y := [1 x 2 z];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1ssm1,
-    "x := [4]; z := [5]; y := [x 1 2 z];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 5.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1sm1s,
-    "x := [4]; z := [5]; y := [x 1 z 2];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 2.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1m1sm1,
-    "x := [4]; z := [5]; w := [6]; y := [x z 1 w];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 1.0, 6.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1m1m1s,
-    "x := [4]; z := [5]; w := [6]; y := [x z w 1];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 1.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1sm1m1,
-    "x := [4]; z := [5]; w := [6]; y := [x 1 z w];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 6.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_sm1m1m1,
-    "x := [4]; z := [5]; w := [6]; y := [1 x z w];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 5.0, 6.0], 1, 4))
-);
-test_interpreter!(
-    interpret_horzcat_m1m1m1m1,
-    "x := [4]; z := [5]; w := [6]; v := [7]; y := [x z w v];",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 7.0], 1, 4))
-);
+test_interpreter!(interpret_horzcat_sssm1, "x := [4]; y := [1 2 3 x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1sss, "x := [4]; y := [x 1 2 3];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_sm1ss, "x := [4]; y := [1 x 2 3];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_ssm1s, "x := [4]; y := [1 2 x 3];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 4.0, 3.0], 1, 4)));
+test_interpreter!(interpret_horzcat_sm1sm1, "x := [4]; z := [5]; y := [1 x 2 z];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1ssm1, "x := [4]; z := [5]; y := [x 1 2 z];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 5.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1sm1s, "x := [4]; z := [5]; y := [x 1 z 2];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 2.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1m1sm1, "x := [4]; z := [5]; w := [6]; y := [x z 1 w];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 1.0, 6.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1m1m1s, "x := [4]; z := [5]; w := [6]; y := [x z w 1];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 1.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1sm1m1, "x := [4]; z := [5]; w := [6]; y := [x 1 z w];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 6.0], 1, 4)));
+test_interpreter!(interpret_horzcat_sm1m1m1, "x := [4]; z := [5]; w := [6]; y := [1 x z w];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 5.0, 6.0], 1, 4)));
+test_interpreter!(interpret_horzcat_m1m1m1m1, "x := [4]; z := [5]; w := [6]; v := [7]; y := [x z w v];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 7.0], 1, 4)));
 
-test_interpreter!(
-    interpret_horzcat_m2m2m2,
-    "x := [1 2]; y := [x x x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 1, 6))
-);
+test_interpreter!(interpret_horzcat_m2m2m2, "x := [1 2]; y := [x x x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 1, 6)));
 
-test_interpreter!(
-    interpret_horzcat_rd2,
-    "x := [1 2 3 4 5]; y := [x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5))
-);
-test_interpreter!(
-    interpret_horzcat_rd4,
-    "a := [1];b := [2 3];c := [4 5 6];d := [7 8 9 10];z := [a b c d];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
-        1,
-        10
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_rd3,
-    "a := [1 1]; z := [a a a];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0], 1, 6))
-);
-test_interpreter!(
-    interpret_horzcat_rdn,
-    "a := [1 2 3]; z := [0 0 0 0 0 a];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
-        1,
-        8
-    ))
-);
+test_interpreter!(interpret_horzcat_rd2, "x := [1 2 3 4 5]; y := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5)));
+test_interpreter!(interpret_horzcat_rd4, "a := [1];b := [2 3];c := [4 5 6];d := [7 8 9 10];z := [a b c d];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], 1, 10)));
+test_interpreter!(interpret_horzcat_rd3, "a := [1 1]; z := [a a a];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0], 1, 6)));
+test_interpreter!(interpret_horzcat_rdn, "a := [1 2 3]; z := [0 0 0 0 0 a];", Value::MatrixF64(Matrix::from_vec(vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0], 1, 8)));
 
-test_interpreter!(
-    interpret_horzcat_m2m2,
-    "a := [1 2; 3 4]; z := [a a];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 3.0, 2.0, 4.0, 1.0, 3.0, 2.0, 4.0],
-        2,
-        4
-    ))
-);
+test_interpreter!(interpret_horzcat_m2m2, "a := [1 2; 3 4]; z := [a a];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0, 1.0, 3.0, 2.0, 4.0], 2, 4)));
 
-test_interpreter!(
-    interpret_horzcat_m2x3v2,
-    "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [x z];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 7.0, 8.0],
-        2,
-        4
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_v2m2x3,
-    "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [z x];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![7.0, 8.0, 1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
-        2,
-        4
-    ))
-);
+test_interpreter!(interpret_horzcat_m2x3v2, "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [x z];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 7.0, 8.0], 2, 4)));
+test_interpreter!(interpret_horzcat_v2m2x3, "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [z x];", Value::MatrixF64(Matrix::from_vec(vec![7.0, 8.0, 1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 4)));
 
-test_interpreter!(
-    interpret_horzcat_v2v2,
-    "x := [1;2]; y := [x x];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 2, 2))
-);
-test_interpreter!(
-    interpret_horzcat_v3v3,
-    "x := [1;2;3]; y := [x x];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0], 3, 2))
-);
-test_interpreter!(
-    interpret_horzcat_v4v4,
-    "x := [1;2;3;4]; y := [x x];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
-        4,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_vdvd,
-    "x := [1;2;3;4;5]; y := [x x];",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0],
-        5,
-        2
-    ))
-);
+test_interpreter!(interpret_horzcat_v2v2, "x := [1;2]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 2, 2)));
+test_interpreter!(interpret_horzcat_v3v3, "x := [1;2;3]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0], 3, 2)));
+test_interpreter!(interpret_horzcat_v4v4, "x := [1;2;3;4]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0], 4, 2)));
+test_interpreter!(interpret_horzcat_vdvd, "x := [1;2;3;4;5]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0], 5, 2)));
 
-test_interpreter!(
-    interpret_horzcat_v2m2,
-    "x := [1 2; 3 4]; y := [1; 2]; z := [y x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 3.0, 2.0, 4.0], 2, 3))
-);
-test_interpreter!(
-    interpret_horzcat_m2v2,
-    "x := [1 2; 3 4]; y := [1; 2]; z := [x y]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0, 1.0, 2.0], 2, 3))
-);
+test_interpreter!(interpret_horzcat_v2m2, "x := [1 2; 3 4]; y := [1; 2]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 3.0, 2.0, 4.0], 2, 3)));
+test_interpreter!(interpret_horzcat_m2v2, "x := [1 2; 3 4]; y := [1; 2]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0, 1.0, 2.0], 2, 3)));
 
-test_interpreter!(
-    interpret_horzcat_m3x2v3,
-    "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [x y]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0, 1.0, 2.0, 3.0],
-        3,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_v3m3x2,
-    "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [y x]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 3.0, 1.0, 3.0, 5.0, 2.0, 4.0, 6.0],
-        3,
-        3
-    ))
-);
 
-test_interpreter!(
-    interpret_horzcat_mdv4,
-    "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [x y]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0, 1.0, 2.0, 3.0, 4.0],
-        4,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_v4md,
-    "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [y x]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 3.0, 4.0, 1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0],
-        4,
-        3
-    ))
-);
+test_interpreter!(interpret_horzcat_m3x2v3, "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0, 1.0, 2.0, 3.0], 3, 3)));
+test_interpreter!(interpret_horzcat_v3m3x2, "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 3)));
 
-test_interpreter!(
-    interpret_horzcat_mdvd,
-    "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [x y]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0, 1.0, 2.0, 3.0, 4.0, 5.0],
-        5,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_vdmd,
-    "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [y x]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0],
-        5,
-        3
-    ))
-);
+test_interpreter!(interpret_horzcat_mdv4, "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0, 1.0, 2.0, 3.0, 4.0], 4, 3)));
+test_interpreter!(interpret_horzcat_v4md, "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0], 4, 3)));
 
-test_interpreter!(
-    interpret_horzcat_m2,
-    "x := [1 2; 3 4]; z := [x]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2))
-);
+test_interpreter!(interpret_horzcat_mdvd, "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0, 1.0, 2.0, 3.0, 4.0, 5.0], 5, 3)));
+test_interpreter!(interpret_horzcat_vdmd, "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0], 5, 3)));
 
-test_interpreter!(
-    interpret_horzcat_m3v3,
-    "x := [1 2 3; 4 5 6; 7 8 9]; y := [1;2;3]; z := [x y]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0, 1.0, 2.0, 3.0],
-        3,
-        4
-    ))
-);
+test_interpreter!(interpret_horzcat_m2, "x := [1 2; 3 4]; z := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
 
-test_interpreter!(
-    interpret_horzcat_v2v2v2v2,
-    "x := [1; 2;]; z := [x x x x] ",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
-        2,
-        4
-    ))
-);
-test_interpreter!(
-    interpret_horzcat_v2v2v2v2v2,
-    "x := [1; 2;]; z := [x x x x x] ",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
-        2,
-        5
-    ))
-);
-test_interpreter!(
-    interpret_vertcat_vd2,
-    "x := [1;2;3;4]; z := [5]; y := [x;z]",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 5, 1))
-);
-test_interpreter!(
-    interpret_vertcat_vd3,
-    "x := [1;2;3]; z := [5]; y := [z;z;x]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 1.0, 2.0, 3.0], 5, 1))
-);
-test_interpreter!(
-    interpret_vertcat_m1m1m1m1,
-    "x := [5]; y := [x;x;x;x]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0], 4, 1))
-);
-test_interpreter!(
-    interpret_vertcat_vd4,
-    "x := [5]; z := [1;2]; y := [x;x;x;z]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 1.0, 2.0], 5, 1))
-);
+test_interpreter!(interpret_horzcat_m3v3, "x := [1 2 3; 4 5 6; 7 8 9]; y := [1;2;3]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0, 1.0, 2.0, 3.0], 3, 4)));
 
-test_interpreter!(
-    interpret_vertcat_vdn,
-    "x := [5]; y := [x;x;x;x;x]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0, 5.0], 5, 1))
-);
-test_interpreter!(
-    interpret_vertcat_r2m2,
-    "x := [5 2;3 4]; y := [8 9];z := [y;x]",
-    Value::MatrixF64(Matrix::from_vec(vec![8.0, 5.0, 3.0, 9.0, 2.0, 4.0], 3, 2))
-);
-test_interpreter!(
-    interpret_vertcat_m2r2,
-    "x := [5 2;3 4]; y := [8 9];z := [x;y]",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 3.0, 8.0, 2.0, 4.0, 9.0], 3, 2))
-);
+test_interpreter!(interpret_horzcat_v2v2v2v2, "x := [1; 2;]; z := [x x x x] ", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 2, 4)));
+test_interpreter!(interpret_horzcat_v2v2v2v2v2, "x := [1; 2;]; z := [x x x x x] ", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 2, 5)));
+test_interpreter!(interpret_vertcat_vd2, "x := [1;2;3;4]; z := [5]; y := [x;z]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 5, 1)));
+test_interpreter!(interpret_vertcat_vd3, "x := [1;2;3]; z := [5]; y := [z;z;x]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 1.0, 2.0, 3.0], 5, 1)));
+test_interpreter!(interpret_vertcat_m1m1m1m1, "x := [5]; y := [x;x;x;x]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0], 4, 1)));
+test_interpreter!(interpret_vertcat_vd4, "x := [5]; z := [1;2]; y := [x;x;x;z]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 1.0, 2.0], 5, 1)));
 
-test_interpreter!(
-    interpret_vertcat_r2m2x3,
-    "x := [1 2 3; 4 5 6]; y := [7 8 9]; z := [y;x]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![7.0, 1.0, 4.0, 8.0, 2.0, 5.0, 9.0, 3.0, 6.0],
-        3,
-        3
-    ))
-);
+test_interpreter!(interpret_vertcat_vdn, "x := [5]; y := [x;x;x;x;x]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0, 5.0], 5, 1)));
+test_interpreter!(interpret_vertcat_r2m2, "x := [5 2;3 4]; y := [8 9];z := [y;x]", Value::MatrixF64(Matrix::from_vec(vec![8.0, 5.0, 3.0, 9.0, 2.0, 4.0], 3, 2)));
+test_interpreter!(interpret_vertcat_m2r2, "x := [5 2;3 4]; y := [8 9];z := [x;y]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 3.0, 8.0, 2.0, 4.0, 9.0], 3, 2)));
 
-test_interpreter!(
-    interpret_stats_sum_rowm2,
-    "x := [1 2; 4 5]; y := stats/sum/row(x);",
-    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0], 1, 2))
-);
+test_interpreter!(interpret_vertcat_r2m2x3, "x := [1 2 3; 4 5 6]; y := [7 8 9]; z := [y;x]", Value::MatrixF64(Matrix::from_vec(vec![7.0, 1.0, 4.0, 8.0, 2.0, 5.0, 9.0, 3.0, 6.0], 3, 3)));
 
-test_interpreter!(
-    interpret_add_assign,
-    "~x := 10; x += 20",
-    Value::F64(Ref::new(30.0))
-);
-test_interpreter!(
-    interpret_add_assign_formula,
-    "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] += y;",
-    Value::MatrixF64(Matrix::from_vec(vec![11.0, 7.0, 8.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_add_assign_formula_all_m2m2,
-    "~x := [1 2; 3 4]; y := [1 1 1 1];z := [10 10; 20 20]; x[y,:] += z;",
-    Value::MatrixF64(Matrix::from_vec(vec![61.0, 3.0, 62.0, 4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_sub_assign_formula,
-    "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] -= y;",
-    Value::MatrixF64(Matrix::from_vec(vec![-9.0, -3.0, -2.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_mul_assign_formula,
-    "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] *= y;",
-    Value::MatrixF64(Matrix::from_vec(vec![25.0, 10.0, 15.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_add_assign_range,
-    "~x := [1 2; 3 4]; x[1..3] += 1",
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_div_assign_range_all,
-    "~x := [1 2; 3 4; 5 6]; x[1..3,:] /= [1 2; 3 4];",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 5.0, 1.0, 1.0, 6.0], 3, 2))
-);
-test_interpreter!(
-    interpret_div_assign_range,
-    "~x := [1 2 3 4]; x[1..3] /= 2;",
-    Value::MatrixF64(Matrix::from_vec(vec![0.5, 1.0, 3.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_add_assign_range_vec,
-    "~x := [1 2 3 4]; x[1..3] += 2;",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 3.0, 4.0], 1, 4))
-);
+test_interpreter!(interpret_stats_sum_rowm2, "x := [1 2; 4 5]; y := stats/sum/row(x);", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0], 1, 2)));
 
-test_interpreter!(
-    interpret_set_logical_ram2m2_bool,
-    "~x := [1 2; 3 4]; y := [true false]; z := [10 20; 30 40]; x[y,:] = z;",
-    Value::MatrixF64(Matrix::from_vec(vec![10.0, 3.0, 20.0, 4.0], 2, 2))
-);
-test_interpreter!(
-    interpret_set_logical_ram3m3_bool,
-    "~x := [1 2 3; 4 5 6; 7 8 9]; y := [true false true]; z := [10 20 30; 40 50 60; 70 80 90]; x[y,:] = z;",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![10.0, 4.0, 70.0, 20.0, 5.0, 80.0, 30.0, 6.0, 90.0],
-        3,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_set_logical_ram4m4_bool,
-    "~x := [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]; y := [true false true false]; z := [10 20 30 40; 50 60 70 80; 90 100 110 120; 130 140 150 160]; x[y,:] = z;",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![
-            10.0, 5.0, 90.0, 13.0, 20.0, 6.0, 100.0, 14.0, 30.0, 7.0, 110.0, 15.0, 40.0, 8.0,
-            120.0, 16.0
-        ],
-        4,
-        4
-    ))
-);
+test_interpreter!(interpret_add_assign, "~x := 10; x += 20", Value::F64(Ref::new(30.0)));
+test_interpreter!(interpret_add_assign_formula, "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] += y;", Value::MatrixF64(Matrix::from_vec(vec![11.0, 7.0, 8.0, 4.0], 1, 4)));
+test_interpreter!(interpret_add_assign_formula_all_m2m2,"~x := [1 2; 3 4]; y := [1 1 1 1];z := [10 10; 20 20]; x[y,:] += z;", Value::MatrixF64(Matrix::from_vec(vec![61.0, 3.0, 62.0, 4.0], 2, 2)));
+test_interpreter!(interpret_sub_assign_formula, "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] -= y;", Value::MatrixF64(Matrix::from_vec(vec![-9.0, -3.0, -2.0, 4.0], 1, 4)));
+test_interpreter!(interpret_mul_assign_formula, "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] *= y;", Value::MatrixF64(Matrix::from_vec(vec![25.0, 10.0, 15.0, 4.0], 1, 4)));
+test_interpreter!(interpret_add_assign_range, "~x := [1 2; 3 4]; x[1..3] += 1", Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2)));
+test_interpreter!(interpret_div_assign_range_all, "~x := [1 2; 3 4; 5 6]; x[1..3,:] /= [1 2; 3 4];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 5.0, 1.0, 1.0, 6.0], 3, 2)));
+test_interpreter!(interpret_div_assign_range, "~x := [1 2 3 4]; x[1..3] /= 2;", Value::MatrixF64(Matrix::from_vec(vec![0.5, 1.0, 3.0, 4.0], 1, 4)));
+test_interpreter!(interpret_add_assign_range_vec, "~x := [1 2 3 4]; x[1..3] += 2;", Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 3.0, 4.0], 1, 4)));
 
-test_interpreter!(
-    interpret_set_logical_ram2m2,
-    "~x := [1 2; 3 4]; y := [2 1]; x[y,:] = x;",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0], 2, 2))
-);
-test_interpreter!(
-    interpret_set_logical_ram3m3,
-    "~x := [1 2 3; 4 5 6; 7 8 9]; y := [2 1 3]; x[y,:] = x;",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![1.0, 1.0, 7.0, 2.0, 2.0, 8.0, 3.0, 3.0, 9.0],
-        3,
-        3
-    ))
-);
+test_interpreter!(interpret_set_logical_ram2m2_bool,"~x := [1 2; 3 4]; y := [true false]; z := [10 20; 30 40]; x[y,:] = z;", Value::MatrixF64(Matrix::from_vec(vec![10.0, 3.0, 20.0, 4.0], 2, 2)));
+test_interpreter!(interpret_set_logical_ram3m3_bool,"~x := [1 2 3; 4 5 6; 7 8 9]; y := [true false true]; z := [10 20 30; 40 50 60; 70 80 90]; x[y,:] = z;", Value::MatrixF64(Matrix::from_vec(vec![10.0, 4.0, 70.0, 20.0, 5.0, 80.0, 30.0, 6.0, 90.0], 3, 3)));
+test_interpreter!(interpret_set_logical_ram4m4_bool,"~x := [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]; y := [true false true false]; z := [10 20 30 40; 50 60 70 80; 90 100 110 120; 130 140 150 160]; x[y,:] = z;", Value::MatrixF64(Matrix::from_vec(vec![10.0, 5.0, 90.0, 13.0, 20.0, 6.0, 100.0, 14.0, 30.0, 7.0, 110.0, 15.0, 40.0, 8.0, 120.0, 16.0], 4, 4)));
 
-test_interpreter!(
-    interpret_modulus,
-    "[1 2 3 4 5] % 5",
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 0.0], 1, 5))
-);
+test_interpreter!(interpret_set_logical_ram2m2,"~x := [1 2; 3 4]; y := [2 1]; x[y,:] = x;", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0], 2, 2)));
+test_interpreter!(interpret_set_logical_ram3m3,"~x := [1 2 3; 4 5 6; 7 8 9]; y := [2 1 3]; x[y,:] = x;", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 7.0, 2.0, 2.0, 8.0, 3.0, 3.0, 9.0], 3, 3)));
 
-test_interpreter!(
-    interpret_horzcat_rdn2,
-    "y := [4 5 6]; [y y y * 2]",
-    Value::MatrixF64(Matrix::from_vec(
-        vec![4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0],
-        1,
-        9
-    ))
-);
+test_interpreter!(interpret_modulus,"[1 2 3 4 5] % 5", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 0.0], 1, 5)));
+
+test_interpreter!(interpret_horzcat_rdn2, "y := [4 5 6]; [y y y * 2]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0], 1, 9)));
 
 #[cfg(feature = "u8")]
-test_interpreter!(
-    interpret_fancy_table,
-    r#"x := |x<f64> y<u8>|
+test_interpreter!(interpret_fancy_table, r#"x := |x<f64> y<u8>|
      |1      2    |
      |3      4    |
      |5      6    |
-x.x"#,
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0], 3, 1))
-);
+x.x"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0], 3, 1)));
 
-test_interpreter!(
-    interpret_fancy_matrix,
-    r#"
+test_interpreter!(interpret_fancy_matrix, r#"
 x := ┏       ┓
      ┃ 1   2 ┃
      ┃ 3   4 ┃
-     ┗       ┛"#,
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2))
-);
+     ┗       ┛"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
 
 #[cfg(all(feature = "f32", feature = "u64"))]
-test_interpreter!(
-    interpret_fancy_table2,
-    r#"
+test_interpreter!(interpret_fancy_table2, r#"
 x:=╭────────┬────────╮
    │ x<u64> │ y<f32> │
    ├────────┼────────┤
@@ -2886,27 +994,19 @@ x:=╭────────┬────────╮
    ├────────┼────────┤
    │   3    │   4    │
    ╰────────┴────────╯
-x.x"#,
-    Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1))
-);
+x.x"#, Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1)));
 
 #[cfg(all(feature = "f32", feature = "u64"))]
-test_interpreter!(
-    interpret_fancy_table3,
-    r#"
+test_interpreter!(interpret_fancy_table3, r#"
 x:=╭────────┬────────╮
    │ x<u64> │ y<f32> │
    │   1    │   2    │
    │   3    │   4    │
    ╰────────┴────────╯
-x.x"#,
-    Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1))
-);
+x.x"#, Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1)));
 
 #[cfg(all(feature = "f32", feature = "u64"))]
-test_interpreter!(
-    interpret_fancy_table4,
-    r#"
+test_interpreter!(interpret_fancy_table4, r#"
 x:=╭────────┬────────╮
    │ x<u64> │ y<f32> │
    ├────────┼────────┤
@@ -2917,630 +1017,150 @@ x:=╭────────┬────────╮
    │   3    │   4    │
    │        │        │
    ╰────────┴────────╯
-x.x"#,
-    Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1))
-);
+x.x"#, Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1)));
 #[cfg(feature = "f32")]
-test_interpreter!(
-    interpret_table_access_element,
-    r#"a:=|x<f32>|1.2|1.3|; a.x[1]"#,
-    Value::F32(Ref::new(1.2))
-);
+test_interpreter!(interpret_table_access_element, r#"a:=|x<f32>|1.2|1.3|; a.x[1]"#, Value::F32(Ref::new(1.2)));
 #[cfg(all(feature = "f32", feature = "u8"))]
-test_interpreter!(
-    interpret_table_access_row,
-    r#"x:=|a<f32> b<u8>|1.2 3 |1.3 4|; x[2]"#,
-    Value::Record(Ref::new(MechRecord::new(vec![
-        ("a", Value::F32(Ref::new(1.3))),
-        ("b", Value::U8(Ref::new(4)))
-    ])))
-);
-test_interpreter!(
-    interpret_table_append_row,
-    r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {a<f64>: 5, b<f64>: 6}; x[3]"#,
-    Value::Record(Ref::new(MechRecord::new(vec![
-        ("a", Value::F64(Ref::new(5.0))),
-        ("b", Value::F64(Ref::new(6.0)))
-    ])))
-);
-test_interpreter!(
-    interpret_table_append_row2,
-    r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {b<f64>: 6, a<f64>: 5}; x[3]"#,
-    Value::Record(Ref::new(MechRecord::new(vec![
-        ("b", Value::F64(Ref::new(6.0))),
-        ("a", Value::F64(Ref::new(5.0)))
-    ])))
-);
+test_interpreter!(interpret_table_access_row, r#"x:=|a<f32> b<u8>|1.2 3 |1.3 4|; x[2]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::F32(Ref::new(1.3))),("b",Value::U8(Ref::new(4)))]))));
+test_interpreter!(interpret_table_append_row, r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {a<f64>: 5, b<f64>: 6}; x[3]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::F64(Ref::new(5.0))),("b",Value::F64(Ref::new(6.0)))]))));
+test_interpreter!(interpret_table_append_row2, r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {b<f64>: 6, a<f64>: 5}; x[3]"#, Value::Record(Ref::new(MechRecord::new(vec![("b",Value::F64(Ref::new(6.0))),("a",Value::F64(Ref::new(5.0)))]))));
 #[cfg(all(feature = "u8", feature = "u64"))]
-test_interpreter!(
-    interpret_table_append_row3,
-    r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |; a:=13; b:=14; y := {c<bool>: false, a<u64>: a, b<u8>: b}; x += y; x[3]"#,
-    Value::Record(Ref::new(MechRecord::new(vec![
-        ("a", Value::U64(Ref::new(13))),
-        ("b", Value::U8(Ref::new(14)))
-    ])))
-);
+test_interpreter!(interpret_table_append_row3, r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |; a:=13; b:=14; y := {c<bool>: false, a<u64>: a, b<u8>: b}; x += y; x[3]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::U64(Ref::new(13))),("b",Value::U8(Ref::new(14)))]))));
 #[cfg(all(feature = "u8", feature = "u64"))]
-test_interpreter!(
-    interpret_table_append_table,
-    r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |;y := |a<u64> b<u8>| 5 6 | 7 8 |; x += y; x[4]"#,
-    Value::Record(Ref::new(MechRecord::new(vec![
-        ("a", Value::U64(Ref::new(7))),
-        ("b", Value::U8(Ref::new(8)))
-    ])))
-);
+test_interpreter!(interpret_table_append_table, r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |;y := |a<u64> b<u8>| 5 6 | 7 8 |; x += y; x[4]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::U64(Ref::new(7))),("b",Value::U8(Ref::new(8)))]))));
 #[cfg(all(feature = "u8", feature = "u64"))]
-test_interpreter!(
-    interpret_table_select_rows,
-    r#"x := |a<u64> b<u8>| 1 2 | 3 4 | 5 6 |; x[[1,3]]"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("a", Value::U64(Ref::new(1))),
-                ("b", Value::U8(Ref::new(2)))
-            ]),
-            MechRecord::new(vec![
-                ("a", Value::U64(Ref::new(5))),
-                ("b", Value::U8(Ref::new(6)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(interpret_table_select_rows, r#"x := |a<u64> b<u8>| 1 2 | 3 4 | 5 6 |; x[[1,3]]"#, Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("a",Value::U64(Ref::new(1))),("b",Value::U8(Ref::new(2)))]),MechRecord::new(vec![("a",Value::U64(Ref::new(5))),("b",Value::U8(Ref::new(6)))]),]).expect("Failed to create MechTable"))));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_table_select_logical,
-    r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.y}"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("x", Value::U64(Ref::new(2))),
-                ("y", Value::Bool(Ref::new(true)))
-            ]),
-            MechRecord::new(vec![
-                ("x", Value::U64(Ref::new(5))),
-                ("y", Value::Bool(Ref::new(true)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(interpret_table_select_logical, r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.y}"#, Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x",Value::U64(Ref::new(2))),("y",Value::Bool(Ref::new(true)))]),MechRecord::new(vec![("x",Value::U64(Ref::new(5))),("y",Value::Bool(Ref::new(true)))]),]).expect("Failed to create MechTable"))));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_table_select_logical2,
-    r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.x > 3<u64>}"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("x", Value::U64(Ref::new(4))),
-                ("y", Value::Bool(Ref::new(false)))
-            ]),
-            MechRecord::new(vec![
-                ("x", Value::U64(Ref::new(5))),
-                ("y", Value::Bool(Ref::new(true)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(interpret_table_select_logical2, r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.x > 3<u64>}"#, Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x",Value::U64(Ref::new(4))),("y",Value::Bool(Ref::new(false)))]),MechRecord::new(vec![("x",Value::U64(Ref::new(5))),("y",Value::Bool(Ref::new(true)))]),]).expect("Failed to create MechTable"))));
 
-test_interpreter!(
-    interpret_table_from_matrix,
-    r#"x := [1 2; 3 4]; a<|foo<f64>,bar<f64>|> := x"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("foo", Value::F64(Ref::new(1.0))),
-                ("bar", Value::F64(Ref::new(2.0)))
-            ]),
-            MechRecord::new(vec![
-                ("foo", Value::F64(Ref::new(3.0))),
-                ("bar", Value::F64(Ref::new(4.0)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
-test_interpreter!(
-    interpret_table_from_matrix_infer_any_columns,
-    r#"x := [1 2; 3 4]; c<|foo<*> bar<*>|:2> := x"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("foo", Value::F64(Ref::new(1.0))),
-                ("bar", Value::F64(Ref::new(2.0)))
-            ]),
-            MechRecord::new(vec![
-                ("foo", Value::F64(Ref::new(3.0))),
-                ("bar", Value::F64(Ref::new(4.0)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(interpret_table_from_matrix,r#"x := [1 2; 3 4]; a<|foo<f64>,bar<f64>|> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("foo", Value::F64(Ref::new(1.0))),("bar", Value::F64(Ref::new(2.0)))]),MechRecord::new(vec![("foo", Value::F64(Ref::new(3.0))),("bar", Value::F64(Ref::new(4.0)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(interpret_table_from_matrix_infer_any_columns,r#"x := [1 2; 3 4]; c<|foo<*> bar<*>|:2> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("foo", Value::F64(Ref::new(1.0))),("bar", Value::F64(Ref::new(2.0)))]),MechRecord::new(vec![("foo", Value::F64(Ref::new(3.0))),("bar", Value::F64(Ref::new(4.0)))]),]).expect("Failed to create MechTable"))));
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_table_from_matrix_infer_kinds_and_size,
-    r#"x := [1 2; 3 4]; b<|foo,bar|:1> := x"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![MechRecord::new(vec![
-            ("foo", Value::U64(Ref::new(1))),
-            ("bar", Value::U64(Ref::new(2)))
-        ]),])
-        .expect("Failed to create MechTable")
-    ))
-);
-test_interpreter!(
-    interpret_table_from_matrix2,
-    r#"x := ["true" "false"; "true" "false"]; a<|x<string> y<string>|> := x"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("x", Value::String(Ref::new("true".to_string()))),
-                ("y", Value::String(Ref::new("false".to_string())))
-            ]),
-            MechRecord::new(vec![
-                ("x", Value::String(Ref::new("true".to_string()))),
-                ("y", Value::String(Ref::new("false".to_string())))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
-test_interpreter!(
-    interpret_table_from_matrix3,
-    r#"x:=[true false; true false]; a<|x<bool> y<bool>|> := x;"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("x", Value::Bool(Ref::new(true))),
-                ("y", Value::Bool(Ref::new(false)))
-            ]),
-            MechRecord::new(vec![
-                ("x", Value::Bool(Ref::new(true))),
-                ("y", Value::Bool(Ref::new(false)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(interpret_table_from_matrix_infer_kinds_and_size,r#"x := [1 2; 3 4]; b<|foo,bar|:1> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("foo", Value::U64(Ref::new(1))),("bar", Value::U64(Ref::new(2)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(interpret_table_from_matrix2,r#"x := ["true" "false"; "true" "false"]; a<|x<string> y<string>|> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x", Value::String(Ref::new("true".to_string()))),("y", Value::String(Ref::new("false".to_string())))]),MechRecord::new(vec![("x", Value::String(Ref::new("true".to_string()))),("y", Value::String(Ref::new("false".to_string())))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(interpret_table_from_matrix3,r#"x:=[true false; true false]; a<|x<bool> y<bool>|> := x;"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x", Value::Bool(Ref::new(true))),("y", Value::Bool(Ref::new(false)))]),MechRecord::new(vec![("x", Value::Bool(Ref::new(true))),("y", Value::Bool(Ref::new(false)))]),]).expect("Failed to create MechTable"))));
 #[cfg(all(feature = "i8", feature = "u8"))]
-test_interpreter!(
-    interpret_table_from_matrix4,
-    r#"x:=[1 2; 3 4]; a<|x<u8> y<i8>|> := x;"#,
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![
-                ("x", Value::U8(Ref::new(1))),
-                ("y", Value::I8(Ref::new(2)))
-            ]),
-            MechRecord::new(vec![
-                ("x", Value::U8(Ref::new(3))),
-                ("y", Value::I8(Ref::new(4)))
-            ]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(interpret_table_from_matrix4,r#"x:=[1 2; 3 4]; a<|x<u8> y<i8>|> := x;"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x", Value::U8(Ref::new(1))),("y", Value::I8(Ref::new(2)))]),MechRecord::new(vec![("x", Value::U8(Ref::new(3))),("y", Value::I8(Ref::new(4)))]),]).expect("Failed to create MechTable"))));
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_inner_join_symbol,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋈ B; J.b[1]"#,
-    Value::U64(Ref::new(200))
-);
+test_interpreter!(interpret_table_inner_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋈ B; J.b[1]"#, Value::U64(Ref::new(200)));
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_inner_join_word,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/join(A, B); J.b[2]"#,
-    Value::U64(Ref::new(300))
-);
+test_interpreter!(interpret_table_inner_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/join(A, B); J.b[2]"#, Value::U64(Ref::new(300)));
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_left_outer_join_symbol,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟕ B; J.id[1]"#,
-    Value::U64(Ref::new(1))
-);
+test_interpreter!(interpret_table_left_outer_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟕ B; J.id[1]"#, Value::U64(Ref::new(1)));
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_left_outer_join_word,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-outer-join(A, B); J.id[2]"#,
-    Value::U64(Ref::new(2))
-);
+test_interpreter!(interpret_table_left_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-outer-join(A, B); J.id[2]"#, Value::U64(Ref::new(2)));
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_right_outer_join_symbol,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟖ B; J.id[3]"#,
-    Value::U64(Ref::new(4))
-);
+test_interpreter!(interpret_table_right_outer_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟖ B; J.id[3]"#, Value::U64(Ref::new(4)));
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_right_outer_join_word,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/right-outer-join(A, B); J.id[3]"#,
-    Value::U64(Ref::new(4))
-);
+test_interpreter!(interpret_table_right_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/right-outer-join(A, B); J.id[3]"#, Value::U64(Ref::new(4)));
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_full_outer_join_symbol,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟗ B; J.id[4]"#,
-    Value::U64(Ref::new(4))
-);
+test_interpreter!(interpret_table_full_outer_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟗ B; J.id[4]"#, Value::U64(Ref::new(4)));
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_full_outer_join_word,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/full-outer-join(A, B); J.id[1]"#,
-    Value::U64(Ref::new(1))
-);
+test_interpreter!(interpret_table_full_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/full-outer-join(A, B); J.id[1]"#, Value::U64(Ref::new(1)));
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_left_semi_join_symbol,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋉ B; J.a[2]"#,
-    Value::U64(Ref::new(30))
-);
+test_interpreter!(interpret_table_left_semi_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋉ B; J.a[2]"#, Value::U64(Ref::new(30)));
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_left_semi_join_word,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-semi-join(A, B); J.id[1]"#,
-    Value::U64(Ref::new(2))
-);
+test_interpreter!(interpret_table_left_semi_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-semi-join(A, B); J.id[1]"#, Value::U64(Ref::new(2)));
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_left_anti_join_symbol,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ▷ B; J.id[1]"#,
-    Value::U64(Ref::new(1))
-);
+test_interpreter!(interpret_table_left_anti_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ▷ B; J.id[1]"#, Value::U64(Ref::new(1)));
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(
-    interpret_table_left_anti_join_word,
-    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-anti-join(A, B); J.a[1]"#,
-    Value::U64(Ref::new(10))
-);
+test_interpreter!(interpret_table_left_anti_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-anti-join(A, B); J.a[1]"#, Value::U64(Ref::new(10)));
 
 #[cfg(feature = "u64")]
-test_interpreter!(
-    interpret_matrix_reshape,
-    r#"x:=[1 3; 2 4]; y<[u64]:4,1> := x"#,
-    Value::MatrixU64(Matrix::from_vec(vec![1, 2, 3, 4], 4, 1))
-);
+test_interpreter!(interpret_matrix_reshape,r#"x:=[1 3; 2 4]; y<[u64]:4,1> := x"#, Value::MatrixU64(Matrix::from_vec(vec![1, 2, 3, 4], 4, 1)));
 
-test_interpreter!(
-    interpret_matrix_reshape2,
-    r#"x:=[1 2 3 4]; y<[string]:2,2> := x"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec![
-            String::from("1"),
-            String::from("2"),
-            String::from("3"),
-            String::from("4")
-        ],
-        2,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_matrix_convert_str,
-    r#"x:=1..=4; out<[string]>:=x"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec![
-            String::from("1"),
-            String::from("2"),
-            String::from("3"),
-            String::from("4")
-        ],
-        1,
-        4
-    ))
-);
+test_interpreter!(interpret_matrix_reshape2,r#"x:=[1 2 3 4]; y<[string]:2,2> := x"#, Value::MatrixString(Matrix::from_vec(vec![String::from("1"), String::from("2"), String::from("3"), String::from("4")], 2, 2)));  
+test_interpreter!(interpret_matrix_convert_str,r#"x:=1..=4; out<[string]>:=x"#, Value::MatrixString(Matrix::from_vec(vec![String::from("1"), String::from("2"), String::from("3"), String::from("4")], 1, 4)));
 
-test_interpreter!(
-    interpret_matrix_build_rational,
-    r#"x<[r64]:1,2> := 1/2"#,
-    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 2), R64::new(1, 2)], 1, 2))
-);
+test_interpreter!(interpret_matrix_build_rational,r#"x<[r64]:1,2> := 1/2"#, Value::MatrixR64(Matrix::from_vec(vec![R64::new(1,2), R64::new(1,2)], 1, 2)));
 
-test_interpreter!(
-    interpret_convert_rational_to_string,
-    r#"x<string>:=1/2"#,
-    Value::String(Ref::new(String::from("1/2")))
-);
-test_interpreter!(
-    interpret_convert_f64_to_string2,
-    r#"x<string>:=123"#,
-    Value::String(Ref::new(String::from("123")))
-);
+test_interpreter!(interpret_convert_rational_to_string,r#"x<string>:=1/2"#, Value::String(Ref::new(String::from("1/2"))));
+test_interpreter!(interpret_convert_f64_to_string2,r#"x<string>:=123"#, Value::String(Ref::new(String::from("123"))));
 
-test_interpreter!(
-    interpret_convert_f64_to_rational_to_string,
-    r#"x<string> := 0.5<r64>"#,
-    Value::String(Ref::new(String::from("1/2")))
-);
-test_interpreter!(
-    interpret_convert_matrix_to_optional_unsized_matrix,
-    r#"x<[u64]?> := [1u64 2u64 3u64]; x[1]"#,
-    Value::U64(Ref::new(1u64))
-);
-test_interpreter!(
-    interpret_user_function_input_annotation_optional_promotion,
-    r#"
+test_interpreter!(interpret_convert_f64_to_rational_to_string,r#"x<string> := 0.5<r64>"#,Value::String(Ref::new(String::from("1/2"))));
+test_interpreter!(interpret_convert_matrix_to_optional_unsized_matrix, r#"x<[u64]?> := [1u64 2u64 3u64]; x[1]"#, Value::U64(Ref::new(1u64)));
+test_interpreter!(interpret_user_function_input_annotation_optional_promotion, r#"
 x := [1u64 2u64 3u64]
 head(x<[u64]?>) => <u64?>
   | [] => _
   | [h ...] => h
   | _ => _.
 head(x)
-"#,
-    Value::U64(Ref::new(1u64))
-);
+"#, Value::U64(Ref::new(1u64)));
 
-test_interpreter!(
-    interpret_matrix_power_and_addition,
-    "~μ := [1 2 3]; K := [0.1 0.2 0.3; 0.4 0.5 0.6; 0.7 0.8 0.9]; Ẑ := [0.01; 0.02; 0.03]; μ = μ + (K ** Ẑ)'",
-    Value::MatrixF64(Matrix::from_vec(vec![1.014, 2.032, 3.05], 1, 3))
-);
-test_interpreter!(
-    interpret_assign_scalar_no_space,
-    "~z:=10;z=20",
-    Value::F64(Ref::new(20.0))
-);
+test_interpreter!(interpret_matrix_power_and_addition,"~μ := [1 2 3]; K := [0.1 0.2 0.3; 0.4 0.5 0.6; 0.7 0.8 0.9]; Ẑ := [0.01; 0.02; 0.03]; μ = μ + (K ** Ẑ)'", Value::MatrixF64(Matrix::from_vec(vec![1.014, 2.032, 3.05], 1, 3)));
+test_interpreter!(interpret_assign_scalar_no_space, "~z:=10;z=20", Value::F64(Ref::new(20.0)));
 
-test_interpreter!(
-    interpret_paren_term_whitespace,
-    "fahrenheit := ( 25 * 9 / 5 ) + 32",
-    Value::F64(Ref::new(77.0))
-);
 
-test_interpreter!(
-    interpret_formulas_no_whitespace,
-    "x:=10*[1,2,3]**[4,5,6]';",
-    Value::MatrixF64(Matrix::from_vec(vec![320.0], 1, 1))
-);
+test_interpreter!(interpret_paren_term_whitespace, "fahrenheit := ( 25 * 9 / 5 ) + 32", Value::F64(Ref::new(77.0)));
 
-test_interpreter!(
-    interpret_matrix_negatives,
-    r#"
+test_interpreter!(interpret_formulas_no_whitespace, "x:=10*[1,2,3]**[4,5,6]';", Value::MatrixF64(Matrix::from_vec(vec![320.0], 1, 1)));
+
+test_interpreter!(interpret_matrix_negatives, r#"
 A := [2.0, 1.0, -1.0
       -3.0, -1.0, 2.0
-      -2.0, 1.0, 2.0]"#,
-    Value::MatrixF64(Matrix::from_vec(
-        vec![2.0, -3.0, -2.0, 1.0, -1.0, 1.0, -1.0, 2.0, 2.0],
-        3,
-        3
-    ))
-);
+      -2.0, 1.0, 2.0]"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, -3.0, -2.0, 1.0, -1.0, 1.0, -1.0, 2.0, 2.0], 3, 3)));
 
-test_interpreter!(
-    interpret_matrix_solve,
-    r#"A := [2.0, 1.0, -1.0;-3.0, -1.0, 2.0;-2.0, 1.0, 2.0];b := [8.0, -11.0, -3.0]'; math/round(A \ b)"#,
-    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, -1.0], 3, 1))
-);
+test_interpreter!(interpret_matrix_solve, r#"A := [2.0, 1.0, -1.0;-3.0, -1.0, 2.0;-2.0, 1.0, 2.0];b := [8.0, -11.0, -3.0]'; math/round(A \ b)"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, -1.0], 3, 1)));
 
 // │ y │ true │ false │
 
-test_interpreter!(
-    table_column_inference,
-    "| y | true | false |",
-    Value::Table(Ref::new(
-        MechTable::from_records(vec![
-            MechRecord::new(vec![("y", Value::Bool(Ref::new(true)))]),
-            MechRecord::new(vec![("y", Value::Bool(Ref::new(false)))]),
-        ])
-        .expect("Failed to create MechTable")
-    ))
-);
+test_interpreter!(table_column_inference, "| y | true | false |", Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("y",Value::Bool(Ref::new(true)))]),MechRecord::new(vec![("y",Value::Bool(Ref::new(false)))]),]).expect("Failed to create MechTable"))));
 
-test_interpreter!(
-    interpret_set_union,
-    r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∪ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::F64(Ref::new(2.0)),
-        Value::F64(Ref::new(3.0)),
-        Value::F64(Ref::new(4.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_intersection,
-    r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∩ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(2.0)),
-        Value::F64(Ref::new(3.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_difference,
-    r#"A := {"a", "b", "c"}; B := {"b", "c", "d"}; U := A ∖ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new(
-        "a".to_string()
-    ))])))
-);
-test_interpreter!(
-    interpret_set_subset,
-    r#"A := {"b", "c"}; B := {"b", "c", "d"}; C := A ⊆ B"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_superset,
-    r#"A := {"b", "c", "d"}; B := {"b", "c"}; C := A ⊇ B"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_membership,
-    r#"A := {1, 2, 3}; B := 2 ∈ A;"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_not_membership,
-    r#"A := {1, 2, 3}; B := 4 ∉ A;"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_strict_subset,
-    r#"A := {1, 2}; B := {1, 2, 3}; C := A ⊂ B"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_strict_superset,
-    r#"A := {1, 2, 3}; B := {1, 2}; C := A ⊃ B"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_set_strict_subset2,
-    r#"A := {1, 2}; B := {1, 2}; C := A ⊊ B"#,
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_set_strict_superset2,
-    r#"A := {1, 2}; B := {1, 2}; C := A ⊋ B"#,
-    Value::Bool(Ref::new(false))
-);
+test_interpreter!(interpret_set_union, r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∪ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0)), Value::F64(Ref::new(4.0))]))));
+test_interpreter!(interpret_set_intersection, r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∩ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
+test_interpreter!(interpret_set_difference, r#"A := {"a", "b", "c"}; B := {"b", "c", "d"}; U := A ∖ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new("a".to_string()))]))));
+test_interpreter!(interpret_set_subset, r#"A := {"b", "c"}; B := {"b", "c", "d"}; C := A ⊆ B"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_superset, r#"A := {"b", "c", "d"}; B := {"b", "c"}; C := A ⊇ B"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_membership, r#"A := {1, 2, 3}; B := 2 ∈ A;"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_not_membership, r#"A := {1, 2, 3}; B := 4 ∉ A;"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_strict_subset, r#"A := {1, 2}; B := {1, 2, 3}; C := A ⊂ B"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_strict_superset, r#"A := {1, 2, 3}; B := {1, 2}; C := A ⊃ B"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_set_strict_subset2, r#"A := {1, 2}; B := {1, 2}; C := A ⊊ B"#, Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_set_strict_superset2, r#"A := {1, 2}; B := {1, 2}; C := A ⊋ B"#, Value::Bool(Ref::new(false)));
 
-test_interpreter!(
-    interpret_set_union_empty,
-    r#"A := {}; B := {1, 2}; U := A ∪ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::F64(Ref::new(2.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_intersection_empty,
-    r#"A := {}; B := {1, 2, 3}; U := A ∩ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![])))
-);
-test_interpreter!(
-    interpret_set_difference_empty,
-    r#"A := {1, 2}; B := {1, 2}; U := A ∖ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![])))
-);
-test_interpreter!(
-    interpret_set_union_duplicates,
-    r#"A := {1, 1, 2}; B := {2, 2, 3}; U := A ∪ B"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::F64(Ref::new(2.0)),
-        Value::F64(Ref::new(3.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_subset_empty_left,
-    r#"A := {}; B := {1}; C := A ⊆ B"#,
-    Value::Bool(Ref::new(true))
-);
+test_interpreter!(interpret_set_union_empty, r#"A := {}; B := {1, 2}; U := A ∪ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0))]))));
+test_interpreter!(interpret_set_intersection_empty, r#"A := {}; B := {1, 2, 3}; U := A ∩ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![]))));
+test_interpreter!(interpret_set_difference_empty, r#"A := {1, 2}; B := {1, 2}; U := A ∖ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![]))));
+test_interpreter!(interpret_set_union_duplicates, r#"A := {1, 1, 2}; B := {2, 2, 3}; U := A ∪ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
+test_interpreter!(interpret_set_subset_empty_left, r#"A := {}; B := {1}; C := A ⊆ B"#, Value::Bool(Ref::new(true)));
 
-test_interpreter!(
-    interpret_compare_max_scalar,
-    "compare/max(5,3)",
-    Value::F64(Ref::new(5.0))
-);
-test_interpreter!(
-    interpret_compare_max_vector,
-    "compare/max([3 4 5 6],4)",
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 4.0, 5.0, 6.0], 1, 4))
-);
-test_interpreter!(
-    interpret_compare_max_vector_vector,
-    "compare/max([3 4 5 6],[6 5 4 3])",
-    Value::MatrixF64(Matrix::from_vec(vec![6.0, 5.0, 5.0, 6.0], 1, 4))
-);
-test_interpreter!(
-    interpret_compare_min_scalar,
-    "compare/min(5,3)",
-    Value::F64(Ref::new(3.0))
-);
-test_interpreter!(
-    interpret_compare_min_vector,
-    "compare/min([3 4 5 6],4)",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 4.0], 1, 4))
-);
-test_interpreter!(
-    interpret_compare_min_vector_vector,
-    "compare/min([3 4 5 6],[6 5 4 3])",
-    Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 3.0], 1, 4))
-);
+test_interpreter!(interpret_compare_max_scalar, "compare/max(5,3)", Value::F64(Ref::new(5.0)));
+test_interpreter!(interpret_compare_max_vector, "compare/max([3 4 5 6],4)", Value::MatrixF64(Matrix::from_vec(vec![4.0, 4.0, 5.0, 6.0], 1, 4)));
+test_interpreter!(interpret_compare_max_vector_vector, "compare/max([3 4 5 6],[6 5 4 3])", Value::MatrixF64(Matrix::from_vec(vec![6.0, 5.0, 5.0, 6.0], 1, 4)));
+test_interpreter!(interpret_compare_min_scalar, "compare/min(5,3)", Value::F64(Ref::new(3.0)));
+test_interpreter!(interpret_compare_min_vector, "compare/min([3 4 5 6],4)", Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 4.0], 1, 4)));
+test_interpreter!(interpret_compare_min_vector_vector, "compare/min([3 4 5 6],[6 5 4 3])", Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 3.0], 1, 4)));
 
-test_interpreter!(
-    interpret_set_comprehension,
-    r#"{ x * x | x <- {1,2,3,4}, y := 2, (x % 2) == 0 }"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(4.0)),
-        Value::F64(Ref::new(16.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_comprehension_variable,
-    r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::F64(Ref::new(9.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_comprehension_tuple,
-    r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(1.0)),
-        Value::F64(Ref::new(9.0)),
-        Value::F64(Ref::new(25.0)),
-        Value::F64(Ref::new(49.0))
-    ])))
-);
-test_interpreter!(
-    interpret_set_comprehension_fof,
-    r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#,
-    Value::Set(Ref::new(MechSet::from_vec(vec![
-        Value::F64(Ref::new(5.0)),
-        Value::F64(Ref::new(9.0)),
-        Value::F64(Ref::new(8.0))
-    ])))
-);
+test_interpreter!(interpret_set_comprehension, r#"{ x * x | x <- {1,2,3,4}, y := 2, (x % 2) == 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(4.0)), Value::F64(Ref::new(16.0))]))));
+test_interpreter!(interpret_set_comprehension_variable, r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0))]))));
+test_interpreter!(interpret_set_comprehension_tuple, r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(25.0)), Value::F64(Ref::new(49.0))]))));
+test_interpreter!(interpret_set_comprehension_fof, r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(8.0))]))));
 
-test_interpreter!(
-    interpret_matrix_comprehension,
-    r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#,
-    Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2))
-);
-test_interpreter!(
-    interpret_matrix_comprehension_variable,
-    r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#,
-    Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2))
-);
+test_interpreter!(interpret_matrix_comprehension, r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2)));
+test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2)));
 
-test_interpreter!(
-    interpret_table_record_mutation,
-    r#"~T:=|x<f64> y<bool>|1.2 true|1.3 false|;~r:=T[1];r.x=42;T.x[1]"#,
-    Value::F64(Ref::new(42.0))
-);
+test_interpreter!(interpret_table_record_mutation, r#"~T:=|x<f64> y<bool>|1.2 true|1.3 false|;~r:=T[1];r.x=42;T.x[1]"#, Value::F64(Ref::new(42.0)));
 //test_interpreter!("interpret_table_record_mutation_fail", r#"T := | x<f64>  y<bool> |  1.2     true   |  1.3     false  |;~r := T{1};r.x = 42;T.x[1]"#, Value::F64(Ref::new(1.2)));
 
-test_interpreter!(
-    interpret_define_custom_enum,
-    r#"<color>:=:red|:green|:blue; x<color>:=:red;"#,
-    Value::Atom(Ref::new(MechAtom::new(hash_str("red"))))
-);
-test_interpreter!(
-    interpret_kind_membership_enum_payload,
-    r#"
+test_interpreter!(interpret_define_custom_enum, r#"<color>:=:red|:green|:blue; x<color>:=:red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
+test_interpreter!(interpret_kind_membership_enum_payload, r#"
 <color> := :red<u64> | :green<u64> | :blue
 :red(300) ∈ <color>
-"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_kind_not_membership_enum_payload,
-    r#"
+"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_kind_not_membership_enum_payload, r#"
 <color> := :red<u64> | :green<u64> | :blue
 :red("300") ∉ <color>
-"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_tagged_union_nested_match,
-    r#"
+"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_tagged_union_nested_match, r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:ok(42u64))
@@ -3550,12 +1170,8 @@ result := x?
   | :none          => 0u64
   | *              => 0u64.
 result + 0u64
-"#,
-    Value::U64(Ref::new(42u64))
-);
-test_interpreter!(
-    interpret_tagged_union_function_input_enum_kind,
-    r#"
+"#, Value::U64(Ref::new(42u64)));
+test_interpreter!(interpret_tagged_union_function_input_enum_kind, r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:err("this sucks"))
@@ -3566,12 +1182,10 @@ unwrap(x<option>) => <u64>
   | :none          => 0u64.
 
 unwrap(x)
-"#,
-    Value::U64(Ref::new(0u64))
-);
+"#, Value::U64(Ref::new(0u64)));
 #[test]
 fn interpret_tagged_union_function_match_requires_exhaustive_arms() {
-    let s = r#"
+  let s = r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:err("this sucks"))
@@ -3582,118 +1196,30 @@ unwrap(x<option>) => <u64>
 
 unwrap(x)
 "#;
-    let tree = parser::parse(s).unwrap();
-    let mut intrp = Interpreter::new(0);
-    let err = intrp.interpret(&tree).unwrap_err();
-    let msg = format!("{:?}", err);
-    assert!(msg.contains("FunctionMatchNonExhaustive"));
-    assert!(msg.contains(":none"));
-    assert!(msg.contains("wildcard"));
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("FunctionMatchNonExhaustive"));
+  assert!(msg.contains(":none"));
+  assert!(msg.contains("wildcard"));
 }
-test_interpreter!(
-    interpret_string_concatenation,
-    r#"x := "Hello, " + "world!""#,
-    Value::String(Ref::new("Hello, world!".to_string()))
-);
-test_interpreter!(
-    interpret_string_concatenation2,
-    r#""a" + "b" + "c""#,
-    Value::String(Ref::new("abc".to_string()))
-);
-test_interpreter!(
-    interpret_string_concatenation_var,
-    r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#,
-    Value::String(Ref::new("Hello, Alice!".to_string()))
-);
-test_interpreter!(
-    interpret_string_concatenation_matrix,
-    r#"["a" "b"] + "c""#,
-    Value::MatrixString(Matrix::from_vec(
-        vec!["ac".to_string(), "bc".to_string()],
-        1,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_string_concatenation_matrix2,
-    r#"["a" "b"; "c" "d"] + ["1" "2"; "3" "4"]"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec![
-            "a1".to_string(),
-            "c3".to_string(),
-            "b2".to_string(),
-            "d4".to_string()
-        ],
-        2,
-        2
-    ))
-);
-test_interpreter!(
-    interpret_string_concatenation_matrix3,
-    r#"prefix := "Item"; letters := ["A" "B" "C"]; labels := prefix + letters"#,
-    Value::MatrixString(Matrix::from_vec(
-        vec![
-            "ItemA".to_string(),
-            "ItemB".to_string(),
-            "ItemC".to_string()
-        ],
-        1,
-        3
-    ))
-);
-test_interpreter!(
-    interpret_string_raw_literal,
-    r#""""C:\Users\Name\Documents""""#,
-    Value::String(Ref::new(r"C:\Users\Name\Documents".to_string()))
-);
-test_interpreter!(
-    interpret_string_raw_literal_multiline,
-    r#""""This is a raw string literal.It can span multiple lines
-and include "quotes" and \backslashes\ without needing escapes.""""#,
-    Value::String(Ref::new(
-        r#"This is a raw string literal.It can span multiple lines
-and include "quotes" and \backslashes\ without needing escapes."#
-            .to_string()
-    ))
-);
-test_interpreter!(
-    interpret_atom_equality,
-    r#"a := :status/active; b := :status/active; c := (a == b);"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_atom_inequality_false,
-    r#"a := :status/active; b := :status/active; c := (a != b);"#,
-    Value::Bool(Ref::new(false))
-);
-test_interpreter!(
-    interpret_atom_inequality,
-    r#"a := :status/active; b := :status/inactive; c := (a != b);"#,
-    Value::Bool(Ref::new(true))
-);
-test_interpreter!(
-    interpret_atom_equality_false,
-    r#"a := :status/active; b := :status/inactive; c := (a == b);"#,
-    Value::Bool(Ref::new(false))
-);
+test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
+test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));
+test_interpreter!(interpret_string_concatenation_var, r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#, Value::String(Ref::new("Hello, Alice!".to_string())));
+test_interpreter!(interpret_string_concatenation_matrix, r#"["a" "b"] + "c""#, Value::MatrixString(Matrix::from_vec(vec!["ac".to_string(), "bc".to_string()], 1, 2)));
+test_interpreter!(interpret_string_concatenation_matrix2, r#"["a" "b"; "c" "d"] + ["1" "2"; "3" "4"]"#, Value::MatrixString(Matrix::from_vec(vec!["a1".to_string(), "c3".to_string(), "b2".to_string(), "d4".to_string()], 2, 2)));
+test_interpreter!(interpret_string_concatenation_matrix3, r#"prefix := "Item"; letters := ["A" "B" "C"]; labels := prefix + letters"#, Value::MatrixString(Matrix::from_vec(vec!["ItemA".to_string(), "ItemB".to_string(), "ItemC".to_string()], 1, 3)));
+test_interpreter!(interpret_string_raw_literal, r#""""C:\Users\Name\Documents""""#, Value::String(Ref::new(r"C:\Users\Name\Documents".to_string())));
+test_interpreter!(interpret_string_raw_literal_multiline, r#""""This is a raw string literal.It can span multiple lines
+and include "quotes" and \backslashes\ without needing escapes.""""#, Value::String(Ref::new(r#"This is a raw string literal.It can span multiple lines
+and include "quotes" and \backslashes\ without needing escapes."#.to_string())));
+test_interpreter!(interpret_atom_equality, r#"a := :status/active; b := :status/active; c := (a == b);"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_atom_inequality_false, r#"a := :status/active; b := :status/active; c := (a != b);"#, Value::Bool(Ref::new(false)));
+test_interpreter!(interpret_atom_inequality, r#"a := :status/active; b := :status/inactive; c := (a != b);"#, Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_atom_equality_false, r#"a := :status/active; b := :status/inactive; c := (a == b);"#, Value::Bool(Ref::new(false)));
 
-test_interpreter!(
-    interpreter_mika_micromica,
-    r#"╭⦿╯"#,
-    Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯")))
-);
-test_interpreter!(
-    interpreter_mika_micromica_gripper,
-    r#"Ɔ∞⦿╯"#,
-    Value::Atom(Ref::new(MechAtom::from_name("Ɔ∞⦿╯")))
-);
-test_interpreter!(
-    interpreter_mika_minimika,
-    r#"(˙◯˙)"#,
-    Value::Atom(Ref::new(MechAtom::from_name("(˙◯˙)")))
-);
-test_interpreter!(
-    interpreter_mika_micromica_mikasection,
-    r#"╭⦿╯ ⸢Hello, I'm Mika!⸥"#,
-    Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯")))
-);
+test_interpreter!(interpreter_mika_micromica, r#"╭⦿╯"#, Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯"))));
+test_interpreter!(interpreter_mika_micromica_gripper, r#"Ɔ∞⦿╯"#, Value::Atom(Ref::new(MechAtom::from_name("Ɔ∞⦿╯"))));
+test_interpreter!(interpreter_mika_minimika, r#"(˙◯˙)"#, Value::Atom(Ref::new(MechAtom::from_name("(˙◯˙)"))));
+test_interpreter!(interpreter_mika_micromica_mikasection, r#"╭⦿╯ ⸢Hello, I'm Mika!⸥"#, Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯"))));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1,236 +1,311 @@
 #![allow(warnings)]
-extern crate mech_syntax;
 extern crate mech_core;
+extern crate mech_syntax;
 extern crate nalgebra as na;
-use std::cell::RefCell;
-use std::rc::Rc;
+use indexmap::set::IndexSet;
 use mech_core::matrix::Matrix;
-use mech_syntax::*;
 use mech_core::*;
 use mech_interpreter::*;
-use indexmap::set::IndexSet;
+use mech_syntax::*;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 /// Compare interpreter output to expected value
 macro_rules! test_interpreter {
-  ($func:ident, $input:tt, $expected:expr) => (
-    #[test]
-    fn $func() {
-      let s = $input;
-      match parser::parse(&s) {
-          Ok(tree) => { 
-            let mut intrp = Interpreter::new(0);
-            let result = intrp.interpret(&tree).unwrap();
-            assert_eq!(result, $expected);
-          },
-          Err(err) => {panic!("{:?}", err);}
-      }   
-    }
-  )
+    ($func:ident, $input:tt, $expected:expr) => {
+        #[test]
+        fn $func() {
+            let s = $input;
+            match parser::parse(&s) {
+                Ok(tree) => {
+                    let mut intrp = Interpreter::new(0);
+                    let result = intrp.interpret(&tree).unwrap();
+                    assert_eq!(result, $expected);
+                }
+                Err(err) => {
+                    panic!("{:?}", err);
+                }
+            }
+        }
+    };
 }
 
 /////////////////////////////////////////////////////////////////////////////////
 
-test_interpreter!(interpret_literal_integer, "123", Value::F64(Ref::new(123.0)));
+test_interpreter!(
+    interpret_literal_integer,
+    "123",
+    Value::F64(Ref::new(123.0))
+);
 test_interpreter!(interpret_literal_sci, "1.23e2", Value::F64(Ref::new(123.0)));
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_formula_literal_suffix, "100u8", Value::U8(Ref::new(100)));
+test_interpreter!(
+    interpret_formula_literal_suffix,
+    "100u8",
+    Value::U8(Ref::new(100))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_literal_bin, "0b10101", Value::I64(Ref::new(0b10101)));
+test_interpreter!(
+    interpret_literal_bin,
+    "0b10101",
+    Value::I64(Ref::new(0b10101))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_literal_hex, "0x123abc", Value::I64(Ref::new(0x123abc)));
+test_interpreter!(
+    interpret_literal_hex,
+    "0x123abc",
+    Value::I64(Ref::new(0x123abc))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_literal_oct, "0o1234", Value::I64(Ref::new(0o1234)));
+test_interpreter!(
+    interpret_literal_oct,
+    "0o1234",
+    Value::I64(Ref::new(0o1234))
+);
 #[cfg(feature = "i64")]
 test_interpreter!(interpret_literal_dec, "0d1234", Value::I64(Ref::new(1234)));
 test_interpreter!(interpret_literal_float, "1.23", Value::F64(Ref::new(1.23)));
-test_interpreter!(interpret_literal_string, r#""Hello""#, Value::String(Ref::new("Hello".to_string())));
-test_interpreter!(interpret_literal_string_empty, r#""""#, Value::String(Ref::new("".to_string())));
-test_interpreter!(interpret_literal_string_multiline, r#""Hello 
- World""#, Value::String(Ref::new("Hello \n World".to_string())));
+test_interpreter!(
+    interpret_literal_string,
+    r#""Hello""#,
+    Value::String(Ref::new("Hello".to_string()))
+);
+test_interpreter!(
+    interpret_literal_string_empty,
+    r#""""#,
+    Value::String(Ref::new("".to_string()))
+);
+test_interpreter!(
+    interpret_literal_string_multiline,
+    r#""Hello 
+ World""#,
+    Value::String(Ref::new("Hello \n World".to_string()))
+);
 test_interpreter!(interpret_literal_true, "true", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_literal_true2, "✓ ", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_literal_false, "false", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_literal_atom, ":A", Value::Atom(Ref::new(MechAtom::new(55450514845822917))));
+test_interpreter!(
+    interpret_literal_false,
+    "false",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_literal_atom,
+    ":A",
+    Value::Atom(Ref::new(MechAtom::new(55450514845822917)))
+);
 test_interpreter!(interpret_literal_empty, "_", Value::Empty);
 
 test_interpreter!(
-  interpret_fsm_counter_accepts_typed_input,
-  "#Counter(n<u64>) => <u64>\n  ├ :Count(n<u64>)\n  └ :Done(n<u64>).\n\n#Counter(n<u64>) -> :Count(n)\n  :Count(n)\n    ├ n > 0u64 -> :Count(n - 1u64)\n    └ n == 0u64 -> :Done(0u64)\n  :Done(n) => n.\n\n#Counter(5u64)",
-  Value::U64(Ref::new(0))
+    interpret_fsm_counter_accepts_typed_input,
+    "#Counter(n<u64>) => <u64>\n  ├ :Count(n<u64>)\n  └ :Done(n<u64>).\n\n#Counter(n<u64>) -> :Count(n)\n  :Count(n)\n    ├ n > 0u64 -> :Count(n - 1u64)\n    └ n == 0u64 -> :Done(0u64)\n  :Done(n) => n.\n\n#Counter(5u64)",
+    Value::U64(Ref::new(0))
 );
 
 test_interpreter!(
-  interpret_fsm_fibonacci_accepts_typed_input,
-  "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0u64, 1u64)\n  :Compute(n, a, b)\n    ├ n > 0u64 -> :Compute(n - 1u64, b, a + b)\n    └ n == 0u64 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10u64)",
-  Value::U64(Ref::new(55))
+    interpret_fsm_fibonacci_accepts_typed_input,
+    "#Fibonacci(n<u64>) => <u64>\n  ├ :Compute(n<u64>, a<u64>, b<u64>)\n  └ :Done(n<u64>).\n\n#Fibonacci(n<u64>) -> :Compute(n, 0u64, 1u64)\n  :Compute(n, a, b)\n    ├ n > 0u64 -> :Compute(n - 1u64, b, a + b)\n    └ n == 0u64 -> :Done(a)\n  :Done(n) => n.\n\n#Fibonacci(10u64)",
+    Value::U64(Ref::new(55))
 );
 
 #[test]
 fn interpret_fsm_fails_when_transition_targets_undefined_state() {
-  let s = "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  └ :Open(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Open(n) => n.\n\n#Door(1u64)";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  assert!(intrp.interpret(&tree).is_err());
+    let s = "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  └ :Open(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Open(n) => n.\n\n#Door(1u64)";
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    assert!(intrp.interpret(&tree).is_err());
 }
 
 test_interpreter!(
-  interpret_fsm_accepts_when_all_states_are_implemented,
-  "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  ├ :Open(n<u64>)\n  └ :Locked(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Locked(n) -> :Open(n)\n  :Open(n) => n.\n\n#Door(1u64)",
-  Value::U64(Ref::new(1))
+    interpret_fsm_accepts_when_all_states_are_implemented,
+    "#Door(n<u64>) => <u64>\n  ├ :Closed(n<u64>)\n  ├ :Open(n<u64>)\n  └ :Locked(n<u64>).\n\n#Door(n<u64>) -> :Closed(n)\n  :Closed(n) -> :Locked(n)\n  :Locked(n) -> :Open(n)\n  :Open(n) => n.\n\n#Door(1u64)",
+    Value::U64(Ref::new(1))
 );
 test_interpreter!(interpret_variable_define_empty, "em := _", Value::Empty);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_variable_define_kind_literal, "x := <u8>;", Value::Kind(ValueKind::U8));
+test_interpreter!(
+    interpret_variable_define_kind_literal,
+    "x := <u8>;",
+    Value::Kind(ValueKind::U8)
+);
 #[test]
 fn interpret_variable_define_undefined_kind_literal_error() {
-  let s = "x := <foo>;";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  assert!(intrp.interpret(&tree).is_err());
+    let s = "x := <foo>;";
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    assert!(intrp.interpret(&tree).is_err());
 }
-test_interpreter!(interpret_variable_define_typed_empty, "emp<_> := _", Value::Empty);
-#[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_variable_define_typed_option_some,
-  "x<u64?> := 123u64",
-  Value::U64(Ref::new(123))
+    interpret_variable_define_typed_empty,
+    "emp<_> := _",
+    Value::Empty
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_variable_define_typed_option_none,
-  "x<u64?> := _",
-  Value::Empty
+    interpret_variable_define_typed_option_some,
+    "x<u64?> := 123u64",
+    Value::U64(Ref::new(123))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_option_match_scalar_some,
-  "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
-  Value::U64(Ref::new(4))
+    interpret_variable_define_typed_option_none,
+    "x<u64?> := _",
+    Value::Empty
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_option_match_literal_pattern_matches_inner_value,
-  "foo<u64?> := 0\n\nfoo?\n  | 0 => 9\n  | * => 10.",
-  Value::F64(Ref::new(9.0))
+    interpret_option_match_scalar_some,
+    "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
+    Value::U64(Ref::new(4))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_option_match_tuple_destructure,
-  "x<u64?> := 2u64; y<u64?> := _; (x2,y2) := (x,y)? | (x,y) => (x,y) | * => (0u64,0u64).; x2 + y2",
-  Value::U64(Ref::new(0))
+    interpret_option_match_literal_pattern_matches_inner_value,
+    "foo<u64?> := 0\n\nfoo?\n  | 0 => 9\n  | * => 10.",
+    Value::F64(Ref::new(9.0))
+);
+#[cfg(feature = "u64")]
+test_interpreter!(
+    interpret_option_match_tuple_destructure,
+    "x<u64?> := 2u64; y<u64?> := _; (x2,y2) := (x,y)? | (x,y) => (x,y) | * => (0u64,0u64).; x2 + y2",
+    Value::U64(Ref::new(0))
 );
 test_interpreter!(
-  interpret_match_allows_unreachable_wildcard_with_different_kind,
-  "foo<f64?> := 1234\n\nbar := foo?\n  | x => \"One Two Three\"\n  | * => 12.\n\nbar + \"\"",
-  Value::String(Ref::new("One Two Three".to_string()))
+    interpret_match_allows_unreachable_wildcard_with_different_kind,
+    "foo<f64?> := 1234\n\nbar := foo?\n  | x => \"One Two Three\"\n  | * => 12.\n\nbar + \"\"",
+    Value::String(Ref::new("One Two Three".to_string()))
 );
 
 #[test]
 fn interpret_option_match_requires_wildcard_arm() {
-  let s = "foo<u64?> := 1234\n\nbar := foo?\n  | 0 => 9.\n\nbar";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  assert!(intrp.interpret(&tree).is_err());
+    let s = "foo<u64?> := 1234\n\nbar := foo?\n  | 0 => 9.\n\nbar";
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    assert!(intrp.interpret(&tree).is_err());
 }
 
 #[test]
 fn interpret_enum_match_reports_missing_variants_color() {
-  let s = r#"
+    let s = r#"
 <color> := :red | :green | :blue
 my-color<color> := :red
 string-color := my-color?
   | :red   => "red"
   | :green => "green".
 "#;
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let err = intrp.interpret(&tree).unwrap_err();
-  let msg = format!("{:?}", err);
-  assert!(msg.contains("MatchNonExhaustive"));
-  assert!(msg.contains(":blue"));
-  assert!(msg.contains("wildcard"));
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    let err = intrp.interpret(&tree).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("MatchNonExhaustive"));
+    assert!(msg.contains(":blue"));
+    assert!(msg.contains("wildcard"));
 }
 
 #[test]
 fn interpret_enum_match_reports_missing_variants_generalized() {
-  let s = r#"
+    let s = r#"
 <door> := :open | :closed | :locked
 state<door> := :open
 label := state?
   | :open   => "open"
   | :closed => "closed".
 "#;
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let err = intrp.interpret(&tree).unwrap_err();
-  let msg = format!("{:?}", err);
-  assert!(msg.contains("MatchNonExhaustive"));
-  assert!(msg.contains(":locked"));
-  assert!(msg.contains("wildcard"));
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    let err = intrp.interpret(&tree).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("MatchNonExhaustive"));
+    assert!(msg.contains(":locked"));
+    assert!(msg.contains("wildcard"));
 }
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_match_array_pattern_head,
-  "xs := [10u64 20u64 30u64]; y := xs? | [x ...] => x | * => 0u64.; y + 0u64",
-  Value::U64(Ref::new(10))
+    interpret_match_array_pattern_head,
+    "xs := [10u64 20u64 30u64]; y := xs? | [x ...] => x | * => 0u64.; y + 0u64",
+    Value::U64(Ref::new(10))
 );
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_match_array_pattern_last,
-  "xs := [10u64 20u64 30u64]; y := xs? | [... x] => x | * => 0u64.; y + 0u64",
-  Value::U64(Ref::new(30))
-);
-
-
-#[cfg(feature = "u64")]
-test_interpreter!(
-  interpret_match_array_pattern_rest_binding,
-  "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest? | [r ...] => r | * => 0u64. | * => 0u64.; y + 0u64",
-  Value::U64(Ref::new(30))
+    interpret_match_array_pattern_last,
+    "xs := [10u64 20u64 30u64]; y := xs? | [... x] => x | * => 0u64.; y + 0u64",
+    Value::U64(Ref::new(30))
 );
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_match_array_pattern_rest_binding_returns_matrix,
-  "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest | * => [0u64].; z := y? | [h ... t] => h + t | * => 0u64.; z + 0u64",
-  Value::U64(Ref::new(70))
+    interpret_match_array_pattern_rest_binding,
+    "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest? | [r ...] => r | * => 0u64. | * => 0u64.; y + 0u64",
+    Value::U64(Ref::new(30))
 );
 
 #[cfg(feature = "u64")]
 test_interpreter!(
-  interpret_match_tuple_pattern_with_guards,
-  "foo := (1u64, 2u64, 3u64)\n\nmax<u64> := foo?\n  | (a, b, c), a > b && a > c => a\n  | (a, b, c), b > a && b > c => b\n  | (a, b, c), c > a && c > b => c\n  | * => 0u64.\n\nmax + 0u64",
-  Value::U64(Ref::new(3))
+    interpret_match_array_pattern_rest_binding_returns_matrix,
+    "xs := [10u64 20u64 30u64 40u64]; y := xs? | [a, b | rest] => rest | * => [0u64].; z := y? | [h ... t] => h + t | * => 0u64.; z + 0u64",
+    Value::U64(Ref::new(70))
 );
 
-test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64", Value::U64(Ref::new(9)));
+#[cfg(feature = "u64")]
+test_interpreter!(
+    interpret_match_tuple_pattern_with_guards,
+    "foo := (1u64, 2u64, 3u64)\n\nmax<u64> := foo?\n  | (a, b, c), a > b && a > c => a\n  | (a, b, c), b > a && b > c => b\n  | (a, b, c), c > a && c > b => c\n  | * => 0u64.\n\nmax + 0u64",
+    Value::U64(Ref::new(3))
+);
+
+test_interpreter!(
+    interpret_option_match_tuple_struct_pattern,
+    "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64",
+    Value::U64(Ref::new(9))
+);
 #[test]
 fn interpret_tagged_union_match_requires_exhaustive_arms() {
-  let s = r#"
+    let s = r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:ok(42u64))
 result := x?
   | :some(:ok(n)) => n.
 "#;
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  assert!(intrp.interpret(&tree).is_err());
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    assert!(intrp.interpret(&tree).is_err());
 }
 test_interpreter!(
-  interpret_function_shorthand_match_arm_broadcasts_over_matrix_input,
-  "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
-  Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
+    interpret_function_shorthand_match_arm_broadcasts_over_matrix_input,
+    "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
 );
-test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) => <u64>\n  | [x ...] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
-test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x ... y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
-test_interpreter!(interpret_fsm_accepts_unsized_vector_input, "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(5)));
-test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a | tail])\n    └ * -> :Done(0u64)\n  :Pass([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
-test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a | tail], [b | acc], swaps + 1u64)\n    └ *     -> :Pass([b | tail], [a | acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x | acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x | acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
-test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>
+test_interpreter!(
+    interpret_function_array_pattern_arms,
+    "head(xs<[u64]:1,3>) => <u64>\n  | [x ...] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64",
+    Value::U64(Ref::new(10))
+);
+test_interpreter!(
+    interpret_fsm_array_pattern_state_arguments,
+    "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x ... y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)",
+    Value::U64(Ref::new(4))
+);
+test_interpreter!(
+    interpret_fsm_accepts_unsized_vector_input,
+    "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])",
+    Value::U64(Ref::new(5))
+);
+test_interpreter!(
+    interpret_fsm_array_spread_reconstruction_keeps_scalar_guards,
+    "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a | tail])\n    └ * -> :Done(0u64)\n  :Pass([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])",
+    Value::U64(Ref::new(0))
+);
+test_interpreter!(
+    interpret_fsm_bubble_sort_returns_typed_u64_matrix,
+    "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a | tail], [b | acc], swaps + 1u64)\n    └ *     -> :Pass([b | tail], [a | acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x | acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x | acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])",
+    Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4))
+);
+test_interpreter!(
+    interpret_fsm_bubble_sort_assigns_matrix_value,
+    "#bubble-sort(arr<[u64]>) => <[u64]>
   ├ :Start(arr<[u64]>)
   ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)
   ├ :Next(arr<[u64]>, swaps<u64>)
@@ -251,125 +326,360 @@ test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(
   :Done(arr) ⇒ arr.
 
 x := [5u64 3u64 8u64 1u64]
-y := #bubble-sort(x)", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
+y := #bubble-sort(x)",
+    Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4))
+);
 #[test]
 fn interpret_variable_define_typed_set_from_range_matrix() {
-  let s = "input<{f64}> := 1..=5";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let result = intrp.interpret(&tree).unwrap();
-  match result {
-    Value::Set(mset) => {
-      let mset = mset.borrow();
-      assert_eq!(mset.set.len(), 5);
-      for value in [1.0, 2.0, 3.0, 4.0, 5.0] {
-        assert!(mset.set.contains(&Value::F64(Ref::new(value))));
-      }
+    let s = "input<{f64}> := 1..=5";
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    let result = intrp.interpret(&tree).unwrap();
+    match result {
+        Value::Set(mset) => {
+            let mset = mset.borrow();
+            assert_eq!(mset.set.len(), 5);
+            for value in [1.0, 2.0, 3.0, 4.0, 5.0] {
+                assert!(mset.set.contains(&Value::F64(Ref::new(value))));
+            }
+        }
+        _ => panic!("Expected set output"),
     }
-    _ => panic!("Expected set output"),
-  }
 }
 #[test]
 fn interpret_variable_define_typed_set_from_matrix() {
-  let s = "input<{f64}> := [1 2; 3 4; 5 6]";
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let result = intrp.interpret(&tree).unwrap();
-  match result {
-    Value::Set(mset) => {
-      let mset = mset.borrow();
-      assert_eq!(mset.set.len(), 6);
-      for value in [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] {
-        assert!(mset.set.contains(&Value::F64(Ref::new(value))));
-      }
+    let s = "input<{f64}> := [1 2; 3 4; 5 6]";
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    let result = intrp.interpret(&tree).unwrap();
+    match result {
+        Value::Set(mset) => {
+            let mset = mset.borrow();
+            assert_eq!(mset.set.len(), 6);
+            for value in [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] {
+                assert!(mset.set.contains(&Value::F64(Ref::new(value))));
+            }
+        }
+        _ => panic!("Expected set output"),
     }
-    _ => panic!("Expected set output"),
-  }
 }
-test_interpreter!(interpret_literal_complex, "5+4i", Value::C64(Ref::new(C64::new(5.0, 4.0))));
-test_interpreter!(interpret_literal_complex2, "5-4i", Value::C64(Ref::new(C64::new(5.0, -4.0))));
-test_interpreter!(interpret_literal_complex3, "5-4j", Value::C64(Ref::new(C64::new(5.0, -4.0))));
-test_interpreter!(interpret_literal_rational, "1/2", Value::R64(Ref::new(R64::new(1, 2))));
-
-test_interpreter!(interpret_comment, "123 -- comment", Value::F64(Ref::new(123.0)));
-test_interpreter!(interpret_comment2, "123 // comment", Value::F64(Ref::new(123.0)));
-
-test_interpreter!(interpret_formula_math_add, "2 + 2", Value::F64(Ref::new(4.0)));
-test_interpreter!(interpret_formula_math_sub, "2 - 2", Value::F64(Ref::new(0.0)));
-test_interpreter!(interpret_formula_math_mul, "2 * 2", Value::F64(Ref::new(4.0)));
-test_interpreter!(interpret_formula_math_div, "2 / 2", Value::F64(Ref::new(1.0)));
-test_interpreter!(interpret_formula_precedence_mul_before_compare, "1 * 2 > 1 * 1", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_precedence_add_before_compare, "1 + 2 > 1", Value::Bool(Ref::new(true)));
-#[cfg(feature = "u8")]
-test_interpreter!(interpret_formula_math_pow, "2<u8> ^ 2<u8>", Value::U8(Ref::new(4)));
-test_interpreter!(interpret_formula_math_pow_f64, "2.0 ^ 2.0", Value::F64(Ref::new(4.0)));
-test_interpreter!(interpret_formulat_math_add_rational, "1/10 + 2/10 + 3/10", Value::R64(Ref::new(R64::new(6, 10))));
-test_interpreter!(interpret_formulat_math_sub_rational, "1/10 - 2/10 - 3/10", Value::R64(Ref::new(R64::new(-4, 10))));
-test_interpreter!(interpret_formula_math_mul_rational, "1/10 * 2/10 * 3/10", Value::R64(Ref::new(R64::new(3, 500))));
-test_interpreter!(interpret_formula_math_div_rational, "1/10 / 2/10 / 3/10", Value::R64(Ref::new(R64::new(5, 3))));
-test_interpreter!(interpret_formula_math_add_complex, "1+2i + 3+4i", Value::C64(Ref::new(C64::new(4.0, 6.0))));
-test_interpreter!(interpret_formula_math_add_complex_real_rhs, "4i + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
-test_interpreter!(interpret_formula_math_add_complex_real_lhs, "1 + 4i", Value::C64(Ref::new(C64::new(1.0, 4.0))));
-test_interpreter!(interpret_variable_define_complex_real_sum, "y := 4i + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
-test_interpreter!(interpret_variable_add_complex_real, "z := 4i; z + 1", Value::C64(Ref::new(C64::new(1.0, 4.0))));
-test_interpreter!(interpret_formula_math_sub_complex, "1+2i - 3+4i", Value::C64(Ref::new(C64::new(-2.0, -2.0))));
-test_interpreter!(interpret_formula_math_mul_complex, "1+2i * 3+4i", Value::C64(Ref::new(C64::new(-5.0, 10.0))));
-test_interpreter!(interpret_formula_math_div_complex, "1+2i / 3+4i", Value::C64(Ref::new(C64::new(0.44, 0.08))));
-
-test_interpreter!(interpret_matrix_rational, "[1/2 3/4]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 2), R64::new(3, 4)], 1, 2)));
-test_interpreter!(interpret_matrix_complex, "[1+2i 3+4i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(1.0, 2.0), C64::new(3.0, 4.0)], 1, 2)));
-test_interpreter!(interpret_matrix_add_rational, "[1/2 3/4] + [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(3, 4), R64::new(5, 4)], 1, 2)));
-test_interpreter!(interpret_matrix_add_complex, "[1+2i 3+4i] + [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(6.0, 8.0), C64::new(10.0, 12.0)], 1, 2)));
-test_interpreter!(interpret_matrix_sub_rational, "[1/2 3/4] - [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 4), R64::new(1, 4)], 1, 2)));
-test_interpreter!(interpret_matrix_sub_complex, "[1+2i 3+4i] - [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(-4.0, -4.0), C64::new(-4.0, -4.0)], 1, 2)));
-test_interpreter!(interpret_matrix_mul_rational, "[1/2 3/4] * [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 8), R64::new(3, 8)], 1, 2)));
-test_interpreter!(interpret_matrix_mul_complex, "[1+2i 3+4i] * [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(-7.0, 16.0), C64::new(-11.0, 52.0)], 1, 2)));
-test_interpreter!(interpret_matrix_div_rational, "[1/2 3/4] / [1/4 1/2]", Value::MatrixR64(Matrix::from_vec(vec![R64::new(2, 1), R64::new(3, 2)], 1, 2)));
-test_interpreter!(interpret_matrix_div_complex, "[1+2i 3+4i] / [5+6i 7+8i]", Value::MatrixC64(Matrix::from_vec(vec![C64::new(0.2786885245901639, 0.06557377049180328), C64::new(0.4690265486725664, 0.035398230088495575)], 1, 2)));
-
-test_interpreter!(interpret_matrix_eq_rational, "[1/2 3/4] == [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_eq_complex, "[1+2i 3+4i] == [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_neq_rational, "[1/2 3/4] != [1/2 3/5]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
-test_interpreter!(interpret_matrix_neq_complex, "[1+2i 3+4i] != [1+2i 3+5i]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
-test_interpreter!(interpret_matrix_gt_rational, "[1/2 3/4] > [1/4 1/2]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_gt_complex, "[1+2i 3+4i] > [1+1i 3+3i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_gte_rational, "[1/2 3/4] >= [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_gte_complex, "[1+2i 3+4i] >= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_lt_rational, "[1/2 3/4] < [3/4 1/2]", Value::MatrixBool(Matrix::from_vec(vec![true, false], 1, 2)));
-test_interpreter!(interpret_matrix_lt_complex, "[1+2i 3+4i] < [2+3i 4+5i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_lte_rational, "[1/2 3/4] <= [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_lte_complex, "[1+2i 3+4i] <= [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_matrix_assignment_copy_index, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b[2,3]", Value::F64(Ref::new(6.0)));
-test_interpreter!(interpret_matrix_assignment_copy_eq, "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b == a", Value::MatrixBool(Matrix::from_vec(vec![true, true, true, true, true, true, true, true, true], 3, 3)));
 test_interpreter!(
-  interpret_table_wildcard_access_returns_matrix,
-  "b := |a<f64> b<f64>| 1 2 | 3 4|; b<[*]>",
-  Value::MatrixValue(Matrix::from_vec(
-    vec![
-      Value::F64(Ref::new(1.0)),
-      Value::F64(Ref::new(3.0)),
-      Value::F64(Ref::new(2.0)),
-      Value::F64(Ref::new(4.0)),
-    ],
-    2,
-    2
-  ))
+    interpret_literal_complex,
+    "5+4i",
+    Value::C64(Ref::new(C64::new(5.0, 4.0)))
+);
+test_interpreter!(
+    interpret_literal_complex2,
+    "5-4i",
+    Value::C64(Ref::new(C64::new(5.0, -4.0)))
+);
+test_interpreter!(
+    interpret_literal_complex3,
+    "5-4j",
+    Value::C64(Ref::new(C64::new(5.0, -4.0)))
+);
+test_interpreter!(
+    interpret_literal_rational,
+    "1/2",
+    Value::R64(Ref::new(R64::new(1, 2)))
+);
+
+test_interpreter!(
+    interpret_comment,
+    "123 -- comment",
+    Value::F64(Ref::new(123.0))
+);
+test_interpreter!(
+    interpret_comment2,
+    "123 // comment",
+    Value::F64(Ref::new(123.0))
+);
+
+test_interpreter!(
+    interpret_formula_math_add,
+    "2 + 2",
+    Value::F64(Ref::new(4.0))
+);
+test_interpreter!(
+    interpret_formula_math_sub,
+    "2 - 2",
+    Value::F64(Ref::new(0.0))
+);
+test_interpreter!(
+    interpret_formula_math_mul,
+    "2 * 2",
+    Value::F64(Ref::new(4.0))
+);
+test_interpreter!(
+    interpret_formula_math_div,
+    "2 / 2",
+    Value::F64(Ref::new(1.0))
+);
+test_interpreter!(
+    interpret_formula_precedence_mul_before_compare,
+    "1 * 2 > 1 * 1",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_precedence_add_before_compare,
+    "1 + 2 > 1",
+    Value::Bool(Ref::new(true))
+);
+#[cfg(feature = "u8")]
+test_interpreter!(
+    interpret_formula_math_pow,
+    "2<u8> ^ 2<u8>",
+    Value::U8(Ref::new(4))
+);
+test_interpreter!(
+    interpret_formula_math_pow_f64,
+    "2.0 ^ 2.0",
+    Value::F64(Ref::new(4.0))
+);
+test_interpreter!(
+    interpret_formulat_math_add_rational,
+    "1/10 + 2/10 + 3/10",
+    Value::R64(Ref::new(R64::new(6, 10)))
+);
+test_interpreter!(
+    interpret_formulat_math_sub_rational,
+    "1/10 - 2/10 - 3/10",
+    Value::R64(Ref::new(R64::new(-4, 10)))
+);
+test_interpreter!(
+    interpret_formula_math_mul_rational,
+    "1/10 * 2/10 * 3/10",
+    Value::R64(Ref::new(R64::new(3, 500)))
+);
+test_interpreter!(
+    interpret_formula_math_div_rational,
+    "1/10 / 2/10 / 3/10",
+    Value::R64(Ref::new(R64::new(5, 3)))
+);
+test_interpreter!(
+    interpret_formula_math_add_complex,
+    "1+2i + 3+4i",
+    Value::C64(Ref::new(C64::new(4.0, 6.0)))
+);
+test_interpreter!(
+    interpret_formula_math_add_complex_real_rhs,
+    "4i + 1",
+    Value::C64(Ref::new(C64::new(1.0, 4.0)))
+);
+test_interpreter!(
+    interpret_formula_math_add_complex_real_lhs,
+    "1 + 4i",
+    Value::C64(Ref::new(C64::new(1.0, 4.0)))
+);
+test_interpreter!(
+    interpret_variable_define_complex_real_sum,
+    "y := 4i + 1",
+    Value::C64(Ref::new(C64::new(1.0, 4.0)))
+);
+test_interpreter!(
+    interpret_variable_add_complex_real,
+    "z := 4i; z + 1",
+    Value::C64(Ref::new(C64::new(1.0, 4.0)))
+);
+test_interpreter!(
+    interpret_formula_math_sub_complex,
+    "1+2i - 3+4i",
+    Value::C64(Ref::new(C64::new(-2.0, -2.0)))
+);
+test_interpreter!(
+    interpret_formula_math_mul_complex,
+    "1+2i * 3+4i",
+    Value::C64(Ref::new(C64::new(-5.0, 10.0)))
+);
+test_interpreter!(
+    interpret_formula_math_div_complex,
+    "1+2i / 3+4i",
+    Value::C64(Ref::new(C64::new(0.44, 0.08)))
+);
+
+test_interpreter!(
+    interpret_matrix_rational,
+    "[1/2 3/4]",
+    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 2), R64::new(3, 4)], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_complex,
+    "[1+2i 3+4i]",
+    Value::MatrixC64(Matrix::from_vec(
+        vec![C64::new(1.0, 2.0), C64::new(3.0, 4.0)],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_add_rational,
+    "[1/2 3/4] + [1/4 1/2]",
+    Value::MatrixR64(Matrix::from_vec(vec![R64::new(3, 4), R64::new(5, 4)], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_add_complex,
+    "[1+2i 3+4i] + [5+6i 7+8i]",
+    Value::MatrixC64(Matrix::from_vec(
+        vec![C64::new(6.0, 8.0), C64::new(10.0, 12.0)],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_sub_rational,
+    "[1/2 3/4] - [1/4 1/2]",
+    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 4), R64::new(1, 4)], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_sub_complex,
+    "[1+2i 3+4i] - [5+6i 7+8i]",
+    Value::MatrixC64(Matrix::from_vec(
+        vec![C64::new(-4.0, -4.0), C64::new(-4.0, -4.0)],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_mul_rational,
+    "[1/2 3/4] * [1/4 1/2]",
+    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 8), R64::new(3, 8)], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_mul_complex,
+    "[1+2i 3+4i] * [5+6i 7+8i]",
+    Value::MatrixC64(Matrix::from_vec(
+        vec![C64::new(-7.0, 16.0), C64::new(-11.0, 52.0)],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_div_rational,
+    "[1/2 3/4] / [1/4 1/2]",
+    Value::MatrixR64(Matrix::from_vec(vec![R64::new(2, 1), R64::new(3, 2)], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_div_complex,
+    "[1+2i 3+4i] / [5+6i 7+8i]",
+    Value::MatrixC64(Matrix::from_vec(
+        vec![
+            C64::new(0.2786885245901639, 0.06557377049180328),
+            C64::new(0.4690265486725664, 0.035398230088495575)
+        ],
+        1,
+        2
+    ))
+);
+
+test_interpreter!(
+    interpret_matrix_eq_rational,
+    "[1/2 3/4] == [1/2 3/4]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_eq_complex,
+    "[1+2i 3+4i] == [1+2i 3+4i]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_neq_rational,
+    "[1/2 3/4] != [1/2 3/5]",
+    Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_neq_complex,
+    "[1+2i 3+4i] != [1+2i 3+5i]",
+    Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_gt_rational,
+    "[1/2 3/4] > [1/4 1/2]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_gt_complex,
+    "[1+2i 3+4i] > [1+1i 3+3i]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_gte_rational,
+    "[1/2 3/4] >= [1/2 3/4]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_gte_complex,
+    "[1+2i 3+4i] >= [1+2i 3+4i]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_lt_rational,
+    "[1/2 3/4] < [3/4 1/2]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, false], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_lt_complex,
+    "[1+2i 3+4i] < [2+3i 4+5i]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_lte_rational,
+    "[1/2 3/4] <= [1/2 3/4]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_lte_complex,
+    "[1+2i 3+4i] <= [1+2i 3+4i]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_assignment_copy_index,
+    "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b[2,3]",
+    Value::F64(Ref::new(6.0))
+);
+test_interpreter!(
+    interpret_matrix_assignment_copy_eq,
+    "a := [1 2 3; 4 5 6; 7 8 9]; b := a; b == a",
+    Value::MatrixBool(Matrix::from_vec(
+        vec![true, true, true, true, true, true, true, true, true],
+        3,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_table_wildcard_access_returns_matrix,
+    "b := |a<f64> b<f64>| 1 2 | 3 4|; b<[*]>",
+    Value::MatrixValue(Matrix::from_vec(
+        vec![
+            Value::F64(Ref::new(1.0)),
+            Value::F64(Ref::new(3.0)),
+            Value::F64(Ref::new(2.0)),
+            Value::F64(Ref::new(4.0)),
+        ],
+        2,
+        2
+    ))
 );
 #[cfg(feature = "u64")]
 test_interpreter!(interpret_kind_annotation, "1<u64>", Value::U64(Ref::new(1)));
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_kind_annotation_math, "1<u64> + 1<u64>", Value::U64(Ref::new(2)));
+test_interpreter!(
+    interpret_kind_annotation_math,
+    "1<u64> + 1<u64>",
+    Value::U64(Ref::new(2))
+);
 #[cfg(feature = "f64")]
 test_interpreter!(
-  interpret_nested_kind_matrix_literal,
-  "<<[f64]:3>>",
-  Value::Kind(ValueKind::Kind(Box::new(ValueKind::Matrix(Box::new(ValueKind::F64), vec![3]))))
+    interpret_nested_kind_matrix_literal,
+    "<<[f64]:3>>",
+    Value::Kind(ValueKind::Kind(Box::new(ValueKind::Matrix(
+        Box::new(ValueKind::F64),
+        vec![3]
+    ))))
 );
 
 // New tests overflow - unsigned
 // test_interpreter!(interpret_kind_math_overflow_u64, "18446744073709551615<u64> + 1<u64>", Value::U64(Ref::new(0)));
 // test_interpreter!(interpret_kind_math_overflow_u128, "340282366920938463463374607431768211455<u128> + 1<u128>", Value::U128(Ref::new(0)));
-
 
 // New tests overflow - unsigned
 // test_interpreter!(interpret_kind_math_overflow_u64, "18446744073709551615<u64> + 1<u64>", Value::U64(Ref::new(0)));
@@ -388,288 +698,960 @@ test_interpreter!(
 // New tests nominal with type def - unsigned
 //u8
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_formula_math_add_u8, "2<u8> + 2<u8>", Value::U8(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_u8,
+    "2<u8> + 2<u8>",
+    Value::U8(Ref::new(4))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_formula_math_sub_u8, "2<u8> - 2<u8>", Value::U8(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_u8,
+    "2<u8> - 2<u8>",
+    Value::U8(Ref::new(0))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_formula_math_div_u8, "2<u8> / 2<u8>", Value::U8(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_u8,
+    "2<u8> / 2<u8>",
+    Value::U8(Ref::new(1))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_formula_math_mul_u8, "2<u8> * 2<u8>", Value::U8(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_u8,
+    "2<u8> * 2<u8>",
+    Value::U8(Ref::new(4))
+);
 // u16
 #[cfg(feature = "u16")]
-test_interpreter!(interpret_formula_math_add_u16, "2<u16> + 2<u16>", Value::U16(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_u16,
+    "2<u16> + 2<u16>",
+    Value::U16(Ref::new(4))
+);
 #[cfg(feature = "u16")]
-test_interpreter!(interpret_formula_math_sub_u16, "2<u16> - 2<u16>", Value::U16(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_u16,
+    "2<u16> - 2<u16>",
+    Value::U16(Ref::new(0))
+);
 #[cfg(feature = "u16")]
-test_interpreter!(interpret_formula_math_div_u16, "2<u16> / 2<u16>", Value::U16(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_u16,
+    "2<u16> / 2<u16>",
+    Value::U16(Ref::new(1))
+);
 #[cfg(feature = "u16")]
-test_interpreter!(interpret_formula_math_mul_u16, "2<u16> * 2<u16>", Value::U16(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_u16,
+    "2<u16> * 2<u16>",
+    Value::U16(Ref::new(4))
+);
 // u32
 #[cfg(feature = "u32")]
-test_interpreter!(interpret_formula_math_add_u32, "2<u32> + 2<u32>", Value::U32(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_u32,
+    "2<u32> + 2<u32>",
+    Value::U32(Ref::new(4))
+);
 #[cfg(feature = "u32")]
-test_interpreter!(interpret_formula_math_sub_u32, "2<u32> - 2<u32>", Value::U32(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_u32,
+    "2<u32> - 2<u32>",
+    Value::U32(Ref::new(0))
+);
 #[cfg(feature = "u32")]
-test_interpreter!(interpret_formula_math_div_u32, "2<u32> / 2<u32>", Value::U32(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_u32,
+    "2<u32> / 2<u32>",
+    Value::U32(Ref::new(1))
+);
 #[cfg(feature = "u32")]
-test_interpreter!(interpret_formula_math_mul_u32, "2<u32> * 2<u32>", Value::U32(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_u32,
+    "2<u32> * 2<u32>",
+    Value::U32(Ref::new(4))
+);
 // u64
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_math_add_u64, "2<u64> + 2<u64>", Value::U64(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_u64,
+    "2<u64> + 2<u64>",
+    Value::U64(Ref::new(4))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_math_sub_u64, "2<u64> - 2<u64>", Value::U64(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_u64,
+    "2<u64> - 2<u64>",
+    Value::U64(Ref::new(0))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_math_sub_u64_with_default_literal_rhs, "2<u64> - 1", Value::U64(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_sub_u64_with_default_literal_rhs,
+    "2<u64> - 1",
+    Value::U64(Ref::new(1))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_math_div_u64, "2<u64> / 2<u64>", Value::U64(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_u64,
+    "2<u64> / 2<u64>",
+    Value::U64(Ref::new(1))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_math_mul_u64, "2<u64> * 2<u64>", Value::U64(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_u64,
+    "2<u64> * 2<u64>",
+    Value::U64(Ref::new(4))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_compare_gt_u64_with_default_literal_rhs, "2<u64> > 1", Value::Bool(Ref::new(true)));
+test_interpreter!(
+    interpret_formula_compare_gt_u64_with_default_literal_rhs,
+    "2<u64> > 1",
+    Value::Bool(Ref::new(true))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_formula_compare_gt_u64_with_default_literal_lhs, "2 > 1<u64>", Value::Bool(Ref::new(true)));
+test_interpreter!(
+    interpret_formula_compare_gt_u64_with_default_literal_lhs,
+    "2 > 1<u64>",
+    Value::Bool(Ref::new(true))
+);
 // u128
 #[cfg(feature = "u128")]
-test_interpreter!(interpret_formula_math_add_u128, "2<u128> + 2<u128>", Value::U128(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_u128,
+    "2<u128> + 2<u128>",
+    Value::U128(Ref::new(4))
+);
 #[cfg(feature = "u128")]
-test_interpreter!(interpret_formula_math_sub_u128, "2<u128> - 2<u128>", Value::U128(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_u128,
+    "2<u128> - 2<u128>",
+    Value::U128(Ref::new(0))
+);
 #[cfg(feature = "u128")]
-test_interpreter!(interpret_formula_math_div_u128, "2<u128> / 2<u128>", Value::U128(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_u128,
+    "2<u128> / 2<u128>",
+    Value::U128(Ref::new(1))
+);
 #[cfg(feature = "u128")]
-test_interpreter!(interpret_formula_math_mul_u128, "2<u128> * 2<u128>", Value::U128(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_u128,
+    "2<u128> * 2<u128>",
+    Value::U128(Ref::new(4))
+);
 
 // New tests nominal with type def - signed
 //i8
 #[cfg(feature = "i8")]
-test_interpreter!(interpret_formula_math_add_i8, "2<i8> + 2<i8>", Value::I8(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_i8,
+    "2<i8> + 2<i8>",
+    Value::I8(Ref::new(4))
+);
 #[cfg(feature = "i8")]
-test_interpreter!(interpret_formula_math_sub_i8, "2<i8> - 2<i8>", Value::I8(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_i8,
+    "2<i8> - 2<i8>",
+    Value::I8(Ref::new(0))
+);
 #[cfg(feature = "i8")]
-test_interpreter!(interpret_formula_math_div_i8, "2<i8> / 2<i8>", Value::I8(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_i8,
+    "2<i8> / 2<i8>",
+    Value::I8(Ref::new(1))
+);
 #[cfg(feature = "i8")]
-test_interpreter!(interpret_formula_math_mul_i8, "2<i8> * 2<i8>", Value::I8(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_i8,
+    "2<i8> * 2<i8>",
+    Value::I8(Ref::new(4))
+);
 // i16
 #[cfg(feature = "i16")]
-test_interpreter!(interpret_formula_math_add_i16, "2<i16> + 2<i16>", Value::I16(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_i16,
+    "2<i16> + 2<i16>",
+    Value::I16(Ref::new(4))
+);
 #[cfg(feature = "i16")]
-test_interpreter!(interpret_formula_math_sub_i16, "2<i16> - 2<i16>", Value::I16(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_i16,
+    "2<i16> - 2<i16>",
+    Value::I16(Ref::new(0))
+);
 #[cfg(feature = "i16")]
-test_interpreter!(interpret_formula_math_div_i16, "2<i16> / 2<i16>", Value::I16(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_i16,
+    "2<i16> / 2<i16>",
+    Value::I16(Ref::new(1))
+);
 #[cfg(feature = "i16")]
-test_interpreter!(interpret_formula_math_mul_i16, "2<i16> * 2<i16>", Value::I16(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_i16,
+    "2<i16> * 2<i16>",
+    Value::I16(Ref::new(4))
+);
 // i32
 #[cfg(feature = "i32")]
-test_interpreter!(interpret_formula_math_add_i32, "2<i32> + 2<i32>", Value::I32(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_i32,
+    "2<i32> + 2<i32>",
+    Value::I32(Ref::new(4))
+);
 #[cfg(feature = "i32")]
-test_interpreter!(interpret_formula_math_sub_i32, "2<i32> - 2<i32>", Value::I32(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_i32,
+    "2<i32> - 2<i32>",
+    Value::I32(Ref::new(0))
+);
 #[cfg(feature = "i32")]
-test_interpreter!(interpret_formula_math_div_i32, "2<i32> / 2<i32>", Value::I32(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_i32,
+    "2<i32> / 2<i32>",
+    Value::I32(Ref::new(1))
+);
 #[cfg(feature = "i32")]
-test_interpreter!(interpret_formula_math_mul_i32, "2<i32> * 2<i32>", Value::I32(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_i32,
+    "2<i32> * 2<i32>",
+    Value::I32(Ref::new(4))
+);
 // i64
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_formula_math_add_i64, "2<i64> + 2<i64>", Value::I64(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_i64,
+    "2<i64> + 2<i64>",
+    Value::I64(Ref::new(4))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_formula_math_sub_i64, "2<i64> - 2<i64>", Value::I64(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_i64,
+    "2<i64> - 2<i64>",
+    Value::I64(Ref::new(0))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_formula_math_div_i64, "2<i64> / 2<i64>", Value::I64(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_i64,
+    "2<i64> / 2<i64>",
+    Value::I64(Ref::new(1))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_formula_math_mul_i64, "2<i64> * 2<i64>", Value::I64(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_i64,
+    "2<i64> * 2<i64>",
+    Value::I64(Ref::new(4))
+);
 // i128
 #[cfg(feature = "i128")]
-test_interpreter!(interpret_formula_math_add_i128, "2<i128> + 2<i128>", Value::I128(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_add_i128,
+    "2<i128> + 2<i128>",
+    Value::I128(Ref::new(4))
+);
 #[cfg(feature = "i128")]
-test_interpreter!(interpret_formula_math_sub_i128, "2<i128> - 2<i128>", Value::I128(Ref::new(0)));
+test_interpreter!(
+    interpret_formula_math_sub_i128,
+    "2<i128> - 2<i128>",
+    Value::I128(Ref::new(0))
+);
 #[cfg(feature = "i128")]
-test_interpreter!(interpret_formula_math_div_i128, "2<i128> / 2<i128>", Value::I128(Ref::new(1)));
+test_interpreter!(
+    interpret_formula_math_div_i128,
+    "2<i128> / 2<i128>",
+    Value::I128(Ref::new(1))
+);
 #[cfg(feature = "i128")]
-test_interpreter!(interpret_formula_math_mul_i128, "2<i128> * 2<i128>", Value::I128(Ref::new(4)));
+test_interpreter!(
+    interpret_formula_math_mul_i128,
+    "2<i128> * 2<i128>",
+    Value::I128(Ref::new(4))
+);
 
 // New tests for nominal with type def - floats
 // f32
 #[cfg(feature = "f32")]
-test_interpreter!(interpret_formula_math_add_f32, "2.0<f32> + 2.0<f32>", Value::F32(Ref::new(4.0)));
+test_interpreter!(
+    interpret_formula_math_add_f32,
+    "2.0<f32> + 2.0<f32>",
+    Value::F32(Ref::new(4.0))
+);
 #[cfg(feature = "f32")]
-test_interpreter!(interpret_formula_math_sub_f32, "2.0<f32> - 2.0<f32>", Value::F32(Ref::new(0.0)));
+test_interpreter!(
+    interpret_formula_math_sub_f32,
+    "2.0<f32> - 2.0<f32>",
+    Value::F32(Ref::new(0.0))
+);
 #[cfg(feature = "f32")]
-test_interpreter!(interpret_formula_math_div_f32, "2.0<f32> / 2.0<f32>", Value::F32(Ref::new(1.0)));
+test_interpreter!(
+    interpret_formula_math_div_f32,
+    "2.0<f32> / 2.0<f32>",
+    Value::F32(Ref::new(1.0))
+);
 #[cfg(feature = "f32")]
-test_interpreter!(interpret_formula_math_mul_f32, "2.0<f32> * 2.0<f32>", Value::F32(Ref::new(4.0)));
+test_interpreter!(
+    interpret_formula_math_mul_f32,
+    "2.0<f32> * 2.0<f32>",
+    Value::F32(Ref::new(4.0))
+);
 //f64
-test_interpreter!(interpret_formula_math_add_f64, "2.0<f64> + 2.0<f64>", Value::F64(Ref::new(4.0)));
-test_interpreter!(interpret_formula_math_sub_f64, "2.0<f64> - 2.0<f64>", Value::F64(Ref::new(0.0)));
-test_interpreter!(interpret_formula_math_div_f64, "2.0<f64> / 2.0<f64>", Value::F64(Ref::new(1.0)));
-test_interpreter!(interpret_formula_math_mul_f64, "2.0<f64> * 2.0<f64>", Value::F64(Ref::new(4.0)));
+test_interpreter!(
+    interpret_formula_math_add_f64,
+    "2.0<f64> + 2.0<f64>",
+    Value::F64(Ref::new(4.0))
+);
+test_interpreter!(
+    interpret_formula_math_sub_f64,
+    "2.0<f64> - 2.0<f64>",
+    Value::F64(Ref::new(0.0))
+);
+test_interpreter!(
+    interpret_formula_math_div_f64,
+    "2.0<f64> / 2.0<f64>",
+    Value::F64(Ref::new(1.0))
+);
+test_interpreter!(
+    interpret_formula_math_mul_f64,
+    "2.0<f64> * 2.0<f64>",
+    Value::F64(Ref::new(4.0))
+);
 
 #[cfg(feature = "u16")]
-test_interpreter!(interpret_kind_math_no_overflow, "255<u16> + 1<u16>", Value::U16(Ref::new(256)));
+test_interpreter!(
+    interpret_kind_math_no_overflow,
+    "255<u16> + 1<u16>",
+    Value::U16(Ref::new(256))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_kind_matrix_row3, "[1<u8> 2<u8> 3<u8>]", Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3)));
+test_interpreter!(
+    interpret_kind_matrix_row3,
+    "[1<u8> 2<u8> 3<u8>]",
+    Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_kind_lhs_define, "x<u64> := 1", Value::U64(Ref::new(1)));
+test_interpreter!(
+    interpret_kind_lhs_define,
+    "x<u64> := 1",
+    Value::U64(Ref::new(1))
+);
 #[cfg(all(feature = "u64", feature = "i8"))]
-test_interpreter!(interpret_kind_convert_twice, "x<u64> := 1; y<i8> := x", Value::I8(Ref::new(1)));
+test_interpreter!(
+    interpret_kind_convert_twice,
+    "x<u64> := 1; y<i8> := x",
+    Value::I8(Ref::new(1))
+);
 #[cfg(feature = "f32")]
-test_interpreter!(interpret_kind_convert_float, "x<f32> := 123;", Value::F32(Ref::new(123.0)));
-test_interpreter!(interpret_kind_convert_rational, "x<r64> := 1 / 2; y<f64> := x", Value::F64(Ref::new(0.5)));
-test_interpreter!(interpret_kind_convert_rational2, "x<f64> := 1/2; y<r64> := x", Value::R64(Ref::new(R64::new(1, 2))));
-test_interpreter!(interpret_kind_convert_mat_to_any, "x := [2 3 4]; y<[*]> := x", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
+test_interpreter!(
+    interpret_kind_convert_float,
+    "x<f32> := 123;",
+    Value::F32(Ref::new(123.0))
+);
+test_interpreter!(
+    interpret_kind_convert_rational,
+    "x<r64> := 1 / 2; y<f64> := x",
+    Value::F64(Ref::new(0.5))
+);
+test_interpreter!(
+    interpret_kind_convert_rational2,
+    "x<f64> := 1/2; y<r64> := x",
+    Value::R64(Ref::new(R64::new(1, 2)))
+);
+test_interpreter!(
+    interpret_kind_convert_mat_to_any,
+    "x := [2 3 4]; y<[*]> := x",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
+);
 
-test_interpreter!(interpret_kind_define, "<foo> := <f64>; x<foo> := 123", Value::F64(Ref::new(123.0)));
+test_interpreter!(
+    interpret_kind_define,
+    "<foo> := <f64>; x<foo> := 123",
+    Value::F64(Ref::new(123.0))
+);
 test_interpreter!(interpret_formula_math_neg, "-1", Value::F64(Ref::new(-1.0)));
-test_interpreter!(interpret_formula_math_multiple_terms, "1 + 2 + 3", Value::F64(Ref::new(6.0)));
-test_interpreter!(interpret_formula_comparison_bool, "true == false", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_formula_comparison_bool2, "true == true", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_comparison_eq, "10 == 11", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_formula_comparison_string_eq, r#"["a" "b"] == ["a" "b"]"#, Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
-test_interpreter!(interpret_formula_comparison_string_neq, r#"["a" "b"] != ["a" "c"]"#, Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
-test_interpreter!(interpret_formula_comparison_neq, "10 != 11", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_comparison_neq_bool, "false != true", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_comparison_gt, "10 > 11", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_formula_comparison_lt, "10 < 11", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_comparison_gte, "10 >= 10", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_comparison_lte, "10 <= 10", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_comparison_gt_vec, "[1 8; 10 5] > [7 2; 4 11]", Value::MatrixBool(Matrix::from_vec(vec![false, true, true, false], 2, 2)));
-test_interpreter!(interpret_formula_comparison_lt_vec, "[1 8 10 5] < [7 2 4 11]", Value::MatrixBool(Matrix::from_vec(vec![true, false, false, true], 1, 4)));
-test_interpreter!(interpret_formula_unicode, "😃:=1;🤦🏼‍♂️:=2;y̆és:=🤦🏼‍♂️ + 😃", Value::F64(Ref::new(3.0)));
-test_interpreter!(interpret_formula_logic_and, "true && true", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_logic_and_vec, "[true false] && [false false]", Value::MatrixBool(Matrix::from_vec(vec![false, false], 1, 2)));
-test_interpreter!(interpret_formula_logic_and2, "true && false", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_formula_logic_or_vec, "[true false true] || [false false true]", Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3)));
-test_interpreter!(interpret_formula_logic_or, "true || false", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_logic_or2, "false || false", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_formula_logic_xor_vec, "[true false false true] ⊕ [true true false true]", Value::MatrixBool(Matrix::from_vec(vec![false, true, false, false], 1, 4)));
-test_interpreter!(interpret_formula_logic_not, "!false", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_formula_logic_not_vec, "![false true false]", Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3)));
-test_interpreter!(interpret_formula_logic_not_vec1, "![false]", Value::MatrixBool(Matrix::from_vec(vec![true], 1, 1)));
+test_interpreter!(
+    interpret_formula_math_multiple_terms,
+    "1 + 2 + 3",
+    Value::F64(Ref::new(6.0))
+);
+test_interpreter!(
+    interpret_formula_comparison_bool,
+    "true == false",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_formula_comparison_bool2,
+    "true == true",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_comparison_eq,
+    "10 == 11",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_formula_comparison_string_eq,
+    r#"["a" "b"] == ["a" "b"]"#,
+    Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2))
+);
+test_interpreter!(
+    interpret_formula_comparison_string_neq,
+    r#"["a" "b"] != ["a" "c"]"#,
+    Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2))
+);
+test_interpreter!(
+    interpret_formula_comparison_neq,
+    "10 != 11",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_comparison_neq_bool,
+    "false != true",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_comparison_gt,
+    "10 > 11",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_formula_comparison_lt,
+    "10 < 11",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_comparison_gte,
+    "10 >= 10",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_comparison_lte,
+    "10 <= 10",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_comparison_gt_vec,
+    "[1 8; 10 5] > [7 2; 4 11]",
+    Value::MatrixBool(Matrix::from_vec(vec![false, true, true, false], 2, 2))
+);
+test_interpreter!(
+    interpret_formula_comparison_lt_vec,
+    "[1 8 10 5] < [7 2 4 11]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, false, false, true], 1, 4))
+);
+test_interpreter!(
+    interpret_formula_unicode,
+    "😃:=1;🤦🏼‍♂️:=2;y̆és:=🤦🏼‍♂️ + 😃",
+    Value::F64(Ref::new(3.0))
+);
+test_interpreter!(
+    interpret_formula_logic_and,
+    "true && true",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_logic_and_vec,
+    "[true false] && [false false]",
+    Value::MatrixBool(Matrix::from_vec(vec![false, false], 1, 2))
+);
+test_interpreter!(
+    interpret_formula_logic_and2,
+    "true && false",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_formula_logic_or_vec,
+    "[true false true] || [false false true]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3))
+);
+test_interpreter!(
+    interpret_formula_logic_or,
+    "true || false",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_logic_or2,
+    "false || false",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_formula_logic_xor_vec,
+    "[true false false true] ⊕ [true true false true]",
+    Value::MatrixBool(Matrix::from_vec(vec![false, true, false, false], 1, 4))
+);
+test_interpreter!(
+    interpret_formula_logic_not,
+    "!false",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_formula_logic_not_vec,
+    "![false true false]",
+    Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 1, 3))
+);
+test_interpreter!(
+    interpret_formula_logic_not_vec1,
+    "![false]",
+    Value::MatrixBool(Matrix::from_vec(vec![true], 1, 1))
+);
 
-test_interpreter!(interpret_statement_variable_define, "x := 123", Value::F64(Ref::new(123.0)));
+test_interpreter!(
+    interpret_statement_variable_define,
+    "x := 123",
+    Value::F64(Ref::new(123.0))
+);
 
-test_interpreter!(interpret_reference_bool, "x := false; y := true; x && y", Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_reference_bool2, "x := false; x && true", Value::Bool(Ref::new(false)));
+test_interpreter!(
+    interpret_reference_bool,
+    "x := false; y := true; x && y",
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_reference_bool2,
+    "x := false; x && true",
+    Value::Bool(Ref::new(false))
+);
 
-test_interpreter!(interpret_variable_recall, "a := 1; b := 2; a", Value::MutableReference(Ref::new(Value::F64(Ref::new(1.0)))));
+test_interpreter!(
+    interpret_variable_recall,
+    "a := 1; b := 2; a",
+    Value::MutableReference(Ref::new(Value::F64(Ref::new(1.0))))
+);
 
-test_interpreter!(interpret_matrix_range_exclusive, "1..4", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
-test_interpreter!(interpret_matrix_range_exclusive_step, "1..4..13", Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0], 1, 3)));
+test_interpreter!(
+    interpret_matrix_range_exclusive,
+    "1..4",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_range_exclusive_step,
+    "1..4..13",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0], 1, 3))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_matrix_range_exclusive_u8, "1<u8>..4<u8>", Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3)));
-test_interpreter!(interpret_matrix_range_inclusive, "1..=4", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
-test_interpreter!(interpret_matrix_range_inclusive_step, "1..4..=13", Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0, 13.0], 1, 4)));
+test_interpreter!(
+    interpret_matrix_range_exclusive_u8,
+    "1<u8>..4<u8>",
+    Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_range_inclusive,
+    "1..=4",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_matrix_range_inclusive_step,
+    "1..4..=13",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 9.0, 13.0], 1, 4))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_matrix_range_inclusive_u8, "1<u8>..=4<u8>", Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3, 4], 1, 4)));
-test_interpreter!(interpret_matrix_empty, "[]", Value::MatrixValue(Matrix::from_vec(vec![], 0, 0)));
-test_interpreter!(interpret_matrix_row3, "[1 2 3]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
-test_interpreter!(interpret_matrix_mat1, "[123]", Value::MatrixF64(Matrix::from_vec(vec![123.0], 1, 1)));
-test_interpreter!(interpret_matrix_row3_float, "[1.2 2.3 3.4]", Value::MatrixF64(Matrix::from_vec(vec![1.2, 2.3, 3.4], 1, 3)));
-test_interpreter!(interpret_matrix_mat2, "[1 2; 3 4]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
-test_interpreter!(interpret_matrix_transpose, "[1 2; 3 4]'", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 2, 2)));
+test_interpreter!(
+    interpret_matrix_range_inclusive_u8,
+    "1<u8>..=4<u8>",
+    Value::MatrixU8(Matrix::from_vec(vec![1, 2, 3, 4], 1, 4))
+);
+test_interpreter!(
+    interpret_matrix_empty,
+    "[]",
+    Value::MatrixValue(Matrix::from_vec(vec![], 0, 0))
+);
+test_interpreter!(
+    interpret_matrix_row3,
+    "[1 2 3]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_mat1,
+    "[123]",
+    Value::MatrixF64(Matrix::from_vec(vec![123.0], 1, 1))
+);
+test_interpreter!(
+    interpret_matrix_row3_float,
+    "[1.2 2.3 3.4]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.2, 2.3, 3.4], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_mat2,
+    "[1 2; 3 4]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_transpose,
+    "[1 2; 3 4]'",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 2, 2))
+);
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_matrix_transpose_u8, "[1<u8> 2<u8> 3<u8>]'", Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 3, 1)));
-test_interpreter!(interpret_matrix_transpose_float, "[1.0 2.0 3.0; 4.0 5.0 6.0]'", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2)));
+test_interpreter!(
+    interpret_matrix_transpose_u8,
+    "[1<u8> 2<u8> 3<u8>]'",
+    Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 3, 1))
+);
+test_interpreter!(
+    interpret_matrix_transpose_float,
+    "[1.0 2.0 3.0; 4.0 5.0 6.0]'",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_matrix_transpose_vector, "x := | x<i64> | 1 | 3 | 5 |; x.x'", Value::MatrixI64(Matrix::from_vec(vec![1i64, 3, 5], 1, 3)));
-test_interpreter!(interpret_matrix_add_v2s, "[1;2] + 3", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 2, 1)));
+test_interpreter!(
+    interpret_matrix_transpose_vector,
+    "x := | x<i64> | 1 | 3 | 5 |; x.x'",
+    Value::MatrixI64(Matrix::from_vec(vec![1i64, 3, 5], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_add_v2s,
+    "[1;2] + 3",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 2, 1))
+);
 
-test_interpreter!(interpret_matrix_mat2_f64, "[1.1 2.2; 3.3 4.4]", Value::MatrixF64(Matrix::from_vec(vec![1.1, 3.3, 2.2, 4.4], 2, 2)));
-test_interpreter!(interpret_matrix_negate, "-[1 2; 3 4]", Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2)));
-test_interpreter!(interpret_matrix_negate_float, "-[1.0 2.0; 3.0 4.0]", Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2)));
-test_interpreter!(interpret_matrix_negate_mat1, "-[1]", Value::MatrixF64(Matrix::from_vec(vec![-1.0], 1, 1)));
+test_interpreter!(
+    interpret_matrix_mat2_f64,
+    "[1.1 2.2; 3.3 4.4]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.1, 3.3, 2.2, 4.4], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_negate,
+    "-[1 2; 3 4]",
+    Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_negate_float,
+    "-[1.0 2.0; 3.0 4.0]",
+    Value::MatrixF64(Matrix::from_vec(vec![-1.0, -3.0, -2.0, -4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_negate_mat1,
+    "-[1]",
+    Value::MatrixF64(Matrix::from_vec(vec![-1.0], 1, 1))
+);
 
-test_interpreter!(interpret_matrix_row3_add, "[1 2 3] + [4 5 6]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3)));
-test_interpreter!(interpret_matrix_row3_mul_scalar, "[1 2 3] * 3", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3)));
-test_interpreter!(interpret_matrix_row3_mul_scalar2, "3 * [1 2 3]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3)));
-test_interpreter!(interpret_matrix_row3_add_float, "[1.0 2.0 3.0] + [4.0 5.0 6.0]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3)));
-test_interpreter!(interpret_matrix_row3_sub, "[1 2 3] - [4 5 6]", Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3)));
-test_interpreter!(interpret_matrix_row3_sub_float, "[1.0 2.0 3.0] - [4.0 5.0 6.0]", Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3)));
-test_interpreter!(interpret_matrix_row3_add_ref, "a := [1 2 3]; b := [4 5 6]; c := a + b", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3)));
-test_interpreter!(interpret_matrix_dynamic_add, "[1 2 3 4; 5 6 7 8] + [1 2 3 4; 5 6 7 8]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 10.0, 4.0, 12.0, 6.0, 14.0, 8.0, 16.0], 2, 4)));
-test_interpreter!(interpret_matrix_dynamic_div, "[2 4 6 8] / [2 2 2 2]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
-test_interpreter!(interpret_matrix_gt, "x := [66.0 2.0 3.0; 66.0 5.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x > y", Value::MatrixBool(Matrix::from_vec(vec![true, true, false, false, false, true], 2, 3)));
-test_interpreter!(interpret_matrix_lt, "x := [66.0 2.0 3.0; 66.0 4.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x < y", Value::MatrixBool(Matrix::from_vec(vec![false, false, false, true, false, false], 2, 3)));
-test_interpreter!(interpret_matrix_lt_int, "x := [66 2 3; 66 4 66]; y := [1 2 3; 4 5 6]; x < y", Value::MatrixBool(Matrix::from_vec(vec![false, false, false, true, false, false], 2, 3)));
-test_interpreter!(interpret_matrix_add_m2v2, "[1 1; 2 2] + [1;2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2)));
-test_interpreter!(interpret_matrix_add_v2m2, "[1;2] + [1 1; 2 2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2)));
-test_interpreter!(interpret_matrix_add_r2m2, "[1 2] + [1 1; 1 1]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2)));
-test_interpreter!(interpret_matrix_add_m2r2, "[1 1; 1 1] + [1 2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2)));
+test_interpreter!(
+    interpret_matrix_row3_add,
+    "[1 2 3] + [4 5 6]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_row3_mul_scalar,
+    "[1 2 3] * 3",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_row3_mul_scalar2,
+    "3 * [1 2 3]",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_row3_add_float,
+    "[1.0 2.0 3.0] + [4.0 5.0 6.0]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_row3_sub,
+    "[1 2 3] - [4 5 6]",
+    Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_row3_sub_float,
+    "[1.0 2.0 3.0] - [4.0 5.0 6.0]",
+    Value::MatrixF64(Matrix::from_vec(vec![-3.0, -3.0, -3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_row3_add_ref,
+    "a := [1 2 3]; b := [4 5 6]; c := a + b",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0, 9.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrix_dynamic_add,
+    "[1 2 3 4; 5 6 7 8] + [1 2 3 4; 5 6 7 8]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![2.0, 10.0, 4.0, 12.0, 6.0, 14.0, 8.0, 16.0],
+        2,
+        4
+    ))
+);
+test_interpreter!(
+    interpret_matrix_dynamic_div,
+    "[2 4 6 8] / [2 2 2 2]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_matrix_gt,
+    "x := [66.0 2.0 3.0; 66.0 5.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x > y",
+    Value::MatrixBool(Matrix::from_vec(
+        vec![true, true, false, false, false, true],
+        2,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_matrix_lt,
+    "x := [66.0 2.0 3.0; 66.0 4.0 66.0]; y := [1.0 2.0 3.0; 4.0 5.0 6.0]; x < y",
+    Value::MatrixBool(Matrix::from_vec(
+        vec![false, false, false, true, false, false],
+        2,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_matrix_lt_int,
+    "x := [66 2 3; 66 4 66]; y := [1 2 3; 4 5 6]; x < y",
+    Value::MatrixBool(Matrix::from_vec(
+        vec![false, false, false, true, false, false],
+        2,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_matrix_add_m2v2,
+    "[1 1; 2 2] + [1;2]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_add_v2m2,
+    "[1;2] + [1 1; 2 2]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_add_r2m2,
+    "[1 2] + [1 1; 1 1]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_add_m2r2,
+    "[1 1; 1 1] + [1 2]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0, 3.0, 3.0], 2, 2))
+);
 
-test_interpreter!(interpret_matrix_dot, "[1 2 3] · [4 5 6]", Value::F64(Ref::new(32.0)));
-test_interpreter!(interpret_matrix_matmul_mat1, "[2] ** [10]", Value::MatrixF64(Matrix::from_vec(vec![20.0], 1, 1)));
-test_interpreter!(interpret_matrix_matmul_mat2_ref, "a := [1 2; 3 4]; b := [4 5; 6 7]; c := a ** b", Value::MatrixF64(Matrix::from_vec(vec![16.0, 36.0, 19.0, 43.0], 2, 2)));
-test_interpreter!(interpret_matrixmatmul_mat2x3_ref, "a := [1.0 2.0 3.0; 4.0 5.0 6.0]; b := [4.0 5.0; 6.0 7.0; 8.0 9.0]; c := a ** b", Value::MatrixF64(Matrix::from_vec(vec![40.0, 94.0, 46.0, 109.0], 2, 2)));
-test_interpreter!(interpret_matrixmatmul_r3m3, "a := [1.0 2.0 3.0]; b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; c := a ** b", Value::MatrixF64(Matrix::from_vec(vec![48.0, 54.0, 60.0], 1, 3)));
-test_interpreter!(interpret_matrixmatmul_m3v3, "b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; a := [1.0 2.0 3.0]'; c := b ** a", Value::MatrixF64(Matrix::from_vec(vec![32.0, 50.0, 68.0], 3, 1)));
-test_interpreter!(interpret_matrix_string, r#"["Hello" "World"]"#, Value::MatrixString(Matrix::from_vec(vec!["Hello".to_string(), "World".to_string()], 1, 2)));
-test_interpreter!(interpret_matrix_string_access, r#"x:=["Hello" "World"];x[2]"#, Value::String(Ref::new("World".to_string())));
-test_interpreter!(interpret_matrix_string_assign, r#"~x:=["Hello" "World"];x[1]="Foo";[x[1] x[2]]"#, Value::MatrixString(Matrix::from_vec(vec!["Foo".to_string(), "World".to_string()], 1, 2)));
-test_interpreter!(interpret_matrix_string_assign_logical, r#"~x := ["Hello", "World", "!"]; x[[true false true]] = "Foo";"#, Value::MatrixString(Matrix::from_vec(vec!["Foo".to_string(), "World".to_string(), "Foo".to_string()], 1, 3)));
-test_interpreter!(interpret_table_string_access, r#"x:=|x<string> y<string> | "a" "b" | "c" "d" |; x.y"#, Value::MatrixString(Matrix::from_vec(vec!["b".to_string(), "d".to_string()], 2, 1)));
-test_interpreter!(interpret_matrix_define_ref, r#"x:=123;y<[f64]:1,4>:=x;"#, Value::MatrixF64(Matrix::from_vec(vec![123.0; 4], 1, 4)));
+test_interpreter!(
+    interpret_matrix_dot,
+    "[1 2 3] · [4 5 6]",
+    Value::F64(Ref::new(32.0))
+);
+test_interpreter!(
+    interpret_matrix_matmul_mat1,
+    "[2] ** [10]",
+    Value::MatrixF64(Matrix::from_vec(vec![20.0], 1, 1))
+);
+test_interpreter!(
+    interpret_matrix_matmul_mat2_ref,
+    "a := [1 2; 3 4]; b := [4 5; 6 7]; c := a ** b",
+    Value::MatrixF64(Matrix::from_vec(vec![16.0, 36.0, 19.0, 43.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrixmatmul_mat2x3_ref,
+    "a := [1.0 2.0 3.0; 4.0 5.0 6.0]; b := [4.0 5.0; 6.0 7.0; 8.0 9.0]; c := a ** b",
+    Value::MatrixF64(Matrix::from_vec(vec![40.0, 94.0, 46.0, 109.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrixmatmul_r3m3,
+    "a := [1.0 2.0 3.0]; b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; c := a ** b",
+    Value::MatrixF64(Matrix::from_vec(vec![48.0, 54.0, 60.0], 1, 3))
+);
+test_interpreter!(
+    interpret_matrixmatmul_m3v3,
+    "b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; a := [1.0 2.0 3.0]'; c := b ** a",
+    Value::MatrixF64(Matrix::from_vec(vec![32.0, 50.0, 68.0], 3, 1))
+);
+test_interpreter!(
+    interpret_matrix_string,
+    r#"["Hello" "World"]"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec!["Hello".to_string(), "World".to_string()],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_string_access,
+    r#"x:=["Hello" "World"];x[2]"#,
+    Value::String(Ref::new("World".to_string()))
+);
+test_interpreter!(
+    interpret_matrix_string_assign,
+    r#"~x:=["Hello" "World"];x[1]="Foo";[x[1] x[2]]"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec!["Foo".to_string(), "World".to_string()],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_string_assign_logical,
+    r#"~x := ["Hello", "World", "!"]; x[[true false true]] = "Foo";"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec!["Foo".to_string(), "World".to_string(), "Foo".to_string()],
+        1,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_table_string_access,
+    r#"x:=|x<string> y<string> | "a" "b" | "c" "d" |; x.y"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec!["b".to_string(), "d".to_string()],
+        2,
+        1
+    ))
+);
+test_interpreter!(
+    interpret_matrix_define_ref,
+    r#"x:=123;y<[f64]:1,4>:=x;"#,
+    Value::MatrixF64(Matrix::from_vec(vec![123.0; 4], 1, 4))
+);
 #[cfg(all(feature = "f64", feature = "u8"))]
-test_interpreter!(interpret_matrix_define_convert, r#"y<[f64]:1,3> := 123<u8>;"#, Value::MatrixF64(Matrix::from_vec(vec![123.0; 3], 1, 3)));
+test_interpreter!(
+    interpret_matrix_define_convert,
+    r#"y<[f64]:1,3> := 123<u8>;"#,
+    Value::MatrixF64(Matrix::from_vec(vec![123.0; 3], 1, 3))
+);
 #[cfg(all(feature = "u64", feature = "u8"))]
-test_interpreter!(interpret_matrix_define_convert_matrix, r#"x := [1 2 3];y<[u64]> := x;z<[u8]> := y;"#, Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 1, 3)));
+test_interpreter!(
+    interpret_matrix_define_convert_matrix,
+    r#"x := [1 2 3];y<[u64]> := x;z<[u8]> := y;"#,
+    Value::MatrixU8(Matrix::from_vec(vec![1u8, 2, 3], 1, 3))
+);
 
-// 2x2 Nominal Operations 
-test_interpreter!(interpret_matrix_add_2x2, "[1 2; 3 4] + [5 6; 7 8]", Value::MatrixF64(Matrix::from_vec(vec![6.0, 10.0, 8.0, 12.0], 2, 2)));
-test_interpreter!(interpret_matrix_sub_2x2, "[1 2; 3 4] - [5 6; 7 8]", Value::MatrixF64(Matrix::from_vec(vec![-4.0, -4.0, -4.0, -4.0], 2, 2)));
-test_interpreter!(interpret_matrix_mul_2x2, "[1 2; 3 4] * [5 6; 7 8]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 21.0, 12.0, 32.0], 2, 2)));
-test_interpreter!(interpret_matrix_div_2x2, "[20 30; 40 50] / [2 3; 4 5]", Value::MatrixF64(Matrix::from_vec(vec![10.0, 10.0, 10.0, 10.0], 2, 2)));
+// 2x2 Nominal Operations
+test_interpreter!(
+    interpret_matrix_add_2x2,
+    "[1 2; 3 4] + [5 6; 7 8]",
+    Value::MatrixF64(Matrix::from_vec(vec![6.0, 10.0, 8.0, 12.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_sub_2x2,
+    "[1 2; 3 4] - [5 6; 7 8]",
+    Value::MatrixF64(Matrix::from_vec(vec![-4.0, -4.0, -4.0, -4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_mul_2x2,
+    "[1 2; 3 4] * [5 6; 7 8]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 21.0, 12.0, 32.0], 2, 2))
+);
+test_interpreter!(
+    interpret_matrix_div_2x2,
+    "[20 30; 40 50] / [2 3; 4 5]",
+    Value::MatrixF64(Matrix::from_vec(vec![10.0, 10.0, 10.0, 10.0], 2, 2))
+);
 
 // 3x3 Nominal Operations
-test_interpreter!(interpret_matrix_add_3x3, "[1 2 3; 4 5 6; 7 8 9] + [9 8 7; 6 5 4; 3 2 1]", Value::MatrixF64(Matrix::from_vec(vec![10.0; 9], 3, 3)));
-test_interpreter!(interpret_matrix_mul_3x3, "[1 2 3; 4 5 6; 7 8 9] * [9 8 7; 6 5 4; 3 2 1]", Value::MatrixF64(Matrix::from_vec(vec![9.0, 24.0, 21.0, 16.0, 25.0, 16.0, 21.0, 24.0, 9.0], 3, 3)));
-test_interpreter!(interpret_matrix_div_3x3, "[10 20 30; 40 50 60; 70 80 90] / [10 10 10; 10 10 10; 10 10 10]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0], 3, 3)));
-
+test_interpreter!(
+    interpret_matrix_add_3x3,
+    "[1 2 3; 4 5 6; 7 8 9] + [9 8 7; 6 5 4; 3 2 1]",
+    Value::MatrixF64(Matrix::from_vec(vec![10.0; 9], 3, 3))
+);
+test_interpreter!(
+    interpret_matrix_mul_3x3,
+    "[1 2 3; 4 5 6; 7 8 9] * [9 8 7; 6 5 4; 3 2 1]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![9.0, 24.0, 21.0, 16.0, 25.0, 16.0, 21.0, 24.0, 9.0],
+        3,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_matrix_div_3x3,
+    "[10 20 30; 40 50 60; 70 80 90] / [10 10 10; 10 10 10; 10 10 10]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0],
+        3,
+        3
+    ))
+);
 
 // 4x4 Nominal Operations
-test_interpreter!(interpret_matrix_add_4x4, 
-          "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] + [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]", 
-          Value::MatrixF64(Matrix::from_vec(vec![18.0, 26.0, 34.0, 42.0, 
-                              20.0, 28.0, 36.0, 44.0, 
-                              22.0, 30.0, 38.0, 46.0, 
-                              24.0, 32.0, 40.0, 48.0], 4, 4)));
+test_interpreter!(
+    interpret_matrix_add_4x4,
+    "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] + [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![
+            18.0, 26.0, 34.0, 42.0, 20.0, 28.0, 36.0, 44.0, 22.0, 30.0, 38.0, 46.0, 24.0, 32.0,
+            40.0, 48.0
+        ],
+        4,
+        4
+    ))
+);
 
-test_interpreter!(interpret_matrix_sub_4x4, 
-          "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] - [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]", 
-          Value::MatrixF64(Matrix::from_vec(vec![-16.0, -16.0, -16.0, -16.0, 
-                              -16.0, -16.0, -16.0, -16.0, 
-                              -16.0, -16.0, -16.0, -16.0, 
-                              -16.0, -16.0, -16.0, -16.0], 4, 4)));
+test_interpreter!(
+    interpret_matrix_sub_4x4,
+    "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] - [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![
+            -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0, -16.0,
+            -16.0, -16.0, -16.0, -16.0
+        ],
+        4,
+        4
+    ))
+);
 
-test_interpreter!(interpret_matrix_mul_4x4, 
-          "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] * [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]", 
-          Value::MatrixF64(Matrix::from_vec(vec![17.0, 105.0, 225.0, 377.0, 
-                              36.0, 132.0, 260.0, 420.0, 
-                              57.0, 161.0, 297.0, 465.0, 
-                              80.0, 192.0, 336.0, 512.0], 4, 4)));
+test_interpreter!(
+    interpret_matrix_mul_4x4,
+    "[1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16] * [17 18 19 20; 21 22 23 24; 25 26 27 28; 29 30 31 32]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![
+            17.0, 105.0, 225.0, 377.0, 36.0, 132.0, 260.0, 420.0, 57.0, 161.0, 297.0, 465.0, 80.0,
+            192.0, 336.0, 512.0
+        ],
+        4,
+        4
+    ))
+);
 
-test_interpreter!(interpret_matrix_div_4x4, 
-          "[2 3 4 5; 6 7 8 9; 10 11 12 13; 14 15 16 17] / [2 2 2 2; 3 3 3 3; 4 4 4 4; 5 5 5 5]", 
-          Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 2.5, 2.8, 
-                              1.5, 2.3333333333333335, 2.75, 3.0, 
-                              2.0, 2.6666666666666665, 3.0, 3.2, 
-                              2.5, 3.0, 3.25, 3.4], 4, 4)));
+test_interpreter!(
+    interpret_matrix_div_4x4,
+    "[2 3 4 5; 6 7 8 9; 10 11 12 13; 14 15 16 17] / [2 2 2 2; 3 3 3 3; 4 4 4 4; 5 5 5 5]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![
+            1.0,
+            2.0,
+            2.5,
+            2.8,
+            1.5,
+            2.3333333333333335,
+            2.75,
+            3.0,
+            2.0,
+            2.6666666666666665,
+            3.0,
+            3.2,
+            2.5,
+            3.0,
+            3.25,
+            3.4
+        ],
+        4,
+        4
+    ))
+);
 
 // 2x3 Nominal Operations
-test_interpreter!(interpret_matrix_sub_2x3, "[1 2 3; 4 5 6] - [7 8 9; 10 11 12]", 
-          Value::MatrixF64(Matrix::from_vec(vec![-6.0, -6.0, -6.0, 
-                              -6.0, -6.0, -6.0], 2, 3)));
+test_interpreter!(
+    interpret_matrix_sub_2x3,
+    "[1 2 3; 4 5 6] - [7 8 9; 10 11 12]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![-6.0, -6.0, -6.0, -6.0, -6.0, -6.0],
+        2,
+        3
+    ))
+);
 
 // 3x2 Nominal Operations
-test_interpreter!(interpret_matrix_sub_3x2, "[1 2; 3 4; 5 6] - [7 8; 9 10; 11 12]", 
-          Value::MatrixF64(Matrix::from_vec(vec![-6.0, -6.0, 
-                              -6.0, -6.0, 
-                              -6.0, -6.0], 3, 2)));
+test_interpreter!(
+    interpret_matrix_sub_3x2,
+    "[1 2; 3 4; 5 6] - [7 8; 9 10; 11 12]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![-6.0, -6.0, -6.0, -6.0, -6.0, -6.0],
+        3,
+        2
+    ))
+);
 
 // u8 2x2 Underflow/Overflow
 /*test_interpreter!(interpret_matrix_underflow_2x2_u8_sub,
   "[1 2; 3 4] - [5 6; 7 8]",
-  Ref::new(Matrix2::from_vec(vec![254u8, 255u8, 253u8, 254u8])).to_value() 
+  Ref::new(Matrix2::from_vec(vec![254u8, 255u8, 253u8, 254u8])).to_value()
 );*/
 /*test_interpreter!(interpret_matrix_overflow_2x2_u8_add,
   "[250 251; 252 253] + [10 11; 12 13]",
-  Ref::new(Matrix2::from_vec(vec![4u8, 6u8, 8u8, 10u8])).to_value() 
+  Ref::new(Matrix2::from_vec(vec![4u8, 6u8, 8u8, 10u8])).to_value()
 );*/
 
 // u8 3x3 Underflow/Overflow
@@ -682,302 +1664,1221 @@ test_interpreter!(interpret_matrix_sub_3x2, "[1 2; 3 4; 5 6] - [7 8; 9 10; 11 12
   Ref::new(Matrix3::from_vec(vec![4u8, 6u8, 8u8, 10u8, 11u8, 12u8, 16u8, 18u8, 20u8])).to_value()
 );*/
 
-test_interpreter!(interpret_tuple, "(1,true)", Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::F64(Ref::new(1.0)), Value::Bool(Ref::new(true))]))));
-test_interpreter!(interpret_tuple_nested, r#"(1,("Hello",false))"#, Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::F64(Ref::new(1.0)), Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::String(Ref::new("Hello".to_string())), Value::Bool(Ref::new(false))])))]))));
-test_interpreter!(interpret_tuple_access, r#"q := (10, "b", true); r := (q.3, q.2, q.1)"#, Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::Bool(Ref::new(true)), Value::String(Ref::new("b".to_string())), Value::F64(Ref::new(10.0))]))));
-test_interpreter!(interpret_tuple_destructure, r#"a := (10, 11, 12); (x,y,z) := a; x + y + z"#, Value::F64(Ref::new(33.0)));
-test_interpreter!(interpret_tuple_assign, r#"~t := (1,2); t.1 = 10; t.1 + t.2"#, Value::F64(Ref::new(12.0)));
+test_interpreter!(
+    interpret_tuple,
+    "(1,true)",
+    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::Bool(Ref::new(true))
+    ])))
+);
+test_interpreter!(
+    interpret_tuple_nested,
+    r#"(1,("Hello",false))"#,
+    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::String(Ref::new("Hello".to_string())),
+            Value::Bool(Ref::new(false))
+        ])))
+    ])))
+);
+test_interpreter!(
+    interpret_tuple_access,
+    r#"q := (10, "b", true); r := (q.3, q.2, q.1)"#,
+    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+        Value::Bool(Ref::new(true)),
+        Value::String(Ref::new("b".to_string())),
+        Value::F64(Ref::new(10.0))
+    ])))
+);
+test_interpreter!(
+    interpret_tuple_destructure,
+    r#"a := (10, 11, 12); (x,y,z) := a; x + y + z"#,
+    Value::F64(Ref::new(33.0))
+);
+test_interpreter!(
+    interpret_tuple_assign,
+    r#"~t := (1,2); t.1 = 10; t.1 + t.2"#,
+    Value::F64(Ref::new(12.0))
+);
 
-test_interpreter!(interpret_slice, "a := [1,2,3]; a[2]", Value::F64(Ref::new(2.0)));
-test_interpreter!(interpret_slice_v, "a := [1,2,3]'; a[2]", Value::F64(Ref::new(2.0)));
-test_interpreter!(interpret_slice_2d, "a := [1,2;3,4]; a[1,2]", Value::F64(Ref::new(2.0)));
-test_interpreter!(interpret_slice_f64, "a := [1.0,2.0,3.0]; a[2]", Value::F64(Ref::new(2.0)));
-test_interpreter!(interpret_slice_2d_f64, "a := [1,2;3,4]; a[2,1]", Value::F64(Ref::new(3.0)));
-test_interpreter!(interpret_slice_range_2d, "x := [1 2 3; 4 5 6; 7 8 9]; x[2..=3, 2..=3]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 8.0, 6.0, 9.0], 2, 2)));
-test_interpreter!(interpret_slice_sclar_range, "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[2,ix]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 6.0], 1, 2)));
-test_interpreter!(interpret_slice_range_scalar, "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[ix,2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 8.0], 2, 1)));
-test_interpreter!(interpret_slice_all, "x := [1 2; 4 5]; x[:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 4, 1)));
-test_interpreter!(interpret_slice_all_2d, "x := [1 2; 4 5]; x[:,2]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 5.0], 2, 1)));
-test_interpreter!(interpret_slice_all_2d_row, "x := [1 2; 4 5]; x[2,:]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2)));
-test_interpreter!(interpret_slice_all_2d_row2, "x := [1 2 3 4 5; 6 7 8 9 10]; x[1,:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5)));
-test_interpreter!(interpret_slice_all_range, "x := [1 2 3 4; 5 6 7 8]; x[:,1..=2]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 2.0, 6.0], 2, 2)));
-test_interpreter!(interpret_slice_range_all, "x := [1 2 3; 4 5 6; 7 8 9]; x[1..=2,:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3)));
-test_interpreter!(interpret_slice_range_dupe, "x := [1 2 3; 4 5 6; 7 8 9]; x[[1 1],:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0], 2, 3)));
-test_interpreter!(interpret_slice_all_reshape, "x := [1 2 3; 4 5 6; 7 8 9]; y := x[:,[1,1]]; y[:]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 1.0, 4.0, 7.0], 6, 1)));
-test_interpreter!(interpret_slice_ix_ref, "x := [94 53 13]; y := [3 3]; x[y]", Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1)));
-test_interpreter!(interpret_slice_ix_ref2, "x := [94 53 13]; y := [3; 3]; x[y]", Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1)));
-test_interpreter!(interpret_slice_ix_ref3, "x := [94 53 13]; y := 3; x[y]", Value::F64(Ref::new(13.0)));
-test_interpreter!(interpret_slice_logical_ix, "x := [94 53 13]; ix := [false true true]; x[ix]", Value::MatrixF64(Matrix::from_vec(vec![53.0, 13.0], 2, 1)));
-test_interpreter!(interpret_slice_row, "x := [94 53 13; 4 5 6; 7 8 9]; x[2,1..3]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2)));
-test_interpreter!(interpret_slice_col, "x := [94 53 13; 4 5 6; 7 8 9]; x[1..3,2]", Value::MatrixF64(Matrix::from_vec(vec![53.0, 5.0], 2, 1)));
-test_interpreter!(interpret_slice_dynamic, "x := 1..10; y := x'; ix := 1..5; y[ix]'", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
-test_interpreter!(interpret_slice_all_bool, "ix := [false, false, true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[:,ix]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 3, 1)));
-test_interpreter!(interpret_slice_ix_bool, "ix := [false, false, true]; x := [1 2 3; 4 5 6; 7 8 9]; x[[1,2,3,3],ix]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0, 9.0], 4, 1)));
-test_interpreter!(interpret_slice_bool_bool, "ix := [true, false, true]; x := [1 2 3; 4 5 6;7 8 9]; x[ix,ix]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 7.0, 3.0, 9.0], 2, 2)));
-test_interpreter!(interpret_slice_ix_bool_v, "ix1 := [false, false, true]; ix2 := [1,2,3,3]; x := [1 2 3; 4 5 6; 7 8 9]; x[ix1',ix2']", Value::MatrixF64(Matrix::from_vec(vec![7.0, 8.0, 9.0, 9.0], 1, 4)));
+test_interpreter!(
+    interpret_slice,
+    "a := [1,2,3]; a[2]",
+    Value::F64(Ref::new(2.0))
+);
+test_interpreter!(
+    interpret_slice_v,
+    "a := [1,2,3]'; a[2]",
+    Value::F64(Ref::new(2.0))
+);
+test_interpreter!(
+    interpret_slice_2d,
+    "a := [1,2;3,4]; a[1,2]",
+    Value::F64(Ref::new(2.0))
+);
+test_interpreter!(
+    interpret_slice_f64,
+    "a := [1.0,2.0,3.0]; a[2]",
+    Value::F64(Ref::new(2.0))
+);
+test_interpreter!(
+    interpret_slice_2d_f64,
+    "a := [1,2;3,4]; a[2,1]",
+    Value::F64(Ref::new(3.0))
+);
+test_interpreter!(
+    interpret_slice_range_2d,
+    "x := [1 2 3; 4 5 6; 7 8 9]; x[2..=3, 2..=3]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 8.0, 6.0, 9.0], 2, 2))
+);
+test_interpreter!(
+    interpret_slice_sclar_range,
+    "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[2,ix]",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 6.0], 1, 2))
+);
+test_interpreter!(
+    interpret_slice_range_scalar,
+    "ix := [true false true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[ix,2]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 8.0], 2, 1))
+);
+test_interpreter!(
+    interpret_slice_all,
+    "x := [1 2; 4 5]; x[:]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 4, 1))
+);
+test_interpreter!(
+    interpret_slice_all_2d,
+    "x := [1 2; 4 5]; x[:,2]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 5.0], 2, 1))
+);
+test_interpreter!(
+    interpret_slice_all_2d_row,
+    "x := [1 2; 4 5]; x[2,:]",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2))
+);
+test_interpreter!(
+    interpret_slice_all_2d_row2,
+    "x := [1 2 3 4 5; 6 7 8 9 10]; x[1,:]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5))
+);
+test_interpreter!(
+    interpret_slice_all_range,
+    "x := [1 2 3 4; 5 6 7 8]; x[:,1..=2]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 5.0, 2.0, 6.0], 2, 2))
+);
+test_interpreter!(
+    interpret_slice_range_all,
+    "x := [1 2 3; 4 5 6; 7 8 9]; x[1..=2,:]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3))
+);
+test_interpreter!(
+    interpret_slice_range_dupe,
+    "x := [1 2 3; 4 5 6; 7 8 9]; x[[1 1],:]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0], 2, 3))
+);
+test_interpreter!(
+    interpret_slice_all_reshape,
+    "x := [1 2 3; 4 5 6; 7 8 9]; y := x[:,[1,1]]; y[:]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 1.0, 4.0, 7.0], 6, 1))
+);
+test_interpreter!(
+    interpret_slice_ix_ref,
+    "x := [94 53 13]; y := [3 3]; x[y]",
+    Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1))
+);
+test_interpreter!(
+    interpret_slice_ix_ref2,
+    "x := [94 53 13]; y := [3; 3]; x[y]",
+    Value::MatrixF64(Matrix::from_vec(vec![13.0, 13.0], 2, 1))
+);
+test_interpreter!(
+    interpret_slice_ix_ref3,
+    "x := [94 53 13]; y := 3; x[y]",
+    Value::F64(Ref::new(13.0))
+);
+test_interpreter!(
+    interpret_slice_logical_ix,
+    "x := [94 53 13]; ix := [false true true]; x[ix]",
+    Value::MatrixF64(Matrix::from_vec(vec![53.0, 13.0], 2, 1))
+);
+test_interpreter!(
+    interpret_slice_row,
+    "x := [94 53 13; 4 5 6; 7 8 9]; x[2,1..3]",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0], 1, 2))
+);
+test_interpreter!(
+    interpret_slice_col,
+    "x := [94 53 13; 4 5 6; 7 8 9]; x[1..3,2]",
+    Value::MatrixF64(Matrix::from_vec(vec![53.0, 5.0], 2, 1))
+);
+test_interpreter!(
+    interpret_slice_dynamic,
+    "x := 1..10; y := x'; ix := 1..5; y[ix]'",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_slice_all_bool,
+    "ix := [false, false, true]'; x := [1 2 3; 4 5 6; 7 8 9]; x[:,ix]",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0], 3, 1))
+);
+test_interpreter!(
+    interpret_slice_ix_bool,
+    "ix := [false, false, true]; x := [1 2 3; 4 5 6; 7 8 9]; x[[1,2,3,3],ix]",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 6.0, 9.0, 9.0], 4, 1))
+);
+test_interpreter!(
+    interpret_slice_bool_bool,
+    "ix := [true, false, true]; x := [1 2 3; 4 5 6;7 8 9]; x[ix,ix]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 7.0, 3.0, 9.0], 2, 2))
+);
+test_interpreter!(
+    interpret_slice_ix_bool_v,
+    "ix1 := [false, false, true]; ix2 := [1,2,3,3]; x := [1 2 3; 4 5 6; 7 8 9]; x[ix1',ix2']",
+    Value::MatrixF64(Matrix::from_vec(vec![7.0, 8.0, 9.0, 9.0], 1, 4))
+);
 
-
-test_interpreter!(interpret_swizzle_record, "x := {x: 1, y: 2, z: 3}; x.y,z,z", Value::Tuple(Ref::new(MechTuple::from_vec(vec![Value::F64(Ref::new(2.0)),Value::F64(Ref::new(3.0)),Value::F64(Ref::new(3.0))]))));
+test_interpreter!(
+    interpret_swizzle_record,
+    "x := {x: 1, y: 2, z: 3}; x.y,z,z",
+    Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+        Value::F64(Ref::new(2.0)),
+        Value::F64(Ref::new(3.0)),
+        Value::F64(Ref::new(3.0))
+    ])))
+);
 //test_interpreter!(interpret_swizzle_table, "x := | x<i64> y<u8>| 1 2 | 4 5 |; x.x,x,y", Value::Tuple(MechTuple::from_vec(vec![Matrix::Vector2(Ref::new(Vector2::from_vec(vec![Value::I64(Ref::new(1)),Value::I64(Ref::new(4))]))).to_value(),Matrix::Vector2(Ref::new(Vector2::from_vec(vec![Value::I64(Ref::new(1)),Value::I64(Ref::new(4))]))).to_value(),Matrix::Vector2(Ref::new(Vector2::from_vec(vec![Value::U8(Ref::new(2)),Value::U8(Ref::new(5))]))).to_value()])));
 
-test_interpreter!(interpret_dot_record, "x := {x: 1, y: 2, z: 3}; x.x", Value::F64(Ref::new(1.0)));
+test_interpreter!(
+    interpret_dot_record,
+    "x := {x: 1, y: 2, z: 3}; x.x",
+    Value::F64(Ref::new(1.0))
+);
 
-test_interpreter!(interpret_dot_int_matrix, "x := [1,2,3]; x.1", Value::F64(Ref::new(1.0)));
+test_interpreter!(
+    interpret_dot_int_matrix,
+    "x := [1,2,3]; x.1",
+    Value::F64(Ref::new(1.0))
+);
 #[cfg(all(feature = "i64", feature = "u8"))]
-test_interpreter!(interpret_dot_index_table, "x :=  | x<i64> y<u8>| 1 2 | 4 5|; x.x", Value::MatrixI64(Matrix::from_vec(vec![1, 4], 2, 1)));
+test_interpreter!(
+    interpret_dot_index_table,
+    "x :=  | x<i64> y<u8>| 1 2 | 4 5|; x.x",
+    Value::MatrixI64(Matrix::from_vec(vec![1, 4], 2, 1))
+);
 #[cfg(all(feature = "i64", feature = "u8"))]
-test_interpreter!(interpret_dot_index_table2, "x := | x<i64> y<u8>| 1 2 | 4 5|; x.y", Value::MatrixU8(Matrix::from_vec(vec![2, 5], 2, 1)));
+test_interpreter!(
+    interpret_dot_index_table2,
+    "x := | x<i64> y<u8>| 1 2 | 4 5|; x.y",
+    Value::MatrixU8(Matrix::from_vec(vec![2, 5], 2, 1))
+);
 #[cfg(feature = "i64")]
-test_interpreter!(interpret_dot_index_table3, "x := | x<i64> y<bool>| 1 true | 4 false | 3 true|; x.y", Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 3, 1)));
+test_interpreter!(
+    interpret_dot_index_table3,
+    "x := | x<i64> y<bool>| 1 true | 4 false | 3 true|; x.y",
+    Value::MatrixBool(Matrix::from_vec(vec![true, false, true], 3, 1))
+);
 #[cfg(all(feature = "i64", feature = "u8"))]
-test_interpreter!(interpret_dot_index_table4, "x := | x<i64> y<u8>| 1 2| 3 4| 5 6| 7 8 |; x.x", Value::MatrixI64(Matrix::from_vec(vec![1, 3, 5, 7], 4, 1)));
+test_interpreter!(
+    interpret_dot_index_table4,
+    "x := | x<i64> y<u8>| 1 2| 3 4| 5 6| 7 8 |; x.x",
+    Value::MatrixI64(Matrix::from_vec(vec![1, 3, 5, 7], 4, 1))
+);
 #[cfg(all(feature = "i64", feature = "i8"))]
-test_interpreter!(interpret_dot_index_table5, "x := | x<i64> y<i8>| 1 2| 3 4| 5 6| 7 8 |; x.y", Value::MatrixI8(Matrix::from_vec(vec![2, 4, 6, 8], 4, 1)));
+test_interpreter!(
+    interpret_dot_index_table5,
+    "x := | x<i64> y<i8>| 1 2| 3 4| 5 6| 7 8 |; x.y",
+    Value::MatrixI8(Matrix::from_vec(vec![2, 4, 6, 8], 4, 1))
+);
 #[cfg(all(feature = "u32", feature = "f32", feature = "i8"))]
-test_interpreter!(interpret_dot_index_table6, "x := | x<u32> y<f32> z<i8>|1 2 3|4 5 6|; x.y", Value::MatrixF32(Matrix::from_vec(vec![2.0, 5.0], 2, 1)));
+test_interpreter!(
+    interpret_dot_index_table6,
+    "x := | x<u32> y<f32> z<i8>|1 2 3|4 5 6|; x.y",
+    Value::MatrixF32(Matrix::from_vec(vec![2.0, 5.0], 2, 1))
+);
 
-test_interpreter!(interpret_set_empty,"{_}", Value::Set(Ref::new(MechSet::from_vec(vec![]))));
-test_interpreter!(interpret_set_empty2,"{}", Value::Set(Ref::new(MechSet::from_vec(vec![]))));
-test_interpreter!(interpret_set, "{1,2,3}", Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
-test_interpreter!(interpret_record,r#"{a: 1, b: "Hello"}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::String(Ref::new("Hello".to_string())))]))));
-test_interpreter!(interpret_define_custom_record, r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::F64(Ref::new(2.0)))]))));
-test_interpreter!(interpret_record_field_access,r#"a := {x: 1,  y: 2}; a.y"#, Value::F64(Ref::new(2.0)));
-test_interpreter!(interpret_map, r#"{"a": 1, "b": 2}"#, Value::Map(Ref::new(MechMap::from_vec(vec![(Value::String(Ref::new("a".to_string())),Value::F64(Ref::new(1.0))), (Value::String(Ref::new("b".to_string())),Value::F64(Ref::new(2.0)))]))));
-test_interpreter!(interpret_map_access, r#"m := {"a": 10, "b": 20}; m{"b"}"#, Value::F64(Ref::new(20.0)));
-test_interpreter!(interpret_map_assign, r#"~m := {"a": 10, "b": 20}; m{"b"} = 42; m{"b"}"#, Value::F64(Ref::new(42.0)));
-test_interpreter!(interpret_map_assign2, r#"~m := {"a": 10, "b": 20}; m{"c"} = 42; m{"c"}"#, Value::F64(Ref::new(42.0)));
-test_interpreter!(interpret_set_rational, r#"{1/2, 3/4}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::R64(Ref::new(R64::new(1, 2))), Value::R64(Ref::new(R64::new(3, 4)))]))));
+test_interpreter!(
+    interpret_set_empty,
+    "{_}",
+    Value::Set(Ref::new(MechSet::from_vec(vec![])))
+);
+test_interpreter!(
+    interpret_set_empty2,
+    "{}",
+    Value::Set(Ref::new(MechSet::from_vec(vec![])))
+);
+test_interpreter!(
+    interpret_set,
+    "{1,2,3}",
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::F64(Ref::new(2.0)),
+        Value::F64(Ref::new(3.0))
+    ])))
+);
+test_interpreter!(
+    interpret_record,
+    r#"{a: 1, b: "Hello"}"#,
+    Value::Record(Ref::new(MechRecord::from_vec(vec![
+        (
+            (55170961230981453, "a".to_string()),
+            Value::F64(Ref::new(1.0))
+        ),
+        (
+            (44311847522083591, "b".to_string()),
+            Value::String(Ref::new("Hello".to_string()))
+        )
+    ])))
+);
+test_interpreter!(
+    interpret_define_custom_record,
+    r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#,
+    Value::Record(Ref::new(MechRecord::from_vec(vec![
+        (
+            (55170961230981453, "a".to_string()),
+            Value::F64(Ref::new(1.0))
+        ),
+        (
+            (44311847522083591, "b".to_string()),
+            Value::F64(Ref::new(2.0))
+        )
+    ])))
+);
+test_interpreter!(
+    interpret_record_field_access,
+    r#"a := {x: 1,  y: 2}; a.y"#,
+    Value::F64(Ref::new(2.0))
+);
+test_interpreter!(
+    interpret_map,
+    r#"{"a": 1, "b": 2}"#,
+    Value::Map(Ref::new(MechMap::from_vec(vec![
+        (
+            Value::String(Ref::new("a".to_string())),
+            Value::F64(Ref::new(1.0))
+        ),
+        (
+            Value::String(Ref::new("b".to_string())),
+            Value::F64(Ref::new(2.0))
+        )
+    ])))
+);
+test_interpreter!(
+    interpret_map_access,
+    r#"m := {"a": 10, "b": 20}; m{"b"}"#,
+    Value::F64(Ref::new(20.0))
+);
+test_interpreter!(
+    interpret_map_assign,
+    r#"~m := {"a": 10, "b": 20}; m{"b"} = 42; m{"b"}"#,
+    Value::F64(Ref::new(42.0))
+);
+test_interpreter!(
+    interpret_map_assign2,
+    r#"~m := {"a": 10, "b": 20}; m{"c"} = 42; m{"c"}"#,
+    Value::F64(Ref::new(42.0))
+);
+test_interpreter!(
+    interpret_set_rational,
+    r#"{1/2, 3/4}"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::R64(Ref::new(R64::new(1, 2))),
+        Value::R64(Ref::new(R64::new(3, 4)))
+    ])))
+);
 
-test_interpreter!(interpret_function_define,r#"foo(x<f64>) = z<f64> :=
+test_interpreter!(
+    interpret_function_define,
+    r#"foo(x<f64>) = z<f64> :=
 z := 10 + x.
-foo(10)"#, Value::F64(Ref::new(20.0)));
-test_interpreter!(interpret_function_define_2_args,r#"foo(x<f64>, y<f64>) = z<f64> :=
+foo(10)"#,
+    Value::F64(Ref::new(20.0))
+);
+test_interpreter!(
+    interpret_function_define_2_args,
+    r#"foo(x<f64>, y<f64>) = z<f64> :=
 z := x + y.
-foo(10,20)"#, Value::F64(Ref::new(30.0)));
-test_interpreter!(interpret_function_define_statements,r#"foo(x<f64>, y<f64>) = z<f64> :=
+foo(10,20)"#,
+    Value::F64(Ref::new(30.0))
+);
+test_interpreter!(
+    interpret_function_define_statements,
+    r#"foo(x<f64>, y<f64>) = z<f64> :=
     a := 1 + x
     b := y + 1
     z := a + b.
-foo(10,20)"#, Value::F64(Ref::new(32.0)));
-test_interpreter!(interpret_function_define_nested_call,r#"bar(x<f64>) = z<f64> :=
+foo(10,20)"#,
+    Value::F64(Ref::new(32.0))
+);
+test_interpreter!(
+    interpret_function_define_nested_call,
+    r#"bar(x<f64>) = z<f64> :=
 z := 10 + x.
 foo(x<f64>) = z<f64> :=
 z := bar(x).
-foo(10)"#, Value::F64(Ref::new(20.0)));
+foo(10)"#,
+    Value::F64(Ref::new(20.0))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_function_recursive_max,r#"max(x<u64>, y<u64>) => <u64>
+test_interpreter!(
+    interpret_function_recursive_max,
+    r#"max(x<u64>, y<u64>) => <u64>
   ├ (0, y) => y
   ├ (x, 0) => x
   └ (x, y) => max(x - 1<u64>, y - 1<u64>) + 1<u64>.
-max(4<u64>, 7<u64>)"#, Value::U64(Ref::new(7)));
+max(4<u64>, 7<u64>)"#,
+    Value::U64(Ref::new(7))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_function_recursive_is_zero,r#"is-zero(x<u64>) => <bool>
+test_interpreter!(
+    interpret_function_recursive_is_zero,
+    r#"is-zero(x<u64>) => <bool>
   ├ 0 => true
   └ * => false.
-is-zero(0<u64>)"#, Value::Bool(Ref::new(true)));
+is-zero(0<u64>)"#,
+    Value::Bool(Ref::new(true))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_function_recursive_factorial_tree,r#"factorial(x<u64>) => <u64>
+test_interpreter!(
+    interpret_function_recursive_factorial_tree,
+    r#"factorial(x<u64>) => <u64>
   ├ 0 => 1
   └ n => n * factorial(n - 1<u64>).
-factorial(5<u64>)"#, Value::U64(Ref::new(120)));
+factorial(5<u64>)"#,
+    Value::U64(Ref::new(120))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_function_recursive_factorial_bar,r#"factorial(x<u64>) => <u64>
+test_interpreter!(
+    interpret_function_recursive_factorial_bar,
+    r#"factorial(x<u64>) => <u64>
   | 0 => 1
   | n => n * factorial(n - 1<u64>).
-factorial(6<u64>)"#, Value::U64(Ref::new(720)));
+factorial(6<u64>)"#,
+    Value::U64(Ref::new(720))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_function_recursive_fib,r#"fib(x<u64>) => <u64>
+test_interpreter!(
+    interpret_function_recursive_fib,
+    r#"fib(x<u64>) => <u64>
   ├ 0 => 0
   ├ 1 => 1
   └ n => fib(n - 1<u64>) + fib(n - 2<u64>).
-fib(10<u64>)"#, Value::U64(Ref::new(55)));
+fib(10<u64>)"#,
+    Value::U64(Ref::new(55))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_function_recursive_power,r#"power(x<u64>, y<u64>) => <u64>
+test_interpreter!(
+    interpret_function_tail_recursive_countdown,
+    r#"countdown(n<u64>) => <u64>
+  └ n => countdown-acc(n, 0<u64>).
+
+countdown-acc(n<u64>, acc<u64>) => <u64>
+  ├ (0<u64>, acc) => acc
+  └ (n, acc) => countdown-acc(n - 1<u64>, acc + 1<u64>).
+
+countdown(50000<u64>)"#,
+    Value::U64(Ref::new(50000))
+);
+#[cfg(feature = "u64")]
+test_interpreter!(
+    interpret_function_recursive_power,
+    r#"power(x<u64>, y<u64>) => <u64>
   ├ (*, 0) => 1
   └ (x, y) => x * power(x, y - 1<u64>).
-power(2<u64>, 10<u64>)"#, Value::U64(Ref::new(1024)));
-test_interpreter!(interpret_function_call_native_vector, "math/sin([1.570796327 1.570796327])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
-test_interpreter!(interpret_function_call_native, r#"math/sin(1.5707963267948966)"#, Value::F64(Ref::new(1.0)));
-test_interpreter!(interpret_function_call_native_cos, r#"math/cos(0.0)"#, Value::F64(Ref::new(1.0)));
-test_interpreter!(interpret_function_call_native_vector2, "math/cos([0.0 0.0])", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2)));
-test_interpreter!(interpret_user_function_scalar_auto_broadcast, r#"add-one(x<f64>) => <f64>
+power(2<u64>, 10<u64>)"#,
+    Value::U64(Ref::new(1024))
+);
+test_interpreter!(
+    interpret_function_call_native_vector,
+    "math/sin([1.570796327 1.570796327])",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2))
+);
+test_interpreter!(
+    interpret_function_call_native,
+    r#"math/sin(1.5707963267948966)"#,
+    Value::F64(Ref::new(1.0))
+);
+test_interpreter!(
+    interpret_function_call_native_cos,
+    r#"math/cos(0.0)"#,
+    Value::F64(Ref::new(1.0))
+);
+test_interpreter!(
+    interpret_function_call_native_vector2,
+    "math/cos([0.0 0.0])",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0], 1, 2))
+);
+test_interpreter!(
+    interpret_user_function_scalar_auto_broadcast,
+    r#"add-one(x<f64>) => <f64>
   | * => x + 1.
-add-one([1 2 3])"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
+add-one([1 2 3])"#,
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
+);
 
-test_interpreter!(interpret_set_value,"~x := 1.23; x = 4.56;", Value::F64(Ref::new(4.56)));
-test_interpreter!(interpret_set_value_row_vector,"~x := [6,2]; x[1] = 4;", Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2)));
-test_interpreter!(interpret_set_value_col_vector,"~x := [false false true true]'; x[1] = true; x[1]", Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_value_scalar_scalar,"~x := [1 2; 3 4]; x[2,2] = 42; x[2,2];", Value::F64(Ref::new(42.0)));
-test_interpreter!(interpret_set_value_all,"~x := [1 2; 3 4]; x[:] = 42; x[1] + x[2] + x[3] + x[4]; ", Value::F64(Ref::new(168.0)));
-test_interpreter!(interpret_set_value_all_scalar,"~x := [1 2; 3 4]; x[:,1] = 42; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(90.0)));
-test_interpreter!(interpret_set_value_scalar_all,"~x := [1 2; 3 4]; x[1,:] = 42; x[1] + x[3];", Value::F64(Ref::new(84.0)));
-test_interpreter!(interpret_set_value_slice,"~x := [1 2 3 4]; x[[1 3]] = 42; x[1] + x[2] + x[3] + x[4];", Value::F64(Ref::new(90.0)));
-test_interpreter!(interpret_set_value_scalar_slice,"~x := [1 2 3; 4 5 6; 7 8 9]; x[1,[1,3]] = 42; x[1] + x[7];", Value::F64(Ref::new(84.0)));
-test_interpreter!(interpret_set_value_slice_slice,"~x := [1 2 3; 5 6 7; 9 10 11]; x[1..3,1..3] = 42; x[1] + x[2] + x[4] + x[5]", Value::F64(Ref::new(168.0)));
-test_interpreter!(interpret_set_value_all_slice,"~x := [1 2 3; 5 6 7]; x[:,1..3] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]", Value::F64(Ref::new(178.0)));
-test_interpreter!(interpret_set_value_all_slice_vec,"~x := [1;6]; x = [4;5]; x[1] + x[2];", Value::F64(Ref::new(9.0)));
-test_interpreter!(interpret_set_value_slice_all,"~x := [1 2 3; 5 6 7]'; x[1..3,:] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]", Value::F64(Ref::new(178.0)));
-test_interpreter!(interpret_set_value_slice_vec,"~x := [1 2 3 4]; x[1..=3] = [10 20 30]; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(64.0)));
+test_interpreter!(
+    interpret_set_value,
+    "~x := 1.23; x = 4.56;",
+    Value::F64(Ref::new(4.56))
+);
+test_interpreter!(
+    interpret_set_value_row_vector,
+    "~x := [6,2]; x[1] = 4;",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2))
+);
+test_interpreter!(
+    interpret_set_value_col_vector,
+    "~x := [false false true true]'; x[1] = true; x[1]",
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_value_scalar_scalar,
+    "~x := [1 2; 3 4]; x[2,2] = 42; x[2,2];",
+    Value::F64(Ref::new(42.0))
+);
+test_interpreter!(
+    interpret_set_value_all,
+    "~x := [1 2; 3 4]; x[:] = 42; x[1] + x[2] + x[3] + x[4]; ",
+    Value::F64(Ref::new(168.0))
+);
+test_interpreter!(
+    interpret_set_value_all_scalar,
+    "~x := [1 2; 3 4]; x[:,1] = 42; x[1] + x[2] + x[3] + x[4]",
+    Value::F64(Ref::new(90.0))
+);
+test_interpreter!(
+    interpret_set_value_scalar_all,
+    "~x := [1 2; 3 4]; x[1,:] = 42; x[1] + x[3];",
+    Value::F64(Ref::new(84.0))
+);
+test_interpreter!(
+    interpret_set_value_slice,
+    "~x := [1 2 3 4]; x[[1 3]] = 42; x[1] + x[2] + x[3] + x[4];",
+    Value::F64(Ref::new(90.0))
+);
+test_interpreter!(
+    interpret_set_value_scalar_slice,
+    "~x := [1 2 3; 4 5 6; 7 8 9]; x[1,[1,3]] = 42; x[1] + x[7];",
+    Value::F64(Ref::new(84.0))
+);
+test_interpreter!(
+    interpret_set_value_slice_slice,
+    "~x := [1 2 3; 5 6 7; 9 10 11]; x[1..3,1..3] = 42; x[1] + x[2] + x[4] + x[5]",
+    Value::F64(Ref::new(168.0))
+);
+test_interpreter!(
+    interpret_set_value_all_slice,
+    "~x := [1 2 3; 5 6 7]; x[:,1..3] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]",
+    Value::F64(Ref::new(178.0))
+);
+test_interpreter!(
+    interpret_set_value_all_slice_vec,
+    "~x := [1;6]; x = [4;5]; x[1] + x[2];",
+    Value::F64(Ref::new(9.0))
+);
+test_interpreter!(
+    interpret_set_value_slice_all,
+    "~x := [1 2 3; 5 6 7]'; x[1..3,:] = 42; x[1] + x[2] + x[3] + x[4] + x[5] + x[6]",
+    Value::F64(Ref::new(178.0))
+);
+test_interpreter!(
+    interpret_set_value_slice_vec,
+    "~x := [1 2 3 4]; x[1..=3] = [10 20 30]; x[1] + x[2] + x[3] + x[4]",
+    Value::F64(Ref::new(64.0))
+);
 
-test_interpreter!(interpret_set_record_field,"~x := {a: 1, b: true}; x.a = 2; x.a;", Value::F64(Ref::new(2.0)));
-test_interpreter!(interpret_set_record_field2,"~x := {a: 1, b: true}; x.b = false; x.b;", Value::Bool(Ref::new(false)));
+test_interpreter!(
+    interpret_set_record_field,
+    "~x := {a: 1, b: true}; x.a = 2; x.a;",
+    Value::F64(Ref::new(2.0))
+);
+test_interpreter!(
+    interpret_set_record_field2,
+    "~x := {a: 1, b: true}; x.b = false; x.b;",
+    Value::Bool(Ref::new(false))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_set_record_field3,"~x := {a: 1<u64>, b: true}; x.a = 2<u64>; x.a;", Value::U64(Ref::new(2)));
+test_interpreter!(
+    interpret_set_record_field3,
+    "~x := {a: 1<u64>, b: true}; x.a = 2<u64>; x.a;",
+    Value::U64(Ref::new(2))
+);
 
-test_interpreter!(interpret_set_table_col,"~x := | x<f64> y<f64> | 1 2 | 3 4 |; x.x = [42;46]; y := x.x; y[1] + y[2]", Value::F64(Ref::new(88.0)));
-test_interpreter!(interpret_set_table_col2,"~x := | x<f64> y<f64> | 1 2 | 3 4 | 5 6 | 7 8 |; x.x = [42;46;47;48]; y := x.x; y[1] + y[2] + y[3] + y[4];", Value::F64(Ref::new(183.0)));
-test_interpreter!(interpret_set_table_col_string,r#"~x := | x<string> | "a" | "b" |; x.x = ["c";"d"]; x.x"#, Value::MatrixString(Matrix::from_vec(vec!["c".to_string(), "d".to_string()], 2, 1)));
+test_interpreter!(
+    interpret_set_table_col,
+    "~x := | x<f64> y<f64> | 1 2 | 3 4 |; x.x = [42;46]; y := x.x; y[1] + y[2]",
+    Value::F64(Ref::new(88.0))
+);
+test_interpreter!(
+    interpret_set_table_col2,
+    "~x := | x<f64> y<f64> | 1 2 | 3 4 | 5 6 | 7 8 |; x.x = [42;46;47;48]; y := x.x; y[1] + y[2] + y[3] + y[4];",
+    Value::F64(Ref::new(183.0))
+);
+test_interpreter!(
+    interpret_set_table_col_string,
+    r#"~x := | x<string> | "a" | "b" |; x.x = ["c";"d"]; x.x"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec!["c".to_string(), "d".to_string()],
+        2,
+        1
+    ))
+);
 
-test_interpreter!(interpret_set_logical,"~x := [1 2 3]; ix := [true false true]; x[ix] = 4; x[1] + x[2] + x[3];", Value::F64(Ref::new(10.0)));
-test_interpreter!(interpret_set_logical2,"~x := [1 2 3 4]; ix := [true false true true]; x[ix] = 5; x[1] + x[2] + x[3] + x[4];", Value::F64(Ref::new(17.0)));
-test_interpreter!(interpret_set_logical_scalar,"~x := [1 2 3]; x[4 > 3] = 5; x[1] + x[2] + x[3]", Value::F64(Ref::new(15.0)));
+test_interpreter!(
+    interpret_set_logical,
+    "~x := [1 2 3]; ix := [true false true]; x[ix] = 4; x[1] + x[2] + x[3];",
+    Value::F64(Ref::new(10.0))
+);
+test_interpreter!(
+    interpret_set_logical2,
+    "~x := [1 2 3 4]; ix := [true false true true]; x[ix] = 5; x[1] + x[2] + x[3] + x[4];",
+    Value::F64(Ref::new(17.0))
+);
+test_interpreter!(
+    interpret_set_logical_scalar,
+    "~x := [1 2 3]; x[4 > 3] = 5; x[1] + x[2] + x[3]",
+    Value::F64(Ref::new(15.0))
+);
 
-test_interpreter!(interpret_set_logical_vector_scalar_bool,"~x := [1 2; 4 5]; x[[true false], 2] = 42; x[1] + x[2] + x[3] + x[4];", Value::F64(Ref::new(52.0)));
-test_interpreter!(interpret_set_logical_scalar_vector_bool,"~x := [1 2; 4 5]; x[2,[false true]] = 42; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(49.0)));
-test_interpreter!(interpret_set_logical_vector_vector_bool,"~x := [1 2; 4 5]; x[[true false],[false true]] = 42;", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 42.0, 5.0], 2, 2)));
+test_interpreter!(
+    interpret_set_logical_vector_scalar_bool,
+    "~x := [1 2; 4 5]; x[[true false], 2] = 42; x[1] + x[2] + x[3] + x[4];",
+    Value::F64(Ref::new(52.0))
+);
+test_interpreter!(
+    interpret_set_logical_scalar_vector_bool,
+    "~x := [1 2; 4 5]; x[2,[false true]] = 42; x[1] + x[2] + x[3] + x[4]",
+    Value::F64(Ref::new(49.0))
+);
+test_interpreter!(
+    interpret_set_logical_vector_vector_bool,
+    "~x := [1 2; 4 5]; x[[true false],[false true]] = 42;",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 42.0, 5.0], 2, 2))
+);
 
-test_interpreter!(interpret_set_logical_all_vector_bool,"~x := [1 2; 4 5]; x[:,[1 2]] = 42; x[1] + x[2] + x[3] + x[4]", Value::F64(Ref::new(168.0)));
+test_interpreter!(
+    interpret_set_logical_all_vector_bool,
+    "~x := [1 2; 4 5]; x[:,[1 2]] = 42; x[1] + x[2] + x[3] + x[4]",
+    Value::F64(Ref::new(168.0))
+);
 
-test_interpreter!(interpret_horzcat,"x := [1 2]; y := [x 3]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
-test_interpreter!(interpret_horzcat_r2m1,"x := [1 2]; z := [3]; y := [x z]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
-test_interpreter!(interpret_horzcat_m1r2,"x := [1 2]; z := [3]; y := [z x]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
-test_interpreter!(interpret_horzcat_sr2,"x := [1 2]; y := [3 x]; y[1] + y[2] + y[3]", Value::F64(Ref::new(6.0)));
+test_interpreter!(
+    interpret_horzcat,
+    "x := [1 2]; y := [x 3]; y[1] + y[2] + y[3]",
+    Value::F64(Ref::new(6.0))
+);
+test_interpreter!(
+    interpret_horzcat_r2m1,
+    "x := [1 2]; z := [3]; y := [x z]; y[1] + y[2] + y[3]",
+    Value::F64(Ref::new(6.0))
+);
+test_interpreter!(
+    interpret_horzcat_m1r2,
+    "x := [1 2]; z := [3]; y := [z x]; y[1] + y[2] + y[3]",
+    Value::F64(Ref::new(6.0))
+);
+test_interpreter!(
+    interpret_horzcat_sr2,
+    "x := [1 2]; y := [3 x]; y[1] + y[2] + y[3]",
+    Value::F64(Ref::new(6.0))
+);
 
-test_interpreter!(interpret_horzcat_r2s,"x := [1 2]; y := [x 3];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
-test_interpreter!(interpret_horzcat_m1,"x := [1]; y := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0], 1, 1)));
-test_interpreter!(interpret_horzcat_r2,"x := [1 2]; y := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2)));
+test_interpreter!(
+    interpret_horzcat_r2s,
+    "x := [1 2]; y := [x 3];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_m1,
+    "x := [1]; y := [x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0], 1, 1))
+);
+test_interpreter!(
+    interpret_horzcat_r2,
+    "x := [1 2]; y := [x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2))
+);
 
-test_interpreter!(interpret_horzcat_sm1,"x := [2]; y := [1 x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2)));
-test_interpreter!(interpret_horzcat_m1s,"x := [2]; y := [x 1]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0], 1, 2)));
-test_interpreter!(interpret_horzcat_m1m1,"x := [2]; y := [x x]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0], 1, 2)));
+test_interpreter!(
+    interpret_horzcat_sm1,
+    "x := [2]; y := [1 x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0], 1, 2))
+);
+test_interpreter!(
+    interpret_horzcat_m1s,
+    "x := [2]; y := [x 1]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0], 1, 2))
+);
+test_interpreter!(
+    interpret_horzcat_m1m1,
+    "x := [2]; y := [x x]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 2.0], 1, 2))
+);
 
-test_interpreter!(interpret_horzcat_sr3,"x := [1 2 3]; y := [1 x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r3s,"x := [1 2 3]; y := [x 1]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r2r2,"x := [1 2]; y := [x x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1r3,"x := [1 2 3]; z := [1]; y := [z x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r3m1,"x := [1 2 3]; z := [1]; y := [x z]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
+test_interpreter!(
+    interpret_horzcat_sr3,
+    "x := [1 2 3]; y := [1 x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r3s,
+    "x := [1 2 3]; y := [x 1]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r2r2,
+    "x := [1 2]; y := [x x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1r3,
+    "x := [1 2 3]; z := [1]; y := [z x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r3m1,
+    "x := [1 2 3]; z := [1]; y := [x z]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
+);
 
-test_interpreter!(interpret_horzcat_ssm1,"x := [3]; y := [1 2 x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
-test_interpreter!(interpret_horzcat_sm1s,"x := [3]; y := [1 x 2]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0], 1, 3)));
-test_interpreter!(interpret_horzcat_m1ss,"x := [3]; y := [x 1 2]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 1.0, 2.0], 1, 3)));
-test_interpreter!(interpret_horzcat_m1m1m1,"x := [3]; y := [x x x]", Value::MatrixF64(Matrix::from_vec(vec![3.0, 3.0, 3.0], 1, 3)));
-test_interpreter!(interpret_horzcat_sm1m1,"x := [3]; z:= [2]; y := [1 z x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3)));
-test_interpreter!(interpret_horzcat_m1sm1,"x := [3]; z:= [2]; y := [z 1 x]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0, 3.0], 1, 3)));
-test_interpreter!(interpret_horzcat_m1m1s,"x := [3]; z:= [2]; y := [z x 1]", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0], 1, 3)));
+test_interpreter!(
+    interpret_horzcat_ssm1,
+    "x := [3]; y := [1 2 x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_sm1s,
+    "x := [3]; y := [1 x 2]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_m1ss,
+    "x := [3]; y := [x 1 2]",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 1.0, 2.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_m1m1m1,
+    "x := [3]; y := [x x x]",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 3.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_sm1m1,
+    "x := [3]; z:= [2]; y := [1 z x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_m1sm1,
+    "x := [3]; z:= [2]; y := [z 1 x]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 1.0, 3.0], 1, 3))
+);
+test_interpreter!(
+    interpret_horzcat_m1m1s,
+    "x := [3]; z:= [2]; y := [z x 1]",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0], 1, 3))
+);
 
-test_interpreter!(interpret_horzcat_m1m1r2,"x := [1]; y:= [2 3]; z := [x x y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1r2m1,"x := [1]; y:= [2 3]; z := [x y x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r2m1m1,"x := [1]; y:= [2 3]; z := [y x x];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
+test_interpreter!(
+    interpret_horzcat_m1m1r2,
+    "x := [1]; y:= [2 3]; z := [x x y];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1r2m1,
+    "x := [1]; y:= [2 3]; z := [x y x];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r2m1m1,
+    "x := [1]; y:= [2 3]; z := [y x x];",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
+);
 
-test_interpreter!(interpret_horzcat_ssr2,"y:= [2 3]; z := [1 1 y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_sr2s,"y:= [2 3]; z := [1 y 1];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r2ss,"y:= [2 3]; z := [y 1 1];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
+test_interpreter!(
+    interpret_horzcat_ssr2,
+    "y:= [2 3]; z := [1 1 y];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_sr2s,
+    "y:= [2 3]; z := [1 y 1];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r2ss,
+    "y:= [2 3]; z := [y 1 1];",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
+);
 
-test_interpreter!(interpret_horzcat_sm1r2,"x := [1]; y:= [2 3]; z := [1 x y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1sr2, "x := [1]; y:= [2 3]; z := [x 1 y];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_sr2m1, "x := [1]; y:= [2 3]; z := [1 y x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1r2s, "x := [1]; y:= [2 3]; z := [x y 1];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r2sm1, "x := [1]; y:= [2 3]; z := [y 1 x];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_r2m1s, "x := [1]; y:= [2 3]; z := [y x 1];", Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4)));
+test_interpreter!(
+    interpret_horzcat_sm1r2,
+    "x := [1]; y:= [2 3]; z := [1 x y];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1sr2,
+    "x := [1]; y:= [2 3]; z := [x 1 y];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_sr2m1,
+    "x := [1]; y:= [2 3]; z := [1 y x];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1r2s,
+    "x := [1]; y:= [2 3]; z := [x y 1];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r2sm1,
+    "x := [1]; y:= [2 3]; z := [y 1 x];",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_r2m1s,
+    "x := [1]; y:= [2 3]; z := [y x 1];",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 1.0, 1.0], 1, 4))
+);
 
-test_interpreter!(interpret_horzcat_sssm1, "x := [4]; y := [1 2 3 x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1sss, "x := [4]; y := [x 1 2 3];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_sm1ss, "x := [4]; y := [1 x 2 3];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_ssm1s, "x := [4]; y := [1 2 x 3];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 4.0, 3.0], 1, 4)));
-test_interpreter!(interpret_horzcat_sm1sm1, "x := [4]; z := [5]; y := [1 x 2 z];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1ssm1, "x := [4]; z := [5]; y := [x 1 2 z];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 5.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1sm1s, "x := [4]; z := [5]; y := [x 1 z 2];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 2.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1m1sm1, "x := [4]; z := [5]; w := [6]; y := [x z 1 w];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 1.0, 6.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1m1m1s, "x := [4]; z := [5]; w := [6]; y := [x z w 1];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 1.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1sm1m1, "x := [4]; z := [5]; w := [6]; y := [x 1 z w];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 6.0], 1, 4)));
-test_interpreter!(interpret_horzcat_sm1m1m1, "x := [4]; z := [5]; w := [6]; y := [1 x z w];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 5.0, 6.0], 1, 4)));
-test_interpreter!(interpret_horzcat_m1m1m1m1, "x := [4]; z := [5]; w := [6]; v := [7]; y := [x z w v];", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 7.0], 1, 4)));
+test_interpreter!(
+    interpret_horzcat_sssm1,
+    "x := [4]; y := [1 2 3 x];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1sss,
+    "x := [4]; y := [x 1 2 3];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_sm1ss,
+    "x := [4]; y := [1 x 2 3];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_ssm1s,
+    "x := [4]; y := [1 2 x 3];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 4.0, 3.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_sm1sm1,
+    "x := [4]; z := [5]; y := [1 x 2 z];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1ssm1,
+    "x := [4]; z := [5]; y := [x 1 2 z];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 2.0, 5.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1sm1s,
+    "x := [4]; z := [5]; y := [x 1 z 2];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 2.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1m1sm1,
+    "x := [4]; z := [5]; w := [6]; y := [x z 1 w];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 1.0, 6.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1m1m1s,
+    "x := [4]; z := [5]; w := [6]; y := [x z w 1];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 1.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1sm1m1,
+    "x := [4]; z := [5]; w := [6]; y := [x 1 z w];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 1.0, 5.0, 6.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_sm1m1m1,
+    "x := [4]; z := [5]; w := [6]; y := [1 x z w];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 5.0, 6.0], 1, 4))
+);
+test_interpreter!(
+    interpret_horzcat_m1m1m1m1,
+    "x := [4]; z := [5]; w := [6]; v := [7]; y := [x z w v];",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 7.0], 1, 4))
+);
 
-test_interpreter!(interpret_horzcat_m2m2m2, "x := [1 2]; y := [x x x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 1, 6)));
+test_interpreter!(
+    interpret_horzcat_m2m2m2,
+    "x := [1 2]; y := [x x x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 1, 6))
+);
 
-test_interpreter!(interpret_horzcat_rd2, "x := [1 2 3 4 5]; y := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5)));
-test_interpreter!(interpret_horzcat_rd4, "a := [1];b := [2 3];c := [4 5 6];d := [7 8 9 10];z := [a b c d];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], 1, 10)));
-test_interpreter!(interpret_horzcat_rd3, "a := [1 1]; z := [a a a];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0], 1, 6)));
-test_interpreter!(interpret_horzcat_rdn, "a := [1 2 3]; z := [0 0 0 0 0 a];", Value::MatrixF64(Matrix::from_vec(vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0], 1, 8)));
+test_interpreter!(
+    interpret_horzcat_rd2,
+    "x := [1 2 3 4 5]; y := [x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 5))
+);
+test_interpreter!(
+    interpret_horzcat_rd4,
+    "a := [1];b := [2 3];c := [4 5 6];d := [7 8 9 10];z := [a b c d];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        1,
+        10
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_rd3,
+    "a := [1 1]; z := [a a a];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0], 1, 6))
+);
+test_interpreter!(
+    interpret_horzcat_rdn,
+    "a := [1 2 3]; z := [0 0 0 0 0 a];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
+        1,
+        8
+    ))
+);
 
-test_interpreter!(interpret_horzcat_m2m2, "a := [1 2; 3 4]; z := [a a];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0, 1.0, 3.0, 2.0, 4.0], 2, 4)));
+test_interpreter!(
+    interpret_horzcat_m2m2,
+    "a := [1 2; 3 4]; z := [a a];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 3.0, 2.0, 4.0, 1.0, 3.0, 2.0, 4.0],
+        2,
+        4
+    ))
+);
 
-test_interpreter!(interpret_horzcat_m2x3v2, "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [x z];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 7.0, 8.0], 2, 4)));
-test_interpreter!(interpret_horzcat_v2m2x3, "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [z x];", Value::MatrixF64(Matrix::from_vec(vec![7.0, 8.0, 1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 4)));
+test_interpreter!(
+    interpret_horzcat_m2x3v2,
+    "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [x z];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 7.0, 8.0],
+        2,
+        4
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_v2m2x3,
+    "x := [1 2 3; 4 5 6]; z := [7 8]'; a := [z x];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![7.0, 8.0, 1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+        2,
+        4
+    ))
+);
 
-test_interpreter!(interpret_horzcat_v2v2, "x := [1;2]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 2, 2)));
-test_interpreter!(interpret_horzcat_v3v3, "x := [1;2;3]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0], 3, 2)));
-test_interpreter!(interpret_horzcat_v4v4, "x := [1;2;3;4]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0], 4, 2)));
-test_interpreter!(interpret_horzcat_vdvd, "x := [1;2;3;4;5]; y := [x x];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0], 5, 2)));
+test_interpreter!(
+    interpret_horzcat_v2v2,
+    "x := [1;2]; y := [x x];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0], 2, 2))
+);
+test_interpreter!(
+    interpret_horzcat_v3v3,
+    "x := [1;2;3]; y := [x x];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0], 3, 2))
+);
+test_interpreter!(
+    interpret_horzcat_v4v4,
+    "x := [1;2;3;4]; y := [x x];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
+        4,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_vdvd,
+    "x := [1;2;3;4;5]; y := [x x];",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        5,
+        2
+    ))
+);
 
-test_interpreter!(interpret_horzcat_v2m2, "x := [1 2; 3 4]; y := [1; 2]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 3.0, 2.0, 4.0], 2, 3)));
-test_interpreter!(interpret_horzcat_m2v2, "x := [1 2; 3 4]; y := [1; 2]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0, 1.0, 2.0], 2, 3)));
+test_interpreter!(
+    interpret_horzcat_v2m2,
+    "x := [1 2; 3 4]; y := [1; 2]; z := [y x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 3.0, 2.0, 4.0], 2, 3))
+);
+test_interpreter!(
+    interpret_horzcat_m2v2,
+    "x := [1 2; 3 4]; y := [1; 2]; z := [x y]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0, 1.0, 2.0], 2, 3))
+);
 
+test_interpreter!(
+    interpret_horzcat_m3x2v3,
+    "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [x y]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0, 1.0, 2.0, 3.0],
+        3,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_v3m3x2,
+    "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [y x]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 3.0, 1.0, 3.0, 5.0, 2.0, 4.0, 6.0],
+        3,
+        3
+    ))
+);
 
-test_interpreter!(interpret_horzcat_m3x2v3, "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0, 1.0, 2.0, 3.0], 3, 3)));
-test_interpreter!(interpret_horzcat_v3m3x2, "x := [1 2; 3 4; 5 6]; y := [1; 2; 3]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 3)));
+test_interpreter!(
+    interpret_horzcat_mdv4,
+    "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [x y]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0, 1.0, 2.0, 3.0, 4.0],
+        4,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_v4md,
+    "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [y x]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 3.0, 4.0, 1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0],
+        4,
+        3
+    ))
+);
 
-test_interpreter!(interpret_horzcat_mdv4, "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0, 1.0, 2.0, 3.0, 4.0], 4, 3)));
-test_interpreter!(interpret_horzcat_v4md, "x := [1 2; 3 4; 5 6; 7 8]; y := [1; 2; 3; 4]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 1.0, 3.0, 5.0, 7.0, 2.0, 4.0, 6.0, 8.0], 4, 3)));
+test_interpreter!(
+    interpret_horzcat_mdvd,
+    "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [x y]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        5,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_vdmd,
+    "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [y x]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0],
+        5,
+        3
+    ))
+);
 
-test_interpreter!(interpret_horzcat_mdvd, "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0, 1.0, 2.0, 3.0, 4.0, 5.0], 5, 3)));
-test_interpreter!(interpret_horzcat_vdmd, "x := [1 2; 3 4; 5 6; 7 8; 9 10]; y := [1; 2; 3; 4; 5]; z := [y x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 3.0, 5.0, 7.0, 9.0, 2.0, 4.0, 6.0, 8.0, 10.0], 5, 3)));
+test_interpreter!(
+    interpret_horzcat_m2,
+    "x := [1 2; 3 4]; z := [x]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2))
+);
 
-test_interpreter!(interpret_horzcat_m2, "x := [1 2; 3 4]; z := [x]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
+test_interpreter!(
+    interpret_horzcat_m3v3,
+    "x := [1 2 3; 4 5 6; 7 8 9]; y := [1;2;3]; z := [x y]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0, 1.0, 2.0, 3.0],
+        3,
+        4
+    ))
+);
 
-test_interpreter!(interpret_horzcat_m3v3, "x := [1 2 3; 4 5 6; 7 8 9]; y := [1;2;3]; z := [x y]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0, 1.0, 2.0, 3.0], 3, 4)));
+test_interpreter!(
+    interpret_horzcat_v2v2v2v2,
+    "x := [1; 2;]; z := [x x x x] ",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+        2,
+        4
+    ))
+);
+test_interpreter!(
+    interpret_horzcat_v2v2v2v2v2,
+    "x := [1; 2;]; z := [x x x x x] ",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+        2,
+        5
+    ))
+);
+test_interpreter!(
+    interpret_vertcat_vd2,
+    "x := [1;2;3;4]; z := [5]; y := [x;z]",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 5, 1))
+);
+test_interpreter!(
+    interpret_vertcat_vd3,
+    "x := [1;2;3]; z := [5]; y := [z;z;x]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 1.0, 2.0, 3.0], 5, 1))
+);
+test_interpreter!(
+    interpret_vertcat_m1m1m1m1,
+    "x := [5]; y := [x;x;x;x]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0], 4, 1))
+);
+test_interpreter!(
+    interpret_vertcat_vd4,
+    "x := [5]; z := [1;2]; y := [x;x;x;z]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 1.0, 2.0], 5, 1))
+);
 
-test_interpreter!(interpret_horzcat_v2v2v2v2, "x := [1; 2;]; z := [x x x x] ", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 2, 4)));
-test_interpreter!(interpret_horzcat_v2v2v2v2v2, "x := [1; 2;]; z := [x x x x x] ", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0], 2, 5)));
-test_interpreter!(interpret_vertcat_vd2, "x := [1;2;3;4]; z := [5]; y := [x;z]", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0], 5, 1)));
-test_interpreter!(interpret_vertcat_vd3, "x := [1;2;3]; z := [5]; y := [z;z;x]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 1.0, 2.0, 3.0], 5, 1)));
-test_interpreter!(interpret_vertcat_m1m1m1m1, "x := [5]; y := [x;x;x;x]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0], 4, 1)));
-test_interpreter!(interpret_vertcat_vd4, "x := [5]; z := [1;2]; y := [x;x;x;z]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 1.0, 2.0], 5, 1)));
+test_interpreter!(
+    interpret_vertcat_vdn,
+    "x := [5]; y := [x;x;x;x;x]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0, 5.0], 5, 1))
+);
+test_interpreter!(
+    interpret_vertcat_r2m2,
+    "x := [5 2;3 4]; y := [8 9];z := [y;x]",
+    Value::MatrixF64(Matrix::from_vec(vec![8.0, 5.0, 3.0, 9.0, 2.0, 4.0], 3, 2))
+);
+test_interpreter!(
+    interpret_vertcat_m2r2,
+    "x := [5 2;3 4]; y := [8 9];z := [x;y]",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 3.0, 8.0, 2.0, 4.0, 9.0], 3, 2))
+);
 
-test_interpreter!(interpret_vertcat_vdn, "x := [5]; y := [x;x;x;x;x]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 5.0, 5.0, 5.0, 5.0], 5, 1)));
-test_interpreter!(interpret_vertcat_r2m2, "x := [5 2;3 4]; y := [8 9];z := [y;x]", Value::MatrixF64(Matrix::from_vec(vec![8.0, 5.0, 3.0, 9.0, 2.0, 4.0], 3, 2)));
-test_interpreter!(interpret_vertcat_m2r2, "x := [5 2;3 4]; y := [8 9];z := [x;y]", Value::MatrixF64(Matrix::from_vec(vec![5.0, 3.0, 8.0, 2.0, 4.0, 9.0], 3, 2)));
+test_interpreter!(
+    interpret_vertcat_r2m2x3,
+    "x := [1 2 3; 4 5 6]; y := [7 8 9]; z := [y;x]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![7.0, 1.0, 4.0, 8.0, 2.0, 5.0, 9.0, 3.0, 6.0],
+        3,
+        3
+    ))
+);
 
-test_interpreter!(interpret_vertcat_r2m2x3, "x := [1 2 3; 4 5 6]; y := [7 8 9]; z := [y;x]", Value::MatrixF64(Matrix::from_vec(vec![7.0, 1.0, 4.0, 8.0, 2.0, 5.0, 9.0, 3.0, 6.0], 3, 3)));
+test_interpreter!(
+    interpret_stats_sum_rowm2,
+    "x := [1 2; 4 5]; y := stats/sum/row(x);",
+    Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0], 1, 2))
+);
 
-test_interpreter!(interpret_stats_sum_rowm2, "x := [1 2; 4 5]; y := stats/sum/row(x);", Value::MatrixF64(Matrix::from_vec(vec![5.0, 7.0], 1, 2)));
+test_interpreter!(
+    interpret_add_assign,
+    "~x := 10; x += 20",
+    Value::F64(Ref::new(30.0))
+);
+test_interpreter!(
+    interpret_add_assign_formula,
+    "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] += y;",
+    Value::MatrixF64(Matrix::from_vec(vec![11.0, 7.0, 8.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_add_assign_formula_all_m2m2,
+    "~x := [1 2; 3 4]; y := [1 1 1 1];z := [10 10; 20 20]; x[y,:] += z;",
+    Value::MatrixF64(Matrix::from_vec(vec![61.0, 3.0, 62.0, 4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_sub_assign_formula,
+    "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] -= y;",
+    Value::MatrixF64(Matrix::from_vec(vec![-9.0, -3.0, -2.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_mul_assign_formula,
+    "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] *= y;",
+    Value::MatrixF64(Matrix::from_vec(vec![25.0, 10.0, 15.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_add_assign_range,
+    "~x := [1 2; 3 4]; x[1..3] += 1",
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_div_assign_range_all,
+    "~x := [1 2; 3 4; 5 6]; x[1..3,:] /= [1 2; 3 4];",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 5.0, 1.0, 1.0, 6.0], 3, 2))
+);
+test_interpreter!(
+    interpret_div_assign_range,
+    "~x := [1 2 3 4]; x[1..3] /= 2;",
+    Value::MatrixF64(Matrix::from_vec(vec![0.5, 1.0, 3.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_add_assign_range_vec,
+    "~x := [1 2 3 4]; x[1..3] += 2;",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 3.0, 4.0], 1, 4))
+);
 
-test_interpreter!(interpret_add_assign, "~x := 10; x += 20", Value::F64(Ref::new(30.0)));
-test_interpreter!(interpret_add_assign_formula, "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] += y;", Value::MatrixF64(Matrix::from_vec(vec![11.0, 7.0, 8.0, 4.0], 1, 4)));
-test_interpreter!(interpret_add_assign_formula_all_m2m2,"~x := [1 2; 3 4]; y := [1 1 1 1];z := [10 10; 20 20]; x[y,:] += z;", Value::MatrixF64(Matrix::from_vec(vec![61.0, 3.0, 62.0, 4.0], 2, 2)));
-test_interpreter!(interpret_sub_assign_formula, "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] -= y;", Value::MatrixF64(Matrix::from_vec(vec![-9.0, -3.0, -2.0, 4.0], 1, 4)));
-test_interpreter!(interpret_mul_assign_formula, "ix := [1 1 2 3]; y := 5; ~x := [1 2 3 4]; x[ix] *= y;", Value::MatrixF64(Matrix::from_vec(vec![25.0, 10.0, 15.0, 4.0], 1, 4)));
-test_interpreter!(interpret_add_assign_range, "~x := [1 2; 3 4]; x[1..3] += 1", Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 2.0, 4.0], 2, 2)));
-test_interpreter!(interpret_div_assign_range_all, "~x := [1 2; 3 4; 5 6]; x[1..3,:] /= [1 2; 3 4];", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 5.0, 1.0, 1.0, 6.0], 3, 2)));
-test_interpreter!(interpret_div_assign_range, "~x := [1 2 3 4]; x[1..3] /= 2;", Value::MatrixF64(Matrix::from_vec(vec![0.5, 1.0, 3.0, 4.0], 1, 4)));
-test_interpreter!(interpret_add_assign_range_vec, "~x := [1 2 3 4]; x[1..3] += 2;", Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 3.0, 4.0], 1, 4)));
+test_interpreter!(
+    interpret_set_logical_ram2m2_bool,
+    "~x := [1 2; 3 4]; y := [true false]; z := [10 20; 30 40]; x[y,:] = z;",
+    Value::MatrixF64(Matrix::from_vec(vec![10.0, 3.0, 20.0, 4.0], 2, 2))
+);
+test_interpreter!(
+    interpret_set_logical_ram3m3_bool,
+    "~x := [1 2 3; 4 5 6; 7 8 9]; y := [true false true]; z := [10 20 30; 40 50 60; 70 80 90]; x[y,:] = z;",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![10.0, 4.0, 70.0, 20.0, 5.0, 80.0, 30.0, 6.0, 90.0],
+        3,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_set_logical_ram4m4_bool,
+    "~x := [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]; y := [true false true false]; z := [10 20 30 40; 50 60 70 80; 90 100 110 120; 130 140 150 160]; x[y,:] = z;",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![
+            10.0, 5.0, 90.0, 13.0, 20.0, 6.0, 100.0, 14.0, 30.0, 7.0, 110.0, 15.0, 40.0, 8.0,
+            120.0, 16.0
+        ],
+        4,
+        4
+    ))
+);
 
-test_interpreter!(interpret_set_logical_ram2m2_bool,"~x := [1 2; 3 4]; y := [true false]; z := [10 20; 30 40]; x[y,:] = z;", Value::MatrixF64(Matrix::from_vec(vec![10.0, 3.0, 20.0, 4.0], 2, 2)));
-test_interpreter!(interpret_set_logical_ram3m3_bool,"~x := [1 2 3; 4 5 6; 7 8 9]; y := [true false true]; z := [10 20 30; 40 50 60; 70 80 90]; x[y,:] = z;", Value::MatrixF64(Matrix::from_vec(vec![10.0, 4.0, 70.0, 20.0, 5.0, 80.0, 30.0, 6.0, 90.0], 3, 3)));
-test_interpreter!(interpret_set_logical_ram4m4_bool,"~x := [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]; y := [true false true false]; z := [10 20 30 40; 50 60 70 80; 90 100 110 120; 130 140 150 160]; x[y,:] = z;", Value::MatrixF64(Matrix::from_vec(vec![10.0, 5.0, 90.0, 13.0, 20.0, 6.0, 100.0, 14.0, 30.0, 7.0, 110.0, 15.0, 40.0, 8.0, 120.0, 16.0], 4, 4)));
+test_interpreter!(
+    interpret_set_logical_ram2m2,
+    "~x := [1 2; 3 4]; y := [2 1]; x[y,:] = x;",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0], 2, 2))
+);
+test_interpreter!(
+    interpret_set_logical_ram3m3,
+    "~x := [1 2 3; 4 5 6; 7 8 9]; y := [2 1 3]; x[y,:] = x;",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![1.0, 1.0, 7.0, 2.0, 2.0, 8.0, 3.0, 3.0, 9.0],
+        3,
+        3
+    ))
+);
 
-test_interpreter!(interpret_set_logical_ram2m2,"~x := [1 2; 3 4]; y := [2 1]; x[y,:] = x;", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 2.0, 2.0], 2, 2)));
-test_interpreter!(interpret_set_logical_ram3m3,"~x := [1 2 3; 4 5 6; 7 8 9]; y := [2 1 3]; x[y,:] = x;", Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 7.0, 2.0, 2.0, 8.0, 3.0, 3.0, 9.0], 3, 3)));
+test_interpreter!(
+    interpret_modulus,
+    "[1 2 3 4 5] % 5",
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 0.0], 1, 5))
+);
 
-test_interpreter!(interpret_modulus,"[1 2 3 4 5] % 5", Value::MatrixF64(Matrix::from_vec(vec![1.0, 2.0, 3.0, 4.0, 0.0], 1, 5)));
-
-test_interpreter!(interpret_horzcat_rdn2, "y := [4 5 6]; [y y y * 2]", Value::MatrixF64(Matrix::from_vec(vec![4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0], 1, 9)));
+test_interpreter!(
+    interpret_horzcat_rdn2,
+    "y := [4 5 6]; [y y y * 2]",
+    Value::MatrixF64(Matrix::from_vec(
+        vec![4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0],
+        1,
+        9
+    ))
+);
 
 #[cfg(feature = "u8")]
-test_interpreter!(interpret_fancy_table, r#"x := |x<f64> y<u8>|
+test_interpreter!(
+    interpret_fancy_table,
+    r#"x := |x<f64> y<u8>|
      |1      2    |
      |3      4    |
      |5      6    |
-x.x"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0], 3, 1)));
+x.x"#,
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 5.0], 3, 1))
+);
 
-test_interpreter!(interpret_fancy_matrix, r#"
+test_interpreter!(
+    interpret_fancy_matrix,
+    r#"
 x := ┏       ┓
      ┃ 1   2 ┃
      ┃ 3   4 ┃
-     ┗       ┛"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
+     ┗       ┛"#,
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2))
+);
 
 #[cfg(all(feature = "f32", feature = "u64"))]
-test_interpreter!(interpret_fancy_table2, r#"
+test_interpreter!(
+    interpret_fancy_table2,
+    r#"
 x:=╭────────┬────────╮
    │ x<u64> │ y<f32> │
    ├────────┼────────┤
@@ -985,19 +2886,27 @@ x:=╭────────┬────────╮
    ├────────┼────────┤
    │   3    │   4    │
    ╰────────┴────────╯
-x.x"#, Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1)));
+x.x"#,
+    Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1))
+);
 
 #[cfg(all(feature = "f32", feature = "u64"))]
-test_interpreter!(interpret_fancy_table3, r#"
+test_interpreter!(
+    interpret_fancy_table3,
+    r#"
 x:=╭────────┬────────╮
    │ x<u64> │ y<f32> │
    │   1    │   2    │
    │   3    │   4    │
    ╰────────┴────────╯
-x.x"#, Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1)));
+x.x"#,
+    Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1))
+);
 
 #[cfg(all(feature = "f32", feature = "u64"))]
-test_interpreter!(interpret_fancy_table4, r#"
+test_interpreter!(
+    interpret_fancy_table4,
+    r#"
 x:=╭────────┬────────╮
    │ x<u64> │ y<f32> │
    ├────────┼────────┤
@@ -1008,150 +2917,630 @@ x:=╭────────┬────────╮
    │   3    │   4    │
    │        │        │
    ╰────────┴────────╯
-x.x"#, Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1)));
+x.x"#,
+    Value::MatrixU64(Matrix::from_vec(vec![1_u64, 3], 2, 1))
+);
 #[cfg(feature = "f32")]
-test_interpreter!(interpret_table_access_element, r#"a:=|x<f32>|1.2|1.3|; a.x[1]"#, Value::F32(Ref::new(1.2)));
+test_interpreter!(
+    interpret_table_access_element,
+    r#"a:=|x<f32>|1.2|1.3|; a.x[1]"#,
+    Value::F32(Ref::new(1.2))
+);
 #[cfg(all(feature = "f32", feature = "u8"))]
-test_interpreter!(interpret_table_access_row, r#"x:=|a<f32> b<u8>|1.2 3 |1.3 4|; x[2]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::F32(Ref::new(1.3))),("b",Value::U8(Ref::new(4)))]))));
-test_interpreter!(interpret_table_append_row, r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {a<f64>: 5, b<f64>: 6}; x[3]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::F64(Ref::new(5.0))),("b",Value::F64(Ref::new(6.0)))]))));
-test_interpreter!(interpret_table_append_row2, r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {b<f64>: 6, a<f64>: 5}; x[3]"#, Value::Record(Ref::new(MechRecord::new(vec![("b",Value::F64(Ref::new(6.0))),("a",Value::F64(Ref::new(5.0)))]))));
+test_interpreter!(
+    interpret_table_access_row,
+    r#"x:=|a<f32> b<u8>|1.2 3 |1.3 4|; x[2]"#,
+    Value::Record(Ref::new(MechRecord::new(vec![
+        ("a", Value::F32(Ref::new(1.3))),
+        ("b", Value::U8(Ref::new(4)))
+    ])))
+);
+test_interpreter!(
+    interpret_table_append_row,
+    r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {a<f64>: 5, b<f64>: 6}; x[3]"#,
+    Value::Record(Ref::new(MechRecord::new(vec![
+        ("a", Value::F64(Ref::new(5.0))),
+        ("b", Value::F64(Ref::new(6.0)))
+    ])))
+);
+test_interpreter!(
+    interpret_table_append_row2,
+    r#"~x:=|a<f64> b<f64>|1 2 |3 4|; x += {b<f64>: 6, a<f64>: 5}; x[3]"#,
+    Value::Record(Ref::new(MechRecord::new(vec![
+        ("b", Value::F64(Ref::new(6.0))),
+        ("a", Value::F64(Ref::new(5.0)))
+    ])))
+);
 #[cfg(all(feature = "u8", feature = "u64"))]
-test_interpreter!(interpret_table_append_row3, r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |; a:=13; b:=14; y := {c<bool>: false, a<u64>: a, b<u8>: b}; x += y; x[3]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::U64(Ref::new(13))),("b",Value::U8(Ref::new(14)))]))));
+test_interpreter!(
+    interpret_table_append_row3,
+    r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |; a:=13; b:=14; y := {c<bool>: false, a<u64>: a, b<u8>: b}; x += y; x[3]"#,
+    Value::Record(Ref::new(MechRecord::new(vec![
+        ("a", Value::U64(Ref::new(13))),
+        ("b", Value::U8(Ref::new(14)))
+    ])))
+);
 #[cfg(all(feature = "u8", feature = "u64"))]
-test_interpreter!(interpret_table_append_table, r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |;y := |a<u64> b<u8>| 5 6 | 7 8 |; x += y; x[4]"#, Value::Record(Ref::new(MechRecord::new(vec![("a",Value::U64(Ref::new(7))),("b",Value::U8(Ref::new(8)))]))));
+test_interpreter!(
+    interpret_table_append_table,
+    r#"~x := |a<u64> b<u8>| 1 2 | 3 4 |;y := |a<u64> b<u8>| 5 6 | 7 8 |; x += y; x[4]"#,
+    Value::Record(Ref::new(MechRecord::new(vec![
+        ("a", Value::U64(Ref::new(7))),
+        ("b", Value::U8(Ref::new(8)))
+    ])))
+);
 #[cfg(all(feature = "u8", feature = "u64"))]
-test_interpreter!(interpret_table_select_rows, r#"x := |a<u64> b<u8>| 1 2 | 3 4 | 5 6 |; x[[1,3]]"#, Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("a",Value::U64(Ref::new(1))),("b",Value::U8(Ref::new(2)))]),MechRecord::new(vec![("a",Value::U64(Ref::new(5))),("b",Value::U8(Ref::new(6)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    interpret_table_select_rows,
+    r#"x := |a<u64> b<u8>| 1 2 | 3 4 | 5 6 |; x[[1,3]]"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("a", Value::U64(Ref::new(1))),
+                ("b", Value::U8(Ref::new(2)))
+            ]),
+            MechRecord::new(vec![
+                ("a", Value::U64(Ref::new(5))),
+                ("b", Value::U8(Ref::new(6)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_table_select_logical, r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.y}"#, Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x",Value::U64(Ref::new(2))),("y",Value::Bool(Ref::new(true)))]),MechRecord::new(vec![("x",Value::U64(Ref::new(5))),("y",Value::Bool(Ref::new(true)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    interpret_table_select_logical,
+    r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.y}"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("x", Value::U64(Ref::new(2))),
+                ("y", Value::Bool(Ref::new(true)))
+            ]),
+            MechRecord::new(vec![
+                ("x", Value::U64(Ref::new(5))),
+                ("y", Value::Bool(Ref::new(true)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_table_select_logical2, r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.x > 3<u64>}"#, Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x",Value::U64(Ref::new(4))),("y",Value::Bool(Ref::new(false)))]),MechRecord::new(vec![("x",Value::U64(Ref::new(5))),("y",Value::Bool(Ref::new(true)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    interpret_table_select_logical2,
+    r#"a := | x<u64>  y<bool> | 2 true  | 3 false | 4 false | 5 true |; a{a.x > 3<u64>}"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("x", Value::U64(Ref::new(4))),
+                ("y", Value::Bool(Ref::new(false)))
+            ]),
+            MechRecord::new(vec![
+                ("x", Value::U64(Ref::new(5))),
+                ("y", Value::Bool(Ref::new(true)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 
-test_interpreter!(interpret_table_from_matrix,r#"x := [1 2; 3 4]; a<|foo<f64>,bar<f64>|> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("foo", Value::F64(Ref::new(1.0))),("bar", Value::F64(Ref::new(2.0)))]),MechRecord::new(vec![("foo", Value::F64(Ref::new(3.0))),("bar", Value::F64(Ref::new(4.0)))]),]).expect("Failed to create MechTable"))));
-test_interpreter!(interpret_table_from_matrix_infer_any_columns,r#"x := [1 2; 3 4]; c<|foo<*> bar<*>|:2> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("foo", Value::F64(Ref::new(1.0))),("bar", Value::F64(Ref::new(2.0)))]),MechRecord::new(vec![("foo", Value::F64(Ref::new(3.0))),("bar", Value::F64(Ref::new(4.0)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    interpret_table_from_matrix,
+    r#"x := [1 2; 3 4]; a<|foo<f64>,bar<f64>|> := x"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("foo", Value::F64(Ref::new(1.0))),
+                ("bar", Value::F64(Ref::new(2.0)))
+            ]),
+            MechRecord::new(vec![
+                ("foo", Value::F64(Ref::new(3.0))),
+                ("bar", Value::F64(Ref::new(4.0)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
+test_interpreter!(
+    interpret_table_from_matrix_infer_any_columns,
+    r#"x := [1 2; 3 4]; c<|foo<*> bar<*>|:2> := x"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("foo", Value::F64(Ref::new(1.0))),
+                ("bar", Value::F64(Ref::new(2.0)))
+            ]),
+            MechRecord::new(vec![
+                ("foo", Value::F64(Ref::new(3.0))),
+                ("bar", Value::F64(Ref::new(4.0)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_table_from_matrix_infer_kinds_and_size,r#"x := [1 2; 3 4]; b<|foo,bar|:1> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("foo", Value::U64(Ref::new(1))),("bar", Value::U64(Ref::new(2)))]),]).expect("Failed to create MechTable"))));
-test_interpreter!(interpret_table_from_matrix2,r#"x := ["true" "false"; "true" "false"]; a<|x<string> y<string>|> := x"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x", Value::String(Ref::new("true".to_string()))),("y", Value::String(Ref::new("false".to_string())))]),MechRecord::new(vec![("x", Value::String(Ref::new("true".to_string()))),("y", Value::String(Ref::new("false".to_string())))]),]).expect("Failed to create MechTable"))));
-test_interpreter!(interpret_table_from_matrix3,r#"x:=[true false; true false]; a<|x<bool> y<bool>|> := x;"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x", Value::Bool(Ref::new(true))),("y", Value::Bool(Ref::new(false)))]),MechRecord::new(vec![("x", Value::Bool(Ref::new(true))),("y", Value::Bool(Ref::new(false)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    interpret_table_from_matrix_infer_kinds_and_size,
+    r#"x := [1 2; 3 4]; b<|foo,bar|:1> := x"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![MechRecord::new(vec![
+            ("foo", Value::U64(Ref::new(1))),
+            ("bar", Value::U64(Ref::new(2)))
+        ]),])
+        .expect("Failed to create MechTable")
+    ))
+);
+test_interpreter!(
+    interpret_table_from_matrix2,
+    r#"x := ["true" "false"; "true" "false"]; a<|x<string> y<string>|> := x"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("x", Value::String(Ref::new("true".to_string()))),
+                ("y", Value::String(Ref::new("false".to_string())))
+            ]),
+            MechRecord::new(vec![
+                ("x", Value::String(Ref::new("true".to_string()))),
+                ("y", Value::String(Ref::new("false".to_string())))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
+test_interpreter!(
+    interpret_table_from_matrix3,
+    r#"x:=[true false; true false]; a<|x<bool> y<bool>|> := x;"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("x", Value::Bool(Ref::new(true))),
+                ("y", Value::Bool(Ref::new(false)))
+            ]),
+            MechRecord::new(vec![
+                ("x", Value::Bool(Ref::new(true))),
+                ("y", Value::Bool(Ref::new(false)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 #[cfg(all(feature = "i8", feature = "u8"))]
-test_interpreter!(interpret_table_from_matrix4,r#"x:=[1 2; 3 4]; a<|x<u8> y<i8>|> := x;"#,Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("x", Value::U8(Ref::new(1))),("y", Value::I8(Ref::new(2)))]),MechRecord::new(vec![("x", Value::U8(Ref::new(3))),("y", Value::I8(Ref::new(4)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    interpret_table_from_matrix4,
+    r#"x:=[1 2; 3 4]; a<|x<u8> y<i8>|> := x;"#,
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![
+                ("x", Value::U8(Ref::new(1))),
+                ("y", Value::I8(Ref::new(2)))
+            ]),
+            MechRecord::new(vec![
+                ("x", Value::U8(Ref::new(3))),
+                ("y", Value::I8(Ref::new(4)))
+            ]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_inner_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋈ B; J.b[1]"#, Value::U64(Ref::new(200)));
+test_interpreter!(
+    interpret_table_inner_join_symbol,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋈ B; J.b[1]"#,
+    Value::U64(Ref::new(200))
+);
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_inner_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/join(A, B); J.b[2]"#, Value::U64(Ref::new(300)));
+test_interpreter!(
+    interpret_table_inner_join_word,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/join(A, B); J.b[2]"#,
+    Value::U64(Ref::new(300))
+);
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_left_outer_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟕ B; J.id[1]"#, Value::U64(Ref::new(1)));
+test_interpreter!(
+    interpret_table_left_outer_join_symbol,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟕ B; J.id[1]"#,
+    Value::U64(Ref::new(1))
+);
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_left_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-outer-join(A, B); J.id[2]"#, Value::U64(Ref::new(2)));
+test_interpreter!(
+    interpret_table_left_outer_join_word,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-outer-join(A, B); J.id[2]"#,
+    Value::U64(Ref::new(2))
+);
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_right_outer_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟖ B; J.id[3]"#, Value::U64(Ref::new(4)));
+test_interpreter!(
+    interpret_table_right_outer_join_symbol,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟖ B; J.id[3]"#,
+    Value::U64(Ref::new(4))
+);
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_right_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/right-outer-join(A, B); J.id[3]"#, Value::U64(Ref::new(4)));
+test_interpreter!(
+    interpret_table_right_outer_join_word,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/right-outer-join(A, B); J.id[3]"#,
+    Value::U64(Ref::new(4))
+);
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_full_outer_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟗ B; J.id[4]"#, Value::U64(Ref::new(4)));
+test_interpreter!(
+    interpret_table_full_outer_join_symbol,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⟗ B; J.id[4]"#,
+    Value::U64(Ref::new(4))
+);
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_full_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/full-outer-join(A, B); J.id[1]"#, Value::U64(Ref::new(1)));
+test_interpreter!(
+    interpret_table_full_outer_join_word,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/full-outer-join(A, B); J.id[1]"#,
+    Value::U64(Ref::new(1))
+);
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_left_semi_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋉ B; J.a[2]"#, Value::U64(Ref::new(30)));
+test_interpreter!(
+    interpret_table_left_semi_join_symbol,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋉ B; J.a[2]"#,
+    Value::U64(Ref::new(30))
+);
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_left_semi_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-semi-join(A, B); J.id[1]"#, Value::U64(Ref::new(2)));
+test_interpreter!(
+    interpret_table_left_semi_join_word,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-semi-join(A, B); J.id[1]"#,
+    Value::U64(Ref::new(2))
+);
 
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_left_anti_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ▷ B; J.id[1]"#, Value::U64(Ref::new(1)));
+test_interpreter!(
+    interpret_table_left_anti_join_symbol,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ▷ B; J.id[1]"#,
+    Value::U64(Ref::new(1))
+);
 #[cfg(all(feature = "table", feature = "u64"))]
-test_interpreter!(interpret_table_left_anti_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-anti-join(A, B); J.a[1]"#, Value::U64(Ref::new(10)));
+test_interpreter!(
+    interpret_table_left_anti_join_word,
+    r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/left-anti-join(A, B); J.a[1]"#,
+    Value::U64(Ref::new(10))
+);
 
 #[cfg(feature = "u64")]
-test_interpreter!(interpret_matrix_reshape,r#"x:=[1 3; 2 4]; y<[u64]:4,1> := x"#, Value::MatrixU64(Matrix::from_vec(vec![1, 2, 3, 4], 4, 1)));
+test_interpreter!(
+    interpret_matrix_reshape,
+    r#"x:=[1 3; 2 4]; y<[u64]:4,1> := x"#,
+    Value::MatrixU64(Matrix::from_vec(vec![1, 2, 3, 4], 4, 1))
+);
 
-test_interpreter!(interpret_matrix_reshape2,r#"x:=[1 2 3 4]; y<[string]:2,2> := x"#, Value::MatrixString(Matrix::from_vec(vec![String::from("1"), String::from("2"), String::from("3"), String::from("4")], 2, 2)));  
-test_interpreter!(interpret_matrix_convert_str,r#"x:=1..=4; out<[string]>:=x"#, Value::MatrixString(Matrix::from_vec(vec![String::from("1"), String::from("2"), String::from("3"), String::from("4")], 1, 4)));
+test_interpreter!(
+    interpret_matrix_reshape2,
+    r#"x:=[1 2 3 4]; y<[string]:2,2> := x"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec![
+            String::from("1"),
+            String::from("2"),
+            String::from("3"),
+            String::from("4")
+        ],
+        2,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_matrix_convert_str,
+    r#"x:=1..=4; out<[string]>:=x"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec![
+            String::from("1"),
+            String::from("2"),
+            String::from("3"),
+            String::from("4")
+        ],
+        1,
+        4
+    ))
+);
 
-test_interpreter!(interpret_matrix_build_rational,r#"x<[r64]:1,2> := 1/2"#, Value::MatrixR64(Matrix::from_vec(vec![R64::new(1,2), R64::new(1,2)], 1, 2)));
+test_interpreter!(
+    interpret_matrix_build_rational,
+    r#"x<[r64]:1,2> := 1/2"#,
+    Value::MatrixR64(Matrix::from_vec(vec![R64::new(1, 2), R64::new(1, 2)], 1, 2))
+);
 
-test_interpreter!(interpret_convert_rational_to_string,r#"x<string>:=1/2"#, Value::String(Ref::new(String::from("1/2"))));
-test_interpreter!(interpret_convert_f64_to_string2,r#"x<string>:=123"#, Value::String(Ref::new(String::from("123"))));
+test_interpreter!(
+    interpret_convert_rational_to_string,
+    r#"x<string>:=1/2"#,
+    Value::String(Ref::new(String::from("1/2")))
+);
+test_interpreter!(
+    interpret_convert_f64_to_string2,
+    r#"x<string>:=123"#,
+    Value::String(Ref::new(String::from("123")))
+);
 
-test_interpreter!(interpret_convert_f64_to_rational_to_string,r#"x<string> := 0.5<r64>"#,Value::String(Ref::new(String::from("1/2"))));
-test_interpreter!(interpret_convert_matrix_to_optional_unsized_matrix, r#"x<[u64]?> := [1u64 2u64 3u64]; x[1]"#, Value::U64(Ref::new(1u64)));
-test_interpreter!(interpret_user_function_input_annotation_optional_promotion, r#"
+test_interpreter!(
+    interpret_convert_f64_to_rational_to_string,
+    r#"x<string> := 0.5<r64>"#,
+    Value::String(Ref::new(String::from("1/2")))
+);
+test_interpreter!(
+    interpret_convert_matrix_to_optional_unsized_matrix,
+    r#"x<[u64]?> := [1u64 2u64 3u64]; x[1]"#,
+    Value::U64(Ref::new(1u64))
+);
+test_interpreter!(
+    interpret_user_function_input_annotation_optional_promotion,
+    r#"
 x := [1u64 2u64 3u64]
 head(x<[u64]?>) => <u64?>
   | [] => _
   | [h ...] => h
   | _ => _.
 head(x)
-"#, Value::U64(Ref::new(1u64)));
+"#,
+    Value::U64(Ref::new(1u64))
+);
 
-test_interpreter!(interpret_matrix_power_and_addition,"~μ := [1 2 3]; K := [0.1 0.2 0.3; 0.4 0.5 0.6; 0.7 0.8 0.9]; Ẑ := [0.01; 0.02; 0.03]; μ = μ + (K ** Ẑ)'", Value::MatrixF64(Matrix::from_vec(vec![1.014, 2.032, 3.05], 1, 3)));
-test_interpreter!(interpret_assign_scalar_no_space, "~z:=10;z=20", Value::F64(Ref::new(20.0)));
+test_interpreter!(
+    interpret_matrix_power_and_addition,
+    "~μ := [1 2 3]; K := [0.1 0.2 0.3; 0.4 0.5 0.6; 0.7 0.8 0.9]; Ẑ := [0.01; 0.02; 0.03]; μ = μ + (K ** Ẑ)'",
+    Value::MatrixF64(Matrix::from_vec(vec![1.014, 2.032, 3.05], 1, 3))
+);
+test_interpreter!(
+    interpret_assign_scalar_no_space,
+    "~z:=10;z=20",
+    Value::F64(Ref::new(20.0))
+);
 
+test_interpreter!(
+    interpret_paren_term_whitespace,
+    "fahrenheit := ( 25 * 9 / 5 ) + 32",
+    Value::F64(Ref::new(77.0))
+);
 
-test_interpreter!(interpret_paren_term_whitespace, "fahrenheit := ( 25 * 9 / 5 ) + 32", Value::F64(Ref::new(77.0)));
+test_interpreter!(
+    interpret_formulas_no_whitespace,
+    "x:=10*[1,2,3]**[4,5,6]';",
+    Value::MatrixF64(Matrix::from_vec(vec![320.0], 1, 1))
+);
 
-test_interpreter!(interpret_formulas_no_whitespace, "x:=10*[1,2,3]**[4,5,6]';", Value::MatrixF64(Matrix::from_vec(vec![320.0], 1, 1)));
-
-test_interpreter!(interpret_matrix_negatives, r#"
+test_interpreter!(
+    interpret_matrix_negatives,
+    r#"
 A := [2.0, 1.0, -1.0
       -3.0, -1.0, 2.0
-      -2.0, 1.0, 2.0]"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, -3.0, -2.0, 1.0, -1.0, 1.0, -1.0, 2.0, 2.0], 3, 3)));
+      -2.0, 1.0, 2.0]"#,
+    Value::MatrixF64(Matrix::from_vec(
+        vec![2.0, -3.0, -2.0, 1.0, -1.0, 1.0, -1.0, 2.0, 2.0],
+        3,
+        3
+    ))
+);
 
-test_interpreter!(interpret_matrix_solve, r#"A := [2.0, 1.0, -1.0;-3.0, -1.0, 2.0;-2.0, 1.0, 2.0];b := [8.0, -11.0, -3.0]'; math/round(A \ b)"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, -1.0], 3, 1)));
+test_interpreter!(
+    interpret_matrix_solve,
+    r#"A := [2.0, 1.0, -1.0;-3.0, -1.0, 2.0;-2.0, 1.0, 2.0];b := [8.0, -11.0, -3.0]'; math/round(A \ b)"#,
+    Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, -1.0], 3, 1))
+);
 
 // │ y │ true │ false │
 
-test_interpreter!(table_column_inference, "| y | true | false |", Value::Table(Ref::new(MechTable::from_records(vec![MechRecord::new(vec![("y",Value::Bool(Ref::new(true)))]),MechRecord::new(vec![("y",Value::Bool(Ref::new(false)))]),]).expect("Failed to create MechTable"))));
+test_interpreter!(
+    table_column_inference,
+    "| y | true | false |",
+    Value::Table(Ref::new(
+        MechTable::from_records(vec![
+            MechRecord::new(vec![("y", Value::Bool(Ref::new(true)))]),
+            MechRecord::new(vec![("y", Value::Bool(Ref::new(false)))]),
+        ])
+        .expect("Failed to create MechTable")
+    ))
+);
 
-test_interpreter!(interpret_set_union, r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∪ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0)), Value::F64(Ref::new(4.0))]))));
-test_interpreter!(interpret_set_intersection, r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∩ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
-test_interpreter!(interpret_set_difference, r#"A := {"a", "b", "c"}; B := {"b", "c", "d"}; U := A ∖ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new("a".to_string()))]))));
-test_interpreter!(interpret_set_subset, r#"A := {"b", "c"}; B := {"b", "c", "d"}; C := A ⊆ B"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_superset, r#"A := {"b", "c", "d"}; B := {"b", "c"}; C := A ⊇ B"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_membership, r#"A := {1, 2, 3}; B := 2 ∈ A;"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_not_membership, r#"A := {1, 2, 3}; B := 4 ∉ A;"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_strict_subset, r#"A := {1, 2}; B := {1, 2, 3}; C := A ⊂ B"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_strict_superset, r#"A := {1, 2, 3}; B := {1, 2}; C := A ⊃ B"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_set_strict_subset2, r#"A := {1, 2}; B := {1, 2}; C := A ⊊ B"#, Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_set_strict_superset2, r#"A := {1, 2}; B := {1, 2}; C := A ⊋ B"#, Value::Bool(Ref::new(false)));
+test_interpreter!(
+    interpret_set_union,
+    r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∪ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::F64(Ref::new(2.0)),
+        Value::F64(Ref::new(3.0)),
+        Value::F64(Ref::new(4.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_intersection,
+    r#"A := {1, 2, 3}; B := {2, 3, 4}; U := A ∩ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(2.0)),
+        Value::F64(Ref::new(3.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_difference,
+    r#"A := {"a", "b", "c"}; B := {"b", "c", "d"}; U := A ∖ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new(
+        "a".to_string()
+    ))])))
+);
+test_interpreter!(
+    interpret_set_subset,
+    r#"A := {"b", "c"}; B := {"b", "c", "d"}; C := A ⊆ B"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_superset,
+    r#"A := {"b", "c", "d"}; B := {"b", "c"}; C := A ⊇ B"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_membership,
+    r#"A := {1, 2, 3}; B := 2 ∈ A;"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_not_membership,
+    r#"A := {1, 2, 3}; B := 4 ∉ A;"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_strict_subset,
+    r#"A := {1, 2}; B := {1, 2, 3}; C := A ⊂ B"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_strict_superset,
+    r#"A := {1, 2, 3}; B := {1, 2}; C := A ⊃ B"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_set_strict_subset2,
+    r#"A := {1, 2}; B := {1, 2}; C := A ⊊ B"#,
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_set_strict_superset2,
+    r#"A := {1, 2}; B := {1, 2}; C := A ⊋ B"#,
+    Value::Bool(Ref::new(false))
+);
 
-test_interpreter!(interpret_set_union_empty, r#"A := {}; B := {1, 2}; U := A ∪ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0))]))));
-test_interpreter!(interpret_set_intersection_empty, r#"A := {}; B := {1, 2, 3}; U := A ∩ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![]))));
-test_interpreter!(interpret_set_difference_empty, r#"A := {1, 2}; B := {1, 2}; U := A ∖ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![]))));
-test_interpreter!(interpret_set_union_duplicates, r#"A := {1, 1, 2}; B := {2, 2, 3}; U := A ∪ B"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
-test_interpreter!(interpret_set_subset_empty_left, r#"A := {}; B := {1}; C := A ⊆ B"#, Value::Bool(Ref::new(true)));
+test_interpreter!(
+    interpret_set_union_empty,
+    r#"A := {}; B := {1, 2}; U := A ∪ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::F64(Ref::new(2.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_intersection_empty,
+    r#"A := {}; B := {1, 2, 3}; U := A ∩ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![])))
+);
+test_interpreter!(
+    interpret_set_difference_empty,
+    r#"A := {1, 2}; B := {1, 2}; U := A ∖ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![])))
+);
+test_interpreter!(
+    interpret_set_union_duplicates,
+    r#"A := {1, 1, 2}; B := {2, 2, 3}; U := A ∪ B"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::F64(Ref::new(2.0)),
+        Value::F64(Ref::new(3.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_subset_empty_left,
+    r#"A := {}; B := {1}; C := A ⊆ B"#,
+    Value::Bool(Ref::new(true))
+);
 
-test_interpreter!(interpret_compare_max_scalar, "compare/max(5,3)", Value::F64(Ref::new(5.0)));
-test_interpreter!(interpret_compare_max_vector, "compare/max([3 4 5 6],4)", Value::MatrixF64(Matrix::from_vec(vec![4.0, 4.0, 5.0, 6.0], 1, 4)));
-test_interpreter!(interpret_compare_max_vector_vector, "compare/max([3 4 5 6],[6 5 4 3])", Value::MatrixF64(Matrix::from_vec(vec![6.0, 5.0, 5.0, 6.0], 1, 4)));
-test_interpreter!(interpret_compare_min_scalar, "compare/min(5,3)", Value::F64(Ref::new(3.0)));
-test_interpreter!(interpret_compare_min_vector, "compare/min([3 4 5 6],4)", Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 4.0], 1, 4)));
-test_interpreter!(interpret_compare_min_vector_vector, "compare/min([3 4 5 6],[6 5 4 3])", Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 3.0], 1, 4)));
+test_interpreter!(
+    interpret_compare_max_scalar,
+    "compare/max(5,3)",
+    Value::F64(Ref::new(5.0))
+);
+test_interpreter!(
+    interpret_compare_max_vector,
+    "compare/max([3 4 5 6],4)",
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 4.0, 5.0, 6.0], 1, 4))
+);
+test_interpreter!(
+    interpret_compare_max_vector_vector,
+    "compare/max([3 4 5 6],[6 5 4 3])",
+    Value::MatrixF64(Matrix::from_vec(vec![6.0, 5.0, 5.0, 6.0], 1, 4))
+);
+test_interpreter!(
+    interpret_compare_min_scalar,
+    "compare/min(5,3)",
+    Value::F64(Ref::new(3.0))
+);
+test_interpreter!(
+    interpret_compare_min_vector,
+    "compare/min([3 4 5 6],4)",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 4.0], 1, 4))
+);
+test_interpreter!(
+    interpret_compare_min_vector_vector,
+    "compare/min([3 4 5 6],[6 5 4 3])",
+    Value::MatrixF64(Matrix::from_vec(vec![3.0, 4.0, 4.0, 3.0], 1, 4))
+);
 
-test_interpreter!(interpret_set_comprehension, r#"{ x * x | x <- {1,2,3,4}, y := 2, (x % 2) == 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(4.0)), Value::F64(Ref::new(16.0))]))));
-test_interpreter!(interpret_set_comprehension_variable, r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0))]))));
-test_interpreter!(interpret_set_comprehension_tuple, r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(25.0)), Value::F64(Ref::new(49.0))]))));
-test_interpreter!(interpret_set_comprehension_fof, r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(8.0))]))));
+test_interpreter!(
+    interpret_set_comprehension,
+    r#"{ x * x | x <- {1,2,3,4}, y := 2, (x % 2) == 0 }"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(4.0)),
+        Value::F64(Ref::new(16.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_comprehension_variable,
+    r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::F64(Ref::new(9.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_comprehension_tuple,
+    r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(1.0)),
+        Value::F64(Ref::new(9.0)),
+        Value::F64(Ref::new(25.0)),
+        Value::F64(Ref::new(49.0))
+    ])))
+);
+test_interpreter!(
+    interpret_set_comprehension_fof,
+    r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#,
+    Value::Set(Ref::new(MechSet::from_vec(vec![
+        Value::F64(Ref::new(5.0)),
+        Value::F64(Ref::new(9.0)),
+        Value::F64(Ref::new(8.0))
+    ])))
+);
 
-test_interpreter!(interpret_matrix_comprehension, r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2)));
-test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2)));
+test_interpreter!(
+    interpret_matrix_comprehension,
+    r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#,
+    Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2))
+);
+test_interpreter!(
+    interpret_matrix_comprehension_variable,
+    r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#,
+    Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2))
+);
 
-test_interpreter!(interpret_table_record_mutation, r#"~T:=|x<f64> y<bool>|1.2 true|1.3 false|;~r:=T[1];r.x=42;T.x[1]"#, Value::F64(Ref::new(42.0)));
+test_interpreter!(
+    interpret_table_record_mutation,
+    r#"~T:=|x<f64> y<bool>|1.2 true|1.3 false|;~r:=T[1];r.x=42;T.x[1]"#,
+    Value::F64(Ref::new(42.0))
+);
 //test_interpreter!("interpret_table_record_mutation_fail", r#"T := | x<f64>  y<bool> |  1.2     true   |  1.3     false  |;~r := T{1};r.x = 42;T.x[1]"#, Value::F64(Ref::new(1.2)));
 
-test_interpreter!(interpret_define_custom_enum, r#"<color>:=:red|:green|:blue; x<color>:=:red;"#, Value::Atom(Ref::new(MechAtom::new(hash_str("red")))));
-test_interpreter!(interpret_kind_membership_enum_payload, r#"
+test_interpreter!(
+    interpret_define_custom_enum,
+    r#"<color>:=:red|:green|:blue; x<color>:=:red;"#,
+    Value::Atom(Ref::new(MechAtom::new(hash_str("red"))))
+);
+test_interpreter!(
+    interpret_kind_membership_enum_payload,
+    r#"
 <color> := :red<u64> | :green<u64> | :blue
 :red(300) ∈ <color>
-"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_kind_not_membership_enum_payload, r#"
+"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_kind_not_membership_enum_payload,
+    r#"
 <color> := :red<u64> | :green<u64> | :blue
 :red("300") ∉ <color>
-"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_tagged_union_nested_match, r#"
+"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_tagged_union_nested_match,
+    r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:ok(42u64))
@@ -1161,8 +3550,12 @@ result := x?
   | :none          => 0u64
   | *              => 0u64.
 result + 0u64
-"#, Value::U64(Ref::new(42u64)));
-test_interpreter!(interpret_tagged_union_function_input_enum_kind, r#"
+"#,
+    Value::U64(Ref::new(42u64))
+);
+test_interpreter!(
+    interpret_tagged_union_function_input_enum_kind,
+    r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:err("this sucks"))
@@ -1173,10 +3566,12 @@ unwrap(x<option>) => <u64>
   | :none          => 0u64.
 
 unwrap(x)
-"#, Value::U64(Ref::new(0u64)));
+"#,
+    Value::U64(Ref::new(0u64))
+);
 #[test]
 fn interpret_tagged_union_function_match_requires_exhaustive_arms() {
-  let s = r#"
+    let s = r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none
 x<option> := :some(:err("this sucks"))
@@ -1187,30 +3582,118 @@ unwrap(x<option>) => <u64>
 
 unwrap(x)
 "#;
-  let tree = parser::parse(s).unwrap();
-  let mut intrp = Interpreter::new(0);
-  let err = intrp.interpret(&tree).unwrap_err();
-  let msg = format!("{:?}", err);
-  assert!(msg.contains("FunctionMatchNonExhaustive"));
-  assert!(msg.contains(":none"));
-  assert!(msg.contains("wildcard"));
+    let tree = parser::parse(s).unwrap();
+    let mut intrp = Interpreter::new(0);
+    let err = intrp.interpret(&tree).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(msg.contains("FunctionMatchNonExhaustive"));
+    assert!(msg.contains(":none"));
+    assert!(msg.contains("wildcard"));
 }
-test_interpreter!(interpret_string_concatenation, r#"x := "Hello, " + "world!""#, Value::String(Ref::new("Hello, world!".to_string())));
-test_interpreter!(interpret_string_concatenation2, r#""a" + "b" + "c""#, Value::String(Ref::new("abc".to_string())));
-test_interpreter!(interpret_string_concatenation_var, r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#, Value::String(Ref::new("Hello, Alice!".to_string())));
-test_interpreter!(interpret_string_concatenation_matrix, r#"["a" "b"] + "c""#, Value::MatrixString(Matrix::from_vec(vec!["ac".to_string(), "bc".to_string()], 1, 2)));
-test_interpreter!(interpret_string_concatenation_matrix2, r#"["a" "b"; "c" "d"] + ["1" "2"; "3" "4"]"#, Value::MatrixString(Matrix::from_vec(vec!["a1".to_string(), "c3".to_string(), "b2".to_string(), "d4".to_string()], 2, 2)));
-test_interpreter!(interpret_string_concatenation_matrix3, r#"prefix := "Item"; letters := ["A" "B" "C"]; labels := prefix + letters"#, Value::MatrixString(Matrix::from_vec(vec!["ItemA".to_string(), "ItemB".to_string(), "ItemC".to_string()], 1, 3)));
-test_interpreter!(interpret_string_raw_literal, r#""""C:\Users\Name\Documents""""#, Value::String(Ref::new(r"C:\Users\Name\Documents".to_string())));
-test_interpreter!(interpret_string_raw_literal_multiline, r#""""This is a raw string literal.It can span multiple lines
-and include "quotes" and \backslashes\ without needing escapes.""""#, Value::String(Ref::new(r#"This is a raw string literal.It can span multiple lines
-and include "quotes" and \backslashes\ without needing escapes."#.to_string())));
-test_interpreter!(interpret_atom_equality, r#"a := :status/active; b := :status/active; c := (a == b);"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_atom_inequality_false, r#"a := :status/active; b := :status/active; c := (a != b);"#, Value::Bool(Ref::new(false)));
-test_interpreter!(interpret_atom_inequality, r#"a := :status/active; b := :status/inactive; c := (a != b);"#, Value::Bool(Ref::new(true)));
-test_interpreter!(interpret_atom_equality_false, r#"a := :status/active; b := :status/inactive; c := (a == b);"#, Value::Bool(Ref::new(false)));
+test_interpreter!(
+    interpret_string_concatenation,
+    r#"x := "Hello, " + "world!""#,
+    Value::String(Ref::new("Hello, world!".to_string()))
+);
+test_interpreter!(
+    interpret_string_concatenation2,
+    r#""a" + "b" + "c""#,
+    Value::String(Ref::new("abc".to_string()))
+);
+test_interpreter!(
+    interpret_string_concatenation_var,
+    r#"greeting := "Hello"; name := "Alice"; message := greeting + ", " + name + "!""#,
+    Value::String(Ref::new("Hello, Alice!".to_string()))
+);
+test_interpreter!(
+    interpret_string_concatenation_matrix,
+    r#"["a" "b"] + "c""#,
+    Value::MatrixString(Matrix::from_vec(
+        vec!["ac".to_string(), "bc".to_string()],
+        1,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_string_concatenation_matrix2,
+    r#"["a" "b"; "c" "d"] + ["1" "2"; "3" "4"]"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec![
+            "a1".to_string(),
+            "c3".to_string(),
+            "b2".to_string(),
+            "d4".to_string()
+        ],
+        2,
+        2
+    ))
+);
+test_interpreter!(
+    interpret_string_concatenation_matrix3,
+    r#"prefix := "Item"; letters := ["A" "B" "C"]; labels := prefix + letters"#,
+    Value::MatrixString(Matrix::from_vec(
+        vec![
+            "ItemA".to_string(),
+            "ItemB".to_string(),
+            "ItemC".to_string()
+        ],
+        1,
+        3
+    ))
+);
+test_interpreter!(
+    interpret_string_raw_literal,
+    r#""""C:\Users\Name\Documents""""#,
+    Value::String(Ref::new(r"C:\Users\Name\Documents".to_string()))
+);
+test_interpreter!(
+    interpret_string_raw_literal_multiline,
+    r#""""This is a raw string literal.It can span multiple lines
+and include "quotes" and \backslashes\ without needing escapes.""""#,
+    Value::String(Ref::new(
+        r#"This is a raw string literal.It can span multiple lines
+and include "quotes" and \backslashes\ without needing escapes."#
+            .to_string()
+    ))
+);
+test_interpreter!(
+    interpret_atom_equality,
+    r#"a := :status/active; b := :status/active; c := (a == b);"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_atom_inequality_false,
+    r#"a := :status/active; b := :status/active; c := (a != b);"#,
+    Value::Bool(Ref::new(false))
+);
+test_interpreter!(
+    interpret_atom_inequality,
+    r#"a := :status/active; b := :status/inactive; c := (a != b);"#,
+    Value::Bool(Ref::new(true))
+);
+test_interpreter!(
+    interpret_atom_equality_false,
+    r#"a := :status/active; b := :status/inactive; c := (a == b);"#,
+    Value::Bool(Ref::new(false))
+);
 
-test_interpreter!(interpreter_mika_micromica, r#"╭⦿╯"#, Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯"))));
-test_interpreter!(interpreter_mika_micromica_gripper, r#"Ɔ∞⦿╯"#, Value::Atom(Ref::new(MechAtom::from_name("Ɔ∞⦿╯"))));
-test_interpreter!(interpreter_mika_minimika, r#"(˙◯˙)"#, Value::Atom(Ref::new(MechAtom::from_name("(˙◯˙)"))));
-test_interpreter!(interpreter_mika_micromica_mikasection, r#"╭⦿╯ ⸢Hello, I'm Mika!⸥"#, Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯"))));
+test_interpreter!(
+    interpreter_mika_micromica,
+    r#"╭⦿╯"#,
+    Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯")))
+);
+test_interpreter!(
+    interpreter_mika_micromica_gripper,
+    r#"Ɔ∞⦿╯"#,
+    Value::Atom(Ref::new(MechAtom::from_name("Ɔ∞⦿╯")))
+);
+test_interpreter!(
+    interpreter_mika_minimika,
+    r#"(˙◯˙)"#,
+    Value::Atom(Ref::new(MechAtom::from_name("(˙◯˙)")))
+);
+test_interpreter!(
+    interpreter_mika_micromica_mikasection,
+    r#"╭⦿╯ ⸢Hello, I'm Mika!⸥"#,
+    Value::Atom(Ref::new(MechAtom::from_name("╭⦿╯")))
+);


### PR DESCRIPTION
### Motivation
- Prevent deep-recursive user functions from growing the call stack by supporting tail-call elimination in the interpreter. 
- Increase test coverage across many language features and surface regressions by modernizing and expanding the interpreter test suite.

### Description
- Implement tail-call elimination by introducing `FunctionCallStep` (`Return` / `TailCall`), changing `execute_function_match_arms` to return a `FunctionCallStep`, and detecting self tail-calls in match arms to return `TailCall` instead of a normal `Return`.
- Update `execute_user_function` to loop on `TailCall` steps, re-binding inputs inside each iteration and creating/dropping a `FunctionScope` per iteration to avoid stacking scopes for tail recursion.
- Apply small refactors and formatting fixes in `functions.rs`, including adjustments to kind coercion, enum payload matching, and matrix-building closures.
- Replace and greatly expand `tests/interpreter.rs` test cases, modernize the `test_interpreter!` macro usage, and add many new tests exercising tail recursion, matrix/table operations, set/map behaviors, and other language features.

### Testing
- Ran the interpreter tests with `cargo test` (including the updated `tests/interpreter.rs`) and verified the suite succeeded.
- The new tail-recursive test `interpret_function_tail_recursive_countdown` and the expanded function recursion tests passed under the updated executor loop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd305a766c832abc659a1f68da6456)