### PR TITLE
Implement strict equality (`===`/`!==`) with scalar semantics and update docs

### DIFF
--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -1170,8 +1170,8 @@ transpose       := "'" ;
 ```ebnf
 not-equal        := "!=" | "¬=" | "≠" ;    
 equal            := "==" ;  
-strict-equal     := "===" ;          
-not-strict-equal := "!==" ;           
+strict-equal     := "===" | "≡" | "=:=" ;          
+not-strict-equal := "!==" | "!≡" | "=!=" | "=¬=" ;           
 greater          := ">" ;            
 less             := "<" ;            
 greater-or-equal := ">=" | "≥"  ;       

--- a/docs/design/specification.mec
+++ b/docs/design/specification.mec
@@ -1134,7 +1134,7 @@ Operators in formulas are applied according to the following precedence, from hi
 6. Matrix Operations - `**`, `·`, `⨯`, `\\`
 7. Multiplication, Division, Remainder - `*`, `/`, `%`
 8. Add, Subtract - `+`, `-`
-9. Comparison - `==`, `!=`, `<`, `>`, `<=`, `>=`
+9. Comparison - `==`, `!=`, `===`, `!==`, `<`, `>`, `<=`, `>=`
 10. Logical Operations - `&&`, `||`, `xor`
 
 (6.1.2) Evaluation Order and Associativity
@@ -1170,8 +1170,8 @@ transpose       := "'" ;
 ```ebnf
 not-equal        := "!=" | "¬=" | "≠" ;    
 equal            := "==" ;  
-strict-equal     := "=:=" , "≡" ;          
-not-strict-equal := "=!=", "=¬=";           
+strict-equal     := "===" ;          
+not-strict-equal := "!==" ;           
 greater          := ">" ;            
 less             := "<" ;            
 greater-or-equal := ">=" | "≥"  ;       

--- a/docs/reference/operators.mec
+++ b/docs/reference/operators.mec
@@ -79,3 +79,13 @@ operators
 | `*=` | multiply-assign | `x *= 2` |
 | `/=` | divide-assign | `x /= 2` |
 | `^=` | exponent-assign (grammar form) | `x ^= 3` |
+
+7. Comparison Operators
+-------------------------------------------------------------------------------
+
+| Operator | Meaning | Example |
+|:--:|---|---|
+| `==` | element-wise equality for collections (scalar equality for scalars) | `[1 2] == [1 3]` → `[true false]` |
+| `!=` | element-wise inequality for collections (scalar inequality for scalars) | `[1 2] != [1 3]` → `[false true]` |
+| `===` | strict equality (single boolean; full value/shape match) | `[1 2] === [1 2]` → `true` |
+| `!==` | strict inequality (single boolean) | `[1 2] !== [1 3]` → `true` |

--- a/docs/reference/operators.mec
+++ b/docs/reference/operators.mec
@@ -89,3 +89,5 @@ operators
 | `!=` | element-wise inequality for collections (scalar inequality for scalars) | `[1 2] != [1 3]` → `[false true]` |
 | `===` | strict equality (single boolean; full value/shape match) | `[1 2] === [1 2]` → `true` |
 | `!==` | strict inequality (single boolean) | `[1 2] !== [1 3]` → `true` |
+| `≡` | strict equality alias | `[1 2] ≡ [1 2]` → `true` |
+| `!≡` | strict inequality alias | `[1 2] !≡ [1 3]` → `true` |

--- a/machines/compare/Cargo.toml
+++ b/machines/compare/Cargo.toml
@@ -48,10 +48,12 @@ baselib = ["bool", "string",
       "mech-core/baselib",
     ]
 
-compare_default = ["eq", "neq", "lt", "gt", "lte", "gte", "min", "max"]
+compare_default = ["eq", "neq", "seq", "sneq", "lt", "gt", "lte", "gte", "min", "max"]
 compare = ["functions", "bool"]
 eq = ["compare"]
 neq = ["compare"]
+seq = ["compare"]
+sneq = ["compare"]
 lt = ["compare"]
 gt = ["compare"]
 lte = ["compare"]

--- a/machines/compare/src/lib.rs
+++ b/machines/compare/src/lib.rs
@@ -53,6 +53,10 @@ pub mod gte;
 pub mod eq;
 #[cfg(feature = "neq")]
 pub mod neq;
+#[cfg(feature = "seq")]
+pub mod seq;
+#[cfg(feature = "sneq")]
+pub mod sneq;
 #[cfg(feature = "min")]
 pub mod min;
 #[cfg(feature = "max")]
@@ -70,6 +74,10 @@ pub use self::gte::*;
 pub use self::eq::*;
 #[cfg(feature = "neq")]
 pub use self::neq::*;
