### PR TITLE
Add K:V front-matter parsing and new title placeholders (author/date/kicker/next/previous)

### DIFF
--- a/docs/mechdown/template-placeholders.mec
+++ b/docs/mechdown/template-placeholders.mec
@@ -15,7 +15,11 @@ This allows one Mechdown source document to be rendered into different layouts b
 
 - `{{STYLESHEET}}` — Injected CSS content.
 - `{{TITLE}}` — Document title text.
-- `{{BYLINE}}` — Formatted byline content from the title block.
+- `{{AUTHOR}}` — Inline author paragraph from title front matter.
+- `{{DATE}}` — Inline date paragraph from title front matter.
+- `{{KICKER}}` — Inline kicker paragraph from title front matter.
+- `{{NEXT}}` — Inline next-link paragraph from title front matter.
+- `{{PREVIOUS}}` — Inline previous-link paragraph from title front matter.
 - `{{HERO}}` — Hero media/content from the title block.
 - `{{SUMMARY}}` — Synopsis content from the title block.
 - `{{TOC}}` — Generated table of contents.

--- a/docs/mechdown/title.mec
+++ b/docs/mechdown/title.mec
@@ -12,14 +12,14 @@ Mechdown supports hierarchical titles:
 
 It also supports optional **front matter** directly beneath the document title. Front matter ends with a second `===` separator and can include:
 
-- optional byline (first line)
+- optional K:V front matter fields (`author`, `date`, `hero`, `kicker`, `summary`, `next`, `previous`)
 - optional hero media (`![caption](src)` or a `| ... |` figures row/table)
 - optional summary paragraph
 
 1. Rules and conventions
 -------------------------------------------------------------------------------
 
-- Use one document title per file. The document can have an optional byline (author, date, etc.) immediately following the title.
+- Use one document title per file. The document can have optional K:V front matter immediately following the title.
 - Keep section numbering sequential.
 - Keep subsection numbering aligned with the parent section.
 - Prefer short, descriptive titles so generated navigation remains readable.
@@ -71,7 +71,11 @@ In HTML shims, these placeholders are available:
 
 - `{{STYLESHEET}}`
 - `{{TITLE}}`
-- `{{BYLINE}}`
+- `{{AUTHOR}}`
+- `{{DATE}}`
+- `{{KICKER}}`
+- `{{NEXT}}`
+- `{{PREVIOUS}}`
 - `{{HERO}}`
 - `{{SUMMARY}}`
 - `{{TOC}}`

--- a/include/blog.css
+++ b/include/blog.css
@@ -318,7 +318,7 @@ body.console-fullscreen .workspace {
   letter-spacing: 0.01em;
 }
 
