### PR TITLE
Fix #278: broadcast user functions over same-shape multi-argument vec…

### DIFF
--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -291,62 +291,151 @@ enum FunctionCallStep {
   TailCall(Vec<Value>),
 }
 
-// If the function is single-input / single-output with matching scalar kinds,
-// and the actual argument is a matrix, run the function on each element and
-// reassemble the result into a matrix of the same shape.
-// Returns None if any condition for broadcasting isn't met, so the caller can
-// fall through to normal execution.
+// Attempts element-wise broadcasting for user functions whose declared
+// parameter kinds are all scalar but are called with matrix arguments.
+//
+// Single-argument path: unchanged original behaviour — requires input and
+// output kinds to match (e.g. f64→f64).
+//
+// Multi-argument path: if every matrix argument shares the same shape, zip
+// corresponding elements from each argument and call the function once per
+// position, then reassemble into a matrix of that shape. Scalar arguments are
+// repeated at every position. Input/output kinds may differ (e.g. f64,f64→bool).
+//
+// Returns None if any precondition is not met so the caller falls through to
+// normal (non-broadcasting) execution.
 #[cfg(feature = "matrix")]
 fn try_broadcast_user_function(
   fxn_def: &FunctionDefinition,
   input_arg_values: &Vec<Value>,
   p: &Interpreter,
 ) -> MResult<Option<Value>> {
-  if input_arg_values.len() != 1
+  let n_args = input_arg_values.len();
+
+  if n_args == 0
     || fxn_def.code.output.len() != 1
-    || fxn_def.code.input.len() != 1
+    || fxn_def.code.input.len() != n_args
   {
     return Ok(None);
   }
 
-  let source = detach_value(&input_arg_values[0]);
-  if !source.is_matrix() {
+  // ── Single-argument path (original behaviour, unchanged) ──────────────────
+  if n_args == 1 {
+    let source = detach_value(&input_arg_values[0]);
+    if !source.is_matrix() {
+      return Ok(None);
+    }
+
+    #[cfg(feature = "kind_annotation")]
+    let (input_kind, output_kind) = {
+      let input_kind = kind_annotation(&fxn_def.code.input[0].kind.kind, p)?
+        .to_value_kind(&p.state.borrow().kinds)?;
+      let output_kind = kind_annotation(&fxn_def.code.output[0].kind.kind, p)?
+        .to_value_kind(&p.state.borrow().kinds)?;
+      (input_kind, output_kind)
+    };
+
+    #[cfg(not(feature = "kind_annotation"))]
+    let (input_kind, output_kind) = {
+      return Ok(None);
+    };
+
+    if input_kind != output_kind || matches!(input_kind, ValueKind::Matrix(_, _)) {
+      return Ok(None);
+    }
+
+    let Some(elements) = crate::patterns::matrix_like_values(&source) else {
+      return Ok(None);
+    };
+
+    let mut outputs = Vec::with_capacity(elements.len());
+    for element in elements {
+      outputs.push(execute_user_function(fxn_def, &vec![element], p)?);
+    }
+
+    let shape = source.shape();
+    return Ok(Some(build_typed_matrix_from_values(
+      &output_kind,
+      outputs,
+      shape[0],
+      shape[1],
+    )));
+  }
+
+  // ── Multi-argument path ───────────────────────────────────────────────────
+  // At least one argument must be a matrix, otherwise there is nothing to broadcast.
+  let has_matrix = input_arg_values.iter().any(|v| detach_value(v).is_matrix());
+  if !has_matrix {
     return Ok(None);
   }
 
-  // Resolve the declared input and output kinds from their annotations.
-  // Without kind_annotation feature we can't know the element type, so bail.
+  // Resolve declared input and output kinds. Bail if kind_annotation is absent.
   #[cfg(feature = "kind_annotation")]
-  let (input_kind, output_kind) = {
-    let input_kind = kind_annotation(&fxn_def.code.input[0].kind.kind, p)?
+  let (input_kinds, output_kind) = {
+    let mut iks: Vec<ValueKind> = Vec::with_capacity(n_args);
+    for input_arg in &fxn_def.code.input {
+      iks.push(
+        kind_annotation(&input_arg.kind.kind, p)?
+          .to_value_kind(&p.state.borrow().kinds)?,
+      );
+    }
+    let ok = kind_annotation(&fxn_def.code.output[0].kind.kind, p)?
       .to_value_kind(&p.state.borrow().kinds)?;
-    let output_kind = kind_annotation(&fxn_def.code.output[0].kind.kind, p)?
-      .to_value_kind(&p.state.borrow().kinds)?;
-    (input_kind, output_kind)
+    (iks, ok)
   };
 
   #[cfg(not(feature = "kind_annotation"))]
-  let (input_kind, output_kind) = {
+  let (input_kinds, output_kind) = {
     return Ok(None);
   };
 
-  // Only broadcast when input and output kinds are the same scalar kind.
-  // If the input is already a matrix kind, don't recurse.
-  if input_kind != output_kind || matches!(input_kind, ValueKind::Matrix(_, _)) {
+  // All declared parameter kinds and the output kind must be scalar — if any
+  // is already a matrix type, this function is designed to receive matrices
+  // directly and should not broadcast.
+  if input_kinds.iter().any(|k| matches!(k, ValueKind::Matrix(_, _)))
+    || matches!(output_kind, ValueKind::Matrix(_, _))
+  {
     return Ok(None);
   }
 
-  let Some(elements) = crate::patterns::matrix_like_values(&source) else {
-    return Ok(None);
-  };
+  // All matrix arguments must share the same shape; mixed shapes are not supported.
+  let mut broadcast_shape: Option<Vec<usize>> = None;
+  for v in input_arg_values {
+    let dv = detach_value(v);
+    if dv.is_matrix() {
+      let s = dv.shape();
+      if let Some(ref existing) = broadcast_shape {
+        if existing != &s {
+          return Ok(None);
+        }
+      } else {
+        broadcast_shape = Some(s);
+      }
+    }
+  }
+  let shape = broadcast_shape.unwrap(); // safe: has_matrix was true above
+  let n = shape[0] * shape[1];
 
-  // Apply the function element-wise, then reassemble into the original shape.
-  let mut outputs = Vec::with_capacity(elements.len());
-  for element in elements {
-    outputs.push(execute_user_function(fxn_def, &vec![element], p)?);
+  // Flatten each argument into a list of scalars; scalar arguments are repeated.
+  let all_elements: Vec<Vec<Value>> = input_arg_values
+    .iter()
+    .map(|v| {
+      let dv = detach_value(v);
+      if dv.is_matrix() {
+        crate::patterns::matrix_like_values(&dv).unwrap_or_default()
+      } else {
+        vec![dv; n]
+      }
+    })
+    .collect();
+
+  // Call the function once per element position.
+  let mut outputs = Vec::with_capacity(n);
+  for i in 0..n {
+    let args: Vec<Value> = all_elements.iter().map(|col| col[i].clone()).collect();
+    outputs.push(execute_user_function(fxn_def, &args, p)?);
   }
 
-  let shape = source.shape();
   Ok(Some(build_typed_matrix_from_values(
     &output_kind,
     outputs,

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -983,6 +983,22 @@ test_interpreter!(interpret_user_function_scalar_auto_broadcast, r#"add-one(x<f6
   | * => x + 1.
 add-one([1 2 3])"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3)));
 
+// Multi-argument broadcast: two same-shape vectors, constant body.
+// Issue #278 case 1: body returns 1.0 regardless of inputs — should give [1 1 1].
+test_interpreter!(interpret_broadcast_multi_arg_constant, r#"const-one(x<f64>, y<f64>) => <f64>
+  | (*, *) => 1.0.
+const-one([1 2 3], [1 2 3])"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 1.0, 1.0], 1, 3)));
+
+// Multi-argument broadcast: element-wise product of two same-shape vectors.
+test_interpreter!(interpret_broadcast_multi_arg_mul, r#"mul(x<f64>, y<f64>) => <f64>
+  | (*, *) => x * y.
+mul([1 2 3], [4 5 6])"#, Value::MatrixF64(Matrix::from_vec(vec![4.0, 10.0, 18.0], 1, 3)));
+
+// Multi-argument broadcast: one matrix arg, one scalar arg (scalar repeats).
+test_interpreter!(interpret_broadcast_multi_arg_scalar_repeat, r#"scale(x<f64>, y<f64>) => <f64>
+  | (*, *) => x * y.
+scale([1 2 3], 2.0)"#, Value::MatrixF64(Matrix::from_vec(vec![2.0, 4.0, 6.0], 1, 3)));
+
 test_interpreter!(interpret_set_value,"~x := 1.23; x = 4.56;", Value::F64(Ref::new(4.56)));
 test_interpreter!(interpret_set_value_row_vector,"~x := [6,2]; x[1] = 4;", Value::MatrixF64(Matrix::from_vec(vec![4.0, 2.0], 1, 2)));
 test_interpreter!(interpret_set_value_col_vector,"~x := [false false true true]'; x[1] = true; x[1]", Value::Bool(Ref::new(true)));


### PR DESCRIPTION
When a function declares scalar parameters (e.g. `func(x<f64>, y<f64>)`) but is called      
  with vector/matrix arguments of the same shape, mech should apply the function element-wise 
  and return a vector of results. This worked for single-argument functions but was          
  completely absent for functions with two or more arguments.                                 
                                                                                              
      func(x<f64>, y<f64>) => <f64>                                                           
        | (*, *) => x * y.                                                                    
                                                                                            
      func([1 2 3], [4 5 6])   -- expected [4 10 18], got wrong result or error               
                                                                                              
  ## Root cause
                                                                                              
  `try_broadcast_user_function` had a hard check at the top:                                
                                                            
      if input_arg_values.len() != 1 { return Ok(None); }
                                                         
  This skipped broadcasting entirely for any function with more than one argument,            
  passing raw matrices into the body instead.                                     
                                                                                              
  ## Fix                                                                                    
                                                                                              
  Added a multi-argument path to `try_broadcast_user_function` that:
  1. Verifies all declared parameter and output kinds are scalar                              
  2. Requires all matrix arguments to share the same shape                                    
  3. Zips corresponding elements across all arguments (scalars repeat at every position)
  4. Calls the function once per position and reassembles the results into a matrix           
                                                                                            
  The original single-argument path is untouched.                                             
                                                 
  ## Tests                                                                                    
                                                                                            
  Three new tests added to `tests/interpreter.rs`:                                            
  - `interpret_broadcast_multi_arg_constant` — constant body broadcasts to `[1 1 1]`        
  - `interpret_broadcast_multi_arg_mul` — element-wise product `[1 2 3] * [4 5 6]` = `[4 10   
  18]`                                                                                      
  - `interpret_broadcast_multi_arg_scalar_repeat` — scalar arg repeats at each position
                                                                                       
  Full test suite: 565/565 pass.                                                              
                                                                                              
  Fixes #278                                                                                  