### PR TITLE
Fix inline eval IDs for repeated expressions

### DIFF
--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -434,7 +434,9 @@ impl Formatter {
         }
       },
       ParagraphElement::EvalInlineMechCode(expr) => {
-        let code_id = hash_str(&format!("{:?}", expr));
+        // Include token locations in the hash so identical inline expressions
+        // on different lines receive distinct DOM ids.
+        let code_id = hash_str(&format!("{:?}:{:?}", expr, expr.tokens()));
         let result = self.expression(expr);
         if self.html {
           format!("<code id=\"{}\" class=\"mech-inline-mech-code\">{}</code>", code_id, result)


### PR DESCRIPTION
### Motivation
- Inline evaluated expressions (e.g. `{ans}`) used the same hash for identical expressions, causing repeated inline sites to share a DOM id and display the same output value.
- The intent is to make each inline evaluation site unique so each line reports its own computed value.

### Description
- Change `ParagraphElement::EvalInlineMechCode` id generation to include token locations by hashing `format!("{:?}:{:?}", expr, expr.tokens())` so identical expressions on different lines get distinct ids.
- Update made in `src/syntax/src/formatter.rs` to produce stable but unique DOM ids for inline evals.

### Testing
- Ran `cargo test -p mech-syntax` which executed the unit tests for the syntax package and all tests passed.
- Test run output: "4 passed; 0 failed" for the mech-syntax test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a13880ac832ab7c13720dc01960d)