### PR TITLE
docs(spec): add Mika (micro/mini-mika) syntax and examples

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -2146,7 +2146,181 @@ This renders as:
 The result of 6 times 7 is {6 * 7}.
 The syntax for defining a variable in Mech is {{var-name := value}}.
 
-11. Notation
+(11) Mika
+-------------------------------------------------------------------------------
+
+Mika is a first-class syntactic construct in Mech. The syntax parser supports both compact body forms (*MicroMika* / `micromika`) and parenthesized facial-expression forms (*MiniMika* / `minimika`), plus optional speech-bubble sections.
+
+(11.1) Grammar
+
+```ebnf
+mika := (mini-mika | micro-mika), ws0, ?mika-section, ws0 ;
+
+micro-mika := mika-arm-left, mika-nose, mika-arm-right ;
+mini-mika := ?mika-arm-left
+           , "("
+           , ?mika-arm-right
+           , mika-expression-inner
+           , ?mika-arm-left
+           , ")"
+           , ?mika-arm-right ;
+
+mika-section := "⸢", +section-element, "⸥" ;
+```
+
+The parser attempts `mini-mika` first, then `micro-mika`, and finally an optional `mika-section`.
+
+(11.2) MicroMika
+
+MicroMika is the compact 3-part form:
+
+```ebnf
+micro-mika := mika-arm-left, mika-nose, mika-arm-right ;
+```
+
+(11.2.1) Arm terminals
+
+```ebnf
+mika-arm-left := "Ɔ∞" | "›─" | "›⌣" | "·¬" | "-◡" | "ᗑ" | "ᕦ" | "~" | "⌣"
+               | "╭" | "⸌" | "⸸" | "─" | "ᓂ" | "ᓇ" | "╰" ;
+
+mika-arm-right := "∞C" | "─‹" | "⌣‹" | "⌐·" | "◡-" | "ᗑ" | "ᕤ" | "~" | "⌣"
+                | "╮" | "⸍" | "ᗢ" | "─" | "ᓀ" | "ᓄ" | "╯" ;
+```
+
+(11.2.2) Nose terminals
+
+```ebnf
+mika-nose := "⦿" | "◯" | "⊕" | "∘" | "⦾" | "⊖" | "⦵"
+           | "⊗" | "⏺" | "⍜" | "⬢" | "⬟" | "⬣" | "⎔" ;
+```
+
+(11.2.3) Named MicroMika forms
+
+The platform includes the following canonical MicroMika forms:
+
+- `ᗑ⦿ᗑ` (Bat)
+- `›⌣⦿⌣‹` (BigHug)
+- `⸌⦿⸍` (Cheer)
+- `~⦿~` (Dance)
+- `╰⦿╯` (Goal)
+- `›─⦿╮` (GripperLeft)
+- `╭⦿─‹` (GripperRight)
+- `⌣⦿╮` (GestureLeft)
+- `╭⦿⌣` (GestureRight)
+- `╭⦿╮` (Idle)
+- `⸸⦿ᗢ` (Knight)
+- `·¬⦿⌐·` (Matrix)
+- `⸸⦿ᗑ` (OneWing)
+- `─⦿╮` (PointLeft)
+- `╭⦿─` (PointRight)
+- `ᓂ⦿ᓄ` (Punch)
+- `·¬⦿╮` (ShootLeft)
+- `╭⦿⌐·` (ShootRight)
+- `-◡⦿◡-` (Shrug)
+- `-◡⦿╮` (ServeLeft)
+- `╭⦿◡-` (ServeRight)
+- `╰⦿╮` (WaveLeft)
+- `╭⦿╯` (WaveRight)
+
+(11.3) MiniMika
+
+MiniMika is the expression form using eyes + nose:
+
+```ebnf
+mini-mika := ?mika-arm-left
+           , "("
+           , ?mika-arm-right
+           , mika-expression-inner
+           , ?mika-arm-left
+           , ")"
+           , ?mika-arm-right ;
+
+mika-expression-inner := mika-eye-left, mika-nose, mika-eye-right ;
+```
+
+(11.3.1) Eye terminals
+
+```ebnf
+mika-eye-left := "⌐▰" | "ˆ" | "ಠ" | "╥" | "⋇" | "✖" | "≻" | "ᗒ" | "ㆆ" | "◜"
+               | "˙" | "⚆" | "☉" | "◠" | "◡̀" | "◕" | "◞" | "Ͼ" | "⹇" | "ᗣ"
+               | "≖" | "°" | "ᗩ" | "¬" | "◉" ;
+
+mika-eye-right := "ˆ" | "ಠ" | "╥" | "⋇" | "✖" | "≺" | "ᗕ" | "ㆆ" | "◝" | "˙"
+                | "⚆" | "☉" | "◠" | "◡́" | "◕" | "◟" | "Ͽ" | "▰" | "⹇" | "ᗣ"
+                | "≖" | "°" | "ᗩ" | "¬" | "◉" ;
+```
+
+(11.3.2) Canonical MiniMika expressions
+
+The syntax layer recognizes canonical eye/nose/right-eye combinations (e.g. `(˙◯˙)`, `(ㆆ⍜ㆆ)`, `(⌐▰◯▰)`), represented internally as expression variants such as `Normal`, `Glaring`, `Shades`, `Resolved`, `Sleeping`, etc.
+
+(11.3.3) Named MiniMika forms
+
+Canonical MiniMika expressions include:
+
+- `(ˆ◯ˆ)` (Content)
+- `(ಠ◯ಠ)` (Confused)
+- `(╥◯╥)` (Crying)
+- `(⋇◯⋇)` (Dazed)
+- `(✖◯✖)` (Dead)
+- `(≻◯≺)` (EyesSqueezed)
+- `(ᗒ◯ᗕ)` (SuperSqueezed)
+- `(ㆆ⍜ㆆ)` (Glaring)
+- `(◜◯◝)` (Happy)
+- `(˙◯˙)` (Normal)
+- `(⚆◯⚆)` (PeerRight)
+- `(☉◯☉)` (PeerStraight)
+- `(◠◯◠)` (Pleased)
+- `(◡̀◯◡́)` (Resolved)
+- `(◕◯◕)` (RollingEyes)
+- `(◞◯◟)` (Sad)
+- `(Ͼ◯Ͽ)` (Scared)
+- `(⌐▰◯▰)` (Shades)
+- `(⹇◯⹇)` (Sleeping)
+- `(ᗣ◯ᗣ)` (Smiling)
+- `(≖◯≖)` (Squinting)
+- `(°◯°)` (Surprised)
+- `(ᗩ◯ᗩ)` (TearingUp)
+- `(¬◯¬)` (Unimpressed)
+- `(◉◯◉)` (Wired)
+
+Additional legacy/design forms used in documentation examples include:
+
+- `(❛◯❛)` (Scowl-style variant)
+- `(-◯-)` (sleeping-style variant)
+
+(11.4) Mika sections (speech bubbles / blocks)
+
+Mika can attach an inline block payload:
+
+```ebnf
+mika-section := "⸢", +section-element, "⸥" ;
+```
+
+`mika-section` is parsed as part of `mika` and supports normal section elements inside the delimiters, enabling rich speech-bubble content.
+
+(11.5) Examples
+
+```
+╭⦿╯
+╭⦿╯ ⸢Hello, I'm Mika!⸥
+(˙◯˙)
+ᕦ(◡̀◯◡́)ᕤ
+```
+
+(11.6) Common animation form sequences
+
+In practice, Mika animations are written as frame sequences over MicroMika or MiniMika forms. Common documented sequences include:
+
+```ebnf
+sleep-sequence := "╭⦿╮", "->", "╭⦾╮", "->", "╭⊚╮", "->", "╭⊙╮", "->", "╭◯╮" ;
+wake-sequence := "╭◯╮", "->", "╭⊙╮", "->", "╭⊚╮", "->", "╭⦾╮", "->", "╭⦿╮" ;
+blink-sequence := "╭⦿╮", "->", "╭⊖╮", "->", "╭⦿╮" ;
+pulse-sequence := "╭⦿╮", "->", "╭⦾╮", "->", "╭⊚╮", "->", "╭⊙╮", "->", "╭⊚╮", "->", "╭⦾╮", "->", "╭⦿╮" ;
+```
+
+12. Notation
 -------------------------------------------------------------------------------
 
 The grammar is specified using extended Extended Backus-Naur Form (EBNF):


### PR DESCRIPTION
### Motivation
- Introduce and document a first-class syntactic construct called Mika to the language specification so authors can use compact (MicroMika) and parenthesized (MiniMika) facial-expression forms and attach speech-bubble sections.

### Description
- Add a new section `(11) Mika` to `docs/design/specification.mec` that defines grammar rules for `mika`, `micro-mika`, `mini-mika`, and `mika-section` using EBNF. 
- Define terminal sets and named canonical forms for MicroMika arms and noses and for MiniMika eyes, and enumerate a set of canonical and named examples. 
- Provide parsing rules, examples, and common animation/sequence patterns (sleep, wake, blink, pulse) for writing Mika frame sequences. 
- Renumber the subsequent Notation section (now `12. Notation`) to account for the inserted Mika section.

### Testing
- Built the documentation with `make docs` to ensure the updated specification renders, and the build completed successfully. 
- Ran the repository test suite with `make test`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84b6c7fc0832a88b6ddf3e4e3cc97)