### PR TITLE
runtime: add basic smoke-test binary

### DIFF
--- a/src/runtime/src/bin/basic_runtime.rs
+++ b/src/runtime/src/bin/basic_runtime.rs
@@ -1,0 +1,104 @@
+use std::sync::Arc;
+
+use mech_core::{MResult, Value};
+use mech_runtime::{
+  BasicCapability,
+  BasicCapabilityKernel,
+  BasicOperation,
+  BasicResource,
+  BasicSubject,
+  CapabilityId,
+  ClosureHostFunction,
+  HostCall,
+  InMemoryHostRegistry,
+  InMemorySourceResolver,
+  RuntimeBuilder,
+  RuntimeConfig,
+  RuntimeContextBuilder,
+  SourceRequest,
+};
+
+fn main() -> MResult<()> {
+  let mut source_resolver = InMemorySourceResolver::new();
+  source_resolver.insert_string("main", "x := 1")?;
+
+  let mut host_registry = InMemoryHostRegistry::new();
+  host_registry.insert(ClosureHostFunction::new("host.empty", |_ctx, _args| {
+    Ok(Value::Empty)
+  }))?;
+
+  let mut runtime = RuntimeBuilder::new()
+    .config(RuntimeConfig::default())
+    .source_resolver(source_resolver)
+    .host_registry(host_registry)
+    .capability_kernel(BasicCapabilityKernel::new())
+    .build()?;
+
+  println!("runtime: {}", runtime.id());
+
+  let run_result = runtime.run_string("x := 1")?;
+  println!("run_string result: {:?}", run_result);
+
+  let version = runtime
+    .resolve_and_store_module_source(
+      SourceRequest::new("main"),
+      env!("CARGO_PKG_VERSION"),
+      "mech-current",
+      &[],
+      &[],
+    )?
+    .expect("expected in-memory source to resolve");
+
+  println!("stored module version: {}", version);
+
+  let actor = runtime.create_actor("actor:example", Some(version), None, Vec::new())?;
+
+  println!("actor: {}", actor);
+
+  let message = runtime.send_message(actor, "ping", b"hello".to_vec())?;
+
+  println!("message: {}", message);
+
+  let popped = runtime
+    .pop_message(actor)?
+    .expect("expected message in actor mailbox");
+
+  println!(
+    "popped message kind={} payload={:?}",
+    popped.kind,
+    String::from_utf8_lossy(&popped.payload),
+  );
+
+  let subject = BasicSubject::new("task:host-example");
+  let resource = BasicResource::new("host:host.empty");
+
+  let capability = BasicCapability::new(
+    CapabilityId(1),
+    &subject,
+    &resource,
+    [BasicOperation::new("call")],
+  );
+
+  runtime.grant_capability(Arc::new(capability))?;
+
+  let mut host_context = RuntimeContextBuilder::new(runtime.id())
+    .subject("task:host-example")
+    .build()?;
+
+  let host_result = runtime.call_host_with_context(
+    &mut host_context,
+    HostCall::new("host.empty", Vec::new()),
+  )?;
+
+  println!("host call result: {:?}", host_result);
+
+  println!("events:");
+
+  for event in runtime.list_events(None)? {
+    println!("  #{:03} {} {:?}", event.sequence, event.name(), event.kind,);
+  }
+
+  runtime.shutdown()?;
+
+  Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide a compact, runtime-only smoke test that exercises the host integration and capability boundary without depending on the scheduler or filesystem resolver.
- Give a simple example that constructs a runtime, exercises program execution and host calls, and exposes emitted events for quick verification.

### Description
- Add a new binary at `src/runtime/src/bin/basic_runtime.rs` which builds a `MechRuntime` using `InMemorySourceResolver` and `InMemoryHostRegistry` and a `BasicCapabilityKernel`.
- The binary runs a source string via `run_string`, resolves and stores an in-memory module via `resolve_and_store_module_source`, creates an actor, sends and pops a mailbox message, grants a capability, and invokes a host function with an explicit `RuntimeContext`.
- The program prints the runtime id, `run_string` result, stored module version, actor/message ids, host call result, and the runtime event stream before calling `shutdown`.
- The example uses `BasicOperation::new("call")` (no API surface changes required) and is self-contained using only in-memory resolvers/registries.

### Testing
- Ran `cargo run -p mech-runtime --bin basic_runtime`, which builds and runs the binary successfully and prints the expected runtime id, `run_string` output, stored module version, actor/message information, host call result, and event list.
- The build produced only minor warnings (unused imports) and finished cleanly, and the binary run completed with the expected output (events showing program start/completion, source resolved, module compiled, actor/message events, and capability granted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11108f76d0832ab421d7da8eb8d0bd)