### PR TITLE
Fix `{ans}` evaluation in fenced Mech code blocks

### DIFF
--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -76,8 +76,11 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
       }
       let code_id = block.config.namespace;
       if code_id == 0 {
-        for (c,_) in &block.code {
+        for (c,cmmnt) in &block.code {
           out = mech_code(&c, &p)?;
+          if let Some(cmmnt) = cmmnt {
+            let _ = comment(cmmnt, p)?;
+          }
         }
         // Save the output of the last code block in the parent interpreter
         // so we can reference it later.
@@ -94,8 +97,11 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
           .entry(code_id)
           .or_insert(Box::new(new_sub_interpreter))
           .as_mut();
-        for (c,_) in &block.code {
+        for (c,cmmnt) in &block.code {
           out = mech_code(&c, &pp)?;
+          if let Some(cmmnt) = cmmnt {
+            let _ = comment(cmmnt, pp)?;
+          }
         }
         // Save the output of the last code block in the parent interpreter
         // so we can reference it later.


### PR DESCRIPTION
### Motivation
- Fenced Mech code blocks were not executing per-line comment payloads, so inline evaluation annotations like `-- {ans}` did not produce the linked inline outputs. 
- The goal is to make fenced blocks behave like raw `MechCode` sections and also support sub-interpreter fenced blocks (e.g. `mech:sub-intrp2`).

### Description
- Updated `SectionElement::FencedMechCode` in `src/interpreter/src/mechdown.rs` to iterate over `(c, cmmnt)` and execute `comment(cmmnt, ...)` when present for the main interpreter branch. 
- Applied the same change for the sub-interpreter branch so comments are executed in `pp` as well. 
- Kept existing output wiring intact by continuing to insert the last code block output into `out_values` as before.

### Testing
- Ran `cargo check -p mech-interpreter` and the package type-checked successfully. 
- Ran `cargo test -p mech-interpreter --lib --quiet` which completed successfully (0 tests run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28f3d20c4832ab7bababfc5d02fa7)