### PR TITLE
Use Arc for native function compiler table

### DIFF
--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -15,12 +15,13 @@ use tabled::{
   Tabled,
 };
 use std::fmt;
+use std::sync::Arc;
 
 // Functions ------------------------------------------------------------------
 
 pub type FunctionsRef = Ref<Functions>;
 pub type FunctionTable = HashMap<u64, fn(FunctionArgs) -> MResult<Box<dyn MechFunction>>>;
-pub type FunctionCompilerTable = HashMap<u64, &'static dyn NativeFunctionCompiler>;
+pub type FunctionCompilerTable = HashMap<u64, Arc<dyn NativeFunctionCompiler>>;
 pub type UserFunctionTable = HashMap<u64, FunctionDefinition>;
 
 #[derive(Clone,Debug)]
@@ -102,6 +103,21 @@ impl<T> MechFunction for T where T: MechFunctionImpl {}
 
 pub trait NativeFunctionCompiler {
   fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>>;
+}
+
+
+pub struct StaticNativeFunctionCompiler {
+  inner: &'static dyn NativeFunctionCompiler,
+}
+
+impl StaticNativeFunctionCompiler {
+  pub fn new(inner: &'static dyn NativeFunctionCompiler) -> Self { Self { inner } }
+}
+
+impl NativeFunctionCompiler for StaticNativeFunctionCompiler {
+  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+    self.inner.compile(arguments)
+  }
 }
 
 #[derive(Clone)]

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -406,7 +406,7 @@ pub fn set_comprehension(set_comp: &SetComprehension, p: &Interpreter) -> MResul
             .borrow()
             .function_compilers
             .get(&set_define_id)
