### PR TITLE
Fix Mechdown list parsing for parenthesized bullets with separators

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -1703,18 +1703,36 @@ This is a paragraph with a footnote reference.[^1] Here is a citation reference.
 ```ebnf
 unordered-list := +list-item, ?new-line, ws0 ;
 ordered-list := +ordered-list-item, ?new-line, ws0 ;
+check-list := +check-list-item, ?new-line, ws0 ;
 ordered-list-item := integer-literal
       , "."
       , *space
       , paragraph
       , *new-line ;
+check-list-item := checked-item | unchecked-item ;
+checked-item := "-"
+      , "["
+      , ("x" | "✓" | "✗")
+      , "]"
+      , paragraph
+      , *new-line ;
+unchecked-item := "-"
+      , "["
+      , *space
+      , "]"
+      , paragraph
+      , *new-line ;
+unordered-list-bullet := "("
+      , +raw-text
+      , ")" ;
 list-item := dash
+      , ?unordered-list-bullet
       , +space
       , paragraph
       , *new-line ;
 ```
 
-There are two varities of lists, unordered, which are delinated with a `-` or a graphicl and ordered list, which are delinated with a numeral like `1.`, and are numbered in order automatically when formatted.
+There are three primary varieties of lists: unordered lists delimited with `-`, ordered lists delimited with a numeral like `1.`, and checklist items delimited with `-[ ]` / `-[x]`. Unordered lists can also use a parenthesized custom bullet like `-(📍)` before the item paragraph.
 
 **Example:**
 
@@ -1763,9 +1781,17 @@ Here's a list of some of the features of lists:
     8. Two
     9. Three
 5. Check lists
-    -[ ] One
-    -[x] Two
-    -[ ] Three
+    -[ ] Todo
+    -[x] Done
+
+Custom bullets can be used with emphasized labels and explicit separators:
+
+```
+-(☑️) **v0.1** - proof of concept system - minimum viable language implementation
+-(☑️) **v0.2** - data specification - formulas, defining and manipulating data
+-(📍) **v0.3** - program specification - functions, modules, state machines, Mika
+-(☐) **v0.4** - system specification - tools, distributed programs, capabilities
+```
 
 (10.6) Thematic Breaks
 

--- a/docs/mechdown/list.mec
+++ b/docs/mechdown/list.mec
@@ -68,6 +68,17 @@ Mechdown supports custom bullet symbols using the syntax `-(symbol)`, where the 
 -(🏴‍☠️) Pirate
 -(🐷) Pig
 
+(2.3.1) Custom Bullets with Separator Text
+
+Custom bullets also support emphasized labels followed by a separator dash.
+
+```
+-(☑️) **v0.1** - proof of concept system - minimum viable language implementation
+-(☑️) **v0.2** - data specification - formulas, defining and manipulating data
+-(📍) **v0.3** - program specification - functions, modules, state machines, Mika
+-(☐) **v0.4** - system specification - tools, distributed programs, capabilities
+```
+
 (2.4) Nested Lists
 
 Lists can be nested to any depth by indenting child items with at least two spaces. Sub lists can be any valid list type.

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -419,7 +419,7 @@ pub fn ordered_list_item(input: ParseString) -> ParseResult<(Number,Paragraph)> 
   Ok((input, (number,list_item)))
 }
 
