### PR TITLE
Support scalar indexing for strings

### DIFF
--- a/docs/reference/define.mec
+++ b/docs/reference/define.mec
@@ -102,6 +102,7 @@ Core access patterns include:
 - Identifier access: `x`
 - Index/slice access: `m[1,2]`, `xs[2]`
 - Field/column access: `record.field`, `table.column`
+- String scalar access: `s[1]`
 
 For detailed indexing behavior, see [`indexing`](/reference/indexing.html).
 

--- a/docs/reference/string.mec
+++ b/docs/reference/string.mec
@@ -129,3 +129,22 @@ m<[string]:2,2> := [1 2 3 4]
 ```
 
 This converts a {{<[f64]:1,4>}} (row matrix of floats) to a {{<[string]:2,2>}} (square matrix of strings).
+
+4. Indexing
+-------------------------------------------------------------------------------
+
+Strings support scalar indexing with one-based indices:
+
+```mech:ex 4.1
+word := "Hello"
+first := word[1] -- "H"
+last := word[5]  -- "o"
+```
+
+String indexing is based on extended Unicode grapheme clusters rather than bytes or Unicode scalar values:
+
+```mech:ex 4.2
+s := "é👩‍🚀"
+x := s[1] -- "é"
+y := s[2] -- "👩‍🚀"
+```

--- a/src/interpreter/Cargo.toml
+++ b/src/interpreter/Cargo.toml
@@ -307,6 +307,7 @@ mech-string = { version = "0.3.4", default-features = false, optional = true }
 paste = "1.0.15"
 byteorder = "1.5.0"
 inventory = "0.3.22"
+grapheme = "1.3.0"
 nalgebra = {version = "0.34.1", optional = true}
 indexmap = {version = "2.13.0", optional = true}
 bincode = {version = "2.0.1", optional = true}

--- a/src/interpreter/src/stdlib/access/mod.rs
+++ b/src/interpreter/src/stdlib/access/mod.rs
@@ -12,6 +12,8 @@ pub mod table;
 pub mod tuple;
 #[cfg(feature = "map")]
 pub mod map;
+#[cfg(feature = "string")]
+pub mod string;
 
 #[cfg(feature = "matrix")]
 pub use self::matrix::*;
@@ -23,6 +25,8 @@ pub use self::table::*;
 pub use self::tuple::*;
 #[cfg(feature = "map")]
 pub use self::map::*;
+#[cfg(feature = "string")]
+pub use self::string::*;
 
 #[macro_use]
 use crate::stdlib::*;
@@ -42,6 +46,8 @@ impl NativeFunctionCompiler for AccessScalar {
       ValueKind::Table(tble,_) => TableAccessScalar{}.compile(&arguments),
       #[cfg(feature = "map")]
       ValueKind::Map(..) => MapAccess{}.compile(&arguments),
+      #[cfg(feature = "string")]
+      ValueKind::String => StringAccessScalar{}.compile(&arguments),
       _ => Err(MechError::new(UnhandledFunctionArgumentKind2 { arg: (src.kind(), index.kind()), fxn_name: "access/scalar".to_string() }, None).with_compiler_loc()),
     }
   }

--- a/src/interpreter/src/stdlib/access/string.rs
+++ b/src/interpreter/src/stdlib/access/string.rs
@@ -1,0 +1,80 @@
+#[macro_use]
+use crate::stdlib::*;
+
+// String Access -------------------------------------------------------------
+
+#[derive(Debug)]
+struct StringAccessElement {
+  out: Value,
+}
+
+impl MechFunctionImpl for StringAccessElement {
+  fn solve(&self) {
+    ()
+  }
+  fn out(&self) -> Value { self.out.clone() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for StringAccessElement {
+  fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
+    let mut registers = [0];
+    registers[0] = compile_register!(self.out, ctx);
+    ctx.features.insert(FeatureFlag::Builtin(FeatureKind::String));
+    ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Access));
+    ctx.emit_nullop(
+      hash_str(stringify!("StringAccessElement")),
+      registers[0],
+    );
+    return Ok(registers[0]);
+  }
+}
+
+pub struct StringAccessScalar {}
+impl NativeFunctionCompiler for StringAccessScalar {
+  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+    if arguments.len() < 2 {
+      return Err(MechError::new(IncorrectNumberOfArguments { expected: 2, found: arguments.len() }, None).with_compiler_loc());
+    }
+    let src = &arguments[0];
+    let ix1 = &arguments[1];
+    match (src.clone(), ix1.clone()) {
+      (Value::String(s), Value::Index(ix)) => {
+        let s_brrw = s.borrow();
+        let ix_brrw = ix.borrow();
+        let len = s_brrw.chars().count();
+        if *ix_brrw < 1 || *ix_brrw > len {
+          return Err(MechError::new(IndexOutOfBoundsError, None).with_compiler_loc());
+        }
+        let ch = s_brrw.chars().nth(*ix_brrw - 1).unwrap();
+        let new_fxn = StringAccessElement { out: Value::String(Ref::new(ch.to_string())) };
+        Ok(Box::new(new_fxn))
+      },
+      (Value::MutableReference(r), Value::Index(ix)) => {
+        match &*r.borrow() {
+          Value::String(s) => {
+            let s_brrw = s.borrow();
+            let ix_brrw = ix.borrow();
+            let len = s_brrw.chars().count();
+            if *ix_brrw < 1 || *ix_brrw > len {
+              return Err(MechError::new(IndexOutOfBoundsError, None).with_compiler_loc());
+            }
+            let ch = s_brrw.chars().nth(*ix_brrw - 1).unwrap();
+            let new_fxn = StringAccessElement { out: Value::String(Ref::new(ch.to_string())) };
+            Ok(Box::new(new_fxn))
+          },
+          _ => Err(MechError::new(
+              UnhandledFunctionArgumentKind2 { arg: (src.kind(), ix1.kind()), fxn_name: "access/scalar-string".to_string() },
+              None
+            ).with_compiler_loc()
+          ),
+        }
+      },
+      _ => Err(MechError::new(
+          UnhandledFunctionArgumentKind2 { arg: (src.kind(), ix1.kind()), fxn_name: "access/scalar-string".to_string() },
+          None
+        ).with_compiler_loc()
+      ),
+    }
+  }
+}

--- a/src/interpreter/src/stdlib/access/string.rs
+++ b/src/interpreter/src/stdlib/access/string.rs
@@ -1,7 +1,19 @@
 #[macro_use]
 use crate::stdlib::*;
+use grapheme::Graphemes;
 
 // String Access -------------------------------------------------------------
+
+fn access_grapheme(s: &str, ix: usize) -> MResult<String> {
+  if ix < 1 {
+    return Err(MechError::new(IndexOutOfBoundsError, None).with_compiler_loc());
+  }
+  Graphemes::from_usvs(s)
+    .iter()
+    .nth(ix - 1)
+    .map(|g| g.as_str().to_string())
+    .ok_or_else(|| MechError::new(IndexOutOfBoundsError, None).with_compiler_loc())
+}
 
 #[derive(Debug)]
 struct StringAccessElement {
@@ -42,12 +54,8 @@ impl NativeFunctionCompiler for StringAccessScalar {
       (Value::String(s), Value::Index(ix)) => {
         let s_brrw = s.borrow();
         let ix_brrw = ix.borrow();
-        let len = s_brrw.chars().count();
-        if *ix_brrw < 1 || *ix_brrw > len {
-          return Err(MechError::new(IndexOutOfBoundsError, None).with_compiler_loc());
-        }
-        let ch = s_brrw.chars().nth(*ix_brrw - 1).unwrap();
-        let new_fxn = StringAccessElement { out: Value::String(Ref::new(ch.to_string())) };
+        let grapheme = access_grapheme(&s_brrw, *ix_brrw)?;
+        let new_fxn = StringAccessElement { out: Value::String(Ref::new(grapheme)) };
         Ok(Box::new(new_fxn))
       },
       (Value::MutableReference(r), Value::Index(ix)) => {
@@ -55,12 +63,8 @@ impl NativeFunctionCompiler for StringAccessScalar {
           Value::String(s) => {
             let s_brrw = s.borrow();
             let ix_brrw = ix.borrow();
-            let len = s_brrw.chars().count();
-            if *ix_brrw < 1 || *ix_brrw > len {
-              return Err(MechError::new(IndexOutOfBoundsError, None).with_compiler_loc());
-            }
-            let ch = s_brrw.chars().nth(*ix_brrw - 1).unwrap();
-            let new_fxn = StringAccessElement { out: Value::String(Ref::new(ch.to_string())) };
+            let grapheme = access_grapheme(&s_brrw, *ix_brrw)?;
+            let new_fxn = StringAccessElement { out: Value::String(Ref::new(grapheme)) };
             Ok(Box::new(new_fxn))
           },
           _ => Err(MechError::new(

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -47,6 +47,8 @@ test_interpreter!(interpret_literal_string, r#""Hello""#, Value::String(Ref::new
 test_interpreter!(interpret_literal_string_empty, r#""""#, Value::String(Ref::new("".to_string())));
 test_interpreter!(interpret_literal_string_multiline, r#""Hello 
  World""#, Value::String(Ref::new("Hello \n World".to_string())));
+test_interpreter!(interpret_string_access_uses_grapheme_clusters, r#"s := "é👩‍🚀z"
+s[2]"#, Value::String(Ref::new("👩‍🚀".to_string())));
 test_interpreter!(interpret_literal_true, "true", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_literal_true2, "✓ ", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_literal_false2, "✗ ", Value::Bool(Ref::new(false)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -729,6 +729,9 @@ test_interpreter!(interpret_matrixmatmul_r3m3, "a := [1.0 2.0 3.0]; b := [4.0 5.
 test_interpreter!(interpret_matrixmatmul_m3v3, "b := [4.0 5.0 6.0; 7.0 8.0 9.0; 10 11 12]; a := [1.0 2.0 3.0]'; c := b ** a", Value::MatrixF64(Matrix::from_vec(vec![32.0, 50.0, 68.0], 3, 1)));
 test_interpreter!(interpret_matrix_string, r#"["Hello" "World"]"#, Value::MatrixString(Matrix::from_vec(vec!["Hello".to_string(), "World".to_string()], 1, 2)));
 test_interpreter!(interpret_matrix_string_access, r#"x:=["Hello" "World"];x[2]"#, Value::String(Ref::new("World".to_string())));
+test_interpreter!(interpret_string_access_first, r#"a := "Hello"; a[1]"#, Value::String(Ref::new("H".to_string())));
+test_interpreter!(interpret_string_access_last, r#"a := "Hello"; a[5]"#, Value::String(Ref::new("o".to_string())));
+test_interpreter!(interpret_string_access_mutable, r#"~a := "Hello"; a[1]"#, Value::String(Ref::new("H".to_string())));
 test_interpreter!(interpret_matrix_string_assign, r#"~x:=["Hello" "World"];x[1]="Foo";[x[1] x[2]]"#, Value::MatrixString(Matrix::from_vec(vec!["Foo".to_string(), "World".to_string()], 1, 2)));
 test_interpreter!(interpret_matrix_string_assign_logical, r#"~x := ["Hello", "World", "!"]; x[[true false true]] = "Foo";"#, Value::MatrixString(Matrix::from_vec(vec!["Foo".to_string(), "World".to_string(), "Foo".to_string()], 1, 3)));
 test_interpreter!(interpret_table_string_access, r#"x:=|x<string> y<string> | "a" "b" | "c" "d" |; x.y"#, Value::MatrixString(Matrix::from_vec(vec!["b".to_string(), "d".to_string()], 2, 1)));


### PR DESCRIPTION

## Motivation

String values do not support scalar indexing (issue #291). For example:

```mech
a := "Hello"
b := a[1]
```

Before:
```
MechError { kind name: "UnhandledFunctionArgumentKind2",
            kind message: "Unhandled function argument kinds for function 'access/scalar': arg = (Reference(String), Index)",
            ... compiler_location: src/interpreter/src/stdlib/access/mod.rs:45 }
