### PR TITLE
Add right-aligned GitHub star widget to docs header

### DIFF
--- a/include/index.html
+++ b/include/index.html
@@ -218,10 +218,46 @@
     font-size: 1.2rem;
     font-weight: bold;
   }
-  #github {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
+  #header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .widget.widget-lg {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 0.875rem;
+  }
+
+  .widget.widget-lg .btn,
+  .widget.widget-lg .social-count {
+    display: inline-flex;
+    align-items: center;
+    height: 32px;
+    padding: 0 0.75rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #f0f6fc;
+    text-decoration: none;
+    background: #21262d;
+  }
+
+  .widget.widget-lg .btn:hover,
+  .widget.widget-lg .social-count:hover {
+    background: #30363d;
+  }
+
+  .widget.widget-lg .social-count {
+    min-width: 3rem;
+    justify-content: center;
+  }
+
+  .octicon-mark-github {
+    fill: currentColor;
   }
   /* compress the header if the view is small */
   @media (max-width: 840px) {
@@ -242,10 +278,8 @@
       font-size: 0.9rem;
       padding-top: 0px;
     }
-    #github {
-      position: absolute;
-      top: 2px;
-      right: 1rem;
+    #header-actions {
+      margin-left: auto;
     }
   }
   @media (max-width: 650px) {
@@ -268,7 +302,7 @@
       padding-top: 0px;
       justify-content: center; /* Center navigation links */
     }
-    #github {
+    #header-actions {
       position: relative;
       top: inherit;
       right: inherit;
@@ -276,7 +310,6 @@
     }
   }
   </style>
-  <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 <body>
   <header id="header">
@@ -292,8 +325,16 @@
       <span class="active"><a href="https://docs.mech-lang.org">Docs</a></span>
       <span><a href="https://try.mech-lang.org">Explore</a></span>
     </div>
-    <div id="github">
-      <a class="github-button" href="https://github.com/mech-lang/mech" data-color-scheme="no-preference: light; light: light; dark: dark;" data-size="large" data-show-count="true" aria-label="Star mech-lang/mech on GitHub">Star</a>
+    <div id="header-actions">
+      <div class="widget widget-lg">
+        <a class="btn" href="https://github.com/mech-lang/mech" rel="noopener" target="_blank" aria-label="Star mech-lang/mech on GitHub">
+          <svg viewBox="0 0 16 16" width="16" height="16" class="octicon octicon-mark-github" aria-hidden="true">
+            <path d="M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656"></path>
+          </svg>
+          &nbsp;<span>Star</span>
+        </a>
+        <a class="social-count" href="https://github.com/mech-lang/mech/stargazers" rel="noopener" target="_blank" aria-label="Stargazers on GitHub">279</a>
+      </div>
     </div>
   </header>
   <div class="container mech-root" mech-interpreter-id=0>


### PR DESCRIPTION
### Motivation
- Provide a dedicated right-aligned area in the site header for action buttons so widgets can appear at the top-right beside the nav. 
- Replace the previous script-driven GitHub button with a static, stylable widget that matches the requested Star button + count layout. 
- Ensure the new widget respects responsive breakpoints and centers on small screens.

### Description
- Added a `#header-actions` flex container to the header and moved the GitHub controls into it to right-align actions. 
- Introduced `.widget.widget-lg`, `.btn`, and `.social-count` CSS to recreate the GitHub-style button and count with consistent sizing, hover state, and icon coloring. 
- Replaced the `buttons.github.io` script-driven button markup with a static SVG-based Star button and a `social-count` link for stargazers in `include/index.html`. 
- Updated responsive rules so `#header-actions` remains right-aligned on medium screens and becomes centered/relative on narrow screens.

### Testing
- Ran `rg -n "header-actions|widget widget-lg|social-count" include/index.html` to verify the new selectors are present and the search succeeded. 
- Attempted `python -m py_compile - <<'PY'\nprint('noop')\nPY` which failed due to invalid invocation in this environment and is not indicative of template correctness. 
- The change was committed locally with message `Add right-aligned GitHub star widget to docs header` and the modified file is `include/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9e23b6d0832a98eea3704e99a0f6)