### PR TITLE
Support optional external-link citations in Works Cited

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -2094,9 +2094,24 @@ mark {
     transition: color 0.2s ease;
 }
 
-.mech-citation-link:hover {
+.mech-citation-link-icon {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
     color: var(--main-color-low);
-    text-decoration: underline;
+    background-color: currentColor;
+    -webkit-mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTE1IDNoNnY2Ii8+PHBhdGggZD0iTTEwIDE0IDIxIDMiLz48cGF0aCBkPSJNMTggMTN2NmEyIDIgMCAwIDEtMiAySDVhMiAyIDAgMCAxLTItMlY4YTIgMiAwIDAgMSAyLTJoNiIvPjwvc3ZnPg==");
+    mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTE1IDNoNnY2Ii8+PHBhdGggZD0iTTEwIDE0IDIxIDMiLz48cGF0aCBkPSJNMTggMTN2NmEyIDIgMCAwIDEtMiAySDVhMiAyIDAgMCAxLTItMlY4YTIgMiAwIDAgMSAyLTJoNiIvPjwvc3ZnPg==");
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-position: center;
+    mask-position: center;
+}
+
+.mech-citation-link-icon:hover {
+    color: var(--main-color-high);
 }
 
 .mech-repl {

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -1416,6 +1416,27 @@ mark {
     padding: 3px 10px 3px 10px;
 }
 
+.mech-citation-text {
+    display: inline;
+}
+
+.mech-citation-external-link {
+    color: #F3B62D;
+    margin-left: 6px;
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+}
+
+.mech-citation-external-link:hover {
+    color: #F8D07A;
+}
+
+.mech-citation-link-icon {
+    width: 0.9em;
+    height: 0.9em;
+}
+
 .mech-citation-link {
     color: #F8D07A;
     text-decoration: none;

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -1422,19 +1422,43 @@ mark {
 
 .mech-citation-external-link {
     color: #F3B62D;
-    margin-left: 6px;
-    display: inline-flex;
-    align-items: center;
+    display: inline;
     text-decoration: none;
 }
 
-.mech-citation-external-link:hover {
+.mech-citation-link-text {
+    color: #f2ead9;
+}
+
+.mech-citation-link-icon-wrap {
+    display: inline-block;
+    margin-left: 0.25em;
+    vertical-align: -0.08em;
+    line-height: 1;
+}
+
+.mech-citation-external-link:hover .mech-citation-link-text,
+.mech-citation-external-link:focus-visible .mech-citation-link-text {
+    text-decoration: underline;
+    text-decoration-color: #F3B62D;
+    text-underline-offset: 0.12em;
+}
+
+.mech-citation-external-link:hover .mech-citation-link-icon,
+.mech-citation-external-link:focus-visible .mech-citation-link-icon {
     color: #F8D07A;
 }
 
+.mech-citation-external-link:focus-visible {
+    outline: 2px solid #F3B62D;
+    outline-offset: 2px;
+    border-radius: 3px;
+}
+
 .mech-citation-link-icon {
-    width: 0.9em;
-    height: 0.9em;
+    width: 13px;
+    height: 13px;
+    color: #F3B62D;
 }
 
 .mech-citation-link {

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -1457,9 +1457,19 @@ mark {
 }
 
 .mech-citation-link-icon {
+    display: inline-block;
     width: 13px;
     height: 13px;
     color: var(--accent-primary, #F3B62D);
+    background-color: currentColor;
+    -webkit-mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTE1IDNoNnY2Ii8+PHBhdGggZD0iTTEwIDE0IDIxIDMiLz48cGF0aCBkPSJNMTggMTN2NmEyIDIgMCAwIDEtMiAySDVhMiAyIDAgMCAxLTItMlY4YTIgMiAwIDAgMSAyLTJoNiIvPjwvc3ZnPg==");
+    mask-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTE1IDNoNnY2Ii8+PHBhdGggZD0iTTEwIDE0IDIxIDMiLz48cGF0aCBkPSJNMTggMTN2NmEyIDIgMCAwIDEtMiAySDVhMiAyIDAgMCAxLTItMlY4YTIgMiAwIDAgMSAyLTJoNiIvPjwvc3ZnPg==");
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-position: center;
+    mask-position: center;
 }
 
 .mech-citation-link {

--- a/mech-app/src/css/style.css
+++ b/mech-app/src/css/style.css
@@ -1421,7 +1421,7 @@ mark {
 }
 
 .mech-citation-external-link {
-    color: #F3B62D;
+    color: var(--accent-primary, #F3B62D);
     display: inline;
     text-decoration: none;
 }
@@ -1431,10 +1431,11 @@ mark {
 }
 
 .mech-citation-link-icon-wrap {
-    display: inline-block;
-    margin-left: 0.25em;
+    display: inline-flex;
+    align-items: baseline;
     vertical-align: -0.08em;
     line-height: 1;
+    white-space: nowrap;
 }
 
 .mech-citation-external-link:hover .mech-citation-link-text,
@@ -1446,11 +1447,11 @@ mark {
 
 .mech-citation-external-link:hover .mech-citation-link-icon,
 .mech-citation-external-link:focus-visible .mech-citation-link-icon {
-    color: #F8D07A;
+    color: var(--accent-hover, #F8D07A);
 }
 
 .mech-citation-external-link:focus-visible {
-    outline: 2px solid #F3B62D;
+    outline: 2px solid var(--accent-primary, #F3B62D);
     outline-offset: 2px;
     border-radius: 3px;
 }
@@ -1458,7 +1459,7 @@ mark {
 .mech-citation-link-icon {
     width: 13px;
     height: 13px;
-    color: #F3B62D;
+    color: var(--accent-primary, #F3B62D);
 }
 
 .mech-citation-link {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -882,9 +882,9 @@ impl Formatter {
     let formatted_citation = if self.html {
       let citation_body = match parsed_citation {
         Ok((citation_text, Some(link))) => format!(
-          "<span class=\"mech-citation-text\">{}</span><a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Open citation link\">{}</a>",
-          citation_text,
+          "<a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\"><span class=\"mech-citation-link-text\">{}</span><span class=\"mech-citation-link-icon-wrap\" aria-hidden=\"true\">{}</span></a>",
           link,
+          citation_text,
           self.citation_external_link_icon(),
         ),
         Ok((citation_text, None)) => format!("<span class=\"mech-citation-text\">{}</span>", citation_text),

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -31,6 +31,27 @@ pub struct Formatter{
 }
 
 impl Formatter {
+  fn citation_paragraph_with_optional_link(&mut self, paragraph: &Paragraph) -> Result<(String, Option<String>), String> {
+    let mut link: Option<String> = None;
+    let mut rendered = String::new();
+    for element in &paragraph.elements {
+      match element {
+        ParagraphElement::Hyperlink((text, url)) => {
+          if link.is_some() {
+            return Err("Citations may contain at most one link.".to_string());
+          }
+          link = Some(url.to_string());
+          rendered.push_str(&self.inline_paragraph(text));
+        }
+        _ => rendered.push_str(&self.paragraph_element(element)),
+      }
+    }
+    Ok((rendered, link))
+  }
+
+  fn citation_external_link_icon(&self) -> &'static str {
+    r#"<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link-icon mech-citation-link-icon"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>"#
+  }
 
   fn mika_interpreter_id(parent_id: u64, node: &(Mika, Option<MikaSection>)) -> u64 {
     hash_str(&format!("mika:{}:{:?}", parent_id, (&node.0, &node.1)))
@@ -847,7 +868,7 @@ impl Formatter {
 
   pub fn citation(&mut self, node: &Citation) -> String {
     let id = hash_str(&format!("{}",node.id.to_string()));
-    let citation_text = self.paragraph(&node.text);
+    let parsed_citation = self.citation_paragraph_with_optional_link(&node.text);
     let citation_num = match self.citation_map.get(&id) {
       Some(&num) => num,
       None => {
@@ -859,11 +880,26 @@ impl Formatter {
     };
     self.citations.resize(self.citation_num, String::new());
     let formatted_citation = if self.html {
+      let citation_body = match parsed_citation {
+        Ok((citation_text, Some(link))) => format!(
+          "<span class=\"mech-citation-text\">{}</span><a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Open citation link\">{}</a>",
+          citation_text,
+          link,
+          self.citation_external_link_icon(),
+        ),
+        Ok((citation_text, None)) => format!("<span class=\"mech-citation-text\">{}</span>", citation_text),
+        Err(err) => format!("<span class=\"mech-error\">{}</span>", err),
+      };
       format!("<div id=\"{}\" class=\"mech-citation\">
       <div class=\"mech-citation-id\">[{}]:</div>
       {}
-    </div>",id, citation_num, citation_text)
+    </div>",id, citation_num, citation_body)
     } else {
+      let citation_text = match parsed_citation {
+        Ok((citation_text, Some(link))) => format!("{} {}", citation_text, link),
+        Ok((citation_text, None)) => citation_text,
+        Err(err) => format!("ERROR: {}", err),
+      };
       format!("[{}]: {}",node.id.to_string(), citation_text)
     };
     self.citations[citation_num - 1] = formatted_citation;

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -5,6 +5,19 @@ use colored::Colorize;
 use std::io::{Read, Write, Cursor};
 use crate::*;
 
+#[derive(Debug, Clone)]
+struct InvalidCitationLinkCountError;
+
+impl MechErrorKind for InvalidCitationLinkCountError {
+  fn name(&self) -> &str {
+    "InvalidCitationLinkCount"
+  }
+
+  fn message(&self) -> String {
+    "Citations may contain at most one link.".to_string()
+  }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Formatter{
   identifiers: HashMap<u64, String>,
@@ -31,14 +44,14 @@ pub struct Formatter{
 }
 
 impl Formatter {
-  fn citation_paragraph_with_optional_link(&mut self, paragraph: &Paragraph) -> Result<(String, Option<String>), String> {
+  fn citation_paragraph_with_optional_link(&mut self, paragraph: &Paragraph) -> MResult<(String, Option<String>)> {
     let mut link: Option<String> = None;
     let mut rendered = String::new();
     for element in &paragraph.elements {
       match element {
         ParagraphElement::Hyperlink((text, url)) => {
           if link.is_some() {
-            return Err("Citations may contain at most one link.".to_string());
+            return Err(MechError::new(InvalidCitationLinkCountError, None).with_compiler_loc());
           }
           link = Some(url.to_string());
           rendered.push_str(&self.inline_paragraph(text));
@@ -888,7 +901,7 @@ impl Formatter {
           self.citation_external_link_icon(),
         ),
         Ok((citation_text, None)) => format!("<span class=\"mech-citation-text\">{}</span>", citation_text),
-        Err(err) => format!("<span class=\"mech-error\">{}</span>", err),
+        Err(err) => format!("<span class=\"mech-error\">{}</span>", err.display_message()),
       };
       format!("<div id=\"{}\" class=\"mech-citation\">
       <div class=\"mech-citation-id\">[{}]:</div>
@@ -898,7 +911,7 @@ impl Formatter {
       let citation_text = match parsed_citation {
         Ok((citation_text, Some(link))) => format!("{} {}", citation_text, link),
         Ok((citation_text, None)) => citation_text,
-        Err(err) => format!("ERROR: {}", err),
+        Err(err) => format!("ERROR: {}", err.display_message()),
       };
       format!("[{}]: {}",node.id.to_string(), citation_text)
     };

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -62,10 +62,6 @@ impl Formatter {
     Ok((rendered, link))
   }
 
-  fn citation_external_link_icon(&self) -> &'static str {
-    r#"<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link-icon mech-citation-link-icon"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>"#
-  }
-
   fn mika_interpreter_id(parent_id: u64, node: &(Mika, Option<MikaSection>)) -> u64 {
     hash_str(&format!("mika:{}:{:?}", parent_id, (&node.0, &node.1)))
   }
@@ -895,10 +891,9 @@ impl Formatter {
     let formatted_citation = if self.html {
       let citation_body = match parsed_citation {
         Ok((citation_text, Some(link))) => format!(
-          "<a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\"><span class=\"mech-citation-link-text\">{}</span><span class=\"mech-citation-link-icon-wrap\" aria-hidden=\"true\">&nbsp;{}</span></a>",
+          "<a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\"><span class=\"mech-citation-link-text\">{}</span><span class=\"mech-citation-link-icon-wrap\" aria-hidden=\"true\">&nbsp;<span class=\"mech-citation-link-icon\"></span></span></a>",
           link,
           citation_text,
-          self.citation_external_link_icon(),
         ),
         Ok((citation_text, None)) => format!("<span class=\"mech-citation-text\">{}</span>", citation_text),
         Err(err) => format!("<span class=\"mech-error\">{}</span>", err.display_message()),

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -882,7 +882,7 @@ impl Formatter {
     let formatted_citation = if self.html {
       let citation_body = match parsed_citation {
         Ok((citation_text, Some(link))) => format!(
-          "<a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\"><span class=\"mech-citation-link-text\">{}</span><span class=\"mech-citation-link-icon-wrap\" aria-hidden=\"true\">{}</span></a>",
+          "<a href=\"{}\" class=\"mech-citation-external-link\" target=\"_blank\" rel=\"noopener noreferrer\"><span class=\"mech-citation-link-text\">{}</span><span class=\"mech-citation-link-icon-wrap\" aria-hidden=\"true\">&nbsp;{}</span></a>",
           link,
           citation_text,
           self.citation_external_link_icon(),


### PR DESCRIPTION
### Motivation
- Allow Works Cited entries to include an optional link (or be entirely a link) while keeping citation text rendered as normal prose and signaling the external target with a trailing icon.
- Prevent ambiguous rendering when multiple links appear in one citation by surfacing an error instead of silently picking one.

### Description
- Added `citation_paragraph_with_optional_link` to extract at most one `Hyperlink` from a citation paragraph and return the rendered text plus an optional URL, returning an error if more than one link is present.
- Added `citation_external_link_icon` to inline a Lucide-style external-link SVG and updated `pub fn citation` to append a single trailing anchor with that SVG when one link is present, or render an error message when multiple links are found.
- Updated non-HTML formatting of citations to include the extracted URL at the end when present.
- Added CSS classes `.mech-citation-text`, `.mech-citation-external-link`, and `.mech-citation-link-icon` to style the icon and use the project accent coloring.

### Testing
- Ran `cargo test -p mech-syntax --quiet` which completed successfully (no tests were present to run). 
- Attempted `cargo test -p syntax --quiet` which failed because the workspace package name is `mech-syntax` not `syntax`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa12fe1380832ab5386677795c1589)