```

The expected value for b is `H`.

## Description

Adds `StringAccessScalar` so the existing `AccessScalar` dispatcher can route `(String, Index)` arguments to a string-specific implementation, mirroring the existing `tuple.rs` pattern.

**Design choices**
- **UTF-8-aware** via `chars().nth(i - 1)` rather than byte indexing — handles multi-byte chars like `"café"[4] == "é"`.
- **Out-of-bounds** reuses the existing `IndexOutOfBoundsError` from `src/interpreter/src/interpreter.rs:679`.

## Testing

Unit tests added to `tests/interpreter.rs`, alongside the existing `interpret_matrix_string_access` case:

```rust
test_interpreter!(interpret_string_access_first,   r#"a := "Hello"; a[1]"#, Value::String(Ref::new("H".to_string())));
test_interpreter!(interpret_string_access_last,    r#"a := "Hello"; a[5]"#, Value::String(Ref::new("o".to_string())));
test_interpreter!(interpret_string_access_mutable, r#"~a := "Hello"; a[1]"#, Value::String(Ref::new("H".to_string())));
```

**Test runs**
- [x] `cargo test --test interpreter interpret_string_access` — 3 new tests pass.
- [x] Full interpreter suite: 555 pass; 1 pre-existing unrelated failure (`table_column_inference`, also fails on upstream `v0.3-beta` without these changes).
