### PR TITLE
Fix floated section elements so wrapped content is executed

### DIFF
--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -54,7 +54,11 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
     SectionElement::ErrorBlock(x) => x.hash(&mut hasher),
     SectionElement::IdeaBlock(x) => x.hash(&mut hasher),
     SectionElement::Image(x) => x.hash(&mut hasher),
-    SectionElement::Float(x) => x.hash(&mut hasher),
+    SectionElement::Float((el, _direction)) => {
+      // Floated nodes should still be interpreted just like their wrapped
+      // section element (e.g. fenced Mech code, inline eval in captions, etc).
+      return section_element(el, p);
+    },
     SectionElement::Citation(x) => x.hash(&mut hasher),
     SectionElement::Equation(x) => x.hash(&mut hasher),
     SectionElement::Abstract(x) => x.hash(&mut hasher),


### PR DESCRIPTION
### Motivation
- Floated section elements (left `<<` or right `>>`) were treated as inert wrappers during interpretation, so any executable content they contained (fenced Mech code, inline-eval in captions, etc.) was skipped. 
- The intent is for floated elements to render visually while still executing the wrapped section element and producing output values.

### Description
- Change the interpreter handling of `SectionElement::Float` in `src/interpreter/src/mechdown.rs` to match `SectionElement::Float((el, _direction))` and delegate interpretation to `section_element(el, p)` so the wrapped node is executed. 
- This preserves the previous behavior for non-executable floats while allowing wrapped executable nodes (e.g. fenced Mech blocks and inline evals) to run and populate `out_values` as before. 
- No public API changes; the fix is localized to the Mechdown traversal in the interpreter.

### Testing
- Attempted to run `cargo test -p mech-interpreter --quiet`, but the test invocation blocked/hung in this environment and produced no test output before the job was interrupted. 
- No automated tests passed or failed in this run due to the blocked test process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bd90ec40832aa654cbdfe4adaa13)