### PR TITLE
Ignore stray float tokens in code block identifiers and trim id before matching

### DIFF
--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -723,7 +723,10 @@ pub fn code_block(input: ParseString) -> ParseResult<SectionElement> {
   let (input, (end_sgl,r)) = range(codeblock_sigil)(input)?;
   let (input, _) = many0(space_tab)(input)?;
   let (input, code_id) = many0(tuple((is_not(left_brace),text)))(input)?;
-  let code_id = code_id.into_iter().map(|(_,tkn)| tkn).collect::<Vec<Token>>();
+  let code_id = code_id.into_iter()
+    .map(|(_,tkn)| tkn)
+    .filter(|tkn| !matches!(tkn.kind, TokenKind::FloatLeft | TokenKind::FloatRight))
+    .collect::<Vec<Token>>();
   let (input, options) = opt(option_map)(input)?;
   let (input, _) = many0(space_tab)(input)?;
   let (input, _) = label!(new_line, msg2)(input)?;
@@ -737,7 +740,7 @@ pub fn code_block(input: ParseString) -> ParseResult<SectionElement> {
   let code_token = Token::new(TokenKind::CodeBlock, src_range, block_src.clone());
 
   let code_id = code_id.iter().flat_map(|tkn| tkn.chars.clone().into_iter().collect::<Vec<char>>()).collect::<String>();
-  match code_id.as_str() {
+  match code_id.trim() {
     "ebnf" => {
       let ebnf_text = block_src.iter().collect::<String>();
       match parse_grammar(&ebnf_text) {


### PR DESCRIPTION
### Motivation

- Prevent spurious `FloatLeft`/`FloatRight` tokens from contaminating code block language/identifier parsing when extracting `code_id` from the sigil line.
- Ensure code block identifier comparisons are robust to surrounding whitespace by trimming before matching.
- Fix minor formatting (end-of-file newline) introduced by the change.

### Description

- Filter out tokens with `TokenKind::FloatLeft` or `TokenKind::FloatRight` from the collected `code_id` tokens before reconstructing the identifier string. 
- Use `code_id.trim()` when matching against language/identifier strings (e.g. `"ebnf"` and `mech` prefixes) to ignore leading/trailing whitespace.
- Apply small formatting cleanup (line breaks and reflowed iterator mapping) in `code_block` parsing logic.

### Testing

- Ran `cargo build` to ensure the project compiles successfully and it completed without errors.
- Ran `cargo test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ae93e1c4832a9843ff3458d230e9)