### PR TITLE
Revamp VS Code TextMate grammar for markdown-focused highlighting

### DIFF
--- a/src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json
+++ b/src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json
@@ -1,61 +1,170 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "mech",
+	"scopeName": "source.mech",
 	"patterns": [
 		{
-      		"match": "^=+$",
-      		"name": "markup.heading.underline.mech"
+			"include": "#heading-setext"
 		},
 		{
-			"match": "^-+$",
-			"name": "markup.heading.underline.mech"
-    	},
-		{
-			"match": "^(\\d+\\. )",
-			"name": "markup.heading.mech"
+			"include": "#heading-atx"
 		},
 		{
-			"match": "^\\(\\d+(?:\\.\\d+)+\\)",
-			"name": "markup.heading.mech"
+			"include": "#fenced-code-block"
 		},
 		{
-			"begin": "\\$\\$",
-			"end": "\\$\\$|\\n",
-			"name": "string"
+			"include": "#blockquote"
 		},
 		{
-		    "match": "\\b\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?\\b",
-  		    "name": "constant.numeric"
+			"include": "#list"
 		},
 		{
-			"begin": "^\\s*([^\\s\\+\\-\\*\\/\\^]+(?:\\[[^\\]]*\\])?)\\s*([\\+\\-\\*\\/\\^]=|:=)",
-			"end": "$",
-			"beginCaptures": {
-				"1": {
-				"name": "variable.name"
-				},
-				"2": {
-				"name": "string"
-				}
-			},
-			"patterns": [
-				{
-				"match": "[^\\s\\d\\.\\^\\*\\+\\-\\/\\(\\)]+(?:\\/[\\w\\/]+)*(?:\\[[^\\]]*\\])?",
-				"name": "variable.name"
-				},
-				{
-				"match": "\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?",
-				"name": "constant.numeric"
-				},
-				{
-				"match": "[\\+\\-\\*\\/\\^]",
-				"name": "string"
-				}
-			]
+			"include": "#thematic-break"
+		},
+		{
+			"include": "#image"
+		},
+		{
+			"include": "#link"
+		},
+		{
+			"include": "#inline-code"
+		},
+		{
+			"include": "#bold"
+		},
+		{
+			"include": "#italic"
 		}
 	],
 	"repository": {
-		
-	},
-	"scopeName": "source.mech"
+		"heading-atx": {
+			"patterns": [
+				{
+					"match": "^(#{1,6})\\s+(.+?)\\s*(?:#+\\s*)?$",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.heading.markdown"
+						},
+						"2": {
+							"name": "markup.heading.markdown"
+						}
+					}
+				}
+			]
+		},
+		"heading-setext": {
+			"patterns": [
+				{
+					"match": "^.+\\n=+\\s*$",
+					"name": "markup.heading.1.markdown"
+				},
+				{
+					"match": "^.+\\n-+\\s*$",
+					"name": "markup.heading.2.markdown"
+				}
+			]
+		},
+		"fenced-code-block": {
+			"patterns": [
+				{
+					"begin": "^(```|~~~)\\s*([a-zA-Z0-9_+-]*)\\s*$",
+					"end": "^(\\1)\\s*$",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.fenced.markdown"
+						},
+						"2": {
+							"name": "fenced_code.block.language.markdown"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.fenced.markdown"
+						}
+					},
+					"name": "markup.fenced_code.block.markdown"
+				}
+			]
+		},
+		"blockquote": {
+			"patterns": [
+				{
+					"match": "^\\s*>\\s?.*$",
+					"name": "markup.quote.markdown"
+				}
+			]
+		},
+		"list": {
+			"patterns": [
+				{
+					"match": "^\\s*(?:[-+*]|\\d+\\.)\\s+",
+					"name": "markup.list.markdown"
+				}
+			]
+		},
+		"thematic-break": {
+			"patterns": [
+				{
+					"match": "^\\s*(?:[-*_]\\s*){3,}$",
+					"name": "meta.separator.markdown"
+				}
+			]
+		},
+		"inline-code": {
+			"patterns": [
+				{
+					"match": "`[^`\\n]+`",
+					"name": "markup.inline.raw.string.markdown"
+				}
+			]
+		},
+		"bold": {
+			"patterns": [
+				{
+					"match": "(\\*\\*|__)(?=\\S)(.+?)(?<=\\S)\\1",
+					"name": "markup.bold.markdown"
+				}
+			]
+		},
+		"italic": {
+			"patterns": [
+				{
+					"match": "(\\*|_)(?=\\S)(.+?)(?<=\\S)\\1",
+					"name": "markup.italic.markdown"
+				}
+			]
+		},
+		"link": {
+			"patterns": [
+				{
+					"match": "\\[([^\\]]+)\\]\\(([^)\\s]+)(?:\\s+\\\"[^\\\"]*\\\")?\\)",
+					"captures": {
+						"1": {
+							"name": "string.other.link.title.markdown"
+						},
+						"2": {
+							"name": "markup.underline.link.markdown"
+						}
+					}
+				}
+			]
+		},
+		"image": {
+			"patterns": [
+				{
+					"match": "!\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\\\"[^\\\"]*\\\")?\\)",
+					"captures": {
+						"1": {
+							"name": "string.other.link.description.markdown"
+						},
+						"2": {
+							"name": "markup.underline.link.image.markdown"
+						}
+					},
+					"name": "meta.image.inline.markdown"
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
### Motivation
- Make the VS Code TextMate grammar prioritize Markdown/Mechdown authoring so documentation and markdown files get accurate heading and inline formatting highlighting.
- Defer Mech language-specific syntax highlighting for a future pass and keep the grammar focused on commonly used Markdown constructs instead.

### Description
- Replaced mech-specific patterns with a markdown-first grammar in `src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json`, adding repository entries and includes for ATX and Setext headings, fenced code blocks, blockquotes, lists, thematic breaks, links, images, inline code, bold, and italic text.
- Retained the grammar identity as `"name": "mech"` and `"scopeName": "source.mech"` while switching token names to standard markdown scopes such as `markup.heading.markdown` and `markup.fenced_code.block.markdown`.
- Removed previous numeric/variable/mech-expression focused rules to avoid conflicting markdown highlighting.

### Testing
- Validated the updated JSON grammar with `jq empty src/syntax/editor-modes/vscode/syntaxes/mech.tmLanguage.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d1df338832a978389e7a82dd958)