### PR TITLE
Add footnote teleport anchors and return links

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -1857,6 +1857,16 @@ a.mech-footnote-reference {
     text-decoration: underline;
 }
 
+a.mech-footnote-back {
+    margin-left: 0.35em;
+    text-decoration: none;
+    color: var(--main-color-high);
+}
+
+a.mech-footnote-back:hover {
+    text-decoration: underline;
+}
+
 .mech-abstract {
     background-color: var(--abstract-background-color);
     border: 1px solid var(--main-color-mid);

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -437,7 +437,7 @@ impl Formatter {
     let id_string = node.to_string();
     let id_hash = hash_str(&format!("footnote-{}",id_string));
     if self.html {
-      format!("<a id=\"footnote-ref-{}\" href=\"#{}\" class=\"mech-footnote-reference\">{}</a>",id_hash,id_hash,id_string)
+      format!("<a id=\"footnote-ref-{}\" href=\"#{}\" class=\"mech-footnote-reference\" onclick=\"event.preventDefault();document.getElementById('{}')?.scrollIntoView({{behavior:'auto',block:'start'}});history.replaceState(null,'','#{}');\">{}</a>",id_hash,id_hash,id_hash,id_hash,id_string)
     } else {
       format!("[^{}]",id_string)
     }
@@ -1025,9 +1025,9 @@ impl Formatter {
     let id: u64 = hash_str(&format!("footnote-{}",id_name.to_string()));
     if self.html {
       format!("<div class=\"mech-footnote\" id=\"{}\">
-        <div class=\"mech-footnote-id\">{}: <a href=\"#footnote-ref-{}\" class=\"mech-footnote-back\" aria-label=\"Back to footnote reference\">↩</a></div>
+        <div class=\"mech-footnote-id\">{}: <a href=\"#footnote-ref-{}\" class=\"mech-footnote-back\" aria-label=\"Back to footnote reference\" onclick=\"event.preventDefault();document.getElementById('footnote-ref-{}')?.scrollIntoView({{behavior:'auto',block:'nearest'}});history.replaceState(null,'','#footnote-ref-{}');\">↩</a></div>
         {}
-      </div>",id, id_name.to_string(), id, note_paragraph)  
+      </div>",id, id_name.to_string(), id, id, id, note_paragraph)  
     } else {
       format!("[^{}]: {}\n",id_name.to_string(), note_paragraph)
     }

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -437,7 +437,7 @@ impl Formatter {
     let id_string = node.to_string();
     let id_hash = hash_str(&format!("footnote-{}",id_string));
     if self.html {
-      format!("<a href=\"#{}\" class=\"mech-footnote-reference\">{}</a>",id_hash, id_string)
+      format!("<a id=\"footnote-ref-{}\" href=\"#{}\" class=\"mech-footnote-reference\">{}</a>",id_hash,id_hash,id_string)
     } else {
       format!("[^{}]",id_string)
     }
@@ -1025,9 +1025,9 @@ impl Formatter {
     let id: u64 = hash_str(&format!("footnote-{}",id_name.to_string()));
     if self.html {
       format!("<div class=\"mech-footnote\" id=\"{}\">
-        <div class=\"mech-footnote-id\">{}:</div>
+        <div class=\"mech-footnote-id\">{}: <a href=\"#footnote-ref-{}\" class=\"mech-footnote-back\" aria-label=\"Back to footnote reference\">↩</a></div>
         {}
-      </div>",id, id_name.to_string(), note_paragraph)  
+      </div>",id, id_name.to_string(), id, note_paragraph)  
     } else {
       format!("[^{}]: {}\n",id_name.to_string(), note_paragraph)
     }


### PR DESCRIPTION
### Motivation
- Enable direct navigation (teleport) from in-text footnote references to their rendered footnote and provide an easy way to return to the original reference.

### Description
- Add a stable `id` attribute to rendered footnote references (format `footnote-ref-<hash>`) and keep the `href` pointing to the footnote target in `src/syntax/src/formatter.rs` via `fn footnote_reference`.
- Render a back-link (`↩`) next to each rendered footnote label that targets `#footnote-ref-<hash>` and includes an `aria-label` for accessibility in `pub fn footnote` in `src/syntax/src/formatter.rs`.
- Add CSS rules for the new `.mech-footnote-back` selector in `include/style.css` to style the return link and hover state.

### Testing
- Ran `cargo test -p mech-syntax --quiet` which completed successfully (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f161d0c0b4832aad88faa3ef2e6c38)