### PR TITLE
Parse multiline record kind annotations and add tests

### DIFF
--- a/docs/reference/validation.mec
+++ b/docs/reference/validation.mec
@@ -3,7 +3,7 @@ Validation
 
 %% Integrity constraints (invariants) are statements that must evaluate to `true`.
 
-```mech
+```mech:disabled
 foo! := EXPRESSION
 ```
 
@@ -42,7 +42,7 @@ ready! := state == :ready
 
 Data structures can also be used in invariants:
 
-```mech:disabled
+```mech:ex-1
 my-list := 1 + [1 2 3]
 sorted! := my-list === [2 3 4]
 ```
@@ -54,7 +54,6 @@ my-list := 1 + [1 2 3]
 -- Invalid because it evaluates to {{<[bool]>}}, expected {{<bool>}}.
 sorted! := my-list == [2 3 4]
 ```
-
 
 2. Output Formats (`-o`, `--out`)
 -------------------------------------------------------------------------------

--- a/include/style.css
+++ b/include/style.css
@@ -28,6 +28,7 @@
   --code-output-background-color: #020303;
   --var-name-color: hsl(290, 45%, 90%);
   --field-name-color: #63abb7;
+  --invariant-name-color: hsl(130, 100%, 75%);
   --kind-annotation-color: #f09fca;
   --kind-annotation-color-dark: #d574a8;
   --body-background-color: hsl(216, 28%, 7%);
@@ -53,6 +54,20 @@
   --pattern-color: hsl(133, 33%, 70%);
   --pattern-parent-color: hsl(133, 33%, 70%);
   --logo-color: rgb(246,192,78);
+}
+
+.mech-invariant-define {
+    color: var(--op-color);
+}
+
+.mech-invariant-name {
+    color: var(--warning-color);
+}
+
+.mech-invariant-define-op {
+    padding-left: 6px;
+    padding-right: 6px;
+    color: var(--op-color);
 }
 
 html {
@@ -331,7 +346,7 @@ body {
     padding-right: 10px;
 }
 
-.mech-variable-assign-op {
+.mech-variable-define-op {
     padding-left:  6px;
     padding-right: 6px;
     color: var(--op-color);

--- a/include/style.css
+++ b/include/style.css
@@ -2808,67 +2808,108 @@ mark {
 }
 
 /* Record kinds with 3+ fields */
-.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field) {
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field) {
   display: block;
   white-space: pre;
   margin-left: 2ch; 
 }
 
 /* newline after { */
-.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field)
   > .mech-record-kind-open::after {
   content: "\A  ";
 }
 
 /* newline before every field except the first one */
-.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field)
   > .mech-record-field + .mech-record-field::before {
   content: "\A  ";
 }
 
 /* newline before } */
-.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field)
   > .mech-record-kind-close::before {
   content: "\A";
 }
 
 /* when the previous field had a nested record-kind (already a block),
    skip the \A and just add the indent */
-.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field)
   > .mech-record-field:has(.mech-record-kind) + .mech-record-field::before {
   content: "  ";
 }
 
-.mech-record-kind::before { 
-    content: "<"; 
+.mech-matrix-kind::before { 
+    content: "⟨";
     color: var(--kind-annotation-color-dark);
 }
+
+.mech-matrix-kind::after  { 
+    content: "⟩"; 
+    color: var(--kind-annotation-color-dark);
+}
+
+
+.mech-record-kind::before { 
+    content: "⟨";
+    color: var(--kind-annotation-color-dark);
+}
+
 .mech-record-kind::after  { 
-    content: ">"; 
+    content: "⟩"; 
     color: var(--kind-annotation-color-dark);
 }
 
 .mech-kind-define > .mech-kind-annotation:first-child::before {
-    content: "<";
+    content: "⟨";
     color: var(--kind-annotation-color-dark);
 }
 
 .mech-kind-define > .mech-kind-annotation:first-child::after {
-    content: ">";
+    content: "⟩";
     color: var(--kind-annotation-color-dark);
 }
 
-.mech-scalar-kind::before { 
-    content: "<"; 
-    color: var(--kind-annotation-color-dark);
+/* Optional scalar: string? -> ⟨string?⟩ */
+.mech-kind:has(> .mech-kind > .mech-scalar-kind):has(> .mech-option-question)::before {
+  content: "⟨";
+  color: var(--kind-annotation-color-dark);
 }
 
-.mech-scalar-kind::after  { 
-    content: ">"; 
-    color: var(--kind-annotation-color-dark);
+.mech-kind:has(> .mech-kind > .mech-scalar-kind):has(> .mech-option-question)::after {
+  content: "⟩";
+  color: var(--kind-annotation-color-dark);
+}
+
+/* Plain scalar: string -> ⟨string⟩
+   But NOT inside matrix inner, and NOT when followed by ? */
+.mech-kind:has(> .mech-scalar-kind):not(.mech-matrix-kind-inner > .mech-kind):not(:has(+ .mech-option-question))::before {
+  content: "⟨";
+  color: var(--kind-annotation-color-dark);
+}
+
+.mech-kind:has(> .mech-scalar-kind):not(.mech-matrix-kind-inner > .mech-kind):not(:has(+ .mech-option-question))::after {
+  content: "⟩";
+  color: var(--kind-annotation-color-dark);
 }
 
 .mech-kind:has(.mech-record-kind),
 .mech-kind-annotation:has(.mech-record-kind) {
   display: contents;
+}
+
+.mech-record-kind-open {
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-record-kind-close {
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-matrix-kind-open {
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-matrix-kind-close {
+    color: var(--kind-annotation-color-dark);
 }

--- a/include/style.css
+++ b/include/style.css
@@ -2806,3 +2806,69 @@ mark {
 .mech-tuple-struct {
     color: var(--literal-color);
 }
+
+/* Record kinds with 3+ fields */
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field) {
+  display: block;
+  white-space: pre;
+  margin-left: 2ch; 
+}
+
+/* newline after { */
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+  > .mech-record-kind-open::after {
+  content: "\A  ";
+}
+
+/* newline before every field except the first one */
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+  > .mech-record-field + .mech-record-field::before {
+  content: "\A  ";
+}
+
+/* newline before } */
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+  > .mech-record-kind-close::before {
+  content: "\A";
+}
+
+/* when the previous field had a nested record-kind (already a block),
+   skip the \A and just add the indent */
+.mech-record-kind:has(.mech-record-field ~ .mech-record-field ~ .mech-record-field)
+  > .mech-record-field:has(.mech-record-kind) + .mech-record-field::before {
+  content: "  ";
+}
+
+.mech-record-kind::before { 
+    content: "<"; 
+    color: var(--kind-annotation-color-dark);
+}
+.mech-record-kind::after  { 
+    content: ">"; 
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-kind-define > .mech-kind-annotation:first-child::before {
+    content: "<";
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-kind-define > .mech-kind-annotation:first-child::after {
+    content: ">";
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-scalar-kind::before { 
+    content: "<"; 
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-scalar-kind::after  { 
+    content: ">"; 
+    color: var(--kind-annotation-color-dark);
+}
+
+.mech-kind:has(.mech-record-kind),
+.mech-kind-annotation:has(.mech-record-kind) {
+  display: contents;
+}

--- a/src/core/src/structures/table.rs
+++ b/src/core/src/structures/table.rs
@@ -314,17 +314,17 @@ impl MechTable {
             .unwrap_or_else(|| key.to_string());
 
         let kind_str = format!(
-            "<span class=\"mech-kind-annotation\">&lt;<span class=\"mech-kind\">{}</span>&gt;</span>",
+            "<span class=\"mech-kind-annotation\"><span class=\"mech-kind-annotation-open\">&lt;</span><span class=\"mech-kind\">{}</span><span class=\"mech-kind-annotation-close\">&gt;</span></span>",
             kind
         );
 
         html.push_str(&format!(
-            "<th class=\"mech-table-field\">\
-                <div class=\"mech-field\">\
-                  <span class=\"mech-field-name\">{}</span>\
-                  <span class=\"mech-field-kind\">{}</span>\
-                </div>\
-            </th>",
+r#"<th class="mech-table-field">
+  <div class="mech-field">
+    <span class="mech-field-name">{}</span>
+    <span class="mech-field-kind">{}</span>
+  </div>
+</th>"#,
             col_name, kind_str
         ));
     }

--- a/src/syntax/src/base.rs
+++ b/src/syntax/src/base.rs
@@ -113,11 +113,13 @@ leaf!{left_bracket, "[", TokenKind::LeftBracket}
 leaf!{left_parenthesis, "(", TokenKind::LeftParenthesis}
 leaf!{left_brace, "{", TokenKind::LeftBrace}
 leaf!{left_angle, "<", TokenKind::LeftAngle}
+leaf!{left_angle2, "⟨", TokenKind::LeftAngle}
 
 leaf!{right_bracket, "]", TokenKind::RightBracket}
 leaf!{right_parenthesis, ")", TokenKind::RightParenthesis}
 leaf!{right_brace, "}", TokenKind::RightBrace}
 leaf!{right_angle, ">", TokenKind::RightAngle}
+leaf!{right_angle2, "⟩", TokenKind::RightAngle}
 
 leaf!{box_tl_round, "╭", TokenKind::BoxDrawing}
 leaf!{box_tr_round, "╮", TokenKind::BoxDrawing}

--- a/src/syntax/src/base.rs
+++ b/src/syntax/src/base.rs
@@ -112,13 +112,13 @@ leaf!{tab, "\t", TokenKind::Tab}
 leaf!{left_bracket, "[", TokenKind::LeftBracket}
 leaf!{left_parenthesis, "(", TokenKind::LeftParenthesis}
 leaf!{left_brace, "{", TokenKind::LeftBrace}
-leaf!{left_angle, "<", TokenKind::LeftAngle}
+leaf!{left_angle1, "<", TokenKind::LeftAngle}
 leaf!{left_angle2, "⟨", TokenKind::LeftAngle}
 
 leaf!{right_bracket, "]", TokenKind::RightBracket}
 leaf!{right_parenthesis, ")", TokenKind::RightParenthesis}
 leaf!{right_brace, "}", TokenKind::RightBrace}
-leaf!{right_angle, ">", TokenKind::RightAngle}
+leaf!{right_angle1, ">", TokenKind::RightAngle}
 leaf!{right_angle2, "⟩", TokenKind::RightAngle}
 
 leaf!{box_tl_round, "╭", TokenKind::BoxDrawing}

--- a/src/syntax/src/expressions.rs
+++ b/src/syntax/src/expressions.rs
@@ -429,18 +429,18 @@ pub fn equal_to(input: ParseString) -> ParseResult<ComparisonOp> {
   Ok((input, ComparisonOp::Equal))
 }
 
-// strict-not-equal := "!==" | "!≡" | "=!=" | "=¬=" ;
+// strict-not-equal := "!==" | "!≡" | "¬≡" | "¬==" ;
 pub fn strict_not_equal(input: ParseString) -> ParseResult<ComparisonOp> {
   let (input, _) = ws0e(input)?;
-  let (input, _) = alt((tag("!=="),tag("!≡"),tag("=!="),tag("=¬=")))(input)?;
+  let (input, _) = alt((tag("!=="),tag("!≡"),tag("¬≡"),tag("¬==")))(input)?;
   let (input, _) = ws0e(input)?;
   Ok((input, ComparisonOp::StrictNotEqual))
 }
 
-// strict-equal := "===" | "≡" | "=:=" ;
+// strict-equal := "===" | "≡";
 pub fn strict_equal(input: ParseString) -> ParseResult<ComparisonOp> {
   let (input, _) = ws0e(input)?;
-  let (input, _) = alt((tag("==="),tag("≡"),tag("=:=")))(input)?;
+  let (input, _) = alt((tag("==="),tag("≡")))(input)?;
   let (input, _) = ws0e(input)?;
   Ok((input, ComparisonOp::StrictEqual))
 }

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2866,17 +2866,28 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
         format!("[{}]{}", src, src2)
       },
       Kind::Record(kinds) => {
-        let mut src = "".to_string();
-        for (i, (ident, kind)) in kinds.iter().enumerate() {
-          let k = self.kind(kind);
-          let ident_s = ident.to_string();
-          if i == 0 {
-            src = format!("{}&lt;{}&gt;", ident_s, k);
-          } else {
-            src = format!("{},{}&lt;{}&gt;", src, ident_s, k);
+        const VERTICAL_RECORD_KIND_THRESHOLD: usize = 4;
+        if kinds.len() >= VERTICAL_RECORD_KIND_THRESHOLD {
+          let mut rows: Vec<String> = Vec::new();
+          for (ident, kind) in kinds.iter() {
+            let k = self.kind(kind);
+            let ident_s = ident.to_string();
+            rows.push(format!("  {}&lt;{}&gt;", ident_s, k));
           }
+          format!("{{\n{}\n}}", rows.join("\n"))
+        } else {
+          let mut src = "".to_string();
+          for (i, (ident, kind)) in kinds.iter().enumerate() {
+            let k = self.kind(kind);
+            let ident_s = ident.to_string();
+            if i == 0 {
+              src = format!("{}&lt;{}&gt;", ident_s, k);
+            } else {
+              src = format!("{},{}&lt;{}&gt;", src, ident_s, k);
+            }
+          }
+          format!("{{{}}}", src)
         }
-        format!("{{{}}}", src)
       },
       Kind::Table((kinds, literal)) => {
         let mut src = "".to_string();

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2010,9 +2010,9 @@ impl Formatter {
       }
     }
     if self.html {
-      format!("<span class=\"mech-enum-define\"><span class=\"mech-kind-annotation\"><span class=\"mech-kind-annotation-open\">&lt;</span><span class=\"mech-enum-name\">{}</span><span class=\"mech-kind-annotation-close\">&gt;</span></span><span class=\"mech-enum-define-op\">:=</span><span class=\"mech-enum-variants\">{}</span></span>",name,variants)
+      format!("<span class=\"mech-enum-define\"><span class=\"mech-kind-annotation\"><span class=\"mech-enum-name\">{}</span></span><span class=\"mech-enum-define-op\">:=</span><span class=\"mech-enum-variants\">{}</span></span>",name,variants)
     } else {
-      format!("<{}> := {}", name, variants)
+      format!("⟨{}⟩ := {}", name, variants)
     }
   }
 
@@ -2805,7 +2805,7 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
         <span class=\"mech-kind-annotation\">{}</span>
       </span>",name,kind)
     } else {
-      format!("<{}> := {}", name, kind)
+      format!("⟨{}⟩ := {}", name, kind)
     }
   }
 
@@ -2817,7 +2817,7 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
         <span class=\"mech-kind\">{}</span>
       </span>",kind)
     } else {
-      format!("<{}>", kind)
+      format!("⟨{}⟩", kind)
     }
   }
 
@@ -2826,9 +2826,9 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
       Kind::Kind(kind) => {
         let kind_kind = self.kind(kind);
         if self.html {
-          format!("<span class=\"mech-kind-annotation\">&lt;{}&gt;</span>",kind_kind)
+          format!("<span class=\"mech-kind-annotation\">{}</span>",kind_kind)
         } else {
-          format!("<{}>", kind_kind)
+          format!("⟨{}⟩", kind_kind)
         }
       },
       Kind::Option(kind) => {
@@ -2938,13 +2938,13 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
             if self.html {
               src = format!("<span class=\"mech-record-field\"><span class=\"mech-record-field-name\">{}</span><span class=\"mech-record-field-kind\">{}</span></span>", ident_s, k);
             } else {
-              src = format!("{}<{}>", ident_s, k);
+              src = format!("{}⟨{}⟩", ident_s, k);
             }
           } else {
             if self.html {
               src = format!("{}<span class=\"mech-record-field\"><span class=\"mech-record-field-name\">{}</span><span class=\"mech-record-field-kind\">{}</span></span>", src, ident_s, k);
             } else {
-              src = format!("{},{}<{}>", src, ident_s, k);
+              src = format!("{},{}⟨{}⟩", src, ident_s, k);
             }
           }
         }

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2010,7 +2010,7 @@ impl Formatter {
       }
     }
     if self.html {
-      format!("<span class=\"mech-enum-define\"><span class=\"mech-kind-annotation\">&lt;<span class=\"mech-enum-name\">{}</span>&gt;</span><span class=\"mech-enum-define-op\">:=</span><span class=\"mech-enum-variants\">{}</span></span>",name,variants)
+      format!("<span class=\"mech-enum-define\"><span class=\"mech-kind-annotation\"><span class=\"mech-kind-annotation-open\">&lt;</span><span class=\"mech-enum-name\">{}</span><span class=\"mech-kind-annotation-close\">&gt;</span></span><span class=\"mech-enum-define-op\">:=</span><span class=\"mech-enum-variants\">{}</span></span>",name,variants)
     } else {
       format!("<{}> := {}", name, variants)
     }
@@ -2029,16 +2029,6 @@ impl Formatter {
       format!("<span class=\"mech-enum-variant\"><span class=\"mech-enum-variant-name\">:{}</span><span class=\"mech-enum-variant-kind\">{}</span></span>",name,kind)
     } else {
       format!(":{}{}", name, kind)
-    }
-  }
-
-  pub fn kind_define(&mut self, node: &KindDefine) -> String {
-    let name = node.name.to_string();
-    let kind = self.kind_annotation(&node.kind.kind);
-    if self.html {
-      format!("<span class=\"mech-kind-define\"><span class=\"mech-kind-annotation\">&lt;<span class=\"mech-kind\">{}</span>&gt;</span><span class=\"mech-kind-define-op\">:=</span><span class=\"mech-kind-annotation\">{}</span></span>",name,kind)
-    } else {
-      format!("<{}> := {}", name, kind)
     }
   }
 
@@ -2802,10 +2792,30 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
     }
   }
 
+  pub fn kind_define(&mut self, node: &KindDefine) -> String {
+    let name = node.name.to_string();
+    let kind = self.kind_annotation(&node.kind.kind);
+    if self.html {
+      format!("
+      <span class=\"mech-kind-define\">
+        <span class=\"mech-kind-annotation\">
+          <span class=\"mech-kind\">{}</span>
+        </span>
+        <span class=\"mech-kind-define-op\">:=</span>
+        <span class=\"mech-kind-annotation\">{}</span>
+      </span>",name,kind)
+    } else {
+      format!("<{}> := {}", name, kind)
+    }
+  }
+
   pub fn kind_annotation(&mut self, node: &Kind) -> String {
     let kind = self.kind(node);
     if self.html {
-      format!("<span class=\"mech-kind-annotation\">&lt;{}&gt;</span>",kind)
+      format!("
+      <span class=\"mech-kind-annotation\">
+        <span class=\"mech-kind\">{}</span>
+      </span>",kind)
     } else {
       format!("<{}>", kind)
     }
@@ -2834,16 +2844,48 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
         let size_str = match size{
           Some(size) => {
             let size_ltrl = self.literal(size);
-            format!(":{}", size_ltrl)
+            if self.html {
+              format!("<span class=\"mech-set-size\">:{}</span>", size_ltrl)
+            } else {
+              format!(":{}", size_ltrl)
+            }
           }
           None => "".to_string(),
         };
-        format!("{{{}}}{}", k, size_str)
+        if self.html {
+          format!("<span class=\"mech-set-kind\"><span class=\"mech-set-kind-open\">{{</span><span class=\"mech-set-kind-inner\">{}</span><span class=\"mech-set-kind-close\">}}</span>{}</span>", k, size_str)
+        } else {
+          format!("{{{}}}{}", k, size_str)
+        }
       },
-      Kind::Any => "*".to_string(),
-      Kind::Scalar(ident) => ident.to_string(),
-      Kind::Empty => "_".to_string(),
-      Kind::Atom(ident) => format!(":{}",ident.to_string()),
+      Kind::Any => {
+        if self.html {
+          format!("<span class=\"mech-any-kind\">*</span>")
+        } else {
+          "*".to_string()
+        }
+      },
+      Kind::Scalar(ident) => {
+        if self.html {
+          format!("<span class=\"mech-scalar-kind\">{}</span>", ident.to_string())
+        } else {
+          ident.to_string()
+        }
+      }
+      Kind::Empty => {
+        if self.html {
+          format!("<span class=\"mech-empty-kind\">_</span>")
+        } else {
+          "_".to_string()
+        }
+      }
+      Kind::Atom(ident) => {
+        if self.html {
+          format!("<span class=\"mech-atom-kind\">{}</span>", ident.to_string())
+        } else {
+          format!(":{}",ident.to_string())
+        }
+      }
       Kind::Tuple(kinds) => {
         let mut src = "".to_string();
         for (i, kind) in kinds.iter().enumerate() {
@@ -2854,7 +2896,11 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
             src = format!("{},{}", src, k);
           }
         }
-        format!("({})", src)
+        if self.html {
+          format!("<span class=\"mech-tuple-kind\"><span class=\"mech-tuple-kind-open\">(</span><span class=\"mech-tuple-kind-inner\">{}</span><span class=\"mech-tuple-kind-close\">)</span></span>", src)
+        } else {
+          format!("({})", src)
+        }
       },
       Kind::Matrix((kind, literals)) => {
         let mut src = "".to_string();
@@ -2864,34 +2910,47 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
         for (i, literal) in literals.iter().enumerate() {
           let l = self.literal(literal);
           if i == 0 {
-            src2 = format!(":{}", l);
+            src2 = if self.html {
+              format!("<span class=\"mech-matrix-literal\">:{}</span>", l)
+            } else {
+              format!(":{}", l)
+            };
           } else {
-            src2 = format!("{},{}", src2, l);
+            src2 = if self.html {
+              format!("{}<span class=\"mech-matrix-literal\">:{}</span>", src2, l)
+            } else {
+              format!("{},:{}", src2, l)
+            };
           }
         }
-        format!("[{}]{}", src, src2)
+        if self.html {
+          format!("<span class=\"mech-matrix-kind\"><span class=\"mech-matrix-kind-open\">[</span><span class=\"mech-matrix-kind-inner\">{}</span><span class=\"mech-matrix-kind-close\">]</span>{}</span>", src, src2)
+        } else {
+          format!("[{}]{}", src, src2)
+        }
       },
       Kind::Record(kinds) => {
-        const VERTICAL_RECORD_KIND_THRESHOLD: usize = 4;
-        if kinds.len() >= VERTICAL_RECORD_KIND_THRESHOLD {
-          let mut rows: Vec<String> = Vec::new();
-          for (ident, kind) in kinds.iter() {
-            let k = self.kind(kind);
-            let ident_s = ident.to_string();
-            rows.push(format!("  {}&lt;{}&gt;", ident_s, k));
-          }
-          format!("{{\n{}\n}}", rows.join("\n"))
-        } else {
-          let mut src = "".to_string();
-          for (i, (ident, kind)) in kinds.iter().enumerate() {
-            let k = self.kind(kind);
-            let ident_s = ident.to_string();
-            if i == 0 {
-              src = format!("{}&lt;{}&gt;", ident_s, k);
+        let mut src = "".to_string();
+        for (i, (ident, kind)) in kinds.iter().enumerate() {
+          let k = self.kind(kind);
+          let ident_s = ident.to_string();
+          if i == 0 {
+            if self.html {
+              src = format!("<span class=\"mech-record-field\"><span class=\"mech-record-field-name\">{}</span><span class=\"mech-record-field-kind\">{}</span></span>", ident_s, k);
             } else {
-              src = format!("{},{}&lt;{}&gt;", src, ident_s, k);
+              src = format!("{}<{}>", ident_s, k);
+            }
+          } else {
+            if self.html {
+              src = format!("{}<span class=\"mech-record-field\"><span class=\"mech-record-field-name\">{}</span><span class=\"mech-record-field-kind\">{}</span></span>", src, ident_s, k);
+            } else {
+              src = format!("{},{}<{}>", src, ident_s, k);
             }
           }
+        }
+        if self.html {
+          format!("<span class=\"mech-record-kind\"><span class=\"mech-record-kind-open\">{{</span>{}<span class=\"mech-record-kind-close\">}}</span></span>", src)
+        } else {
           format!("{{{}}}", src)
         }
       },
@@ -2901,22 +2960,41 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
           let k = self.kind(kind);
           let ident_s = ident.to_string();
           if i == 0 {
-            src = format!("{}&lt;{}&gt;", ident_s, k);
+            if self.html {
+              src = format!("<span class=\"mech-record-field-name\">{}</span><span class=\"mech-record-field-kind\"><span class=\"mech-record-field-kind-open\">&lt;</span>{}<span class=\"mech-record-field-kind-close\">&gt;</span></span>", ident_s, k);
+            } else {
+              src = format!("{}&lt;{}&gt;", ident_s, k);
+            }
           } else {
-            src = format!("{},{}&lt;{}&gt;", src, ident_s, k);
+            if self.html {
+              src = format!("{},<span class=\"mech-record-field-name\">{}</span><span class=\"mech-record-field-kind\"><span class=\"mech-record-field-kind-open\">&lt;</span>{}<span class=\"mech-record-field-kind-close\">&gt;</span></span>", src, ident_s, k);
+            } else {
+              src = format!("{},{}&lt;{}&gt;", src, ident_s, k);
+            }
           }
         }
-        let mut src2 = "".to_string();
         let sz = match &**literal {
           Literal::Empty(_) => "".to_string(),
-          _ => format!(":{}", self.literal(literal)),
+          _ => if self.html {
+            format!("<span class=\"mech-table-kind-size\">:{}</span>", self.literal(literal))
+          } else {
+            format!(":{}", self.literal(literal))
+          },
         };
-        format!("|{}|{}", src, sz)
+        if self.html {
+          format!("<span class=\"mech-table-kind\"><span class=\"mech-table-kind-open\">|</span>{}<span class=\"mech-table-kind-close\">|</span>{}</span>", src, sz)
+        } else {
+          format!("|{}|{}", src, sz)
+        }
       },
       Kind::Map(kind1, kind2) => {
         let k1 = self.kind(kind1);
         let k2 = self.kind(kind2);
-        format!("{{{}:{}}}", k1, k2)
+        if self.html {
+          format!("<span class=\"mech-map-kind\"><span class=\"mech-map-kind-open\">{{</span>{}<span class=\"mech-map-kind-sep\">:</span>{}<span class=\"mech-map-kind-close\">}}</span></span>", k1, k2)
+        } else {
+          format!("{{{}:{}}}", k1, k2)
+        }
       },
     };
     if self.html {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -1943,6 +1943,7 @@ impl Formatter {
     }
   }
 
+  #[cfg(feature = "variable_define")]
   pub fn variable_define(&mut self, node: &VariableDefine) -> String {
     let mut mutable = if node.mutable {
       "~".to_string()
@@ -1952,24 +1953,29 @@ impl Formatter {
     let var = self.var(&node.var);
     let expression = self.expression(&node.expression);
     if self.html {
-      format!("<span class=\"mech-variable-define\"><span class=\"mech-variable-mutable\">{}</span>{}<span class=\"mech-variable-assign-op\">:=</span>{}</span>",mutable, var, expression)
+      format!("<span class=\"mech-variable-define\"><span class=\"mech-variable-mutable\">{}</span>{}<span class=\"mech-variable-define-op\">:=</span>{}</span>",mutable, var, expression)
     } else {
       format!("{}{} {} {}", mutable, var, ":=", expression)
     }
   }
 
+  #[cfg(feature = "invariant_define")]
+  pub fn invariant_define(&mut self, node: &InvariantDefine) -> String {
+    let name = node.name.to_string();
+    let expression = self.expression(&node.expression);
+    if self.html {
+      format!("<span class=\"mech-invariant-define\"><span class=\"mech-invariant-name\">{}</span><span class=\"mech-invariant-define-op\">:=</span><span class=\"mech-invariant-expression\">{}</span></span>", name, expression)
+    } else {
+      format!("{} {} {}", name, ":=", expression)
+    }
+  }
+
   pub fn statement(&mut self, node: &Statement) -> String {
     let s = match node {
+      #[cfg(feature = "variable_define")]
       Statement::VariableDefine(var_def) => self.variable_define(var_def),
       #[cfg(feature = "invariant_define")]
-      Statement::InvariantDefine(inv_def) => {
-        let mut name = inv_def.name.to_string();
-        if self.html {
-          format!("<span class=\"mech-variable-define\">{}<span class=\"mech-variable-assign-op\">:=</span>{}</span>", name, self.expression(&inv_def.expression))
-        } else {
-          format!("{} {} {}", name, ":=", self.expression(&inv_def.expression))
-        }
-      },
+      Statement::InvariantDefine(inv_def) => self.invariant_define(inv_def),
       Statement::OpAssign(op_asgn) => self.op_assign(op_asgn),
       Statement::VariableAssign(var_asgn) => self.variable_assign(var_asgn),
       Statement::TupleDestructure(tpl_dstrct) => self.tuple_destructure(tpl_dstrct),
@@ -3041,8 +3047,8 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
   pub fn comparison_op(&mut self, node: &ComparisonOp) -> String {
     match node {
       ComparisonOp::Equal => "⩵".to_string(),
-      ComparisonOp::StrictEqual => "=:=".to_string(),
-      ComparisonOp::StrictNotEqual => "=/=".to_string(),
+      ComparisonOp::StrictEqual => "≡".to_string(),
+      ComparisonOp::StrictNotEqual => "¬≡".to_string(),
       ComparisonOp::NotEqual => "≠".to_string(),
       ComparisonOp::GreaterThan => ">".to_string(),
       ComparisonOp::GreaterThanEqual => "≥".to_string(),

--- a/src/syntax/src/literals.rs
+++ b/src/syntax/src/literals.rs
@@ -324,9 +324,9 @@ pub fn empty(input: ParseString) -> ParseResult<Token> {
 // kind_annotation := left_angle, kind, ?question, right_angle ;
 pub fn kind_annotation(input: ParseString) -> ParseResult<KindAnnotation> {
   let msg3 = "Expects right angle";
-  let (input, (_, r)) = range(left_angle)(input)?;
+  let (input, (_, r)) = range(alt((left_angle, left_angle2)))(input)?;
   let (input, kind) = kind_with_option(input)?;
-  let (input, _) = label!(right_angle, msg3, r)(input)?;
+  let (input, _) = label!(alt((right_angle, right_angle2)), msg3, r)(input)?;
   Ok((input, KindAnnotation{ kind }))
 }
 
@@ -361,10 +361,10 @@ pub fn kind_with_option(input: ParseString) -> ParseResult<Kind> {
 // kind-kind := "<", kind, ">" ;
 pub fn kind_kind(input: ParseString) -> ParseResult<Kind> {
   let msg3 = "Expects right angle";
-  let (input, (_, r)) = range(left_angle)(input)?;
+  let (input, (_, r)) = range(alt((left_angle, left_angle2)))(input)?;
 
   let (input, kind) = kind_with_option(input)?;
-  let (input, _) = label!(right_angle, msg3, r)(input)?;
+  let (input, _) = label!(alt((right_angle, right_angle2)), msg3, r)(input)?;
   Ok((input, Kind::Kind(Box::new(kind))))
 }
 

--- a/src/syntax/src/literals.rs
+++ b/src/syntax/src/literals.rs
@@ -436,10 +436,13 @@ pub fn kind_map(input: ParseString) -> ParseResult<Kind> {
 // kind-record := "{", list1(",", (identifier, kind)), "}" ;
 pub fn kind_record(input: ParseString) -> ParseResult<Kind> {
   let (input, _) = left_brace(input)?;
-  let (input, _) = space_tab0(input)?;
-  let (input, elements) = separated_list1(alt((list_separator,space_tab1)), nom_tuple((identifier, kind_annotation)))(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, elements) = separated_list1(
+    alt((null(list_separator), null(whitespace1))),
+    nom_tuple((identifier, kind_annotation))
+  )(input)?;
   let (input, _) = opt(tag(",…"))(input)?;
-  let (input, _) = space_tab0(input)?;
+  let (input, _) = whitespace0(input)?;
   let (input, _) = right_brace(input)?;
   let elements = elements.into_iter().map(|(id, knd)| (id, knd.kind)).collect();
   Ok((input, Kind::Record(elements)))
@@ -480,4 +483,37 @@ pub fn kind_scalar(input: ParseString) -> ParseResult<Kind> {
   let (input, kind) = identifier(input)?;
   let (input, range) = opt(tuple((colon,range_expression)))(input)?;
   Ok((input, Kind::Scalar(kind)))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn kind_annotation_parses_multiline_record_fields() {
+    let src = "<{\n  files-total<u64>\n  files-passed<u64>\n  files-failed<u64>\n}>";
+    let graphemes = crate::graphemes::init_source(src);
+    let input = ParseString::new(&graphemes);
+
+    let (_, annotation) = kind_annotation(input).expect("expected multiline record kind annotation to parse");
+
+    match annotation.kind {
+      Kind::Record(fields) => assert_eq!(fields.len(), 3),
+      other => panic!("expected Kind::Record, got {:?}", other),
+    }
+  }
+
+  #[test]
+  fn kind_annotation_parses_multiline_record_with_nested_kinds() {
+    let src = "<{\n  path<string>\n  result<test-file-result>\n  failed<[test-case-detail]>\n  run-error<string?>\n}>";
+    let graphemes = crate::graphemes::init_source(src);
+    let input = ParseString::new(&graphemes);
+
+    let (_, annotation) = kind_annotation(input).expect("expected nested multiline record kind annotation to parse");
+
+    match annotation.kind {
+      Kind::Record(fields) => assert_eq!(fields.len(), 4),
+      other => panic!("expected Kind::Record, got {:?}", other),
+    }
+  }
 }

--- a/src/syntax/src/literals.rs
+++ b/src/syntax/src/literals.rs
@@ -321,12 +321,23 @@ pub fn empty(input: ParseString) -> ParseResult<Token> {
 // Kind Annotations
 // ----------------------------------------------------------------------------
 
+pub fn left_angle(input: ParseString) -> ParseResult<Token> {
+  let (input, token) = alt((left_angle1, left_angle2))(input)?;
+  Ok((input, token))
+}
+
+pub fn right_angle(input: ParseString) -> ParseResult<Token> {
+  let (input, token) = alt((right_angle1, right_angle2))(input)?;
+  Ok((input, token))
+}
+
+
 // kind_annotation := left_angle, kind, ?question, right_angle ;
 pub fn kind_annotation(input: ParseString) -> ParseResult<KindAnnotation> {
   let msg3 = "Expects right angle";
-  let (input, (_, r)) = range(alt((left_angle, left_angle2)))(input)?;
+  let (input, (_, r)) = range(left_angle)(input)?;
   let (input, kind) = kind_with_option(input)?;
-  let (input, _) = label!(alt((right_angle, right_angle2)), msg3, r)(input)?;
+  let (input, _) = label!(right_angle, msg3, r)(input)?;
   Ok((input, KindAnnotation{ kind }))
 }
 
@@ -361,10 +372,10 @@ pub fn kind_with_option(input: ParseString) -> ParseResult<Kind> {
 // kind-kind := "<", kind, ">" ;
 pub fn kind_kind(input: ParseString) -> ParseResult<Kind> {
   let msg3 = "Expects right angle";
-  let (input, (_, r)) = range(alt((left_angle, left_angle2)))(input)?;
+  let (input, (_, r)) = range(left_angle)(input)?;
 
   let (input, kind) = kind_with_option(input)?;
-  let (input, _) = label!(alt((right_angle, right_angle2)), msg3, r)(input)?;
+  let (input, _) = label!(right_angle, msg3, r)(input)?;
   Ok((input, Kind::Kind(Box::new(kind))))
 }
 

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -225,9 +225,9 @@ pub fn statement(input: ParseString) -> ParseResult<Statement> {
 
 // enum-define := "<", identifier, ">", define-operator, list1(enum-separator, enum-variant);
 pub fn enum_define(input: ParseString) -> ParseResult<EnumDefine> {
-  let (input, _) = left_angle(input)?;
+  let (input, _) = label!(left_angle, "Expects left angle")(input)?;
   let (input, name) = identifier(input)?;
-  let (input, _) = right_angle(input)?;
+  let (input, _) = label!(right_angle, "Expects right angle")(input)?;
   let (input, _) = define_operator(input)?;
   let (input, variants) = separated_list1(enum_separator, enum_variant)(input)?;
   Ok((input, EnumDefine{name, variants}))
@@ -258,9 +258,9 @@ pub fn enum_variant_inline_kind(input: ParseString) -> ParseResult<KindAnnotatio
 
 // kind-define := "<", identifier, ">", define-operator, kind-annotation ;
 pub fn kind_define(input: ParseString) -> ParseResult<KindDefine> {
-  let (input, _) = left_angle(input)?;
+  let (input, _) = label!(left_angle, "Expects left angle")(input)?;
   let (input, name) = identifier(input)?;
-  let (input, _) = right_angle(input)?;
+  let (input, _) = label!(right_angle, "Expects right angle")(input)?;
   let (input, _) = define_operator(input)?;
   let (input, knd) = kind_annotation(input)?;
   Ok((input, KindDefine{name,kind:knd}))

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -225,9 +225,9 @@ pub fn statement(input: ParseString) -> ParseResult<Statement> {
 
 // enum-define := "<", identifier, ">", define-operator, list1(enum-separator, enum-variant);
 pub fn enum_define(input: ParseString) -> ParseResult<EnumDefine> {
-  let (input, _) = label!(left_angle, "Expects left angle")(input)?;
+  let (input, (_, r)) = range(left_angle)(input)?;
   let (input, name) = identifier(input)?;
-  let (input, _) = label!(right_angle, "Expects right angle")(input)?;
+  let (input, _) = label!(right_angle, "Expects right angle", r)(input)?;
   let (input, _) = define_operator(input)?;
   let (input, variants) = separated_list1(enum_separator, enum_variant)(input)?;
   Ok((input, EnumDefine{name, variants}))
@@ -258,9 +258,9 @@ pub fn enum_variant_inline_kind(input: ParseString) -> ParseResult<KindAnnotatio
 
 // kind-define := "<", identifier, ">", define-operator, kind-annotation ;
 pub fn kind_define(input: ParseString) -> ParseResult<KindDefine> {
-  let (input, _) = label!(left_angle, "Expects left angle")(input)?;
+  let (input, (_, r)) = range(left_angle)(input)?;
   let (input, name) = identifier(input)?;
-  let (input, _) = label!(right_angle, "Expects right angle")(input)?;
+  let (input, _) = label!(right_angle, "Expects right angle", r)(input)?;
   let (input, _) = define_operator(input)?;
   let (input, knd) = kind_annotation(input)?;
   Ok((input, KindDefine{name,kind:knd}))


### PR DESCRIPTION
### Motivation
- Record kind parsing needed to accept multiline field lists with standard whitespace handling and correctly parse nested kinds.
- The previous `space_tab0/1` separators were replaced to use unified `whitespace0/1` and null-wrapped separators to better handle newline-separated fields.

### Description
- Updated `kind_record` to use `whitespace0`/`whitespace1` and `separated_list1(alt((null(list_separator), null(whitespace1))), ...)` to allow multiline and whitespace-separated record fields. 
- Replaced occurrences of `space_tab0/1` with `whitespace0/1` in the parser implementation for consistent whitespace treatment.
- Added a `#[cfg(test)]` module with two unit tests: `kind_annotation_parses_multiline_record_fields` and `kind_annotation_parses_multiline_record_with_nested_kinds` to validate multiline record parsing and nested kind parsing.
- Minor formatting/cleanup of surrounding functions (`kind_scalar` brace/format adjustments).

### Testing
- Added unit tests `kind_annotation_parses_multiline_record_fields` and `kind_annotation_parses_multiline_record_with_nested_kinds` under the parser module.
- Ran the crate test suite with `cargo test`, and the new tests passed along with the existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f39c07c4832a829ecc24c02a8d20)