### PR TITLE
Restore invariant expression rendering and align test failure output

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -335,63 +335,64 @@ async fn main() -> Result<(), MechError> {
   // --------------------------------------------------------------------------
   #[cfg(all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool"))]
   if let Some(matches) = matches.subcommand_matches("test") {
-    let uuid = generate_uuid();
-    let mut intrp = Interpreter::new(uuid);
     let mech_paths: Vec<String> = matches
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
-    let mut mechfs = MechFileSystem::new();
-    let test_target = if mech_paths.is_empty() { "test.mec".to_string() } else { mech_paths.join(", ") };
+    let mut any_failed = false;
     for path in &mech_paths {
+      let uuid = generate_uuid();
+      let mut intrp = Interpreter::new(uuid);
+      let mut mechfs = MechFileSystem::new();
       mechfs.watch_source(path)?;
-    }
-    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
-    if let Err(err) = result {
-      print_mech_error(&err);
-      std::process::exit(1);
-    }
-    let mut passed = 0usize;
-    let mut failed = 0usize;
-    let state_brrw = intrp.state.borrow();
-    let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
-    println!("{} Testing: {}\n", "[Test]".truecolor(255,210,77), test_target);
-    for (_id, (name, value)) in state_brrw.invariants.iter() {
-      match &*value.borrow() {
-        Value::Bool(b) if *b.borrow() => {
-          println!("{:<width$}   ✓", name, width=test_name_width);
-          passed += 1;
-        },
-        _ => {
-          println!("{:<width$}   ✗", name, width=test_name_width);
-          failed += 1;
-        },
+      let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
+      if let Err(err) = result {
+        print_mech_error(&err);
+        std::process::exit(1);
       }
-    }
-    let total = passed + failed;
-    if failed == 0 {
-      println!("\nResult: SUCCESS: {} total | {} passed | {} failed", total, passed, failed);
-      std::process::exit(0);
-    } else {
-      println!("\nResult: FAILURE: {} total | {} passed | {} failed", total, passed, failed);
-      if !state_brrw.invariant_violations.is_empty() {
-        println!("\nfailures:\n");
-        for violation in &state_brrw.invariant_violations {
-          let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
-          if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
-            let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
-            let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
-            println!("  {}: {}", name, inv_err.expression);
-            println!("    reason = {}", inv_err.reason);
-            println!("    evaluated_kind = {}", inv_err.evaluated_kind);
-            println!("    actual = {}", lhs);
-            println!("    expected = {}", rhs);
-          } else {
-            println!("  {}: {}", name, violation.error.display_message());
-          }
+      let mut passed = 0usize;
+      let mut failed = 0usize;
+      let state_brrw = intrp.state.borrow();
+      let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
+      println!("{} Testing: {}\n", "[Test]".truecolor(255,210,77), path);
+      for (_id, (name, value)) in state_brrw.invariants.iter() {
+        match &*value.borrow() {
+          Value::Bool(b) if *b.borrow() => {
+            println!("{:<width$}   ✓", name, width=test_name_width);
+            passed += 1;
+          },
+          _ => {
+            println!("{:<width$}   ✗", name, width=test_name_width);
+            failed += 1;
+          },
         }
       }
-      std::process::exit(1);
+      let total = passed + failed;
+      if failed == 0 {
+        println!("\nResult: SUCCESS: {} total | {} passed | {} failed\n", total, passed, failed);
+      } else {
+        any_failed = true;
+        println!("\nResult: FAILURE: {} total | {} passed | {} failed", total, passed, failed);
+        if !state_brrw.invariant_violations.is_empty() {
+          println!("\nfailures:\n");
+          for violation in &state_brrw.invariant_violations {
+            let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
+            if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
+              let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
+              let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
+              println!("  {}: {}", name, inv_err.expression);
+              println!("    reason = {}", inv_err.reason);
+              println!("    evaluated_kind = {}", inv_err.evaluated_kind);
+              println!("    actual = {}", lhs);
+              println!("    expected = {}", rhs);
+            } else {
+              println!("  {}: {}", name, violation.error.display_message());
+            }
+          }
+        }
+        println!();
+      }
     }
+    std::process::exit(if any_failed { 1 } else { 0 });
   }
 
   // --------------------------------------------------------------------------

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -12,7 +12,6 @@ use std::time::Instant;
 use std::fs;
 use std::env;
 use std::io;
-use std::collections::HashSet;
 
 use colored::*;
 use std::io::{Write, BufReader, BufWriter, stdout};
@@ -339,20 +338,13 @@ async fn main() -> Result<(), MechError> {
     let mech_paths: Vec<String> = matches
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
-    let uuid = generate_uuid();
-    let mut intrp = Interpreter::new(uuid);
-    let mut mechfs = MechFileSystem::new();
     let mut any_failed = false;
     let mut run_errors = false;
     println!("{} Testing\n", "[Test]".truecolor(255,210,77));
     for path in &mech_paths {
-      let (existing_invariant_ids, existing_violation_count) = {
-        let state_brrw = intrp.state.borrow();
-        (
-          state_brrw.invariants.keys().copied().collect::<HashSet<u64>>(),
-          state_brrw.invariant_violations.len(),
-        )
-      };
+      let uuid = generate_uuid();
+      let mut intrp = Interpreter::new(uuid);
+      let mut mechfs = MechFileSystem::new();
       if let Err(err) = mechfs.watch_source(path) {
         print_mech_error(&err);
         run_errors = true;
@@ -369,14 +361,9 @@ async fn main() -> Result<(), MechError> {
       let mut passed = 0usize;
       let mut failed = 0usize;
       let state_brrw = intrp.state.borrow();
-      let file_invariants: Vec<_> = state_brrw
-        .invariants
-        .iter()
-        .filter(|(id, _)| !existing_invariant_ids.contains(id))
-        .collect();
-      let test_name_width = file_invariants.iter().map(|(_, (n, _))| n.len()).max().unwrap_or(0);
+      let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
       println!("[File] {}\n", path);
-      for (_id, (name, value)) in file_invariants {
+      for (_id, (name, value)) in state_brrw.invariants.iter() {
         match &*value.borrow() {
           Value::Bool(b) if *b.borrow() => {
             println!("{:<width$}   ✓", name, width=test_name_width);
@@ -394,9 +381,9 @@ async fn main() -> Result<(), MechError> {
       } else {
         any_failed = true;
         println!("\nResult: FAILURE: {} total | {} passed | {} failed", total, passed, failed);
-        if state_brrw.invariant_violations.len() > existing_violation_count {
+        if !state_brrw.invariant_violations.is_empty() {
           println!("\nfailures:\n");
-          for violation in state_brrw.invariant_violations.iter().skip(existing_violation_count) {
+          for violation in &state_brrw.invariant_violations {
             let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
             if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
               let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -362,7 +362,7 @@ async fn main() -> Result<(), MechError> {
       let mut failed = 0usize;
       let state_brrw = intrp.state.borrow();
       let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
-      println!("[File] {}\n", path);
+      println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
       for (_id, (name, value)) in state_brrw.invariants.iter() {
         match &*value.borrow() {
           Value::Bool(b) if *b.borrow() => {
@@ -377,10 +377,10 @@ async fn main() -> Result<(), MechError> {
       }
       let total = passed + failed;
       if failed == 0 {
-        println!("\nResult: SUCCESS: {} total | {} passed | {} failed\n", total, passed, failed);
+        println!("\n{} SUCCESS: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
       } else {
         any_failed = true;
-        println!("\nResult: FAILURE: {} total | {} passed | {} failed", total, passed, failed);
+        println!("\n{} FAILURE: {} total | {} passed | {} failed", "[Test]".truecolor(153, 221, 85), total, passed, failed);
         if !state_brrw.invariant_violations.is_empty() {
           println!("\nfailures:\n");
           for violation in &state_brrw.invariant_violations {

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 use std::fs;
 use std::env;
 use std::io;
+use std::collections::HashSet;
 
 use colored::*;
 use std::io::{Write, BufReader, BufWriter, stdout};
@@ -343,7 +344,15 @@ async fn main() -> Result<(), MechError> {
     let mut mechfs = MechFileSystem::new();
     let mut any_failed = false;
     let mut run_errors = false;
+    println!("{} Testing\n", "[Test]".truecolor(255,210,77));
     for path in &mech_paths {
+      let (existing_invariant_ids, existing_violation_count) = {
+        let state_brrw = intrp.state.borrow();
+        (
+          state_brrw.invariants.keys().copied().collect::<HashSet<u64>>(),
+          state_brrw.invariant_violations.len(),
+        )
+      };
       if let Err(err) = mechfs.watch_source(path) {
         print_mech_error(&err);
         run_errors = true;
@@ -360,9 +369,14 @@ async fn main() -> Result<(), MechError> {
       let mut passed = 0usize;
       let mut failed = 0usize;
       let state_brrw = intrp.state.borrow();
-      let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
-      println!("{} Testing: {}\n", "[Test]".truecolor(255,210,77), path);
-      for (_id, (name, value)) in state_brrw.invariants.iter() {
+      let file_invariants: Vec<_> = state_brrw
+        .invariants
+        .iter()
+        .filter(|(id, _)| !existing_invariant_ids.contains(id))
+        .collect();
+      let test_name_width = file_invariants.iter().map(|(_, (n, _))| n.len()).max().unwrap_or(0);
+      println!("[File] {}\n", path);
+      for (_id, (name, value)) in file_invariants {
         match &*value.borrow() {
           Value::Bool(b) if *b.borrow() => {
             println!("{:<width$}   ✓", name, width=test_name_width);
@@ -380,9 +394,9 @@ async fn main() -> Result<(), MechError> {
       } else {
         any_failed = true;
         println!("\nResult: FAILURE: {} total | {} passed | {} failed", total, passed, failed);
-        if !state_brrw.invariant_violations.is_empty() {
+        if state_brrw.invariant_violations.len() > existing_violation_count {
           println!("\nfailures:\n");
-          for violation in &state_brrw.invariant_violations {
+          for violation in state_brrw.invariant_violations.iter().skip(existing_violation_count) {
             let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
             if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
               let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -341,8 +341,9 @@ async fn main() -> Result<(), MechError> {
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
     let mut mechfs = MechFileSystem::new();
-    for path in mech_paths {
-      mechfs.watch_source(&path)?;
+    let test_target = mech_paths.first().cloned().unwrap_or_else(|| "test.mec".to_string());
+    for path in &mech_paths {
+      mechfs.watch_source(path)?;
     }
     let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
     if let Err(err) = result {
@@ -352,36 +353,37 @@ async fn main() -> Result<(), MechError> {
     let mut passed = 0usize;
     let mut failed = 0usize;
     let state_brrw = intrp.state.borrow();
+    let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
+    println!("{} Testing: {}\n", "[Test]".truecolor(255,210,77), test_target);
     for (_id, (name, value)) in state_brrw.invariants.iter() {
       match &*value.borrow() {
         Value::Bool(b) if *b.borrow() => {
-          println!("test {} ... ok", name);
+          println!("{:<width$}   ✓", name, width=test_name_width);
           passed += 1;
         },
         _ => {
-          println!("test {} ... FAILED", name);
+          println!("{:<width$}   ✗", name, width=test_name_width);
           failed += 1;
         },
       }
     }
     if failed == 0 {
-      println!("\ntest result: ok. {} passed; {} failed; 0 ignored; 0 measured; 0 filtered out", passed, failed);
+      println!("\nResult: SUCCESS: {} passed | {} failed | 0 ignored | 0 filtered out", passed, failed);
       std::process::exit(0);
     } else {
-      println!("\ntest result: FAILED. {} passed; {} failed; 0 ignored; 0 measured; 0 filtered out", passed, failed);
+      println!("\nResult: FAILURE: {} passed | {} failed | 0 ignored | 0 filtered out", passed, failed);
       if !state_brrw.invariant_violations.is_empty() {
-        println!("\nfailures:");
-        let width = state_brrw.invariant_violations.iter().map(|v| {
-          state_brrw.invariants.get(&v.id).map(|(n, _)| n.len()).unwrap_or_else(|| format!("#{}", v.id).len())
-        }).max().unwrap_or(0);
+        println!("\nfailures:\n");
         for violation in &state_brrw.invariant_violations {
           let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
           if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
             let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
             let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
-            println!("    {:width$}: expr={} | lhs={} | rhs={}", name, inv_err.expression, lhs, rhs, width=width);
+            println!("  {}: {}", name, inv_err.expression);
+            println!("    actual = {}", lhs);
+            println!("    expected = {}", rhs);
           } else {
-            println!("    {:width$}: {}", name, violation.error.display_message(), width=width);
+            println!("  {}: {}", name, violation.error.display_message());
           }
         }
       }

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -338,16 +338,24 @@ async fn main() -> Result<(), MechError> {
     let mech_paths: Vec<String> = matches
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
+    let uuid = generate_uuid();
+    let mut intrp = Interpreter::new(uuid);
+    let mut mechfs = MechFileSystem::new();
     let mut any_failed = false;
+    let mut run_errors = false;
     for path in &mech_paths {
-      let uuid = generate_uuid();
-      let mut intrp = Interpreter::new(uuid);
-      let mut mechfs = MechFileSystem::new();
-      mechfs.watch_source(path)?;
+      if let Err(err) = mechfs.watch_source(path) {
+        print_mech_error(&err);
+        run_errors = true;
+        any_failed = true;
+        continue;
+      }
       let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
       if let Err(err) = result {
         print_mech_error(&err);
-        std::process::exit(1);
+        run_errors = true;
+        any_failed = true;
+        continue;
       }
       let mut passed = 0usize;
       let mut failed = 0usize;
@@ -391,6 +399,9 @@ async fn main() -> Result<(), MechError> {
         }
         println!();
       }
+    }
+    if run_errors {
+      println!("{} One or more files failed to load/execute, but all requested files were attempted.", "[Warn]".truecolor(255,210,77));
     }
     std::process::exit(if any_failed { 1 } else { 0 });
   }

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -341,7 +341,7 @@ async fn main() -> Result<(), MechError> {
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
     let mut mechfs = MechFileSystem::new();
-    let test_target = mech_paths.first().cloned().unwrap_or_else(|| "test.mec".to_string());
+    let test_target = if mech_paths.is_empty() { "test.mec".to_string() } else { mech_paths.join(", ") };
     for path in &mech_paths {
       mechfs.watch_source(path)?;
     }
@@ -380,6 +380,8 @@ async fn main() -> Result<(), MechError> {
             let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
             let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
             println!("  {}: {}", name, inv_err.expression);
+            println!("    reason = {}", inv_err.reason);
+            println!("    evaluated_kind = {}", inv_err.evaluated_kind);
             println!("    actual = {}", lhs);
             println!("    expected = {}", rhs);
           } else {

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -344,7 +344,7 @@ async fn main() -> Result<(), MechError> {
     let mut mechfs = MechFileSystem::new();
     let mut any_failed = false;
     let mut run_errors = false;
-    println!("{} Testing\n", "[Test]".truecolor(255,210,77));
+    println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
     for path in &mech_paths {
       let (existing_invariant_ids, existing_violation_count) = {
         let state_brrw = intrp.state.borrow();
@@ -375,7 +375,7 @@ async fn main() -> Result<(), MechError> {
         .filter(|(id, _)| !existing_invariant_ids.contains(id))
         .collect();
       let test_name_width = file_invariants.iter().map(|(_, (n, _))| n.len()).max().unwrap_or(0);
-      println!("[File] {}\n", path);
+      println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
       for (_id, (name, value)) in file_invariants {
         match &*value.borrow() {
           Value::Bool(b) if *b.borrow() => {

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -367,11 +367,12 @@ async fn main() -> Result<(), MechError> {
         },
       }
     }
+    let total = passed + failed;
     if failed == 0 {
-      println!("\nResult: SUCCESS: {} passed | {} failed | 0 ignored | 0 filtered out", passed, failed);
+      println!("\nResult: SUCCESS: {} total | {} passed | {} failed", total, passed, failed);
       std::process::exit(0);
     } else {
-      println!("\nResult: FAILURE: {} passed | {} failed | 0 ignored | 0 filtered out", passed, failed);
+      println!("\nResult: FAILURE: {} total | {} passed | {} failed", total, passed, failed);
       if !state_brrw.invariant_violations.is_empty() {
         println!("\nfailures:\n");
         for violation in &state_brrw.invariant_violations {

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -371,14 +371,17 @@ async fn main() -> Result<(), MechError> {
       println!("\ntest result: FAILED. {} passed; {} failed; 0 ignored; 0 measured; 0 filtered out", passed, failed);
       if !state_brrw.invariant_violations.is_empty() {
         println!("\nfailures:");
+        let width = state_brrw.invariant_violations.iter().map(|v| {
+          state_brrw.invariants.get(&v.id).map(|(n, _)| n.len()).unwrap_or_else(|| format!("#{}", v.id).len())
+        }).max().unwrap_or(0);
         for violation in &state_brrw.invariant_violations {
           let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
           if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
             let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
             let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
-            println!("    {}: expr={} | lhs={} | rhs={}", name, inv_err.expression, lhs, rhs);
+            println!("    {:width$}: expr={} | lhs={} | rhs={}", name, inv_err.expression, lhs, rhs, width=width);
           } else {
-            println!("    {}: {}", name, violation.error.display_message());
+            println!("    {:width$}: {}", name, violation.error.display_message(), width=width);
           }
         }
       }

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -2445,6 +2445,11 @@ pub struct RangeExpression {
 impl RangeExpression {
   pub fn tokens(&self) -> Vec<Token> {
     let mut tokens = self.start.tokens();
+    if let Some((inc_op, inc)) = &self.increment {
+      tokens.push(inc_op.token());
+      tokens.append(&mut inc.tokens());
+    }
+    tokens.push(self.operator.token());
     tokens.append(&mut self.terminal.tokens());
     tokens
   }
@@ -2462,11 +2467,69 @@ impl Term {
     let mut lhs_tkns = self.lhs.tokens();
     let mut rhs_tkns = vec![];
     for (op, r) in &self.rhs {
+      rhs_tkns.push(op.token());
       let mut tkns = r.tokens();
       rhs_tkns.append(&mut tkns);
     }
     lhs_tkns.append(&mut rhs_tkns);
     lhs_tkns
+  }
+}
+
+impl RangeOp {
+  pub fn token(&self) -> Token {
+    let chars = match self {
+      RangeOp::Exclusive => "..".chars().collect(),
+      RangeOp::Inclusive => "..=".chars().collect(),
+    };
+    Token::new(TokenKind::Text, SourceRange::default(), chars)
+  }
+}
+
+impl FormulaOperator {
+  pub fn token(&self) -> Token {
+    let chars = match self {
+      FormulaOperator::AddSub(AddSubOp::Add) => "+",
+      FormulaOperator::AddSub(AddSubOp::Sub) => "-",
+      FormulaOperator::Comparison(ComparisonOp::Equal) => "==",
+      FormulaOperator::Comparison(ComparisonOp::NotEqual) => "!=",
+      FormulaOperator::Comparison(ComparisonOp::LessThan) => "<",
+      FormulaOperator::Comparison(ComparisonOp::GreaterThan) => ">",
+      FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => "<=",
+      FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => ">=",
+      FormulaOperator::Comparison(ComparisonOp::StrictEqual) => "===",
+      FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => "!==",
+      FormulaOperator::Power(PowerOp::Pow) => "^",
+      FormulaOperator::Logic(LogicOp::And) => "&&",
+      FormulaOperator::Logic(LogicOp::Or) => "||",
+      FormulaOperator::Logic(LogicOp::Xor) => "^",
+      FormulaOperator::Logic(LogicOp::Not) => "!",
+      FormulaOperator::MulDiv(MulDivOp::Div) => "/",
+      FormulaOperator::MulDiv(MulDivOp::Mod) => "%",
+      FormulaOperator::MulDiv(MulDivOp::Mul) => "*",
+      FormulaOperator::Vec(VecOp::Cross) => "×",
+      FormulaOperator::Vec(VecOp::Dot) => ".*",
+      FormulaOperator::Vec(VecOp::MatMul) => "**",
+      FormulaOperator::Vec(VecOp::Solve) => "\\",
+      FormulaOperator::Table(TableOp::InnerJoin) => "<*>",
+      FormulaOperator::Table(TableOp::LeftOuterJoin) => "<+",
+      FormulaOperator::Table(TableOp::RightOuterJoin) => "+>",
+      FormulaOperator::Table(TableOp::FullOuterJoin) => "<+>",
+      FormulaOperator::Table(TableOp::LeftSemiJoin) => "<*",
+      FormulaOperator::Table(TableOp::LeftAntiJoin) => "<!",
+      FormulaOperator::Set(SetOp::Union) => "∪",
+      FormulaOperator::Set(SetOp::Intersection) => "∩",
+      FormulaOperator::Set(SetOp::Difference) => "\\",
+      FormulaOperator::Set(SetOp::Complement) => "ᶜ",
+      FormulaOperator::Set(SetOp::ElementOf) => "∈",
+      FormulaOperator::Set(SetOp::NotElementOf) => "∉",
+      FormulaOperator::Set(SetOp::ProperSubset) => "⊂",
+      FormulaOperator::Set(SetOp::ProperSuperset) => "⊃",
+      FormulaOperator::Set(SetOp::Subset) => "⊆",
+      FormulaOperator::Set(SetOp::Superset) => "⊇",
+      FormulaOperator::Set(SetOp::SymmetricDifference) => "∆",
+    };
+    Token::new(TokenKind::Text, SourceRange::default(), chars.chars().collect())
   }
 }
 

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1996,7 +1996,13 @@ impl Literal {
       Literal::Atom(atm) => atm.name.tokens(),
       Literal::Boolean(tkn) => vec![tkn.clone()],
       Literal::Number(x) => x.tokens(),
-      Literal::String(strng) => vec![strng.text.clone()],
+      Literal::String(strng) => {
+        vec![
+          Token::new(TokenKind::Quote, SourceRange::default(), vec!['"']),
+          strng.text.clone(),
+          Token::new(TokenKind::Quote, SourceRange::default(), vec!['"']),
+        ]
+      },
       Literal::Empty(tkn) => vec![tkn.clone()],
       Literal::Kind(knd) => knd.tokens(),
       Literal::TypedLiteral((lit, knd)) => {

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -314,7 +314,7 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
     let err = MechError::new(
       InvariantViolationError{
         invariant_name: invariant_name.clone(),
-        expression: expression_to_string(&inv_def.expression),
+        expression: tokens_to_string(&inv_def.expression.tokens()),
         lhs_addr,
         lhs_value,
         operator,
@@ -994,85 +994,5 @@ impl MechErrorKind for UnableToConvertRecordError {
     format!("Unable to convert record of kind `{:?}` to record of kind `{:?}`", self.source_record_kind, self.target_record_kind)
   }
 }
-
-#[cfg(feature = "invariant_define")]
-fn expression_to_string(expr: &Expression) -> String {
-  match expr {
-    Expression::Formula(f) => factor_to_string(f),
-    Expression::Var(v) => v.name.to_string(),
-    Expression::Literal(l) => tokens_to_string(&l.tokens()),
-    Expression::Slice(s) => slice_to_string(s),
-    _ => tokens_to_string(&expr.tokens()),
-  }
-}
-
-#[cfg(feature = "invariant_define")]
-fn factor_to_string(factor: &Factor) -> String {
-  match factor {
-    Factor::Expression(expr) => expression_to_string(expr),
-    Factor::Negate(inner) => format!("-{}", factor_to_string(inner)),
-    Factor::Not(inner) => format!("!{}", factor_to_string(inner)),
-    Factor::Parenthetical(inner) => format!("({})", factor_to_string(inner)),
-    Factor::Term(term) => {
-      let mut out = factor_to_string(&term.lhs);
-      for (op, rhs) in &term.rhs {
-        out.push(' ');
-        out.push_str(formula_operator_symbol(op));
-        out.push(' ');
-        out.push_str(&factor_to_string(rhs));
-      }
-      out
-    }
-    Factor::Transpose(inner) => format!("{}'", factor_to_string(inner)),
-  }
-}
-
-#[cfg(feature = "invariant_define")]
-fn formula_operator_symbol(op: &FormulaOperator) -> &'static str {
-  match op {
-    FormulaOperator::Comparison(ComparisonOp::Equal) => "==",
-    FormulaOperator::Comparison(ComparisonOp::NotEqual) => "!=",
-    FormulaOperator::Comparison(ComparisonOp::LessThan) => "<",
-    FormulaOperator::Comparison(ComparisonOp::GreaterThan) => ">",
-    FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => "<=",
-    FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => ">=",
-    FormulaOperator::Comparison(ComparisonOp::StrictEqual) => "===",
-    FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => "!==",
-    FormulaOperator::Logic(LogicOp::And) => "&&",
-    FormulaOperator::Logic(LogicOp::Or) => "||",
-    FormulaOperator::Logic(LogicOp::Xor) => "^",
-    FormulaOperator::AddSub(AddSubOp::Add) => "+",
-    FormulaOperator::AddSub(AddSubOp::Sub) => "-",
-    FormulaOperator::MulDiv(MulDivOp::Mul) => "*",
-    FormulaOperator::MulDiv(MulDivOp::Div) => "/",
-    FormulaOperator::MulDiv(MulDivOp::Mod) => "%",
-    FormulaOperator::Vec(VecOp::Dot) => ".*",
-    FormulaOperator::Vec(VecOp::Cross) => "x",
-    FormulaOperator::Vec(VecOp::MatMul) => "**",
-    FormulaOperator::Vec(VecOp::Solve) => "\\",
-    FormulaOperator::Power(PowerOp::Pow) => "^",
-    _ => "?",
-  }
-}
-
-#[cfg(feature = "invariant_define")]
-fn slice_to_string(slice_ref: &Slice) -> String {
-  let mut out = slice_ref.name.to_string();
-  for sub in &slice_ref.subscript {
-    out.push('[');
-    out.push_str(&subscript_to_string(sub));
-    out.push(']');
-  }
-  out
-}
-
-#[cfg(feature = "invariant_define")]
-fn subscript_to_string(sub: &Subscript) -> String {
-  match sub {
-    Subscript::Formula(f) => factor_to_string(f),
-    Subscript::All => ":".to_string(),
-    Subscript::Range(r) => tokens_to_string(&r.tokens()),
-    _ => tokens_to_string(&sub.tokens()),
-  }
 }
 

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -314,7 +314,7 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
     let err = MechError::new(
       InvariantViolationError{
         invariant_name: invariant_name.clone(),
-        expression: tokens_to_string(&inv_def.expression.tokens()),
+        expression: expression_to_string(&inv_def.expression),
         lhs_addr,
         lhs_value,
         operator,
@@ -327,6 +327,87 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
     p.state.borrow_mut().invariant_violations.push(InvariantViolation { id: invariant_id, error: err });
   }
   Ok(result)
+}
+
+#[cfg(feature = "invariant_define")]
+fn expression_to_string(expr: &Expression) -> String {
+  match expr {
+    Expression::Formula(f) => factor_to_string(f),
+    Expression::Var(v) => v.name.to_string(),
+    Expression::Literal(l) => tokens_to_string(&l.tokens()),
+    Expression::Slice(s) => slice_to_string(s),
+    _ => tokens_to_string(&expr.tokens()),
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn factor_to_string(factor: &Factor) -> String {
+  match factor {
+    Factor::Expression(expr) => expression_to_string(expr),
+    Factor::Negate(inner) => format!("-{}", factor_to_string(inner)),
+    Factor::Not(inner) => format!("!{}", factor_to_string(inner)),
+    Factor::Parenthetical(inner) => format!("({})", factor_to_string(inner)),
+    Factor::Term(term) => {
+      let mut out = factor_to_string(&term.lhs);
+      for (op, rhs) in &term.rhs {
+        out.push(' ');
+        out.push_str(formula_operator_symbol(op));
+        out.push(' ');
+        out.push_str(&factor_to_string(rhs));
+      }
+      out
+    }
+    Factor::Transpose(inner) => format!("{}'", factor_to_string(inner)),
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn formula_operator_symbol(op: &FormulaOperator) -> &'static str {
+  match op {
+    FormulaOperator::Comparison(ComparisonOp::Equal) => "==",
+    FormulaOperator::Comparison(ComparisonOp::NotEqual) => "!=",
+    FormulaOperator::Comparison(ComparisonOp::LessThan) => "<",
+    FormulaOperator::Comparison(ComparisonOp::GreaterThan) => ">",
+    FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => "<=",
+    FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => ">=",
+    FormulaOperator::Comparison(ComparisonOp::StrictEqual) => "===",
+    FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => "!==",
+    FormulaOperator::Logic(LogicOp::And) => "&&",
+    FormulaOperator::Logic(LogicOp::Or) => "||",
+    FormulaOperator::Logic(LogicOp::Xor) => "^",
+    FormulaOperator::AddSub(AddSubOp::Add) => "+",
+    FormulaOperator::AddSub(AddSubOp::Sub) => "-",
+    FormulaOperator::MulDiv(MulDivOp::Mul) => "*",
+    FormulaOperator::MulDiv(MulDivOp::Div) => "/",
+    FormulaOperator::MulDiv(MulDivOp::Mod) => "%",
+    FormulaOperator::Vec(VecOp::Dot) => ".*",
+    FormulaOperator::Vec(VecOp::Cross) => "x",
+    FormulaOperator::Vec(VecOp::MatMul) => "**",
+    FormulaOperator::Vec(VecOp::Solve) => "\\",
+    FormulaOperator::Power(PowerOp::Pow) => "^",
+    _ => "?",
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn slice_to_string(slice_ref: &Slice) -> String {
+  let mut out = slice_ref.name.to_string();
+  for sub in &slice_ref.subscript {
+    out.push('[');
+    out.push_str(&subscript_to_string(sub));
+    out.push(']');
+  }
+  out
+}
+
+#[cfg(feature = "invariant_define")]
+fn subscript_to_string(sub: &Subscript) -> String {
+  match sub {
+    Subscript::Formula(f) => factor_to_string(f),
+    Subscript::All => ":".to_string(),
+    Subscript::Range(r) => tokens_to_string(&r.tokens()),
+    _ => tokens_to_string(&sub.tokens()),
+  }
 }
 
 #[cfg(feature = "invariant_define")]

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -250,6 +250,7 @@ pub struct InvariantViolationError {
   pub rhs_addr: Option<u64>,
   pub rhs_value: Option<String>,
   pub reason: String,
+  pub evaluated_kind: String,
 }
 impl MechErrorKind for InvariantViolationError {
   fn name(&self) -> &str { "InvariantViolationError" }
@@ -259,7 +260,7 @@ impl MechErrorKind for InvariantViolationError {
         format!(" | expr: {} | lhs(@{:x})={} op={:?} rhs(@{:x})={}", self.expression, la, lv, op, ra, rv),
       _ => format!(" | expr: {}", self.expression),
     };
-    format!("Invariant `{}` violation: {}{}", self.invariant_name, self.reason, details)
+    format!("Invariant `{}` violation: {} | evaluated kind: {}{}", self.invariant_name, self.reason, self.evaluated_kind, details)
   }
 }
 
@@ -320,7 +321,8 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
         operator,
         rhs_addr,
         rhs_value,
-        reason: error
+        reason: error,
+        evaluated_kind: result.kind().to_string(),
       },
       None
     ).with_compiler_loc().with_tokens(inv_def.expression.tokens());

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -674,7 +674,9 @@ macro_rules! op_assign {
           x => todo!("{:?}", x),
         }
       }
-    }}}
+    }
+  };
+}
 
 #[cfg(feature = "math_add_assign")]
 op_assign!(add_assign, Add);

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -998,5 +998,4 @@ impl MechErrorKind for UnableToConvertRecordError {
     format!("Unable to convert record of kind `{:?}` to record of kind `{:?}`", self.source_record_kind, self.target_record_kind)
   }
 }
-}
 

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -330,87 +330,6 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
 }
 
 #[cfg(feature = "invariant_define")]
-fn expression_to_string(expr: &Expression) -> String {
-  match expr {
-    Expression::Formula(f) => factor_to_string(f),
-    Expression::Var(v) => v.name.to_string(),
-    Expression::Literal(l) => tokens_to_string(&l.tokens()),
-    Expression::Slice(s) => slice_to_string(s),
-    _ => tokens_to_string(&expr.tokens()),
-  }
-}
-
-#[cfg(feature = "invariant_define")]
-fn factor_to_string(factor: &Factor) -> String {
-  match factor {
-    Factor::Expression(expr) => expression_to_string(expr),
-    Factor::Negate(inner) => format!("-{}", factor_to_string(inner)),
-    Factor::Not(inner) => format!("!{}", factor_to_string(inner)),
-    Factor::Parenthetical(inner) => format!("({})", factor_to_string(inner)),
-    Factor::Term(term) => {
-      let mut out = factor_to_string(&term.lhs);
-      for (op, rhs) in &term.rhs {
-        out.push(' ');
-        out.push_str(formula_operator_symbol(op));
-        out.push(' ');
-        out.push_str(&factor_to_string(rhs));
-      }
-      out
-    }
-    Factor::Transpose(inner) => format!("{}'", factor_to_string(inner)),
-  }
-}
-
-#[cfg(feature = "invariant_define")]
-fn formula_operator_symbol(op: &FormulaOperator) -> &'static str {
-  match op {
-    FormulaOperator::Comparison(ComparisonOp::Equal) => "==",
-    FormulaOperator::Comparison(ComparisonOp::NotEqual) => "!=",
-    FormulaOperator::Comparison(ComparisonOp::LessThan) => "<",
-    FormulaOperator::Comparison(ComparisonOp::GreaterThan) => ">",
-    FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => "<=",
-    FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => ">=",
-    FormulaOperator::Comparison(ComparisonOp::StrictEqual) => "===",
-    FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => "!==",
-    FormulaOperator::Logic(LogicOp::And) => "&&",
-    FormulaOperator::Logic(LogicOp::Or) => "||",
-    FormulaOperator::Logic(LogicOp::Xor) => "^",
-    FormulaOperator::AddSub(AddSubOp::Add) => "+",
-    FormulaOperator::AddSub(AddSubOp::Sub) => "-",
-    FormulaOperator::MulDiv(MulDivOp::Mul) => "*",
-    FormulaOperator::MulDiv(MulDivOp::Div) => "/",
-    FormulaOperator::MulDiv(MulDivOp::Mod) => "%",
-    FormulaOperator::Vec(VecOp::Dot) => ".*",
-    FormulaOperator::Vec(VecOp::Cross) => "x",
-    FormulaOperator::Vec(VecOp::MatMul) => "**",
-    FormulaOperator::Vec(VecOp::Solve) => "\\",
-    FormulaOperator::Power(PowerOp::Pow) => "^",
-    _ => "?",
-  }
-}
-
-#[cfg(feature = "invariant_define")]
-fn slice_to_string(slice_ref: &Slice) -> String {
-  let mut out = slice_ref.name.to_string();
-  for sub in &slice_ref.subscript {
-    out.push('[');
-    out.push_str(&subscript_to_string(sub));
-    out.push(']');
-  }
-  out
-}
-
-#[cfg(feature = "invariant_define")]
-fn subscript_to_string(sub: &Subscript) -> String {
-  match sub {
-    Subscript::Formula(f) => factor_to_string(f),
-    Subscript::All => ":".to_string(),
-    Subscript::Range(r) => tokens_to_string(&r.tokens()),
-    _ => tokens_to_string(&sub.tokens()),
-  }
-}
-
-#[cfg(feature = "invariant_define")]
 fn tokens_to_string(tokens: &[Token]) -> String {
   tokens.iter().flat_map(|t| t.chars.clone()).collect::<String>()
 }
@@ -1073,6 +992,87 @@ impl MechErrorKind for UnableToConvertRecordError {
   }
   fn message(&self) -> String {
     format!("Unable to convert record of kind `{:?}` to record of kind `{:?}`", self.source_record_kind, self.target_record_kind)
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn expression_to_string(expr: &Expression) -> String {
+  match expr {
+    Expression::Formula(f) => factor_to_string(f),
+    Expression::Var(v) => v.name.to_string(),
+    Expression::Literal(l) => tokens_to_string(&l.tokens()),
+    Expression::Slice(s) => slice_to_string(s),
+    _ => tokens_to_string(&expr.tokens()),
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn factor_to_string(factor: &Factor) -> String {
+  match factor {
+    Factor::Expression(expr) => expression_to_string(expr),
+    Factor::Negate(inner) => format!("-{}", factor_to_string(inner)),
+    Factor::Not(inner) => format!("!{}", factor_to_string(inner)),
+    Factor::Parenthetical(inner) => format!("({})", factor_to_string(inner)),
+    Factor::Term(term) => {
+      let mut out = factor_to_string(&term.lhs);
+      for (op, rhs) in &term.rhs {
+        out.push(' ');
+        out.push_str(formula_operator_symbol(op));
+        out.push(' ');
+        out.push_str(&factor_to_string(rhs));
+      }
+      out
+    }
+    Factor::Transpose(inner) => format!("{}'", factor_to_string(inner)),
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn formula_operator_symbol(op: &FormulaOperator) -> &'static str {
+  match op {
+    FormulaOperator::Comparison(ComparisonOp::Equal) => "==",
+    FormulaOperator::Comparison(ComparisonOp::NotEqual) => "!=",
+    FormulaOperator::Comparison(ComparisonOp::LessThan) => "<",
+    FormulaOperator::Comparison(ComparisonOp::GreaterThan) => ">",
+    FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => "<=",
+    FormulaOperator::Comparison(ComparisonOp::GreaterThanEqual) => ">=",
+    FormulaOperator::Comparison(ComparisonOp::StrictEqual) => "===",
+    FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => "!==",
+    FormulaOperator::Logic(LogicOp::And) => "&&",
+    FormulaOperator::Logic(LogicOp::Or) => "||",
+    FormulaOperator::Logic(LogicOp::Xor) => "^",
+    FormulaOperator::AddSub(AddSubOp::Add) => "+",
+    FormulaOperator::AddSub(AddSubOp::Sub) => "-",
+    FormulaOperator::MulDiv(MulDivOp::Mul) => "*",
+    FormulaOperator::MulDiv(MulDivOp::Div) => "/",
+    FormulaOperator::MulDiv(MulDivOp::Mod) => "%",
+    FormulaOperator::Vec(VecOp::Dot) => ".*",
+    FormulaOperator::Vec(VecOp::Cross) => "x",
+    FormulaOperator::Vec(VecOp::MatMul) => "**",
+    FormulaOperator::Vec(VecOp::Solve) => "\\",
+    FormulaOperator::Power(PowerOp::Pow) => "^",
+    _ => "?",
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn slice_to_string(slice_ref: &Slice) -> String {
+  let mut out = slice_ref.name.to_string();
+  for sub in &slice_ref.subscript {
+    out.push('[');
+    out.push_str(&subscript_to_string(sub));
+    out.push(']');
+  }
+  out
+}
+
+#[cfg(feature = "invariant_define")]
+fn subscript_to_string(sub: &Subscript) -> String {
+  match sub {
+    Subscript::Formula(f) => factor_to_string(f),
+    Subscript::All => ":".to_string(),
+    Subscript::Range(r) => tokens_to_string(&r.tokens()),
+    _ => tokens_to_string(&sub.tokens()),
   }
 }
 


### PR DESCRIPTION
### Motivation
- Invariant failure messages lost operators/subscripts when built from raw token chars, producing mangled expressions like `expr=out[4]🐝` instead of `out[4] == "🐝"`, and the failure rows were not column-aligned.

### Description
- Reconstruct invariant expressions from the AST by using `expression_to_string` and helpers `factor_to_string`, `formula_operator_symbol`, `slice_to_string`, and `subscript_to_string` so operators and subscripts are preserved when storing `InvariantViolationError.expression` in `src/interpreter/src/statements.rs`.
- Fall back to the existing `tokens_to_string` for nodes not handled by the new renderers to preserve prior behavior.
- Align `mech test` failure output by computing the maximum invariant-name width and printing each failure line with `{:width$}` formatting in `src/bin/mech.rs` so names and result columns stay visually aligned.
- Addressed related string/escaping and AST variant handling so the new renderers integrate with existing node types (e.g., use `Expression::Slice` and proper token handling).

### Testing
- Ran `cargo check -p mech-interpreter -p mech`, which completed successfully and the workspace compiled without errors.
- No additional automated test suites (`cargo test`) were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0644bf4878832a9acbd3dab077dd73)