### PR TITLE
Preserve enum shape for tuple-struct constructors (emit Value::Enum)

### DIFF
--- a/src/core/src/structures/enums.rs
+++ b/src/core/src/structures/enums.rs
@@ -30,6 +30,13 @@ impl MechEnum {
   }
 
   pub fn kind(&self) -> ValueKind {
+    if self.variants.len() == 1 {
+      let variant_id = self.variants[0].0;
+      let names_brrw = self.names.borrow();
+      if let Some(variant_name) = names_brrw.get(&variant_id) {
+        return ValueKind::Enum(self.id, variant_name.clone());
+      }
+    }
     ValueKind::Enum(self.id, self.name())
   }
 

--- a/src/core/src/structures/enums.rs
+++ b/src/core/src/structures/enums.rs
@@ -31,10 +31,23 @@ impl MechEnum {
 
   pub fn kind(&self) -> ValueKind {
     if self.variants.len() == 1 {
-      let variant_id = self.variants[0].0;
+      let (variant_id, payload) = &self.variants[0];
       let names_brrw = self.names.borrow();
-      if let Some(variant_name) = names_brrw.get(&variant_id) {
-        return ValueKind::Enum(self.id, variant_name.clone());
+      if let Some(variant_name) = names_brrw.get(variant_id) {
+        let short_variant_name = variant_name
+          .rsplit('/')
+          .next()
+          .unwrap_or(variant_name)
+          .to_string();
+        if let Some(value) = payload {
+          if !matches!(value, Value::Kind(_)) {
+            return ValueKind::Enum(
+              self.id,
+              format!("{}({})", short_variant_name, enum_payload_kind(value)),
+            );
+          }
+        }
+        return ValueKind::Enum(self.id, short_variant_name);
       }
     }
     ValueKind::Enum(self.id, self.name())
@@ -86,5 +99,27 @@ impl MechErrorKind for UnknownEnumVariantError {
       "Unknown variant {} for enum {}",
       self.given_variant_id, self.enum_id
     )
+  }
+}
+
+fn enum_payload_kind(value: &Value) -> String {
+  match value {
+    Value::Enum(enum_value) => {
+      let enum_brrw = enum_value.borrow();
+      if enum_brrw.variants.len() == 1 {
+        let (variant_id, payload) = &enum_brrw.variants[0];
+        let names_brrw = enum_brrw.names.borrow();
+        let variant_name = names_brrw
+          .get(variant_id)
+          .map(|name| name.rsplit('/').next().unwrap_or(name).to_string())
+          .unwrap_or_else(|| format!("{}", variant_id));
+        return match payload {
+          Some(inner_payload) => format!(":{}({})", variant_name, enum_payload_kind(inner_payload)),
+          None => format!(":{}", variant_name),
+        };
+      }
+      format!("{}", enum_brrw.kind())
+    }
+    _ => format!("{}", value.kind()),
   }
 }

--- a/src/core/src/structures/enums.rs
+++ b/src/core/src/structures/enums.rs
@@ -61,10 +61,6 @@ impl MechEnum {
 #[cfg(feature = "pretty_print")]
 impl PrettyPrint for MechEnum {
   fn pretty_print(&self) -> String {
-    println!("Pretty printing enum...");
-    println!("Enum ID: {}", self.id);
-    println!("Variants: {:?}", self.variants);
-    println!("Names: {:?}", self.names.borrow());
     let mut variants = Vec::new();
     let dict_brrw = self.names.borrow();
     let enum_name = dict_brrw.get(&self.id).unwrap();
@@ -74,9 +70,9 @@ impl PrettyPrint for MechEnum {
         None => "None".to_string(),
       };
       let variant_name = dict_brrw.get(id).unwrap();
-      variants.push(format!("{}: {}", variant_name, value_str));
+      variants.push(format!("{}(\n{})", variant_name, value_str));
     }
-    format!("`{} {{ {} }}", enum_name, variants.join(" | "))
+    format!(":{}/{}", enum_name, variants.join(" | "))
   }
 }
 

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1598,6 +1598,14 @@ impl Value {
       Value::Enum(e) => {
         let enm = e.borrow();
         let dict = enm.names.borrow();
+        if enm.variants.len() == 1 {
+          let (variant_id, payload) = &enm.variants[0];
+          let variant_name = dict.get(variant_id).cloned().unwrap_or_else(|| format!("{}", variant_id));
+          return match payload {
+            Some(value) => format!(":{}({})", variant_name, value.format_value_inline()),
+            None => format!(":{}", variant_name),
+          };
+        }
         let name = dict.get(&enm.id).cloned().unwrap_or_else(|| format!("{}", enm.id));
         let vals = enm.variants.iter().map(|(id, v)| {
           let variant_name = dict.get(id).cloned().unwrap_or_else(|| format!("{}", id));

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -2556,6 +2556,8 @@ impl ToValue for Ref<R64> { fn to_value(&self) -> Value { Value::R64(self.clone(
 impl ToValue for Ref<C64> { fn to_value(&self) -> Value { Value::C64(self.clone()) } }
 #[cfg(feature = "atom")]
 impl ToValue for Ref<MechAtom> { fn to_value(&self) -> Value { Value::Atom(self.clone()) } }
+#[cfg(feature = "enum")]
+impl ToValue for Ref<MechEnum> { fn to_value(&self) -> Value { Value::Enum(self.clone()) } }
 
 impl ToValue for Ref<Value> { fn to_value(&self) -> Value { (*self.borrow()).clone() } }
 

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1600,7 +1600,10 @@ impl Value {
         let dict = enm.names.borrow();
         if enm.variants.len() == 1 {
           let (variant_id, payload) = &enm.variants[0];
-          let variant_name = dict.get(variant_id).cloned().unwrap_or_else(|| format!("{}", variant_id));
+          let variant_name = dict
+            .get(variant_id)
+            .map(|name| name.rsplit('/').next().unwrap_or(name).to_string())
+            .unwrap_or_else(|| format!("{}", variant_id));
           return match payload {
             Some(value) => format!(":{}({})", variant_name, value.format_value_inline()),
             None => format!(":{}", variant_name),

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1388,6 +1388,34 @@ fn enum_value_matches_kind(value: &Value, enum_id: u64, state: &ProgramState) ->
         short_variant == short_atom
     };
     match value {
+        Value::Enum(enum_value) => {
+            let enum_value_brrw = enum_value.borrow();
+            if enum_value_brrw.id != enum_id {
+                return false;
+            }
+            if enum_value_brrw.variants.len() != 1 {
+                return false;
+            }
+            let (variant_id, payload) = &enum_value_brrw.variants[0];
+            let (_, declared_payload_kind) = match enum_def
+                .variants
+                .iter()
+                .find(|(known_variant, _)| *known_variant == *variant_id)
+            {
+                Some(entry) => entry,
+                None => return false,
+            };
+            match (payload, declared_payload_kind) {
+                (None, None) => true,
+                (Some(payload_value), Some(Value::Kind(expected_kind))) => match expected_kind {
+                    ValueKind::Enum(inner_enum_id, _) => {
+                        enum_value_matches_kind(payload_value, *inner_enum_id, state)
+                    }
+                    _ => payload_value.kind() == expected_kind.clone() || payload_value.convert_to(expected_kind).is_some(),
+                },
+                _ => false,
+            }
+        }
         Value::Atom(atom) => {
             let atom_brrw = atom.borrow();
             let variant_id = atom_brrw.id();

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -722,6 +722,37 @@ fn enum_value_matches(value: Value, enum_id: u64, state: &ProgramState) -> bool 
     short_variant == short_atom
   };
   match value {
+    Value::Enum(enum_value) => {
+      let enum_value_brrw = enum_value.borrow();
+      if enum_value_brrw.id != enum_id {
+        return false;
+      }
+      if enum_value_brrw.variants.len() != 1 {
+        return false;
+      }
+      let (variant_id, payload) = &enum_value_brrw.variants[0];
+      let (_, declared_payload_kind) = match enum_def
+        .variants
+        .iter()
+        .find(|(known_variant, _)| *known_variant == *variant_id)
+      {
+        Some(entry) => entry,
+        None => return false,
+      };
+      match (payload, declared_payload_kind) {
+        (None, None) => true,
+        (Some(payload_value), Some(Value::Kind(expected_kind))) => match expected_kind {
+          ValueKind::Enum(inner_enum_id, _) => {
+            enum_value_matches(payload_value.clone(), *inner_enum_id, state)
+          }
+          _ => {
+            payload_value.kind() == expected_kind.clone()
+              || payload_value.convert_to(expected_kind).is_some()
+          }
+        },
+        _ => false,
+      }
+    }
     // Bare atom: check that the atom's id is a known payload-less variant.
     Value::Atom(atom) => {
       let atom_brrw = atom.borrow();

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -147,6 +147,35 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
     #[cfg(all(feature = "tuple", feature = "atom"))]
     Pattern::TupleStruct(pat_struct) => {
       match detached_value {
+        #[cfg(feature = "enum")]
+        Value::Enum(enum_value) => {
+          let enum_brrw = enum_value.borrow();
+          if enum_brrw.variants.len() != 1 {
+            return Ok(false);
+          }
+          let (variant_id, payload) = &enum_brrw.variants[0];
+          let expected_variant_id = pat_struct.name.hash();
+          if *variant_id != expected_variant_id {
+            return Ok(false);
+          }
+          match payload {
+            Some(payload_value) => {
+              if pat_struct.patterns.len() != 1 {
+                return Ok(false);
+              }
+              return pattern_matches_value_with_semantics(
+                &pat_struct.patterns[0],
+                payload_value,
+                env,
+                p,
+                semantics,
+              );
+            }
+            None => {
+              return Ok(pat_struct.patterns.is_empty());
+            }
+          }
+        }
         Value::Tuple(tuple) => {
           let tuple_brrw = tuple.borrow();
           if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
@@ -224,6 +253,31 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
     }
     #[cfg(all(feature = "tuple", feature = "atom"))]
     Pattern::TupleStruct(pattern_tuple_struct) => {
+      #[cfg(feature = "enum")]
+      {
+        let variant_id = pattern_tuple_struct.name.hash();
+        if let Some((enum_id, enum_def)) = p
+          .state
+          .borrow()
+          .enums
+          .iter()
+          .find(|(_, enm)| enm.variants.iter().any(|(known_variant, _)| *known_variant == variant_id))
+        {
+          let payload = if pattern_tuple_struct.patterns.len() == 1 {
+            Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
+          } else if pattern_tuple_struct.patterns.is_empty() {
+            None
+          } else {
+            return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
+          };
+          let enm = MechEnum {
+            id: *enum_id,
+            variants: vec![(variant_id, payload)],
+            names: enum_def.names.clone(),
+          };
+          return Ok(Value::Enum(Ref::new(enm)));
+        }
+      }
       let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
       values.push(atom(&Atom {name: pattern_tuple_struct.name.clone()}, p));
       for inner in &pattern_tuple_struct.patterns {

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -258,6 +258,33 @@ fn value_matches_enum_variant(value: &Value, enum_id: u64, state: &ProgramState)
     short_variant == short_atom
   };
   match value {
+    Value::Enum(enum_value) => {
+      let enum_value_brrw = enum_value.borrow();
+      if enum_value_brrw.id != enum_id {
+        return false;
+      }
+      if enum_value_brrw.variants.len() != 1 {
+        return false;
+      }
+      let (variant_id, payload) = &enum_value_brrw.variants[0];
+      let (_, declared_payload_kind) = match my_enum.variants.iter().find(|(known_variant, _)| {
+        *known_variant == *variant_id
+      }) {
+        Some(v) => v,
+        None => return false,
+      };
+      match (payload, declared_payload_kind) {
+        (None, None) => true,
+        (Some(payload_value), Some(Value::Kind(expected_kind))) => match expected_kind {
+          ValueKind::Enum(inner_enum_id, _) => value_matches_enum_variant(payload_value, *inner_enum_id, state),
+          _ => {
+            payload_value.kind() == expected_kind.clone() ||
+            ConvertKind{}.compile(&vec![payload_value.clone(), Value::Kind(expected_kind.clone())]).is_ok()
+          }
+        },
+        _ => false,
+      }
+    }
     Value::Atom(atom_variant) => {
       let atom_brrw = atom_variant.borrow();
       let variant_id = atom_brrw.id();

--- a/src/interpreter/src/stdlib/convert/scalar.rs
+++ b/src/interpreter/src/stdlib/convert/scalar.rs
@@ -286,16 +286,28 @@ macro_rules! impl_conversion_match_arms {
           Ok(Box::new(ConvertSRationalToF64{arg: rat.clone(), out: Ref::new(f64::default())}))
         }
         #[cfg(all(feature = "atom", feature = "enum"))]
-        (Value::Atom(atom), Value::Kind(ValueKind::Enum(enum_id, enum_variant_name))) => {
+        (Value::Atom(atom), Value::Kind(ValueKind::Enum(enum_id, _))) => {
           let atom_brrw = atom.borrow();
           let variant_id = atom_brrw.id();
-          let atom_name = atom_brrw.name();
           let variants = vec![(variant_id,None)];
           let dictionary = (*atom_brrw).dictionary();
           let enm = MechEnum{id: enum_id, variants, names: dictionary};
           let val = Ref::new(enm.clone());
-          todo!("This isn't finished yet");
           Ok(Box::new(ConvertSEnum{out: val}))
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(enm), Value::Kind(ValueKind::Enum(enum_id, _))) => {
+          let enum_brrw = enm.borrow();
+          if enum_brrw.id != enum_id {
+            return Err(MechError::new(
+              UnsupportedConversionError {
+                from: ValueKind::Enum(enum_brrw.id, enum_brrw.name()),
+                to: ValueKind::Enum(enum_id, "".to_string()),
+              },
+              None,
+            ).with_compiler_loc());
+          }
+          Ok(Box::new(ConvertSEnum{out: enm.clone()}))
         }
         (Value::Empty, Value::Kind(ValueKind::Empty)) => {
           Ok(Box::new(ConvertSEmpty { out: Ref::new(Value::Empty) }))

--- a/src/interpreter/src/stdlib/define.rs
+++ b/src/interpreter/src/stdlib/define.rs
@@ -167,6 +167,8 @@ impl_variable_define_fxn!(MechRecord);
 impl_variable_define_fxn!(MechMap);
 #[cfg(feature = "atom")]
 impl_variable_define_fxn!(MechAtom);
+#[cfg(feature = "enum")]
+impl_variable_define_fxn!(MechEnum);
 
 #[derive(Debug, Clone)]
 pub struct VariableDefineEmpty {
@@ -328,6 +330,8 @@ fn impl_var_define_fxn(var: Value, name: Value, mutable: Value, id: u64) -> MRes
     (Value::Map(sink), name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineMechMap{ var: sink.clone(), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     #[cfg(feature = "atom")]
     (Value::Atom(sink), name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineMechAtom{ var: sink.clone(), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
+    #[cfg(feature = "enum")]
+    (Value::Enum(sink), name, mutable, id) => return box_mech_fxn(Ok(Box::new(VariableDefineMechEnum{ var: sink.clone(), name: name.as_string()?, mutable: mutable.as_bool()?, id } ))),
     _ => (),
   }
 

--- a/src/interpreter/src/structures.rs
+++ b/src/interpreter/src/structures.rs
@@ -38,10 +38,26 @@ pub fn tuple(tpl: &Tuple, env: Option<&Environment>, p: &Interpreter) -> MResult
 
 #[cfg(all(feature = "tuple", feature = "atom"))]
 pub fn tuple_struct(tpl: &TupleStruct, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let payload = expression(&tpl.value, env, p)?;
+  let variant_id = tpl.name.hash();
+  let state_brrw = p.state.borrow();
+  if let Some((enum_id, enum_def)) = state_brrw
+    .enums
+    .iter()
+    .find(|(_, enm)| enm.variants.iter().any(|(known_variant, _)| *known_variant == variant_id))
+  {
+    let variants = vec![(variant_id, Some(payload))];
+    let enm = MechEnum {
+      id: *enum_id,
+      variants,
+      names: enum_def.names.clone(),
+    };
+    return Ok(Value::Enum(Ref::new(enm)));
+  }
+  drop(state_brrw);
   let mut elements = vec![];
   let atom_value = atom(&Atom { name: tpl.name.clone() }, p);
   elements.push(Box::new(atom_value));
-  let payload = expression(&tpl.value, env, p)?;
   elements.push(Box::new(payload));
   Ok(Value::Tuple(Ref::new(MechTuple { elements })))
 }

--- a/src/syntax/src/literals.rs
+++ b/src/syntax/src/literals.rs
@@ -421,7 +421,7 @@ pub fn kind_empty(input: ParseString) -> ParseResult<Kind> {
   Ok((input, Kind::Empty))
 }
 
-// kind-atom := "`", identifier ;
+// kind-atom := ":", identifier ;
 pub fn kind_atom(input: ParseString) -> ParseResult<Kind> {
   let (input, _) = colon(input)?;
   let (input, atm) = identifier(input)?;


### PR DESCRIPTION
### Motivation
- Tuple-struct expressions that represent enum variants were being materialized as raw `Tuple` values at runtime, losing the enum shape and producing tuple-like tuples instead of enum constructors.
- This made output formatting, kind reporting, and enum membership/kind checks inconsistent for constructor-style values like `:option/some(:result/ok(42u64))`.
- The intent is to preserve runtime enum structure when a tuple-struct's tag matches a declared enum variant so downstream checks and formatting see a proper `Value::Enum`.

### Description
- Emit `Value::Enum` from `tuple_struct` when the tuple-struct tag matches a declared enum variant, otherwise fall back to the old `Tuple` behavior (changed `src/interpreter/src/structures.rs`).
- When a runtime `MechEnum` contains a single variant, surface that variant name in the enum kind (`MechEnum::kind`) so kinds can reflect `:option/some` for single-variant values (changed `src/core/src/structures/enums.rs`).
- Format single-variant runtime enums with constructor-style inline output (`:variant(payload)` or `:variant`) to match the constructor syntax (`src/core/src/value.rs`).
- Extend enum membership and kind-checking paths to accept `Value::Enum` directly in addition to the existing atom/tuple checks so the new runtime representation is recognized in `statements`, `functions`, and `expressions` checks (`src/interpreter/src/statements.rs`, `src/interpreter/src/functions.rs`, `src/interpreter/src/expressions.rs`).

### Testing
- Ran `cargo test -p mech-interpreter` which completed successfully (no failing tests).
- Ran `cargo test -p mech-core` which completed successfully (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1937009b8832aa4093a0f57d2f15d)