### PR TITLE
Update table reference docs for optional outer-join columns

### DIFF
--- a/docs/reference/table.mec
+++ b/docs/reference/table.mec
@@ -258,6 +258,30 @@ Returns all rows from both sides, combining matches when available.
 a ⟗ b -- table/full-outer-join(a,b)
 ```
 
+When an outer join introduces missing values in non-key columns, those columns are promoted to optional kinds. If a column was declared as `T`, the joined column kind becomes `[T?]` (a column vector of optional `T` values).
+
+For example, `hw1<u8>` from `a` becomes `[u8?]` after a full outer join because row `id=4` has no `a.hw1` value:
+
+```mech:join-optional
+a := |id<u64> hw1<u8>| 1 10 | 2 20 | 3 30 |
+b := |id<u64> hw2<u8>| 2 200 | 3 255 | 4 42 |
+x := a ⟗ b
+x.hw1
+```
+
+Indexing into such a column returns an optional scalar (`T?`):
+
+```mech:join-optional
+x.hw1[1] -- some(10u8)
+x.hw1[4] -- none<u8>
+```
+
+You can destructure optional values with `?` and `match` to provide a fallback:
+
+```mech:join-optional
+y<u8> := x.hw1[4]? | v => v | * => 0.
+```
+
 (6.5) Left Semi Join `⋉`
 
 Returns only left rows that have at least one match in the right table.


### PR DESCRIPTION
### Motivation
- Document the recent change where outer joins promote non-key table columns from `T` to optional column kinds (`[T?]`) so the reference matches interpreter behavior and tests.
- Provide concrete examples showing the promoted column kind and how scalar indexing yields `T?` values to clarify how to destructure optionals.

### Description
- Updated `docs/reference/table.mec` to explain that outer joins promote non-key columns to optional kinds and to show the notation that a declared `T` column becomes a column of optional `T` values (`[T?]`).
- Added a full outer join example using `a ⟗ b` that demonstrates `hw1<u8>` becoming `[u8?]` and shows the printed column kind after the join.
- Added examples showing scalar indexing of the joined optional column (`x.hw1[1]` -> `some(10u8)`, `x.hw1[4]` -> `none<u8>`) and a `?` + `match` destructuring example for providing fallbacks.
- Committed the modified file `docs/reference/table.mec` with the new documentation and examples.

### Testing
- Attempted to run `cargo test --test interpreter interpret_table_full_outer_join_optional_column_unwrap_none -- --nocapture` to validate against the recent regression tests, but the command did not complete in this environment due to prolonged compilation / build lock behavior. No automated test failures were observed locally because the run did not finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9c200124832ab1c6d96ab142a06b)