### PR TITLE
Add backmatter with `{{FOOTNOTES}}` and `{{CITED}}` and update blog styles

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -428,8 +428,8 @@ body.console-fullscreen .workspace {
 .article-layout {
   min-width: 0;
   display: grid;
-  grid-template-columns: var(--toc-width) minmax(0, 1fr);
-  gap: 48px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 40px;
   align-items: start;
 }
 
@@ -438,6 +438,58 @@ body.console-fullscreen .workspace {
 .article-layout.no-sections { display: block; }
 .article-layout.no-sections .toc { display: none; }
 .content-shell.hidden { display: none; }
+
+.article-backmatter {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 28px;
+  border-top: 1px solid var(--border);
+  padding-top: 20px;
+  margin-top: 8px;
+}
+
+.backmatter-column {
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-elevated) 78%, transparent);
+}
+
+.backmatter-column h2 {
+  margin: 0;
+  padding: 10px 14px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-hover);
+  border-bottom: 1px solid var(--border);
+}
+
+.backmatter-body {
+  padding: 12px 14px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  font-size: 14px;
+}
+
+.backmatter-body h1,
+.backmatter-body h2,
+.backmatter-body h3,
+.backmatter-body h4,
+.backmatter-body h5,
+.backmatter-body h6 {
+  all: unset;
+  display: block;
+}
+
+.backmatter-body ol,
+.backmatter-body ul {
+  margin: 0;
+  padding-left: 1.2em;
+}
+
+.backmatter-body li + li {
+  margin-top: 8px;
+}
+
 
 body.narrow-content .mech-float.left,
 body.narrow-content .mech-float.right {
@@ -1175,6 +1227,7 @@ body.console-fullscreen .console-fullscreen-toggle .icon-exit {
   .console-pane, .resize-handle, .edge-handle { display: none; }
   .workspace { grid-template-columns: 1fr; }
   .article-layout { grid-template-columns: 1fr; }
+  .article-backmatter { grid-template-columns: 1fr; }
   .toc { display: none; }
   .footer-main {
     grid-template-columns: max-content minmax(0, 1fr);

--- a/include/blog.html
+++ b/include/blog.html
@@ -69,24 +69,24 @@
       <div class="article-intro" id="articleIntro">
         {{INTRO}}
       </div>
-      <div class="article-layout hide-toc" id="articleLayout">
+      <div class="article-layout" id="articleLayout">
+        {{TOC}}
         <article class="main-content">
           {{CONTENT}}
         </article>
-        <section class="article-backmatter" aria-label="Notes and Works Cited">
-          <div class="backmatter-column backmatter-notes">
-            <h2>Notes</h2>
-            <div class="backmatter-body">
-              {{FOOTNOTES}}
-            </div>
+      </div>
+      <section class="article-backmatter" aria-label="Notes and Works Cited">
+        <div class="backmatter-column backmatter-notes">
+          <div class="backmatter-body">
+            {{FOOTNOTES}}
           </div>
-          <div class="backmatter-column backmatter-cited">
-            <h2>Works Cited</h2>
-            <div class="backmatter-body">
-              {{CITED}}
-            </div>
+        </div>
+        <div class="backmatter-column backmatter-cited">
+          <div class="backmatter-body">
+            {{CITED}}
           </div>
-        </section>
+        </div>
+      </section>
       <footer class="footer">
         <div class="footer-inner">
 
@@ -192,7 +192,6 @@
 
         </div>
       </footer>
-      </div>
     </div>
   </section>
 

--- a/include/blog.html
+++ b/include/blog.html
@@ -69,11 +69,24 @@
       <div class="article-intro" id="articleIntro">
         {{INTRO}}
       </div>
-      <div class="article-layout" id="articleLayout">
-        {{TOC}}
+      <div class="article-layout hide-toc" id="articleLayout">
         <article class="main-content">
           {{CONTENT}}
         </article>
+        <section class="article-backmatter" aria-label="Notes and Works Cited">
+          <div class="backmatter-column backmatter-notes">
+            <h2>Notes</h2>
+            <div class="backmatter-body">
+              {{FOOTNOTES}}
+            </div>
+          </div>
+          <div class="backmatter-column backmatter-cited">
+            <h2>Works Cited</h2>
+            <div class="backmatter-body">
+              {{CITED}}
+            </div>
+          </div>
+        </section>
       <footer class="footer">
         <div class="footer-inner">
 


### PR DESCRIPTION
### Motivation
- Replace the in-article TOC layout for long posts with explicit backmatter so footnotes and citations can be rendered side-by-side and not be part of the TOC or numbered section flow.
- Address the sticky TOC usability issue on long-scrolling articles by moving to a continuous article flow for this template variant while still supporting back-compat CSS/JS paths.

### Description
- Updated `include/blog.html` to remove the inline `{{TOC}}` placement and add a backmatter `section.article-backmatter` after `{{CONTENT}}` containing two columns: left `Notes` with `{{FOOTNOTES}}` and right `Works Cited` with `{{CITED}}`, and added the `hide-toc` class to the article layout wrapper.
- Modified `include/blog.css` to change `.article-layout` to a single-column flow and added `.article-backmatter`, `.backmatter-column`, and `.backmatter-body` rules to provide a two-column desktop layout with a thin 1px themed border and background for each column.
- Reset heading styles inside `.backmatter-body` so Notes and Works Cited are unnumbered and won’t inherit the article’s editorial numbering or heading decorations.
- Added responsive behavior so the backmatter collapses to a single column on narrow viewports and left existing TOC styles in place for other layouts where applicable.

### Testing
- No automated test suite was executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f973037128832abf6276996d8c600e)