### PR TITLE
Reduce call-path allocations and change call APIs to slices; add performance review docs and tests

### DIFF
--- a/docs/user-function-performance-review.md
+++ b/docs/user-function-performance-review.md
@@ -1,0 +1,148 @@
+# User-Defined Function Call Performance Review
+
+## Scope
+
+This review focuses on runtime behavior for user-defined function invocation and pattern-based dispatch in the interpreter, centered on:
+
+- `src/interpreter/src/functions.rs`
+- `src/interpreter/src/patterns.rs`
+- `src/interpreter/src/expressions.rs` (function-call entrypoint)
+
+## Current call architecture (high level)
+
+1. `expression(...)` delegates `Expression::FunctionCall` nodes to `function_call(...)`.
+2. `function_call(...)` resolves user-defined functions by hashed name, evaluates call arguments, then executes the interpreted function body.
+3. `execute_user_function(...)` performs argument count checks, optional matrix broadcasting, then executes either:
+   - match-arm dispatch (`execute_function_match_arms(...)`) with a tail-call loop, or
+   - sequential statement execution with output collection.
+4. A `FunctionScope` swaps in a fresh symbol table and plan per invocation and restores caller state on drop.
+
+This design is clean and semantically robust, but several hotspots can generate significant allocation and cloning overhead in hot call paths.
+
+## Performance-impacting implementation details
+
+### 1) Repeated argument evaluation/collection per call path
+
+`function_call(...)` materializes `Vec<Value>` for user functions and again for native compiler paths. In high-frequency calls, this creates repeated allocation pressure and temporary `Value` cloning.
+
+**Impact:** high allocation churn in dispatch-heavy workloads.
+
+### 2) Full function-local state swap on every invocation
+
+`FunctionScope::enter(...)` replaces symbol table + plan and restores both on drop for each call. This guarantees isolation, but creates frequent container replacement/copy activity even for tiny pure functions.
+
+**Impact:** call overhead grows with call count, reducing throughput for fine-grained functions.
+
+### 3) Recursive value detaching/cloning is pervasive
+
+`detach_value(...)` and `deep_detach_value(...)` recursively clone values. They are used in argument binding, pattern matching, output collection, and enum checks.
+
+**Impact:** expensive deep copies for nested tuples/matrices/enum payloads; amplifies with pattern-heavy code.
+
+### 4) Match-arm dispatch is linear with repeated work
+
+`execute_function_match_arms(...)` scans arms in source order and invokes `pattern_matches_arguments(...)` for each. For enum inputs, exhaustiveness bookkeeping can traverse all variants. No indexing/cache exists for frequent shape/kind patterns.
+
+**Impact:** O(number_of_arms) dispatch with repeated pattern evaluation per call.
+
+### 5) Pattern matching allocates intermediate vectors for matrix-like values
+
+`matrix_like_values(...)` converts matrix forms into owned `Vec<Value>`, and array-pattern capture slices into newly allocated matrices (`capture_middle_matrix(...)`).
+
+**Impact:** heavy heap traffic for large matrix patterns, even when only partial inspection is needed.
+
+### 6) Broadcasting path recursively re-enters full user-function execution per element
+
+`try_broadcast_user_function(...)` applies `execute_user_function(...)` per matrix element and then rebuilds output matrix.
+
+**Impact:** multiplies full call overhead by element count; poor scaling on large matrices.
+
+### 7) Type coercion path repeatedly invokes conversion logic
+
+`bind_function_inputs(...)` and output coercion call `convert_to(...)` frequently, often after cloning/detaching.
+
+**Impact:** repeated dynamic conversion checks in inner loops.
+
+## Optimization plan
+
+## Phase 0 — Baseline instrumentation (before behavior changes)
+
+1. Add lightweight counters/timers around:
+   - function dispatch time,
+   - pattern-arm matching time,
+   - detach/clone counts,
+   - conversion attempts and success rate,
+   - per-call allocations (sampled via allocator metrics if available).
+2. Build benchmark corpus:
+   - recursion-heavy scalar functions,
+   - match-arm-heavy enum dispatch,
+   - matrix broadcasting functions,
+   - mixed polymorphic conversions.
+3. Record p50/p95 latency and throughput baselines.
+
+**Goal:** prevent regressions and identify dominant hotspots by workload.
+
+## Phase 1 — Low-risk allocation reductions
+
+1. Replace `&Vec<Value>` parameters with slices (`&[Value]`) where mutation/ownership is not required.
+2. Reuse temporary argument buffers in dispatch paths (small-vector strategy where applicable).
+3. Avoid repeated hash-map borrow/check patterns by consolidating lookups in `function_call(...)`.
+4. Remove duplicated detach/conversion when value kind already matches target kind.
+
+**Expected outcome:** immediate CPU and allocation improvements without semantic changes.
+
+## Phase 2 — Dispatch/path specialization
+
+1. Introduce optional fast path for small pure functions (single expression body, no local plan mutation).
+2. Add arm dispatch index for common discriminants:
+   - enum variant id → candidate arm list,
+   - tuple arity / primitive kind quick filters.
+3. Keep fallback to full linear pattern matcher for complex patterns.
+
+**Expected outcome:** major speedup for common match-arm workloads.
+
+## Phase 3 — Reference-aware pattern matching
+
+1. Introduce borrowed matching APIs to avoid deep cloning in `pattern_matches_*`.
+2. Only detach/clone when binding captured variables or when mutation safety requires ownership.
+3. Refactor matrix-array patterns to operate on slices/views where possible.
+
+**Expected outcome:** significantly lower memory traffic for pattern-heavy and matrix-heavy calls.
+
+## Phase 4 — Broadcasting execution model improvements
+
+1. Compile-and-cache a specialized element kernel for eligible broadcastable user functions.
+2. Execute element kernel over matrix storage directly (typed loops), avoiding per-element full call setup.
+3. Preserve semantic equivalence and fallback to current path when specialization preconditions fail.
+
+**Expected outcome:** order-of-magnitude improvements for large broadcasted calls.
+
+## Phase 5 — Conversion and kind-check optimization
+
+1. Cache resolved input/output `ValueKind` per function definition.
+2. Precompute conversion strategy per parameter (identity, widening, enum-check, etc.).
+3. Skip dynamic conversion dispatch when strategy is identity.
+
+**Expected outcome:** lower overhead in strongly-typed, repeatedly-called functions.
+
+## Risk management and correctness gates
+
+- Add invariant tests for:
+  - scope isolation,
+  - recursive/tail-call semantics,
+  - enum exhaustiveness errors,
+  - pattern-binding behavior,
+  - conversion error reporting.
+- Keep feature-flagged rollout for major execution-path changes (dispatch index, broadcast kernel).
+- Compare trace output equivalence in debug mode before/after each phase.
+
+## Suggested execution order
+
+1. Phase 0 (measure)
+2. Phase 1 (cheap wins)
+3. Phase 5 (cheap typed-call wins)
+4. Phase 2 (dispatch index)
+5. Phase 3 (borrowed matcher)
+6. Phase 4 (broadcast specialization)
+
+This sequence gives early gains with minimal risk, then moves toward deeper architectural speedups.

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -93,11 +93,8 @@ pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Int
 
   // User-defined function: evaluate arguments then run the interpreted body.
   if let Some(user_fxn) = { functions.borrow().user_functions.get(&fxn_name_id).cloned() } {
-    let mut input_arg_values = vec![];
-    for (_, arg_expr) in fxn_call.args.iter() {
-      input_arg_values.push(expression(arg_expr, env, p)?);
-    }
-    return execute_user_function(&user_fxn, &input_arg_values, p);
+    let input_arg_values = evaluate_call_arguments(fxn_call, env, p)?;
+    return execute_user_function(&user_fxn, input_arg_values.as_slice(), p);
   }
 
   // Pre-compiled built-in functions.