-// checked-item := "-", ("[", "x", "]"), paragraph ;
+// checked-item := "-", ("[", ("x" | "✓" | "✗"), "]"), paragraph ;
 pub fn checked_item(input: ParseString) -> ParseResult<(bool,Paragraph)> {
   let (input, _) = dash(input)?;
   let (input, _) = left_bracket(input)?;
@@ -643,6 +643,7 @@ pub fn mechdown_list(input: ParseString) -> ParseResult<MDList> {
   Ok((input, list))
 }
 
+// unordered-list-bullet := "(", +raw-text, ")" ;
 pub fn unordered_list_bullet(input: ParseString) -> ParseResult<Token> {
   let (input, (_, (mut bullet_text, _), _)) = tuple((
     left_parenthesis,
@@ -655,7 +656,7 @@ pub fn unordered_list_bullet(input: ParseString) -> ParseResult<Token> {
   Ok((input, merged))
 }
 
-// list_item := dash, <space+>, <paragraph>, new_line* ;
+// list_item := dash, ?unordered-list-bullet, <space+>, <paragraph>, new_line* ;
 pub fn unordered_list_item(input: ParseString) -> ParseResult<(Option<Token>,Paragraph)> {
   let msg1 = "Expects space after dash";
   let msg2 = "Expects paragraph as list item";

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -643,19 +643,27 @@ pub fn mechdown_list(input: ParseString) -> ParseResult<MDList> {
   Ok((input, list))
 }
 
+pub fn unordered_list_bullet(input: ParseString) -> ParseResult<Token> {
+  let (input, (_, (mut bullet_text, _), _)) = tuple((
+    left_parenthesis,
+    range(many1(tuple((is_not(right_parenthesis), raw_text)))),
+    right_parenthesis
+  ))(input)?;
+  let mut bullet_tokens = bullet_text.into_iter().map(|(_, tkn)| tkn).collect::<Vec<Token>>();
+  let mut merged = Token::merge_tokens(&mut bullet_tokens).unwrap_or_default();
+  merged.kind = TokenKind::Emoji;
+  Ok((input, merged))
+}
+
 // list_item := dash, <space+>, <paragraph>, new_line* ;
 pub fn unordered_list_item(input: ParseString) -> ParseResult<(Option<Token>,Paragraph)> {
   let msg1 = "Expects space after dash";
   let msg2 = "Expects paragraph as list item";
   let (input, _) = dash(input)?;
-  let (input, bullet) = opt(tuple((left_parenthesis, emoji, right_parenthesis)))(input)?;
+  let (input, bullet) = opt(unordered_list_bullet)(input)?;
   let (input, _) = labelr!(null(many1(space)), skip_nil, msg1)(input)?;
   let (input, list_item) = labelr!(paragraph_newline, |input| recover::<Paragraph, _>(input, skip_till_eol), msg2)(input)?;
   let (input, _) = many0(new_line)(input)?;
-  let bullet = match bullet {
-    Some((_,b,_)) => Some(b),
-    None => None,
-  };
   Ok((input,  (bullet, list_item)))
 }
 
@@ -1054,5 +1062,37 @@ mod tests {
     assert_eq!(parsed.rows[1].len(), 1);
     assert_eq!(parsed.rows[0][0].caption.to_string(), "caption a");
     assert_eq!(parsed.rows[0][0].src.to_string(), "img1.jpg");
+  }
+
+  #[test]
+  fn parses_unordered_list_items_with_trailing_dash_after_strong_text() {
+    let src = "-(☑️) **v0.1** - proof of concept system - minimum viable language implementation\n-(☑️) **v0.2** - data specification - formulas, defining and manipulating data\n-(📍) **v0.3** - program specification - functions, modules, state machines, Mika\n-(☐) **v0.4** - system specification - tools, distributed programs, capabilities\n";
+    let gs = graphemes::init_source(src);
+    let input = ParseString::new(&gs);
+    mechdown_list(input).expect("list with strong version labels followed by a dash should parse");
+  }
+
+  #[test]
+  fn parses_body_containing_list_items_with_trailing_dash_after_strong_text() {
+    let src = "-(☑️) **v0.1** - proof of concept system - minimum viable language implementation\n-(☑️) **v0.2** - data specification - formulas, defining and manipulating data\n-(📍) **v0.3** - program specification - functions, modules, state machines, Mika\n-(☐) **v0.4** - system specification - tools, distributed programs, capabilities\n";
+    let gs = graphemes::init_source(src);
+    let input = ParseString::new(&gs);
+    body(input).expect("body should parse when list items contain a trailing dash after strong text");
+  }
+
+  #[test]
+  fn parses_list_item_that_ends_with_a_dash_after_strong_text() {
+    let src = "-(☑️) **v0.1** -\n";
+    let gs = graphemes::init_source(src);
+    let input = ParseString::new(&gs);
+    mechdown_list(input).expect("list item ending in a dash should parse");
+  }
+
+  #[test]
+  fn parses_body_list_with_crlf_and_trailing_dash_after_strong_text() {
+    let src = "-(☑️) **v0.1** - proof of concept system - minimum viable language implementation\r\n-(☑️) **v0.2** - data specification - formulas, defining and manipulating data\r\n-(📍) **v0.3** - program specification - functions, modules, state machines, Mika\r\n-(☐) **v0.4** - system specification - tools, distributed programs, capabilities\r\n";
+    let gs = graphemes::init_source(src);
+    let input = ParseString::new(&gs);
+    body(input).expect("CRLF-terminated list items should parse");
   }
 }


### PR DESCRIPTION
### Motivation
- Some checklist-style Mechdown list items like `-(☑️) **v0.1** - ...` were rejected by the parser because the bullet parser required a strict `emoji` token inside parentheses and didn’t tolerate parenthesized symbols followed by a separator dash.  
- The goal is to accept parenthesized raw-text bullets (emoji or other symbols) so checklist markers are robust and lists with a trailing ` - ` separator parse correctly.

### Description
- Added a new helper parser `unordered_list_bullet` that parses a parenthesized sequence of `raw_text` and merges it into a `Token` (marked as `TokenKind::Emoji`) so markers like `-(☑️)`, `-(📍)`, and `-(☐)` are accepted.  
- Replaced the previous `opt(tuple((left_parenthesis, emoji, right_parenthesis)))` usage in `unordered_list_item` with `opt(unordered_list_bullet)` so bullets are parsed via the new helper.  
- Kept existing `unordered_list_item` behavior and return shape (an `Option<Token>` bullet plus `Paragraph`) unchanged.  
- Added regression unit tests in `src/syntax/src/mechdown.rs` that cover: `-(☑️) **v0.1** - ...` multi-line lists, body-level parsing, single-line items ending with `-`, and CRLF-terminated lines.

### Testing
- Ran targeted unit tests: `cargo test -p mech-syntax parses_unordered_list_items_with_trailing_dash_after_strong_text` and similar individual tests; each test reported `ok`.  
- Ran the mechdown test suite: `cargo test -p mech-syntax mechdown::tests:: -- --nocapture` and observed all added and existing mechdown tests passed (`5 passed; 0 failed`).  
- No test failures observed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0eb565084832aab80cb05e455f07a)