### PR TITLE
Add structured test runner with JSON/.mec output and CLI `--out` support

### DIFF
--- a/docs/getting-started/build-and-run.mec
+++ b/docs/getting-started/build-and-run.mec
@@ -130,10 +130,12 @@ Runs a program and validates invariants defined as `foo! := <expression>`.
 mech test .
 mech test foo
 mech test foo/bar.mec
+mech test test1.mec test2.mec test3.mec
 mech test foo/bar.mec -o report.json
 mech test foo/bar.mec -o report.mec
 mech test foo/bar.mec --verbose
 mech test foo/bar.mec --verbose -o report.json
+mech test test1.mec test2.mec --verbose -o combined-report.mec
 ```
 
 4. Additional Help

--- a/docs/getting-started/build-and-run.mec
+++ b/docs/getting-started/build-and-run.mec
@@ -121,10 +121,19 @@ mech serve -p 3000 -a 0.0.0.0 my_script.mec
 
 Runs a program and validates invariants defined as `foo! := <expression>`.
 
+| Flag                | Value    | Description                                                                 |
+|---------------------|----------|-----------------------------------------------------------------------------|
+| `-o`, `--out`       | `PATH`   | Write test report to `PATH` as `.json` or `.mec` based on file extension. |
+| `-v`, `--verbose`   | (none)   | Print detailed diagnostics for passed invariants in addition to failures.  |
+
 ```sh
 mech test .
 mech test foo
 mech test foo/bar.mec
+mech test foo/bar.mec -o report.json
+mech test foo/bar.mec -o report.mec
+mech test foo/bar.mec --verbose
+mech test foo/bar.mec --verbose -o report.json
 ```
 
 4. Additional Help

--- a/docs/reference/validation.mec
+++ b/docs/reference/validation.mec
@@ -1,7 +1,7 @@
 Validation
 ===============================================================================
 
-Integrity constraints (invariants) are statements that must evaluate to `true`.
+%% Integrity constraints (invariants) are statements that must evaluate to `true`.
 
 ```mech
 foo! := EXPRESSION
@@ -24,7 +24,39 @@ mech test foo/bar.mec -o report.mec
 mech test foo/bar.mec --verbose
 ```
 
-Output Formats (`-o`, `--out`)
+1. Examples
+-------------------------------------------------------------------------------
+
+Examples:
+
+```mech:disabled
+-- Basic invariant
+positive! := x > 0
+
+-- Derived invariant over structures
+within-budget! := total-cost <= budget
+
+-- Another boolean integrity check
+ready! := state == :ready
+```
+
+Data structures can also be used in invariants:
+
+```mech:disabled
+my-list := 1 + [1 2 3]
+sorted! := my-list === [2 3 4]
+```
+
+The strict equality operator (`===`) checks for deep equality, so `sorted!` will evaluate to `true` if `my-list` is exactly `[2 3 4]`. Using the regular equality operator (`==`) would check for element-wise equality, which doesn't satisfy the requirement that the right-hand side of an invariant must evaluate to a single boolean value.
+
+```mech:disabled
+my-list := 1 + [1 2 3]
+-- Invalid because it evaluates to {{<[bool]>}}, expected {{<bool>}}.
+sorted! := my-list == [2 3 4]
+```
+
+
+2. Output Formats (`-o`, `--out`)
 -------------------------------------------------------------------------------
 
 `mech test -o <path>` writes structured output in one of two formats:
@@ -37,44 +69,9 @@ Pass/fail detail level depends on `--verbose`:
 - non-verbose: failed invariants are detailed, passed invariants are summarized by name
 - verbose: failed and passed invariants are both detailed
 
-JSON schema (current):
+(2.1) Mech Record Schema
 
-```json
-{
-  "result": {
-    "files-total": 0,
-    "files-passed": 0,
-    "files-failed": 0,
-    "tests-total": 0,
-    "tests-passed": 0,
-    "tests-failed": 0
-  },
-  "files": [
-    {
-      "path": "test.mec",
-      "result": { "total": 0, "passed": 0, "failed": 0 },
-      "failed": [
-        {
-          "name": "invariant!",
-          "expression": "x==1",
-          "reason": "evaluated to false",
-          "evaluated-kind": "bool",
-          "actual": "U64(@0x...: 2)",
-          "expected": "F64(@0x...: 1.0)"
-        }
-      ],
-      "passed": [
-        { "name": "other!" }
-      ],
-      "run-error": null
-    }
-  ]
-}
-```
-
-In verbose mode, `passed` entries include the same detailed fields as `failed`.
-
-Mech kind definitions (current):
+The Mech record output has the following kind shape:
 
 ```mech:disabled
 <test-summary> := <{
@@ -114,8 +111,8 @@ Mech kind definitions (current):
   run-error<string?>
 }>
 