@@ -116,10 +113,7 @@ pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Int
   };
   match fxn_compiler {
     Some(fxn_compiler) => {
-      let mut input_arg_values = vec![];
-      for (_, arg_expr) in fxn_call.args.iter() {
-        input_arg_values.push(expression(arg_expr, env, p)?);
-      }
+      let input_arg_values = evaluate_call_arguments(fxn_call, env, p)?;
       trace_println!(
         p,
         "{}",
@@ -144,6 +138,18 @@ pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Int
     .with_compiler_loc()
     .with_tokens(fxn_call.name.tokens())),
   }
+}
+
+fn evaluate_call_arguments(
+  fxn_call: &FunctionCall,
+  env: Option<&Environment>,
+  p: &Interpreter,
+) -> MResult<Vec<Value>> {
+  let mut input_arg_values = Vec::with_capacity(fxn_call.args.len());
+  for (_, arg_expr) in fxn_call.args.iter() {
+    input_arg_values.push(expression(arg_expr, env, p)?);
+  }
+  Ok(input_arg_values)
 }
 
 // Asks a native function compiler to select the right concrete implementation
@@ -193,7 +199,7 @@ pub fn execute_native_function_compiler(
 // Logs entry/exit (or failure) via the trace machinery.
 fn execute_user_function(
   fxn_def: &FunctionDefinition,
-  input_arg_values: &Vec<Value>,
+  input_arg_values: &[Value],
   p: &Interpreter,
 ) -> MResult<Value> {
   // Reject calls with the wrong number of arguments before doing anything else.
@@ -234,11 +240,11 @@ fn execute_user_function(
     // Match-arm body: loop to support tail-call optimisation. Each iteration
     // opens a fresh scope, binds the current arguments, runs the arms, then
     // either returns the result or loops with a new argument set.
-    let mut current_args: Vec<Value> = input_arg_values.clone();
+    let mut current_args: Vec<Value> = input_arg_values.to_vec();
     loop {
       let scope = FunctionScope::enter(p);
-      bind_function_inputs(fxn_def, &current_args, p)?;
-      let step: FunctionCallStep = execute_function_match_arms(fxn_def, &current_args, p)?;
+      bind_function_inputs(fxn_def, current_args.as_slice(), p)?;
+      let step: FunctionCallStep = execute_function_match_arms(fxn_def, current_args.as_slice(), p)?;
       drop(scope);
       match step {
         FunctionCallStep::Return(value) => break Ok(value),
@@ -299,7 +305,7 @@ enum FunctionCallStep {
 #[cfg(feature = "matrix")]
 fn try_broadcast_user_function(
   fxn_def: &FunctionDefinition,
-  input_arg_values: &Vec<Value>,
+  input_arg_values: &[Value],
   p: &Interpreter,
 ) -> MResult<Option<Value>> {
   if input_arg_values.len() != 1
@@ -343,7 +349,7 @@ fn try_broadcast_user_function(
   // Apply the function element-wise, then reassemble into the original shape.
   let mut outputs = Vec::with_capacity(elements.len());
   for element in elements {
-    outputs.push(execute_user_function(fxn_def, &vec![element], p)?);
+    outputs.push(execute_user_function(fxn_def, std::slice::from_ref(&element), p)?);
   }
 
   let shape = source.shape();
@@ -391,7 +397,7 @@ fn build_typed_matrix_from_values(
 // Returns an error if no arm matched.
 fn execute_function_match_arms(
   fxn_def: &FunctionDefinition,
-  input_arg_values: &Vec<Value>,
+  input_arg_values: &[Value],
   p: &Interpreter,
 ) -> MResult<FunctionCallStep> {
 
@@ -609,7 +615,7 @@ impl Drop for FunctionScope {
 // special handling for enum types where coercion rules differ.
 fn bind_function_inputs(
   fxn_def: &FunctionDefinition,
-  input_arg_values: &Vec<Value>,
+  input_arg_values: &[Value],
   p: &Interpreter,
 ) -> MResult<()> {
   let scoped_state = p.state.borrow();
@@ -925,5 +931,32 @@ impl MechErrorKind for FunctionInputTypeMismatchError {
       "Function '{}' argument '{}' expected {}, found {}",
       self.function_name, self.argument_name, self.expected, self.found
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn detach_value_unwraps_nested_mutable_references() {
+    let base = Value::Empty;
+    let wrapped_once = Value::MutableReference(Ref::new(base.clone()));
+    let wrapped_twice = Value::MutableReference(Ref::new(wrapped_once));
+
+    let detached = detach_value(&wrapped_twice);
+    assert_eq!(detached, base);
+  }
+
+  #[test]
+  fn pattern_matches_arguments_accepts_single_argument_slice() {
+    let mut env = Environment::new();
+    let interp = Interpreter::new(1);
+    let pat = Pattern::Wildcard;
+    let args = vec![Value::Empty];
+
+    let matched = crate::patterns::pattern_matches_arguments(&pat, args.as_slice(), &mut env, &interp)
+      .expect("pattern matching should succeed");
+    assert!(matched);
   }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -20,7 +20,7 @@ pub enum PatternMatchSemantics {
 // Entry point for multi-argument dispatch. When a function is called with 
 // multiple arguments, this wraps them as if they were a tuple and delegates 
 // to pattern_matches_value.
-pub fn pattern_matches_arguments(pattern: &Pattern, args: &Vec<Value>, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
+pub fn pattern_matches_arguments(pattern: &Pattern, args: &[Value], env: &mut Environment, p: &Interpreter) -> MResult<bool> {
   if args.len() == 1 {
     return pattern_matches_value(pattern, &args[0], env, p);
   }


### PR DESCRIPTION
### Motivation

- Reduce allocation and cloning overhead on hot user-function call paths by avoiding unnecessary `Vec` materialization and enabling borrowing-based APIs.
- Prepare code for further performance work (broadcasting, match-arm dispatch, and pattern matching) by simplifying argument evaluation and introducing a performance review document.

### Description

- Extracted argument evaluation into `evaluate_call_arguments` and replaced duplicated argument-evaluation code with calls to it (`src/interpreter/src/functions.rs`).
- Replaced `&Vec<Value>` parameters with slice-based `&[Value]` in multiple internal functions, including `function_call`, `execute_user_function`, `execute_function_match_arms`, `try_broadcast_user_function`, and `bind_function_inputs`, and changed call sites to pass slices or use `to_vec`/`std::slice::from_ref` where appropriate.
- Updated broadcasting loop to call `execute_user_function` with a slice (`std::slice::from_ref`) instead of allocating a temporary `Vec` per element, and replaced one `.clone()` with `.to_vec()` for clarity when creating `current_args`.
- Changed `pattern_matches_arguments` in `src/interpreter/src/patterns.rs` to accept a slice (`&[Value]`) rather than `&Vec<Value]` to avoid unnecessary borrowing constraints.
- Added a new design/performance document `docs/user-function-performance-review.md` describing hotspots and a phased optimization plan. 
- Added unit tests exercising `detach_value` unwrapping of nested mutable references and that `pattern_matches_arguments` accepts a single-argument slice (`src/interpreter/src/functions.rs` test module).

### Testing

- Ran `cargo test` which executed the interpreter unit tests including the two new tests and the suite completed successfully.
- The new unit tests `detach_value_unwraps_nested_mutable_references` and `pattern_matches_arguments_accepts_single_argument_slice` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81cbbea24832aacccc3d32dd9453b)