### PR TITLE
Support heading numbering through H6 and limit TOC depth to H4

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -1893,6 +1893,10 @@ a.mech-footnote-reference {
     counter-reset: h5;
 }
 
+.mech-content h5 {
+    counter-reset: h6;
+}
+
 h2::before {
     color: var(--main-color-mid);
     counter-increment: h2;
@@ -1915,6 +1919,12 @@ h5::before {
     color: var(--main-color-mid);
     counter-increment: h5;
     content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) " ";
+}
+
+h6::before {
+    color: var(--main-color-mid);
+    counter-increment: h6;
+    content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) " ";
 }
 
 h2:hover a {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -245,6 +245,9 @@ impl Formatter {
           6 => { h6_num += 1; }
           _ => {}
         }
+        if subtitle.level < 3 || subtitle.level > 4 {
+          continue;
+        }
         let target_depth = subtitle.level.saturating_sub(2) as usize;
         while stack_depth < target_depth {
           nested.push_str("<ul class=\"toc-sub\">");
@@ -333,10 +336,16 @@ impl Formatter {
       self.figure_num = 0;
     } else if level == 3 {
       self.h3_num += 1;
+      self.h4_num = 0;
+      self.h5_num = 0;
+      self.h6_num = 0;
     } else if level == 4 {
       self.h4_num += 1;
+      self.h5_num = 0;
+      self.h6_num = 0;
     } else if level == 5 {
       self.h5_num += 1;
+      self.h6_num = 0;
     } else if level == 6 {
       self.h6_num += 1;
     }


### PR DESCRIPTION
### Motivation
- Ensure consistent, hierarchical section numbering up to H6 so deep documents render stable numeric prefixes and anchors.  
- Keep the table of contents concise by showing only H2/H3/H4-level entries (user requested TOC up to H4) while preserving internal counters for deeper headings.

### Description
- Update TOC generation in `src/syntax/src/formatter.rs` to only emit entries for subtitle levels 3 and 4 while still incrementing and tracking H3–H6 counters for correct anchor IDs.  
- Add guards in the TOC loop so subtitles with level <3 or >4 are skipped from being added to the visible TOC.  
- Enhance `subtitle()` logic in `src/syntax/src/formatter.rs` to reset lower-level counters when a higher-level subtitle is encountered so numbering stays consistent across H2..H6.  
- Add CSS support in `include/style.css` for nested counter resets (`.mech-content h5 { counter-reset: h6; }`) and render `h6::before` so numeric prefixes are shown up through H6.

### Testing
- Ran `cargo test -p mech-syntax` which compiled the crate and ran doc-tests; the test run completed successfully with no failures.  
- Verified the repository changes include `src/syntax/src/formatter.rs` and `include/style.css` (compilation and formatter unit/doc verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e7bf4d9c832a8e39c709dd0be299)