### PR TITLE
Make outer join sparse columns optional typed

### DIFF
--- a/src/interpreter/src/stdlib/table_ops.rs
+++ b/src/interpreter/src/stdlib/table_ops.rs
@@ -38,6 +38,7 @@ impl TableJoinFxn {
         }
 
         let common_rhs: HashSet<u64> = common_cols.iter().map(|(_, rhs_id)| *rhs_id).collect();
+        let common_lhs: HashSet<u64> = common_cols.iter().map(|(lhs_id, _)| *lhs_id).collect();
 
         let mut output_cols: Vec<(u64, ValueKind, String)> = vec![];
         for (lhs_id, (kind, _)) in lhs.data.iter() {
@@ -46,7 +47,14 @@ impl TableJoinFxn {
                 .get(lhs_id)
                 .cloned()
                 .unwrap_or_else(|| lhs_id.to_string());
-            output_cols.push((*lhs_id, kind.clone(), name));
+            let out_kind = if !common_lhs.contains(lhs_id)
+                && matches!(mode, JoinMode::RightOuter | JoinMode::FullOuter)
+            {
+                make_optional_kind(kind)
+            } else {
+                kind.clone()
+            };
+            output_cols.push((*lhs_id, out_kind, name));
         }
         for (rhs_id, (kind, _)) in rhs.data.iter() {
             if common_rhs.contains(rhs_id) {
@@ -57,7 +65,12 @@ impl TableJoinFxn {
                 .get(rhs_id)
                 .cloned()
                 .unwrap_or_else(|| rhs_id.to_string());
-            output_cols.push((*rhs_id, kind.clone(), name));
+            let out_kind = if matches!(mode, JoinMode::LeftOuter | JoinMode::FullOuter) {
+                make_optional_kind(kind)
+            } else {
+                kind.clone()
+            };
+            output_cols.push((*rhs_id, out_kind, name));
         }
 
         if matches!(mode, JoinMode::LeftSemi | JoinMode::LeftAnti) {
@@ -218,6 +231,13 @@ impl TableJoinFxn {
             data,
             col_names,
         })
+    }
+}
+
+fn make_optional_kind(kind: &ValueKind) -> ValueKind {
+    match kind {
+        ValueKind::Option(_) => kind.clone(),
+        _ => ValueKind::Option(Box::new(kind.clone())),
     }
 }
 
@@ -471,4 +491,69 @@ register_descriptor! {
     name: "table/left-anti-join",
     ptr: &TableLeftAntiJoin{},
   }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::map::IndexMap;
+    use std::collections::HashMap;
+
+    fn make_table(cols: Vec<(&str, ValueKind, Vec<Value>)>) -> MechTable {
+        let rows = cols.first().map(|(_, _, values)| values.len()).unwrap_or(0);
+        let mut data = IndexMap::new();
+        let mut col_names = HashMap::new();
+        for (name, kind, values) in cols {
+            let col_id = hash_str(name);
+            col_names.insert(col_id, name.to_string());
+            data.insert(
+                col_id,
+                (kind, Matrix::DVector(Ref::new(DVector::from_vec(values)))),
+            );
+        }
+        MechTable {
+            rows,
+            cols: data.len(),
+            data,
+            col_names,
+        }
+    }
+
+    #[test]
+    fn full_outer_join_marks_non_key_columns_optional() {
+        let lhs = make_table(vec![
+            (
+                "id",
+                ValueKind::U64,
+                vec![Value::U64(Ref::new(1)), Value::U64(Ref::new(2))],
+            ),
+            (
+                "hw1",
+                ValueKind::U8,
+                vec![Value::U8(Ref::new(10)), Value::U8(Ref::new(20))],
+            ),
+        ]);
+        let rhs = make_table(vec![
+            (
+                "id",
+                ValueKind::U64,
+                vec![Value::U64(Ref::new(2)), Value::U64(Ref::new(3))],
+            ),
+            (
+                "hw2",
+                ValueKind::U8,
+                vec![Value::U8(Ref::new(200u8)), Value::U8(Ref::new(255u8))],
+            ),
+        ]);
+
+        let joined = TableJoinFxn::build_joined_table(&lhs, &rhs, JoinMode::FullOuter).unwrap();
+
+        let hw1_kind = &joined.data.get(&hash_str("hw1")).unwrap().0;
+        let hw2_kind = &joined.data.get(&hash_str("hw2")).unwrap().0;
+        let id_kind = &joined.data.get(&hash_str("id")).unwrap().0;
+
+        assert_eq!(hw1_kind, &ValueKind::Option(Box::new(ValueKind::U8)));
+        assert_eq!(hw2_kind, &ValueKind::Option(Box::new(ValueKind::U8)));
+        assert_eq!(id_kind, &ValueKind::U64);
+    }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1073,6 +1073,50 @@ test_interpreter!(interpret_table_full_outer_join_symbol, r#"A := |id<u64> a<u64
 #[cfg(all(feature = "table", feature = "u64"))]
 test_interpreter!(interpret_table_full_outer_join_word, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := table/full-outer-join(A, B); J.id[1]"#, Value::U64(Ref::new(1)));
 
+#[cfg(all(feature = "table", feature = "u64", feature = "u8"))]
+#[test]
+fn interpret_table_full_outer_join_marks_sparse_columns_optional() {
+  let s = r#"
+A := |id<u64> hw1<u8>| 1 10 | 2 20 | 3 30 |
+B := |id<u64> hw2<u8>| 2 200 | 3 255 | 4 42 |
+J := A ⟗ B
+J
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let result = intrp.interpret(&tree).unwrap();
+
+  let table = match result {
+    Value::Table(t) => t,
+    Value::MutableReference(r) => {
+      let borrowed = r.borrow();
+      match &*borrowed {
+        Value::Table(t) => t.clone(),
+        other => panic!("Expected mutable reference to table, got {:?}", other),
+      }
+    }
+    other => panic!("Expected table result, got {:?}", other),
+  };
+
+  let table_brrw = table.borrow();
+  let find_col_id = |name: &str| -> u64 {
+    *table_brrw
+      .col_names
+      .iter()
+      .find(|(_, col_name)| col_name.as_str() == name)
+      .map(|(id, _)| id)
+      .unwrap()
+  };
+
+  let id_kind = &table_brrw.data.get(&find_col_id("id")).unwrap().0;
+  let hw1_kind = &table_brrw.data.get(&find_col_id("hw1")).unwrap().0;
+  let hw2_kind = &table_brrw.data.get(&find_col_id("hw2")).unwrap().0;
+
+  assert_eq!(id_kind, &ValueKind::U64);
+  assert_eq!(hw1_kind, &ValueKind::Option(Box::new(ValueKind::U8)));
+  assert_eq!(hw2_kind, &ValueKind::Option(Box::new(ValueKind::U8)));
+}
+
 #[cfg(all(feature = "table", feature = "u64"))]
 test_interpreter!(interpret_table_left_semi_join_symbol, r#"A := |id<u64> a<u64>| 1 10 | 2 20 | 3 30 |; B := |id<u64> b<u64>| 2 200 | 3 300 | 4 400 |; J := A ⋉ B; J.a[2]"#, Value::U64(Ref::new(30)));
 #[cfg(all(feature = "table", feature = "u64"))]


### PR DESCRIPTION
### Motivation
- Outer joins can produce empty cells for columns that are not part of the join key, so the schema should reflect that by marking those columns optional (e.g. `u8` -> `u8?`).
- Preserve non-optional typing for join key columns that remain populated by the matched side.

### Description
- Promote output column kinds to `Option(...)` for columns that can become empty: left-origin non-key columns on `RightOuter`/`FullOuter`, and right-origin non-key columns on `LeftOuter`/`FullOuter` by updating `output_cols` construction in `table_ops::build_joined_table`.
- Add `make_optional_kind(kind: &ValueKind) -> ValueKind` helper to avoid double-wrapping already-optional kinds.
- Compute `common_lhs`/`common_rhs` to identify join keys and apply optional promotion only to non-key columns.
- Add a unit test `full_outer_join_marks_non_key_columns_optional` (with helper `make_table`) validating that non-key columns become `Option` while the shared key column stays non-optional.

### Testing
- Ran `cargo test -p mech-interpreter full_outer_join_marks_non_key_columns_optional -- --nocapture` and the test passed.
- Ran `cargo test --test interpreter interpret_table_full_outer_join_symbol -- --nocapture` and the interpreter test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd794aefa4832a956936d0c310d6fc)