### PR TITLE
Improve VS Code Mech syntax highlighting grammar

### DIFF
--- a/src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json
+++ b/src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json
@@ -4,7 +4,7 @@
   "scopeName": "source.mech",
   "patterns": [
     { "include": "#mechdown" },
-    { "include": "#code" }
+    { "include": "#code-lines" }
   ],
   "repository": {
     "mechdown": {
@@ -48,6 +48,20 @@
           "patterns": [
             { "include": "#code" }
           ]
+        },
+        {
+          "include": "#code-lines"
+        }
+      ]
+    },
+    "code-lines": {
+      "patterns": [
+        {
+          "begin": "^(?=\\s*(?:#|[├└│]|\\||:?\\w[\\w\\-*/+^/]*\\s*(?::=|=>|->|\\?)|<\\w+>|\\w[\\w\\-*/+^/]*\\s*\\(|\\*\\s*=>))",
+          "end": "$",
+          "patterns": [
+            { "include": "#code" }
+          ]
         }
       ]
     },
@@ -60,6 +74,9 @@
         { "include": "#booleans-empty" },
         { "include": "#numbers" },
         { "include": "#operators" },
+        { "include": "#functions" },
+        { "include": "#states" },
+        { "include": "#branches" },
         { "include": "#tables" },
         { "include": "#identifiers" }
       ]
@@ -159,8 +176,40 @@
           "name": "keyword.operator.logical.word.mech"
         },
         {
-          "match": "(?::=|\\+=|-=|\\*=|/=|\\^=|==|!=|<=|>=|&&|\\|\\||\\.\\.|\\.\\.=|->|=>|=|[+\\-*/^!<>~])",
+          "match": "(?::=|\\+=|-=|\\*=|/=|\\^=|==|!=|<=|>=|&&|\\|\\||\\.\\.|\\.\\.=|->|=>|\\?|=|[+\\-*/^!<>~])",
           "name": "keyword.operator.mech"
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "match": "(?<![:#])\\b[\\p{L}][\\p{L}\\p{N}\\-*/+^/]*(?=\\s*\\()",
+          "name": "entity.name.function.mech"
+        }
+      ]
+    },
+    "states": {
+      "patterns": [
+        {
+          "match": "#[\\p{L}][\\p{L}\\p{N}\\-*/+^/]*",
+          "name": "entity.name.type.state-machine.mech"
+        }
+      ]
+    },
+    "branches": {
+      "patterns": [
+        {
+          "match": "^\\s*[├└│]\\s*",
+          "name": "punctuation.definition.branch.tree.mech"
+        },
+        {
+          "match": "^\\s*\\|\\s*",
+          "name": "punctuation.definition.branch.match.mech"
+        },
+        {
+          "match": "(?<=\\|\\s)\\*\\b",
+          "name": "variable.language.wildcard.mech"
         }
       ]
     },
