### PR TITLE
Run built mech binary against examples/working in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           cargo clean
           cargo build --bin mech
+          ./target/debug/mech test examples/working
           cargo build --no-default-features
           cargo test interpret --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"
           cargo test bytecode --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ test:cargo:
   - rustup default nightly-2026-03-03
   - cargo clean
   - cargo build --bin mech
+  - ./target/debug/mech test examples/working
   - cargo build --no-default-features
   - cargo test interpret --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"
   - cargo test bytecode --no-default-features --features "base u8 u16 u32 u64 u128 i8 i16 i32 i64 i128 f32"


### PR DESCRIPTION
### Motivation
- Ensure CI runs the exact `mech` binary built in the job to validate `examples/working` and catch regressions in the shipped executable.

### Description
- Add `./target/debug/mech test examples/working` to both `.gitlab-ci.yml` and `.github/workflows/ci.yml` immediately after `cargo build --bin mech` so the freshly built binary is used to run the examples.

### Testing
- Ran `cargo build --bin mech -q` locally in the environment and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079745a368832aa08016f50e76f197)