### PR TITLE
Fix direct run double execution

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -548,13 +548,8 @@ async fn main() -> Result<(), MechError> {
       if any_look_like_paths {
         let mut run_errors = Vec::new();
         for p in &paths {
-          match std::fs::read_to_string(p) {
-            Ok(src) => {
-              if let Err(err) = program.run_string(&src) {
-                run_errors.push(err);
-              }
-            }
-            Err(err) => run_errors.push(MechError::new(GenericError{msg: format!("Unable to read source `{}`: {}", p, err)}, None).with_compiler_loc()),
+          if let Err(err) = std::fs::read_to_string(p) {
+            run_errors.push(MechError::new(GenericError{msg: format!("Unable to read source `{}`: {}", p, err)}, None).with_compiler_loc());
           }
         }
         if !run_errors.is_empty() {


### PR DESCRIPTION
## Summary

This fixes the direct CLI run path executing source files twice.

Previously, when positional arguments looked like file paths, the CLI read each path and called `program.run_string(&src)` during the validation/error-collection pass. It then read the same paths again and called `program.run_string(&src)` again when computing the final result. The second execution reused the same `MechProgram`, so repeated variable definitions failed with `VariableAlreadyDefined`.

This change keeps the early path/readability validation but removes the first execution. Source files are now executed only once in the final result block.

## Reproduction

Before this patch:

```powershell
./target/debug/mech examples\working\bubble-sort.mec
```

could fail with `VariableAlreadyDefined`, while:

```powershell
./target/debug/mech test examples\working\bubble-sort.mec
```

succeeded because the `test` subcommand exits before entering the direct run path.

## Notes

I did not run the test suite from this environment. The patch is limited to `src/bin/mech.rs` and changes only the direct-run path validation behavior.