### PR TITLE
Add fenced mech block config to disable rendered output line

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -852,6 +852,11 @@ code {
     box-shadow: none;
 }
 
+.mech-fenced-mech-block.no-output .mech-code-block {
+    border-radius: 10px;
+    border-bottom: 1px solid var(--code-border-color);
+}
+
 .mech-inline-mech-code {
     background-color: var(--code-background-color);
     border: 1px solid var(--inline-code-border-color);

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -1192,6 +1192,11 @@ li p {
     margin-bottom: 0px;
 }
 
+.mech-fenced-mech-block.no-output .mech-code-block {
+    border-radius: 10px;
+    border-bottom: 1px solid #888f92;
+}
+
 .mech-block-output {
     margin-top: 0px;
     background-color: #222A30; 

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -496,6 +496,7 @@ pub struct BlockConfig {
   pub namespace: u64,
   pub disabled: bool,
   pub hidden: bool,
+  pub output: bool,
 }
 
 pub type Footnote = (Token, Vec<Paragraph>);

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -498,13 +498,18 @@ impl Formatter {
           let style_str = option_map
             .elements
             .iter()
+            .filter(|(k, _)| k.to_string() != "output")
             .map(|(k, v)| {
               let clean_value = v.to_string().trim_matches('"').to_string();
               format!("{}: {}", k.to_string(), clean_value)
             })
             .collect::<Vec<_>>()
             .join("; ");
-          format!(" style=\"{}\"", style_str)
+          if style_str.is_empty() {
+            "".to_string()
+          } else {
+            format!(" style=\"{}\"", style_str)
+          }
         }
         _ => "".to_string(),
       };
@@ -519,11 +524,16 @@ impl Formatter {
         } else {
           format!("<div class=\"mech-code-block-namespace\"><a href=\"#{}\">{}</a></div>", block_id, namespace_str)
         };
+        let output_node = if block.config.output {
+          format!("<div class=\"mech-block-output\" id=\"{}:{}\"></div>", output_id, intrp_id)
+        } else {
+          "".to_string()
+        };
         format!("<div id=\"{}\" class=\"mech-fenced-mech-block\"{}>
           {}
           <div class=\"mech-code-block\">{}</div>
-          <div class=\"mech-block-output\" id=\"{}:{}\"></div>
-        </div>", block_id, style_attr, namespace_str, src, output_id, intrp_id)
+          {}
+        </div>", block_id, style_attr, namespace_str, src, output_node)
       }
     } else {
       format!("```mech{}\n{}\n```", src, format!(":{}", disabled_tag))

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -529,11 +529,16 @@ impl Formatter {
         } else {
           "".to_string()
         };
-        format!("<div id=\"{}\" class=\"mech-fenced-mech-block\"{}>
+        let block_class = if block.config.output {
+          "mech-fenced-mech-block"
+        } else {
+          "mech-fenced-mech-block no-output"
+        };
+        format!("<div id=\"{}\" class=\"{}\"{}>
           {}
           <div class=\"mech-code-block\">{}</div>
           {}
-        </div>", block_id, style_attr, namespace_str, src, output_node)
+        </div>", block_id, block_class, style_attr, namespace_str, src, output_node)
       }
     } else {
       format!("```mech{}\n{}\n```", src, format!(":{}", disabled_tag))

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -266,11 +266,21 @@ pub fn option_mapping(input: ParseString) -> ParseResult<(Identifier, MechString
   let (input, _) = whitespace0(input)?;
   let (input, _) = colon(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, value) = string(input)?;
+  let (input, value) = option_value(input)?;
   let (input, _) = whitespace0(input)?;
   let (input, _) = opt(comma)(input)?;
   let (input, _) = whitespace0(input)?;
   Ok((input, (key, value)))
+}
+
+// option-value := string | identifier ;
+pub fn option_value(input: ParseString) -> ParseResult<MechString> {
+  if let Ok((input, value)) = string(input.clone()) {
+    return Ok((input, value));
+  }
+  let (input, mut identifier_value) = identifier(input)?;
+  identifier_value.name.kind = TokenKind::String;
+  Ok((input, MechString { text: identifier_value.name }))
 }
 
 // img := "![", *text, "]", "(", +text, ")" , ?option-map ;
@@ -710,10 +720,19 @@ pub fn code_block(input: ParseString) -> ParseResult<SectionElement> {
         // get rid of the prefix and then treat the rest of the string after : as an identifier
         let rest = tag.trim_start_matches("mech").trim_start_matches("mec").trim_start_matches("🤖").trim_start_matches(":");
         
-        let config = if rest == "" {BlockConfig { namespace_str: "".to_string(), namespace: 0, disabled: false, hidden: false}}
-        else if rest == "disabled" { BlockConfig { namespace_str: "".to_string(), namespace: 0, disabled: true, hidden: false} }
-        else if rest == "hidden" { BlockConfig { namespace_str: "".to_string(), namespace: 0, disabled: false, hidden: true} }
-        else { BlockConfig { namespace_str: rest.to_string(), namespace: hash_str(rest), disabled: false, hidden: false} };
+        let mut config = if rest == "" {BlockConfig { namespace_str: "".to_string(), namespace: 0, disabled: false, hidden: false, output: true}}
+        else if rest == "disabled" { BlockConfig { namespace_str: "".to_string(), namespace: 0, disabled: true, hidden: false, output: true} }
+        else if rest == "hidden" { BlockConfig { namespace_str: "".to_string(), namespace: 0, disabled: false, hidden: true, output: true} }
+        else { BlockConfig { namespace_str: rest.to_string(), namespace: hash_str(rest), disabled: false, hidden: false, output: true} };
+
+        if let Some(options_map) = &options {
+          for (key, value) in &options_map.elements {
+            if key.to_string() == "output" {
+              let output_value = value.to_string().trim().trim_matches('"').to_ascii_lowercase();
+              config.output = !matches!(output_value.as_str(), "false" | "no" | "off" | "0");
+            }
+          }
+        }
 
         let mech_src = block_src.iter().collect::<String>();
         let graphemes = graphemes::init_source(&mech_src);


### PR DESCRIPTION
### Motivation

- Allow authors to suppress the rendered output line for fenced Mech code blocks (e.g. ```` ```mech:foo{output: false}`````) while retaining namespace behavior.

### Description

- Add a new `output: bool` field to `BlockConfig` with default `true` in `src/core/src/nodes.rs` so block rendering behavior can be controlled. 
- Accept unquoted identifier values in option maps by adding `option_value` and using it from `option_mapping` in `src/syntax/src/mechdown.rs` so options like `output: false` parse correctly. 
- Map the parsed `output` option into the fenced block `BlockConfig` (treating `false`, `no`, `off`, `0` as falsey) during block parsing in `src/syntax/src/mechdown.rs`. 
- Update HTML formatting in `src/syntax/src/formatter.rs` to filter `output` out of inline style serialization and to omit the `.mech-block-output` container when `block.config.output == false`.

### Testing

- Ran `cargo check -p mech-syntax` which completed successfully. 
- An earlier `cargo check` run failed during an intermediate iteration while implementing parser changes, but the parsing/compilation errors were fixed and the final syntax crate check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f3889c54832a9041f5bb3de4a2bd)