### PR TITLE
Add ModuleBuildOptions and ModuleDependencyGraph; refactor module build API

### DIFF
--- a/src/runtime/examples/actor_context_host.rs
+++ b/src/runtime/examples/actor_context_host.rs
@@ -14,6 +14,7 @@ use mech_runtime::{
   InMemorySourceResolver,
   ObjectRecord,
   RuntimeBuilder,
+  ModuleBuildOptions,
   RuntimeContextBuilder,
   SourceRequest,
   register_actor_context_host_functions,
@@ -42,10 +43,13 @@ fn main() -> MResult<()> {
   let actor_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("actor.behavior"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected actor behavior to resolve");
 

--- a/src/runtime/examples/actor_state_host.rs
+++ b/src/runtime/examples/actor_state_host.rs
@@ -14,6 +14,7 @@ use mech_runtime::{
   InMemorySourceResolver,
   ObjectRecord,
   RuntimeBuilder,
+  ModuleBuildOptions,
   RuntimeContextBuilder,
   SourceRequest,
   register_actor_context_host_functions,
@@ -42,10 +43,13 @@ fn main() -> MResult<()> {
   let actor_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("actor.behavior"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected actor behavior to resolve");
 

--- a/src/runtime/examples/basic_runtime.rs
+++ b/src/runtime/examples/basic_runtime.rs
@@ -13,6 +13,7 @@ use mech_runtime::{
   InMemoryHostRegistry,
   InMemorySourceResolver,
   RuntimeBuilder,
+  ModuleBuildOptions,
   RuntimeConfig,
   RuntimeContextBuilder,
   SourceRequest,
@@ -43,10 +44,13 @@ fn main() -> MResult<()> {
   let version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("main"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected in-memory source to resolve");
 

--- a/src/runtime/examples/dep_cycle.rs
+++ b/src/runtime/examples/dep_cycle.rs
@@ -6,6 +6,7 @@ use mech_core::{MResult, MechSourceCode};
 use mech_runtime::{
   ResolvedSource,
   RuntimeBuilder,
+  ModuleBuildOptions,
   SourceRequest,
   SourceResolver,
 };
@@ -79,15 +80,18 @@ fn main() -> MResult<()> {
     .with_subject("program:runtime-dependency-cycle");
 
   let target = runtime_target();
-
-  let result = runtime.build_module_from_request_with_context(
-    &mut context,
-    SourceRequest::new("a.mec"),
+  let options = ModuleBuildOptions::new(
     env!("CARGO_PKG_VERSION"),
     "mech-current",
     &target,
     &[],
     &[],
+  );
+
+  let result = runtime.build_module_from_request_with_context(
+    &mut context,
+    SourceRequest::new("a.mec"),
+    options,
   );
 
   match result {

--- a/src/runtime/examples/dep_diamond.rs
+++ b/src/runtime/examples/dep_diamond.rs
@@ -7,6 +7,7 @@ use mech_core::{MResult, MechSourceCode};
 use mech_runtime::{
   ResolvedSource,
   RuntimeBuilder,
+  ModuleBuildOptions,
   SourceRequest,
   SourceResolver,
 };
@@ -162,16 +163,19 @@ fn main() -> MResult<()> {
     .with_subject("program:runtime-dependency-diamond");
 
   let target = runtime_target();
+  let options = ModuleBuildOptions::new(
+    env!("CARGO_PKG_VERSION"),
+    "mech-current",
+    &target,
+    &[],
+    &[],
+  );
 
   let root_version = runtime
     .build_module_from_request_with_context(
       &mut context,
       SourceRequest::new("root.mec"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &target,
-      &[],
-      &[],
+      options,
     )?
     .expect("expected root.mec to resolve");
 

--- a/src/runtime/examples/runtime_dep_src.rs
+++ b/src/runtime/examples/runtime_dep_src.rs
@@ -7,6 +7,7 @@ use mech_runtime::{
   FileSourceResolver,
   ResolvedSource,
   RuntimeBuilder,
+  ModuleBuildOptions,
   SourceRequest,
 };
 
@@ -72,15 +73,18 @@ fn main() -> MResult<()> {
   resolved.dependencies.push(SourceRequest::new("dep.mec"));
 
   let target = runtime_target();
-
-  let module_version = runtime.build_module_from_resolved_source_with_context(
-    &mut context,
-    resolved,
+  let options = ModuleBuildOptions::new(
     env!("CARGO_PKG_VERSION"),
     "mech-current",
     &target,
     &[],
     &[],
+  );
+
+  let module_version = runtime.build_module_from_resolved_source_with_context(
+    &mut context,
+    resolved,
+    options,
   )?;
 
   println!("module version: {}", short(module_version));

--- a/src/runtime/examples/runtime_services_host.rs
+++ b/src/runtime/examples/runtime_services_host.rs
@@ -16,6 +16,7 @@ use mech_runtime::{
   InMemorySourceResolver,
   ObjectRecord,
   RuntimeBuilder,
+  ModuleBuildOptions,
   RuntimeContextBuilder,
   SourceRequest,
 };
@@ -53,10 +54,13 @@ fn main() -> MResult<()> {
   let actor_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("actor.behavior"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected actor behavior to resolve");
 

--- a/src/runtime/examples/scheduled_actor_native_functions.rs
+++ b/src/runtime/examples/scheduled_actor_native_functions.rs
@@ -15,6 +15,7 @@ use mech_runtime::{
   InMemorySourceResolver,
   ObjectRecord,
   RuntimeBuilder,
+  ModuleBuildOptions,
   SourceRequest,
 };
 
@@ -66,10 +67,13 @@ fn main() -> MResult<()> {
   let actor_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("actor.behavior"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected actor behavior to resolve");
 

--- a/src/runtime/examples/scheduled_actor_state_host.rs
+++ b/src/runtime/examples/scheduled_actor_state_host.rs
@@ -16,6 +16,7 @@ use mech_runtime::{
   InMemorySourceResolver,
   ObjectRecord,
   RuntimeBuilder,
+  ModuleBuildOptions,
   SourceRequest,
 };
 
@@ -55,10 +56,13 @@ fn main() -> MResult<()> {
   let actor_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("actor.behavior"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected actor behavior to resolve");
 

--- a/src/runtime/examples/scheduled_runtime.rs
+++ b/src/runtime/examples/scheduled_runtime.rs
@@ -3,6 +3,7 @@ use mech_core::MResult;
 use mech_runtime::{
   InMemorySourceResolver,
   RuntimeBuilder,
+  ModuleBuildOptions,
   SourceRequest,
 };
 
@@ -32,20 +33,26 @@ fn main() -> MResult<()> {
   let main_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("main"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected `main` to resolve");
 
   let actor_version = runtime
     .resolve_and_store_module_source(
       SourceRequest::new("actor.behavior"),
-      env!("CARGO_PKG_VERSION"),
-      "mech-current",
-      &[],
-      &[],
+      ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "runtime",
+        &[],
+        &[],
+      ),
     )?
     .expect("expected `actor.behavior` to resolve");
 

--- a/src/runtime/src/module/builder.rs
+++ b/src/runtime/src/module/builder.rs
@@ -12,6 +12,33 @@ use crate::{
 #[derive(Clone, Debug, Default)]
 pub struct ModuleBuilder;
 
+#[derive(Clone, Copy, Debug)]
+pub struct ModuleBuildOptions<'a> {
+  pub compiler_version: &'a str,
+  pub language_edition: &'a str,
+  pub target: &'a str,
+  pub feature_flags: &'a [&'a str],
+  pub capability_requirements: &'a [&'a str],
+}
+
+impl<'a> ModuleBuildOptions<'a> {
+  pub fn new(
+    compiler_version: &'a str,
+    language_edition: &'a str,
+    target: &'a str,
+    feature_flags: &'a [&'a str],
+    capability_requirements: &'a [&'a str],
+  ) -> Self {
+    Self {
+      compiler_version,
+      language_edition,
+      target,
+      feature_flags,
+      capability_requirements,
+    }
+  }
+}
+
 impl ModuleBuilder {
   pub fn new() -> Self {
     Self

--- a/src/runtime/src/module/graph.rs
+++ b/src/runtime/src/module/graph.rs
@@ -1,0 +1,48 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::id::ModuleVersionId;
+
+#[derive(Debug, Default, Clone)]
+pub struct ModuleDependencyGraph {
+  stack: Vec<String>,
+  seen: HashSet<String>,
+  cache: HashMap<String, ModuleVersionId>,
+}
+
+impl ModuleDependencyGraph {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn cached_version(&self, canonical_uri: &str) -> Option<ModuleVersionId> {
+    self.cache.get(canonical_uri).copied()
+  }
+
+  pub fn enter(&mut self, canonical_uri: &str) -> Option<Vec<String>> {
+    if self.seen.contains(canonical_uri) {
+      let mut cycle = self.stack.clone();
+      cycle.push(canonical_uri.to_string());
+      return Some(cycle);
+    }
+
+    self.seen.insert(canonical_uri.to_string());
+    self.stack.push(canonical_uri.to_string());
+    None
+  }
+
+  pub fn leave(&mut self, canonical_uri: &str) {
+    let popped = self.stack.pop();
+
+    debug_assert_eq!(
+      popped.as_deref(),
+      Some(canonical_uri),
+      "module dependency graph leave order mismatch",
+    );
+
+    self.seen.remove(canonical_uri);
+  }
+
+  pub fn cache_version(&mut self, canonical_uri: &str, module_version: ModuleVersionId) {
+    self.cache.insert(canonical_uri.to_string(), module_version);
+  }
+}

--- a/src/runtime/src/module/mod.rs
+++ b/src/runtime/src/module/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod record;
 pub mod builder;
+pub mod graph;
 
 pub use record::*;
 pub use builder::*;
+pub use graph::*;

--- a/src/runtime/src/runtime.rs
+++ b/src/runtime/src/runtime.rs
@@ -1086,14 +1086,6 @@ impl MechRuntime {
     options: ModuleBuildOptions<'_>,
   ) -> MResult<Option<ModuleVersionId>> {
     let mut context = self.runtime_context()?;
-    let target = runtime_target();
-    let options = ModuleBuildOptions::new(
-      options.compiler_version,
-      options.language_edition,
-      &target,
-      options.feature_flags,
-      options.capability_requirements,
-    );
 
     self.build_module_from_request_with_context(
       &mut context,
@@ -1148,15 +1140,6 @@ impl MechRuntime {
       name,
       canonical_uri,
       MechSourceCode::String(source.to_string()),
-    );
-
-    let target = runtime_target();
-    let options = ModuleBuildOptions::new(
-      options.compiler_version,
-      options.language_edition,
-      &target,
-      options.feature_flags,
-      options.capability_requirements,
     );
 
     self.build_module_from_resolved_source_with_context(
@@ -2689,10 +2672,6 @@ impl MechErrorKind for RuntimeInvalidOperationError {
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
-
-fn runtime_target() -> String {
-  format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
-}
 
 fn source_fingerprint(source: &MechSourceCode) -> MResult<String> {
   match source {

--- a/src/runtime/src/runtime.rs
+++ b/src/runtime/src/runtime.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use mech_core::{
   MResult, MechError, MechErrorKind, MechSourceCode, Value, NativeFunctionCompiler, MechFunctionImpl,
@@ -81,7 +81,7 @@ use crate::actor_behavior::{
   ActorBehaviorDriver, ActorBehaviorRuntime, NoActorBehaviorDriver,
 };
 
-use crate::module::ModuleBuilder;
+use crate::module::{ModuleBuilder, ModuleBuildOptions, ModuleDependencyGraph};
 
 // -----------------------------------------------------------------------------
 // Runtime Program Host Functions
@@ -908,22 +908,14 @@ impl MechRuntime {
   pub fn store_resolved_module_source(
     &mut self,
     resolved: ResolvedSource,
-    compiler_version: &str,
-    language_edition: &str,
-    target: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
+    options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
     let mut context = self.runtime_context()?;
 
     self.build_module_from_resolved_source_with_context(
       &mut context,
       resolved,
-      compiler_version,
-      language_edition,
-      target,
-      feature_flags,
-      capability_requirements,
+      options,
     )
   }
 
@@ -931,56 +923,35 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
     resolved: ResolvedSource,
-    compiler_version: &str,
-    language_edition: &str,
-    target: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
+    options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
-    let mut dependency_stack = Vec::new();
-    let mut dependency_seen = HashSet::new();
-    let mut dependency_cache = HashMap::new();
+    let mut dependency_graph = ModuleDependencyGraph::new();
 
-    self.build_module_from_resolved_source_with_context_and_stack(
+    self.build_module_from_resolved_source_with_context_and_graph(
       context,
       resolved,
-      compiler_version,
-      language_edition,
-      target,
-      feature_flags,
-      capability_requirements,
-      &mut dependency_stack,
-      &mut dependency_seen,
-      &mut dependency_cache,
+      options,
+      &mut dependency_graph,
     )
   }
 
-  fn build_module_from_resolved_source_with_context_and_stack(
+  fn build_module_from_resolved_source_with_context_and_graph(
     &mut self,
     context: &mut RuntimeContext,
     resolved: ResolvedSource,
-    compiler_version: &str,
-    language_edition: &str,
-    target: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
-    dependency_stack: &mut Vec<String>,
-    dependency_seen: &mut HashSet<String>,
-    dependency_cache: &mut HashMap<String, ModuleVersionId>,
+    options: ModuleBuildOptions<'_>,
+    dependency_graph: &mut ModuleDependencyGraph,
   ) -> MResult<ModuleVersionId> {
     context.validate()?;
     context.charge_step()?;
 
     let canonical_uri = resolved.canonical_uri.clone();
 
-    if let Some(module_version) = dependency_cache.get(&canonical_uri) {
-      return Ok(*module_version);
+    if let Some(module_version) = dependency_graph.cached_version(&canonical_uri) {
+      return Ok(module_version);
     }
 
-    if dependency_seen.contains(&canonical_uri) {
-      let mut cycle = dependency_stack.clone();
-      cycle.push(canonical_uri);
-
+    if let Some(cycle) = dependency_graph.enter(&canonical_uri) {
       return Err(MechError::new(
         RuntimeModuleDependencyCycleError {
           cycle,
@@ -989,18 +960,17 @@ impl MechRuntime {
       ));
     }
 
-    dependency_seen.insert(canonical_uri.clone());
-    dependency_stack.push(canonical_uri.clone());
-
     let result = (|| -> MResult<ModuleVersionId> {
-      let feature_flags_owned = feature_flags
+      let feature_flags_owned = options
+        .feature_flags
         .iter()
         .map(|flag| (*flag).to_string())
         .collect::<Vec<_>>();
 
       let mut resolved = resolved;
 
-      let explicit_capability_requirements = capability_requirements
+      let explicit_capability_requirements = options
+        .capability_requirements
         .iter()
         .map(|resource| {
           CapabilityRequest::from_keys(
@@ -1021,17 +991,11 @@ impl MechRuntime {
       let mut dependency_versions = Vec::new();
 
       for dependency in resolved.dependencies.iter() {
-        if let Some(dependency_version) = self.build_module_from_request_with_context_and_stack(
+        if let Some(dependency_version) = self.build_module_from_request_with_context_and_graph(
           context,
           dependency.clone(),
-          compiler_version,
-          language_edition,
-          target,
-          feature_flags,
-          capability_requirements,
-          dependency_stack,
-          dependency_seen,
-          dependency_cache,
+          options,
+          dependency_graph,
         )? {
           dependency_versions.push(dependency_version);
         }
@@ -1039,9 +1003,9 @@ impl MechRuntime {
 
       let record = self.module_builder.build_resolved_source(
         resolved,
-        compiler_version.to_string(),
-        language_edition.to_string(),
-        target.to_string(),
+        options.compiler_version.to_string(),
+        options.language_edition.to_string(),
+        options.target.to_string(),
         &feature_flags_owned,
         &dependency_versions,
         &concrete_capability_requirements,
@@ -1063,7 +1027,7 @@ impl MechRuntime {
         .get_module_version(record.module_version)?
         .is_some()
       {
-        dependency_cache.insert(canonical_uri.clone(), record.module_version);
+        dependency_graph.cache_version(&canonical_uri, record.module_version);
         return Ok(record.module_version);
       }
 
@@ -1078,7 +1042,7 @@ impl MechRuntime {
 
       self.store.put_module_version(version)?;
 
-      dependency_cache.insert(canonical_uri.clone(), record.module_version);
+      dependency_graph.cache_version(&canonical_uri, record.module_version);
 
       self.emit_event_to_context(
         context,
@@ -1090,41 +1054,28 @@ impl MechRuntime {
       Ok(record.module_version)
     })();
 
-    dependency_stack.pop();
-    dependency_seen.remove(&canonical_uri);
+    dependency_graph.leave(&canonical_uri);
 
     result
   }
 
-  fn build_module_from_request_with_context_and_stack(
+  fn build_module_from_request_with_context_and_graph(
     &mut self,
     context: &mut RuntimeContext,
     request: impl Into<SourceRequest>,
-    compiler_version: &str,
-    language_edition: &str,
-    target: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
-    dependency_stack: &mut Vec<String>,
-    dependency_seen: &mut HashSet<String>,
-    dependency_cache: &mut HashMap<String, ModuleVersionId>,
+    options: ModuleBuildOptions<'_>,
+    dependency_graph: &mut ModuleDependencyGraph,
   ) -> MResult<Option<ModuleVersionId>> {
     let Some(resolved) = self.resolve_source_with_context(context, request)? else {
       return Ok(None);
     };
 
     Ok(Some(
-      self.build_module_from_resolved_source_with_context_and_stack(
+      self.build_module_from_resolved_source_with_context_and_graph(
         context,
         resolved,
-        compiler_version,
-        language_edition,
-        target,
-        feature_flags,
-        capability_requirements,
-        dependency_stack,
-        dependency_seen,
-        dependency_cache,
+        options,
+        dependency_graph,
       )?,
     ))
   }
@@ -1132,22 +1083,22 @@ impl MechRuntime {
   pub fn resolve_and_store_module_source(
     &mut self,
     request: impl Into<SourceRequest>,
-    compiler_version: &str,
-    language_edition: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
+    options: ModuleBuildOptions<'_>,
   ) -> MResult<Option<ModuleVersionId>> {
     let mut context = self.runtime_context()?;
     let target = runtime_target();
+    let options = ModuleBuildOptions::new(
+      options.compiler_version,
+      options.language_edition,
+      &target,
+      options.feature_flags,
+      options.capability_requirements,
+    );
 
     self.build_module_from_request_with_context(
       &mut context,
       request,
-      compiler_version,
-      language_edition,
-      &target,
-      feature_flags,
-      capability_requirements,
+      options,
     )
   }
 
@@ -1155,27 +1106,15 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
     request: impl Into<SourceRequest>,
-    compiler_version: &str,
-    language_edition: &str,
-    target: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
+    options: ModuleBuildOptions<'_>,
   ) -> MResult<Option<ModuleVersionId>> {
-    let mut dependency_stack = Vec::new();
-    let mut dependency_seen = HashSet::new();
-    let mut dependency_cache = HashMap::new();
+    let mut dependency_graph = ModuleDependencyGraph::new();
 
-    self.build_module_from_request_with_context_and_stack(
+    self.build_module_from_request_with_context_and_graph(
       context,
       request,
-      compiler_version,
-      language_edition,
-      target,
-      feature_flags,
-      capability_requirements,
-      &mut dependency_stack,
-      &mut dependency_seen,
-      &mut dependency_cache,
+      options,
+      &mut dependency_graph,
     )
   }
 
@@ -1184,10 +1123,7 @@ impl MechRuntime {
     name: &str,
     canonical_uri: &str,
     source: &str,
-    compiler_version: &str,
-    language_edition: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
+    options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
     let mut context = self.runtime_context()?;
 
@@ -1196,10 +1132,7 @@ impl MechRuntime {
       name,
       canonical_uri,
       source,
-      compiler_version,
-      language_edition,
-      feature_flags,
-      capability_requirements,
+      options,
     )
   }
 
@@ -1209,10 +1142,7 @@ impl MechRuntime {
     name: &str,
     canonical_uri: &str,
     source: &str,
-    compiler_version: &str,
-    language_edition: &str,
-    feature_flags: &[&str],
-    capability_requirements: &[&str],
+    options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
     let resolved = ResolvedSource::new(
       name,
@@ -1221,15 +1151,18 @@ impl MechRuntime {
     );
 
     let target = runtime_target();
+    let options = ModuleBuildOptions::new(
+      options.compiler_version,
+      options.language_edition,
+      &target,
+      options.feature_flags,
+      options.capability_requirements,
+    );
 
     self.build_module_from_resolved_source_with_context(
       context,
       resolved,
-      compiler_version,
-      language_edition,
-      &target,
-      feature_flags,
-      capability_requirements,
+      options,
     )
   }
 


### PR DESCRIPTION
### Motivation

- Introduce a single options struct for module build parameters to simplify and centralize build configuration for module compilation and to prepare for consistent target/feature/capability handling. 
- Replace ad-hoc dependency tracking state with a dedicated dependency graph to improve cycle detection and caching during recursive module builds.

### Description

- Add `ModuleBuildOptions` to `module::builder` and thread it through runtime APIs, replacing multiple individual build parameters (`compiler_version`, `language_edition`, `target`, `feature_flags`, `capability_requirements`).
- Implement `ModuleDependencyGraph` in `module::graph` and switch the runtime to use it for dependency traversal, cycle detection, and cached version lookup.
- Refactor runtime module build APIs to accept `ModuleBuildOptions` and to use the new `ModuleDependencyGraph`, including `build_module_from_resolved_source_with_context`, `build_module_from_request_with_context`, `resolve_and_store_module_source`, and related helpers.
- Update `module::mod` exports and update example binaries to construct and pass `ModuleBuildOptions::new(...)` instead of separate parameters.

### Testing

- Ran `cargo build` for the workspace to verify compilation after the refactor and the build completed successfully.
- Ran the crate unit tests with `cargo test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149286d928832a9498f7229acd35b7)