### PR TITLE
Improve enum match non-exhaustive diagnostics

### DIFF
--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1028,29 +1028,30 @@ fn infer_missing_enum_match_patterns(
     source: &Value,
     p: &Interpreter,
 ) -> Option<(String, Vec<String>)> {
-    let source_tag = match source {
+    let (source_enum_id, source_tag) = match source {
         Value::Enum(enum_value) => {
             let enum_brrw = enum_value.borrow();
             if enum_brrw.variants.len() != 1 {
-                None
+                (Some(enum_brrw.id), None)
             } else {
-                Some(enum_brrw.variants[0].0)
+                (Some(enum_brrw.id), Some(enum_brrw.variants[0].0))
             }
         }
-        Value::Atom(atom) => Some(atom.borrow().id()),
+        Value::Atom(atom) => (None, Some(atom.borrow().id())),
         #[cfg(feature = "tuple")]
         Value::Tuple(tuple_val) => {
             let tuple_brrw = tuple_val.borrow();
             match tuple_brrw.elements.first() {
                 Some(tag) => match tag.as_ref() {
-                    Value::Atom(atom) => Some(atom.borrow().id()),
-                    _ => None,
+                    Value::Atom(atom) => (None, Some(atom.borrow().id())),
+                    _ => (None, None),
                 },
-                None => None,
+                None => (None, None),
             }
         }
-        _ => None,
-    }?;
+        _ => (None, None),
+    };
+    let source_tag = source_tag?;
 
     let mut arm_tags: HashSet<u64> = HashSet::new();
     for arm in &match_expr.arms {
@@ -1070,18 +1071,22 @@ fn infer_missing_enum_match_patterns(
     }
 
     let state_brrw = p.state.borrow();
-    let candidates: Vec<&MechEnum> = state_brrw
-        .enums
-        .values()
-        .filter(|enm| {
-            let variant_ids: HashSet<u64> = enm.variants.iter().map(|(id, _)| *id).collect();
-            variant_ids.contains(&source_tag) && arm_tags.is_subset(&variant_ids)
-        })
-        .collect();
-    if candidates.len() != 1 {
-        return None;
-    }
-    let enum_def = candidates[0];
+    let enum_def = if let Some(enum_id) = source_enum_id {
+        state_brrw.enums.get(&enum_id)?
+    } else {
+        let candidates: Vec<&MechEnum> = state_brrw
+            .enums
+            .values()
+            .filter(|enm| {
+                let variant_ids: HashSet<u64> = enm.variants.iter().map(|(id, _)| *id).collect();
+                variant_ids.contains(&source_tag) && arm_tags.is_subset(&variant_ids)
+            })
+            .collect();
+        if candidates.len() != 1 {
+            return None;
+        }
+        candidates[0]
+    };
     let variant_ids: HashSet<u64> = enum_def.variants.iter().map(|(id, _)| *id).collect();
     let missing_ids: Vec<u64> = variant_ids.difference(&arm_tags).copied().collect();
     if missing_ids.is_empty() {

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1029,6 +1029,14 @@ fn infer_missing_enum_match_patterns(
     p: &Interpreter,
 ) -> Option<(String, Vec<String>)> {
     let source_tag = match source {
+        Value::Enum(enum_value) => {
+            let enum_brrw = enum_value.borrow();
+            if enum_brrw.variants.len() != 1 {
+                None
+            } else {
+                Some(enum_brrw.variants[0].0)
+            }
+        }
         Value::Atom(atom) => Some(atom.borrow().id()),
         #[cfg(feature = "tuple")]
         Value::Tuple(tuple_val) => {


### PR DESCRIPTION
### Motivation
- Improve diagnostics for non-exhaustive `match` expressions so the compiler can report which enum variants are missing instead of only requiring a wildcard arm.
- Currently `infer_missing_enum_match_patterns` only recognized atom/tuple-tag sources, which missed cases where the runtime `source` is a `Value::Enum`.

### Description
- Add handling for `Value::Enum` in `infer_missing_enum_match_patterns` to extract the single variant tag id when the enum value contains exactly one variant, while preserving existing atom/tuple-tag logic.
- Change implemented in `src/interpreter/src/expressions.rs` by adding a `Value::Enum` branch that borrows the enum and returns the variant id for exhaustiveness inference.

### Testing
- Ran `cargo test -p mech-interpreter --lib`, which compiled the interpreter and completed with `test result: ok`.
- The test run included a successful compilation of `mech-interpreter` and related workspace crates and reported no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab7a28874832a8c5d36729f449088)