### PR TITLE
Reject pattern/rest spread in FSM RHS and fix matrix RHS construction semantics

### DIFF
--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -34,6 +34,8 @@ pub struct Interpreter {
   pub inline_eval_counter: Ref<u64>,
   #[cfg(feature = "state_machines")]
   pub user_state_machines: Ref<HashMap<u64, FsmImplementation>>,
+  #[cfg(feature = "state_machines")]
+  pub user_state_machine_specs: Ref<HashMap<u64, FsmSpecification>>,
   pub sub_interpreters: Ref<HashMap<u64, Box<Interpreter>>>,
 }
 
@@ -63,6 +65,8 @@ impl Clone for Interpreter {
       inline_eval_counter: self.inline_eval_counter.clone(),
       #[cfg(feature = "state_machines")]
       user_state_machines: self.user_state_machines.clone(),
+      #[cfg(feature = "state_machines")]
+      user_state_machine_specs: self.user_state_machine_specs.clone(),
       sub_interpreters: self.sub_interpreters.clone(),
     }
   }
@@ -96,6 +100,8 @@ impl Interpreter {
       inline_eval_counter: Ref::new(0),
       #[cfg(feature = "state_machines")]
       user_state_machines: Ref::new(HashMap::new()),
+      #[cfg(feature = "state_machines")]
+      user_state_machine_specs: Ref::new(HashMap::new()),
       code: Vec::new(),
       #[cfg(feature = "compiler")]
       context: None,

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -216,6 +216,12 @@ pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
   let out = match &code {
     MechCode::Expression(expr) => expression(&expr, None, p),
     MechCode::Statement(stmt) => statement(&stmt, None, p),
+    #[cfg(feature = "state_machines")]
+    MechCode::FsmSpecification(fsm_spec) => {
+      crate::state_machines::register_fsm_specification(fsm_spec, p)?;
+      Ok(Value::Empty)
+    },
+    #[cfg(not(feature = "state_machines"))]
     MechCode::FsmSpecification(_) => Ok(Value::Empty),
     #[cfg(feature = "state_machines")]
     MechCode::FsmImplementation(fsm_impl) => {

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -234,7 +234,12 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
     Pattern::Array(array) => {
       let mut values = Vec::new();
       for inner in &array.prefix {
-        values.push(pattern_to_value(inner, env, p)?);
+        let inner_value = pattern_to_value(inner, env, p)?;
+        if let Some(inner_values) = matrix_like_values(&inner_value) {
+          values.extend(inner_values);
+        } else {
+          values.push(inner_value);
+        }
       }
       if let Some(spread) = &array.spread {
         if let Some(binding) = &spread.binding {
@@ -247,7 +252,12 @@ pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -
         }
       }
       for inner in &array.suffix {
-        values.push(pattern_to_value(inner, env, p)?);
+        let inner_value = pattern_to_value(inner, env, p)?;
+        if let Some(inner_values) = matrix_like_values(&inner_value) {
+          values.extend(inner_values);
+        } else {
+          values.push(inner_value);
+        }
       }
       return Ok(build_row_matrix_from_values(values));
     }

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -9,6 +9,16 @@ use std::collections::HashSet;
 // ----------------------------------------------------------------------------
 
 fn fsm_argument_kind_matches(expected: &ValueKind, actual: &ValueKind) -> bool {
+  fn strip_references<'a>(kind: &'a ValueKind) -> &'a ValueKind {
+    match kind {
+      ValueKind::Reference(inner) => strip_references(inner.as_ref()),
+      _ => kind,
+    }
+  }
+
+  let expected = strip_references(expected);
+  let actual = strip_references(actual);
+
   match (expected, actual) {
     (ValueKind::Matrix(expected_element, expected_dims), ValueKind::Matrix(actual_element, _actual_dims))
       if expected_dims.is_empty() =>

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -8,6 +8,17 @@ use std::collections::HashSet;
 // Finite State Machines
 // ----------------------------------------------------------------------------
 
+fn fsm_argument_kind_matches(expected: &ValueKind, actual: &ValueKind) -> bool {
+  match (expected, actual) {
+    (ValueKind::Matrix(expected_element, expected_dims), ValueKind::Matrix(actual_element, _actual_dims))
+      if expected_dims.is_empty() =>
+    {
+      expected_element.as_ref() == actual_element.as_ref()
+    }
+    _ => expected == actual,
+  }
+}
+
 // Review: how does this fail?
 pub fn register_fsm_implementation(fsm: &FsmImplementation, p: &Interpreter) -> MResult<()> {
   let fsm_id = fsm.name.hash();
@@ -19,6 +30,14 @@ pub fn register_fsm_implementation(fsm: &FsmImplementation, p: &Interpreter) -> 
     .dictionary
     .borrow_mut()
     .insert(fsm_id, fsm.name.to_string());
+  Ok(())
+}
+
+pub fn register_fsm_specification(fsm: &FsmSpecification, p: &Interpreter) -> MResult<()> {
+  let fsm_id = fsm.name.hash();
+  p.user_state_machine_specs
+    .borrow_mut()
+    .insert(fsm_id, fsm.clone());
   Ok(())
 }
 
@@ -46,10 +65,19 @@ pub fn execute_fsm_pipe(fsm_pipe: &FsmPipe, env: Option<&Environment>, p: &Inter
       args.push(expression(arg_expr, env, p)?);
     }
   }
-  if fsm.input.len() != args.len() {
+  let input_decls = {
+    let specs = p.user_state_machine_specs.borrow();
+    if let Some(spec) = specs.get(&fsm_id) {
+      spec.input.clone()
+    } else {
+      fsm.input.clone()
+    }
+  };
+
+  if input_decls.len() != args.len() {
     return Err(MechError::new(
       IncorrectNumberOfArguments {
-        expected: fsm.input.len(),
+        expected: input_decls.len(),
         found: args.len(),
       },
       None,
@@ -57,15 +85,14 @@ pub fn execute_fsm_pipe(fsm_pipe: &FsmPipe, env: Option<&Environment>, p: &Inter
     .with_compiler_loc()
     .with_tokens(fsm_pipe.start.tokens()));
   }
-  for (arg_decl, arg_value) in fsm.input.iter().zip(args.iter()) {
+  for (arg_decl, arg_value) in input_decls.iter().zip(args.iter()) {
     let detached_arg = detach_value(arg_value);
     #[cfg(feature = "kind_annotation")]
     if let Some(kind_annotation_node) = &arg_decl.kind {
       let expected_kind = kind_annotation(&kind_annotation_node.kind, p)?
           .to_value_kind(&p.state.borrow().kinds)?;
       let actual_kind = arg_value.kind();
-      let converted_arg = detached_arg.convert_to(&expected_kind);
-      if actual_kind != expected_kind && converted_arg.is_none() {
+      if !fsm_argument_kind_matches(&expected_kind, &actual_kind) {
         return Err(MechError::new(
           FsmArgumentKindMismatchError {
             argument: arg_decl.name.to_string(),
@@ -77,7 +104,7 @@ pub fn execute_fsm_pipe(fsm_pipe: &FsmPipe, env: Option<&Environment>, p: &Inter
         .with_compiler_loc()
         .with_tokens(fsm_pipe.start.tokens()));
       }
-      call_env.insert(arg_decl.name.hash(), converted_arg.unwrap_or(detached_arg));
+      call_env.insert(arg_decl.name.hash(), detached_arg);
       continue;
     }
     call_env.insert(arg_decl.name.hash(), detached_arg);

--- a/src/syntax/src/expressions.rs
+++ b/src/syntax/src/expressions.rs
@@ -698,6 +698,12 @@ pub fn matrix_comprehension(input: ParseString) -> ParseResult<MatrixComprehensi
   let (input, _) = bar(input)?;
   let (input, _) = space_tab0(input)?;
   let (input, quals) = separated_list1(list_separator, comprehension_qualifier)(input)?;
+  if !quals.iter().any(|q| matches!(q, ComprehensionQualifier::Generator(_) | ComprehensionQualifier::Let(_))) {
+    return Err(nom::Err::Error(ParseError::new(
+      input,
+      "Matrix comprehension requires at least one generator (<-) or let (:=) qualifier",
+    )));
+  }
   let (input, _) = space_tab0(input)?;
   let (input, _) = right_bracket(input)?;
   Ok((input, MatrixComprehension{ expression: expr, qualifiers: quals }))

--- a/src/syntax/src/state_machines.rs
+++ b/src/syntax/src/state_machines.rs
@@ -5,12 +5,44 @@ use nom::{
   sequence::tuple as nom_tuple,
 };
 
-fn validate_fsm_value_pattern(ptrn: &Pattern) -> Result<(), &'static str> {
+#[derive(Debug, Clone)]
+struct InvalidFsmValuePatternError {
+  message: String,
+}
+
+impl MechErrorKind for InvalidFsmValuePatternError {
+  fn name(&self) -> &str {
+    "InvalidFsmValuePattern"
+  }
+
+  fn message(&self) -> String {
+    self.message.clone()
+  }
+}
+
+fn invalid_fsm_value_pattern(msg: &str, ptrn: &Pattern) -> MechError {
+  MechError::new(
+    InvalidFsmValuePatternError {
+      message: msg.to_string(),
+    },
+    None,
+  )
+  .with_compiler_loc()
+  .with_tokens(ptrn.tokens())
+}
+
+fn validate_fsm_value_pattern(ptrn: &Pattern) -> MResult<()> {
   match ptrn {
-    Pattern::Wildcard => Err("Wildcard `*` is only valid in pattern-matching positions"),
+    Pattern::Wildcard => Err(invalid_fsm_value_pattern(
+      "Wildcard `*` is only valid in pattern-matching positions",
+      ptrn,
+    )),
     Pattern::Array(arr) => {
       if arr.spread.is_some() {
-        return Err("Array spread/rest syntax (`...` or `|`) is only valid in pattern-matching positions");
+        return Err(invalid_fsm_value_pattern(
+          "Array spread/rest syntax (`...` or `|`) is only valid in pattern-matching positions",
+          ptrn,
+        ));
       }
       for item in arr.prefix.iter().chain(arr.suffix.iter()) {
         validate_fsm_value_pattern(item)?;
@@ -35,8 +67,11 @@ fn validate_fsm_value_pattern(ptrn: &Pattern) -> Result<(), &'static str> {
 
 fn fsm_value(input: ParseString) -> ParseResult<Pattern> {
   let (input, ptrn) = pattern(input)?;
-  if let Err(msg) = validate_fsm_value_pattern(&ptrn) {
-    return Err(nom::Err::Error(ParseError::new(input, msg)));
+  if validate_fsm_value_pattern(&ptrn).is_err() {
+    return Err(nom::Err::Error(ParseError::new(
+      input,
+      "FSM RHS expects value syntax; wildcard and array spread/rest are only allowed in match patterns",
+    )));
   }
   Ok((input, ptrn))
 }

--- a/src/syntax/src/state_machines.rs
+++ b/src/syntax/src/state_machines.rs
@@ -5,6 +5,42 @@ use nom::{
   sequence::tuple as nom_tuple,
 };
 
+fn validate_fsm_value_pattern(ptrn: &Pattern) -> Result<(), &'static str> {
+  match ptrn {
+    Pattern::Wildcard => Err("Wildcard `*` is only valid in pattern-matching positions"),
+    Pattern::Array(arr) => {
+      if arr.spread.is_some() {
+        return Err("Array spread/rest syntax (`...` or `|`) is only valid in pattern-matching positions");
+      }
+      for item in arr.prefix.iter().chain(arr.suffix.iter()) {
+        validate_fsm_value_pattern(item)?;
+      }
+      Ok(())
+    }
+    Pattern::Tuple(tpl) => {
+      for item in tpl.0.iter() {
+        validate_fsm_value_pattern(item)?;
+      }
+      Ok(())
+    }
+    Pattern::TupleStruct(tpl) => {
+      for item in tpl.patterns.iter() {
+        validate_fsm_value_pattern(item)?;
+      }
+      Ok(())
+    }
+    Pattern::Expression(_) => Ok(()),
+  }
+}
+
+fn fsm_value(input: ParseString) -> ParseResult<Pattern> {
+  let (input, ptrn) = pattern(input)?;
+  if let Err(msg) = validate_fsm_value_pattern(&ptrn) {
+    return Err(nom::Err::Error(ParseError::new(input, msg)));
+  }
+  Ok((input, ptrn))
+}
+
 // State Machines
 // ----------------------------------------------------------------------------
 
@@ -24,7 +60,7 @@ pub fn fsm_implementation(input: ParseString) -> ParseResult<FsmImplementation> 
   let (input, input_vars) = separated_list0(list_separator, var)(input)?;
   let (input, _) = right_parenthesis(input)?;
   let (input, _) = transition_operator(input)?;
-  let (input, start) = pattern(input)?;
+  let (input, start) = fsm_value(input)?;
   let (input, _) = whitespace0(input)?;
   let (input, arms) = many1(fsm_arm)(input)?;
   let (input, _) = period(input)?;
@@ -78,14 +114,14 @@ pub fn fsm_transition(input: ParseString) -> ParseResult<FsmArm> {
 // fsm_state_transition := transition_operator, atom ;
 pub fn fsm_state_transition(input: ParseString) -> ParseResult<Transition> {
   let (input, _) = transition_operator(input)?;
-  let (input, ptrn) = pattern(input)?;
+  let (input, ptrn) = fsm_value(input)?;
   Ok((input, Transition::Next(ptrn)))
 }
 
 // fsm_async_transition := async_transition_operator, atom ;
 pub fn fsm_async_transition(input: ParseString) -> ParseResult<Transition> {
   let (input, _) = async_transition_operator(input)?;
-  let (input, ptrn) = pattern(input)?;
+  let (input, ptrn) = fsm_value(input)?;
   Ok((input, Transition::Async(ptrn)))
 }
 
@@ -109,7 +145,7 @@ pub fn fsm_block_transition(input: ParseString) -> ParseResult<Transition> {
 // fsm_output := output_operator, pattern ;
 pub fn fsm_output(input: ParseString) -> ParseResult<Transition> {
   let (input, _) = output_operator(input)?;
-  let ((input, ptrn)) = pattern(input)?;
+  let ((input, ptrn)) = fsm_value(input)?;
   Ok((input, Transition::Output(ptrn)))
 }
 

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -95,7 +95,7 @@ pub fn matrix(input: ParseString) -> ParseResult<Matrix> {
   Ok((input, Matrix{rows}))
 }
 
-// matrix-column := (space | tab)*, expression, ((space | tab)*, ("," | table-separator)?, (space | tab)*) ;
+// matrix-column := (space | tab)*, expression, ((space | tab)*, ","?, (space | tab)*) ;
 pub fn matrix_column(input: ParseString) -> ParseResult<MatrixColumn> {
   let (input, _) = space_tab0(input)?;
   let (input, element) = match expression(input) {
@@ -104,7 +104,7 @@ pub fn matrix_column(input: ParseString) -> ParseResult<MatrixColumn> {
       return Err(err);
     }
   };
-  let (input, _) = nom_tuple((space_tab0,opt(alt((comma,table_separator))), space_tab0))(input)?;
+  let (input, _) = nom_tuple((space_tab0,opt(comma), space_tab0))(input)?;
   Ok((input, MatrixColumn{element}))
 }
 

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -104,7 +104,7 @@ pub fn matrix_column(input: ParseString) -> ParseResult<MatrixColumn> {
       return Err(err);
     }
   };
-  let (input, _) = nom_tuple((space_tab0,opt(comma), space_tab0))(input)?;
+  let (input, _) = nom_tuple((space_tab0,opt(alt((comma, box_vert, box_vert_bold))), space_tab0))(input)?;
   Ok((input, MatrixColumn{element}))
 }
 

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -303,8 +303,8 @@ test_interpreter!(
 test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) => <u64>\n  | [x …] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
 test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x … y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
 test_interpreter!(interpret_fsm_accepts_unsized_vector_input, "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(5)));
-test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a | tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
-test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a | tail], [b | acc], swaps + 1u64)\n    └ *     -> :Pass([b | tail], [a | acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x | acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x | acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
+test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
+test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>
   ├ :Start(arr<[u64]>)
   ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)
@@ -315,12 +315,12 @@ test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(
 #bubble-sort(arr) → :Start(arr)
   :Start(arr) → :Pass(arr, [], 0u64)
   :Pass([a, b | tail], acc, swaps)
-    ├ a > b → :Pass([a | tail], [b | acc], swaps + 1u64)
-    └ *     → :Pass([b | tail], [a | acc], swaps)
-  :Pass([x], acc, swaps) → :Next([x | acc], swaps)
+    ├ a > b → :Pass([a tail], [b acc], swaps + 1u64)
+    └ *     → :Pass([b tail], [a acc], swaps)
+  :Pass([x], acc, swaps) → :Next([x acc], swaps)
   :Pass([], acc, swaps)  → :Next(acc, swaps)
   :Next(arr, swaps) → :Reverse(arr, [], swaps)
-  :Reverse([x | tail], acc, swaps) → :Reverse(tail, [x | acc], swaps)
+  :Reverse([x | tail], acc, swaps) → :Reverse(tail, [x acc], swaps)
   :Reverse([], acc, 0u64)     → :Done(acc)
   :Reverse([], acc, swaps) → :Pass(acc, [], 0u64)
   :Done(arr) ⇒ arr.

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -327,6 +327,70 @@ test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(
 
 x := [5u64 3u64 8u64 1u64]
 y := #bubble-sort(x)", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
+#[test]
+fn interpret_fsm_bubble_sort_rejects_f64_argument_kind() {
+  let s = r#"
+#bubble-sort(arr<[u64]>) => <[u64]>
+  ├ :Start(arr<[u64]>)
+  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)
+  ├ :Next(arr<[u64]>, swaps<u64>)
+  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)
+  └ :Done(arr<[u64]>).
+
+#bubble-sort(arr) -> :Start(arr)
+  :Start(arr) -> :Pass(arr, [], 0u64)
+  :Pass([a, b | tail], acc, swaps)
+    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)
+    └ *     -> :Pass([b tail], [a acc], swaps)
+  :Pass([x], acc, swaps) -> :Next([x acc], swaps)
+  :Pass([], acc, swaps)  -> :Next(acc, swaps)
+  :Next(arr, swaps) -> :Reverse(arr, [], swaps)
+  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)
+  :Reverse([], acc, 0u64)     -> :Done(acc)
+  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)
+  :Done(arr) => arr.
+
+x<[f64]> := [3 5 4 1 2]
+#bubble-sort(x)
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("FsmArgumentKindMismatch"));
+}
+#[test]
+fn interpret_fsm_bubble_sort_rejects_untyped_numeric_matrix_argument_kind() {
+  let s = r#"
+#bubble-sort(arr<[u64]>) => <[u64]>
+  ├ :Start(arr<[u64]>)
+  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)
+  ├ :Next(arr<[u64]>, swaps<u64>)
+  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)
+  └ :Done(arr<[u64]>).
+
+#bubble-sort(arr) -> :Start(arr)
+  :Start(arr) -> :Pass(arr, [], 0u64)
+  :Pass([a, b | tail], acc, swaps)
+    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)
+    └ *     -> :Pass([b tail], [a acc], swaps)
+  :Pass([x], acc, swaps) -> :Next([x acc], swaps)
+  :Pass([], acc, swaps)  -> :Next(acc, swaps)
+  :Next(arr, swaps) -> :Reverse(arr, [], swaps)
+  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)
+  :Reverse([], acc, 0u64)     -> :Done(acc)
+  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)
+  :Done(arr) => arr.
+
+y := [3 5 4 1 2]
+#bubble-sort(y)
+"#;
+  let tree = parser::parse(s).unwrap();
+  let mut intrp = Interpreter::new(0);
+  let err = intrp.interpret(&tree).unwrap_err();
+  let msg = format!("{:?}", err);
+  assert!(msg.contains("FsmArgumentKindMismatch"));
+}
 test_interpreter!(
   interpret_variable_define_typed_set_from_range_matrix,
   "input<{f64}> := 1..=5",

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -62,3 +62,10 @@ fn parser_match_expression_requires_terminating_period() {
     .any(|ctx| ctx.err_message == "Unexpected character");
   assert!(!has_unexpected_char, "missing-period case should avoid generic unexpected-character noise");
 }
+
+#[test]
+fn parser_rejects_pattern_rest_syntax_on_rhs_matrix_construction() {
+  let source = "#demo(xs<[u64]>) => <[u64]>\n  ├ :Pass(xs<[u64]>)\n  └ :Done(out<[u64]>).\n\n#demo(xs) -> :Pass(xs)\n  :Pass([x | tail]) -> :Done([x | tail])\n  :Done(out) => out.\n\n#demo([1u64 2u64])";
+  let result = parse(source);
+  assert!(result.is_err(), "RHS [x | tail] should not parse as matrix construction");
+}


### PR DESCRIPTION
### Motivation
- FSM transition and output RHS positions were incorrectly accepting pattern-only constructs (wildcard, array spread/rest) which should be restricted to LHS pattern matching and not used for value construction.
- Matrix/matrix-comprehension parsing treated `|` and rest-like patterns ambiguously, allowing RHS pattern-rest syntax to be parsed as matrix construction.
- The interpreter reconstructed array-pattern values without flattening matrix-like subvalues, leading to incorrect nested/misaligned matrices for RHS constructions like `[x acc]`.

### Description
- Add `fsm_value` validation in `src/syntax/src/state_machines.rs` to reject wildcard and array spread/rest constructs in FSM RHS positions and use it for start state, state transitions and outputs.
- Require at least one generator (`<-`) or let (`:=`) qualifier in matrix comprehensions in `src/syntax/src/expressions.rs` to avoid ambiguous `[expr | ...]` forms.
- Change matrix column parsing in `src/syntax/src/structures.rs` to stop accepting `|`/table-separator as a general column separator and normalize to optional comma spacing, preventing pattern-rest from being accepted as matrix syntax.
- Update interpreter `pattern_to_value` in `src/interpreter/src/patterns.rs` to flatten matrix-like values when reconstructing arrays so RHS constructions like `[x acc]` concatenate correctly, and update tests to use the corrected RHS forms (`[x acc]`, `[a tail]`).

### Testing
- Ran parser regression test `CARGO_TARGET_DIR=/tmp/mech-target cargo test parser_rejects_pattern_rest_syntax_on_rhs_matrix_construction -- --nocapture` which passed.
- Ran interpreter unit `CARGO_TARGET_DIR=/tmp/mech-target cargo test interpret_fsm_bubble_sort_returns_typed_u64_matrix -- --nocapture` which passed.
- Ran interpreter unit `CARGO_TARGET_DIR=/tmp/mech-target cargo test interpret_fsm_bubble_sort_assigns_matrix_value -- --nocapture` which passed.
- Ran interpreter unit `CARGO_TARGET_DIR=/tmp/mech-target cargo test interpret_fsm_array_spread_reconstruction_keeps_scalar_guards -- --nocapture` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57cf7c7c4832aae153c60d98e3d5d)