### PR TITLE
Keep matrix comprehensions on one line in HTML output

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -379,6 +379,21 @@ h5.toc::before {
     display: inline-flex;
 }
 
+.mech-matrix-comprehension {
+    display: inline-flex;
+    align-items: flex-end;
+    white-space: nowrap;
+}
+
+.mech-matrix-comprehension .mech-comp-expr,
+.mech-matrix-comprehension .mech-comp-quals {
+    display: inline-flex;
+}
+
+.mech-matrix-comprehension .mech-bracket.end {
+    margin-left: 0;
+}
+
 .mech-bracket.end {
     align-self: flex-end;
     margin-left: -10px;

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -239,6 +239,21 @@ h4.toc::before {
     display: inline-flex;
 }
 
+.mech-matrix-comprehension {
+    display: inline-flex;
+    align-items: flex-end;
+    white-space: nowrap;
+}
+
+.mech-matrix-comprehension .mech-comp-expr,
+.mech-matrix-comprehension .mech-comp-quals {
+    display: inline-flex;
+}
+
+.mech-matrix-comprehension .mech-bracket.end {
+    margin-left: 0;
+}
+
 .mech-bracket.end {
     align-self: flex-end;
     margin-left: -10px;


### PR DESCRIPTION
### Motivation
- Matrix comprehensions in HTML output could wrap so the closing `]` landed on the next line due to no scoped layout rules and the global negative margin on `.mech-bracket.end` interfering with inline flow. 
- The intent is to make a comprehension render as a single inline unit so expressions and qualifiers don't cause awkward wrapping or misalignment.

### Description
- Added a `.mech-matrix-comprehension` rule in `include/style.css` and `mech-app/src/css/style.css` to render comprehensions as `inline-flex`, set `align-items: flex-end`, and prevent internal wrapping with `white-space: nowrap`.
- Made the comprehension subparts `.mech-comp-expr` and `.mech-comp-quals` `display: inline-flex` so nested content stays inline.
- Scoped override `.mech-matrix-comprehension .mech-bracket.end { margin-left: 0; }` to avoid the global negative margin shifting the closing bracket out of line.
- Applied identical fixes to both shipped stylesheet variants so behavior is consistent in the library and app bundles.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff-check issues, which succeeded. 
- Ran `git status --short` to confirm the intended files were updated, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ef5511d8832a87b6ba1f776ea4d1)