### PR TITLE
Allow enum variant matching by atom short-name as well as id

### DIFF
--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1374,13 +1374,28 @@ fn enum_value_matches_kind(value: &Value, enum_id: u64, state: &ProgramState) ->
         Some(enm) => enm,
         None => return false,
     };
+    let names_brrw = enum_def.names.borrow();
+    let atom_matches_variant = |variant_id: u64, atom_id: u64, atom_name: &str| {
+        if variant_id == atom_id {
+            return true;
+        }
+        let variant_name = match names_brrw.get(&variant_id) {
+            Some(name) => name.as_str(),
+            None => return false,
+        };
+        let short_variant = variant_name.rsplit('/').next().unwrap_or(variant_name);
+        let short_atom = atom_name.rsplit('/').next().unwrap_or(atom_name);
+        short_variant == short_atom
+    };
     match value {
         Value::Atom(atom) => {
-            let variant_id = atom.borrow().id();
+            let atom_brrw = atom.borrow();
+            let variant_id = atom_brrw.id();
+            let atom_name = atom_brrw.name();
             enum_def
                 .variants
                 .iter()
-                .any(|(known_variant, payload_kind)| *known_variant == variant_id && payload_kind.is_none())
+                .any(|(known_variant, payload_kind)| atom_matches_variant(*known_variant, variant_id, &atom_name) && payload_kind.is_none())
         }
         #[cfg(feature = "tuple")]
         Value::Tuple(tuple_val) => {
@@ -1388,15 +1403,18 @@ fn enum_value_matches_kind(value: &Value, enum_id: u64, state: &ProgramState) ->
             if tuple_brrw.elements.len() != 2 {
                 return false;
             }
-            let tag = match tuple_brrw.elements[0].as_ref() {
-                Value::Atom(atom) => atom.borrow().id(),
+            let (tag, tag_name) = match tuple_brrw.elements[0].as_ref() {
+                Value::Atom(atom) => {
+                    let atom_brrw = atom.borrow();
+                    (atom_brrw.id(), atom_brrw.name())
+                }
                 _ => return false,
             };
             let payload = tuple_brrw.elements[1].as_ref();
             let (_, declared_payload_kind) = match enum_def
                 .variants
                 .iter()
-                .find(|(known_variant, _)| *known_variant == tag)
+                .find(|(known_variant, _)| atom_matches_variant(*known_variant, tag, &tag_name))
             {
                 Some(entry) => entry,
                 None => return false,

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -708,15 +708,30 @@ fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool 
     Some(enm) => enm,
     None => return false,
   };
+  let names_brrw = enum_def.names.borrow();
+  let atom_matches_variant = |variant_id: u64, atom_id: u64, atom_name: &str| {
+    if variant_id == atom_id {
+      return true;
+    }
+    let variant_name = match names_brrw.get(&variant_id) {
+      Some(name) => name.as_str(),
+      None => return false,
+    };
+    let short_variant = variant_name.rsplit('/').next().unwrap_or(variant_name);
+    let short_atom = atom_name.rsplit('/').next().unwrap_or(atom_name);
+    short_variant == short_atom
+  };
   match value {
     // Bare atom: check that the atom's id is a known payload-less variant.
     Value::Atom(atom) => {
-      let variant_id = atom.borrow().id();
+      let atom_brrw = atom.borrow();
+      let variant_id = atom_brrw.id();
+      let atom_name = atom_brrw.name();
       enum_def
         .variants
         .iter()
         .any(|(known_variant, payload_kind)| {
-          *known_variant == variant_id && payload_kind.is_none()
+          atom_matches_variant(*known_variant, variant_id, &atom_name) && payload_kind.is_none()
         })
     }
     // Tuple-struct variant: a 2-element tuple of (atom-tag, payload).
@@ -728,15 +743,18 @@ fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool 
       if tuple_brrw.elements.len() != 2 {
         return false;
       }
-      let tag = match tuple_brrw.elements[0].as_ref() {
-        Value::Atom(atom) => atom.borrow().id(),
+      let (tag, tag_name) = match tuple_brrw.elements[0].as_ref() {
+        Value::Atom(atom) => {
+          let atom_brrw = atom.borrow();
+          (atom_brrw.id(), atom_brrw.name())
+        }
         _ => return false,
       };
       let payload = tuple_brrw.elements[1].as_ref().clone();
       let (_, declared_payload_kind) = match enum_def
         .variants
         .iter()
-        .find(|(known_variant, _)| *known_variant == tag)
+        .find(|(known_variant, _)| atom_matches_variant(*known_variant, tag, &tag_name))
       {
         Some(entry) => entry,
         None => return false,

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -244,10 +244,27 @@ fn value_matches_enum_variant(value: &Value, enum_id: u64, state: &ProgramState)
     Some(enm) => enm,
     None => return false,
   };
+  let names_brrw = my_enum.names.borrow();
+  let atom_matches_variant = |variant_id: u64, atom_id: u64, atom_name: &str| {
+    if variant_id == atom_id {
+      return true;
+    }
+    let variant_name = match names_brrw.get(&variant_id) {
+      Some(name) => name.as_str(),
+      None => return false,
+    };
+    let short_variant = variant_name.rsplit('/').next().unwrap_or(variant_name);
+    let short_atom = atom_name.rsplit('/').next().unwrap_or(atom_name);
+    short_variant == short_atom
+  };
   match value {
     Value::Atom(atom_variant) => {
-      let variant_id = atom_variant.borrow().id();
-      my_enum.variants.iter().any(|(known_variant, payload_kind)| *known_variant == variant_id && payload_kind.is_none())
+      let atom_brrw = atom_variant.borrow();
+      let variant_id = atom_brrw.id();
+      let atom_name = atom_brrw.name();
+      my_enum.variants.iter().any(|(known_variant, payload_kind)| {
+        atom_matches_variant(*known_variant, variant_id, &atom_name) && payload_kind.is_none()
+      })
     }
     #[cfg(feature = "tuple")]
     Value::Tuple(tuple_val) => {
@@ -260,8 +277,11 @@ fn value_matches_enum_variant(value: &Value, enum_id: u64, state: &ProgramState)
         _ => return false,
       };
       let variant_id = variant_atom.id();
+      let atom_name = variant_atom.name();
       let payload = tuple_brrw.elements[1].as_ref();
-      let (_, declared_payload_kind) = match my_enum.variants.iter().find(|(known_variant, _)| *known_variant == variant_id) {
+      let (_, declared_payload_kind) = match my_enum.variants.iter().find(|(known_variant, _)| {
+        atom_matches_variant(*known_variant, variant_id, &atom_name)
+      }) {
         Some(v) => v,
         None => return false,
       };


### PR DESCRIPTION
### Motivation
- Improve enum variant matching so atoms can match variants either by numeric id or by the short name portion of a qualified name (e.g. allow `Module/Variant` and `Variant` to match).

### Description
- In `expressions.rs`, `functions.rs`, and `statements.rs` add a shared `atom_matches_variant` closure that accepts `variant_id`, `atom_id`, and `atom_name`, and returns true if the id matches or the short name (after splitting on `/`) matches.
- Use borrowed atom name and id values (avoid repeated `borrow()` calls) and apply `atom_matches_variant` when checking bare-atom variants and tuple-struct (tag + payload) variants.
- Adjust tuple handling to extract the tag name alongside the tag id when validating payload kinds.
- Add a final newline at end of `functions.rs` to satisfy formatting.

### Testing
- Ran the interpreter crate unit tests via `cargo test` in the workspace, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12c246348832a92b08cca3f351ad5)