### PR TITLE
Expand `mech test` directory inputs into per-file test runs

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,29 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+fn collect_test_targets(path: &Path) -> io::Result<Vec<PathBuf>> {
+  if !path.is_dir() {
+    return Ok(vec![path.to_path_buf()]);
+  }
+
+  let mut files = Vec::new();
+  for entry in std::fs::read_dir(path)? {
+    let entry = entry?;
+    let entry_path = entry.path();
+    if entry_path.is_dir() {
+      files.extend(collect_test_targets(&entry_path)?);
+    } else if matches!(
+      entry_path.extension().and_then(OsStr::to_str),
+      Some("mec" | "🤖" | "mecb")
+    ) {
+      files.push(entry_path);
+    }
+  }
+  files.sort();
+  Ok(files)
+}
 
 // Test
 // -----------------------------------------------------------------------------
@@ -152,11 +174,28 @@ pub fn run_mech_tests(
   output_path: Option<String>,
   verbose: bool,
 ) -> Result<i32, MechError> {
+  let mut expanded_paths = Vec::new();
+  for input in mech_paths {
+    let input_path = Path::new(&input);
+    let targets = collect_test_targets(input_path).map_err(|e| {
+      MechError::new(
+        GenericError {
+          msg: format!("Unable to collect test targets for `{}`: {}", input, e),
+        },
+        None,
+      )
+      .with_compiler_loc()
+    })?;
+    for target in targets {
+      expanded_paths.push(target.display().to_string());
+    }
+  }
+
   let mut any_failed = false;
   let mut run_errors = false;
   let mut file_reports = Vec::new();
   println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
-  for path in &mech_paths {
+  for path in &expanded_paths {
     let uuid = generate_uuid();
     let mut intrp = Interpreter::new(uuid);
     let mut mechfs = MechFileSystem::new();


### PR DESCRIPTION
### Motivation
- Invoking `mech test <directory>` should run tests in each file independently, but previously directories were treated as a single watched source which could yield `0 total` tests even when files contained invariants. 
- The change makes directory invocation behave like running each file separately to surface per-file test results.

### Description
- Added `collect_test_targets(path: &Path) -> io::Result<Vec<PathBuf>>` to recursively expand directory inputs into individual testable files. 
- Filtered collected files to testable extensions (`.mec`, `🤖`, `.mecb`) and sorted paths for deterministic ordering. 
- Updated `run_mech_tests` to expand incoming `mech_paths` into `expanded_paths` and iterate over those per-file targets instead of iterating the raw inputs. 
- Mapped directory-collection errors to a `MechError` with context using `GenericError { msg: ... }` and added the `Path` import used by the new helper.

### Testing
- Ran `cargo check -q` which completed successfully and the codebase compiles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0782a5e580832abb191097ac1d33a5)