-            .copied()
+            .cloned()
     };
     match set_define {
         Some(compiler) => execute_native_function_compiler(compiler, &values, p),
@@ -435,7 +435,7 @@ pub fn matrix_comprehension(matrix_comp: &MatrixComprehension, p: &Interpreter) 
             .borrow()
             .function_compilers
             .get(&horzcat_id)
-            .copied()
+            .cloned()
     };
     match horzcat {
         Some(compiler) => execute_native_function_compiler(compiler, &values, p),
@@ -1094,7 +1094,7 @@ fn infer_missing_enum_match_patterns(
         candidates[0]
     };
     let variant_ids: HashSet<u64> = enum_def.variants.iter().map(|(id, _)| *id).collect();
-    let missing_ids: Vec<u64> = variant_ids.difference(&arm_tags).copied().collect();
+    let missing_ids: Vec<u64> = variant_ids.difference(&arm_tags).cloned().collect();
     let names_brrw = enum_def.names.borrow();
     let missing_patterns = enum_def
         .variants

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -9,6 +9,7 @@ use crate::tracing::{
 #[cfg(all(feature = "kind_annotation", feature = "enum"))]
 use std::collections::HashSet;
 use crate::*;
+use std::sync::Arc;
 
 // Functions
 // ============================================================================
@@ -112,7 +113,7 @@ pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Int
       .borrow()
       .function_compilers
       .get(&fxn_name_id)
-      .copied()
+      .cloned()
   };
   match fxn_compiler {
     Some(fxn_compiler) => {
@@ -150,7 +151,7 @@ pub fn function_call(fxn_call: &FunctionCall, env: Option<&Environment>, p: &Int
 // for the given argument types, runs it once to produce an initial value, then
 // pushes it onto the reactive plan so it re-runs when its inputs change.
 pub fn execute_native_function_compiler(
-  fxn_compiler: &'static dyn NativeFunctionCompiler,
+  fxn_compiler: Arc<dyn NativeFunctionCompiler>,
   input_arg_values: &Vec<Value>,
   p: &Interpreter,
 ) -> MResult<Value> {

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -150,6 +150,7 @@ pub use mech_matrix::*;
 pub use mech_set::*;
 #[cfg(feature = "stats")]
 pub use mech_stats::*;
+use std::sync::Arc;
 
 pub fn load_stdkinds(kinds: &mut KindTable) {
   #[cfg(feature = "u8")]
@@ -194,7 +195,7 @@ pub fn load_stdlib(fxns: &mut Functions) {
 
   for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
     fxns.function_compilers
-      .insert(hash_str(fxn_comp.name), fxn_comp.ptr);
+      .insert(hash_str(fxn_comp.name), Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)));
   }
 }
 

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
 
@@ -46,140 +47,140 @@ fn new_interpreter(id: u64) -> Interpreter {
       
   // Preload combinatorics functions
   #[cfg(feature = "combinatorics_n_choose_k")]
-  fxns.function_compilers.insert(hash_str("combinatorics/n-choose-k"), &CombinatoricsNChooseK{});
+  fxns.function_compilers.insert(hash_str("combinatorics/n-choose-k"), Arc::new(CombinatoricsNChooseK{}));
 
   
   // Preload stats functions
   #[cfg(feature = "stats_sum")]
-  fxns.function_compilers.insert(hash_str("stats/sum/row"), &StatsSumRow{});
+  fxns.function_compilers.insert(hash_str("stats/sum/row"), Arc::new(StatsSumRow{}));
   #[cfg(feature = "stats_sum")]
-  fxns.function_compilers.insert(hash_str("stats/sum/column"), &StatsSumColumn{});
+  fxns.function_compilers.insert(hash_str("stats/sum/column"), Arc::new(StatsSumColumn{}));
 
   // Preload ops functions
   #[cfg(feature = "math_add")]
-  fxns.function_compilers.insert(hash_str("math/add"), &MathAdd{});
+  fxns.function_compilers.insert(hash_str("math/add"), Arc::new(MathAdd{}));
   #[cfg(feature = "math_sub")]
-  fxns.function_compilers.insert(hash_str("math/sub"), &MathSub{});
+  fxns.function_compilers.insert(hash_str("math/sub"), Arc::new(MathSub{}));
   #[cfg(feature = "math_mul")]
-  fxns.function_compilers.insert(hash_str("math/mul"), &MathMul{});
+  fxns.function_compilers.insert(hash_str("math/mul"), Arc::new(MathMul{}));
   #[cfg(feature = "math_div")]
-  fxns.function_compilers.insert(hash_str("math/div"), &MathDiv{});
+  fxns.function_compilers.insert(hash_str("math/div"), Arc::new(MathDiv{}));
   #[cfg(feature = "math_mod")]
-  fxns.function_compilers.insert(hash_str("math/mod"), &MathMod{});
+  fxns.function_compilers.insert(hash_str("math/mod"), Arc::new(MathMod{}));
   #[cfg(feature = "math_pow")]
-  fxns.function_compilers.insert(hash_str("math/pow"), &MathPow{});
+  fxns.function_compilers.insert(hash_str("math/pow"), Arc::new(MathPow{}));
   #[cfg(feature = "math_neg")]
-  fxns.function_compilers.insert(hash_str("math/neg"), &MathNegate{});
+  fxns.function_compilers.insert(hash_str("math/neg"), Arc::new(MathNegate{}));
   
   // Preload math functions
   #[cfg(feature = "math_sqrt")]
-  fxns.function_compilers.insert(hash_str("math/sqrt"), &MathSqrt{});
+  fxns.function_compilers.insert(hash_str("math/sqrt"), Arc::new(MathSqrt{}));
   
   // Preload trig functions
   #[cfg(feature = "math_sin")]
-  fxns.function_compilers.insert(hash_str("math/sin"), &MathSin{});
+  fxns.function_compilers.insert(hash_str("math/sin"), Arc::new(MathSin{}));
   #[cfg(feature = "math_cos")]
-  fxns.function_compilers.insert(hash_str("math/cos"), &MathCos{});
+  fxns.function_compilers.insert(hash_str("math/cos"), Arc::new(MathCos{}));
   #[cfg(feature = "math_atan2")]
-  fxns.function_compilers.insert(hash_str("math/atan2"), &MathAtan2{});
+  fxns.function_compilers.insert(hash_str("math/atan2"), Arc::new(MathAtan2{}));
   #[cfg(feature = "math_atan")]
-  fxns.function_compilers.insert(hash_str("math/atan"), &MathAtan{});
+  fxns.function_compilers.insert(hash_str("math/atan"), Arc::new(MathAtan{}));
   #[cfg(feature = "math_acos")]
-  fxns.function_compilers.insert(hash_str("math/acos"), &MathAcos{});
+  fxns.function_compilers.insert(hash_str("math/acos"), Arc::new(MathAcos{}));
   #[cfg(feature = "math_acosh")]
-  fxns.function_compilers.insert(hash_str("math/acosh"), &MathAcosh{});
+  fxns.function_compilers.insert(hash_str("math/acosh"), Arc::new(MathAcosh{}));
   #[cfg(feature = "math_acot")]
-  fxns.function_compilers.insert(hash_str("math/acot"), &MathAcot{});
+  fxns.function_compilers.insert(hash_str("math/acot"), Arc::new(MathAcot{}));
   #[cfg(feature = "math_acsc")]
-  fxns.function_compilers.insert(hash_str("math/acsc"), &MathAcsc{});
+  fxns.function_compilers.insert(hash_str("math/acsc"), Arc::new(MathAcsc{}));
   #[cfg(feature = "math_asec")]
-  fxns.function_compilers.insert(hash_str("math/asec"), &MathAsec{});
+  fxns.function_compilers.insert(hash_str("math/asec"), Arc::new(MathAsec{}));
   #[cfg(feature = "math_asin")]
-  fxns.function_compilers.insert(hash_str("math/asin"), &MathAsin{});
+  fxns.function_compilers.insert(hash_str("math/asin"), Arc::new(MathAsin{}));
   #[cfg(feature = "math_sinh")]
-  fxns.function_compilers.insert(hash_str("math/sinh"), &MathSinh{});
+  fxns.function_compilers.insert(hash_str("math/sinh"), Arc::new(MathSinh{}));
   #[cfg(feature = "math_cosh")]
-  fxns.function_compilers.insert(hash_str("math/cosh"), &MathCosh{});
+  fxns.function_compilers.insert(hash_str("math/cosh"), Arc::new(MathCosh{}));
   #[cfg(feature = "math_tanh")]
-  fxns.function_compilers.insert(hash_str("math/tanh"), &MathTanh{});
+  fxns.function_compilers.insert(hash_str("math/tanh"), Arc::new(MathTanh{}));
   #[cfg(feature = "math_atanh")]
-  fxns.function_compilers.insert(hash_str("math/atanh"), &MathAtanh{});
+  fxns.function_compilers.insert(hash_str("math/atanh"), Arc::new(MathAtanh{}));
   #[cfg(feature = "math_cot")]
-  fxns.function_compilers.insert(hash_str("math/cot"), &MathCot{});
+  fxns.function_compilers.insert(hash_str("math/cot"), Arc::new(MathCot{}));
   #[cfg(feature = "math_csc")]
-  fxns.function_compilers.insert(hash_str("math/csc"), &MathCsc{});
+  fxns.function_compilers.insert(hash_str("math/csc"), Arc::new(MathCsc{}));
   #[cfg(feature = "math_sec")]
-  fxns.function_compilers.insert(hash_str("math/sec"), &MathSec{});
+  fxns.function_compilers.insert(hash_str("math/sec"), Arc::new(MathSec{}));
   #[cfg(feature = "math_tan")]
-  fxns.function_compilers.insert(hash_str("math/tan"), &MathTan{});
+  fxns.function_compilers.insert(hash_str("math/tan"), Arc::new(MathTan{}));
 
   // Preload io functions
   //#[cfg(feature = "io_print")]
-  //fxns.function_compilers.insert(hash_str("io/print"), &IoPrint{});
+  //fxns.function_compilers.insert(hash_str("io/print"), Arc::new(IoPrint{}));
   //#[cfg(feature = "io_println")]
-  //fxns.function_compilers.insert(hash_str("io/println"), &IoPrintln{});
+  //fxns.function_compilers.insert(hash_str("io/println"), Arc::new(IoPrintln{}));
 
   // Matrix functions
   #[cfg(feature = "matrix_horzcat")]
-  fxns.function_compilers.insert(hash_str("matrix/horzcat"), &MatrixHorzCat{});
+  fxns.function_compilers.insert(hash_str("matrix/horzcat"), Arc::new(MatrixHorzCat{}));
   #[cfg(feature = "matrix_vertcat")]
-  fxns.function_compilers.insert(hash_str("matrix/vertcat"), &MatrixVertCat{});
+  fxns.function_compilers.insert(hash_str("matrix/vertcat"), Arc::new(MatrixVertCat{}));
   #[cfg(feature = "matrix_transpose")]
-  fxns.function_compilers.insert(hash_str("matrix/transpose"), &MatrixTranspose{});
+  fxns.function_compilers.insert(hash_str("matrix/transpose"), Arc::new(MatrixTranspose{}));
   #[cfg(feature = "matrix_matmul")]
-  fxns.function_compilers.insert(hash_str("matrix/matmul"), &MatrixMatMul{});
+  fxns.function_compilers.insert(hash_str("matrix/matmul"), Arc::new(MatrixMatMul{}));
   #[cfg(feature = "matrix_dot")]
-  fxns.function_compilers.insert(hash_str("matrix/dot"), &MatrixDot{});
+  fxns.function_compilers.insert(hash_str("matrix/dot"), Arc::new(MatrixDot{}));
   #[cfg(feature = "matrix_solve")]
-  fxns.function_compilers.insert(hash_str("matrix/solve"), &MatrixSolve{});
+  fxns.function_compilers.insert(hash_str("matrix/solve"), Arc::new(MatrixSolve{}));
   #[cfg(feature = "matrix_comprehensions")]
-  fxns.function_compilers.insert(hash_str("matrix/comprehension"), &MatrixComprehensionDefine{});
+  fxns.function_compilers.insert(hash_str("matrix/comprehension"), Arc::new(MatrixComprehensionDefine{}));
 
   // Compare functions
   #[cfg(feature = "compare_eq")]
-  fxns.function_compilers.insert(hash_str("compare/eq"), &CompareEqual{});
+  fxns.function_compilers.insert(hash_str("compare/eq"), Arc::new(CompareEqual{}));
   #[cfg(feature = "compare_neq")]
-  fxns.function_compilers.insert(hash_str("compare/neq"), &CompareNotEqual{});
+  fxns.function_compilers.insert(hash_str("compare/neq"), Arc::new(CompareNotEqual{}));
   #[cfg(feature = "compare_lte")]
-  fxns.function_compilers.insert(hash_str("compare/lte"), &CompareLessThanEqual{});
+  fxns.function_compilers.insert(hash_str("compare/lte"), Arc::new(CompareLessThanEqual{}));
   #[cfg(feature = "compare_gte")]
-  fxns.function_compilers.insert(hash_str("compare/gte"), &CompareGreaterThanEqual{});
+  fxns.function_compilers.insert(hash_str("compare/gte"), Arc::new(CompareGreaterThanEqual{}));
   #[cfg(feature = "compare_lt")]
-  fxns.function_compilers.insert(hash_str("compare/lt"), &CompareLessThan{});
+  fxns.function_compilers.insert(hash_str("compare/lt"), Arc::new(CompareLessThan{}));
   #[cfg(feature = "compare_gt")]
-  fxns.function_compilers.insert(hash_str("compare/gt"), &CompareGreaterThan{});
+  fxns.function_compilers.insert(hash_str("compare/gt"), Arc::new(CompareGreaterThan{}));
 
   // Logic functions
   #[cfg(feature = "logic_and")]
-  fxns.function_compilers.insert(hash_str("logic/and"), &LogicAnd{});
+  fxns.function_compilers.insert(hash_str("logic/and"), Arc::new(LogicAnd{}));
   #[cfg(feature = "logic_or")]
-  fxns.function_compilers.insert(hash_str("logic/or"), &LogicOr{});
+  fxns.function_compilers.insert(hash_str("logic/or"), Arc::new(LogicOr{}));
   #[cfg(feature = "logic_not")]
-  fxns.function_compilers.insert(hash_str("logic/not"), &LogicNot{});
+  fxns.function_compilers.insert(hash_str("logic/not"), Arc::new(LogicNot{}));
   #[cfg(feature = "logic_xor")]
-  fxns.function_compilers.insert(hash_str("logic/xor"), &LogicXor{});
+  fxns.function_compilers.insert(hash_str("logic/xor"), Arc::new(LogicXor{}));
 
   // Set Functions
   #[cfg(feature = "set_union")]
-  fxns.function_compilers.insert(hash_str("set/union"), &SetUnion{});
+  fxns.function_compilers.insert(hash_str("set/union"), Arc::new(SetUnion{}));
   #[cfg(feature = "set_intersection")]
-  fxns.function_compilers.insert(hash_str("set/intersection"), &SetIntersection{});
+  fxns.function_compilers.insert(hash_str("set/intersection"), Arc::new(SetIntersection{}));
   #[cfg(feature = "set_difference")]
-  fxns.function_compilers.insert(hash_str("set/difference"), &SetDifference{});
+  fxns.function_compilers.insert(hash_str("set/difference"), Arc::new(SetDifference{}));
   #[cfg(feature = "set_subset")]
-  fxns.function_compilers.insert(hash_str("set/subset"), &SetSubset{});
+  fxns.function_compilers.insert(hash_str("set/subset"), Arc::new(SetSubset{}));
   #[cfg(feature = "set_superset")]
-  fxns.function_compilers.insert(hash_str("set/superset"), &SetSuperset{});
+  fxns.function_compilers.insert(hash_str("set/superset"), Arc::new(SetSuperset{}));
   #[cfg(feature = "set_proper_subset")]
-  fxns.function_compilers.insert(hash_str("set/proper-subset"), &SetProperSubset{});
+  fxns.function_compilers.insert(hash_str("set/proper-subset"), Arc::new(SetProperSubset{}));
   #[cfg(feature = "set_proper_superset")]
-  fxns.function_compilers.insert(hash_str("set/proper-superset"), &SetProperSuperset{});
+  fxns.function_compilers.insert(hash_str("set/proper-superset"), Arc::new(SetProperSuperset{}));
   #[cfg(feature = "set_element_of")]
-  fxns.function_compilers.insert(hash_str("set/element-of"), &SetElementOf{});
+  fxns.function_compilers.insert(hash_str("set/element-of"), Arc::new(SetElementOf{}));
   #[cfg(feature = "set_not_element_of")]
-  fxns.function_compilers.insert(hash_str("set/not-element-of"), &SetNotElementOf{});
+  fxns.function_compilers.insert(hash_str("set/not-element-of"), Arc::new(SetNotElementOf{}));
   #[cfg(feature = "set_comprehensions")]
-  fxns.function_compilers.insert(hash_str("set/comprehension"), &SetComprehensionDefine{});
+  fxns.function_compilers.insert(hash_str("set/comprehension"), Arc::new(SetComprehensionDefine{}));
 
   intrp
 


### PR DESCRIPTION
### Motivation
- Replace static `&'static` references to native function compilers with owned, clonable handles so compiler descriptors can be stored and passed flexibly across modules and runtime components.

### Description
- Changed the type alias `FunctionCompilerTable` to `HashMap<u64, Arc<dyn NativeFunctionCompiler>>` and added `use std::sync::Arc` where needed.
- Added a `StaticNativeFunctionCompiler` adapter that wraps legacy `&'static dyn NativeFunctionCompiler` and forwards `compile` calls to preserve compatibility with `inventory`-registered descriptors.
- Updated stdlib loading (`load_stdlib`) to insert `Arc::new(StaticNativeFunctionCompiler::new(...))` for inventory `FunctionCompilerDescriptor`s and updated wasm preloads to insert `Arc::new(...)` instances.
- Replaced uses of `.copied()` on `function_compilers` lookups with `.cloned()`, and changed `execute_native_function_compiler` to accept `Arc<dyn NativeFunctionCompiler>` so the table entries are cloned and used correctly.

### Testing
- Ran `cargo check -q` for the workspace, which failed due to unrelated top-level crate issues (missing `MechFileSystem` and other pre-existing API mismatches).  
- Ran `cargo check -q -p mech-core -p mech-interpreter -p mech-wasm`, which failed due to a wasm-side `Interpreter::new` signature mismatch and other unrelated compile issues not introduced by this change.  
- Fixed intermediate `Arc` usage errors (replaced `.copied()` with `.cloned()`), and those specific compile errors are resolved; remaining failures are external to the `FunctionCompilerTable` changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1260432cd8832ab5220d7337d2dbc5)