### PR TITLE
Preserve `|` rest syntax in formatted array patterns

### DIFF
--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1007,7 +1007,15 @@ impl PatternArray {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct PatternArraySpread {
+  pub kind: PatternArraySpreadKind,
   pub binding: Option<Box<Pattern>>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum PatternArraySpreadKind {
+  Spread,
+  Rest,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -1892,9 +1892,19 @@ impl Formatter {
       parts.push(self.pattern(p));
     }
     if let Some(spread) = &node.spread {
-      parts.push("…".to_string());
-      if let Some(binding) = &spread.binding {
-        parts.push(self.pattern(binding));
+      match spread.kind {
+        PatternArraySpreadKind::Spread => {
+          parts.push("…".to_string());
+          if let Some(binding) = &spread.binding {
+            parts.push(self.pattern(binding));
+          }
+        }
+        PatternArraySpreadKind::Rest => {
+          parts.push("|".to_string());
+          if let Some(binding) = &spread.binding {
+            parts.push(self.pattern(binding));
+          }
+        }
       }
     }
     for p in &node.suffix {

--- a/src/syntax/src/patterns.rs
+++ b/src/syntax/src/patterns.rs
@@ -164,6 +164,7 @@ pub fn pattern_array(input: ParseString) -> ParseResult<PatternArray> {
       PatternArray {
         prefix,
         spread: Some(PatternArraySpread {
+          kind: PatternArraySpreadKind::Rest,
           binding: Some(Box::new(binding)),
         }),
         suffix: vec![],
@@ -226,10 +227,36 @@ pub fn pattern_array(input: ParseString) -> ParseResult<PatternArray> {
         spread_binding = Some(Box::new(suffix.remove(0)));
       }
     }
-    PatternArraySpread { binding: spread_binding }
+    PatternArraySpread {
+      kind: PatternArraySpreadKind::Spread,
+      binding: spread_binding,
+    }
   });
 
   Ok((input, PatternArray { prefix, spread, suffix }))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_pipe_rest_array_pattern_as_rest_kind() {
+    let gs = graphemes::init_source("[head | tail]");
+    let input = ParseString::new(&gs);
+    let (_, parsed) = pattern_array(input).expect("pipe rest array pattern should parse");
+    let spread = parsed.spread.expect("spread/rest should be present");
+    assert_eq!(spread.kind, PatternArraySpreadKind::Rest);
+  }
+
+  #[test]
+  fn parses_ellipsis_array_pattern_as_spread_kind() {
+    let gs = graphemes::init_source("[first ... last]");
+    let input = ParseString::new(&gs);
+    let (_, parsed) = pattern_array(input).expect("ellipsis array pattern should parse");
+    let spread = parsed.spread.expect("spread/rest should be present");
+    assert_eq!(spread.kind, PatternArraySpreadKind::Spread);
+  }
 }
 
 // pattern_atom_struct := ":", identifier, "(", list1(",", pattern), ")" ;


### PR DESCRIPTION
### Motivation
- The formatter collapsed the two distinct array-pattern syntaxes (`[head | tail]` vs `[first ... last]`) into the same rendered form, changing semantics for readers and examples.
- The AST lacked an explicit marker to distinguish a `|` rest binding from a `...` spread, preventing the formatter from preserving the original operator.

### Description
- Added `PatternArraySpreadKind` and a `kind` field to `PatternArraySpread` to record whether a pattern uses `Spread` (`...`) or `Rest` (`|`) in `src/core/src/nodes.rs`.
- Updated the array-pattern parser in `src/syntax/src/patterns.rs` to tag `|` forms as `Rest` and ellipsis forms as `Spread`, and added unit tests to assert both classifications.
- Updated the formatter in `src/syntax/src/formatter.rs` to render `|` for `Rest` bindings and `…` for `Spread` bindings so HTML/text output preserves original syntax.

### Testing
- Running an incorrect combined cargo invocation (`cargo test -p mech-syntax parses_pipe_rest_array_pattern_as_rest_kind parses_ellipsis_array_pattern_as_spread_kind`) failed due to invalid CLI usage (unexpected argument), not code failure.
- Ran `cargo test -p mech-syntax array_pattern_as`, which compiled and executed the new parser tests: `parses_pipe_rest_array_pattern_as_rest_kind` and `parses_ellipsis_array_pattern_as_spread_kind`, and both tests passed (2 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1329486c832ab3713d5f882e8050)