### PR TITLE
Preserve enum kind annotations and inline tagged tuple display

### DIFF
--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1591,7 +1591,15 @@ impl Value {
       }
       #[cfg(feature = "tuple")]
       Value::Tuple(t) => {
-        let vals = t.borrow().elements.iter().map(|v| v.format_value_inline()).collect::<Vec<_>>();
+        let tuple = t.borrow();
+        if tuple.elements.len() == 2 {
+          if let Value::Atom(tag) = tuple.elements[0].as_ref() {
+            let tag = format!("{}", tag.borrow());
+            let payload = tuple.elements[1].format_value_inline();
+            return format!("{}({})", tag, payload);
+          }
+        }
+        let vals = tuple.elements.iter().map(|v| v.format_value_inline()).collect::<Vec<_>>();
         format!("({})", vals.join(", "))
       }
       #[cfg(feature = "enum")]
@@ -2413,7 +2421,7 @@ impl PrettyPrint for Value {
       #[cfg(feature = "table")]
       Value::Table(x)  => {return x.borrow().pretty_print();},
       #[cfg(feature = "tuple")]
-      Value::Tuple(x)  => {return x.borrow().pretty_print();},
+      Value::Tuple(_)  => {return self.format_value_inline();},
       #[cfg(feature = "record")]
       Value::Record(x) => {return x.borrow().pretty_print();},
       #[cfg(feature = "enum")]

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -923,6 +923,7 @@ pub fn match_expression(
     let source = expression(&match_expr.source, env, p)?;
     let detached_source = match &source {
         Value::MutableReference(reference) => reference.borrow().clone(),
+        Value::Typed(inner, _) => inner.as_ref().clone(),
         _ => source.clone(),
     };
     if !match_expr

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -813,6 +813,7 @@ fn collect_function_output(p: &Interpreter, fxn_def: &FunctionDefinition) -> MRe
 pub(crate) fn detach_value(value: &Value) -> Value {
   match value {
     Value::MutableReference(reference) => detach_value(&reference.borrow()),
+    Value::Typed(inner, _) => detach_value(inner),
     _ => value.clone(),
   }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -241,6 +241,7 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
 fn deep_detach_value(value: &Value) -> Value {
   match value {
     Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
+    Value::Typed(inner, _) => deep_detach_value(inner),
     _ => value.clone(),
   }
 }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -412,13 +412,16 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
       }
       // Kind isn't checked
       x => {
-        let convert_fxn = ConvertKind{}.compile(&vec![result.clone(), Value::Kind(target_knd)])?;
+        let convert_fxn = ConvertKind{}.compile(&vec![result.clone(), Value::Kind(target_knd.clone())])?;
         convert_fxn.solve();
         let converted_result = convert_fxn.out();
         state_brrw.add_plan_step(convert_fxn);
         result = converted_result;
       },
     };
+    if matches!(target_knd, ValueKind::Enum(_, _)) && result.kind() != target_knd {
+      result = Value::Typed(Box::new(result), target_knd.clone());
+    }
     let detached_result = detach_variable_value(&result);
     // Save symbol to interpreter
     let val_ref = state_brrw.save_symbol(var_id, var_name.clone(), detached_result.clone(), var_def.mutable);

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1260,6 +1260,28 @@ result := x?
   | *              => 0u64.
 result + 0u64
 "#, Value::U64(Ref::new(42u64)));
+
+#[test]
+fn interpret_tagged_union_variable_preserves_declared_kind_and_inline_display() {
+  let s = r#"
+<result> := :ok<u64> | :err<string>
+<option> := :some<result> | :none
+x<option> := :some(:ok(42u64))
+x
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let result = intrp.interpret(&tree).unwrap();
+  let x_id = hash_str("x");
+  let x_value = intrp.symbols().borrow().get(x_id).unwrap();
+  let x_brrw = x_value.borrow();
+  assert!(matches!(x_brrw.kind(), ValueKind::Enum(_, _)));
+  let printed = x_brrw.pretty_print();
+  assert!(printed.contains(":some("));
+  assert!(printed.contains(":ok("));
+  assert_eq!(result.pretty_print(), printed);
+}
+
 test_interpreter!(interpret_tagged_union_function_input_enum_kind, r#"
 <result> := :ok<u64> | :err<string>
 <option> := :some<result> | :none


### PR DESCRIPTION
### Motivation
- Ensure values declared with enum kinds retain their declared `ValueKind::Enum` metadata instead of degrading to plain tuple kinds, and improve human-readable output for tagged tuples.
- Fix mismatches between runtime representation (tagged tuples) and match/pattern logic so pattern matching remains correct when values are stored with declared kinds.

### Description
- Render 2-element tagged tuples in inline enum-style notation by updating `format_value_inline` to print `:tag(payload)` when the first element is an atom and make `PrettyPrint` use this inline representation (`src/core/src/value.rs`).
- Preserve declared enum kinds for typed variable definitions by wrapping enum-shaped results in `Value::Typed(..., target_kind.clone())` when the target kind is `ValueKind::Enum` in `variable_define` (`src/interpreter/src/statements.rs`).
- Teach the runtime to unwrap `Value::Typed` where detaching is required by updating `detach_value`, `deep_detach_value`, and match-source detachment so pattern matching and matching exhaustiveness checks operate on the inner value (`src/interpreter/src/functions.rs`, `src/interpreter/src/patterns.rs`, `src/interpreter/src/expressions.rs`).
- Add a regression test `interpret_tagged_union_variable_preserves_declared_kind_and_inline_display` that verifies a variable declared with an enum kind both preserves `ValueKind::Enum` and pretty-prints using inline tagged notation (`tests/interpreter.rs`).

### Testing
- Ran `cargo test interpret_tagged_union_nested_match -- --nocapture` and it passed.
- Ran `cargo test interpret_tagged_union_variable_preserves_declared_kind_and_inline_display -- --nocapture` and it passed.
- Ran `cargo test interpret_variable_define_typed_option_some -- --nocapture` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e188c45398832aa43d88517a62cd7d)