### PR TITLE
Add rich comment parsing with raw-line recovery

### DIFF
--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -14,8 +14,49 @@ pub fn comment_sigil(input: ParseString) -> ParseResult<()> {
 pub fn comment(input: ParseString) -> ParseResult<Comment> {
   let (input, _) = many0(space_tab)(input)?;
   let (input, _) = comment_sigil(input)?;
-  let (input, p) = paragraph(input)?;
-  Ok((input, Comment{paragraph: p}))
+  let (input, line_token) = skip_till_eol(input)?;
+  let comment_text = line_token.to_string();
+
+  if comment_text.is_empty() {
+    return Ok((input, Comment { paragraph: Paragraph { elements: vec![], error_range: None } }));
+  }
+
+  let line_graphemes = graphemes::init_source(&comment_text);
+  let line_input = ParseString::new(&line_graphemes);
+
+  match inline_paragraph(line_input) {
+    Ok((remaining, paragraph)) => {
+      // A rich comment must parse the full line.
+      if new_line(remaining.clone()).is_ok() {
+        Ok((input, Comment { paragraph }))
+      } else {
+        let mut recovered_input = input;
+        let start = line_token.src_range.start;
+        let end = line_token.src_range.end;
+        recovered_input.error_log.push((
+          SourceRange { start, end },
+          ParseErrorDetail {
+            message: "Invalid rich comment syntax, preserving raw comment text",
+            annotation_rngs: vec![],
+          },
+        ));
+        Ok((recovered_input, Comment { paragraph: Paragraph::from_tokens(vec![line_token]) }))
+      }
+    }
+    Err(_) => {
+      let mut recovered_input = input;
+      let start = line_token.src_range.start;
+      let end = line_token.src_range.end;
+      recovered_input.error_log.push((
+        SourceRange { start, end },
+        ParseErrorDetail {
+          message: "Invalid rich comment syntax, preserving raw comment text",
+          annotation_rngs: vec![],
+        },
+      ));
+      Ok((recovered_input, Comment { paragraph: Paragraph::from_tokens(vec![line_token]) }))
+    }
+  }
 }
 
 // op-assign-operator := add-assign-operator | sub-assign-operator | mul-assign-operator | div-assign-operator | exp-assign-operator ;
@@ -207,4 +248,32 @@ pub fn kind_define(input: ParseString) -> ParseResult<KindDefine> {
   let (input, _) = define_operator(input)?;
   let (input, knd) = kind_annotation(input)?;
   Ok((input, KindDefine{name,kind:knd}))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn comment_accepts_rich_markup() {
+    let src = "-- This is a [link](foo.html) with **bold** and `foo := 123`";
+    let graphemes = graphemes::init_source(src);
+    let input = ParseString::new(&graphemes);
+    let (_, comment) = comment(input).expect("comment should parse");
+
+    assert!(!comment.paragraph.elements.is_empty());
+    assert!(comment.paragraph.to_string().contains("[link](foo.html)"));
+  }
+
+  #[test]
+  fn comment_recovers_to_raw_text_for_invalid_markup() {
+    let src = "-- [1 2 3 4]";
+    let graphemes = graphemes::init_source(src);
+    let input = ParseString::new(&graphemes);
+    let (remaining, comment) = comment(input).expect("comment should recover");
+
+    assert_eq!(comment.paragraph.to_string(), " [1 2 3 4]");
+    assert_eq!(remaining.error_log.len(), 1);
+    assert_eq!(remaining.error_log[0].1.message, "Invalid rich comment syntax, preserving raw comment text");
+  }
 }


### PR DESCRIPTION
### Motivation
- Comments were previously parsed as plain paragraphs which rejected many valid inline constructs (e.g. raw bracket sequences) and prevented rich formatting inside comments. 
- We need a new rich-comment behavior that still captures every character after `--` or `//` but also accepts mechdown inline formatting (links, emphasis, inline code, inline mech code, equations, etc.).
- When rich parsing fails, the parser must recover safely by preserving the original raw comment line and recording a parser error so the rest of the document can still be parsed.

### Description
- Changed the `comment` parser in `src/syntax/src/statements.rs` to consume the full line after the sigil via `skip_till_eol` and attempt to parse that line with `inline_paragraph` using `graphemes::init_source`, enabling rich formatting inside comments. 
- On successful parse the parsed `Paragraph` is returned; if parsing fails or only partially parses the implementation pushes a `ParseErrorDetail` into the input `error_log` and falls back to `Paragraph::from_tokens` to preserve the raw comment text. 
- Preserved regular comment semantics of accepting both `--` and `//` sigils and capturing every character after the sigil. 
- Added unit tests alongside the parser in `src/syntax/src/statements.rs` that exercise both successful rich markup parsing and fallback recovery for invalid markup.

### Testing
- Ran the focused test command `cargo test -p mech-syntax comment_`, which executed the two new tests `comment_accepts_rich_markup` and `comment_recovers_to_raw_text_for_invalid_markup`. 
- Test results: both tests passed (`2 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28e0a9fb4832a8a83846c79294261)