### PR TITLE
Add top-matter hero image support for document titles

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -482,62 +482,87 @@ h5.toc::before {
     padding-right: 6px;
 }
 
-.mech-program h1 {
-    width: 900px;
-    font-family: 'FiraCodeRegular', monospace;
-    padding-bottom: 10px;
-    color: var(--text-color);
-    letter-spacing: 2px;
-    font-size: 1.83rem;
-    font-weight: bold;
-    text-align: center;
-    margin-bottom: 16px;
-    margin-left: -100px;
-    position: relative; 
-}
-
 .mech-program-header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 1.5rem;
+  gap: 0.55rem;
+  margin: 0 auto 2.2rem auto;
+  max-width: min(900px, calc(100vw - 48px));
+  position: relative;
 }
 
 .mech-program-hero {
-  width: 900px;
-  margin-left: -100px;
-  margin-bottom: 1rem;
+  width: min(900px, calc(100vw - 48px));
+  margin: 0 auto 1.15rem auto;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(242, 211, 117, 0.34);
 }
 
 .mech-program-hero-image {
   display: block;
   width: 100%;
-  max-height: 360px;
+  max-height: 430px;
+  min-height: 260px;
   object-fit: cover;
-  border-radius: 12px;
-  border: 1px solid var(--h2-underline-color);
 }
 
