### PR TITLE
Use enum variant names in HTML rendering

### DIFF
--- a/src/core/src/structures/enums.rs
+++ b/src/core/src/structures/enums.rs
@@ -18,15 +18,27 @@ impl MechEnum {
 
   #[cfg(feature = "pretty_print")]
   pub fn to_html(&self) -> String {
+    let dict_brrw = self.names.borrow();
     let mut variants = Vec::new();
     for (id, value) in &self.variants {
-      let value_html = match value {
-        Some(v) => v.to_html(),
-        None => "None".to_string(),
+      let variant_name = dict_brrw
+        .get(id)
+        .map(|name| name.rsplit('/').next().unwrap_or(name).to_string())
+        .unwrap_or_else(|| format!("{}", id));
+      let variant_html = match value {
+        Some(v) => format!(
+          "<span class=\"mech-enum-variant-name\">:{}</span><span class=\"mech-enum-variant-payload\">(<span class=\"mech-enum-variant-value\">{}</span>)</span>",
+          variant_name,
+          v.to_html()
+        ),
+        None => format!("<span class=\"mech-enum-variant-name\">:{}</span>", variant_name),
       };
-      variants.push(format!("<span class=\"mech-enum-variant\">{}: {}</span>", id, value_html));
+      variants.push(format!("<span class=\"mech-enum-variant\">{}</span>", variant_html));
     }
-    format!("<span class=\"mech-enum\"><span class=\"mech-start-brace\">{{</span>{}<span class=\"mech-end-brace\">}}</span></span>", variants.join(", "))
+    format!(
+      "<span class=\"mech-enum\">{}</span>",
+      variants.join("<span class=\"mech-enum-variant-sep\"> | </span>")
+    )
   }
 
   pub fn kind(&self) -> ValueKind {


### PR DESCRIPTION
### Motivation
- HTML rendering of enums previously showed numeric IDs which made outputs like `:some(:ok(42))` render with raw hashes instead of human-readable variant names.
- Improve readability of rendered enum/variant values in the UI and preserve nested payload formatting for Option/Result-like enums.
- Skills used: none (not applicable for this change).

### Description
- Update `MechEnum::to_html` in `src/core/src/structures/enums.rs` to look up variant names from the enum dictionary and render them as colon-tagged names instead of printing numeric ids.
- Render variants using a name-first format with an optional payload section (`:<variant>` or `:<variant>(<payload_html>)`) and join variants with a ` | ` separator for readability.
- Keep a graceful fallback to the numeric `id` when a variant name is not present in the dictionary.

### Testing
- Ran `cargo test -p mech-core --lib` and the test profile completed successfully with all test suites passing.
- The change was compiled as part of the `mech-core` crate build and unit tests finished with `test result: ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22aba426c832aac269b35b73d347d)