### PR TITLE
Fix inline output resolution for namespaced mech code blocks

### DIFF
--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -451,7 +451,8 @@ impl Formatter {
         let code_id = self.inline_eval_id();
         let result = self.expression(expr);
         if self.html {
-          format!("<code id=\"{}\" class=\"mech-inline-mech-code\">{}</code>", code_id, result)
+          let element_id = format!("{}:{}", code_id, self.interpreter_id);
+          format!("<code id=\"{}\" class=\"mech-inline-mech-code\">{}</code>", element_id, result)
         } else {
           format!("{{{}}}", result)
         }

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -866,16 +866,56 @@ pub fn attach_repl(&mut self, repl_id: &str) {
     let window = web_sys::window().expect("global window does not exists");    
 		let document = window.document().expect("expecting a document on window"); 
     let inline_elements = document.get_elements_by_class_name("mech-inline-mech-code");
-    let out_values_brrw = self.interpreter.out_values.borrow();
     for j in 0..inline_elements.length() {
       let inline_block = inline_elements.get_with_index(j).unwrap();
       let inline_id = inline_block.id();
-      let inline_id: u64 = inline_id.parse().unwrap();
-      
-      let inline_output = match out_values_brrw.get(&inline_id) {
+      let parsed_id: Vec<&str> = inline_id.split(":").collect();
+      let (inline_output_id, inline_interpreter_id) = match parsed_id.as_slice() {
+        [output_id, interpreter_id] => {
+          match (output_id.parse::<u64>(), interpreter_id.parse::<u64>()) {
+            (Ok(output_id), Ok(interpreter_id)) => (output_id, interpreter_id),
+            _ => {
+              log!("Invalid inline output id format: {}", inline_id);
+              continue;
+            }
+          }
+        }
+        [output_id] => {
+          match output_id.parse::<u64>() {
+            Ok(output_id) => (output_id, 0),
+            Err(_) => {
+              log!("Invalid inline output id format: {}", inline_id);
+              continue;
+            }
+          }
+        }
+        _ => {
+          log!("Invalid inline output id format: {}", inline_id);
+          continue;
+        }
+      };
+      let out_values = match inline_interpreter_id {
+        0 => self.interpreter.out_values.clone(),
+        id => {
+          match self.interpreter.sub_interpreters.borrow().get(&id) {
+            Some(sub_interpreter) => sub_interpreter.out_values.clone(),
+            None => {
+              log!("No sub interpreter found for inline id: {}", id);
+              continue;
+            }
+          }
+        }
+      };
+      let out_values_brrw = out_values.borrow();
+
+      let inline_output = match out_values_brrw.get(&inline_output_id) {
         Some(value) => value,
         None => {
-          log!("No value found for inline output id: {}", inline_id);
+          log!(
+            "No value found for inline output id: {} in interpreter {}",
+            inline_output_id,
+            inline_interpreter_id
+          );
           continue;
         }
       };
@@ -916,8 +956,8 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         let inline_html = format!(
           "<span>{}</span><span class=\"mech-inline-expand\" id=\"{}:{}\">›</span>",
           compact,
-          inline_id,
-          0
+          inline_output_id,
+          inline_interpreter_id
         );
         inline_block.set_inner_html(&inline_html);
       }


### PR DESCRIPTION
### Motivation
- Inline evaluated expressions inside namespaced fenced blocks (e.g. `mech:foo`) generated HTML ids that lacked interpreter context, causing the frontend to look up values only in the main interpreter and report missing inline outputs.
- The change is intended to ensure inline outputs are resolved against the correct interpreter namespace so inline values render properly for sub-interpreters.

### Description
- Include the interpreter id when emitting inline eval HTML ids by changing the id format to `output_id:interpreter_id` in `src/syntax/src/formatter.rs` (use `format!("{}:{}", code_id, self.interpreter_id)`).
- Update WASM inline rendering in `src/wasm/src/lib.rs` to parse ids of the form `output_id:interpreter_id` and to accept legacy `output_id` ids by defaulting to interpreter `0` for backward compatibility.
- Resolve inline output lookups against the correct storage by selecting either `self.interpreter.out_values` or a sub-interpreter's `out_values` from `self.interpreter.sub_interpreters` based on the parsed interpreter id.
- Improve logging messages for invalid id formats and missing outputs, and ensure the inline "expand" control carries the interpreter id so click handlers can target the right interpreter.

### Testing
- Ran `cargo test -p mech-syntax`, which completed successfully (`4 passed; 0 failed`).
- Ran `cargo check -p mech-wasm`, which completed successfully (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3deb3c5a4832ab3aaf5e4b9debaa4)