### PR TITLE
Improve pretty printing readability for small scalar sets and matrices

### DIFF
--- a/src/core/src/structures/matrix.rs
+++ b/src/core/src/structures/matrix.rs
@@ -284,10 +284,33 @@ where T: Hash + nalgebra::Scalar
 }
 
 #[cfg(feature = "pretty_print")]
+const SMALL_SCALAR_MATRIX_CELLS_LIMIT: usize = 36;
+
+#[cfg(feature = "pretty_print")]
+fn is_scalar_type<T>() -> bool {
+  let t = std::any::type_name::<T>();
+  matches!(t, "u8" | "u16" | "u32" | "u64" | "u128" | "i8" | "i16" | "i32" | "i64" | "i128" | "f32" | "f64" | "bool")
+}
+
+#[cfg(feature = "pretty_print")]
 impl<T> PrettyPrint for Matrix<T>
 where T: Debug + Display + Clone + PartialEq + 'static + PrettyPrint
 {
   fn pretty_print(&self) -> String {
+    let shape = self.shape();
+    let num_cells = shape[0] * shape[1];
+    if is_scalar_type::<T>() && num_cells <= SMALL_SCALAR_MATRIX_CELLS_LIMIT {
+      let mut rows = Vec::with_capacity(shape[0]);
+      for i in 0..shape[0] {
+        let row = (0..shape[1])
+          .map(|j| self.index2d(i + 1, j + 1).pretty_print())
+          .collect::<Vec<_>>()
+          .join(", ");
+        rows.push(format!("[{}]", row));
+      }
+      return format!("[{}]", rows.join(", "));
+    }
+
     let mut builder = Builder::default();
     match self {
       #[cfg(feature = "row_vector4")]

--- a/src/core/src/structures/set.rs
+++ b/src/core/src/structures/set.rs
@@ -66,8 +66,50 @@ impl MechSet {
 }
 
 #[cfg(feature = "pretty_print")]
+const SMALL_SCALAR_SET_LIMIT: usize = 16;
+
+#[cfg(feature = "pretty_print")]
+fn is_scalar_kind(kind: &ValueKind) -> bool {
+  match kind {
+    #[cfg(feature = "u8")]
+    ValueKind::U8 => true,
+    #[cfg(feature = "u16")]
+    ValueKind::U16 => true,
+    #[cfg(feature = "u32")]
+    ValueKind::U32 => true,
+    #[cfg(feature = "u64")]
+    ValueKind::U64 => true,
+    #[cfg(feature = "u128")]
+    ValueKind::U128 => true,
+    #[cfg(feature = "i8")]
+    ValueKind::I8 => true,
+    #[cfg(feature = "i16")]
+    ValueKind::I16 => true,
+    #[cfg(feature = "i32")]
+    ValueKind::I32 => true,
+    #[cfg(feature = "i64")]
+    ValueKind::I64 => true,
+    #[cfg(feature = "i128")]
+    ValueKind::I128 => true,
+    #[cfg(feature = "f32")]
+    ValueKind::F32 => true,
+    #[cfg(feature = "f64")]
+    ValueKind::F64 => true,
+    #[cfg(any(feature = "bool", feature = "variable_define"))]
+    ValueKind::Bool => true,
+    ValueKind::Index => true,
+    _ => false,
+  }
+}
+
+#[cfg(feature = "pretty_print")]
 impl PrettyPrint for MechSet {
   fn pretty_print(&self) -> String {
+    if is_scalar_kind(&self.kind) && self.set.len() <= SMALL_SCALAR_SET_LIMIT {
+      let elements = self.set.iter().map(|x| x.pretty_print()).collect::<Vec<_>>().join(", ");
+      return format!("{{{}}}", elements);
+    }
+
     let mut builder = Builder::default();
     let mut element_strings = vec![];
     for x in self.set.iter() {


### PR DESCRIPTION
### Motivation
- Console pretty-print of sets and matrices produced huge boxed tables for small scalar collections, making output hard to read. 
- Provide a compact, human-friendly inline format for small collections of scalar types while preserving the verbose, scalable formatter for larger or complex data.

### Description
- Add `SMALL_SCALAR_SET_LIMIT = 16` and helper `is_scalar_kind` and render `MechSet::pretty_print` as `{a, b, c}` when the set element kind is scalar and size ≤ 16, otherwise fall back to the existing boxed table format (`src/core/src/structures/set.rs`).
- Add `SMALL_SCALAR_MATRIX_CELLS_LIMIT = 36` and helper `is_scalar_type::<T>()` and render `Matrix<T>::pretty_print` as `[[r1], [r2]]` when `T` is a scalar type and total cells ≤ 36, otherwise keep the existing boxed table output (`src/core/src/structures/matrix.rs`).
- Replace a `matches!`-based pattern with `match`-arms guarded by `#[cfg(...)]` to avoid macro expansion issues under feature flags, and switch matrix scalar detection to a generic `type_name` check to keep the logic local and compile-time-friendly.

### Testing
- Ran `cargo check -p mech-core`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0904d97d34832a904277e136d34e99)