--- verbose output shape (passed is detailed)
-<test-file-report-verbose> := <{
+-- verbose output shape (passed has same detail as failed)
+<test-file-report/verbose> := <{
   path<string>
   result<test-file-result>
   failed<[test-case-detail]>
@@ -123,21 +120,54 @@ Mech kind definitions (current):
   run-error<string?>
 }>
 
+-- overall report shape
 <test-report> := <{
   result<test-summary>
   files<[test-file-report]>
 }>
+
+-- overall report shape (verbose)
+<test-report/verbose> := <{
+  result<test-summary>
+  files<[test-file-report/verbose]>
+}>
 ```
 
-Examples:
+(2.2) JSON Schema
 
-```mech
--- Basic invariant
-positive! := x > 0
+The JSON output follows the same structure as the Mech record. The main difference is that the JSON schema uses standard JSON types and nesting, while the Mech record uses Mech's kind system to define the shape of the data. Thus in the JSON output, we have objects and arrays instead of Mech's record and set kinds, but the overall structure and field names is:
 
--- Derived invariant over structures
-within-budget! := total-cost <= budget
-
--- Another boolean integrity check
-ready! := count >= min-count
+```json
+{
+  "result": {
+    "files-total": 0,
+    "files-passed": 0,
+    "files-failed": 0,
+    "tests-total": 0,
+    "tests-passed": 0,
+    "tests-failed": 0
+  },
+  "files": [
+    {
+      "path": "test.mec",
+      "result": { "total": 0, "passed": 0, "failed": 0 },
+      "failed": [
+        {
+          "name": "invariant!",
+          "expression": "x==1",
+          "reason": "evaluated to false",
+          "evaluated-kind": "bool",
+          "actual": "U64(@0x...: 2)",
+          "expected": "F64(@0x...: 1.0)"
+        }
+      ],
+      "passed": [
+        { "name": "other!" }
+      ],
+      "run-error": null
+    }
+  ]
+}
 ```
+
+In verbose mode, `passed` entries include the same detailed fields as `failed`.

--- a/docs/reference/validation.mec
+++ b/docs/reference/validation.mec
@@ -37,7 +37,7 @@ Pass/fail detail level depends on `--verbose`:
 - non-verbose: failed invariants are detailed, passed invariants are summarized by name
 - verbose: failed and passed invariants are both detailed
 
-JSON schema (conceptual):
+JSON schema (current):
 
 ```json
 {
@@ -74,7 +74,7 @@ JSON schema (conceptual):
 
 In verbose mode, `passed` entries include the same detailed fields as `failed`.
 
-Mech kind definitions (conceptual):
+Mech kind definitions (current):
 
 ```mech:disabled
 <test-summary> := <{

--- a/docs/reference/validation.mec
+++ b/docs/reference/validation.mec
@@ -19,6 +19,114 @@ Use `mech test` to run and validate them:
 mech test .
 mech test foo
 mech test foo/bar.mec
+mech test foo/bar.mec -o report.json
+mech test foo/bar.mec -o report.mec
+mech test foo/bar.mec --verbose
+```
+
+Output Formats (`-o`, `--out`)
+-------------------------------------------------------------------------------
+
+`mech test -o <path>` writes structured output in one of two formats:
+
+- `.json` emits JSON
+- `.mec` emits a Mech record
+
+Pass/fail detail level depends on `--verbose`:
+
+- non-verbose: failed invariants are detailed, passed invariants are summarized by name
+- verbose: failed and passed invariants are both detailed
+
+JSON schema (conceptual):
+
+```json
+{
+  "result": {
+    "files-total": 0,
+    "files-passed": 0,
+    "files-failed": 0,
+    "tests-total": 0,
+    "tests-passed": 0,
+    "tests-failed": 0
+  },
+  "files": [
+    {
+      "path": "test.mec",
+      "result": { "total": 0, "passed": 0, "failed": 0 },
+      "failed": [
+        {
+          "name": "invariant!",
+          "expression": "x==1",
+          "reason": "evaluated to false",
+          "evaluated-kind": "bool",
+          "actual": "U64(@0x...: 2)",
+          "expected": "F64(@0x...: 1.0)"
+        }
+      ],
+      "passed": [
+        { "name": "other!" }
+      ],
+      "run-error": null
+    }
+  ]
+}
+```
+
+In verbose mode, `passed` entries include the same detailed fields as `failed`.
+
+Mech kind definitions (conceptual):
+
+```mech:disabled
+<test-summary> := <{
+  files-total<u64>
+  files-passed<u64>
+  files-failed<u64>
+  tests-total<u64>
+  tests-passed<u64>
+  tests-failed<u64>
+}>
+
+<test-case-detail> := <{
+  name<string>
+  expression<string>
+  reason<string>
+  evaluated-kind<string>
+  actual<string>
+  expected<string>
+}>
+
+<test-case-name> := <{
+  name<string>
+}>
+
+<test-file-result> := <{
+  total<u64>
+  passed<u64>
+  failed<u64>
+}>
+
+-- non-verbose output shape
+<test-file-report> := <{
+  path<string>
+  result<test-file-result>
+  failed<[test-case-detail]>
+  passed<[test-case-name]>
+  run-error<string?>
+}>
+
+-- verbose output shape (passed is detailed)
+<test-file-report-verbose> := <{
+  path<string>
+  result<test-file-result>
+  failed<[test-case-detail]>
+  passed<[test-case-detail]>
+  run-error<string?>
+}>
+
+<test-report> := <{
+  result<test-summary>
+  files<[test-file-report]>
+}>
 ```
 
 Examples:

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -6,8 +6,6 @@ use mech_syntax::parser;
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
 use mech_interpreter::interpreter::*;
-#[cfg(feature = "invariant_define")]
-use mech_interpreter::InvariantViolationError;
 use std::time::Instant;
 use std::fs;
 use std::env;
@@ -204,7 +202,12 @@ async fn main() -> Result<(), MechError> {
       .arg(Arg::new("mech_test_file_paths")
         .help("Source .mec and .mecb files")
         .required(false)
-        .action(ArgAction::Append)))
+        .action(ArgAction::Append))
+      .arg(Arg::new("output_path")
+        .short('o')
+        .long("out")
+        .help("Write test output to .json or .mec.")
+        .required(false)))
     .subcommand(Command::new("serve")
       .about("Serve Mech program over an HTTP server.")
       .arg(Arg::new("mech_serve_file_paths")
@@ -338,73 +341,9 @@ async fn main() -> Result<(), MechError> {
     let mech_paths: Vec<String> = matches
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
-    let mut any_failed = false;
-    let mut run_errors = false;
-    println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
-    for path in &mech_paths {
-      let uuid = generate_uuid();
-      let mut intrp = Interpreter::new(uuid);
-      let mut mechfs = MechFileSystem::new();
-      if let Err(err) = mechfs.watch_source(path) {
-        print_mech_error(&err);
-        run_errors = true;
-        any_failed = true;
-        continue;
-      }
-      let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
-      if let Err(err) = result {
-        print_mech_error(&err);
-        run_errors = true;
-        any_failed = true;
-        continue;
-      }
-      let mut passed = 0usize;
-      let mut failed = 0usize;
-      let state_brrw = intrp.state.borrow();
-      let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
-      println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
-      for (_id, (name, value)) in state_brrw.invariants.iter() {
-        match &*value.borrow() {
-          Value::Bool(b) if *b.borrow() => {
-            println!("{:<width$}   ✓", name, width=test_name_width);
-            passed += 1;
-          },
-          _ => {
-            println!("{:<width$}   ✗", name, width=test_name_width);
-            failed += 1;
-          },
-        }
-      }
-      let total = passed + failed;
-      if failed == 0 {
-        println!("\n{} SUCCESS: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
-      } else {
-        any_failed = true;
-        println!("\n{} FAILURE: {} total | {} passed | {} failed", "[Test]".truecolor(153, 221, 85), total, passed, failed);
-        if !state_brrw.invariant_violations.is_empty() {
-          println!("\nfailures:\n");
-          for violation in &state_brrw.invariant_violations {
-            let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
-            if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
-              let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
-              let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
-              println!("  {}: {}", name, inv_err.expression);
-              println!("    reason = {}", inv_err.reason);
-              println!("    evaluated_kind = {}", inv_err.evaluated_kind);
-              println!("    actual = {}", lhs);
-              println!("    expected = {}", rhs);
-            } else {
-              println!("  {}: {}", name, violation.error.display_message());
-            }
-          }
-        }
-        println!();
-      }
-    }
-    if run_errors {
-      println!("{} One or more files failed to load/execute, but all requested files were attempted.", "[Warn]".truecolor(255,210,77));
-    }
-    std::process::exit(if any_failed { 1 } else { 0 });
+    let output_path = matches.get_one::<String>("output_path").cloned();
+    let exit_code = run_mech_tests(mech_paths, tree_flag, debug_flag, time_flag, trace_flag, output_path)?;
+    std::process::exit(exit_code);
   }
 
   // --------------------------------------------------------------------------

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -207,6 +207,12 @@ async fn main() -> Result<(), MechError> {
         .short('o')
         .long("out")
         .help("Write test output to .json or .mec.")
+        .required(false))
+      .arg(Arg::new("verbose")
+        .short('v')
+        .long("verbose")
+        .help("Print verbose pass/fail details.")
+        .action(ArgAction::SetTrue)
         .required(false)))
     .subcommand(Command::new("serve")
       .about("Serve Mech program over an HTTP server.")
@@ -342,7 +348,8 @@ async fn main() -> Result<(), MechError> {
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
     let output_path = matches.get_one::<String>("output_path").cloned();
-    let exit_code = run_mech_tests(mech_paths, tree_flag, debug_flag, time_flag, trace_flag, output_path)?;
+    let verbose = matches.get_flag("verbose");
+    let exit_code = run_mech_tests(mech_paths, tree_flag, debug_flag, time_flag, trace_flag, output_path, verbose)?;
     std::process::exit(exit_code);
   }
 

--- a/src/core/src/program/mod.rs
+++ b/src/core/src/program/mod.rs
@@ -32,6 +32,16 @@ pub type InvariantTable = HashMap<u64, (String, ValRef)>;
 pub type InvariantExpressionTable = HashMap<u64, String>;
 #[cfg(feature = "invariant_define")]
 #[derive(Clone, Debug)]
+pub struct InvariantEvaluation {
+  pub reason: String,
+  pub evaluated_kind: String,
+  pub actual: String,
+  pub expected: String,
+}
+#[cfg(feature = "invariant_define")]
+pub type InvariantEvaluationTable = HashMap<u64, InvariantEvaluation>;
+#[cfg(feature = "invariant_define")]
+#[derive(Clone, Debug)]
 pub struct InvariantViolation {
   pub id: u64,
   pub error: MechError,
@@ -55,6 +65,8 @@ pub struct ProgramState {
   pub invariant_violations: Vec<InvariantViolation>,
   #[cfg(feature = "invariant_define")]
   pub invariant_expressions: InvariantExpressionTable,
+  #[cfg(feature = "invariant_define")]
+  pub invariant_evaluations: InvariantEvaluationTable,
   pub dictionary: Ref<Dictionary>,
 }
 
@@ -78,6 +90,8 @@ impl Clone for ProgramState {
       invariant_violations: self.invariant_violations.clone(),
       #[cfg(feature = "invariant_define")]
       invariant_expressions: self.invariant_expressions.clone(),
+      #[cfg(feature = "invariant_define")]
+      invariant_evaluations: self.invariant_evaluations.clone(),
       dictionary: self.dictionary.clone(),
     }
   }
@@ -103,6 +117,8 @@ impl ProgramState {
       invariant_violations: vec![],
       #[cfg(feature = "invariant_define")]
       invariant_expressions: InvariantExpressionTable::new(),
+      #[cfg(feature = "invariant_define")]
+      invariant_evaluations: InvariantEvaluationTable::new(),
       dictionary: Ref::new(Dictionary::new()),
     }
   }

--- a/src/core/src/program/mod.rs
+++ b/src/core/src/program/mod.rs
@@ -29,6 +29,8 @@ pub type EnumTable = HashMap<u64, MechEnum>;
 #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
 pub type InvariantTable = HashMap<u64, (String, ValRef)>;
 #[cfg(feature = "invariant_define")]
+pub type InvariantExpressionTable = HashMap<u64, String>;
+#[cfg(feature = "invariant_define")]
 #[derive(Clone, Debug)]
 pub struct InvariantViolation {
   pub id: u64,
@@ -51,6 +53,8 @@ pub struct ProgramState {
   pub invariants: InvariantTable,
   #[cfg(feature = "invariant_define")]
   pub invariant_violations: Vec<InvariantViolation>,
+  #[cfg(feature = "invariant_define")]
+  pub invariant_expressions: InvariantExpressionTable,
   pub dictionary: Ref<Dictionary>,
 }
 
@@ -72,6 +76,8 @@ impl Clone for ProgramState {
       invariants: self.invariants.clone(),
       #[cfg(feature = "invariant_define")]
       invariant_violations: self.invariant_violations.clone(),
+      #[cfg(feature = "invariant_define")]
+      invariant_expressions: self.invariant_expressions.clone(),
       dictionary: self.dictionary.clone(),
     }
   }
@@ -95,6 +101,8 @@ impl ProgramState {
       invariants: InvariantTable::new(),
       #[cfg(feature = "invariant_define")]
       invariant_violations: vec![],
+      #[cfg(feature = "invariant_define")]
+      invariant_expressions: InvariantExpressionTable::new(),
       dictionary: Ref::new(Dictionary::new()),
     }
   }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -268,6 +268,7 @@ impl MechErrorKind for InvariantViolationError {
 pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<Value> {
   let invariant_id = inv_def.name.hash();
   let invariant_name = inv_def.name.to_string();
+  let invariant_expression = tokens_to_string(&inv_def.expression.tokens());
   {
     let symbols = p.symbols();
     if symbols.borrow().contains(invariant_id) {
@@ -286,6 +287,7 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
     let var_def_fxn = VarDefine{}.compile(&vec![detached_result.clone(), Value::String(Ref::new(invariant_name.clone())), Value::Bool(Ref::new(false))])?;
     state_brrw.add_plan_step(var_def_fxn);
   }
+  p.state.borrow_mut().invariant_expressions.insert(invariant_id, invariant_expression.clone());
   #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
   {
     let invariant_value = {
@@ -315,7 +317,7 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
     let err = MechError::new(
       InvariantViolationError{
         invariant_name: invariant_name.clone(),
-        expression: tokens_to_string(&inv_def.expression.tokens()),
+        expression: invariant_expression,
         lhs_addr,
         lhs_value,
         operator,

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -302,18 +302,29 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &Interpreter) -> MResult<V
     Value::Bool(b) => if *b.borrow() { None } else { Some("evaluated to false".to_string()) },
     other => Some(format!("must evaluate to bool, got {}", other.kind())),
   };
+  let operand_detail = invariant_operand_refs(inv_def, p);
+  let (lhs_addr, lhs_value, operator, rhs_addr, rhs_value) = match operand_detail {
+    Some((lhs, op, rhs)) => {
+      let lhs_addr = lhs.as_ref().map(|v| v.addr() as u64);
+      let lhs_value = lhs.as_ref().map(|v| format!("{:?}", v.borrow()));
+      let rhs_addr = rhs.as_ref().map(|v| v.addr() as u64);
+      let rhs_value = rhs.as_ref().map(|v| format!("{:?}", v.borrow()));
+      (lhs_addr, lhs_value, op, rhs_addr, rhs_value)
+    }
+    None => (None, None, None, Some(rhs_ref.addr() as u64), Some(format!("{:?}", rhs_ref.borrow()))),
+  };
+  {
+    let reason = violation_error.clone().unwrap_or_else(|| "evaluated to true".to_string());
+    let actual = lhs_value.clone().unwrap_or_else(|| format!("{:?}", rhs_ref.borrow()));
+    let expected = rhs_value.clone().unwrap_or_else(|| format!("{:?}", rhs_ref.borrow()));
+    p.state.borrow_mut().invariant_evaluations.insert(invariant_id, InvariantEvaluation {
+      reason,
+      evaluated_kind: result.kind().to_string(),
+      actual,
+      expected,
+    });
+  }
   if let Some(error) = violation_error {
-    let operand_detail = invariant_operand_refs(inv_def, p);
-    let (lhs_addr, lhs_value, operator, rhs_addr, rhs_value) = match operand_detail {
-      Some((lhs, op, rhs)) => {
-        let lhs_addr = lhs.as_ref().map(|v| v.addr() as u64);
-        let lhs_value = lhs.as_ref().map(|v| format!("{:?}", v.borrow()));
-        let rhs_addr = rhs.as_ref().map(|v| v.addr() as u64);
-        let rhs_value = rhs.as_ref().map(|v| format!("{:?}", v.borrow()));
-        (lhs_addr, lhs_value, op, rhs_addr, rhs_value)
-      }
-      None => (None, None, None, Some(rhs_ref.addr() as u64), Some(format!("{:?}", rhs_ref.borrow()))),
-    };
     let err = MechError::new(
       InvariantViolationError{
         invariant_name: invariant_name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ mod repl;
 mod serve;
 #[cfg(feature = "run")]
 mod run;
+#[cfg(all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool"))]
+mod test;
 #[cfg(feature = "mechfs")]
 mod mechfs;
 
@@ -67,6 +69,8 @@ pub use self::repl::*;
 pub use self::serve::*;
 #[cfg(feature = "run")]
 pub use self::run::*;
+#[cfg(all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool"))]
+pub use self::test::*;
 #[cfg(feature = "mechfs")]
 pub use self::mechfs::*;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -57,6 +57,24 @@ struct TestReport {
   result: SummaryResult,
   files: Vec<FileReport>,
 }
+#[derive(Debug, Serialize)]
+struct NamedCase {
+  name: String,
+}
+#[derive(Debug, Serialize)]
+struct FileReportOut {
+  path: String,
+  result: FileResult,
+  failed: Vec<CaseDetail>,
+  passed: Vec<NamedCase>,
+  #[serde(rename = "run-error")]
+  run_error: Option<String>,
+}
+#[derive(Debug, Serialize)]
+struct TestReportOut {
+  result: SummaryResult,
+  files: Vec<FileReportOut>,
+}
 
 fn mech_bool(v: bool) -> &'static str { if v { "✓" } else { "✗" } }
 fn mech_str(v: &str) -> String { format!("{:?}", v) }
@@ -71,9 +89,13 @@ fn case_to_mech(c: &CaseDetail) -> String {
     mech_str(&c.name), mech_str(&c.expression), mech_str(&c.reason), mech_kind(&c.evaluated_kind), mech_str(&c.actual), mech_str(&c.expected)
   )
 }
-fn file_to_mech(file: &FileReport) -> String {
+fn file_to_mech(file: &FileReport, verbose: bool) -> String {
   let failed_items = file.failed.iter().map(case_to_mech).collect::<Vec<_>>().join("\n");
-  let passed_items = file.passed.iter().map(case_to_mech).collect::<Vec<_>>().join("\n");
+  let passed_items = if verbose {
+    file.passed.iter().map(case_to_mech).collect::<Vec<_>>().join("\n")
+  } else {
+    file.passed.iter().map(|p| format!("{{\n  name: {}\n}}", mech_str(&p.name))).collect::<Vec<_>>().join("\n")
+  };
   let run_error = file.run_error.as_ref().map(|e| mech_str(e)).unwrap_or("_".to_string());
   format!(
     "{{\n  path: {}\n  result: {{\n    total: {}\n    passed: {}\n    failed: {}\n  }}\n  failed: {{\n{}\n  }}\n  passed: {{\n{}\n  }}\n  run-error: {}\n}}",
@@ -85,12 +107,37 @@ fn file_to_mech(file: &FileReport) -> String {
   )
 }
 fn report_to_mech(report: &TestReport) -> String {
-  let files = report.files.iter().map(file_to_mech).collect::<Vec<_>>().join("\n");
+  let files = report.files.iter().map(|f| file_to_mech(f, false)).collect::<Vec<_>>().join("\n");
   format!(
     "{{\n  result: {{\n    files-total: {}\n    files-passed: {}\n    files-failed: {}\n    tests-total: {}\n    tests-passed: {}\n    tests-failed: {}\n  }}\n  files: {{\n{}\n  }}\n}}",
     report.result.files_total, report.result.files_passed, report.result.files_failed, report.result.tests_total, report.result.tests_passed, report.result.tests_failed,
     indent_block(&files, 4)
   )
+}
+
+fn report_to_json(report: &TestReport, verbose: bool) -> Result<String, io::Error> {
+  if verbose {
+    serde_json::to_string_pretty(report).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+  } else {
+    let out = TestReportOut {
+      result: SummaryResult {
+        files_total: report.result.files_total,
+        files_passed: report.result.files_passed,
+        files_failed: report.result.files_failed,
+        tests_total: report.result.tests_total,
+        tests_passed: report.result.tests_passed,
+        tests_failed: report.result.tests_failed,
+      },
+      files: report.files.iter().map(|f| FileReportOut {
+        path: f.path.clone(),
+        result: FileResult { total: f.result.total, passed: f.result.passed, failed: f.result.failed },
+        failed: f.failed.clone(),
+        passed: f.passed.iter().map(|p| NamedCase { name: p.name.clone() }).collect(),
+        run_error: f.run_error.clone(),
+      }).collect(),
+    };
+    serde_json::to_string_pretty(&out).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+  }
 }
 
 pub fn run_mech_tests(
@@ -144,12 +191,11 @@ pub fn run_mech_tests(
 
     let mut passed_cases = Vec::new();
     let mut failed_cases = Vec::new();
+    let width = state.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
     for (id, (name, value)) in state.invariants.iter() {
       match &*value.borrow() {
         Value::Bool(b) if *b.borrow() => {
-          if verbose {
-            println!("{}   ✓", name);
-          }
+          println!("{:<width$}   ✓", name, width=width);
           passed_cases.push(CaseDetail {
             name: name.clone(),
             expression: state.invariant_expressions.get(id).cloned().unwrap_or_else(|| name.clone()),
@@ -160,9 +206,7 @@ pub fn run_mech_tests(
           });
         }
         _ => {
-          if verbose {
-            println!("{}   ✗", name);
-          }
+          println!("{:<width$}   ✗", name, width=width);
           failed_cases.push(violations.remove(id).unwrap_or(CaseDetail {
             name: name.clone(),
             expression: state.invariant_expressions.get(id).cloned().unwrap_or_default(),
@@ -194,15 +238,15 @@ pub fn run_mech_tests(
     } else {
       any_failed = true;
       println!("\n{} FAILURE: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
+      println!("failures:\n");
+      for f in &failed_cases {
+        println!("  {}: {}", f.name, f.expression);
+        println!("    reason = {}", f.reason);
+        println!("    evaluated_kind = {}", f.evaluated_kind);
+        println!("    actual = {}", f.actual);
+        println!("    expected = {}", f.expected);
+      }
       if verbose {
-        println!("failures:\n");
-        for f in &failed_cases {
-          println!("  {}: {}", f.name, f.expression);
-          println!("    reason = {}", f.reason);
-          println!("    evaluated_kind = {}", f.evaluated_kind);
-          println!("    actual = {}", f.actual);
-          println!("    expected = {}", f.expected);
-        }
         println!("\npassed:\n");
         for p in &passed_cases {
           println!("  {}: {}", p.name, p.expression);
@@ -231,7 +275,7 @@ pub fn run_mech_tests(
     let path = PathBuf::from(&output_path);
     let extension = path.extension().and_then(OsStr::to_str).unwrap_or("");
     match extension {
-      "json" => save_to_file(path, &serde_json::to_string_pretty(&report).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?)?,
+      "json" => save_to_file(path, &report_to_json(&report, verbose)?)?,
       "mec" => save_to_file(path, &report_to_mech(&report))?,
       _ => { eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension); return Ok(1); }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Clone)]
-struct FailedCase {
+struct CaseDetail {
   name: String,
   expression: String,
   reason: String,
@@ -30,8 +30,8 @@ struct FileResult {
 struct FileReport {
   path: String,
   result: FileResult,
-  failed: Vec<FailedCase>,
-  passed: Vec<String>,
+  failed: Vec<CaseDetail>,
+  passed: Vec<CaseDetail>,
   #[serde(rename = "run-error")]
   run_error: Option<String>,
 }
@@ -65,22 +65,22 @@ fn indent_block(block: &str, spaces: usize) -> String {
   let pad = " ".repeat(spaces);
   block.lines().map(|line| format!("{pad}{line}")).collect::<Vec<_>>().join("\n")
 }
-fn failed_case_to_mech(c: &FailedCase) -> String {
+fn case_to_mech(c: &CaseDetail) -> String {
   format!(
     "{{\n  name: {}\n  expression: {}\n  reason: {}\n  evaluated-kind: {}\n  actual: {}\n  expected: {}\n}}",
     mech_str(&c.name), mech_str(&c.expression), mech_str(&c.reason), mech_kind(&c.evaluated_kind), mech_str(&c.actual), mech_str(&c.expected)
   )
 }
 fn file_to_mech(file: &FileReport) -> String {
-  let failed_items = file.failed.iter().map(failed_case_to_mech).collect::<Vec<_>>().join("\n");
-  let passed_items = file.passed.iter().map(|p| mech_str(p)).collect::<Vec<_>>().join(" ");
+  let failed_items = file.failed.iter().map(case_to_mech).collect::<Vec<_>>().join("\n");
+  let passed_items = file.passed.iter().map(case_to_mech).collect::<Vec<_>>().join("\n");
   let run_error = file.run_error.as_ref().map(|e| mech_str(e)).unwrap_or("_".to_string());
   format!(
-    "{{\n  path: {}\n  result: {{\n    total: {}\n    passed: {}\n    failed: {}\n  }}\n  failed: {{\n{}\n  }}\n  passed: {{{}}}\n  run-error: {}\n}}",
+    "{{\n  path: {}\n  result: {{\n    total: {}\n    passed: {}\n    failed: {}\n  }}\n  failed: {{\n{}\n  }}\n  passed: {{\n{}\n  }}\n  run-error: {}\n}}",
     mech_str(&file.path),
     file.result.total, file.result.passed, file.result.failed,
     if failed_items.is_empty() { "".to_string() } else { indent_block(&failed_items, 4) },
-    passed_items,
+    if passed_items.is_empty() { "".to_string() } else { indent_block(&passed_items, 4) },
     run_error
   )
 }
@@ -128,10 +128,10 @@ pub fn run_mech_tests(
     let state = intrp.state.borrow();
     println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
 
-    let mut violations: HashMap<u64, FailedCase> = HashMap::new();
+    let mut violations: HashMap<u64, CaseDetail> = HashMap::new();
     for v in &state.invariant_violations {
       if let Some(inv) = v.error.kind_as::<InvariantViolationError>() {
-        violations.insert(v.id, FailedCase {
+        violations.insert(v.id, CaseDetail {
           name: state.invariants.get(&v.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", v.id)),
           expression: inv.expression.clone(),
           reason: inv.reason.clone(),
@@ -142,7 +142,7 @@ pub fn run_mech_tests(
       }
     }
 
-    let mut passed_names = Vec::new();
+    let mut passed_cases = Vec::new();
     let mut failed_cases = Vec::new();
     for (id, (name, value)) in state.invariants.iter() {
       match &*value.borrow() {
@@ -150,28 +150,39 @@ pub fn run_mech_tests(
           if verbose {
             println!("{}   ✓", name);
           }
-          passed_names.push(name.clone());
+          passed_cases.push(CaseDetail {
+            name: name.clone(),
+            expression: name.clone(),
+            reason: "evaluated to true".to_string(),
+            evaluated_kind: "bool".to_string(),
+            actual: "✓".to_string(),
+            expected: "✓".to_string(),
+          });
         }
         _ => {
           if verbose {
             println!("{}   ✗", name);
           }
-          failed_cases.push(violations.remove(id).unwrap_or(FailedCase {
+          failed_cases.push(violations.remove(id).unwrap_or(CaseDetail {
             name: name.clone(), expression: "".to_string(), reason: "Invariant evaluated to false or non-bool value".to_string(), evaluated_kind: "bool".to_string(), actual: "?".to_string(), expected: "?".to_string()
           }));
         }
       }
     }
 
-    let passed = passed_names.len();
+    let passed = passed_cases.len();
     let failed = failed_cases.len();
     let total = passed + failed;
     if failed == 0 {
       println!("\n{} SUCCESS: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
       if verbose {
         println!("passed:\n");
-        for p in &passed_names {
-          println!("  {}", p);
+        for p in &passed_cases {
+          println!("  {}: {}", p.name, p.expression);
+          println!("    reason = {}", p.reason);
+          println!("    evaluated_kind = {}", p.evaluated_kind);
+          println!("    actual = {}", p.actual);
+          println!("    expected = {}", p.expected);
         }
         println!();
       }
@@ -188,13 +199,17 @@ pub fn run_mech_tests(
           println!("    expected = {}", f.expected);
         }
         println!("\npassed:\n");
-        for p in &passed_names {
-          println!("  {}", p);
+        for p in &passed_cases {
+          println!("  {}: {}", p.name, p.expression);
+          println!("    reason = {}", p.reason);
+          println!("    evaluated_kind = {}", p.evaluated_kind);
+          println!("    actual = {}", p.actual);
+          println!("    expected = {}", p.expected);
         }
         println!();
       }
     }
-    file_reports.push(FileReport { path: path.clone(), result: FileResult { total, passed, failed }, failed: failed_cases, passed: passed_names, run_error: None });
+    file_reports.push(FileReport { path: path.clone(), result: FileResult { total, passed, failed }, failed: failed_cases, passed: passed_cases, run_error: None });
   }
 
   let files_passed = file_reports.iter().filter(|f| f.run_error.is_none() && f.result.failed == 0).count();

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,251 @@
+use crate::*;
+use mech_interpreter::interpreter::*;
+#[cfg(feature = "invariant_define")]
+use mech_interpreter::InvariantViolationError;
+use serde::Serialize;
+use std::ffi::OsStr;
+use std::io;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+struct TestCaseResult {
+  name: String,
+  passed: bool,
+  expression: Option<String>,
+  reason: Option<String>,
+  evaluated_kind: Option<String>,
+  actual: Option<String>,
+  expected: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TestFileResult {
+  path: String,
+  total: usize,
+  passed: usize,
+  failed: usize,
+  cases: Vec<TestCaseResult>,
+  run_error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TestReport {
+  total_files: usize,
+  files_passed: usize,
+  files_failed: usize,
+  total_tests: usize,
+  passed_tests: usize,
+  failed_tests: usize,
+  files: Vec<TestFileResult>,
+}
+
+fn mech_bool(v: bool) -> &'static str {
+  if v { "✓" } else { "✗" }
+}
+
+fn mech_str(v: &str) -> String {
+  format!("{:?}", v)
+}
+
+fn mech_opt_str(name: &str, v: &Option<String>) -> String {
+  match v {
+    Some(s) => format!("{name}: {}", mech_str(s)),
+    None => format!("{name}: empty"),
+  }
+}
+
+fn test_case_to_mech(test_case: &TestCaseResult) -> String {
+  format!(
+    "{{ name: {}, passed: {}, {}, {}, {}, {}, {} }}",
+    mech_str(&test_case.name),
+    mech_bool(test_case.passed),
+    mech_opt_str("expression", &test_case.expression),
+    mech_opt_str("reason", &test_case.reason),
+    mech_opt_str("evaluated-kind", &test_case.evaluated_kind),
+    mech_opt_str("actual", &test_case.actual),
+    mech_opt_str("expected", &test_case.expected),
+  )
+}
+
+fn test_file_to_mech(file: &TestFileResult) -> String {
+  let cases = file.cases.iter().map(test_case_to_mech).collect::<Vec<_>>().join(" ");
+  format!(
+    "{{ path: {}, total: {}, passed: {}, failed: {}, cases: [{}], {} }}",
+    mech_str(&file.path),
+    file.total,
+    file.passed,
+    file.failed,
+    cases,
+    mech_opt_str("run-error", &file.run_error),
+  )
+}
+
+fn report_to_mech(report: &TestReport) -> String {
+  let files = report.files.iter().map(test_file_to_mech).collect::<Vec<_>>().join(" ");
+  format!(
+    "test-output := {{ total-files: {}, files-passed: {}, files-failed: {}, total-tests: {}, passed-tests: {}, failed-tests: {}, files: [{}] }}",
+    report.total_files,
+    report.files_passed,
+    report.files_failed,
+    report.total_tests,
+    report.passed_tests,
+    report.failed_tests,
+    files
+  )
+}
+
+pub fn run_mech_tests(
+  mech_paths: Vec<String>,
+  tree_flag: bool,
+  debug_flag: bool,
+  time_flag: bool,
+  trace_flag: bool,
+  output_path: Option<String>,
+) -> Result<i32, MechError> {
+  let mut any_failed = false;
+  let mut run_errors = false;
+  let mut file_results = Vec::new();
+  println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
+  for path in &mech_paths {
+    let uuid = generate_uuid();
+    let mut intrp = Interpreter::new(uuid);
+    let mut mechfs = MechFileSystem::new();
+    if let Err(err) = mechfs.watch_source(path) {
+      eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
+      run_errors = true;
+      any_failed = true;
+      file_results.push(TestFileResult {
+        path: path.clone(),
+        total: 0,
+        passed: 0,
+        failed: 0,
+        cases: vec![],
+        run_error: Some(err.display_message()),
+      });
+      continue;
+    }
+    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
+    if let Err(err) = result {
+      eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
+      run_errors = true;
+      any_failed = true;
+      file_results.push(TestFileResult {
+        path: path.clone(),
+        total: 0,
+        passed: 0,
+        failed: 0,
+        cases: vec![],
+        run_error: Some(err.display_message()),
+      });
+      continue;
+    }
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let state_brrw = intrp.state.borrow();
+    let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
+    println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
+    let mut cases = Vec::new();
+    for (_id, (name, value)) in state_brrw.invariants.iter() {
+      match &*value.borrow() {
+        Value::Bool(b) if *b.borrow() => {
+          println!("{:<width$}   ✓", name, width=test_name_width);
+          passed += 1;
+          cases.push(TestCaseResult { name: name.clone(), passed: true, expression: None, reason: None, evaluated_kind: None, actual: None, expected: None });
+        },
+        _ => {
+          println!("{:<width$}   ✗", name, width=test_name_width);
+          failed += 1;
+          let violation = state_brrw.invariant_violations.iter().find(|v| v.id == *_id);
+          if let Some(v) = violation {
+            if let Some(inv_err) = v.error.kind_as::<InvariantViolationError>() {
+              cases.push(TestCaseResult {
+                name: name.clone(),
+                passed: false,
+                expression: Some(inv_err.expression.clone()),
+                reason: Some(inv_err.reason.clone()),
+                evaluated_kind: Some(inv_err.evaluated_kind.clone()),
+                actual: inv_err.lhs_value.clone(),
+                expected: inv_err.rhs_value.clone(),
+              });
+            } else {
+              cases.push(TestCaseResult {
+                name: name.clone(),
+                passed: false,
+                expression: None,
+                reason: Some(v.error.display_message()),
+                evaluated_kind: None,
+                actual: None,
+                expected: None,
+              });
+            }
+          } else {
+            cases.push(TestCaseResult {
+            name: name.clone(),
+            passed: false,
+            expression: None,
+            reason: Some("Invariant evaluated to false or non-bool value".to_string()),
+            evaluated_kind: None,
+            actual: None,
+            expected: None,
+          });
+          }
+        },
+      }
+    }
+    let total = passed + failed;
+    if failed == 0 {
+      println!("\n{} SUCCESS: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
+    } else {
+      any_failed = true;
+      println!("\n{} FAILURE: {} total | {} passed | {} failed", "[Test]".truecolor(153, 221, 85), total, passed, failed);
+      if !state_brrw.invariant_violations.is_empty() {
+        println!("\nfailures:\n");
+        for violation in &state_brrw.invariant_violations {
+          let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
+          if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
+            let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
+            let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
+            println!("  {}: {}", name, inv_err.expression);
+            println!("    reason = {}", inv_err.reason);
+            println!("    evaluated_kind = {}", inv_err.evaluated_kind);
+            println!("    actual = {}", lhs);
+            println!("    expected = {}", rhs);
+          } else {
+            println!("  {}: {}", name, violation.error.display_message());
+          }
+        }
+      }
+      println!();
+    }
+    file_results.push(TestFileResult { path: path.clone(), total, passed, failed, cases, run_error: None });
+  }
+
+  if let Some(output_path) = output_path {
+    let files_passed = file_results.iter().filter(|f| f.run_error.is_none() && f.failed == 0).count();
+    let files_failed = file_results.len().saturating_sub(files_passed);
+    let total_tests = file_results.iter().map(|f| f.total).sum();
+    let passed_tests = file_results.iter().map(|f| f.passed).sum();
+    let failed_tests = file_results.iter().map(|f| f.failed).sum();
+    let report = TestReport { total_files: file_results.len(), files_passed, files_failed, total_tests, passed_tests, failed_tests, files: file_results };
+    let path = PathBuf::from(&output_path);
+    let extension = path.extension().and_then(OsStr::to_str).unwrap_or("");
+    match extension {
+      "json" => {
+        let content = serde_json::to_string_pretty(&report).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        save_to_file(path, &content)?;
+      }
+      "mec" => {
+        let content = report_to_mech(&report);
+        save_to_file(path, &content)?;
+      }
+      _ => {
+        eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension);
+        return Ok(1);
+      }
+    }
+  }
+  if run_errors {
+    println!("{} One or more files failed to load/execute, but all requested files were attempted.", "[Warn]".truecolor(255,210,77));
+  }
+  Ok(if any_failed { 1 } else { 0 })
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,6 +8,9 @@ use std::ffi::OsStr;
 use std::io;
 use std::path::PathBuf;
 
+// Test
+// -----------------------------------------------------------------------------
+
 #[derive(Debug, Serialize, Clone)]
 struct CaseDetail {
   name: String,

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 #[derive(Debug, Serialize, Clone)]
 struct FailedCase {
   name: String,
-  passed: bool,
   expression: String,
   reason: String,
   #[serde(rename = "evaluated-kind")]
@@ -68,8 +67,8 @@ fn indent_block(block: &str, spaces: usize) -> String {
 }
 fn failed_case_to_mech(c: &FailedCase) -> String {
   format!(
-    "{{\n  name: {}\n  passed: {}\n  expression: {}\n  reason: {}\n  evaluated-kind: {}\n  actual: {}\n  expected: {}\n}}",
-    mech_str(&c.name), mech_bool(c.passed), mech_str(&c.expression), mech_str(&c.reason), mech_kind(&c.evaluated_kind), mech_str(&c.actual), mech_str(&c.expected)
+    "{{\n  name: {}\n  expression: {}\n  reason: {}\n  evaluated-kind: {}\n  actual: {}\n  expected: {}\n}}",
+    mech_str(&c.name), mech_str(&c.expression), mech_str(&c.reason), mech_kind(&c.evaluated_kind), mech_str(&c.actual), mech_str(&c.expected)
   )
 }
 fn file_to_mech(file: &FileReport) -> String {
@@ -101,6 +100,7 @@ pub fn run_mech_tests(
   time_flag: bool,
   trace_flag: bool,
   output_path: Option<String>,
+  verbose: bool,
 ) -> Result<i32, MechError> {
   let mut any_failed = false;
   let mut run_errors = false;
@@ -126,7 +126,6 @@ pub fn run_mech_tests(
     }
 
     let state = intrp.state.borrow();
-    let width = state.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
     println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
 
     let mut violations: HashMap<u64, FailedCase> = HashMap::new();
@@ -134,7 +133,6 @@ pub fn run_mech_tests(
       if let Some(inv) = v.error.kind_as::<InvariantViolationError>() {
         violations.insert(v.id, FailedCase {
           name: state.invariants.get(&v.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", v.id)),
-          passed: false,
           expression: inv.expression.clone(),
           reason: inv.reason.clone(),
           evaluated_kind: inv.evaluated_kind.clone(),
@@ -149,13 +147,17 @@ pub fn run_mech_tests(
     for (id, (name, value)) in state.invariants.iter() {
       match &*value.borrow() {
         Value::Bool(b) if *b.borrow() => {
-          println!("{:<width$}   ✓", name, width=width);
+          if verbose {
+            println!("{}   ✓", name);
+          }
           passed_names.push(name.clone());
         }
         _ => {
-          println!("{:<width$}   ✗", name, width=width);
+          if verbose {
+            println!("{}   ✗", name);
+          }
           failed_cases.push(violations.remove(id).unwrap_or(FailedCase {
-            name: name.clone(), passed: false, expression: "".to_string(), reason: "Invariant evaluated to false or non-bool value".to_string(), evaluated_kind: "bool".to_string(), actual: "?".to_string(), expected: "?".to_string()
+            name: name.clone(), expression: "".to_string(), reason: "Invariant evaluated to false or non-bool value".to_string(), evaluated_kind: "bool".to_string(), actual: "?".to_string(), expected: "?".to_string()
           }));
         }
       }
@@ -166,9 +168,31 @@ pub fn run_mech_tests(
     let total = passed + failed;
     if failed == 0 {
       println!("\n{} SUCCESS: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
+      if verbose {
+        println!("passed:\n");
+        for p in &passed_names {
+          println!("  {}", p);
+        }
+        println!();
+      }
     } else {
       any_failed = true;
       println!("\n{} FAILURE: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
+      if verbose {
+        println!("failures:\n");
+        for f in &failed_cases {
+          println!("  {}: {}", f.name, f.expression);
+          println!("    reason = {}", f.reason);
+          println!("    evaluated_kind = {}", f.evaluated_kind);
+          println!("    actual = {}", f.actual);
+          println!("    expected = {}", f.expected);
+        }
+        println!("\npassed:\n");
+        for p in &passed_names {
+          println!("  {}", p);
+        }
+        println!();
+      }
     }
     file_reports.push(FileReport { path: path.clone(), result: FileResult { total, passed, failed }, failed: failed_cases, passed: passed_names, run_error: None });
   }

--- a/src/test.rs
+++ b/src/test.rs
@@ -106,8 +106,8 @@ fn file_to_mech(file: &FileReport, verbose: bool) -> String {
     run_error
   )
 }
-fn report_to_mech(report: &TestReport) -> String {
-  let files = report.files.iter().map(|f| file_to_mech(f, false)).collect::<Vec<_>>().join("\n");
+fn report_to_mech(report: &TestReport, verbose: bool) -> String {
+  let files = report.files.iter().map(|f| file_to_mech(f, verbose)).collect::<Vec<_>>().join("\n");
   format!(
     "{{\n  result: {{\n    files-total: {}\n    files-passed: {}\n    files-failed: {}\n    tests-total: {}\n    tests-passed: {}\n    tests-failed: {}\n  }}\n  files: {{\n{}\n  }}\n}}",
     report.result.files_total, report.result.files_passed, report.result.files_failed, report.result.tests_total, report.result.tests_passed, report.result.tests_failed,
@@ -276,7 +276,7 @@ pub fn run_mech_tests(
     let extension = path.extension().and_then(OsStr::to_str).unwrap_or("");
     match extension {
       "json" => save_to_file(path, &report_to_json(&report, verbose)?)?,
-      "mec" => save_to_file(path, &report_to_mech(&report))?,
+      "mec" => save_to_file(path, &report_to_mech(&report, verbose))?,
       _ => { eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension); return Ok(1); }
     }
   }

--- a/src/test.rs
+++ b/src/test.rs
@@ -153,10 +153,10 @@ pub fn run_mech_tests(
           passed_cases.push(CaseDetail {
             name: name.clone(),
             expression: state.invariant_expressions.get(id).cloned().unwrap_or_else(|| name.clone()),
-            reason: "evaluated to true".to_string(),
-            evaluated_kind: "bool".to_string(),
-            actual: "true".to_string(),
-            expected: "true".to_string(),
+            reason: state.invariant_evaluations.get(id).map(|e| e.reason.clone()).unwrap_or_else(|| "evaluated to true".to_string()),
+            evaluated_kind: state.invariant_evaluations.get(id).map(|e| e.evaluated_kind.clone()).unwrap_or_else(|| "bool".to_string()),
+            actual: state.invariant_evaluations.get(id).map(|e| e.actual.clone()).unwrap_or_else(|| "true".to_string()),
+            expected: state.invariant_evaluations.get(id).map(|e| e.expected.clone()).unwrap_or_else(|| "true".to_string()),
           });
         }
         _ => {

--- a/src/test.rs
+++ b/src/test.rs
@@ -152,11 +152,11 @@ pub fn run_mech_tests(
           }
           passed_cases.push(CaseDetail {
             name: name.clone(),
-            expression: name.clone(),
+            expression: state.invariant_expressions.get(id).cloned().unwrap_or_else(|| name.clone()),
             reason: "evaluated to true".to_string(),
             evaluated_kind: "bool".to_string(),
-            actual: "✓".to_string(),
-            expected: "✓".to_string(),
+            actual: "true".to_string(),
+            expected: "true".to_string(),
           });
         }
         _ => {
@@ -164,7 +164,12 @@ pub fn run_mech_tests(
             println!("{}   ✗", name);
           }
           failed_cases.push(violations.remove(id).unwrap_or(CaseDetail {
-            name: name.clone(), expression: "".to_string(), reason: "Invariant evaluated to false or non-bool value".to_string(), evaluated_kind: "bool".to_string(), actual: "?".to_string(), expected: "?".to_string()
+            name: name.clone(),
+            expression: state.invariant_expressions.get(id).cloned().unwrap_or_default(),
+            reason: "Invariant evaluated to false or non-bool value".to_string(),
+            evaluated_kind: "bool".to_string(),
+            actual: "?".to_string(),
+            expected: "?".to_string()
           }));
         }
       }

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,109 +3,93 @@ use mech_interpreter::interpreter::*;
 #[cfg(feature = "invariant_define")]
 use mech_interpreter::InvariantViolationError;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::io;
 use std::path::PathBuf;
 
-#[derive(Debug, Serialize)]
-struct TestCaseResult {
+#[derive(Debug, Serialize, Clone)]
+struct FailedCase {
   name: String,
   passed: bool,
-  expression: Option<String>,
-  reason: Option<String>,
-  evaluated_kind: Option<String>,
-  actual: Option<String>,
-  expected: Option<String>,
+  expression: String,
+  reason: String,
+  #[serde(rename = "evaluated-kind")]
+  evaluated_kind: String,
+  actual: String,
+  expected: String,
 }
 
 #[derive(Debug, Serialize)]
-struct TestFileResult {
-  path: String,
+struct FileResult {
   total: usize,
   passed: usize,
   failed: usize,
-  cases: Vec<TestCaseResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct FileReport {
+  path: String,
+  result: FileResult,
+  failed: Vec<FailedCase>,
+  passed: Vec<String>,
+  #[serde(rename = "run-error")]
   run_error: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
-struct TestReport {
-  total_files: usize,
+struct SummaryResult {
+  #[serde(rename = "files-total")]
+  files_total: usize,
+  #[serde(rename = "files-passed")]
   files_passed: usize,
+  #[serde(rename = "files-failed")]
   files_failed: usize,
-  total_tests: usize,
-  passed_tests: usize,
-  failed_tests: usize,
-  files: Vec<TestFileResult>,
+  #[serde(rename = "tests-total")]
+  tests_total: usize,
+  #[serde(rename = "tests-passed")]
+  tests_passed: usize,
+  #[serde(rename = "tests-failed")]
+  tests_failed: usize,
 }
 
-fn mech_bool(v: bool) -> &'static str {
-  if v { "✓" } else { "✗" }
+#[derive(Debug, Serialize)]
+struct TestReport {
+  result: SummaryResult,
+  files: Vec<FileReport>,
 }
 
-fn mech_str(v: &str) -> String {
-  format!("{:?}", v)
-}
-
-fn mech_opt_str(name: &str, v: &Option<String>) -> String {
-  match v {
-    Some(s) => format!("{name}: {}", mech_str(s)),
-    None => format!("{name}: _"),
-  }
-}
-
-fn mech_opt_kind(name: &str, v: &Option<String>) -> String {
-  match v {
-    Some(s) => format!("{name}: <{}>", s),
-    None => format!("{name}: _"),
-  }
-}
-
-fn test_case_to_mech(test_case: &TestCaseResult) -> String {
-  format!(
-    "{{\n  name: {}\n  passed: {}\n  {}\n  {}\n  {}\n  {}\n  {}\n}}",
-    mech_str(&test_case.name),
-    mech_bool(test_case.passed),
-    mech_opt_str("expression", &test_case.expression),
-    mech_opt_str("reason", &test_case.reason),
-    mech_opt_kind("evaluated_kind", &test_case.evaluated_kind),
-    mech_opt_str("actual", &test_case.actual),
-    mech_opt_str("expected", &test_case.expected),
-  )
-}
-
-fn test_file_to_mech(file: &TestFileResult) -> String {
-  let cases = file.cases.iter().map(test_case_to_mech).collect::<Vec<_>>().join("\n");
-  format!(
-    "{{\n  path: {}\n  total: {}\n  passed: {}\n  failed: {}\n  cases: [\n{}\n  ]\n  {}\n}}",
-    mech_str(&file.path),
-    file.total,
-    file.passed,
-    file.failed,
-    indent_block(&cases, 4),
-    mech_opt_str("run_error", &file.run_error),
-  )
-}
-
+fn mech_bool(v: bool) -> &'static str { if v { "✓" } else { "✗" } }
+fn mech_str(v: &str) -> String { format!("{:?}", v) }
+fn mech_kind(v: &str) -> String { format!("<{}>", v) }
 fn indent_block(block: &str, spaces: usize) -> String {
   let pad = " ".repeat(spaces);
-  block
-    .lines()
-    .map(|line| format!("{pad}{line}"))
-    .collect::<Vec<_>>()
-    .join("\n")
+  block.lines().map(|line| format!("{pad}{line}")).collect::<Vec<_>>().join("\n")
 }
-
-fn report_to_mech(report: &TestReport) -> String {
-  let files = report.files.iter().map(test_file_to_mech).collect::<Vec<_>>().join("\n");
+fn failed_case_to_mech(c: &FailedCase) -> String {
   format!(
-    "test-report := {{\n  totalFiles: {}\n  filesPassed: {}\n  filesFailed: {}\n  totalTests: {}\n  passedTests: {}\n  failedTests: {}\n  files: [\n{}\n  ]\n}}",
-    report.total_files,
-    report.files_passed,
-    report.files_failed,
-    report.total_tests,
-    report.passed_tests,
-    report.failed_tests,
+    "{{\n  name: {}\n  passed: {}\n  expression: {}\n  reason: {}\n  evaluated-kind: {}\n  actual: {}\n  expected: {}\n}}",
+    mech_str(&c.name), mech_bool(c.passed), mech_str(&c.expression), mech_str(&c.reason), mech_kind(&c.evaluated_kind), mech_str(&c.actual), mech_str(&c.expected)
+  )
+}
+fn file_to_mech(file: &FileReport) -> String {
+  let failed_items = file.failed.iter().map(failed_case_to_mech).collect::<Vec<_>>().join("\n");
+  let passed_items = file.passed.iter().map(|p| mech_str(p)).collect::<Vec<_>>().join(" ");
+  let run_error = file.run_error.as_ref().map(|e| mech_str(e)).unwrap_or("_".to_string());
+  format!(
+    "{{\n  path: {}\n  result: {{\n    total: {}\n    passed: {}\n    failed: {}\n  }}\n  failed: {{\n{}\n  }}\n  passed: {{{}}}\n  run-error: {}\n}}",
+    mech_str(&file.path),
+    file.result.total, file.result.passed, file.result.failed,
+    if failed_items.is_empty() { "".to_string() } else { indent_block(&failed_items, 4) },
+    passed_items,
+    run_error
+  )
+}
+fn report_to_mech(report: &TestReport) -> String {
+  let files = report.files.iter().map(file_to_mech).collect::<Vec<_>>().join("\n");
+  format!(
+    "{{\n  result: {{\n    files-total: {}\n    files-passed: {}\n    files-failed: {}\n    tests-total: {}\n    tests-passed: {}\n    tests-failed: {}\n  }}\n  files: {{\n{}\n  }}\n}}",
+    report.result.files_total, report.result.files_passed, report.result.files_failed, report.result.tests_total, report.result.tests_passed, report.result.tests_failed,
     indent_block(&files, 4)
   )
 }
@@ -120,7 +104,7 @@ pub fn run_mech_tests(
 ) -> Result<i32, MechError> {
   let mut any_failed = false;
   let mut run_errors = false;
-  let mut file_results = Vec::new();
+  let mut file_reports = Vec::new();
   println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
   for path in &mech_paths {
     let uuid = generate_uuid();
@@ -130,134 +114,82 @@ pub fn run_mech_tests(
       eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
       run_errors = true;
       any_failed = true;
-      file_results.push(TestFileResult {
-        path: path.clone(),
-        total: 0,
-        passed: 0,
-        failed: 0,
-        cases: vec![],
-        run_error: Some(err.display_message()),
-      });
+      file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
       continue;
     }
-    let result = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag);
-    if let Err(err) = result {
+    if let Err(err) = run_mech_code(&mut intrp, &mechfs, tree_flag, debug_flag, time_flag, trace_flag) {
       eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
       run_errors = true;
       any_failed = true;
-      file_results.push(TestFileResult {
-        path: path.clone(),
-        total: 0,
-        passed: 0,
-        failed: 0,
-        cases: vec![],
-        run_error: Some(err.display_message()),
-      });
+      file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
       continue;
     }
-    let mut passed = 0usize;
-    let mut failed = 0usize;
-    let state_brrw = intrp.state.borrow();
-    let test_name_width = state_brrw.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
+
+    let state = intrp.state.borrow();
+    let width = state.invariants.values().map(|(n, _)| n.len()).max().unwrap_or(0);
     println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
-    let mut cases = Vec::new();
-    for (_id, (name, value)) in state_brrw.invariants.iter() {
-      match &*value.borrow() {
-        Value::Bool(b) if *b.borrow() => {
-          println!("{:<width$}   ✓", name, width=test_name_width);
-          passed += 1;
-          cases.push(TestCaseResult { name: name.clone(), passed: true, expression: None, reason: None, evaluated_kind: None, actual: None, expected: None });
-        },
-        _ => {
-          println!("{:<width$}   ✗", name, width=test_name_width);
-          failed += 1;
-          let violation = state_brrw.invariant_violations.iter().find(|v| v.id == *_id);
-          if let Some(v) = violation {
-            if let Some(inv_err) = v.error.kind_as::<InvariantViolationError>() {
-              cases.push(TestCaseResult {
-                name: name.clone(),
-                passed: false,
-                expression: Some(inv_err.expression.clone()),
-                reason: Some(inv_err.reason.clone()),
-                evaluated_kind: Some(inv_err.evaluated_kind.clone()),
-                actual: inv_err.lhs_value.clone(),
-                expected: inv_err.rhs_value.clone(),
-              });
-            } else {
-              cases.push(TestCaseResult {
-                name: name.clone(),
-                passed: false,
-                expression: None,
-                reason: Some(v.error.display_message()),
-                evaluated_kind: None,
-                actual: None,
-                expected: None,
-              });
-            }
-          } else {
-            cases.push(TestCaseResult {
-            name: name.clone(),
-            passed: false,
-            expression: None,
-            reason: Some("Invariant evaluated to false or non-bool value".to_string()),
-            evaluated_kind: None,
-            actual: None,
-            expected: None,
-          });
-          }
-        },
+
+    let mut violations: HashMap<u64, FailedCase> = HashMap::new();
+    for v in &state.invariant_violations {
+      if let Some(inv) = v.error.kind_as::<InvariantViolationError>() {
+        violations.insert(v.id, FailedCase {
+          name: state.invariants.get(&v.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", v.id)),
+          passed: false,
+          expression: inv.expression.clone(),
+          reason: inv.reason.clone(),
+          evaluated_kind: inv.evaluated_kind.clone(),
+          actual: inv.lhs_value.clone().unwrap_or_else(|| "?".to_string()),
+          expected: inv.rhs_value.clone().unwrap_or_else(|| "?".to_string()),
+        });
       }
     }
+
+    let mut passed_names = Vec::new();
+    let mut failed_cases = Vec::new();
+    for (id, (name, value)) in state.invariants.iter() {
+      match &*value.borrow() {
+        Value::Bool(b) if *b.borrow() => {
+          println!("{:<width$}   ✓", name, width=width);
+          passed_names.push(name.clone());
+        }
+        _ => {
+          println!("{:<width$}   ✗", name, width=width);
+          failed_cases.push(violations.remove(id).unwrap_or(FailedCase {
+            name: name.clone(), passed: false, expression: "".to_string(), reason: "Invariant evaluated to false or non-bool value".to_string(), evaluated_kind: "bool".to_string(), actual: "?".to_string(), expected: "?".to_string()
+          }));
+        }
+      }
+    }
+
+    let passed = passed_names.len();
+    let failed = failed_cases.len();
     let total = passed + failed;
     if failed == 0 {
       println!("\n{} SUCCESS: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
     } else {
       any_failed = true;
-      println!("\n{} FAILURE: {} total | {} passed | {} failed", "[Test]".truecolor(153, 221, 85), total, passed, failed);
-      if !state_brrw.invariant_violations.is_empty() {
-        println!("\nfailures:\n");
-        for violation in &state_brrw.invariant_violations {
-          let name = state_brrw.invariants.get(&violation.id).map(|(n, _)| n.clone()).unwrap_or_else(|| format!("#{}", violation.id));
-          if let Some(inv_err) = violation.error.kind_as::<InvariantViolationError>() {
-            let lhs = inv_err.lhs_value.clone().unwrap_or_else(|| "?".to_string());
-            let rhs = inv_err.rhs_value.clone().unwrap_or_else(|| "?".to_string());
-            println!("  {}: {}", name, inv_err.expression);
-            println!("    reason = {}", inv_err.reason);
-            println!("    evaluated_kind = {}", inv_err.evaluated_kind);
-            println!("    actual = {}", lhs);
-            println!("    expected = {}", rhs);
-          } else {
-            println!("  {}: {}", name, violation.error.display_message());
-          }
-        }
-      }
-      println!();
+      println!("\n{} FAILURE: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
     }
-    file_results.push(TestFileResult { path: path.clone(), total, passed, failed, cases, run_error: None });
+    file_reports.push(FileReport { path: path.clone(), result: FileResult { total, passed, failed }, failed: failed_cases, passed: passed_names, run_error: None });
   }
 
+  let files_passed = file_reports.iter().filter(|f| f.run_error.is_none() && f.result.failed == 0).count();
+  let files_failed = file_reports.len().saturating_sub(files_passed);
+  let tests_total = file_reports.iter().map(|f| f.result.total).sum();
+  let tests_passed = file_reports.iter().map(|f| f.result.passed).sum();
+  let tests_failed = file_reports.iter().map(|f| f.result.failed).sum();
+  let report = TestReport {
+    result: SummaryResult { files_total: file_reports.len(), files_passed, files_failed, tests_total, tests_passed, tests_failed },
+    files: file_reports,
+  };
+
   if let Some(output_path) = output_path {
-    let files_passed = file_results.iter().filter(|f| f.run_error.is_none() && f.failed == 0).count();
-    let files_failed = file_results.len().saturating_sub(files_passed);
-    let total_tests = file_results.iter().map(|f| f.total).sum();
-    let passed_tests = file_results.iter().map(|f| f.passed).sum();
-    let failed_tests = file_results.iter().map(|f| f.failed).sum();
-    let report = TestReport { total_files: file_results.len(), files_passed, files_failed, total_tests, passed_tests, failed_tests, files: file_results };
     let path = PathBuf::from(&output_path);
     let extension = path.extension().and_then(OsStr::to_str).unwrap_or("");
     match extension {
-      "json" => {
-        let content = serde_json::to_string_pretty(&report).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        save_to_file(path, &content)?;
-      }
-      "mec" => {
-        let content = report_to_mech(&report);
-        save_to_file(path, &content)?;
-      }
-      _ => {
-        eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension);
-        return Ok(1);
-      }
+      "json" => save_to_file(path, &serde_json::to_string_pretty(&report).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?)?,
+      "mec" => save_to_file(path, &report_to_mech(&report))?,
+      _ => { eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension); return Ok(1); }
     }
   }
   if run_errors {

--- a/src/test.rs
+++ b/src/test.rs
@@ -50,7 +50,14 @@ fn mech_str(v: &str) -> String {
 fn mech_opt_str(name: &str, v: &Option<String>) -> String {
   match v {
     Some(s) => format!("{name}: {}", mech_str(s)),
-    None => format!("{name}: empty"),
+    None => format!("{name}: _"),
+  }
+}
+
+fn mech_opt_kind(name: &str, v: &Option<String>) -> String {
+  match v {
+    Some(s) => format!("{name}: <{}>", s),
+    None => format!("{name}: _"),
   }
 }
 
@@ -61,7 +68,7 @@ fn test_case_to_mech(test_case: &TestCaseResult) -> String {
     mech_bool(test_case.passed),
     mech_opt_str("expression", &test_case.expression),
     mech_opt_str("reason", &test_case.reason),
-    mech_opt_str("evaluated-kind", &test_case.evaluated_kind),
+    mech_opt_kind("evaluated_kind", &test_case.evaluated_kind),
     mech_opt_str("actual", &test_case.actual),
     mech_opt_str("expected", &test_case.expected),
   )
@@ -76,14 +83,14 @@ fn test_file_to_mech(file: &TestFileResult) -> String {
     file.passed,
     file.failed,
     cases,
-    mech_opt_str("run-error", &file.run_error),
+    mech_opt_str("run_error", &file.run_error),
   )
 }
 
 fn report_to_mech(report: &TestReport) -> String {
   let files = report.files.iter().map(test_file_to_mech).collect::<Vec<_>>().join(" ");
   format!(
-    "test-output := {{ total-files: {}, files-passed: {}, files-failed: {}, total-tests: {}, passed-tests: {}, failed-tests: {}, files: [{}] }}",
+    "test_output := {{ total_files: {}, files_passed: {}, files_failed: {}, total_tests: {}, passed_tests: {}, failed_tests: {}, files: [{}] }}",
     report.total_files,
     report.files_passed,
     report.files_failed,

--- a/src/test.rs
+++ b/src/test.rs
@@ -63,7 +63,7 @@ fn mech_opt_kind(name: &str, v: &Option<String>) -> String {
 
 fn test_case_to_mech(test_case: &TestCaseResult) -> String {
   format!(
-    "{{ name: {}, passed: {}, {}, {}, {}, {}, {} }}",
+    "{{\n  name: {}\n  passed: {}\n  {}\n  {}\n  {}\n  {}\n  {}\n}}",
     mech_str(&test_case.name),
     mech_bool(test_case.passed),
     mech_opt_str("expression", &test_case.expression),
@@ -75,29 +75,38 @@ fn test_case_to_mech(test_case: &TestCaseResult) -> String {
 }
 
 fn test_file_to_mech(file: &TestFileResult) -> String {
-  let cases = file.cases.iter().map(test_case_to_mech).collect::<Vec<_>>().join(" ");
+  let cases = file.cases.iter().map(test_case_to_mech).collect::<Vec<_>>().join("\n");
   format!(
-    "{{ path: {}, total: {}, passed: {}, failed: {}, cases: [{}], {} }}",
+    "{{\n  path: {}\n  total: {}\n  passed: {}\n  failed: {}\n  cases: [\n{}\n  ]\n  {}\n}}",
     mech_str(&file.path),
     file.total,
     file.passed,
     file.failed,
-    cases,
+    indent_block(&cases, 4),
     mech_opt_str("run_error", &file.run_error),
   )
 }
 
+fn indent_block(block: &str, spaces: usize) -> String {
+  let pad = " ".repeat(spaces);
+  block
+    .lines()
+    .map(|line| format!("{pad}{line}"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
 fn report_to_mech(report: &TestReport) -> String {
-  let files = report.files.iter().map(test_file_to_mech).collect::<Vec<_>>().join(" ");
+  let files = report.files.iter().map(test_file_to_mech).collect::<Vec<_>>().join("\n");
   format!(
-    "test_output := {{ total_files: {}, files_passed: {}, files_failed: {}, total_tests: {}, passed_tests: {}, failed_tests: {}, files: [{}] }}",
+    "test-report := {{\n  totalFiles: {}\n  filesPassed: {}\n  filesFailed: {}\n  totalTests: {}\n  passedTests: {}\n  failedTests: {}\n  files: [\n{}\n  ]\n}}",
     report.total_files,
     report.files_passed,
     report.files_failed,
     report.total_tests,
     report.passed_tests,
     report.failed_tests,
-    files
+    indent_block(&files, 4)
   )
 }
 


### PR DESCRIPTION
### Motivation
- Provide a reusable, machine-readable test runner for Mech that can emit structured results for CI or tooling. 
- Replace the large inline test logic in the CLI with a modular function to simplify `mech` binary and support output file formats.

### Description
- Add a new `src/test.rs` module implementing `run_mech_tests` which collects per-file and per-case results, serializes them to JSON or Mech source (`.mec`), and returns an exit code. 
- Wire the new runner into the CLI by adding an `--out` / `-o` argument to the `test` subcommand and replacing the inline test loop in `src/bin/mech.rs` with a call to `run_mech_tests`. 
- Export the `test` module conditionally from `lib.rs` under the same feature gate used for running tests (`all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool")`).
- Implement result data structures (`TestCaseResult`, `TestFileResult`, `TestReport`) and formatters for JSON and Mech-formatted output, and handle unsupported output extensions with a clear error.

### Testing
- Verified the crate compiles with the test-related feature set by running `cargo build --features=run,variable_define,invariant_define,symbol_table,bool` and it succeeded. 
- No new unit tests were added in this change; the new `run_mech_tests` function is exercised via the CLI integration path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0740df33d8832a93397c3d24f2be18)