### PR TITLE
Fix `ans` lifecycle for inline evaluator links

### DIFF
--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -76,6 +76,21 @@ impl Interpreter {
   pub fn new(id: u64) -> Self {
     let mut state = ProgramState::new();
     load_stdkinds(&mut state.kinds);
+    #[cfg(feature = "symbol_table")]
+    {
+      let ans_id = hash_str("ans");
+      state
+        .symbol_table
+        .borrow_mut()
+        .insert(ans_id, Value::Empty, false);
+      state
+        .symbol_table
+        .borrow_mut()
+        .dictionary
+        .borrow_mut()
+        .insert(ans_id, "ans".to_string());
+      state.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
+    }
     #[cfg(feature = "functions")]
     load_stdlib(&mut state.functions.borrow_mut());
     Self {

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -1011,7 +1011,6 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         });
 
         if let Some(output_value) = output {
-          let repl_text = output_value.format_value_inline();
           let kind_str = html_escape(&format!("{}", output_value.kind()));
           let result_html = format!(
             "<div class=\"mech-output-kind\">{}</div><div class=\"mech-output-value\">{}</div>",
@@ -1023,7 +1022,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
           prompt_line.set_class_name("repl-line");
           let input_span = document.create_element("span").unwrap();
           input_span.set_class_name("repl-code");
-          input_span.set_inner_html(&repl_text);
+          input_span.set_inner_html("ans");
           prompt_line.append_child(&input_span).unwrap();
           if let Some(last_child) = last_child.clone() {
             mech_output.insert_before(&prompt_line, Some(&last_child)).unwrap();
@@ -1044,7 +1043,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
             if let Some(ptr) = *mech_ref.borrow() {
               unsafe {
                 (*ptr).bind_ans_symbol_for_interpreter(interpreter_id, &output_value);
-                (*ptr).repl_history.push(repl_text.clone());
+                (*ptr).repl_history.push("ans".to_string());
               }
             }
           });


### PR DESCRIPTION
### Motivation

- The `ans` variable must exist as soon as an interpreter/document loads so inline evaluator links can target and rebind a known symbol. 
- Clicking inline evaluator values should push a prompt that is named `ans` and should replace the prior `ans` binding rather than inserting a prompt with the raw formatted value. 
- The existing machinery to rebind `ans` on click should be preserved while fixing the lifecycle so `ans` is present immediately.

### Description

- Initialize `ans` during interpreter creation by inserting an `ans` entry into the symbol table and dictionary when the `symbol_table` feature is enabled, implemented in `Interpreter::new` (`src/interpreter/src/interpreter.rs`).
- Update the wasm UI click handler used for inline evaluator output so the REPL prompt text is the literal `ans` and REPL history records `ans`, while still calling `bind_ans_symbol_for_interpreter` to bind the clicked value to the `ans` symbol, implemented in `attach_repl` (`src/wasm/src/lib.rs`).
- Remove usage of the inline formatted value as the prompt text so clicks consistently present `ans` and rely on `bind_ans_symbol_for_interpreter` to update the actual symbol value.

### Testing

- Ran `cargo check -p mech-interpreter -p mech-wasm` and it completed successfully. 
- Ran `cargo test -p mech-interpreter --lib --quiet` which completed successfully (no library tests were present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83efff04c832a9dc39efccac5f0b2)