-.mech-byline {
+.mech-meta {
   margin-top: 22px;
   color: var(--hero-text-secondary);
   font-size: 14px;
@@ -327,10 +327,21 @@ body.console-fullscreen .workspace {
   gap: 10px;
 }
 
-.mech-byline p {
+.mech-meta p {
   color: inherit;
   margin: 0px;
   font-weight: 400;
+}
+
+.mech-prev-next {
+  display: flex;
+  justify-content: space-between;
+  margin: 24px 0;
+}
+
+.mech-next,
+.mech-previous {
+  display: inline-block;
 }
 
 .mech-summary {

--- a/include/blog.css
+++ b/include/blog.css
@@ -280,6 +280,18 @@ body.console-fullscreen .workspace {
   gap: 8px;
 }
 
+.breadcrumbs .hero-kicker {
+  margin-bottom: inherit !important;
+  display: inherit !important;
+  flex-wrap: inherit !important;
+  gap: inherit !important;
+  text-transform: inherit !important;
+  letter-spacing: inherit !important;
+  color: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+}
+
 .breadcrumbs .sep { color: var(--accent-primary); }
 .breadcrumbs a:hover { color: var(--accent-primary); }
 
@@ -333,15 +345,76 @@ body.console-fullscreen .workspace {
   font-weight: 400;
 }
 
-.mech-prev-next {
-  display: flex;
-  justify-content: space-between;
-  margin: 24px 0;
+.post-pagination{
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+  margin:32px 0 20px;
+  padding-top:14px;
+  border-top:1px dotted var(--border);
 }
 
-.mech-next,
-.mech-previous {
-  display: inline-block;
+.post-pagination-prev,.post-pagination-next{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.post-pagination-next{
+  text-align:right;
+  align-items:flex-end;
+}
+
+.post-pagination-label{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:var(--text-secondary);
+}
+
+.post-pagination-next .post-pagination-label {
+  margin-right: 25px;
+}
+
+.post-pagination-prev .post-pagination-label {
+  margin-left: 25px;
+}
+
+.post-pagination .mech-previous,
+.post-pagination .mech-next{
+  margin:0;
+}
+
+.post-pagination a{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--text-primary);
+  font-size:16px;
+  text-decoration:none;
+}
+
+.post-pagination-prev a::before{
+  content:"⟨";
+  color:var(--accent-primary);
+  font-size:35px;
+  line-height:1;
+  margin-right:4px;
+  transform: translateY(-15px);
+}
+
+.post-pagination-next a::after{
+  content:"⟩";
+  color:var(--accent-primary);
+  font-size:35px;
+  line-height:1;
+  margin-left:4px;
+  transform: translateY(-15px);
+}
+
+.post-pagination a:hover{
+  color:var(--accent-soft);
 }
 
 .mech-summary {
@@ -388,6 +461,7 @@ body.console-fullscreen .workspace {
   margin-block-end: 0px;
   margin-inline-start: 0px;
   margin-inline-end: 0px;
+  padding-bottom: 0px;
 }
 
 .mech-hero-img figure img {
@@ -439,8 +513,8 @@ body.console-fullscreen .workspace {
 .article-layout {
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 40px;
+  grid-template-columns: var(--toc-width) minmax(0, 1fr);
+  gap: 48px;
   align-items: start;
 }
 
@@ -466,16 +540,6 @@ body.console-fullscreen .workspace {
   padding-top: 20px;
   margin-top: 20px;
   position: relative;
-}
-
-.article-backmatter::before {
-  content: "";
-  display: block;
-  width: 240px;
-  border-top: 1px dotted var(--accent-primary);
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 20px;
 }
 
 .backmatter-row + .backmatter-row {
@@ -753,7 +817,7 @@ section.active-section {
 /* ── Footer ── */
 .footer {
   grid-column: 1 / -1;
-  margin-top: 64px;
+  margin-top: 0px;
   border-top: 1px dotted var(--border);
   background: linear-gradient(90deg, var(--bg-primary), var(--bg-dark), var(--bg-primary));
   color: var(--text-secondary);
@@ -1008,7 +1072,7 @@ section.active-section {
   top: var(--header-height);
   height: calc(100vh - var(--header-height));
   align-self: start;
-  cursor: grab;
+  cursor: ew-resize;
   z-index: 50;
 }
 
@@ -1065,7 +1129,7 @@ section.active-section {
   border-radius: var(--grip-radius) 0 0 var(--grip-radius);
   background: var(--accent-primary);
   border: 1px solid var(--accent-hover);
-  cursor: grab;
+  cursor: ew-resize;
   z-index: 1100;
   display: none;
   transition: right 140ms ease, left 140ms ease;
@@ -1089,7 +1153,7 @@ body.edge-right .resize-handle {
 
 body.is-resizing,
 body.is-resizing * {
-  cursor: grabbing !important;
+  cursor: ew-resize !important;
 }
 
 /* ── Console pane ── */
@@ -1475,3 +1539,26 @@ body.console-fullscreen .console-fullscreen-toggle .icon-exit {
     overflow:auto;
     border-radius: 0 0 8px 8px;
   } 
+
+.mika-separator {
+  position: relative;
+  display: block;
+  width: 55%;
+  height: 0;
+  margin: 64px auto;
+  border-top: 1px dotted #d29a2e;
+}
+
+.mika-separator::before {
+  content: "⦿";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, -50%);
+  font-family: SF Mono, SF Mono Regular, Consolas, "Liberation Mono", "Courier New", monospace;
+  color: #d29a2e;
+  background: var(--bg-primary);
+  padding: 0 12px;
+  font-size: 22px;
+  line-height: 1;
+}

--- a/include/blog.html
+++ b/include/blog.html
@@ -58,9 +58,9 @@
       <div class="hero">
         <div class="hero-panel">
           <div>
-            <p class="hero-kicker">Announcement</p>
+            {{KICKER}}
             <h1>{{TITLE}}</h1>
-            {{BYLINE}}
+            <p class="mech-meta">{{AUTHOR}} {{DATE}}</p>
           </div>
           {{SUMMARY}}
         </div>
@@ -87,6 +87,7 @@
           </div>
         </div>
       </section>
+      <nav class="mech-prev-next">{{PREVIOUS}} {{NEXT}}</nav>
       <footer class="footer">
         <div class="footer-inner">
 

--- a/include/blog.html
+++ b/include/blog.html
@@ -8,7 +8,6 @@
 <style>
   {{STYLESHEET}}
 </style>
-<link rel="stylesheet" href="https://mech-lang.org/css/blog.css">
 </head>
 <body>
 
@@ -51,7 +50,7 @@
         <span class="sep">⟩</span>
         <a href="/blog">Blog</a>
         <span class="sep">⟩</span>
-        <a href="/blog/announcements">Announcements</a>
+        <a href="/blog/announcements">{{KICKER}}</a>
         <span class="sep">⟩</span>
         <span aria-current="page">Mech Version 0.3-Beta</span>
       </nav>
@@ -60,7 +59,7 @@
           <div>
             {{KICKER}}
             <h1>{{TITLE}}</h1>
-            <p class="mech-meta">{{AUTHOR}} {{DATE}}</p>
+            <p class="mech-meta">{{AUTHOR}} • {{DATE}}</p>
           </div>
           {{SUMMARY}}
         </div>
@@ -75,6 +74,7 @@
           {{CONTENT}}
         </article>
       </div>
+      <div class="mika-separator"></div>
       <section class="article-backmatter" aria-label="Notes and Works Cited">
         <div class="backmatter-row backmatter-notes">
           <div class="backmatter-body">
@@ -87,7 +87,16 @@
           </div>
         </div>
       </section>
-      <nav class="mech-prev-next">{{PREVIOUS}} {{NEXT}}</nav>
+      <nav class="post-pagination" aria-label="Post navigation">
+        <div class="post-pagination-prev">
+          <span class="post-pagination-label">Previous post</span>
+          {{PREVIOUS}}
+        </div>
+        <div class="post-pagination-next">
+          <span class="post-pagination-label">Next post</span>
+          {{NEXT}}
+        </div>
+      </nav>
       <footer class="footer">
         <div class="footer-inner">
 

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -307,9 +307,13 @@ fn pretty_print(&self) -> String {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Title {
   pub text: Token,
-  pub byline: Option<Paragraph>,
+  pub author: Option<Paragraph>,
+  pub date: Option<Paragraph>,
   pub hero: Option<SectionElement>,
+  pub kicker: Option<Paragraph>,
   pub summary: Option<Paragraph>,
+  pub next: Option<Paragraph>,
+  pub previous: Option<Paragraph>,
 }
 
 impl Title {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -162,7 +162,7 @@ impl Formatter {
     self.html = true;
     self.inline_eval_counters.clear();
 
-    let (formatted_byline, formatted_hero, formatted_synopsis) = self.title_slots(&tree.title);
+    let (formatted_author, formatted_date, formatted_hero, formatted_kicker, formatted_synopsis, formatted_next, formatted_previous) = self.title_slots(&tree.title);
     let (formatted_abstract, formatted_intro, formatted_contents, formatted_cited, formatted_footnotes) = self.document_slots(tree);
     let formatted_src = formatted_contents.clone();
     self.reset_numbering();
@@ -185,7 +185,11 @@ impl Formatter {
 
     let mut rendered = shim.replace("{{STYLESHEET}}", &style)
         .replace("{{TOC}}", &formatted_toc)
-        .replace("{{BYLINE}}", &formatted_byline)
+        .replace("{{AUTHOR}}", &formatted_author)
+        .replace("{{DATE}}", &formatted_date)
+        .replace("{{KICKER}}", &formatted_kicker)
+        .replace("{{NEXT}}", &formatted_next)
+        .replace("{{PREVIOUS}}", &formatted_previous)
         .replace("{{HERO}}", &formatted_hero)
         .replace("{{SUMMARY}}", &formatted_synopsis)
         .replace("{{ABSTRACT}}", &formatted_abstract)
@@ -205,15 +209,19 @@ impl Formatter {
       .replace("{{CONTENTS}}", &formatted_contents)
   }
 
-  fn title_slots(&mut self, title: &Option<Title>) -> (String, String, String) {
+  fn title_slots(&mut self, title: &Option<Title>) -> (String, String, String, String, String, String, String) {
     match title {
       Some(title) => {
-        let byline = title.byline.as_ref().map(|p| self.byline_el(p)).unwrap_or_default();
+        let author = title.author.as_ref().map(|p| self.inline_para_el(p, "mech-author")).unwrap_or_default();
+        let date = title.date.as_ref().map(|p| self.inline_para_el(p, "mech-date")).unwrap_or_default();
         let hero = title.hero.as_ref().map(|h| self.hero_el(h)).unwrap_or_default();
+        let kicker = title.kicker.as_ref().map(|p| self.inline_para_el(p, "hero-kicker")).unwrap_or_default();
         let summary = title.summary.as_ref().map(|p| self.synopsis_el(p)).unwrap_or_default();
-        (byline, hero, summary)
+        let next = title.next.as_ref().map(|p| self.inline_para_el(p, "mech-next")).unwrap_or_default();
+        let previous = title.previous.as_ref().map(|p| self.inline_para_el(p, "mech-previous")).unwrap_or_default();
+        (author, date, hero, kicker, summary, next, previous)
       }
-      None => (String::new(), String::new(), String::new()),
+      None => (String::new(), String::new(), String::new(), String::new(), String::new(), String::new(), String::new()),
     }
   }
 
@@ -1013,6 +1021,15 @@ impl Formatter {
       format!("<div class=\"mech-prompt\"><span class=\"mech-prompt-sigil\">>:</span>{}</div>", prompt_str)
     } else {
       format!(">: {}\n", prompt_str)
+    }
+  }
+
+  pub fn inline_para_el(&mut self, node: &Paragraph, class_name: &str) -> String {
+    let text = self.inline_paragraph(node);
+    if self.html {
+      format!("<span class=\"{}\">{}</span>", class_name, text)
+    } else {
+      text
     }
   }
 

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -5,6 +5,17 @@ use colored::Colorize;
 use std::io::{Read, Write, Cursor};
 use crate::*;
 
+#[derive(Default)]
+struct TitleSlots {
+  author: String,
+  date: String,
+  hero: String,
+  kicker: String,
+  summary: String,
+  next: String,
+  previous: String,
+}
+
 #[derive(Debug, Clone)]
 struct InvalidCitationLinkCountError;
 
@@ -162,7 +173,7 @@ impl Formatter {
     self.html = true;
     self.inline_eval_counters.clear();
 
-    let (formatted_author, formatted_date, formatted_hero, formatted_kicker, formatted_synopsis, formatted_next, formatted_previous) = self.title_slots(&tree.title);
+    let title_slots = self.title_slots(&tree.title);
     let (formatted_abstract, formatted_intro, formatted_contents, formatted_cited, formatted_footnotes) = self.document_slots(tree);
     let formatted_src = formatted_contents.clone();
     self.reset_numbering();
@@ -185,13 +196,13 @@ impl Formatter {
 
     let mut rendered = shim.replace("{{STYLESHEET}}", &style)
         .replace("{{TOC}}", &formatted_toc)
-        .replace("{{AUTHOR}}", &formatted_author)
-        .replace("{{DATE}}", &formatted_date)
-        .replace("{{KICKER}}", &formatted_kicker)
-        .replace("{{NEXT}}", &formatted_next)
-        .replace("{{PREVIOUS}}", &formatted_previous)
-        .replace("{{HERO}}", &formatted_hero)
-        .replace("{{SUMMARY}}", &formatted_synopsis)
+        .replace("{{AUTHOR}}", &title_slots.author)
+        .replace("{{DATE}}", &title_slots.date)
+        .replace("{{KICKER}}", &title_slots.kicker)
+        .replace("{{NEXT}}", &title_slots.next)
+        .replace("{{PREVIOUS}}", &title_slots.previous)
+        .replace("{{HERO}}", &title_slots.hero)
+        .replace("{{SUMMARY}}", &title_slots.summary)
         .replace("{{ABSTRACT}}", &formatted_abstract)
         .replace("{{INTRO}}", &formatted_intro)
         .replace("{{CITED}}", &formatted_cited)
@@ -209,19 +220,20 @@ impl Formatter {
       .replace("{{CONTENTS}}", &formatted_contents)
   }
 
-  fn title_slots(&mut self, title: &Option<Title>) -> (String, String, String, String, String, String, String) {
+  fn title_slots(&mut self, title: &Option<Title>) -> TitleSlots {
     match title {
       Some(title) => {
-        let author = title.author.as_ref().map(|p| self.inline_para_el(p, "mech-author")).unwrap_or_default();
-        let date = title.date.as_ref().map(|p| self.inline_para_el(p, "mech-date")).unwrap_or_default();
-        let hero = title.hero.as_ref().map(|h| self.hero_el(h)).unwrap_or_default();
-        let kicker = title.kicker.as_ref().map(|p| self.inline_para_el(p, "hero-kicker")).unwrap_or_default();
-        let summary = title.summary.as_ref().map(|p| self.synopsis_el(p)).unwrap_or_default();
-        let next = title.next.as_ref().map(|p| self.inline_para_el(p, "mech-next")).unwrap_or_default();
-        let previous = title.previous.as_ref().map(|p| self.inline_para_el(p, "mech-previous")).unwrap_or_default();
-        (author, date, hero, kicker, summary, next, previous)
+        TitleSlots {
+          author: title.author.as_ref().map(|p| self.inline_para_el(p, "mech-author")).unwrap_or_default(),
+          date: title.date.as_ref().map(|p| self.inline_para_el(p, "mech-date")).unwrap_or_default(),
+          hero: title.hero.as_ref().map(|h| self.hero_el(h)).unwrap_or_default(),
+          kicker: title.kicker.as_ref().map(|p| self.inline_para_el(p, "hero-kicker")).unwrap_or_default(),
+          summary: title.summary.as_ref().map(|p| self.synopsis_el(p)).unwrap_or_default(),
+          next: title.next.as_ref().map(|p| self.inline_para_el(p, "mech-next")).unwrap_or_default(),
+          previous: title.previous.as_ref().map(|p| self.inline_para_el(p, "mech-previous")).unwrap_or_default(),
+        }
       }
-      None => (String::new(), String::new(), String::new(), String::new(), String::new(), String::new(), String::new()),
+      None => TitleSlots::default(),
     }
   }
 

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -33,48 +33,50 @@ pub fn title(input: ParseString) -> ParseResult<Title> {
   let (input, front_matter) = opt(title_front_matter)(input)?;
   let mut title = Token::merge_tokens(&mut text).unwrap();
   title.kind = TokenKind::Title;
-  let (byline, hero, summary) = match front_matter {
-    Some((byline, hero, summary)) => (byline, hero, summary),
-    None => (None, None, None),
+  let (author, date, hero, kicker, summary, next, previous) = match front_matter {
+    Some((author, date, hero, kicker, summary, next, previous)) => (author, date, hero, kicker, summary, next, previous),
+    None => (None, None, None, None, None, None, None),
   };
-  Ok((input, Title{text: title, byline, hero, summary}))
+  Ok((input, Title{text: title, author, date, hero, kicker, summary, next, previous}))
 }
 
-pub fn byline(input: ParseString) -> ParseResult<Paragraph> {
-  let (input, byline) = paragraph_newline(input)?;
-  let (input, _) = many1(equal)(input)?;
-  Ok((input, byline))
-}
-
-pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>, Option<SectionElement>, Option<Paragraph>)> {
+pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>, Option<Paragraph>, Option<SectionElement>, Option<Paragraph>, Option<Paragraph>, Option<Paragraph>, Option<Paragraph>)> {
   let mut input = input;
-  let mut byline = None;
+  let mut author = None;
+  let mut date = None;
   let mut hero = None;
+  let mut kicker = None;
   let mut summary = None;
+  let mut next = None;
+  let mut previous = None;
 
-  if let Ok((next_input, parsed_byline)) = paragraph_newline(input.clone()) {
+  while many1(equal)(input.clone()).is_err() {
+    let (next_input, line) = paragraph_newline(input.clone())?;
     input = next_input;
-    byline = Some(parsed_byline);
-  }
-
-  if let Ok((next_input, image)) = img(input.clone()) {
-    let (next_input, _) = whitespace0(next_input)?;
-    input = next_input;
-    hero = Some(SectionElement::Image(image));
-  } else if let Ok((next_input, figure_table)) = figures(input.clone()) {
-    let (next_input, _) = whitespace0(next_input)?;
-    input = next_input;
-    hero = Some(SectionElement::FigureTable(figure_table));
-  }
-
-  if let Ok((next_input, parsed_synopsis)) = paragraph_newline(input.clone()) {
-    input = next_input;
-    summary = Some(parsed_synopsis);
+    if let Some((k, v)) = line.to_string().split_once(':') {
+      let key = k.trim().to_lowercase();
+      let value = v.trim();
+      if value.is_empty() {
+        continue;
+      }
+      let token = Token::new(TokenKind::Text, SourceRange::default(), value.chars().collect());
+      let value_paragraph = Paragraph::from_tokens(vec![token.clone()]);
+      match key.as_str() {
+        "author" => author = Some(value_paragraph),
+        "date" => date = Some(value_paragraph),
+        "kicker" => kicker = Some(value_paragraph),
+        "summary" => summary = Some(value_paragraph),
+        "next" => next = Some(value_paragraph),
+        "previous" => previous = Some(value_paragraph),
+        "hero" => hero = Some(SectionElement::Paragraph(Paragraph::from_tokens(vec![token]))),
+        _ => (),
+      }
+    }
   }
 
   let (input, _) = many1(equal)(input)?;
   let (input, _) = whitespace0(input)?;
-  Ok((input, (byline, hero, summary)))
+  Ok((input, (author, date, hero, kicker, summary, next, previous)))
 }
 
 pub struct MarkdownTableHeader {

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -62,26 +62,37 @@ pub fn title_front_matter(input: ParseString) -> ParseResult<TitleFrontMatter> {
   let mut front_matter = TitleFrontMatter::default();
 
   while many1(equal)(input.clone()).is_err() {
-    let (next_input, line) = paragraph_newline(input.clone())?;
-    input = next_input;
-    if let Some((k, v)) = line.to_string().split_once(':') {
-      let key = k.trim().to_lowercase();
-      let value = v.trim();
-      if value.is_empty() {
+    let (next_input, key) = identifier(input.clone())?;
+    let (next_input, _) = many0(space_tab)(next_input)?;
+    let (next_input, _) = colon(next_input)?;
+    let (next_input, _) = many0(space_tab)(next_input)?;
+    let key_name = key.to_string().to_lowercase();
+
+    if key_name == "hero" {
+      if let Ok((next_input, image)) = img(next_input.clone()) {
+        let (next_input, _) = whitespace0(next_input)?;
+        input = next_input;
+        front_matter.hero = Some(SectionElement::Image(image));
+        continue;
+      } else if let Ok((next_input, figure_table)) = figures(next_input.clone()) {
+        let (next_input, _) = whitespace0(next_input)?;
+        input = next_input;
+        front_matter.hero = Some(SectionElement::FigureTable(figure_table));
         continue;
       }
-      let token = Token::new(TokenKind::Text, SourceRange::default(), value.chars().collect());
-      let value_paragraph = Paragraph::from_tokens(vec![token.clone()]);
-      match key.as_str() {
-        "author" => front_matter.author = Some(value_paragraph),
-        "date" => front_matter.date = Some(value_paragraph),
-        "kicker" => front_matter.kicker = Some(value_paragraph),
-        "summary" => front_matter.summary = Some(value_paragraph),
-        "next" => front_matter.next = Some(value_paragraph),
-        "previous" => front_matter.previous = Some(value_paragraph),
-        "hero" => front_matter.hero = Some(SectionElement::Paragraph(Paragraph::from_tokens(vec![token]))),
-        _ => (),
-      }
+    }
+
+    let (next_input, paragraph) = inline_paragraph(next_input)?;
+    let (next_input, _) = new_line(next_input)?;
+    input = next_input;
+    match key_name.as_str() {
+      "author" => front_matter.author = Some(paragraph),
+      "date" => front_matter.date = Some(paragraph),
+      "kicker" => front_matter.kicker = Some(paragraph),
+      "summary" => front_matter.summary = Some(paragraph),
+      "next" => front_matter.next = Some(paragraph),
+      "previous" => front_matter.previous = Some(paragraph),
+      _ => (),
     }
   }
 

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -21,6 +21,17 @@ use colored::*;
 
 use crate::*;
 
+#[derive(Default)]
+pub struct TitleFrontMatter {
+  pub author: Option<Paragraph>,
+  pub date: Option<Paragraph>,
+  pub hero: Option<SectionElement>,
+  pub kicker: Option<Paragraph>,
+  pub summary: Option<Paragraph>,
+  pub next: Option<Paragraph>,
+  pub previous: Option<Paragraph>,
+}
+
 // Mechdown
 // ============================================================================
 
@@ -33,22 +44,22 @@ pub fn title(input: ParseString) -> ParseResult<Title> {
   let (input, front_matter) = opt(title_front_matter)(input)?;
   let mut title = Token::merge_tokens(&mut text).unwrap();
   title.kind = TokenKind::Title;
-  let (author, date, hero, kicker, summary, next, previous) = match front_matter {
-    Some((author, date, hero, kicker, summary, next, previous)) => (author, date, hero, kicker, summary, next, previous),
-    None => (None, None, None, None, None, None, None),
-  };
-  Ok((input, Title{text: title, author, date, hero, kicker, summary, next, previous}))
+  let front_matter = front_matter.unwrap_or_default();
+  Ok((input, Title{
+    text: title,
+    author: front_matter.author,
+    date: front_matter.date,
+    hero: front_matter.hero,
+    kicker: front_matter.kicker,
+    summary: front_matter.summary,
+    next: front_matter.next,
+    previous: front_matter.previous,
+  }))
 }
 
-pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>, Option<Paragraph>, Option<SectionElement>, Option<Paragraph>, Option<Paragraph>, Option<Paragraph>, Option<Paragraph>)> {
+pub fn title_front_matter(input: ParseString) -> ParseResult<TitleFrontMatter> {
   let mut input = input;
-  let mut author = None;
-  let mut date = None;
-  let mut hero = None;
-  let mut kicker = None;
-  let mut summary = None;
-  let mut next = None;
-  let mut previous = None;
+  let mut front_matter = TitleFrontMatter::default();
 
   while many1(equal)(input.clone()).is_err() {
     let (next_input, line) = paragraph_newline(input.clone())?;
@@ -62,13 +73,13 @@ pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>,
       let token = Token::new(TokenKind::Text, SourceRange::default(), value.chars().collect());
       let value_paragraph = Paragraph::from_tokens(vec![token.clone()]);
       match key.as_str() {
-        "author" => author = Some(value_paragraph),
-        "date" => date = Some(value_paragraph),
-        "kicker" => kicker = Some(value_paragraph),
-        "summary" => summary = Some(value_paragraph),
-        "next" => next = Some(value_paragraph),
-        "previous" => previous = Some(value_paragraph),
-        "hero" => hero = Some(SectionElement::Paragraph(Paragraph::from_tokens(vec![token]))),
+        "author" => front_matter.author = Some(value_paragraph),
+        "date" => front_matter.date = Some(value_paragraph),
+        "kicker" => front_matter.kicker = Some(value_paragraph),
+        "summary" => front_matter.summary = Some(value_paragraph),
+        "next" => front_matter.next = Some(value_paragraph),
+        "previous" => front_matter.previous = Some(value_paragraph),
+        "hero" => front_matter.hero = Some(SectionElement::Paragraph(Paragraph::from_tokens(vec![token]))),
         _ => (),
       }
     }
@@ -76,7 +87,7 @@ pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>,
 
   let (input, _) = many1(equal)(input)?;
   let (input, _) = whitespace0(input)?;
-  Ok((input, (author, date, hero, kicker, summary, next, previous)))
+  Ok((input, front_matter))
 }
 
 pub struct MarkdownTableHeader {


### PR DESCRIPTION
### Motivation

- Enable richer title front matter beyond a single byline so templates can access discrete `author`, `date`, `kicker`, `next`, and `previous` fields. 
- Replace legacy single-byline handling with structured inline placeholders to make HTML shims simpler and more flexible. 
- Update templates and styles to render the new fields and support prev/next links in blog layouts.

### Description

- Extended the `Title` AST in `src/core/src/nodes.rs` to replace `byline` with `author`, `date`, `kicker`, `next`, and `previous` and kept `hero` and `summary` fields. 
- Implemented K:V front-matter parsing in `src/syntax/src/mechdown.rs` with `title_front_matter` to collect `author`, `date`, `hero`, `kicker`, `summary`, `next`, and `previous` from `key: value` lines and return them to the `Title`. 
- Updated HTML formatting in `src/syntax/src/formatter.rs` to produce separate title slots and an `inline_para_el` helper, and to replace the new placeholders `{{AUTHOR}}`, `{{DATE}}`, `{{KICKER}}`, `{{NEXT}}`, and `{{PREVIOUS}}` when rendering. 
- Adjusted templates and assets: updated documentation in `docs/mechdown/*` to list the new placeholders, changed `include/blog.html` to use `{{KICKER}}`, `{{AUTHOR}}`, `{{DATE}}`, `{{NEXT}}`, and `{{PREVIOUS}}`, and updated `include/blog.css` to rename classes and add styling for prev/next and meta elements. 

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa5f5dc04083218335ca434c264a25)