### PR TITLE
Adjust blog footer heading semantics and visual treatments

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -654,7 +654,8 @@ section.active-section {
 }
 
 .footer-heading {
-  display: inline-flex;
+  display: flex;
+  width: 100%;
   align-items: center;
   gap: 8px;
   margin: 0 0 14px;
@@ -674,7 +675,8 @@ section.active-section {
 }
 
 .footer-heading-text {
-  display: inline-block;
+  display: block;
+  flex: 1;
   border-bottom: 1px solid #7f7f7f;
   padding-bottom: 2px;
 }
@@ -771,6 +773,12 @@ section.active-section {
   letter-spacing: 0.05em;
   font-size: 14px;
   
+}
+
+.release-ack .footer-icon {
+  color: var(--accent-primary);
+  border-bottom: 1px solid var(--accent-primary);
+  padding-bottom: 2px;
 }
 
 /* Bottom bar */

--- a/include/blog.css
+++ b/include/blog.css
@@ -653,7 +653,7 @@ section.active-section {
   align-content: start; /* FIX */
 }
 
-.footer-group h4 {
+.footer-heading {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -664,6 +664,21 @@ section.active-section {
   font-size: 13px;
 }
 
+.footer-heading-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-primary);
+  border-bottom: 1px solid var(--accent-primary);
+  padding-bottom: 2px;
+}
+
+.footer-heading-text {
+  display: inline-block;
+  border-bottom: 1px solid #7f7f7f;
+  padding-bottom: 2px;
+}
+
 .footer-icon {
   width: 16px;
   height: 16px;
@@ -671,13 +686,27 @@ section.active-section {
 }
 
 .footer-group a {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
   margin-bottom: 10px;
   font-size: 15px;
   color: var(--text-secondary);
 }
 
+.footer-group a::after {
+  content: "›";
+  color: var(--text-muted);
+  font-size: 14px;
+  margin-left: auto;
+}
+
 .footer-group a:hover {
+  color: var(--accent-hover);
+}
+
+.footer-group a:hover::after {
   color: var(--accent-hover);
 }
 

--- a/include/blog.html
+++ b/include/blog.html
@@ -92,7 +92,7 @@
             <!-- Middle: Links -->
             <div class="footer-links">
               <div class="footer-group">
-                <h4><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-package-icon lucide-package" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><polyline points="3.29 7 12 12 20.71 7"/><path d="m7.5 4.27 9 5.15"/></svg>Product</h4>
+                <div class="footer-heading"><span class="footer-heading-icon"><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-package-icon lucide-package" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><polyline points="3.29 7 12 12 20.71 7"/><path d="m7.5 4.27 9 5.15"/></svg></span><span class="footer-heading-text">Product</span></div>
                 <a href="#">Architecture</a>
                 <a href="#">Workflow</a>
                 <a href="#">API Reference</a>
@@ -100,7 +100,7 @@
               </div>
 
               <div class="footer-group">
-                <h4><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-users-icon lucide-users" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><path d="M16 3.128a4 4 0 0 1 0 7.744"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><circle cx="9" cy="7" r="4"/></svg>Community</h4>
+                <div class="footer-heading"><span class="footer-heading-icon"><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-users-icon lucide-users" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><path d="M16 3.128a4 4 0 0 1 0 7.744"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><circle cx="9" cy="7" r="4"/></svg></span><span class="footer-heading-text">Community</span></div>
                 <a href="#">Discord</a>
                 <a href="#">GitHub</a>
                 <a href="#">Blog</a>
@@ -108,7 +108,7 @@
               </div>
 
               <div class="footer-group">
-                <h4><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-book-text-icon lucide-book-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/><path d="M8 11h8"/><path d="M8 7h6"/></svg>Resources</h4>
+                <div class="footer-heading"><span class="footer-heading-icon"><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-book-text-icon lucide-book-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/><path d="M8 11h8"/><path d="M8 7h6"/></svg></span><span class="footer-heading-text">Resources</span></div>
                 <a href="#">Getting Started</a>
                 <a href="#">Specification</a>
                 <a href="#">REPL Guide</a>


### PR DESCRIPTION
### Motivation
- Footer section labels were implemented as `<h4>` headings and were being picked up by header numbering, so they need non-heading semantics and bespoke styling.
- The visual requirement is for the heading icon to appear yellow with its own underline, the heading text to have a thin grey underline, and each footer link to show a right-aligned chevron.

### Description
- Replaced `<h4>` labels in `include/blog.html` with non-heading wrappers: `<div class="footer-heading">` containing `<span class="footer-heading-icon">` and `<span class="footer-heading-text">` to separate icon and label semantics.
- Added CSS rules in `include/blog.css` for `.footer-heading-icon` to use `var(--accent-primary)` and a bottom border, and for `.footer-heading-text` to use a thin grey bottom border.
- Updated `.footer-group a` to use a flex layout and added a `::after` rule to render a right-aligned chevron (`›`) that inherits hover color.
- Kept the change strictly template/CSS-only and preserved existing footer structure and content.

### Testing
- Ran `rg -n "footer-heading|footer-group a::after" include/blog.html include/blog.css` to confirm new classes and chevron rule are present and the old `h4` usage is removed (passed).
- Inspected the modified files with `sed`/`nl` to verify the updated markup and CSS blocks were written as expected (passed).
- No unit or runtime tests were required because this is a markup/CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c6b0cf3c832abbb43f5697d63c20)