### PR TITLE
Remove Core/compiler dependency; switch runloop messaging to strings and improve error/display handling

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -363,7 +363,7 @@ async fn main() -> Result<(), MechError> {
     let debug_flag = matches.get_flag("debug");
     let mut mechfs = MechFileSystem::new();
 
-    for path in mech_paths {
+    for path in &mech_paths {
       mechfs.watch_source(&path)?;
     }
     let sources = mechfs.sources();
@@ -385,7 +385,7 @@ async fn main() -> Result<(), MechError> {
     let mut program = MechProgram::new(MechProgramConfig { name: format!("program-{}", uuid), environment: MechProgramEnvironment::default() });
     configure_mech_program(&mut program, tree_flag, debug_flag, time_flag, trace_flag);
 
-    let result = run_mech_program_code(&mut program, &mechfs); 
+    let result = run_mech_program_paths(&mut program, &mech_paths); 
 
     let bytecode = program.interpreter.compile()?;
 
@@ -586,7 +586,7 @@ async fn main() -> Result<(), MechError> {
       }
     }
 
-    let result = run_mech_program_code(&mut program, &mechfs); 
+    let result = run_mech_program_paths(&mut program, &paths); 
     if !repl_flag {
       match &result {
         Ok(r) => {

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -539,54 +539,7 @@ async fn main() -> Result<(), MechError> {
       m.map(|s| s.to_string()).collect()
     } else { repl_flag = true; vec![] };
 
-    let mut mechfs = MechFileSystem::new();
-
-    let any_look_like_paths = paths.iter().any(|p| {
-      is_intended_path(p)
-    });
-
-    if !paths.is_empty() {
-      if any_look_like_paths {
-        let mut watch_errors = Vec::new();
-        for p in &paths {
-          match mechfs.watch_source(p) {
-            Ok(r) => {}
-            Err(err) => watch_errors.push(err),
-          }
-        }
-        if !watch_errors.is_empty() {
-          // These looked like paths but failed to watch
-          // Print errors
-          for err in &watch_errors {
-            print_mech_error(err);
-          }
-          std::process::exit(1);
-        }
-      } else {
-        // ---------- 4. Treat the inputs as Mech code ----------
-        program.interpreter.clear();
-        let joined = paths.join(" ");
-        match program.run_program(joined.trim()) {
-          Ok(r) => {
-            println!("{}", r.kind());
-            #[cfg(feature = "pretty_print")]
-            println!("{}", r.pretty_print());
-            #[cfg(not(feature = "pretty_print"))]
-            println!("{:#?}", r);
-            std::process::exit(0);
-          }
-          Err(err) => {
-            println!("{} {:#?}",
-              "[Error]".truecolor(246,98,78),
-              err
-            );
-            std::process::exit(1);
-          }
-        }
-      }
-    }
-
-    let result = run_mech_program_paths(&mut program, &paths); 
+    let result = run_paths_or_inline(&mut program, &paths);
     if !repl_flag {
       match &result {
         Ok(r) => {

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -361,7 +361,7 @@ async fn main() -> Result<(), MechError> {
     let mech_paths: Vec<String> = matches.get_many::<String>("mech_build_file_paths").map_or(vec![], |files| files.map(|file| file.to_string()).collect());
     let output_path = PathBuf::from(matches.get_one::<String>("output_path").cloned().unwrap_or(".".to_string()));
     let debug_flag = matches.get_flag("debug");
-    let mut mechfs = program::MechFileSystem::new();
+    let mut mechfs = MechFileSystem::new();
 
     for path in mech_paths {
       mechfs.watch_source(&path)?;
@@ -382,7 +382,7 @@ async fn main() -> Result<(), MechError> {
     }
 
     let uuid = generate_uuid();
-    let mut program = MechProgram::new(uuid);
+    let mut program = MechProgram::new(MechProgramConfig { name: format!("program-{}", uuid), environment: MechProgramEnvironment::default() });
     configure_mech_program(&mut program, tree_flag, debug_flag, time_flag, trace_flag);
 
     let result = run_mech_program_code(&mut program, &mechfs); 
@@ -442,7 +442,7 @@ async fn main() -> Result<(), MechError> {
         return Ok(());
       }
     }
-    let mut mechfs = program::MechFileSystem::new();
+    let mut mechfs = MechFileSystem::new();
 
     println!("{} Loading resources…", badge);
 
@@ -530,7 +530,7 @@ async fn main() -> Result<(), MechError> {
   #[cfg(feature = "run")]
   let uuid = generate_uuid();
   #[cfg(feature = "run")]
-  let mut program = MechProgram::new(uuid);
+  let mut program = MechProgram::new(MechProgramConfig { name: format!("program-{}", uuid), environment: MechProgramEnvironment::default() });
   #[cfg(feature = "run")]
   configure_mech_program(&mut program, tree_flag, debug_flag, time_flag, trace_flag);
   #[cfg(feature = "run")]
@@ -539,7 +539,7 @@ async fn main() -> Result<(), MechError> {
       m.map(|s| s.to_string()).collect()
     } else { repl_flag = true; vec![] };
 
-    let mut mechfs = program::MechFileSystem::new();
+    let mut mechfs = MechFileSystem::new();
 
     let any_look_like_paths = paths.iter().any(|p| {
       is_intended_path(p)
@@ -566,7 +566,7 @@ async fn main() -> Result<(), MechError> {
         // ---------- 4. Treat the inputs as Mech code ----------
         program.interpreter.clear();
         let joined = paths.join(" ");
-        match program.run_string(joined.trim()) {
+        match program.run_program(joined.trim()) {
           Ok(r) => {
             println!("{}", r.kind());
             #[cfg(feature = "pretty_print")]

--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -1,6 +1,6 @@
-use mech_core::{hash_str, Core, MResult, MechSourceCode, ParsedProgram, Value};
+use mech_core::{hash_str, MResult, MechSourceCode, ParsedProgram, Value};
 use mech_interpreter::Interpreter;
-use mech_syntax::{compiler::Compiler, parser};
+use mech_syntax::parser;
 
 #[derive(Debug, Clone)]
 pub struct ProgramEnvironment {
@@ -37,7 +37,6 @@ impl Default for ProgramConfig {
 
 pub struct Program {
   pub config: ProgramConfig,
-  pub core: Core,
   pub interpreter: Interpreter,
 }
 
@@ -46,13 +45,12 @@ impl Program {
     let id = hash_str(&format!("program/{}", config.name));
     let mut interpreter = Interpreter::new(id);
     interpreter.set_trace_enabled(config.environment.trace_enabled);
-    Self { config, core: Core::new(), interpreter }
+    Self { config, interpreter }
   }
 
   pub fn compile_program(&mut self, source: &str) -> MResult<()> {
-    let mut compiler = Compiler::new();
-    let sections = compiler.compile_str(source)?;
-    self.core.load_sections(sections)?;
+    // Validate source parses successfully before it is run.
+    let _ = parser::parse(source.trim())?;
     Ok(())
   }
 

--- a/src/program/src/runloop.rs
+++ b/src/program/src/runloop.rs
@@ -1,5 +1,6 @@
 use crate::program::{Program, ProgramConfig, ProgramEnvironment};
 use crossbeam_channel::{Receiver, Sender};
+use mech_core::PrettyPrint;
 
 #[derive(Debug, Clone)]
 pub enum ClientMessage {

--- a/src/program/src/runloop.rs
+++ b/src/program/src/runloop.rs
@@ -1,12 +1,11 @@
 use crate::program::{Program, ProgramConfig, ProgramEnvironment};
 use crossbeam_channel::{Receiver, Sender};
-use mech_core::Value;
 
 #[derive(Debug, Clone)]
 pub enum ClientMessage {
   Ready,
   Ack(String),
-  Data(Value),
+  Data(String),
   StepDone,
   Stopped,
   Error(String),
@@ -55,7 +54,7 @@ impl ProgramRunner {
         match msg {
           RunLoopMessage::Load(source) => {
             if let Err(err) = program.compile_program(&source) {
-              let _ = tx_evt.send(ClientMessage::Error(err.to_string()));
+              let _ = tx_evt.send(ClientMessage::Error(err.display_message()));
             } else {
               let _ = tx_evt.send(ClientMessage::Ack("Loaded source".to_string()));
               let _ = tx_evt.send(ClientMessage::StepDone);
@@ -64,11 +63,11 @@ impl ProgramRunner {
           RunLoopMessage::Eval(source) => {
             match program.run_program(&source) {
               Ok(value) => {
-                let _ = tx_evt.send(ClientMessage::Data(value));
+                let _ = tx_evt.send(ClientMessage::Data(value.pretty_print()));
                 let _ = tx_evt.send(ClientMessage::StepDone);
               }
               Err(err) => {
-                let _ = tx_evt.send(ClientMessage::Error(err.to_string()));
+                let _ = tx_evt.send(ClientMessage::Error(err.display_message()));
               }
             }
           }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -59,7 +59,7 @@ impl MechRepl {
   pub fn execute_repl_command(&mut self, repl_cmd: ReplCommand) -> MResult<String> {
 
     let mut intrp = self.interpreters.get_mut(&self.active).unwrap();
-    let mut mechfs = program::MechFileSystem::new();
+    let mut mechfs = MechFileSystem::new();
 
     match repl_cmd {
       ReplCommand::Help => {

--- a/src/run.rs
+++ b/src/run.rs
@@ -36,7 +36,7 @@ macro_rules! print_plan {
 
 pub fn run_mech_code(
   intrp: &mut Interpreter,
-  code: &program::MechFileSystem,
+  code: &MechFileSystem,
   tree_flag: bool,
   debug_flag: bool,
   time_flag: bool,
@@ -135,7 +135,7 @@ pub fn configure_mech_program(program: &mut MechProgram, tree_flag: bool, debug_
   });
 }
 
-pub fn run_mech_program_code(program: &mut MechProgram, code: &program::MechFileSystem) -> MResult<Value> {
+pub fn run_mech_program_code(program: &mut MechProgram, code: &MechFileSystem) -> MResult<Value> {
   let sources = code.sources();
   let sources = sources.read().unwrap();
   for (_, source) in sources.sources_iter() {
@@ -153,7 +153,7 @@ pub fn run_mech_program_code(program: &mut MechProgram, code: &program::MechFile
   Ok(Value::Empty)
 }
 
-fn print_bytecode(fs: &program::MechFileSystem) {
+fn print_bytecode(fs: &MechFileSystem) {
   let sources = fs.sources();
   let sources = sources.read().unwrap();
   for (file, source) in sources.sources_iter() {

--- a/src/run.rs
+++ b/src/run.rs
@@ -135,7 +135,7 @@ pub fn configure_mech_program(program: &mut MechProgram, tree_flag: bool, debug_
   });
 }
 
-pub fn run_mech_program_code(program: &mut MechProgram, code: &MechFileSystem) -> MResult<Value> {
+fn run_mech_program_code_with_fs(program: &mut MechProgram, code: &MechFileSystem) -> MResult<Value> {
   let sources = code.sources();
   let sources = sources.read().unwrap();
   for (_, source) in sources.sources_iter() {
@@ -151,6 +151,20 @@ pub fn run_mech_program_code(program: &mut MechProgram, code: &MechFileSystem) -
     }
   }
   Ok(Value::Empty)
+}
+
+pub fn run_mech_program_code(program: &mut MechProgram, source_code: &MechSourceCode) -> MResult<Value> {
+  let mut mechfs = MechFileSystem::new();
+  mechfs.add_code(source_code)?;
+  run_mech_program_code_with_fs(program, &mechfs)
+}
+
+pub fn run_mech_program_paths(program: &mut MechProgram, paths: &[String]) -> MResult<Value> {
+  let mut mechfs = MechFileSystem::new();
+  for path in paths {
+    mechfs.watch_source(path)?;
+  }
+  run_mech_program_code_with_fs(program, &mechfs)
 }
 
 fn print_bytecode(fs: &MechFileSystem) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -3,6 +3,8 @@ use mech_core::*;
 use mech_syntax::*;
 use mech_interpreter::Interpreter;
 use std::time::Instant;
+use std::ffi::OsStr;
+use std::path::Path;
 
 #[macro_export]
 macro_rules! print_tree {
@@ -165,6 +167,41 @@ pub fn run_mech_program_paths(program: &mut MechProgram, paths: &[String]) -> MR
     mechfs.watch_source(path)?;
   }
   run_mech_program_code_with_fs(program, &mechfs)
+}
+
+pub fn run_paths_or_inline(program: &mut MechProgram, paths: &[String]) -> MResult<Value> {
+  let any_look_like_paths = paths.iter().any(|p| is_intended_path(p));
+  if paths.is_empty() {
+    return Ok(Value::Empty);
+  }
+  if any_look_like_paths {
+    run_mech_program_paths(program, paths)
+  } else {
+    program.interpreter.clear();
+    let joined = paths.join(" ");
+    program.run_program(joined.trim())
+  }
+}
+
+fn is_intended_path(s: &str) -> bool {
+  if s.trim().is_empty() { return false; }
+  let path = Path::new(s);
+  if s.starts_with("./") || s.starts_with(".\\") ||
+    s.starts_with("../") || s.starts_with("..\\") ||
+    s.starts_with('/') || s.starts_with('\\') {
+    return true;
+  }
+  if s.len() > 2 && s.as_bytes()[1] == b':' {
+    return true;
+  }
+  if s.contains('/') || s.contains('\\') {
+    return true;
+  }
+  if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+    matches!(ext, "mec" | "🤖" | "mecb" | "mdoc" | "mpkg" | "m" | "csv" | "tsv" | "txt" | "md" | "json" | "toml" | "yaml" | "html" | "htm" | "css" | "js" | "wasm" | "png" | "jpg" | "jpeg" | "gif" | "svg" | "bmp" | "ico")
+  } else {
+    false
+  }
 }
 
 fn print_bytecode(fs: &MechFileSystem) {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -22,7 +22,7 @@ pub struct MechServer {
 impl MechServer {
 
   pub fn new(name: String, full_address: String, stylesheet: String, html_shim: String, wasm: Vec<u8>, js: Vec<u8>) -> Self {
-    let mut mechfs = program::MechFileSystem::new();
+    let mut mechfs = MechFileSystem::new();
 
     Self {
       badge: format!("[{}] Server", name).truecolor(34, 204, 187),

--- a/src/test.rs
+++ b/src/test.rs
@@ -197,9 +197,12 @@ pub fn run_mech_tests(
   println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
   for path in &expanded_paths {
     let uuid = generate_uuid();
-    let mut program = MechProgram::new(uuid);
+    let mut program = MechProgram::new(MechProgramConfig {
+      name: format!("test-{}", uuid),
+      environment: MechProgramEnvironment::default(),
+    });
     configure_mech_program(&mut program, tree_flag, debug_flag, time_flag, trace_flag);
-    let mut mechfs = program::MechFileSystem::new();
+    let mut mechfs = MechFileSystem::new();
     if let Err(err) = mechfs.watch_source(path) {
       eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
       run_errors = true;

--- a/src/test.rs
+++ b/src/test.rs
@@ -202,15 +202,7 @@ pub fn run_mech_tests(
       environment: MechProgramEnvironment::default(),
     });
     configure_mech_program(&mut program, tree_flag, debug_flag, time_flag, trace_flag);
-    let mut mechfs = MechFileSystem::new();
-    if let Err(err) = mechfs.watch_source(path) {
-      eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
-      run_errors = true;
-      any_failed = true;
-      file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
-      continue;
-    }
-    if let Err(err) = run_mech_program_code(&mut program, &mechfs) {
+    if let Err(err) = run_mech_program_paths(&mut program, &vec![path.clone()]) {
       eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
       run_errors = true;
       any_failed = true;


### PR DESCRIPTION
### Motivation

- Simplify the program runtime by removing the unused `Core`/`Compiler` flow and validate source via the parser before execution.
- Make cross-thread runloop messaging transport-friendly by serializing values and errors to strings instead of sending internal `Value` or raw error types.

### Description

- Removed the `Core` field and related `Compiler` usage from `Program`, and no longer load compiler sections during `compile_program`, instead validating input with `parser::parse`.
- Stopped creating a `Core` instance in `Program::new` and retained the `Interpreter`-based execution flow, preserving trace configuration via `set_trace_enabled`.
- Changed `ClientMessage::Data` to carry a `String` and send interpreter results as `value.pretty_print()` to the runloop, replacing `Value` transport.
- Standardized error messages sent to the runloop by using `err.display_message()` instead of `err.to_string()` for clearer, user-facing text.

### Testing

- Ran `cargo build` which completed successfully and produced a clean build without the removed dependencies.
- Ran `cargo test` and all unit and integration tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b43049b0c832aa835ede3cbf07eaa)