### PR TITLE
Adjust article backmatter layout and add multi-column citation styling

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -444,8 +444,11 @@ body.console-fullscreen .workspace {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 28px;
   border-top: 1px solid var(--border);
-  padding-top: 20px;
+  padding: 20px 32px 0;
   margin-top: 8px;
+  width: 100vw;
+  margin-left: 50%;
+  transform: translateX(-50%);
 }
 
 .backmatter-column {
@@ -486,6 +489,23 @@ body.console-fullscreen .workspace {
 
 .backmatter-body li + li {
   margin-top: 8px;
+}
+
+
+.backmatter-cited .backmatter-body ol,
+.backmatter-cited .backmatter-body ul {
+  column-count: 2;
+  column-gap: 28px;
+  column-fill: balance;
+}
+
+.backmatter-cited .backmatter-body li {
+  break-inside: avoid;
+}
+
+.backmatter-body h2::before,
+.footer-heading::before {
+  content: none !important;
 }
 
 
@@ -1225,7 +1245,9 @@ body.console-fullscreen .console-fullscreen-toggle .icon-exit {
   .console-pane, .resize-handle, .edge-handle { display: none; }
   .workspace { grid-template-columns: 1fr; }
   .article-layout { grid-template-columns: 1fr; }
-  .article-backmatter { grid-template-columns: 1fr; }
+  .article-backmatter { grid-template-columns: 1fr; padding-left: 16px; padding-right: 16px; }
+  .backmatter-cited .backmatter-body ol,
+  .backmatter-cited .backmatter-body ul { column-count: 1; }
   .toc { display: none; }
   .footer-main {
     grid-template-columns: max-content minmax(0, 1fr);


### PR DESCRIPTION
### Motivation
- Improve the visual presentation of article backmatter so it can span the full viewport width and center properly. 
- Provide a readable multi-column layout for cited lists in the backmatter. 
- Remove unwanted pseudo-elements before backmatter headings and ensure responsive behavior on narrow screens.

### Description
- Changed `.article-backmatter` padding to `padding: 20px 32px 0`, set `width: 100vw`, and centered it with `margin-left: 50%` and `transform: translateX(-50%)` to create a full-bleed centered backmatter area. 
- Added `.backmatter-cited` rules to render `.backmatter-body` lists in two balanced columns with `column-count: 2`, `column-gap: 28px`, and `break-inside: avoid` for list items. 
- Suppressed pseudo-element content before headings with `.backmatter-body h2::before, .footer-heading::before { content: none !important; }`. 
- Adjusted responsive rules under `@media (max-width: 900px)` to collapse backmatter to a single column with lateral padding and set cited lists to `column-count: 1` for narrow viewports.

### Testing
- Ran the project stylesheet checks with `stylelint` and the static build with `npm run build`, and both completed successfully. 
- Verified responsive layout behavior by running the development server and inspecting styles in narrow and wide viewports with automated CSS checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97ce503c4832a885bf09189b1a99a)