### PR TITLE
Fix matrix-function typing and tighten matrix '|' parsing

### DIFF
--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1013,10 +1013,15 @@ impl Value {
     (Value::Empty, ValueKind::Option(_)) => Some(Value::Empty),
     (Value::EmptyKind(_), ValueKind::Option(_)) => Some(Value::Empty),
     (value, ValueKind::Option(inner)) => value.convert_to(inner.as_ref()),
-    (value, ValueKind::Matrix(_, target_shape))
-      if target_shape.is_empty() && matches!(value.kind(), ValueKind::Matrix(_, _)) =>
+    (value, ValueKind::Matrix(target_elem_kind, target_shape))
+      if target_shape.is_empty() =>
     {
-      Some(value.clone())
+      match value.kind() {
+        ValueKind::Matrix(source_elem_kind, _) if source_elem_kind == target_elem_kind.clone() => {
+          Some(value.clone())
+        }
+        _ => None,
+      }
     },
     // ==== Unsigned widening and narrowing ====
     #[cfg(all(feature = "u8", feature = "u16"))]

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -365,6 +365,21 @@ fn build_typed_matrix_from_values(
   cols: usize,
 ) -> Value {
   match output_kind {
+    #[cfg(feature = "u64")]
+    ValueKind::U64 => Value::MatrixU64(u64::to_matrix(
+      outputs
+        .into_iter()
+        .map(|value| {
+          value
+            .as_u64()
+            .expect("Expected u64 output")
+            .borrow()
+            .clone()
+        })
+        .collect::<Vec<u64>>(),
+      rows,
+      cols,
+    )),
     #[cfg(feature = "f64")]
     ValueKind::F64 => Value::MatrixF64(f64::to_matrix(
       outputs

--- a/src/syntax/src/expressions.rs
+++ b/src/syntax/src/expressions.rs
@@ -698,6 +698,15 @@ pub fn matrix_comprehension(input: ParseString) -> ParseResult<MatrixComprehensi
   let (input, _) = bar(input)?;
   let (input, _) = space_tab0(input)?;
   let (input, quals) = separated_list1(list_separator, comprehension_qualifier)(input)?;
+  if !quals
+    .iter()
+    .any(|qual| matches!(qual, ComprehensionQualifier::Generator(_)))
+  {
+    return Err(nom::Err::Error(ParseError::new(
+      input,
+      "Matrix comprehensions require at least one generator (<-)",
+    )));
+  }
   let (input, _) = space_tab0(input)?;
   let (input, _) = right_bracket(input)?;
   Ok((input, MatrixComprehension{ expression: expr, qualifiers: quals }))

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -108,10 +108,8 @@ pub fn matrix_column(input: ParseString) -> ParseResult<MatrixColumn> {
   Ok((input, MatrixColumn{element}))
 }
 
-// matrix-row := table-separator?, (space | tab)*, matrix-column+, semicolon?, new-line?, (box-drawing-char+, new-line)? ;
+// matrix-row := (space | tab)*, matrix-column+, semicolon?, new-line?, (box-drawing-char+, new-line)? ;
 pub fn matrix_row(input: ParseString) -> ParseResult<MatrixRow> {
-  let (input, _) = space_tab0(input)?;
-  let (input, _) = opt(table_separator)(input)?;
   let (input, _) = space_tab0(input)?;
   let (input, columns) = match many1(matrix_column)(input) {
     Ok(result) => result,


### PR DESCRIPTION
### Motivation
- Prevent user functions broadcast over matrix inputs from returning generic `MatrixValue` wrappers instead of concrete numeric matrices, and avoid accidental acceptance of `|` in bracketed matrix expressions that led to incorrect parsing and typed mismatches.
- Ensure matrix-kind conversions for unsized (`<[T]>`) annotations are stricter so element kinds must match before conversion is allowed.

### Description
- Return concrete `MatrixU64` when rebuilding broadcasted function outputs for `u64` element kinds in `build_typed_matrix_from_values`. (`src/interpreter/src/functions.rs`)
- Tighten matrix-kind conversion for unsized matrix targets so conversions only succeed when the source matrix element kind equals the declared element kind. (`src/core/src/value.rs`)
- Enforce that matrix comprehensions must include at least one generator (`<-`), rejecting accidental forms like `[a | b]`. (`src/syntax/src/expressions.rs`)
- Remove optional leading `table_separator` handling from `matrix_row` so leading `|` is no longer treated as a row delimiter inside bracketed matrix literals. (`src/syntax/src/structures.rs`)

### Testing
- Ran `cargo test --test interpreter interpret_fsm_bubble_sort_returns_typed_u64_matrix -- --nocapture` and the test passed.
- Ran `cargo test --test interpreter interpret_matrix_comprehension -- --nocapture` (includes the variable variant) and both tests passed.
- Ran the interpreter test binary for the targeted interpreter tests; the exercised tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e570d06d6c832a83cbcd8d13d45b20)