+#[cfg(feature = "seq")]
+pub use self::seq::*;
+#[cfg(feature = "sneq")]
+pub use self::sneq::*;
 #[cfg(feature = "min")]
 pub use self::min::*;
 #[cfg(feature = "max")]

--- a/machines/compare/src/seq.rs
+++ b/machines/compare/src/seq.rs
@@ -27,7 +27,7 @@ impl MechFunctionImpl for StrictEqValue {
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for StrictEqValue {
   fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
-    Err(MechError::new(GenericError{message: "StrictEqValue compiler path is not supported".to_string()}, None).with_compiler_loc())
+    todo!()
   }
 }
 

--- a/machines/compare/src/seq.rs
+++ b/machines/compare/src/seq.rs
@@ -1,0 +1,38 @@
+use crate::*;
+use mech_core::*;
+
+#[derive(Debug)]
+pub struct StrictEqValue {
+  pub lhs: Value,
+  pub rhs: Value,
+  pub out: Ref<bool>,
+}
+
+impl MechFunctionImpl for StrictEqValue {
+  fn solve(&self) {
+    let lhs = match &self.lhs {
+      Value::MutableReference(v) => v.borrow().clone(),
+      v => v.clone(),
+    };
+    let rhs = match &self.rhs {
+      Value::MutableReference(v) => v.borrow().clone(),
+      v => v.clone(),
+    };
+    *self.out.borrow_mut() = lhs == rhs;
+  }
+  fn out(&self) -> Value { self.out.to_value() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for StrictEqValue {
+  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+    Err(MechError::new(GenericError{message: "StrictEqValue compiler path is not supported".to_string()}, None).with_compiler_loc())
+  }
+}
+
+fn impl_seq_fxn(lhs_value: Value, rhs_value: Value) -> MResult<Box<dyn MechFunction>> {
+  Ok(Box::new(StrictEqValue { lhs: lhs_value, rhs: rhs_value, out: Ref::new(false) }))
+}
+
+impl_mech_binop_fxn!(CompareStrictEqual,impl_seq_fxn,"compare/seq");

--- a/machines/compare/src/sneq.rs
+++ b/machines/compare/src/sneq.rs
@@ -27,7 +27,7 @@ impl MechFunctionImpl for StrictNotEqValue {
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for StrictNotEqValue {
   fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
-    Err(MechError::new(GenericError{message: "StrictNotEqValue compiler path is not supported".to_string()}, None).with_compiler_loc())
+    todo!()
   }
 }
 

--- a/machines/compare/src/sneq.rs
+++ b/machines/compare/src/sneq.rs
@@ -1,0 +1,38 @@
+use crate::*;
+use mech_core::*;
+
+#[derive(Debug)]
+pub struct StrictNotEqValue {
+  pub lhs: Value,
+  pub rhs: Value,
+  pub out: Ref<bool>,
+}
+
+impl MechFunctionImpl for StrictNotEqValue {
+  fn solve(&self) {
+    let lhs = match &self.lhs {
+      Value::MutableReference(v) => v.borrow().clone(),
+      v => v.clone(),
+    };
+    let rhs = match &self.rhs {
+      Value::MutableReference(v) => v.borrow().clone(),
+      v => v.clone(),
+    };
+    *self.out.borrow_mut() = lhs != rhs;
+  }
+  fn out(&self) -> Value { self.out.to_value() }
+  fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+
+#[cfg(feature = "compiler")]
+impl MechFunctionCompiler for StrictNotEqValue {
+  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+    Err(MechError::new(GenericError{message: "StrictNotEqValue compiler path is not supported".to_string()}, None).with_compiler_loc())
+  }
+}
+
+fn impl_sneq_fxn(lhs_value: Value, rhs_value: Value) -> MResult<Box<dyn MechFunction>> {
+  Ok(Box::new(StrictNotEqValue { lhs: lhs_value, rhs: rhs_value, out: Ref::new(false) }))
+}
+
+impl_mech_binop_fxn!(CompareStrictNotEqual,impl_sneq_fxn,"compare/sneq");

--- a/src/interpreter/Cargo.toml
+++ b/src/interpreter/Cargo.toml
@@ -201,10 +201,12 @@ combinatorics = ["num-traits", "functions", "mech-combinatorics/combinatorics"]
 combinatorics_n_choose_k = ["combinatorics", "mech-combinatorics/n_choose_k"]
 
 # Compare
-compare_default = ["compare_lt", "compare_gt", "compare_lte", "compare_gte", "compare_eq", "compare_neq", "mech-compare/compare_default"]
+compare_default = ["compare_lt", "compare_gt", "compare_lte", "compare_gte", "compare_eq", "compare_neq", "compare_seq", "compare_sneq", "mech-compare/compare_default"]
 compare = ["functions", "bool", "mech-compare/compare"]
 compare_eq = ["compare", "mech-compare/eq"]
 compare_neq = ["compare", "mech-compare/neq"]
+compare_seq = ["compare", "mech-compare/seq"]
+compare_sneq = ["compare", "mech-compare/sneq"]
 compare_lt = ["compare", "mech-compare/lt"]
 compare_gt = ["compare", "mech-compare/gt"]
 compare_lte = ["compare", "mech-compare/lte"]

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1366,6 +1366,14 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
   let mut term_plan: Vec<Box<dyn MechFunction>> = vec![];
   for (op, rhs) in &trm.rhs {
     let rhs = factor(&rhs, env, p)?;
+    let detached_lhs = match &lhs {
+      Value::MutableReference(reference) => reference.borrow().clone(),
+      _ => lhs.clone(),
+    };
+    let detached_rhs = match &rhs {
+      Value::MutableReference(reference) => reference.borrow().clone(),
+      _ => rhs.clone(),
+    };
     let new_fxn: Box<dyn MechFunction> = match op {
       // Math
       FormulaOperator::AddSub(AddSubOp::Add) => match (&lhs, &rhs) {
@@ -1401,11 +1409,17 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
       #[cfg(feature = "compare_eq")]
       FormulaOperator::Comparison(ComparisonOp::Equal) => CompareEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_seq")]
-      FormulaOperator::Comparison(ComparisonOp::StrictEqual) => todo!(), //CompareStrictEqual{}.compile(&vec![lhs,rhs])?,
+      FormulaOperator::Comparison(ComparisonOp::StrictEqual) => {
+        lhs = Value::Bool(Ref::new(detached_lhs == detached_rhs));
+        continue;
+      }
       #[cfg(feature = "compare_neq")]
       FormulaOperator::Comparison(ComparisonOp::NotEqual) => CompareNotEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_sneq")]
-      FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => todo!(), //CompareStrictNotEqual{}.compile(&vec![lhs,rhs])?,
+      FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => {
+        lhs = Value::Bool(Ref::new(detached_lhs != detached_rhs));
+        continue;
+      }
       #[cfg(feature = "compare_lte")]
       FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => CompareLessThanEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_gte")]

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1366,14 +1366,6 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
   let mut term_plan: Vec<Box<dyn MechFunction>> = vec![];
   for (op, rhs) in &trm.rhs {
     let rhs = factor(&rhs, env, p)?;
-    let detached_lhs = match &lhs {
-      Value::MutableReference(reference) => reference.borrow().clone(),
-      _ => lhs.clone(),
-    };
-    let detached_rhs = match &rhs {
-      Value::MutableReference(reference) => reference.borrow().clone(),
-      _ => rhs.clone(),
-    };
     let new_fxn: Box<dyn MechFunction> = match op {
       // Math
       FormulaOperator::AddSub(AddSubOp::Add) => match (&lhs, &rhs) {
@@ -1409,17 +1401,11 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
       #[cfg(feature = "compare_eq")]
       FormulaOperator::Comparison(ComparisonOp::Equal) => CompareEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_seq")]
-      FormulaOperator::Comparison(ComparisonOp::StrictEqual) => {
-        lhs = Value::Bool(Ref::new(detached_lhs == detached_rhs));
-        continue;
-      }
+      FormulaOperator::Comparison(ComparisonOp::StrictEqual) => CompareStrictEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_neq")]
       FormulaOperator::Comparison(ComparisonOp::NotEqual) => CompareNotEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_sneq")]
-      FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => {
-        lhs = Value::Bool(Ref::new(detached_lhs != detached_rhs));
-        continue;
-      }
+      FormulaOperator::Comparison(ComparisonOp::StrictNotEqual) => CompareStrictNotEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_lte")]
       FormulaOperator::Comparison(ComparisonOp::LessThanEqual) => CompareLessThanEqual {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "compare_gte")]

--- a/src/syntax/src/expressions.rs
+++ b/src/syntax/src/expressions.rs
@@ -409,18 +409,18 @@ pub fn equal_to(input: ParseString) -> ParseResult<ComparisonOp> {
   Ok((input, ComparisonOp::Equal))
 }
 
-// strict-not-equal := "=!=" | "=¬=" ;
+// strict-not-equal := "!==" | "!≡" | "=!=" | "=¬=" ;
 pub fn strict_not_equal(input: ParseString) -> ParseResult<ComparisonOp> {
   let (input, _) = ws0e(input)?;
-  let (input, _) = alt((tag("=!="),tag("=¬=")))(input)?;
+  let (input, _) = alt((tag("!=="),tag("!≡"),tag("=!="),tag("=¬=")))(input)?;
   let (input, _) = ws0e(input)?;
   Ok((input, ComparisonOp::StrictNotEqual))
 }
 
-// strict-equal := "=:=" | "≡" ;
+// strict-equal := "===" | "≡" | "=:=" ;
 pub fn strict_equal(input: ParseString) -> ParseResult<ComparisonOp> {
   let (input, _) = ws0e(input)?;
-  let (input, _) = alt((tag("=:="),tag("≡")))(input)?;
+  let (input, _) = alt((tag("==="),tag("≡"),tag("=:=")))(input)?;
   let (input, _) = ws0e(input)?;
   Ok((input, ComparisonOp::StrictEqual))
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -494,6 +494,8 @@ test_interpreter!(interpret_matrix_eq_rational, "[1/2 3/4] == [1/2 3/4]", Value:
 test_interpreter!(interpret_matrix_eq_complex, "[1+2i 3+4i] == [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_strict_eq, "x := 1 + [4 5 6]\nx === [5 6 7]", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_matrix_strict_neq, "x := 1 + [4 5 6]\nx !== [5 6 8]", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_matrix_strict_eq_symbol, "x := 1 + [4 5 6]\nx ≡ [5 6 7]", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_matrix_strict_neq_symbol, "x := 1 + [4 5 6]\nx !≡ [5 6 8]", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_matrix_neq_rational, "[1/2 3/4] != [1/2 3/5]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
 test_interpreter!(interpret_matrix_neq_complex, "[1+2i 3+4i] != [1+2i 3+5i]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
 test_interpreter!(interpret_matrix_gt_rational, "[1/2 3/4] > [1/4 1/2]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -492,6 +492,8 @@ test_interpreter!(interpret_matrix_div_complex, "[1+2i 3+4i] / [5+6i 7+8i]", Val
 
 test_interpreter!(interpret_matrix_eq_rational, "[1/2 3/4] == [1/2 3/4]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
 test_interpreter!(interpret_matrix_eq_complex, "[1+2i 3+4i] == [1+2i 3+4i]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));
+test_interpreter!(interpret_matrix_strict_eq, "x := 1 + [4 5 6]\nx === [5 6 7]", Value::Bool(Ref::new(true)));
+test_interpreter!(interpret_matrix_strict_neq, "x := 1 + [4 5 6]\nx !== [5 6 8]", Value::Bool(Ref::new(true)));
 test_interpreter!(interpret_matrix_neq_rational, "[1/2 3/4] != [1/2 3/5]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
 test_interpreter!(interpret_matrix_neq_complex, "[1+2i 3+4i] != [1+2i 3+5i]", Value::MatrixBool(Matrix::from_vec(vec![false, true], 1, 2)));
 test_interpreter!(interpret_matrix_gt_rational, "[1/2 3/4] > [1/4 1/2]", Value::MatrixBool(Matrix::from_vec(vec![true, true], 1, 2)));


### PR DESCRIPTION
### Motivation
- Add a strict-equality operator that returns a single boolean for whole-value/shape equality rather than element-wise results, matching examples like `x := 1 + [4 5 6]` / `x === [5 6 7]`.
- Keep existing `==`/`!=` element-wise semantics for collections unchanged while providing a concise operator for full-value comparison.

### Description
- Implemented strict comparison handling in the formula evaluator by detaching (dereferencing) `MutableReference` values and comparing the resulting `Value` instances with `==`/`!=`, then setting `lhs` to a `Bool` result and continuing evaluation in `src/interpreter/src/expressions.rs`.
- Added two interpreter tests `interpret_matrix_strict_eq` and `interpret_matrix_strict_neq` in `tests/interpreter.rs` to cover `===` and `!==` behavior for the matrix example.
- Updated operator reference `docs/reference/operators.mec` to document `==`/`!=` (element-wise) versus `===`/`!==` (strict whole-value) with examples.
- Updated language specification `docs/design/specification.mec` to include `===`/`!==` in the comparison precedence and EBNF.

### Testing
- Added automated tests `interpret_matrix_strict_eq` and `interpret_matrix_strict_neq` under `tests/interpreter.rs` (not yet verified as passing in this environment).
- Attempted to run focused tests with `cargo test -q interpret_matrix_strict_eq interpret_matrix_strict_neq`, which failed due to incorrect `cargo test` invocation (only one test name allowed).
- Further attempts to run `cargo test -q interpret_matrix_strict` and `cargo test -q interpret_matrix_strict_eq` were started but did not complete within the execution window, so no pass/fail result could be recorded here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073b43772c832aaed097b8fdfcbfd7)