### PR TITLE
Add REPL startup hint and mark console output/errors as under construction

### DIFF
--- a/include/blog.html
+++ b/include/blog.html
@@ -213,34 +213,10 @@
         {{REPL}}
       </div>
       <div class="console-panel" data-panel="output">
-        <div class="console-scroll">$ npm run docs:build
-
-vite v6.1.2 building for production...
-✓ 1782 modules transformed.
-dist/index.html                     1.24 kB │ gzip:   0.63 kB
-dist/assets/index-18d97.css       98.31 kB │ gzip:  16.88 kB
-dist/assets/docs-9f22e.js        412.54 kB │ gzip: 125.03 kB
-dist/assets/vendor-f22c1.js      593.77 kB │ gzip: 194.22 kB
-✓ built in 4.78s
-
-$ npm run docs:preview
-➜  Local:   http://localhost:4173/
-➜  Network: use --host to expose
-
-smoke summary:
-- homepage render: pass
-- nav links: pass
-- docs search request: pass
-- static asset cache hit: pass</div>
+        <div class="console-scroll">under construction</div>
       </div>
       <div class="console-panel" data-panel="errors">
-        <div class="console-scroll">[09:10:42] WARN  markdown-lint: docs/api/spec.md line 188 exceeds 100 chars
-[09:10:44] WARN  markdown-lint: docs/operations/runbook.md line 241 trailing spaces
-[09:12:24] WARN  eslint: src/components/ConsolePane.tsx:211 unexpected any (ts-eslint/no-explicit-any)
-[09:12:24] WARN  eslint: src/components/ResizeHandle.tsx:88 React Hook useEffect has missing dependency
-
-No critical runtime errors reported.
-Health checks stayed green during deploy.</div>
+        <div class="console-scroll">under construction</div>
       </div>
     </div>
   </aside>

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -538,6 +538,13 @@ pub fn attach_repl(&mut self, repl_id: &str) {
     closure.forget();
   }));
 
+  let intro_line = document.create_element("div").unwrap();
+  intro_line.set_class_name("repl-result");
+  intro_line.set_inner_html(
+    "<div class=\"mech-output-value\">Enter <code>:help</code> for a list of all commands.</div>",
+  );
+  container.append_child(&intro_line).unwrap();
+
   // Initial prompt
   if let Some(cb) = &*create_prompt.borrow() {
     cb();

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -541,7 +541,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
   let intro_line = document.create_element("div").unwrap();
   intro_line.set_class_name("repl-result");
   intro_line.set_inner_html(
-    "<div class=\"mech-output-value\">Enter <code>:help</code> for a list of all commands.</div>",
+    "<div class=\"mech-output-value\">Enter <code class=\"mech-inline-code\">:help</code> for a list of all commands.</div>",
   );
   container.append_child(&intro_line).unwrap();
 


### PR DESCRIPTION
### Motivation
- Provide a clear first-line hint in the wasm REPL to guide users to `:help` and mark the static console panels as not-yet-implemented.

### Description
- Add an initial REPL result in `attach_repl` that appends `Enter <code>:help</code> for a list of all commands.` to the REPL output in `src/wasm/src/lib.rs`.
- Replace the contents of the console `output` and `errors` panels in `include/blog.html` with the text `under construction`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f507ca30f4832aa62c1340e2ca68bb)