### PR TITLE
Add structured title front-matter and new template placeholders (author, date, kicker, next/previous)

### DIFF
--- a/docs/mechdown/template-placeholders.mec
+++ b/docs/mechdown/template-placeholders.mec
@@ -15,7 +15,11 @@ This allows one Mechdown source document to be rendered into different layouts b
 
 - `{{STYLESHEET}}` — Injected CSS content.
 - `{{TITLE}}` — Document title text.
-- `{{BYLINE}}` — Formatted byline content from the title block.
+- `{{AUTHOR}}` — Author paragraph from title front matter.
+- `{{DATE}}` — Date paragraph from title front matter.
+- `{{KICKER}}` — Inline kicker paragraph from title front matter.
+- `{{NEXT}}` — Next-post link paragraph from title front matter.
+- `{{PREVIOUS}}` — Previous-post link paragraph from title front matter.
 - `{{HERO}}` — Hero media/content from the title block.
 - `{{SUMMARY}}` — Synopsis content from the title block.
 - `{{TOC}}` — Generated table of contents.

--- a/docs/mechdown/title.mec
+++ b/docs/mechdown/title.mec
@@ -12,14 +12,12 @@ Mechdown supports hierarchical titles:
 
 It also supports optional **front matter** directly beneath the document title. Front matter ends with a second `===` separator and can include:
 
-- optional byline (first line)
-- optional hero media (`![caption](src)` or a `| ... |` figures row/table)
-- optional summary paragraph
+- optional key/value front matter entries: `author`, `date`, `hero`, `kicker`, `summary`, `next`, `previous`
 
 1. Rules and conventions
 -------------------------------------------------------------------------------
 
-- Use one document title per file. The document can have an optional byline (author, date, etc.) immediately following the title.
+- Use one document title per file. Optional title front matter is written as key/value pairs beneath the title.
 - Keep section numbering sequential.
 - Keep subsection numbering aligned with the parent section.
 - Prefer short, descriptive titles so generated navigation remains readable.
@@ -42,23 +40,18 @@ Mechdown Title Guide
 
 Section and first-level subsection titles are included in the generated table of contents.
 
-To add a byline, place it immediately after the title and conclude with a second `===` separator:
+Front matter uses key/value pairs and ends with a second `===` separator:
 
 ```
-My Document
+Fall 2025 Progress Report - Mechdown Beta
 ===============================================================================
-By Mika the Mech
-===============================================================================
-```
-
-Front matter with byline, hero, and summary:
-
-```
-This is my title
-===============================================================================
-Foo Bar January 1 2026
-![my hero](hero.png)
-This is my blog and it's good.
+author: Corey Montella
+date: November 12, 2025
+hero: ![Mika operating a printing press.](images/mika-press.png)
+kicker: Announcements
+summary: In this post, we review our progress on Mech so far this year.
+next: [How to Start](/posts/2025-12-13/index.html)
+previous: [Mascots of Mech](/posts/2025-10-14/index.html)
 ===============================================================================
 ```
 
@@ -71,7 +64,11 @@ In HTML shims, these placeholders are available:
 
 - `{{STYLESHEET}}`
 - `{{TITLE}}`
-- `{{BYLINE}}`
+- `{{AUTHOR}}`
+- `{{DATE}}`
+- `{{KICKER}}`
+- `{{NEXT}}`
+- `{{PREVIOUS}}`
 - `{{HERO}}`
 - `{{SUMMARY}}`
 - `{{TOC}}`

--- a/include/blog.css
+++ b/include/blog.css
@@ -318,7 +318,7 @@ body.console-fullscreen .workspace {
   letter-spacing: 0.01em;
 }
 