@@ -175,7 +224,7 @@
     "identifiers": {
       "patterns": [
         {
-          "match": "\\b~?[\\p{L}\\p{N}][\\p{L}\\p{N}*/+\\-^]*(?:/[\\p{L}\\p{N}*/+\\-^]+)*(?:\\[[^\\]\\n]*\\])?",
+          "match": "(?:(?<=^)|(?<=[\\s\\(\\[,]))~?[\\p{L}][\\p{L}\\p{N}*/+\\-^]*(?:/[\\p{L}\\p{N}*/+\\-^]+)*(?:\\[[^\\]\\n]*\\])?(?=\\s*(?:[:=,\\)\\]\\|]|$))",
           "name": "variable.other.mech"
         }
       ]

--- a/src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json
+++ b/src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json
@@ -1,61 +1,184 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "mech",
-	"patterns": [
-		{
-      		"match": "^=+$",
-      		"name": "markup.heading.underline.mech"
-		},
-		{
-			"match": "^-+$",
-			"name": "markup.heading.underline.mech"
-    	},
-		{
-			"match": "^(\\d+\\. )",
-			"name": "markup.heading.mech"
-		},
-		{
-			"match": "^\\(\\d+(?:\\.\\d+)+\\)",
-			"name": "markup.heading.mech"
-		},
-		{
-			"begin": "\\$\\$",
-			"end": "\\$\\$|\\n",
-			"name": "string"
-		},
-		{
-		    "match": "\\b\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\b",
-  		    "name": "constant.numeric"
-		},
-		{
-			"begin": "^\\s*([^\\s\\+\\-\\*\\/\\^]+(?:\\[[^\\]]*\\])?)\\s*([\\+\\-\\*\\/\\^]=|:=)",
-			"end": "$",
-			"beginCaptures": {
-				"1": {
-				"name": "variable.name"
-				},
-				"2": {
-				"name": "string"
-				}
-			},
-			"patterns": [
-				{
-				"match": "[^\\s\\d\\.\\^\\*\\+\\-\\/\\(\\)]+(?:\\/[\\w\\/]+)*(?:\\[[^\\]]*\\])?",
-				"name": "variable.name"
-				},
-				{
-				"match": "\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?",
-				"name": "constant.numeric"
-				},
-				{
-				"match": "[\\+\\-\\*\\/\\^]",
-				"name": "string"
-				}
-			]
-		}
-	],
-	"repository": {
-		
-	},
-	"scopeName": "source.mech"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "mech",
+  "scopeName": "source.mech",
+  "patterns": [
+    { "include": "#mechdown" },
+    { "include": "#code" }
+  ],
+  "repository": {
+    "mechdown": {
+      "patterns": [
+        {
+          "begin": "^```(?:mech(?::[^\\s`]*)?)?\\s*$",
+          "beginCaptures": {
+            "0": { "name": "markup.fenced_code.block.begin.mech" }
+          },
+          "end": "^```\\s*$",
+          "endCaptures": {
+            "0": { "name": "markup.fenced_code.block.end.mech" }
+          },
+          "name": "markup.fenced_code.block.mech",
+          "patterns": [
+            { "include": "#code" }
+          ]
+        },
+        {
+          "match": "^={3,}\\s*$",
+          "name": "markup.heading.underline.mech"
+        },
+        {
+          "match": "^-{3,}\\s*$",
+          "name": "markup.heading.underline.mech"
+        },
+        {
+          "match": "^\\(?\\d+(?:\\.\\d+)*\\)?(?:\\.[^\\s)]*)?\\s+.*$",
+          "name": "markup.heading.numbered.mech"
+        },
+        {
+          "begin": "\\{\\{",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.inline-code.begin.mech" }
+          },
+          "end": "\\}\\}",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.inline-code.end.mech" }
+          },
+          "name": "markup.inline.raw.mech",
+          "patterns": [
+            { "include": "#code" }
+          ]
+        }
+      ]
+    },
+    "code": {
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#strings" },
+        { "include": "#kinds" },
+        { "include": "#atoms" },
+        { "include": "#booleans-empty" },
+        { "include": "#numbers" },
+        { "include": "#operators" },
+        { "include": "#tables" },
+        { "include": "#identifiers" }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "match": "(?<!:)--.*$",
+          "name": "comment.line.double-dash.mech"
+        },
+        {
+          "match": "//.*$",
+          "name": "comment.line.double-slash.mech"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "name": "string.quoted.triple.mech"
+        },
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.mech",
+          "patterns": [
+            {
+              "match": "\\\\(?:[\\\"nrt0]|u[0-9A-Fa-f]{4})",
+              "name": "constant.character.escape.mech"
+            }
+          ]
+        }
+      ]
+    },
+    "kinds": {
+      "patterns": [
+        {
+          "match": "<[^<>\\n]*(?:<[^<>\\n]*>[^<>\\n]*)*>",
+          "name": "storage.type.kind.mech"
+        }
+      ]
+    },
+    "atoms": {
+      "patterns": [
+        {
+          "match": ":[^\\s\\]\\[\\{\\}\\(\\),;]+(?:/[^\\s\\]\\[\\{\\}\\(\\),;]+)*",
+          "name": "constant.language.atom.mech"
+        }
+      ]
+    },
+    "booleans-empty": {
+      "patterns": [
+        {
+          "match": "\\b(?:true|false)\\b|[✓✗]",
+          "name": "constant.language.boolean.mech"
+        },
+        {
+          "match": "\\b_+\\b",
+          "name": "constant.language.empty.mech"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "match": "\\b0[xX][0-9A-Fa-f]+(?:<[A-Za-z][A-Za-z0-9]*>|[iu](?:8|16|32|64|128))?\\b",
+          "name": "constant.numeric.hex.mech"
+        },
+        {
+          "match": "\\b0[oO][0-7]+(?:<[A-Za-z][A-Za-z0-9]*>|[iu](?:8|16|32|64|128))?\\b",
+          "name": "constant.numeric.octal.mech"
+        },
+        {
+          "match": "\\b0[bB][01]+(?:<[A-Za-z][A-Za-z0-9]*>|[iu](?:8|16|32|64|128))?\\b",
+          "name": "constant.numeric.binary.mech"
+        },
+        {
+          "match": "(?<![\\w.])[-+]?\\d+\\/\\d+(?:<r(?:64|s64)>)?(?![\\w/])",
+          "name": "constant.numeric.rational.mech"
+        },
+        {
+          "match": "(?<![\\w.])[-+]?(?:\\d+\\.\\d*|\\.\\d+|\\d+)(?:[eE][+-]?\\d+)?(?:<[A-Za-z][A-Za-z0-9]*>|(?:[ifuc](?:8|16|32|64|128)))?(?![\\w.])",
+          "name": "constant.numeric.float.mech"
+        },
+        {
+          "match": "(?<![\\w.])[-+]?(?:\\d+\\.\\d*|\\.\\d+|\\d+)(?:[eE][+-]?\\d+)?[ij](?![\\w.])",
+          "name": "constant.numeric.complex.mech"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "\\b(?:and|or|not)\\b",
+          "name": "keyword.operator.logical.word.mech"
+        },
+        {
+          "match": "(?::=|\\+=|-=|\\*=|/=|\\^=|==|!=|<=|>=|&&|\\|\\||\\.\\.|\\.\\.=|->|=>|=|[+\\-*/^!<>~])",
+          "name": "keyword.operator.mech"
+        }
+      ]
+    },
+    "tables": {
+      "patterns": [
+        {
+          "match": "^\\s*\\|.*\\|\\s*$",
+          "name": "meta.structure.table.mech"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "match": "\\b~?[\\p{L}\\p{N}][\\p{L}\\p{N}*/+\\-^]*(?:/[\\p{L}\\p{N}*/+\\-^]+)*(?:\\[[^\\]\\n]*\\])?",
+          "name": "variable.other.mech"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
- Align the VS Code TextMate grammar with the language constructs and examples shown in `docs/guides/mech-in-fifteen-minutes.mec` so Mech and Mechdown documents highlight more accurately. 
- Give Mechdown scaffolding and Mech code tokens clear precedence and modularity to make future edits easier and reduce accidental mis-highlighting.

### Description
- Rewrote `src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json` from a handful of flat patterns to a structured repository with top-level `mechdown` and `code` sections and a `scopeName` of `source.mech`.
- Added Mechdown patterns for fenced Mech code blocks, heading underlines, numbered headings, and inline `{{ ... }}` spans that include the `#code` grammar inside them.
- Implemented dedicated `code` sub-grammars for `comments` (both `--` and `//`), `strings` (triple-quoted raw and quoted with escapes), `kinds` (`<...>`), `atoms` (`:name` / namespaced paths), `booleans-empty` (`true|false|✓|✗` and `_`), `numbers` (hex/octal/binary/rational/float/complex with optional suffixes), `operators` (word and symbol forms), `tables` (table-row lines starting/ending with `|`), and `identifiers` (Unicode-aware identifier regex with allowed punctuation and optional indexing).

### Testing
- Ran `jq . src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json` to validate JSON structure, which succeeded.
- Ran `npm run -s compile` in the extension directory, which failed in this environment due to missing VS Code/Node type dependencies (errors for modules like `vscode`, `path`, and `vscode-languageclient/node`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58f49ad10832aab942bea7c10b910)