### PR TITLE
Fix #297: resolve named function arguments by name, not position

### DIFF
--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -93,10 +93,61 @@ pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Int
 
   // User-defined function: evaluate arguments then run the interpreted body.
   if let Some(user_fxn) = { functions.borrow().user_functions.get(&fxn_name_id).cloned() } {
-    let mut input_arg_values = vec![];
-    for (_, arg_expr) in fxn_call.args.iter() {
-      input_arg_values.push(expression(arg_expr, env, p)?);
-    }
+    let all_named = !fxn_call.args.is_empty() && fxn_call.args.iter().all(|(name, _)| name.is_some());
+    let input_arg_values = if all_named {
+      // Build name_hash → value map from the call site.
+      let mut named_values: std::collections::HashMap<u64, Value> = std::collections::HashMap::new();
+      for (maybe_name, arg_expr) in fxn_call.args.iter() {
+        let name_id = maybe_name.as_ref().unwrap().hash();
+        let val = expression(arg_expr, env, p)?;
+        named_values.insert(name_id, val);
+      }
+      // Reject names that don't match any declared parameter.
+      for name_id in named_values.keys() {
+        if !user_fxn.input.contains_key(name_id) {
+          let arg_name = fxn_call.args.iter()
+            .find(|(n, _)| n.as_ref().map(|n| n.hash()) == Some(*name_id))
+            .and_then(|(n, _)| n.as_ref())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| name_id.to_string());
+          return Err(MechError::new(
+            UnknownNamedArgumentError {
+              function_name: user_fxn.name.clone(),
+              argument_name: arg_name,
+            },
+            None,
+          ).with_compiler_loc());
+        }
+      }
+      // Reorder values to match the declaration order.
+      let mut ordered = vec![];
+      for (param_id, _) in user_fxn.input.iter() {
+        match named_values.remove(param_id) {
+          Some(val) => ordered.push(val),
+          None => {
+            let param_name = user_fxn.code.input.iter()
+              .find(|arg| arg.name.hash() == *param_id)
+              .map(|arg| arg.name.to_string())
+              .unwrap_or_else(|| param_id.to_string());
+            return Err(MechError::new(
+              MissingNamedArgumentError {
+                function_name: user_fxn.name.clone(),
+                argument_name: param_name,
+              },
+              None,
+            ).with_compiler_loc());
+          }
+        }
+      }
+      ordered
+    } else {
+      // Positional: evaluate left to right in call order.
+      let mut vals = vec![];
+      for (_, arg_expr) in fxn_call.args.iter() {
+        vals.push(expression(arg_expr, env, p)?);
+      }
+      vals
+    };
     return execute_user_function(&user_fxn, &input_arg_values, p);
   }
 
@@ -924,6 +975,44 @@ impl MechErrorKind for FunctionInputTypeMismatchError {
     format!(
       "Function '{}' argument '{}' expected {}, found {}",
       self.function_name, self.argument_name, self.expected, self.found
+    )
+  }
+}
+
+// A named argument in a call doesn't match any declared parameter name.
+#[derive(Debug, Clone)]
+pub struct UnknownNamedArgumentError {
+  pub function_name: String,
+  pub argument_name: String,
+}
+
+impl MechErrorKind for UnknownNamedArgumentError {
+  fn name(&self) -> &str {
+    "UnknownNamedArgument"
+  }
+  fn message(&self) -> String {
+    format!(
+      "Function '{}' has no parameter named '{}'",
+      self.function_name, self.argument_name
+    )
+  }
+}
+
+// A named call omits a parameter that the function requires.
+#[derive(Debug, Clone)]
+pub struct MissingNamedArgumentError {
+  pub function_name: String,
+  pub argument_name: String,
+}
+
+impl MechErrorKind for MissingNamedArgumentError {
+  fn name(&self) -> &str {
+    "MissingNamedArgument"
+  }
+  fn message(&self) -> String {
+    format!(
+      "Function '{}' call is missing required argument '{}'",
+      self.function_name, self.argument_name
     )
   }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -983,6 +983,21 @@ test_interpreter!(interpret_user_function_scalar_auto_broadcast, r#"add-one(x<f6
   | * => x + 1.
 add-one([1 2 3])"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
 
+// Named arguments: args passed in reversed order should be reordered by name.
+test_interpreter!(interpret_named_args_basic, r#"sub(a<f64>, b<f64>) => <f64>
+  | (*, *) => a - b.
+sub(b: 3.0, a: 10.0)"#, Value::F64(Ref::new(7.0)));
+
+// Named arguments: same order as declaration should still work.
+test_interpreter!(interpret_named_args_same_order, r#"sub(a<f64>, b<f64>) => <f64>
+  | (*, *) => a - b.
+sub(a: 10.0, b: 3.0)"#, Value::F64(Ref::new(7.0)));
+
+// Named arguments: three-parameter function called in a different order.
+test_interpreter!(interpret_named_args_three_params, r#"triple(x<f64>, y<f64>, z<f64>) => <f64>
+  | (*, *, *) => x - y - z.
+triple(z: 1.0, x: 10.0, y: 2.0)"#, Value::F64(Ref::new(7.0)));
+
 test_interpreter!(interpret_set_value,"~x := 1.23; x = 4.56;", Value::F64(Ref::new(4.56)));
 test_interpreter!(interpret_set_value_row_vector,"~x := [6,2]; x[1] = 4;", Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2)));
 test_interpreter!(interpret_set_value_col_vector,"~x := [false false true true]'; x[1] = true; x[1]", Value::Bool(Ref::new(true)));


### PR DESCRIPTION
## Problem

  When calling a user-defined function with named arguments, the runtime ignored
  the argument names and bound values positionally. For example:

      sub(a<f64>, b<f64>) => <f64>
        | (*, *) => a - b.

      sub(b: 3.0, a: 10.0)   -- expected 7, got -7

  The names `a:` and `b:` were discarded; arguments were passed in call-site
  order instead of declaration order.

  ## Root cause

  In `function_call()` (`src/interpreter/src/functions.rs`), the argument name
  stored in each `(Option<Identifier>, Expression)` tuple was dropped with `_`:

      for (_, arg_expr) in fxn_call.args.iter() { ... }

  ## Fix

  When all arguments carry names, the runtime now:
  1. Evaluates each argument and maps it by name hash
  2. Reorders the values to match the function's declared parameter order
  3. Errors clearly if an unknown name is used or a required parameter is omitted

  Positional calls (no names) are unchanged.

  Also adds two new error types: `UnknownNamedArgumentError` and
  `MissingNamedArgumentError`.

  ## Tests

  Three new tests added to `tests/interpreter.rs`:
  - `interpret_named_args_basic` — reversed order resolves correctly
  - `interpret_named_args_same_order` — in-order named call still works
  - `interpret_named_args_three_params` — three-argument reordering works

  Full test suite: 565/565 pass.

  Fixes #297