### PR TITLE
Console: add errors summary panel, count badge, and navigation helpers

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -1044,6 +1044,16 @@ body.console-fullscreen .console-pane {
   border-bottom-color: var(--nav-accent-active);
 }
 
+.console-tab-count {
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 18px;
+  background: var(--error);
+  color: var(--text-primary);
+}
+
 .console-fullscreen-toggle {
   display: inline-flex;
   align-items: center;
@@ -1132,6 +1142,26 @@ body.console-fullscreen .console-fullscreen-toggle .icon-exit {
 .console-scroll::-webkit-scrollbar-thumb:hover {
   background: var(--accent-secondary-purple-soft);
   background-clip: content-box;
+}
+
+.console-errors-list {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.console-errors-list li {
+  margin: 0 0 12px;
+}
+
+.console-error-preview {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.mech-error-target-flash {
+  outline: 2px solid var(--error);
+  outline-offset: 4px;
 }
 
 /* ── Responsive ── */

--- a/include/blog.html
+++ b/include/blog.html
@@ -191,7 +191,7 @@
       <div class="console-tabs" role="tablist" aria-label="Console sections">
         <button class="console-tab active" type="button" role="tab" aria-selected="true" data-tab="console">console</button>
         <button class="console-tab" type="button" role="tab" aria-selected="false" data-tab="output">output</button>
-        <button class="console-tab" type="button" role="tab" aria-selected="false" data-tab="errors">errors</button>
+        <button class="console-tab" type="button" role="tab" aria-selected="false" data-tab="errors">errors <span class="console-tab-count" data-errors-count hidden>0</span></button>
       </div>
       <button class="console-fullscreen-toggle" id="consoleFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter fullscreen">
         <svg class="icon-enter" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -216,7 +216,7 @@
         <div class="console-scroll">under construction</div>
       </div>
       <div class="console-panel" data-panel="errors">
-        <div class="console-scroll">under construction</div>
+        <div class="console-scroll" id="console-errors-list">No block errors found.</div>
       </div>
     </div>
   </aside>
@@ -330,6 +330,8 @@ const edgeHandle    = document.getElementById("edgeHandle");
 const tabButtons    = Array.from(document.querySelectorAll(".console-tab"));
 const tabPanels     = Array.from(document.querySelectorAll(".console-panel"));
 const fullscreenToggle = document.getElementById("consoleFullscreenToggle");
+const errorsPanel = document.getElementById("console-errors-list");
+const errorsTabCount = document.querySelector("[data-errors-count]");
 
 const MIN_CONSOLE_WIDTH  = 320;
 const COLLAPSE_THRESHOLD = 80;
@@ -363,6 +365,65 @@ function setActiveConsoleTab(tabName) {
     panel.classList.toggle("is-active", panel.dataset.panel === tabName);
   });
 }
+
+function buildErrorSummaryHtml(errorItems) {
+  if (!errorItems.length) return "<p>No block errors found.</p>";
+  const links = errorItems.map((item, ix) => {
+    const label = item.label || `Code block ${ix + 1}`;
+    return `
+      <li>
+        <a href="#" data-error-target="${item.id}">${label}</a>
+        <div class="console-error-preview">${item.preview}</div>
+      </li>
+    `;
+  }).join("");
+  return `<ol class="console-errors-list">${links}</ol>`;
+}
+
+function refreshErrorsPanel() {
+  if (!errorsPanel) return;
+  const outputNodes = Array.from(document.querySelectorAll(".mech-block-output"));
+  const errorNodes = outputNodes
+    .map((node, ix) => ({ node, ix }))
+    .filter(({ node }) => {
+      const kind = node.querySelector(".mech-output-kind");
+      return kind && kind.textContent && kind.textContent.trim().toLowerCase() === "error";
+    })
+    .map(({ node, ix }) => {
+      const blockContainer = node.closest(".mech-codeblock, .mech-code, .mech-fenced-code") || node;
+      const id = blockContainer.id || node.id || `mech-error-block-${ix}`;
+      if (!blockContainer.id) blockContainer.id = id;
+      const preview = (node.querySelector(".mech-output-value")?.textContent || "Error")
+        .trim()
+        .replace(/\s+/g, " ")
+        .slice(0, 220);
+      return { id, label: `Code block ${ix + 1}`, preview };
+    });
+
+  errorsPanel.innerHTML = buildErrorSummaryHtml(errorNodes);
+  if (errorsTabCount) {
+    errorsTabCount.textContent = String(errorNodes.length);
+    errorsTabCount.hidden = errorNodes.length === 0;
+  }
+}
+
+document.addEventListener("click", (event) => {
+  const link = event.target.closest("[data-error-target]");
+  if (!link) return;
+  event.preventDefault();
+  const targetId = link.getAttribute("data-error-target");
+  const target = targetId ? document.getElementById(targetId) : null;
+  if (!target) return;
+  target.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
+  target.classList.add("mech-error-target-flash");
+  setTimeout(() => target.classList.remove("mech-error-target-flash"), 1200);
+});
+
+window.addEventListener("load", () => {
+  refreshErrorsPanel();
+  const observer = new MutationObserver(() => refreshErrorsPanel());
+  observer.observe(document.body, { childList: true, subtree: true });
+});
 
 function updateFullscreenToggleLabel() {
   if (!fullscreenToggle) return;


### PR DESCRIPTION
### Motivation

- Provide a quick overview of code block errors in the console pane so users can discover and navigate to failing blocks. 
- Surface an error count on the console tab to make error presence visible without opening the panel. 
- Enable smooth navigation and visual flashing of the error target when a user selects an error from the summary.

### Description

- Added UI elements and styling: `.console-tab-count`, `.console-errors-list`, `.console-error-preview`, and `.mech-error-target-flash` in `include/blog.css` to display the badge, error list, previews, and target flash outline. 
- Updated `include/blog.html` to inject a count badge inside the errors tab and replaced the placeholder errors panel with a `div` with id `console-errors-list` used as the errors summary container. 
- Implemented client-side logic in the site script to discover `.mech-block-output` nodes with an output kind of `error`, build a summarized error list with preview links, keep the tab badge count in sync (`data-errors-count`), and add click handling to scroll and highlight the originating block; added a `MutationObserver` to refresh the summary on DOM changes. 

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6869d77e8832aae6c204f529ca570)