### PR TITLE
Replace footer legal links with Apache 2.0 license link

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -847,7 +847,12 @@ section.active-section {
 
 .footer-meta-links {
   display: flex;
-  gap: 24px;
+}
+
+.footer-meta-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .footer-meta-links a:hover {

--- a/include/blog.html
+++ b/include/blog.html
@@ -238,9 +238,10 @@
 
             </span> in Pennsylvania</div>
             <div class="footer-meta-links">
-              <a href="#">Privacy</a>
-              <a href="#">Terms</a>
-              <a href="#">Code of Conduct</a>
+              <a href="https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/LICENSE" target="_blank" rel="noopener noreferrer">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="footer-icon lucide lucide-scale-icon lucide-scale" aria-hidden="true"><path d="M12 3v18"/><path d="m19 8 3 8a5 5 0 0 1-6 0zV7"/><path d="M3 7h1a17 17 0 0 0 8-2 17 17 0 0 0 8 2h1"/><path d="m5 8 3 8a5 5 0 0 1-6 0zV7"/><path d="M7 21h10"/></svg>
+                <span>Apache 2.0</span>
+              </a>
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation
- Replace the three bottom-of-page legal links with a single, clearly labeled license link using the provided scale icon and the `Apache 2.0` label to simplify the footer and point users to the project license.

### Description
- Updated `include/blog.html` to remove the `Privacy`, `Terms`, and `Code of Conduct` anchors and insert a single anchor linking to `https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/LICENSE` that contains the provided scale SVG and a `span` with `Apache 2.0`.
- Added `target="_blank"` and `rel="noopener noreferrer"` attributes to the new license link for safe external navigation and marked the SVG `aria-hidden="true"` to avoid redundant accessibility verbosity.
- Modified `include/blog.css` to change `.footer-meta-links` layout and add `.footer-meta-links a { display: inline-flex; align-items: center; gap: 8px; }` so the icon and label align and space consistently.

### Testing
- Verified the file changes and diff with `git diff -- include/blog.html include/blog.css`, which showed the intended replacements and stylesheet updates (success).
- Searched the codebase to confirm the original `Privacy`, `Terms`, and `Code of Conduct` anchors were removed using `rg` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d25ee778832aa7842d2333d9b6fa)