### PR TITLE
Refactor module graph build state out of runtime

### DIFF
--- a/src/runtime/src/module/graph.rs
+++ b/src/runtime/src/module/graph.rs
@@ -1,0 +1,62 @@
+use std::collections::{HashMap, HashSet};
+
+use mech_core::{MResult, MechError, MechErrorKind};
+
+use crate::ModuleVersionId;
+
+#[derive(Clone, Debug, Default)]
+pub struct ModuleGraphBuildState {
+  stack: Vec<String>,
+  seen: HashSet<String>,
+  cache: HashMap<String, ModuleVersionId>,
+}
+
+impl ModuleGraphBuildState {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn cached(&self, canonical_uri: &str) -> Option<ModuleVersionId> {
+    self.cache.get(canonical_uri).copied()
+  }
+
+  pub fn cache(&mut self, canonical_uri: impl Into<String>, module_version: ModuleVersionId) {
+    self.cache.insert(canonical_uri.into(), module_version);
+  }
+
+  pub fn enter(&mut self, canonical_uri: impl Into<String>) -> MResult<()> {
+    let canonical_uri = canonical_uri.into();
+
+    if self.seen.contains(&canonical_uri) {
+      let mut cycle = self.stack.clone();
+      cycle.push(canonical_uri);
+
+      return Err(MechError::new(ModuleDependencyCycleError { cycle }, None));
+    }
+
+    self.seen.insert(canonical_uri.clone());
+    self.stack.push(canonical_uri);
+
+    Ok(())
+  }
+
+  pub fn exit(&mut self, canonical_uri: &str) {
+    self.stack.pop();
+    self.seen.remove(canonical_uri);
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModuleDependencyCycleError {
+  pub cycle: Vec<String>,
+}
+
+impl MechErrorKind for ModuleDependencyCycleError {
+  fn name(&self) -> &str {
+    "ModuleDependencyCycle"
+  }
+
+  fn message(&self) -> String {
+    format!("module dependency cycle detected: {}", self.cycle.join(" -> "))
+  }
+}

--- a/src/runtime/src/module/mod.rs
+++ b/src/runtime/src/module/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod record;
 pub mod builder;
+pub mod graph;
 
 pub use record::*;
 pub use builder::*;
+pub use graph::*;


### PR DESCRIPTION
## Summary

This draft starts the module dependency graph refactor by moving the graph bookkeeping concept into the module layer.

Changes included:
- Add `src/runtime/src/module/graph.rs`
- Export `ModuleGraphBuildState` from `src/runtime/src/module/mod.rs`
- Model per-build dependency graph state in the module layer:
  - active stack
  - seen set
  - canonical URI -> `ModuleVersionId` cache
  - module dependency cycle error

## Follow-up wiring

The current runtime still owns the recursive build orchestration because it owns the side effects:
- source resolution and source-resolved events
- `RuntimeContext` validation and budget charging
- `ModuleBuilder` calls
- store writes
- module-compiled events

The next patch should replace the raw runtime parameters:

```rust
&mut Vec<String>,
&mut HashSet<String>,
&mut HashMap<String, ModuleVersionId>,
```

with:

```rust
&mut ModuleGraphBuildState
```

and call:

```rust
state.cached(&canonical_uri)
state.enter(canonical_uri.clone())?
state.cache(canonical_uri.clone(), record.module_version)
state.exit(&canonical_uri)
```

This keeps runtime as the orchestrator while moving module graph bookkeeping out of `runtime.rs`.

## Notes

I left this as a draft because the branch should still be wired through `runtime.rs` before it is ready to merge.