### PR TITLE
docs: document reactive VAR template placeholders

### DIFF
--- a/docs/mechdown/template-placeholders.mec
+++ b/docs/mechdown/template-placeholders.mec
@@ -40,12 +40,24 @@ These placeholders support browser-side Mech runtime integration.
 
 The web runtime expects a mount with id `mech-output` when calling `attach_repl`.
 
+### Reactive variable placeholders
+
+You can embed live interpreter variables directly in a template placeholder:
+
+- `{{VAR:x}}` — Reads variable `x` from the default interpreter.
+- `{{VAR:x@foo}}` — Reads variable `x` from interpreter `foo`.
+
+These bindings are reactive. If `x` changes in Mech, the rendered value in the
+document updates automatically.
+
 4. Placement guidance
 -------------------------------------------------------------------------------
 
 - Place `{{TOC}}`, `{{INTRO}}`, and `{{CONTENT}}` where readers should see navigation and primary content.
 - Place `{{CITED}}` only where references should appear.
 - Place `{{REPL}}` inside your console/pane container where the interactive prompt should appear.
+- Use `{{VAR:...}}` placeholders inline anywhere you want live values to appear
+  (for example, in headings, callouts, or narrative text).
 - Keep runtime bootstrap script placement near the end of `<body>` so DOM targets exist before attach.
 
 5. Related docs


### PR DESCRIPTION
### Motivation

- Document the new Mechdown template placeholder feature that lets authors embed live interpreter variables into rendered documents using a concise `{{VAR:...}}` syntax so pages can reflect runtime state.

### Description

- Added a new “Reactive variable placeholders” section to `docs/mechdown/template-placeholders.mec` describing the `{{VAR:x}}` syntax for the default interpreter and `{{VAR:x@foo}}` to select an interpreter named `foo`.
- Clarified that `VAR` bindings are reactive and added placement guidance recommending inline use of `{{VAR:...}}` in headings, callouts, and narrative text.

### Testing

- Verified the updated file content with `nl -ba docs/mechdown/template-placeholders.mec` and confirmed the new section and examples appear as expected.
- No unit or runtime tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6950d1148832a95fab40e7a22da04)