-.mech-program h1::after {
+.mech-program-title {
+  width: 100%;
+  margin: 0;
+  padding: 0 0 0.8rem 0;
+  font-family: 'FiraCodeRegular', monospace;
+  color: var(--text-color);
+  letter-spacing: 0.8px;
+  line-height: 1.25;
+  font-size: clamp(1.85rem, 2.8vw, 2.65rem);
+  font-weight: 700;
+  text-align: center;
+  text-wrap: balance;
+  position: relative;
+}
+
+.mech-program-title::after {
   content: '';
   position: absolute;
-  left: 0;
+  left: 6%;
+  right: 6%;
   bottom: 0;
-  height: 2px; 
-  width: 100%;
-  background: linear-gradient(to right, var(--body-background-color), var(--title-underline-color), var(--title-underline-color), var(--title-underline-color),  var(--body-background-color));
-  border-radius: 2px;
+  height: 2px;
+  background: linear-gradient(to right, transparent, var(--title-underline-color), transparent);
+  border-radius: 999px;
 }
 
 .mech-program-byline {
-  font-size: 1em;
+  font-size: clamp(1rem, 1.2vw, 1.1rem);
   font-weight: normal;
-  color: #666;      /* subtle, secondary color */
-  margin-top: 0;
-  margin-bottom: 1em;
-  line-height: 1.2;
+  color: #9fa6b2;
+  margin: 0;
+  line-height: 1.35;
   font-style: italic;
   text-align: center;
+  opacity: 0.94;
+}
+
+@media (max-width: 720px) {
+  .mech-program-hero {
+    width: min(900px, calc(100vw - 22px));
+    margin-bottom: 0.8rem;
+    border-radius: 12px;
+  }
+
+  .mech-program-hero-image {
+    min-height: 190px;
+    max-height: 300px;
+  }
+
+  .mech-program-header {
+    max-width: min(900px, calc(100vw - 22px));
+    gap: 0.42rem;
+    margin-bottom: 1.6rem;
+  }
 }
 
 .mech-program h2 a {

--- a/include/style.css
+++ b/include/style.css
@@ -496,6 +496,28 @@ h5.toc::before {
     position: relative; 
 }
 
+.mech-program-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.mech-program-hero {
+  width: 900px;
+  margin-left: -100px;
+  margin-bottom: 1rem;
+}
+
+.mech-program-hero-image {
+  display: block;
+  width: 100%;
+  max-height: 360px;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid var(--h2-underline-color);
+}
+
 .mech-program h1::after {
   content: '';
   position: absolute;

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -303,9 +303,42 @@ h4.toc::before {
     margin-left: -100px;
 }
 
+.mech-program-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.mech-program-hero {
+    width: 900px;
+    margin-left: -100px;
+    margin-bottom: 1rem;
+}
+
+.mech-program-hero-image {
+    display: block;
+    width: 100%;
+    max-height: 360px;
+    object-fit: cover;
+    border-radius: 12px;
+    border: 1px solid #d19710;
+}
+
 .mech-program h2 a {
     color: #f2ead9;
     text-decoration: none;
+}
+
+.mech-program-byline {
+    font-size: 1em;
+    font-weight: normal;
+    color: #ada594;
+    margin-top: 0;
+    margin-bottom: 1em;
+    line-height: 1.2;
+    font-style: italic;
+    text-align: center;
 }
 
 .mech-program h2 {

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -289,40 +289,57 @@ h4.toc::before {
     padding-right: 6px;
 }
 
-.mech-program h1 {
-    width: 900px;
-    font-family: 'FiraCodeRegular', monospace;
-    padding-bottom: 10px;
-    border-bottom: 4px dashed #d19710;
-    color: #f2ead9;
-    letter-spacing: 2px;
-    font-size: 1.83rem;
-    font-weight: bold;
-    text-align: center;
-    margin-bottom: 16px;
-    margin-left: -100px;
-}
-
 .mech-program-header {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 1.5rem;
+    gap: 0.55rem;
+    margin: 0 auto 2.2rem auto;
+    max-width: min(900px, calc(100vw - 48px));
+    position: relative;
 }
 
 .mech-program-hero {
-    width: 900px;
-    margin-left: -100px;
-    margin-bottom: 1rem;
+    width: min(900px, calc(100vw - 48px));
+    margin: 0 auto 1.15rem auto;
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 16px 42px rgba(0, 0, 0, 0.42);
+    border: 1px solid rgba(209, 151, 16, 0.45);
 }
 
 .mech-program-hero-image {
     display: block;
     width: 100%;
-    max-height: 360px;
+    max-height: 430px;
+    min-height: 260px;
     object-fit: cover;
-    border-radius: 12px;
-    border: 1px solid #d19710;
+}
+
+.mech-program-title {
+    width: 100%;
+    margin: 0;
+    padding: 0 0 0.8rem 0;
+    font-family: 'FiraCodeRegular', monospace;
+    color: #f2ead9;
+    letter-spacing: 0.8px;
+    line-height: 1.25;
+    font-size: clamp(1.85rem, 2.8vw, 2.65rem);
+    font-weight: 700;
+    text-align: center;
+    text-wrap: balance;
+    position: relative;
+}
+
+.mech-program-title::after {
+    content: '';
+    position: absolute;
+    left: 6%;
+    right: 6%;
+    bottom: 0;
+    height: 2px;
+    background: linear-gradient(to right, transparent, #d19710, transparent);
+    border-radius: 999px;
 }
 
 .mech-program h2 a {
@@ -331,14 +348,33 @@ h4.toc::before {
 }
 
 .mech-program-byline {
-    font-size: 1em;
+    font-size: clamp(1rem, 1.2vw, 1.1rem);
     font-weight: normal;
     color: #ada594;
-    margin-top: 0;
-    margin-bottom: 1em;
-    line-height: 1.2;
+    margin: 0;
+    line-height: 1.35;
     font-style: italic;
     text-align: center;
+    opacity: 0.94;
+}
+
+@media (max-width: 720px) {
+    .mech-program-hero {
+        width: min(900px, calc(100vw - 22px));
+        margin-bottom: 0.8rem;
+        border-radius: 12px;
+    }
+
+    .mech-program-hero-image {
+        min-height: 190px;
+        max-height: 300px;
+    }
+
+    .mech-program-header {
+        max-width: min(900px, calc(100vw - 22px));
+        gap: 0.42rem;
+        margin-bottom: 1.6rem;
+    }
 }
 
 .mech-program h2 {

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -306,6 +306,7 @@ fn pretty_print(&self) -> String {
 pub struct Title {
   pub text: Token,
   pub byline: Option<Paragraph>,
+  pub hero_image: Option<Image>,
 }
 
 impl Title {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -184,16 +184,47 @@ impl Formatter {
     let title = node.text.to_string();
 
     if self.html {
-      if let Some(byline) = &node.byline {
-        let formatted_byline = self.paragraph(byline);
-        format!(
-          "<h1 class=\"mech-program-title\">{}</h1>\n<div class=\"mech-program-byline\">{}</div>",
-          title,
-          formatted_byline
-        )
-      } else {
-        format!("<h1 class=\"mech-program-title\">{}</h1>", title)
-      }
+      let hero = match &node.hero_image {
+        Some(image) => {
+          let style_attr = match &image.style {
+            Some(option_map) if !option_map.elements.is_empty() => {
+              let style_str = option_map
+                .elements
+                .iter()
+                .map(|(k, v)| {
+                  let clean_value = v.to_string().trim_matches('"').to_string();
+                  format!("{}: {}", k.to_string(), clean_value)
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+              format!(" style=\"{}\"", style_str)
+            }
+            _ => "".to_string(),
+          };
+          let alt = image
+            .caption
+            .as_ref()
+            .map(|caption| self.paragraph(caption))
+            .unwrap_or_default();
+          format!(
+            "<div class=\"mech-program-hero\"><img class=\"mech-program-hero-image\" src=\"{}\" alt=\"{}\"{} /></div>",
+            image.src.to_string(),
+            alt,
+            style_attr
+          )
+        }
+        None => "".to_string(),
+      };
+
+      let byline = match &node.byline {
+        Some(byline) => format!("<div class=\"mech-program-byline\">{}</div>", self.paragraph(byline)),
+        None => "".to_string(),
+      };
+
+      format!(
+        "{}<div class=\"mech-program-header\"><h1 class=\"mech-program-title\">{}</h1>{}</div>",
+        hero, title, byline
+      )
     } else {
       let mut out = format!(
         "{}\n===============================================================================\n",
@@ -202,10 +233,34 @@ impl Formatter {
 
       if let Some(byline) = &node.byline {
         let byline_str = self.paragraph(byline);
-        out.push_str(&format!(
-          "{}\n===============================================================================\n",
-          byline_str
-        ));
+        out.push_str(&format!("{}\n", byline_str));
+      }
+      if let Some(hero_image) = &node.hero_image {
+        let caption = hero_image
+          .caption
+          .as_ref()
+          .map(|p| self.paragraph(p))
+          .unwrap_or_default();
+        let style_str = match &hero_image.style {
+          Some(option_map) if !option_map.elements.is_empty() => {
+            let inner = option_map
+              .elements
+              .iter()
+              .map(|(k, v)| {
+                let clean_value = v.to_string().trim_matches('"').to_string();
+                format!("{}: \"{}\"", k.to_string(), clean_value)
+              })
+              .collect::<Vec<_>>()
+              .join(", ");
+            format!("{{{}}}", inner)
+          }
+          _ => "".to_string(),
+        };
+        let image_str = format!("![{}]({}){}", caption, hero_image.src.to_string(), style_str);
+        out.push_str(&format!("{}\n", image_str));
+      }
+      if node.byline.is_some() || node.hero_image.is_some() {
+        out.push_str("===============================================================================\n");
       }
 
       out

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -204,7 +204,14 @@ impl Formatter {
           let alt = image
             .caption
             .as_ref()
-            .map(|caption| self.paragraph(caption))
+            .map(|caption| {
+              caption
+                .to_string()
+                .replace('&', "&amp;")
+                .replace('"', "&quot;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+            })
             .unwrap_or_default();
           format!(
             "<div class=\"mech-program-hero\"><img class=\"mech-program-hero-image\" src=\"{}\" alt=\"{}\"{} /></div>",

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -30,16 +30,28 @@ pub fn title(input: ParseString) -> ParseResult<Title> {
   let (input, _) = new_line(input)?;
   let (input, _) = many1(equal)(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, byline) = opt(byline)(input)?;
+  let (input, top_matter) = opt(title_top_matter)(input)?;
   let mut title = Token::merge_tokens(&mut text).unwrap();
   title.kind = TokenKind::Title;
-  Ok((input, Title{text: title, byline}))
+  let (byline, hero_image) = match top_matter {
+    Some((byline, hero_image)) => (byline, hero_image),
+    None => (None, None),
+  };
+  Ok((input, Title{text: title, byline, hero_image}))
 }
 
-pub fn byline(input: ParseString) -> ParseResult<Paragraph> {
-  let (input, byline) = paragraph_newline(input)?;
+pub fn title_top_matter(input: ParseString) -> ParseResult<(Option<Paragraph>, Option<Image>)> {
+  let (input, _) = whitespace0(input)?;
+  if let Ok((input, byline)) = paragraph_newline(input.clone()) {
+    let (input, hero_image) = opt(tuple((whitespace0, img, whitespace0)))(input)?;
+    let (input, _) = many1(equal)(input)?;
+    return Ok((input, (Some(byline), hero_image.map(|(_, image, _)| image))));
+  }
+
+  let (input, hero_image) = img(input)?;
+  let (input, _) = whitespace0(input)?;
   let (input, _) = many1(equal)(input)?;
-  Ok((input, byline))
+  Ok((input, (None, Some(hero_image))))
 }
 
 pub struct MarkdownTableHeader {


### PR DESCRIPTION
### Motivation
- Make Mechdown support a hero image in a document's title block so author/date/title pages can include a visual header (e.g. `images/hero.png`) rendered as a hero above the title and byline.
- Keep the existing byline/top-matter conventions while extending them to optionally include an image so existing documents remain valid.

### Description
- Extend the `Title` AST with a new `hero_image` field (`src/core/src/nodes.rs` with `pub hero_image: Option<Image>`). 
- Add a new `title_top_matter` parser that accepts an optional byline and/or image before the closing `===` separator and wire it into `pub fn title` (`src/syntax/src/mechdown.rs`).
- Update HTML/text formatting in the formatter so HTML output emits a hero block and groups the `<h1>` title and byline inside `.mech-program-header`, while non-HTML output preserves the top-matter image and byline (`src/syntax/src/formatter.rs`).
- Add CSS rules for the hero/header/byline (`.mech-program-hero`, `.mech-program-hero-image`, `.mech-program-header`, `.mech-program-byline`) to the shared docs stylesheet and the mech-app stylesheet (`include/style.css` and `mech-app/src/css/style.css`).

### Testing
- Ran `cargo test -p mech-syntax --lib` and all tests passed (`6 passed; 0 failed`).
- The syntax package compiled and unit tests completed successfully for the modified parser/formatter code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec01a6cc88832ab02129cec6d14126)