### PR TITLE
Support multiple `--stylesheet` inputs and inject concatenated CSS into `{{STYLESHEET}}`

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -56,6 +56,26 @@ static STYLESHEET: &str = include_str!("../../include/style.css");
 #[cfg(not(has_file_stylesheet))]
 static STYLESHEET: &str = "No Embedded Stylesheet";
 
+async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
+  if paths.is_empty() {
+    let stylesheet = read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?;
+    return String::from_utf8(stylesheet)
+      .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc());
+  }
+
+  let mut combined = String::new();
+  for path in paths {
+    let stylesheet = read_or_download(path, fallback_url, Some(STYLESHEET.as_bytes())).await?;
+    let stylesheet_str = String::from_utf8(stylesheet)
+      .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc())?;
+    if !combined.is_empty() {
+      combined.push('\n');
+    }
+    combined.push_str(&stylesheet_str);
+  }
+  Ok(combined)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), MechError> {
   /*panic::set_hook(Box::new(|panic_info| {
@@ -134,6 +154,8 @@ async fn main() -> Result<(), MechError> {
         .short('s')
         .long("stylesheet")
         .value_name("STYLESHEET")
+        .num_args(1..)
+        .action(ArgAction::Append)
         .help("Sets the stylesheet for the HTML output"))
       .arg(Arg::new("shim")
         .short('m')
@@ -177,6 +199,8 @@ async fn main() -> Result<(), MechError> {
         .short('s')
         .long("stylesheet")
         .value_name("STYLESHEET")
+        .num_args(1..)
+        .action(ArgAction::Append)
         .help("Sets the stylesheet for the HTML output"))
       .arg(Arg::new("shim")
         .short('m')
@@ -236,7 +260,9 @@ async fn main() -> Result<(), MechError> {
     let address = matches.get_one::<String>("address").cloned().unwrap_or("127.0.0.1".to_string());
     let full_address: String = format!("{}:{}",address,port);
     let mech_paths: Vec<String> = matches.get_many::<String>("mech_serve_file_paths").map_or(vec![], |files| files.map(|file| file.to_string()).collect());
-    let stylesheet_path = matches.get_one::<String>("stylesheet").cloned().unwrap_or("".to_string());
+    let stylesheet_paths: Vec<String> = matches.get_many::<String>("stylesheet").map_or(vec![], |paths| {
+      paths.map(|path| path.to_string()).collect()
+    });
     let wasm_pkg = matches.get_one::<String>("wasm").cloned().unwrap_or("".to_string());
     let shim_path = matches.get_one::<String>("shim").cloned().unwrap_or("".to_string());
 
@@ -246,10 +272,7 @@ async fn main() -> Result<(), MechError> {
     // Load stylesheet
     println!("{} Loading resources…", badge);
     print!("{} Loading stylesheet…", badge);
-    let stylesheet = read_or_download(&stylesheet_path, &stylesheet_backup_url, Some(STYLESHEET.as_bytes()))
-        .await?;
-    let stylesheet_str = String::from_utf8(stylesheet)
-        .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc())?;
+    let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
 
     // Load shim HTML
     print!("{} Loading HTML shim…", badge);
@@ -344,10 +367,9 @@ async fn main() -> Result<(), MechError> {
   if let Some(matches) = matches.subcommand_matches("format") {
     let badge = "[Mech Formatter]".truecolor(34, 204, 187);
     let html_flag = matches.get_flag("html");
-    let stylesheet_path = matches
-        .get_one::<String>("stylesheet")
-        .cloned()
-        .unwrap_or("".to_string());
+    let stylesheet_paths: Vec<String> = matches
+        .get_many::<String>("stylesheet")
+        .map_or(vec![], |paths| paths.map(|path| path.to_string()).collect());
 
     let shim_path = matches
         .get_one::<String>("shim")
@@ -381,17 +403,7 @@ async fn main() -> Result<(), MechError> {
 
     // Load stylesheet
     print!("{} Loading stylesheet…", badge);
-    let stylesheet = read_or_download(&stylesheet_path, &stylesheet_backup_url, Some(STYLESHEET.as_bytes()))
-            .await?;
-    let stylesheet_str = String::from_utf8(stylesheet).map_err(|e| {
-      MechError::new(
-        Utf8ConversionError {
-          source_error: e.to_string(),
-        },
-        None,
-      )
-      .with_compiler_loc()
-    })?;
+    let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
 
     // Load shim HTML
     print!("{} Loading HTML shim…", badge);


### PR DESCRIPTION
### Motivation
- Allow users to pass multiple stylesheet files to the CLI so every provided CSS can be injected into HTML shims at the `{{STYLESHEET}}` placeholder. 
- Preserve existing fallback behavior when no stylesheet is provided while enabling concatenation when multiple paths are given.

### Description
- Added an async helper `load_stylesheets` in `src/bin/mech.rs` that loads either the fallback embedded stylesheet or all provided paths and returns a single concatenated CSS `String` separated by newlines. 
- Updated the Clap configuration for the `format` and `serve` subcommands to accept one-or-more `--stylesheet` values via `.num_args(1..)` and `.action(ArgAction::Append)`. 
- Replaced single-path reads in both `serve` and `format` flows with `matches.get_many::<String>("stylesheet")` to collect multiple paths and call `load_stylesheets` to produce the combined stylesheet string. 
- Kept existing behavior for shim loading and injection, and passed the combined `stylesheet_str` into the `MechServer` and formatter pipeline so `{{STYLESHEET}}` receives all CSS content.

### Testing
- Ran `cargo check -q` and it completed successfully. 
- No additional automated unit tests were modified or added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9273fb6ec832aa18853879642a053)