### PR TITLE
Style unrecognized REPL commands as runtime error cards

### DIFF
--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -635,7 +635,19 @@ pub fn attach_repl(&mut self, repl_id: &str) {
           execute_repl_command(repl_command)
         }
         Err(x) => {
-          format!("Unrecognized command: {}", x)
+          let message = html_escape(&format!("Unrecognized command: {}", x));
+          format!(
+            "<div class=\"mech-output-kind\">Error</div><div class=\"mech-output-value\"><div class=\"mech-runtime-error\">\
+              <div class=\"mech-runtime-error-header\">\
+                <span class=\"mech-runtime-error-icon\" aria-hidden=\"true\"></span>\
+                <div>\
+                  <div class=\"mech-runtime-error-title\">UnrecognizedCommand</div>\
+                  <div class=\"mech-runtime-error-message\">{}</div>\
+                </div>\
+              </div>\
+            </div></div>",
+            message
+          )
         }
       }
       #[cfg(not(feature = "repl"))]


### PR DESCRIPTION
### Motivation
- Make parser failures for `:` REPL commands render consistently with runtime errors by returning the existing `.mech-runtime-error` HTML structure instead of plain text.

### Description
- Update the `eval` path that handles `:` commands in `src/wasm/src/lib.rs` to produce a structured error card with a title `UnrecognizedCommand` and the parser message inside `.mech-runtime-error-message`.
- Escape the parser message with `html_escape` before inserting it into the HTML to keep output safe and consistent with other rendering paths.

### Testing
- Ran `cargo test -q` in the environment but the run did not complete within the session window and produced no pass/fail output.
- Ran `cargo check -q` but it also did not complete within the session window and produced no pass/fail output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50d314b48832aba91c04329bae383)