### PR TITLE
Print aggregate summary when running multiple test files

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -324,7 +324,7 @@ pub fn run_mech_tests(
   }
   if report.result.files_total > 1 {
     println!(
-      "\n{} TOTAL AGGREGATE SUMMARY: {} files | {} passed | {} failed || {} tests | {} passed | {} failed\n",
+      "\n{} AGGREGATE: {} files | {} passed | {} failed || {} tests | {} passed | {} failed\n",
       "[Test]".truecolor(153, 221, 85),
       report.result.files_total,
       report.result.files_passed,
@@ -333,6 +333,13 @@ pub fn run_mech_tests(
       report.result.tests_passed,
       report.result.tests_failed,
     );
+    if report.result.files_failed > 0 {
+      println!("failed files:");
+      for file in report.files.iter().filter(|f| f.run_error.is_some() || f.result.failed > 0) {
+        println!("  {}", file.path);
+      }
+      println!();
+    }
   }
   if run_errors {
     println!("{} One or more files failed to load/execute, but all requested files were attempted.", "[Warn]".truecolor(255,210,77));

--- a/src/test.rs
+++ b/src/test.rs
@@ -322,6 +322,18 @@ pub fn run_mech_tests(
       _ => { eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension); return Ok(1); }
     }
   }
+  if report.result.files_total > 1 {
+    println!(
+      "\n{} TOTAL AGGREGATE SUMMARY: {} files | {} passed | {} failed || {} tests | {} passed | {} failed\n",
+      "[Test]".truecolor(153, 221, 85),
+      report.result.files_total,
+      report.result.files_passed,
+      report.result.files_failed,
+      report.result.tests_total,
+      report.result.tests_passed,
+      report.result.tests_failed,
+    );
+  }
   if run_errors {
     println!("{} One or more files failed to load/execute, but all requested files were attempted.", "[Warn]".truecolor(255,210,77));
   }


### PR DESCRIPTION
### Motivation
- Provide an overall aggregate summary when running tests across multiple files so users can quickly see combined pass/fail counts.

### Description
- Add a conditional block that prints a colored `TOTAL AGGREGATE SUMMARY` when `report.result.files_total > 1`, showing total files, files passed/failed and total tests passed/failed.

### Testing
- Ran `cargo build` and `cargo test` and the project compiled and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a57ffe40832a881062fb3db6b822)