### PR TITLE
Fix hero image filling in blog layout

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -313,9 +313,12 @@ body.console-fullscreen .workspace {
   border-radius: 12px;
   min-height: 320px;
   border: 1px solid var(--border);
+  display: flex;
 }
 
 .hero-visual img {
+  display: block;
+  flex: 1 1 auto;
   width: 100%;
   height: 100%;
   object-fit: cover;


### PR DESCRIPTION
### Motivation
- Ensure the hero visual fills the full card height and remove the bottom gap seen when the adjacent text column is taller.

### Description
- Modify `include/blog.css` to make `.hero-visual` a flex container and make `.hero-visual img` an explicit block-level flex item (`display: block; flex: 1 1 auto;`) while preserving `width/height: 100%` and `object-fit: cover` so the image stretches to fill the container.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f047a2b048832a95c4e62d342deae0)