-.mech-byline {
+.hero-meta {
   margin-top: 22px;
   color: var(--hero-text-secondary);
   font-size: 14px;
@@ -327,11 +327,19 @@ body.console-fullscreen .workspace {
   gap: 10px;
 }
 
-.mech-byline p {
+.hero-meta p {
   color: inherit;
   margin: 0px;
   font-weight: 400;
 }
+
+.mech-kicker{margin:0 0 8px 0; color: var(--kicker-accent); text-transform: uppercase; letter-spacing: .08em; font-weight:700; font-size:12px;}
+.mech-author,.mech-date{margin:0; color:var(--hero-text-secondary);}
+.mech-summary{margin-top:14px;}
+.post-pagination{display:flex; justify-content:space-between; gap:16px; margin:28px 0;}
+.post-pagination-prev,.post-pagination-next{flex:1;}
+.post-pagination-next{text-align:right;}
+.post-pagination a{color:var(--accent-secondary-teal-soft); text-decoration:underline;}
 
 .mech-summary {
   margin-top: 22px;

--- a/include/blog.css
+++ b/include/blog.css
@@ -336,10 +336,77 @@ body.console-fullscreen .workspace {
 .mech-kicker{margin:0 0 8px 0; color: var(--kicker-accent); text-transform: uppercase; letter-spacing: .08em; font-weight:700; font-size:12px;}
 .mech-author,.mech-date{margin:0; color:var(--hero-text-secondary);}
 .mech-summary{margin-top:14px;}
-.post-pagination{display:flex; justify-content:space-between; gap:16px; margin:28px 0;}
-.post-pagination-prev,.post-pagination-next{flex:1;}
-.post-pagination-next{text-align:right;}
-.post-pagination a{color:var(--accent-secondary-teal-soft); text-decoration:underline;}
+.post-pagination{
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+  margin:32px 0 20px;
+  padding-top:14px;
+  border-top:1px solid var(--border);
+}
+
+.post-pagination-prev,.post-pagination-next{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.post-pagination-next{
+  text-align:right;
+  align-items:flex-end;
+}
+
+.post-pagination-label{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:var(--text-muted);
+}
+
+.post-pagination .mech-previous,
+.post-pagination .mech-next{
+  margin:0;
+}
+
+.post-pagination a{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--text-primary);
+  font-size:33px;
+  text-decoration:none;
+  transition:color .18s ease, text-shadow .18s ease, transform .18s ease;
+}
+
+.post-pagination-prev a::before{
+  content:"‹";
+  color:var(--accent-primary);
+  font-size:35px;
+  line-height:1;
+  margin-right:4px;
+}
+
+.post-pagination-next a::after{
+  content:"›";
+  color:var(--accent-primary);
+  font-size:35px;
+  line-height:1;
+  margin-left:4px;
+}
+
+.post-pagination a:hover{
+  color:var(--accent-soft);
+  text-shadow:0 0 12px color-mix(in srgb, var(--accent-primary) 32%, transparent);
+}
+
+.post-pagination-prev a:hover{
+  transform:translateX(-2px);
+}
+
+.post-pagination-next a:hover{
+  transform:translateX(2px);
+}
 
 .mech-summary {
   margin-top: 22px;

--- a/include/blog.html
+++ b/include/blog.html
@@ -58,9 +58,9 @@
       <div class="hero">
         <div class="hero-panel">
           <div>
-            <p class="hero-kicker">Announcement</p>
+            {{KICKER}}
             <h1>{{TITLE}}</h1>
-            {{BYLINE}}
+            <div class="hero-meta">{{AUTHOR}}{{DATE}}</div>
           </div>
           {{SUMMARY}}
         </div>
@@ -75,6 +75,10 @@
           {{CONTENT}}
         </article>
       </div>
+      <nav class="post-pagination" aria-label="Post navigation">
+        <div class="post-pagination-prev">{{PREVIOUS}}</div>
+        <div class="post-pagination-next">{{NEXT}}</div>
+      </nav>
       <section class="article-backmatter" aria-label="Notes and Works Cited">
         <div class="backmatter-row backmatter-notes">
           <div class="backmatter-body">

--- a/include/blog.html
+++ b/include/blog.html
@@ -76,8 +76,14 @@
         </article>
       </div>
       <nav class="post-pagination" aria-label="Post navigation">
-        <div class="post-pagination-prev">{{PREVIOUS}}</div>
-        <div class="post-pagination-next">{{NEXT}}</div>
+        <div class="post-pagination-prev">
+          <span class="post-pagination-label">Previous story</span>
+          {{PREVIOUS}}
+        </div>
+        <div class="post-pagination-next">
+          <span class="post-pagination-label">Next story</span>
+          {{NEXT}}
+        </div>
       </nav>
       <section class="article-backmatter" aria-label="Notes and Works Cited">
         <div class="backmatter-row backmatter-notes">

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -307,9 +307,13 @@ fn pretty_print(&self) -> String {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Title {
   pub text: Token,
-  pub byline: Option<Paragraph>,
+  pub author: Option<Paragraph>,
+  pub date: Option<Paragraph>,
   pub hero: Option<SectionElement>,
+  pub kicker: Option<Paragraph>,
   pub summary: Option<Paragraph>,
+  pub next: Option<Paragraph>,
+  pub previous: Option<Paragraph>,
 }
 
 impl Title {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -43,6 +43,17 @@ pub struct Formatter{
   inline_eval_counters: HashMap<u64, u64>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq)]
+struct TitleSlots {
+  author: Option<String>,
+  date: Option<String>,
+  hero: Option<String>,
+  kicker: Option<String>,
+  summary: Option<String>,
+  next: Option<String>,
+  previous: Option<String>,
+}
+
 impl Formatter {
   fn citation_paragraph_with_optional_link(&mut self, paragraph: &Paragraph) -> MResult<(String, Option<String>)> {
     let mut link: Option<String> = None;
@@ -162,7 +173,7 @@ impl Formatter {
     self.html = true;
     self.inline_eval_counters.clear();
 
-    let (formatted_byline, formatted_hero, formatted_synopsis) = self.title_slots(&tree.title);
+    let title_slots = self.title_slots(&tree.title);
     let (formatted_abstract, formatted_intro, formatted_contents, formatted_cited, formatted_footnotes) = self.document_slots(tree);
     let formatted_src = formatted_contents.clone();
     self.reset_numbering();
@@ -185,9 +196,13 @@ impl Formatter {
 
     let mut rendered = shim.replace("{{STYLESHEET}}", &style)
         .replace("{{TOC}}", &formatted_toc)
-        .replace("{{BYLINE}}", &formatted_byline)
-        .replace("{{HERO}}", &formatted_hero)
-        .replace("{{SUMMARY}}", &formatted_synopsis)
+        .replace("{{AUTHOR}}", title_slots.author.as_deref().unwrap_or_default())
+        .replace("{{DATE}}", title_slots.date.as_deref().unwrap_or_default())
+        .replace("{{HERO}}", title_slots.hero.as_deref().unwrap_or_default())
+        .replace("{{KICKER}}", title_slots.kicker.as_deref().unwrap_or_default())
+        .replace("{{SUMMARY}}", title_slots.summary.as_deref().unwrap_or_default())
+        .replace("{{NEXT}}", title_slots.next.as_deref().unwrap_or_default())
+        .replace("{{PREVIOUS}}", title_slots.previous.as_deref().unwrap_or_default())
         .replace("{{ABSTRACT}}", &formatted_abstract)
         .replace("{{INTRO}}", &formatted_intro)
         .replace("{{CITED}}", &formatted_cited)
@@ -205,15 +220,18 @@ impl Formatter {
       .replace("{{CONTENTS}}", &formatted_contents)
   }
 
-  fn title_slots(&mut self, title: &Option<Title>) -> (String, String, String) {
+  fn title_slots(&mut self, title: &Option<Title>) -> TitleSlots {
     match title {
-      Some(title) => {
-        let byline = title.byline.as_ref().map(|p| self.byline_el(p)).unwrap_or_default();
-        let hero = title.hero.as_ref().map(|h| self.hero_el(h)).unwrap_or_default();
-        let summary = title.summary.as_ref().map(|p| self.synopsis_el(p)).unwrap_or_default();
-        (byline, hero, summary)
-      }
-      None => (String::new(), String::new(), String::new()),
+      Some(title) => TitleSlots {
+        author: title.author.as_ref().map(|p| self.inline_title_meta_el(p, "mech-author")),
+        date: title.date.as_ref().map(|p| self.inline_title_meta_el(p, "mech-date")),
+        hero: title.hero.as_ref().map(|h| self.hero_el(h)),
+        kicker: title.kicker.as_ref().map(|p| self.inline_title_meta_el(p, "mech-kicker")),
+        summary: title.summary.as_ref().map(|p| self.synopsis_el(p)),
+        next: title.next.as_ref().map(|p| self.inline_title_meta_el(p, "mech-next")),
+        previous: title.previous.as_ref().map(|p| self.inline_title_meta_el(p, "mech-previous")),
+      },
+      None => TitleSlots::default(),
     }
   }
 
@@ -1016,12 +1034,12 @@ impl Formatter {
     }
   }
 
-  pub fn byline_el(&mut self, node: &Paragraph) -> String {
-    let byline = self.paragraph(node);
+  pub fn inline_title_meta_el(&mut self, node: &Paragraph, class_name: &str) -> String {
+    let content = self.paragraph(node);
     if self.html {
-      format!("<div class=\"mech-byline\">{}</div>", byline)
+      format!("<p class=\"{}\">{}</p>", class_name, content)
     } else {
-      byline
+      content
     }
   }
 

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -33,11 +33,11 @@ pub fn title(input: ParseString) -> ParseResult<Title> {
   let (input, front_matter) = opt(title_front_matter)(input)?;
   let mut title = Token::merge_tokens(&mut text).unwrap();
   title.kind = TokenKind::Title;
-  let (byline, hero, summary) = match front_matter {
-    Some((byline, hero, summary)) => (byline, hero, summary),
-    None => (None, None, None),
+  let (author, date, hero, kicker, summary, next, previous) = match front_matter {
+    Some((author, date, hero, kicker, summary, next, previous)) => (author, date, hero, kicker, summary, next, previous),
+    None => (None, None, None, None, None, None, None),
   };
-  Ok((input, Title{text: title, byline, hero, summary}))
+  Ok((input, Title{text: title, author, date, hero, kicker, summary, next, previous}))
 }
 
 pub fn byline(input: ParseString) -> ParseResult<Paragraph> {
@@ -46,35 +46,56 @@ pub fn byline(input: ParseString) -> ParseResult<Paragraph> {
   Ok((input, byline))
 }
 
-pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>, Option<SectionElement>, Option<Paragraph>)> {
-  let mut input = input;
-  let mut byline = None;
-  let mut hero = None;
-  let mut summary = None;
-
-  if let Ok((next_input, parsed_byline)) = paragraph_newline(input.clone()) {
-    input = next_input;
-    byline = Some(parsed_byline);
-  }
-
-  if let Ok((next_input, image)) = img(input.clone()) {
-    let (next_input, _) = whitespace0(next_input)?;
-    input = next_input;
-    hero = Some(SectionElement::Image(image));
-  } else if let Ok((next_input, figure_table)) = figures(input.clone()) {
-    let (next_input, _) = whitespace0(next_input)?;
-    input = next_input;
-    hero = Some(SectionElement::FigureTable(figure_table));
-  }
-
-  if let Ok((next_input, parsed_synopsis)) = paragraph_newline(input.clone()) {
-    input = next_input;
-    summary = Some(parsed_synopsis);
-  }
-
+pub fn title_front_matter(input: ParseString) -> ParseResult<(Option<Paragraph>, Option<Paragraph>, Option<SectionElement>, Option<Paragraph>, Option<Paragraph>, Option<Paragraph>, Option<Paragraph>)> {
+  let (input, fields) = many0(front_matter_field)(input)?;
   let (input, _) = many1(equal)(input)?;
   let (input, _) = whitespace0(input)?;
-  Ok((input, (byline, hero, summary)))
+
+  let mut author = None;
+  let mut date = None;
+  let mut hero = None;
+  let mut kicker = None;
+  let mut summary = None;
+  let mut next = None;
+  let mut previous = None;
+
+  for (name, value) in fields {
+    match name.as_str() {
+      "author" => author = value.paragraph,
+      "date" => date = value.paragraph,
+      "hero" => hero = value.hero,
+      "kicker" => kicker = value.paragraph,
+      "summary" => summary = value.paragraph,
+      "next" => next = value.paragraph,
+      "previous" => previous = value.paragraph,
+      _ => {}
+    }
+  }
+
+  Ok((input, (author, date, hero, kicker, summary, next, previous)))
+}
+
+struct FrontMatterValue {
+  paragraph: Option<Paragraph>,
+  hero: Option<SectionElement>,
+}
+
+fn front_matter_field(input: ParseString) -> ParseResult<(String, FrontMatterValue)> {
+  let (input, key_token) = identifier(input)?;
+  let key = key_token.name.to_string().to_lowercase();
+  let (input, _) = whitespace0(input)?;
+  let (input, _) = colon(input)?;
+  let (input, _) = many0(space_tab)(input)?;
+
+  if let Ok((input, image)) = img(input.clone()) {
+    return Ok((input, (key, FrontMatterValue { paragraph: None, hero: Some(SectionElement::Image(image)) })));
+  }
+  if let Ok((input, figure_table)) = figures(input.clone()) {
+    return Ok((input, (key, FrontMatterValue { paragraph: None, hero: Some(SectionElement::FigureTable(figure_table)) })));
+  }
+
+  let (input, paragraph) = paragraph_newline(input)?;
+  Ok((input, (key, FrontMatterValue { paragraph: Some(paragraph), hero: None })))
 }
 
 pub struct MarkdownTableHeader {


### PR DESCRIPTION
### Motivation

- Introduce structured title front-matter so documents can declare `author`, `date`, `kicker`, `next`, and `previous` fields instead of a single byline paragraph. 
- Expose these fields to HTML shims via new template placeholders to improve layout flexibility and support post navigation.

### Description

- Extend the `Title` AST in `src/core/src/nodes.rs` to replace `byline` with `author`, `date`, `kicker`, `next`, and `previous` fields and keep `hero` and `summary` as before. 
- Update the Mechdown parser in `src/syntax/src/mechdown.rs` to parse key/value front matter fields via `front_matter_field` and return `(author, date, hero, kicker, summary, next, previous)` from `title_front_matter`. 
- Rework the HTML formatter in `src/syntax/src/formatter.rs` by introducing a `TitleSlots` struct, changing `title_slots` to populate the new fields, adding `inline_title_meta_el` to render inline title metadata, and replacing `{{BYLINE}}` handling with `{{AUTHOR}}`, `{{DATE}}`, `{{KICKER}}`, `{{NEXT}}`, and `{{PREVIOUS}}` replacements. 
- Update site assets and templates by adding new placeholders and classes in `include/blog.html` and `include/blog.css`, including `.hero-meta`, `.mech-kicker`, `.mech-author`, `.mech-date`, and a `.post-pagination` block for previous/next links. 
- Revise documentation files `docs/mechdown/template-placeholders.mec` and `docs/mechdown/title.mec` to document the new placeholders and front-matter keys. 

### Testing

- Ran the test suite with `cargo test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa347aa278832a83f83a9a234525ef)