### PR TITLE
Build source declaration index from parsed programs

### DIFF
--- a/src/runtime/src/resolver/ast.rs
+++ b/src/runtime/src/resolver/ast.rs
@@ -29,7 +29,10 @@ pub fn contexts_from_program(tree: &Program) -> Vec<SourceContextDeclaration> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::resolver::{FileSourceResolver, SourceDeclaration, SourceRequest, SourceResolver, SourceScope};
+  use crate::resolver::{
+    FileSourceResolver, SourceContextBase, SourceContextCapabilityScope, SourceDeclaration,
+    SourceRequest, SourceResolver, SourceScope,
+  };
 
   fn parse_program(source: &str) -> Program {
     mech_syntax::parser::parse(source).unwrap()

--- a/src/runtime/src/resolver/ast.rs
+++ b/src/runtime/src/resolver/ast.rs
@@ -1,141 +1,132 @@
-use mech_core::{ContextBase, ContextCapabilityScope, MechCode, Program, SectionElement, Statement};
+use mech_core::Program;
 
 use super::{
-  classify_import_specifier, exports_from_fenced_code, imports_from_fenced_code,
-  source_request_for_import, SourceContextBase, SourceContextCapability,
-  SourceContextCapabilityScope, SourceContextDeclaration, SourceExportDeclaration,
-  SourceImportDeclaration, SourceRequest,
+    source_request_for_import, SourceContextDeclaration, SourceExportDeclaration,
+    SourceImportDeclaration, SourceIndex, SourceRequest,
 };
 
 pub fn imports_from_program(tree: &Program) -> Vec<SourceImportDeclaration> {
-  let mut imports = Vec::new();
-  for section in &tree.body.sections {
-    for element in &section.elements {
-      match element {
-        SectionElement::FencedMechCode(code) => imports.extend(imports_from_fenced_code(code)),
-        SectionElement::MechCode(code_items) => {
-          for (code, _) in code_items {
-            if let MechCode::Statement(Statement::ImportDeclaration(import)) = code {
-              imports.push(classify_import_specifier(import.specifier.to_string()));
-            }
-          }
-        }
-        _ => {}
-      }
-    }
-  }
-  imports
+    SourceIndex::from_program(tree).all_imports()
 }
 
 pub fn exports_from_program(tree: &Program) -> Vec<SourceExportDeclaration> {
-  let mut exports = Vec::new();
-  for section in &tree.body.sections {
-    for element in &section.elements {
-      match element {
-        SectionElement::FencedMechCode(code) => exports.extend(exports_from_fenced_code(code)),
-        SectionElement::MechCode(code_items) => {
-          for (code, _) in code_items {
-            if let MechCode::Statement(Statement::ExportDeclaration(export)) = code {
-              exports.push(SourceExportDeclaration {
-                name: export.name.to_string(),
-              });
-            }
-          }
-        }
-        _ => {}
-      }
-    }
-  }
-  exports
+    SourceIndex::from_program(tree).all_exports()
 }
 
 pub fn dependencies_from_program(tree: &Program, referrer: Option<&str>) -> Vec<SourceRequest> {
-  imports_from_program(tree)
-    .iter()
-    .map(|import| source_request_for_import(import, referrer))
-    .collect()
+    SourceIndex::from_program(tree)
+        .all_imports()
+        .iter()
+        .map(|import| source_request_for_import(import, referrer))
+        .collect()
 }
 
-
 pub fn contexts_from_program(tree: &Program) -> Vec<SourceContextDeclaration> {
-  let mut contexts = Vec::new();
-  for section in &tree.body.sections {
-    for element in &section.elements {
-      if let SectionElement::MechCode(code_items) = element {
-        for (code, _) in code_items {
-          if let MechCode::Statement(Statement::ContextDeclaration(context)) = code {
-            let base = match &context.base {
-              ContextBase::ResourceUri(uri) => SourceContextBase::ResourceUri(uri.to_string()),
-              ContextBase::Context(name) => SourceContextBase::Context(name.to_string()),
-            };
-            let capabilities = context.capabilities.iter().map(|capability| {
-              let scope = match &capability.scope {
-                ContextCapabilityScope::Path(path) => SourceContextCapabilityScope::Path(path.to_string()),
-                ContextCapabilityScope::Wildcard(_) => SourceContextCapabilityScope::Wildcard,
-              };
-              SourceContextCapability {
-                operation: capability.operation.to_string(),
-                scope,
-              }
-            }).collect::<Vec<_>>();
-            contexts.push(SourceContextDeclaration {
-              name: context.name.to_string(),
-              base,
-              capabilities,
-            });
-          }
-        }
-      }
-    }
-  }
-  contexts
+    SourceIndex::from_program(tree).all_contexts()
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
+    use crate::resolver::{FileSourceResolver, SourceResolver, SourceScope};
 
-  fn parse_program(source: &str) -> Program {
-    mech_syntax::parser::parse(source).unwrap()
-  }
+    fn parse_program(source: &str) -> Program {
+        mech_syntax::parser::parse(source).unwrap()
+    }
 
-  #[test]
-  fn resolved_source_extracts_resource_context() {
-    let tree = parse_program("@main := db://main{:read(users/*), :write(users/name)}\nx := users/name@main\n");
-    let contexts = contexts_from_program(&tree);
-    assert_eq!(contexts.len(), 1);
-    assert_eq!(contexts[0].name, "main");
-    assert_eq!(contexts[0].base, SourceContextBase::ResourceUri("db://main".to_string()));
-    assert_eq!(contexts[0].capabilities.len(), 2);
-    assert_eq!(contexts[0].capabilities[0].operation, "read");
-    assert_eq!(contexts[0].capabilities[0].scope, SourceContextCapabilityScope::Path("users/*".to_string()));
-    assert_eq!(contexts[0].capabilities[1].operation, "write");
-    assert_eq!(contexts[0].capabilities[1].scope, SourceContextCapabilityScope::Path("users/name".to_string()));
-  }
+    #[test]
+    fn source_index_collects_program_declarations() {
+        let tree = parse_program("@main := db://main{:read(users/*)}\n+> ./math.mec\n<+ tau\n");
+        let index = SourceIndex::from_program(&tree);
+        assert_eq!(index.contexts.len(), 1);
+        assert_eq!(index.imports.len(), 1);
+        assert_eq!(index.exports.len(), 1);
+        assert_eq!(index.contexts[0].occurrence.scope, SourceScope::Program);
+        assert_eq!(index.imports[0].occurrence.scope, SourceScope::Program);
+        assert_eq!(index.exports[0].occurrence.scope, SourceScope::Program);
+        assert!(matches!(
+            index.declarations[0],
+            crate::resolver::SourceDeclaration::Context(_)
+        ));
+        assert!(matches!(
+            index.declarations[1],
+            crate::resolver::SourceDeclaration::Import(_)
+        ));
+        assert!(matches!(
+            index.declarations[2],
+            crate::resolver::SourceDeclaration::Export(_)
+        ));
+    }
 
-  #[test]
-  fn resolved_source_extracts_derived_context() {
-    let tree = parse_program("@main := db://main{:read(users/*), :write(users/name)}\n@users := @main{:read(users/*)}\n");
-    let contexts = contexts_from_program(&tree);
-    assert_eq!(contexts.len(), 2);
-    assert_eq!(contexts[0].base, SourceContextBase::ResourceUri("db://main".to_string()));
-    assert_eq!(contexts[1].name, "users");
-    assert_eq!(contexts[1].base, SourceContextBase::Context("main".to_string()));
-  }
+    #[test]
+    fn source_index_collects_fenced_interpreter_declarations() {
+        let tree = parse_program(
+            "~~~mech:foo\n@main := db://main{:read(users/*)}\n+> math/tau\n<+ result\n~~~\n",
+        );
+        let index = SourceIndex::from_program(&tree);
+        let scopes = index.interpreter_scopes();
+        assert_eq!(scopes.len(), 1);
+        assert_eq!(scopes[0].namespace_str, "foo");
+        let foo_scope = SourceScope::Interpreter(scopes[0].clone());
+        assert_eq!(index.contexts_for_scope(&foo_scope).len(), 1);
+        assert_eq!(index.imports_for_scope(&foo_scope).len(), 1);
+        assert_eq!(index.exports_for_scope(&foo_scope).len(), 1);
+        assert!(index.program_contexts().is_empty());
+        assert!(index.program_imports().is_empty());
+        assert!(index.program_exports().is_empty());
+    }
 
-  #[test]
-  fn resolved_source_extracts_wildcard_context_scope() {
-    let tree = parse_program("@main := db://main{:write(*)}\n");
-    let contexts = contexts_from_program(&tree);
-    assert_eq!(contexts[0].capabilities[0].operation, "write");
-    assert_eq!(contexts[0].capabilities[0].scope, SourceContextCapabilityScope::Wildcard);
-  }
+    #[test]
+    fn source_index_keeps_program_and_interpreter_scopes_separate() {
+        let tree = parse_program(
+            "@doc := db://doc{:read(*)}\n+> ./doc.mec\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n",
+        );
+        let index = SourceIndex::from_program(&tree);
+        assert_eq!(index.program_contexts()[0].name, "doc");
+        assert_eq!(index.program_imports()[0].specifier, "./doc.mec");
+        let foo = index
+            .interpreter_scopes()
+            .into_iter()
+            .find(|s| s.namespace_str == "foo")
+            .unwrap();
+        let foo_scope = SourceScope::Interpreter(foo);
+        assert_eq!(index.contexts_for_scope(&foo_scope)[0].name, "foo-db");
+        assert_eq!(
+            index.imports_for_scope(&foo_scope)[0].specifier,
+            "./foo.mec"
+        );
+        assert_eq!(index.exports_for_scope(&foo_scope)[0].name, "foo-result");
+        assert_eq!(index.all_imports().len(), 2);
+        assert_eq!(index.all_contexts().len(), 2);
+        assert_eq!(index.all_exports().len(), 1);
+    }
 
-  #[test]
-  fn context_extraction_does_not_break_import_export_extraction() {
-    let tree = parse_program("@main := db://main{:read(users/*)}\n+> ./math.mec\n<+ tau\n");
-    assert_eq!(contexts_from_program(&tree).len(), 1);
-    assert_eq!(imports_from_program(&tree).len(), 1);
-    assert_eq!(exports_from_program(&tree).len(), 1);
-  }
+    #[test]
+    fn legacy_helpers_match_source_index_all_views() {
+        let tree = parse_program(
+            "@doc := db://doc{:read(*)}\n+> ./doc.mec\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n",
+        );
+        let index = SourceIndex::from_program(&tree);
+        assert_eq!(imports_from_program(&tree), index.all_imports());
+        assert_eq!(exports_from_program(&tree), index.all_exports());
+        assert_eq!(contexts_from_program(&tree), index.all_contexts());
+    }
+
+    #[test]
+    fn file_resolver_uses_index_without_behavior_change() {
+        let tmp = std::env::temp_dir().join(format!("mech-source-index-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("main.mec");
+        std::fs::write(&path, "@doc := db://doc{:read(*)}\n+> ./doc.mec\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n").unwrap();
+        let tree = parse_program(&std::fs::read_to_string(&path).unwrap());
+        let index = SourceIndex::from_program(&tree);
+        let resolver = FileSourceResolver::new(&tmp);
+        let resolved = resolver
+            .resolve(&crate::resolver::SourceRequest::new("main.mec"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.imports, index.all_imports());
+        assert_eq!(resolved.exports, index.all_exports());
+        assert_eq!(resolved.contexts, index.all_contexts());
+    }
 }

--- a/src/runtime/src/resolver/ast.rs
+++ b/src/runtime/src/resolver/ast.rs
@@ -1,132 +1,116 @@
 use mech_core::Program;
 
 use super::{
-    source_request_for_import, SourceContextDeclaration, SourceExportDeclaration,
-    SourceImportDeclaration, SourceIndex, SourceRequest,
+  source_request_for_import, SourceContextDeclaration, SourceExportDeclaration,
+  SourceImportDeclaration, SourceIndex, SourceRequest,
 };
 
 pub fn imports_from_program(tree: &Program) -> Vec<SourceImportDeclaration> {
-    SourceIndex::from_program(tree).all_imports()
+  SourceIndex::from_program(tree).all_imports()
 }
 
 pub fn exports_from_program(tree: &Program) -> Vec<SourceExportDeclaration> {
-    SourceIndex::from_program(tree).all_exports()
+  SourceIndex::from_program(tree).all_exports()
 }
 
 pub fn dependencies_from_program(tree: &Program, referrer: Option<&str>) -> Vec<SourceRequest> {
-    SourceIndex::from_program(tree)
-        .all_imports()
-        .iter()
-        .map(|import| source_request_for_import(import, referrer))
-        .collect()
+  SourceIndex::from_program(tree)
+    .all_imports()
+    .iter()
+    .map(|import| source_request_for_import(import, referrer))
+    .collect()
 }
 
+
 pub fn contexts_from_program(tree: &Program) -> Vec<SourceContextDeclaration> {
-    SourceIndex::from_program(tree).all_contexts()
+  SourceIndex::from_program(tree).all_contexts()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::resolver::{FileSourceResolver, SourceResolver, SourceScope};
+  use super::*;
+  use crate::resolver::{FileSourceResolver, SourceDeclaration, SourceRequest, SourceResolver, SourceScope};
 
-    fn parse_program(source: &str) -> Program {
-        mech_syntax::parser::parse(source).unwrap()
-    }
+  fn parse_program(source: &str) -> Program {
+    mech_syntax::parser::parse(source).unwrap()
+  }
 
-    #[test]
-    fn source_index_collects_program_declarations() {
-        let tree = parse_program("@main := db://main{:read(users/*)}\n+> ./math.mec\n<+ tau\n");
-        let index = SourceIndex::from_program(&tree);
-        assert_eq!(index.contexts.len(), 1);
-        assert_eq!(index.imports.len(), 1);
-        assert_eq!(index.exports.len(), 1);
-        assert_eq!(index.contexts[0].occurrence.scope, SourceScope::Program);
-        assert_eq!(index.imports[0].occurrence.scope, SourceScope::Program);
-        assert_eq!(index.exports[0].occurrence.scope, SourceScope::Program);
-        assert!(matches!(
-            index.declarations[0],
-            crate::resolver::SourceDeclaration::Context(_)
-        ));
-        assert!(matches!(
-            index.declarations[1],
-            crate::resolver::SourceDeclaration::Import(_)
-        ));
-        assert!(matches!(
-            index.declarations[2],
-            crate::resolver::SourceDeclaration::Export(_)
-        ));
-    }
+  #[test]
+  fn resolved_source_extracts_resource_context() {
+    let tree = parse_program("@main := db://main{:read(users/*), :write(users/name)}\nx := users/name@main\n");
+    let contexts = contexts_from_program(&tree);
+    assert_eq!(contexts.len(), 1);
+    assert_eq!(contexts[0].name, "main");
+    assert_eq!(contexts[0].base, SourceContextBase::ResourceUri("db://main".to_string()));
+    assert_eq!(contexts[0].capabilities.len(), 2);
+    assert_eq!(contexts[0].capabilities[0].operation, "read");
+    assert_eq!(contexts[0].capabilities[0].scope, SourceContextCapabilityScope::Path("users/*".to_string()));
+    assert_eq!(contexts[0].capabilities[1].operation, "write");
+    assert_eq!(contexts[0].capabilities[1].scope, SourceContextCapabilityScope::Path("users/name".to_string()));
+  }
 
-    #[test]
-    fn source_index_collects_fenced_interpreter_declarations() {
-        let tree = parse_program(
-            "~~~mech:foo\n@main := db://main{:read(users/*)}\n+> math/tau\n<+ result\n~~~\n",
-        );
-        let index = SourceIndex::from_program(&tree);
-        let scopes = index.interpreter_scopes();
-        assert_eq!(scopes.len(), 1);
-        assert_eq!(scopes[0].namespace_str, "foo");
-        let foo_scope = SourceScope::Interpreter(scopes[0].clone());
-        assert_eq!(index.contexts_for_scope(&foo_scope).len(), 1);
-        assert_eq!(index.imports_for_scope(&foo_scope).len(), 1);
-        assert_eq!(index.exports_for_scope(&foo_scope).len(), 1);
-        assert!(index.program_contexts().is_empty());
-        assert!(index.program_imports().is_empty());
-        assert!(index.program_exports().is_empty());
-    }
+  #[test]
+  fn resolved_source_extracts_derived_context() {
+    let tree = parse_program("@main := db://main{:read(users/*), :write(users/name)}\n@users := @main{:read(users/*)}\n");
+    let contexts = contexts_from_program(&tree);
+    assert_eq!(contexts.len(), 2);
+    assert_eq!(contexts[0].base, SourceContextBase::ResourceUri("db://main".to_string()));
+    assert_eq!(contexts[1].name, "users");
+    assert_eq!(contexts[1].base, SourceContextBase::Context("main".to_string()));
+  }
 
-    #[test]
-    fn source_index_keeps_program_and_interpreter_scopes_separate() {
-        let tree = parse_program(
-            "@doc := db://doc{:read(*)}\n+> ./doc.mec\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n",
-        );
-        let index = SourceIndex::from_program(&tree);
-        assert_eq!(index.program_contexts()[0].name, "doc");
-        assert_eq!(index.program_imports()[0].specifier, "./doc.mec");
-        let foo = index
-            .interpreter_scopes()
-            .into_iter()
-            .find(|s| s.namespace_str == "foo")
-            .unwrap();
-        let foo_scope = SourceScope::Interpreter(foo);
-        assert_eq!(index.contexts_for_scope(&foo_scope)[0].name, "foo-db");
-        assert_eq!(
-            index.imports_for_scope(&foo_scope)[0].specifier,
-            "./foo.mec"
-        );
-        assert_eq!(index.exports_for_scope(&foo_scope)[0].name, "foo-result");
-        assert_eq!(index.all_imports().len(), 2);
-        assert_eq!(index.all_contexts().len(), 2);
-        assert_eq!(index.all_exports().len(), 1);
-    }
+  #[test]
+  fn resolved_source_extracts_wildcard_context_scope() {
+    let tree = parse_program("@main := db://main{:write(*)}\n");
+    let contexts = contexts_from_program(&tree);
+    assert_eq!(contexts[0].capabilities[0].operation, "write");
+    assert_eq!(contexts[0].capabilities[0].scope, SourceContextCapabilityScope::Wildcard);
+  }
 
-    #[test]
-    fn legacy_helpers_match_source_index_all_views() {
-        let tree = parse_program(
-            "@doc := db://doc{:read(*)}\n+> ./doc.mec\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n",
-        );
-        let index = SourceIndex::from_program(&tree);
-        assert_eq!(imports_from_program(&tree), index.all_imports());
-        assert_eq!(exports_from_program(&tree), index.all_exports());
-        assert_eq!(contexts_from_program(&tree), index.all_contexts());
-    }
+  #[test]
+  fn context_extraction_does_not_break_import_export_extraction() {
+    let tree = parse_program("@main := db://main{:read(users/*)}\n+> ./math.mec\n<+ tau\n");
+    assert_eq!(contexts_from_program(&tree).len(), 1);
+    assert_eq!(imports_from_program(&tree).len(), 1);
+    assert_eq!(exports_from_program(&tree).len(), 1);
+  }
 
-    #[test]
-    fn file_resolver_uses_index_without_behavior_change() {
-        let tmp = std::env::temp_dir().join(format!("mech-source-index-{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
-        let path = tmp.join("main.mec");
-        std::fs::write(&path, "@doc := db://doc{:read(*)}\n+> ./doc.mec\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n").unwrap();
-        let tree = parse_program(&std::fs::read_to_string(&path).unwrap());
-        let index = SourceIndex::from_program(&tree);
-        let resolver = FileSourceResolver::new(&tmp);
-        let resolved = resolver
-            .resolve(&crate::resolver::SourceRequest::new("main.mec"))
-            .unwrap()
-            .unwrap();
-        assert_eq!(resolved.imports, index.all_imports());
-        assert_eq!(resolved.exports, index.all_exports());
-        assert_eq!(resolved.contexts, index.all_contexts());
-    }
+  #[test]
+  fn source_index_collects_program_declarations() {
+    let tree = parse_program("@main := db://main{:read(users/*)}\n+> ./math.mec\n<+ tau\n");
+    let index = SourceIndex::from_program(&tree);
+    assert_eq!(index.contexts.len(), 1);
+    assert_eq!(index.imports.len(), 1);
+    assert_eq!(index.exports.len(), 1);
+    assert_eq!(index.contexts[0].occurrence.scope, SourceScope::Program);
+    assert_eq!(index.imports[0].occurrence.scope, SourceScope::Program);
+    assert_eq!(index.exports[0].occurrence.scope, SourceScope::Program);
+    assert!(matches!(index.declarations[0], SourceDeclaration::Context(_)));
+    assert!(matches!(index.declarations[1], SourceDeclaration::Import(_)));
+    assert!(matches!(index.declarations[2], SourceDeclaration::Export(_)));
+  }
+
+  #[test]
+  fn legacy_helpers_match_source_index_all_views() {
+    let tree = parse_program("@doc := db://doc{:read(*)}\n+> ./doc.mec\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n");
+    let index = SourceIndex::from_program(&tree);
+    assert_eq!(imports_from_program(&tree), index.all_imports());
+    assert_eq!(exports_from_program(&tree), index.all_exports());
+    assert_eq!(contexts_from_program(&tree), index.all_contexts());
+  }
+
+  #[test]
+  fn file_resolver_uses_index_without_behavior_change() {
+    let tmp = std::env::temp_dir().join(format!("mech-source-index-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let path = tmp.join("main.mec");
+    std::fs::write(&path, "@doc := db://doc{:read(*)}\n+> ./doc.mec\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n").unwrap();
+    let tree = parse_program(&std::fs::read_to_string(&path).unwrap());
+    let index = SourceIndex::from_program(&tree);
+    let resolver = FileSourceResolver::new(&tmp);
+    let resolved = resolver.resolve(&SourceRequest::new("main.mec")).unwrap().unwrap();
+    assert_eq!(resolved.imports, index.all_imports());
+    assert_eq!(resolved.exports, index.all_exports());
+    assert_eq!(resolved.contexts, index.all_contexts());
+  }
 }

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -6,438 +6,423 @@ use std::path::{Path, PathBuf};
 use mech_core::{MResult, MechError, MechSourceCode};
 
 use crate::resolver::{
-  contexts_from_program, exports_from_program, imports_from_program, source_request_for_import,
-  ResolvedSource, SourceRequest, SourceResolver,
+    source_request_for_import, ResolvedSource, SourceIndex, SourceRequest, SourceResolver,
 };
 
 use super::{
-  SourceExtensionDecodeFailed, SourceFileOpenFailed, SourceFileReadFailed,
-  SourceIncludeCycle, SourceIncludeReadFailed, SourceKind,
-  SourceUnknownFileExtension,
+    SourceExtensionDecodeFailed, SourceFileOpenFailed, SourceFileReadFailed, SourceIncludeCycle,
+    SourceIncludeReadFailed, SourceKind, SourceUnknownFileExtension,
 };
 
 #[derive(Clone, Debug)]
 pub struct FileSourceResolver {
-  roots: Vec<PathBuf>,
+    roots: Vec<PathBuf>,
 }
 
 impl FileSourceResolver {
-  pub fn new(root: impl Into<PathBuf>) -> Self {
-    Self {
-      roots: vec![root.into()],
-    }
-  }
-
-  pub fn empty() -> Self {
-    Self {
-      roots: Vec::new(),
-    }
-  }
-
-  pub fn with_root(mut self, root: impl Into<PathBuf>) -> Self {
-    self.roots.push(root.into());
-    self
-  }
-
-  pub fn add_root(&mut self, root: impl Into<PathBuf>) {
-    self.roots.push(root.into());
-  }
-
-  pub fn roots(&self) -> &[PathBuf] {
-    &self.roots
-  }
-
-  fn resolve_path(
-    &self,
-    request: &SourceRequest,
-  ) -> MResult<Option<PathBuf>> {
-    let specifier = Path::new(&request.specifier);
-
-    if specifier.is_absolute() && specifier.exists() {
-      return Ok(Some(canonicalize_source_path(specifier)?));
-    }
-
-    if let Some(referrer) = &request.referrer {
-      let referrer_path = Path::new(referrer);
-
-      let parent = if referrer_path.is_dir() {
-        Some(referrer_path)
-      } else {
-        referrer_path.parent()
-      };
-
-      if let Some(parent) = parent {
-        for candidate in path_candidates(parent, specifier) {
-          if candidate.is_file() {
-            return Ok(Some(canonicalize_source_path(&candidate)?));
-          }
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            roots: vec![root.into()],
         }
-      }
     }
 
-    for root in &self.roots {
-      for candidate in path_candidates(root, specifier) {
-        if candidate.is_file() {
-          return Ok(Some(canonicalize_source_path(&candidate)?));
+    pub fn empty() -> Self {
+        Self { roots: Vec::new() }
+    }
+
+    pub fn with_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.roots.push(root.into());
+        self
+    }
+
+    pub fn add_root(&mut self, root: impl Into<PathBuf>) {
+        self.roots.push(root.into());
+    }
+
+    pub fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+
+    fn resolve_path(&self, request: &SourceRequest) -> MResult<Option<PathBuf>> {
+        let specifier = Path::new(&request.specifier);
+
+        if specifier.is_absolute() && specifier.exists() {
+            return Ok(Some(canonicalize_source_path(specifier)?));
         }
-      }
-    }
 
-    Ok(None)
-  }
+        if let Some(referrer) = &request.referrer {
+            let referrer_path = Path::new(referrer);
+
+            let parent = if referrer_path.is_dir() {
+                Some(referrer_path)
+            } else {
+                referrer_path.parent()
+            };
+
+            if let Some(parent) = parent {
+                for candidate in path_candidates(parent, specifier) {
+                    if candidate.is_file() {
+                        return Ok(Some(canonicalize_source_path(&candidate)?));
+                    }
+                }
+            }
+        }
+
+        for root in &self.roots {
+            for candidate in path_candidates(root, specifier) {
+                if candidate.is_file() {
+                    return Ok(Some(canonicalize_source_path(&candidate)?));
+                }
+            }
+        }
+
+        Ok(None)
+    }
 }
 
 impl SourceResolver for FileSourceResolver {
-  fn resolve(
-    &self,
-    request: &SourceRequest,
-  ) -> MResult<Option<ResolvedSource>> {
-    request.validate()?;
+    fn resolve(&self, request: &SourceRequest) -> MResult<Option<ResolvedSource>> {
+        request.validate()?;
 
-    let Some(path) = self.resolve_path(request)? else {
-      return Ok(None);
-    };
+        let Some(path) = self.resolve_path(request)? else {
+            return Ok(None);
+        };
 
-    let kind = SourceKind::from_path(&path);
-    let source = read_runtime_source_file(&path)?;
-    let name = path
-      .file_name()
-      .and_then(|name| name.to_str())
-      .unwrap_or("source")
-      .to_string();
+        let kind = SourceKind::from_path(&path);
+        let source = read_runtime_source_file(&path)?;
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("source")
+            .to_string();
 
-    let mut resolved = ResolvedSource::new(name, file_uri(&path), source).with_kind(kind);
+        let mut resolved = ResolvedSource::new(name, file_uri(&path), source).with_kind(kind);
 
-    if resolved.kind == SourceKind::Mech {
-      if let MechSourceCode::String(source_text) = &resolved.source {
-        let tree = mech_syntax::parser::parse(source_text.trim())?;
-        let referrer = path.to_string_lossy().to_string();
-        let imports = imports_from_program(&tree);
-        let exports = exports_from_program(&tree);
-        let contexts = contexts_from_program(&tree);
-        let dependencies = imports
-          .iter()
-          .map(|import| source_request_for_import(import, Some(&referrer)))
-          .collect::<Vec<_>>();
+        if resolved.kind == SourceKind::Mech {
+            if let MechSourceCode::String(source_text) = &resolved.source {
+                let tree = mech_syntax::parser::parse(source_text.trim())?;
+                let referrer = path.to_string_lossy().to_string();
+                let index = SourceIndex::from_program(&tree);
+                let imports = index.all_imports();
+                let exports = index.all_exports();
+                let contexts = index.all_contexts();
+                let dependencies = imports
+                    .iter()
+                    .map(|import| source_request_for_import(import, Some(&referrer)))
+                    .collect::<Vec<_>>();
 
-        resolved = resolved
-          .with_imports(imports)
-          .with_exports(exports)
-          .with_contexts(contexts)
-          .with_dependencies(dependencies);
-      }
+                resolved = resolved
+                    .with_imports(imports)
+                    .with_exports(exports)
+                    .with_contexts(contexts)
+                    .with_dependencies(dependencies);
+            }
+        }
+
+        Ok(Some(resolved))
     }
-
-    Ok(Some(resolved))
-  }
 }
 
 fn path_candidates(base: &Path, specifier: &Path) -> Vec<PathBuf> {
-  vec![
-    base.join(specifier),
-    base.join(format!("{}.mec", specifier.to_string_lossy())),
-    base.join(specifier).join("index.mec"),
-  ]
+    vec![
+        base.join(specifier),
+        base.join(format!("{}.mec", specifier.to_string_lossy())),
+        base.join(specifier).join("index.mec"),
+    ]
 }
 
 pub fn read_runtime_source_file(path: &Path) -> MResult<MechSourceCode> {
-  let extension = path
-    .extension()
-    .and_then(|extension| extension.to_str())
-    .ok_or_else(|| {
-      MechError::new(
-        SourceExtensionDecodeFailed {
-          path: path.display().to_string(),
-        },
-        None,
-      )
-    })?
-    .to_ascii_lowercase();
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .ok_or_else(|| {
+            MechError::new(
+                SourceExtensionDecodeFailed {
+                    path: path.display().to_string(),
+                },
+                None,
+            )
+        })?
+        .to_ascii_lowercase();
 
-  match extension.as_str() {
-    "mec" | "🤖" => {
-      let expanded = expand_mechdown_includes(path)?;
-      Ok(MechSourceCode::String(expanded))
+    match extension.as_str() {
+        "mec" | "🤖" => {
+            let expanded = expand_mechdown_includes(path)?;
+            Ok(MechSourceCode::String(expanded))
+        }
+
+        "mecb" => {
+            // Keep this as raw bytecode source for now only if your MechSourceCode
+            // supports ByteCode(Vec<u8>). If your current loader needs
+            // `load_program_from_file`, wire that in module builder later.
+            let bytes = read_file_bytes(path)?;
+            Ok(MechSourceCode::ByteCode(bytes))
+        }
+
+        "html" | "htm" | "md" | "css" => Ok(MechSourceCode::Html(read_file_string(path)?)),
+
+        "mdoc" | "mpkg" | "m" | "csv" | "js" => Ok(MechSourceCode::String(read_file_string(path)?)),
+
+        "png" | "jpg" | "jpeg" | "gif" | "svg" => {
+            Ok(MechSourceCode::Image(extension, read_file_bytes(path)?))
+        }
+
+        other => Err(MechError::new(
+            SourceUnknownFileExtension {
+                path: path.display().to_string(),
+                extension: other.to_string(),
+            },
+            None,
+        )),
     }
-
-    "mecb" => {
-      // Keep this as raw bytecode source for now only if your MechSourceCode
-      // supports ByteCode(Vec<u8>). If your current loader needs
-      // `load_program_from_file`, wire that in module builder later.
-      let bytes = read_file_bytes(path)?;
-      Ok(MechSourceCode::ByteCode(bytes))
-    }
-
-    "html" | "htm" | "md" | "css" => {
-      Ok(MechSourceCode::Html(read_file_string(path)?))
-    }
-
-    "mdoc" | "mpkg" | "m" | "csv" | "js" => {
-      Ok(MechSourceCode::String(read_file_string(path)?))
-    }
-
-    "png" | "jpg" | "jpeg" | "gif" | "svg" => {
-      Ok(MechSourceCode::Image(extension, read_file_bytes(path)?))
-    }
-
-    other => Err(MechError::new(
-      SourceUnknownFileExtension {
-        path: path.display().to_string(),
-        extension: other.to_string(),
-      },
-      None,
-    )),
-  }
 }
 
 pub fn read_file_string(path: &Path) -> MResult<String> {
-  let mut file = File::open(path).map_err(|error| {
-    MechError::new(
-      SourceFileOpenFailed {
-        path: path.display().to_string(),
-        source: error.to_string(),
-      },
-      None,
-    )
-  })?;
+    let mut file = File::open(path).map_err(|error| {
+        MechError::new(
+            SourceFileOpenFailed {
+                path: path.display().to_string(),
+                source: error.to_string(),
+            },
+            None,
+        )
+    })?;
 
-  let mut buffer = String::new();
+    let mut buffer = String::new();
 
-  file.read_to_string(&mut buffer).map_err(|error| {
-    MechError::new(
-      SourceFileReadFailed {
-        path: path.display().to_string(),
-        source: error.to_string(),
-      },
-      None,
-    )
-  })?;
+    file.read_to_string(&mut buffer).map_err(|error| {
+        MechError::new(
+            SourceFileReadFailed {
+                path: path.display().to_string(),
+                source: error.to_string(),
+            },
+            None,
+        )
+    })?;
 
-  Ok(buffer)
+    Ok(buffer)
 }
 
 pub fn read_file_bytes(path: &Path) -> MResult<Vec<u8>> {
-  std::fs::read(path).map_err(|error| {
-    MechError::new(
-      SourceFileReadFailed {
-        path: path.display().to_string(),
-        source: error.to_string(),
-      },
-      None,
-    )
-  })
+    std::fs::read(path).map_err(|error| {
+        MechError::new(
+            SourceFileReadFailed {
+                path: path.display().to_string(),
+                source: error.to_string(),
+            },
+            None,
+        )
+    })
 }
 
 pub fn expand_mechdown_includes(path: &Path) -> MResult<String> {
-  let canonical = canonicalize_source_path(path)?;
-  let mut active = HashSet::new();
+    let canonical = canonicalize_source_path(path)?;
+    let mut active = HashSet::new();
 
-  expand_mechdown_includes_inner(&canonical, &mut active)
+    expand_mechdown_includes_inner(&canonical, &mut active)
 }
 
-fn expand_mechdown_includes_inner(
-  path: &Path,
-  active: &mut HashSet<PathBuf>,
-) -> MResult<String> {
-  let canonical = canonicalize_source_path(path)?;
+fn expand_mechdown_includes_inner(path: &Path, active: &mut HashSet<PathBuf>) -> MResult<String> {
+    let canonical = canonicalize_source_path(path)?;
 
-  if active.contains(&canonical) {
-    return Err(MechError::new(
-      SourceIncludeCycle {
-        path: canonical.display().to_string(),
-      },
-      None,
-    ));
-  }
+    if active.contains(&canonical) {
+        return Err(MechError::new(
+            SourceIncludeCycle {
+                path: canonical.display().to_string(),
+            },
+            None,
+        ));
+    }
 
-  active.insert(canonical.clone());
+    active.insert(canonical.clone());
 
-  let source = read_file_string(&canonical)?;
-  let expanded = expand_mechdown_include_tokens(
-    &source,
-    &canonical,
-    active,
-  )?;
+    let source = read_file_string(&canonical)?;
+    let expanded = expand_mechdown_include_tokens(&source, &canonical, active)?;
 
-  active.remove(&canonical);
+    active.remove(&canonical);
 
-  Ok(expanded)
+    Ok(expanded)
 }
 
 fn expand_mechdown_include_tokens(
-  source: &str,
-  canonical_path: &Path,
-  active: &mut HashSet<PathBuf>,
+    source: &str,
+    canonical_path: &Path,
+    active: &mut HashSet<PathBuf>,
 ) -> MResult<String> {
-  let mut result = String::new();
+    let mut result = String::new();
 
-  for line in source.split_inclusive('\n') {
-    let (line_without_newline, newline) = match line.strip_suffix('\n') {
-      Some(prefix) => (prefix, "\n"),
-      None => (line, ""),
-    };
+    for line in source.split_inclusive('\n') {
+        let (line_without_newline, newline) = match line.strip_suffix('\n') {
+            Some(prefix) => (prefix, "\n"),
+            None => (line, ""),
+        };
 
-    if let Some(inner) = standalone_braced_content(line_without_newline) {
-      if looks_like_mech_include(inner) {
-        let include_raw = inner.trim();
-        let parent = canonical_path.parent().unwrap_or(Path::new("."));
-        let include_path = parent.join(include_raw);
+        if let Some(inner) = standalone_braced_content(line_without_newline) {
+            if looks_like_mech_include(inner) {
+                let include_raw = inner.trim();
+                let parent = canonical_path.parent().unwrap_or(Path::new("."));
+                let include_path = parent.join(include_raw);
 
-        let include_canonical = canonicalize_source_path(&include_path)
-          .map_err(|error| {
-            MechError::new(
-              SourceIncludeReadFailed {
-                path: canonical_path.display().to_string(),
-                include: include_raw.to_string(),
-                source: format!("{:?}", error),
-              },
-              None,
-            )
-          })?;
+                let include_canonical =
+                    canonicalize_source_path(&include_path).map_err(|error| {
+                        MechError::new(
+                            SourceIncludeReadFailed {
+                                path: canonical_path.display().to_string(),
+                                include: include_raw.to_string(),
+                                source: format!("{:?}", error),
+                            },
+                            None,
+                        )
+                    })?;
 
-        let include_source =
-          expand_mechdown_includes_inner(&include_canonical, active)?;
+                let include_source = expand_mechdown_includes_inner(&include_canonical, active)?;
 
-        result.push_str(&include_source);
+                result.push_str(&include_source);
 
-        if !include_source.ends_with('\n') {
-          result.push('\n');
+                if !include_source.ends_with('\n') {
+                    result.push('\n');
+                }
+
+                result.push_str(newline);
+
+                continue;
+            }
         }
 
-        result.push_str(newline);
-
-        continue;
-      }
+        result.push_str(line);
     }
 
-    result.push_str(line);
-  }
-
-  Ok(result)
+    Ok(result)
 }
 
 fn looks_like_mech_include(content: &str) -> bool {
-  let trimmed = content.trim();
+    let trimmed = content.trim();
 
-  trimmed.ends_with(".mec") || trimmed.ends_with(".🤖")
+    trimmed.ends_with(".mec") || trimmed.ends_with(".🤖")
 }
 
 fn standalone_braced_content(line_without_newline: &str) -> Option<&str> {
-  let trimmed = line_without_newline.trim();
+    let trimmed = line_without_newline.trim();
 
-  if !(trimmed.starts_with('{') && trimmed.ends_with('}')) {
-    return None;
-  }
+    if !(trimmed.starts_with('{') && trimmed.ends_with('}')) {
+        return None;
+    }
 
-  Some(&trimmed[1..trimmed.len() - 1])
+    Some(&trimmed[1..trimmed.len() - 1])
 }
 
 fn canonicalize_source_path(path: &Path) -> MResult<PathBuf> {
-  path.canonicalize().map_err(|error| {
-    MechError::new(
-      SourceFileReadFailed {
-        path: path.display().to_string(),
-        source: error.to_string(),
-      },
-      None,
-    )
-  })
+    path.canonicalize().map_err(|error| {
+        MechError::new(
+            SourceFileReadFailed {
+                path: path.display().to_string(),
+                source: error.to_string(),
+            },
+            None,
+        )
+    })
 }
 
 fn file_uri(path: &Path) -> String {
-  let mut text = path.display().to_string();
+    let mut text = path.display().to_string();
 
-  if cfg!(windows) {
-    text = text.replace('\\', "/");
-  }
+    if cfg!(windows) {
+        text = text.replace('\\', "/");
+    }
 
-  format!("file://{}", text)
+    format!("file://{}", text)
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use std::time::{SystemTime, UNIX_EPOCH};
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-  fn temp_root(name: &str) -> PathBuf {
-    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    std::env::temp_dir().join(format!("{}-{}", name, nanos))
-  }
+    fn temp_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}-{}", name, nanos))
+    }
 
-  #[test]
-  fn source_kind_classifies_mech_files() {
-    assert_eq!(
-      SourceKind::from_extension("mec"),
-      SourceKind::Mech,
-    );
+    #[test]
+    fn source_kind_classifies_mech_files() {
+        assert_eq!(SourceKind::from_extension("mec"), SourceKind::Mech,);
 
-    assert_eq!(
-      SourceKind::from_extension("mecb"),
-      SourceKind::MechBytecode,
-    );
-  }
+        assert_eq!(SourceKind::from_extension("mecb"), SourceKind::MechBytecode,);
+    }
 
-  #[test]
-  fn file_resolver_resolves_mec_file() {
-    let root = temp_root("mech-runtime-file-resolver-test");
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root).unwrap();
+    #[test]
+    fn file_resolver_resolves_mec_file() {
+        let root = temp_root("mech-runtime-file-resolver-test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
 
-    let path = root.join("index.mec");
-    std::fs::write(&path, "x := 1").unwrap();
+        let path = root.join("index.mec");
+        std::fs::write(&path, "x := 1").unwrap();
 
-    let resolver = FileSourceResolver::new(&root);
-    let request = SourceRequest::new("index.mec");
+        let resolver = FileSourceResolver::new(&root);
+        let request = SourceRequest::new("index.mec");
 
-    let resolved = resolver.resolve(&request).unwrap().unwrap();
+        let resolved = resolver.resolve(&request).unwrap().unwrap();
 
-    assert_eq!(resolved.name, "index.mec");
-    assert_eq!(resolved.kind, SourceKind::Mech);
-    assert!(resolved.canonical_uri.starts_with("file://"));
-    assert!(resolved.is_executable_mech_source());
-  }
+        assert_eq!(resolved.name, "index.mec");
+        assert_eq!(resolved.kind, SourceKind::Mech);
+        assert!(resolved.canonical_uri.starts_with("file://"));
+        assert!(resolved.is_executable_mech_source());
+    }
 
-  #[test]
-  fn resolves_math_to_math_mec() {
-    let root = temp_root("resolve-math-mec");
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "x := 1").unwrap();
-    let resolver = FileSourceResolver::new(&root);
-    let resolved = resolver.resolve(&SourceRequest::new("math")).unwrap().unwrap();
-    assert_eq!(resolved.name, "math.mec");
-  }
+    #[test]
+    fn resolves_math_to_math_mec() {
+        let root = temp_root("resolve-math-mec");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("math.mec"), "x := 1").unwrap();
+        let resolver = FileSourceResolver::new(&root);
+        let resolved = resolver
+            .resolve(&SourceRequest::new("math"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.name, "math.mec");
+    }
 
-  #[test]
-  fn resolves_math_to_math_index_mec_when_no_math_mec() {
-    let root = temp_root("resolve-math-index");
-    std::fs::create_dir_all(root.join("math")).unwrap();
-    std::fs::write(root.join("math/index.mec"), "x := 1").unwrap();
-    let resolver = FileSourceResolver::new(&root);
-    let resolved = resolver.resolve(&SourceRequest::new("math")).unwrap().unwrap();
-    assert_eq!(resolved.name, "index.mec");
-  }
+    #[test]
+    fn resolves_math_to_math_index_mec_when_no_math_mec() {
+        let root = temp_root("resolve-math-index");
+        std::fs::create_dir_all(root.join("math")).unwrap();
+        std::fs::write(root.join("math/index.mec"), "x := 1").unwrap();
+        let resolver = FileSourceResolver::new(&root);
+        let resolved = resolver
+            .resolve(&SourceRequest::new("math"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.name, "index.mec");
+    }
 
-  #[test]
-  fn resolves_math_sin_to_math_sin_mec() {
-    let root = temp_root("resolve-math-sin");
-    std::fs::create_dir_all(root.join("math")).unwrap();
-    std::fs::write(root.join("math/sin.mec"), "x := 1").unwrap();
-    let resolver = FileSourceResolver::new(&root);
-    let resolved = resolver.resolve(&SourceRequest::new("math/sin")).unwrap().unwrap();
-    assert_eq!(resolved.name, "sin.mec");
-  }
+    #[test]
+    fn resolves_math_sin_to_math_sin_mec() {
+        let root = temp_root("resolve-math-sin");
+        std::fs::create_dir_all(root.join("math")).unwrap();
+        std::fs::write(root.join("math/sin.mec"), "x := 1").unwrap();
+        let resolver = FileSourceResolver::new(&root);
+        let resolved = resolver
+            .resolve(&SourceRequest::new("math/sin"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.name, "sin.mec");
+    }
 
-  #[test]
-  fn resolves_relative_import_from_referrer_parent() {
-    let root = temp_root("resolve-referrer-parent");
-    std::fs::create_dir_all(root.join("sub")).unwrap();
-    let referrer = root.join("sub/main.mec");
-    std::fs::write(root.join("sub/math.mec"), "x := 1").unwrap();
-    std::fs::write(&referrer, "+> ./math.mec").unwrap();
-    let resolver = FileSourceResolver::new(&root);
-    let request = SourceRequest::new("./math.mec").with_referrer(referrer.to_string_lossy().to_string());
-    let resolved = resolver.resolve(&request).unwrap().unwrap();
-    assert_eq!(resolved.name, "math.mec");
-  }
-
+    #[test]
+    fn resolves_relative_import_from_referrer_parent() {
+        let root = temp_root("resolve-referrer-parent");
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        let referrer = root.join("sub/main.mec");
+        std::fs::write(root.join("sub/math.mec"), "x := 1").unwrap();
+        std::fs::write(&referrer, "+> ./math.mec").unwrap();
+        let resolver = FileSourceResolver::new(&root);
+        let request =
+            SourceRequest::new("./math.mec").with_referrer(referrer.to_string_lossy().to_string());
+        let resolved = resolver.resolve(&request).unwrap().unwrap();
+        assert_eq!(resolved.name, "math.mec");
+    }
 }

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -6,423 +6,438 @@ use std::path::{Path, PathBuf};
 use mech_core::{MResult, MechError, MechSourceCode};
 
 use crate::resolver::{
-    source_request_for_import, ResolvedSource, SourceIndex, SourceRequest, SourceResolver,
+  source_request_for_import, ResolvedSource, SourceIndex, SourceRequest, SourceResolver,
 };
 
 use super::{
-    SourceExtensionDecodeFailed, SourceFileOpenFailed, SourceFileReadFailed, SourceIncludeCycle,
-    SourceIncludeReadFailed, SourceKind, SourceUnknownFileExtension,
+  SourceExtensionDecodeFailed, SourceFileOpenFailed, SourceFileReadFailed,
+  SourceIncludeCycle, SourceIncludeReadFailed, SourceKind,
+  SourceUnknownFileExtension,
 };
 
 #[derive(Clone, Debug)]
 pub struct FileSourceResolver {
-    roots: Vec<PathBuf>,
+  roots: Vec<PathBuf>,
 }
 
 impl FileSourceResolver {
-    pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            roots: vec![root.into()],
+  pub fn new(root: impl Into<PathBuf>) -> Self {
+    Self {
+      roots: vec![root.into()],
+    }
+  }
+
+  pub fn empty() -> Self {
+    Self {
+      roots: Vec::new(),
+    }
+  }
+
+  pub fn with_root(mut self, root: impl Into<PathBuf>) -> Self {
+    self.roots.push(root.into());
+    self
+  }
+
+  pub fn add_root(&mut self, root: impl Into<PathBuf>) {
+    self.roots.push(root.into());
+  }
+
+  pub fn roots(&self) -> &[PathBuf] {
+    &self.roots
+  }
+
+  fn resolve_path(
+    &self,
+    request: &SourceRequest,
+  ) -> MResult<Option<PathBuf>> {
+    let specifier = Path::new(&request.specifier);
+
+    if specifier.is_absolute() && specifier.exists() {
+      return Ok(Some(canonicalize_source_path(specifier)?));
+    }
+
+    if let Some(referrer) = &request.referrer {
+      let referrer_path = Path::new(referrer);
+
+      let parent = if referrer_path.is_dir() {
+        Some(referrer_path)
+      } else {
+        referrer_path.parent()
+      };
+
+      if let Some(parent) = parent {
+        for candidate in path_candidates(parent, specifier) {
+          if candidate.is_file() {
+            return Ok(Some(canonicalize_source_path(&candidate)?));
+          }
         }
+      }
     }
 
-    pub fn empty() -> Self {
-        Self { roots: Vec::new() }
-    }
-
-    pub fn with_root(mut self, root: impl Into<PathBuf>) -> Self {
-        self.roots.push(root.into());
-        self
-    }
-
-    pub fn add_root(&mut self, root: impl Into<PathBuf>) {
-        self.roots.push(root.into());
-    }
-
-    pub fn roots(&self) -> &[PathBuf] {
-        &self.roots
-    }
-
-    fn resolve_path(&self, request: &SourceRequest) -> MResult<Option<PathBuf>> {
-        let specifier = Path::new(&request.specifier);
-
-        if specifier.is_absolute() && specifier.exists() {
-            return Ok(Some(canonicalize_source_path(specifier)?));
+    for root in &self.roots {
+      for candidate in path_candidates(root, specifier) {
+        if candidate.is_file() {
+          return Ok(Some(canonicalize_source_path(&candidate)?));
         }
-
-        if let Some(referrer) = &request.referrer {
-            let referrer_path = Path::new(referrer);
-
-            let parent = if referrer_path.is_dir() {
-                Some(referrer_path)
-            } else {
-                referrer_path.parent()
-            };
-
-            if let Some(parent) = parent {
-                for candidate in path_candidates(parent, specifier) {
-                    if candidate.is_file() {
-                        return Ok(Some(canonicalize_source_path(&candidate)?));
-                    }
-                }
-            }
-        }
-
-        for root in &self.roots {
-            for candidate in path_candidates(root, specifier) {
-                if candidate.is_file() {
-                    return Ok(Some(canonicalize_source_path(&candidate)?));
-                }
-            }
-        }
-
-        Ok(None)
+      }
     }
+
+    Ok(None)
+  }
 }
 
 impl SourceResolver for FileSourceResolver {
-    fn resolve(&self, request: &SourceRequest) -> MResult<Option<ResolvedSource>> {
-        request.validate()?;
+  fn resolve(
+    &self,
+    request: &SourceRequest,
+  ) -> MResult<Option<ResolvedSource>> {
+    request.validate()?;
 
-        let Some(path) = self.resolve_path(request)? else {
-            return Ok(None);
-        };
+    let Some(path) = self.resolve_path(request)? else {
+      return Ok(None);
+    };
 
-        let kind = SourceKind::from_path(&path);
-        let source = read_runtime_source_file(&path)?;
-        let name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("source")
-            .to_string();
+    let kind = SourceKind::from_path(&path);
+    let source = read_runtime_source_file(&path)?;
+    let name = path
+      .file_name()
+      .and_then(|name| name.to_str())
+      .unwrap_or("source")
+      .to_string();
 
-        let mut resolved = ResolvedSource::new(name, file_uri(&path), source).with_kind(kind);
+    let mut resolved = ResolvedSource::new(name, file_uri(&path), source).with_kind(kind);
 
-        if resolved.kind == SourceKind::Mech {
-            if let MechSourceCode::String(source_text) = &resolved.source {
-                let tree = mech_syntax::parser::parse(source_text.trim())?;
-                let referrer = path.to_string_lossy().to_string();
-                let index = SourceIndex::from_program(&tree);
-                let imports = index.all_imports();
-                let exports = index.all_exports();
-                let contexts = index.all_contexts();
-                let dependencies = imports
-                    .iter()
-                    .map(|import| source_request_for_import(import, Some(&referrer)))
-                    .collect::<Vec<_>>();
+    if resolved.kind == SourceKind::Mech {
+      if let MechSourceCode::String(source_text) = &resolved.source {
+        let tree = mech_syntax::parser::parse(source_text.trim())?;
+        let referrer = path.to_string_lossy().to_string();
+        let index = SourceIndex::from_program(&tree);
+        let imports = index.all_imports();
+        let exports = index.all_exports();
+        let contexts = index.all_contexts();
+        let dependencies = imports
+          .iter()
+          .map(|import| source_request_for_import(import, Some(&referrer)))
+          .collect::<Vec<_>>();
 
-                resolved = resolved
-                    .with_imports(imports)
-                    .with_exports(exports)
-                    .with_contexts(contexts)
-                    .with_dependencies(dependencies);
-            }
-        }
-
-        Ok(Some(resolved))
+        resolved = resolved
+          .with_imports(imports)
+          .with_exports(exports)
+          .with_contexts(contexts)
+          .with_dependencies(dependencies);
+      }
     }
+
+    Ok(Some(resolved))
+  }
 }
 
 fn path_candidates(base: &Path, specifier: &Path) -> Vec<PathBuf> {
-    vec![
-        base.join(specifier),
-        base.join(format!("{}.mec", specifier.to_string_lossy())),
-        base.join(specifier).join("index.mec"),
-    ]
+  vec![
+    base.join(specifier),
+    base.join(format!("{}.mec", specifier.to_string_lossy())),
+    base.join(specifier).join("index.mec"),
+  ]
 }
 
 pub fn read_runtime_source_file(path: &Path) -> MResult<MechSourceCode> {
-    let extension = path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .ok_or_else(|| {
-            MechError::new(
-                SourceExtensionDecodeFailed {
-                    path: path.display().to_string(),
-                },
-                None,
-            )
-        })?
-        .to_ascii_lowercase();
+  let extension = path
+    .extension()
+    .and_then(|extension| extension.to_str())
+    .ok_or_else(|| {
+      MechError::new(
+        SourceExtensionDecodeFailed {
+          path: path.display().to_string(),
+        },
+        None,
+      )
+    })?
+    .to_ascii_lowercase();
 
-    match extension.as_str() {
-        "mec" | "🤖" => {
-            let expanded = expand_mechdown_includes(path)?;
-            Ok(MechSourceCode::String(expanded))
-        }
-
-        "mecb" => {
-            // Keep this as raw bytecode source for now only if your MechSourceCode
-            // supports ByteCode(Vec<u8>). If your current loader needs
-            // `load_program_from_file`, wire that in module builder later.
-            let bytes = read_file_bytes(path)?;
-            Ok(MechSourceCode::ByteCode(bytes))
-        }
-
-        "html" | "htm" | "md" | "css" => Ok(MechSourceCode::Html(read_file_string(path)?)),
-
-        "mdoc" | "mpkg" | "m" | "csv" | "js" => Ok(MechSourceCode::String(read_file_string(path)?)),
-
-        "png" | "jpg" | "jpeg" | "gif" | "svg" => {
-            Ok(MechSourceCode::Image(extension, read_file_bytes(path)?))
-        }
-
-        other => Err(MechError::new(
-            SourceUnknownFileExtension {
-                path: path.display().to_string(),
-                extension: other.to_string(),
-            },
-            None,
-        )),
+  match extension.as_str() {
+    "mec" | "🤖" => {
+      let expanded = expand_mechdown_includes(path)?;
+      Ok(MechSourceCode::String(expanded))
     }
+
+    "mecb" => {
+      // Keep this as raw bytecode source for now only if your MechSourceCode
+      // supports ByteCode(Vec<u8>). If your current loader needs
+      // `load_program_from_file`, wire that in module builder later.
+      let bytes = read_file_bytes(path)?;
+      Ok(MechSourceCode::ByteCode(bytes))
+    }
+
+    "html" | "htm" | "md" | "css" => {
+      Ok(MechSourceCode::Html(read_file_string(path)?))
+    }
+
+    "mdoc" | "mpkg" | "m" | "csv" | "js" => {
+      Ok(MechSourceCode::String(read_file_string(path)?))
+    }
+
+    "png" | "jpg" | "jpeg" | "gif" | "svg" => {
+      Ok(MechSourceCode::Image(extension, read_file_bytes(path)?))
+    }
+
+    other => Err(MechError::new(
+      SourceUnknownFileExtension {
+        path: path.display().to_string(),
+        extension: other.to_string(),
+      },
+      None,
+    )),
+  }
 }
 
 pub fn read_file_string(path: &Path) -> MResult<String> {
-    let mut file = File::open(path).map_err(|error| {
-        MechError::new(
-            SourceFileOpenFailed {
-                path: path.display().to_string(),
-                source: error.to_string(),
-            },
-            None,
-        )
-    })?;
+  let mut file = File::open(path).map_err(|error| {
+    MechError::new(
+      SourceFileOpenFailed {
+        path: path.display().to_string(),
+        source: error.to_string(),
+      },
+      None,
+    )
+  })?;
 
-    let mut buffer = String::new();
+  let mut buffer = String::new();
 
-    file.read_to_string(&mut buffer).map_err(|error| {
-        MechError::new(
-            SourceFileReadFailed {
-                path: path.display().to_string(),
-                source: error.to_string(),
-            },
-            None,
-        )
-    })?;
+  file.read_to_string(&mut buffer).map_err(|error| {
+    MechError::new(
+      SourceFileReadFailed {
+        path: path.display().to_string(),
+        source: error.to_string(),
+      },
+      None,
+    )
+  })?;
 
-    Ok(buffer)
+  Ok(buffer)
 }
 
 pub fn read_file_bytes(path: &Path) -> MResult<Vec<u8>> {
-    std::fs::read(path).map_err(|error| {
-        MechError::new(
-            SourceFileReadFailed {
-                path: path.display().to_string(),
-                source: error.to_string(),
-            },
-            None,
-        )
-    })
+  std::fs::read(path).map_err(|error| {
+    MechError::new(
+      SourceFileReadFailed {
+        path: path.display().to_string(),
+        source: error.to_string(),
+      },
+      None,
+    )
+  })
 }
 
 pub fn expand_mechdown_includes(path: &Path) -> MResult<String> {
-    let canonical = canonicalize_source_path(path)?;
-    let mut active = HashSet::new();
+  let canonical = canonicalize_source_path(path)?;
+  let mut active = HashSet::new();
 
-    expand_mechdown_includes_inner(&canonical, &mut active)
+  expand_mechdown_includes_inner(&canonical, &mut active)
 }
 
-fn expand_mechdown_includes_inner(path: &Path, active: &mut HashSet<PathBuf>) -> MResult<String> {
-    let canonical = canonicalize_source_path(path)?;
+fn expand_mechdown_includes_inner(
+  path: &Path,
+  active: &mut HashSet<PathBuf>,
+) -> MResult<String> {
+  let canonical = canonicalize_source_path(path)?;
 
-    if active.contains(&canonical) {
-        return Err(MechError::new(
-            SourceIncludeCycle {
-                path: canonical.display().to_string(),
-            },
-            None,
-        ));
-    }
+  if active.contains(&canonical) {
+    return Err(MechError::new(
+      SourceIncludeCycle {
+        path: canonical.display().to_string(),
+      },
+      None,
+    ));
+  }
 
-    active.insert(canonical.clone());
+  active.insert(canonical.clone());
 
-    let source = read_file_string(&canonical)?;
-    let expanded = expand_mechdown_include_tokens(&source, &canonical, active)?;
+  let source = read_file_string(&canonical)?;
+  let expanded = expand_mechdown_include_tokens(
+    &source,
+    &canonical,
+    active,
+  )?;
 
-    active.remove(&canonical);
+  active.remove(&canonical);
 
-    Ok(expanded)
+  Ok(expanded)
 }
 
 fn expand_mechdown_include_tokens(
-    source: &str,
-    canonical_path: &Path,
-    active: &mut HashSet<PathBuf>,
+  source: &str,
+  canonical_path: &Path,
+  active: &mut HashSet<PathBuf>,
 ) -> MResult<String> {
-    let mut result = String::new();
+  let mut result = String::new();
 
-    for line in source.split_inclusive('\n') {
-        let (line_without_newline, newline) = match line.strip_suffix('\n') {
-            Some(prefix) => (prefix, "\n"),
-            None => (line, ""),
-        };
+  for line in source.split_inclusive('\n') {
+    let (line_without_newline, newline) = match line.strip_suffix('\n') {
+      Some(prefix) => (prefix, "\n"),
+      None => (line, ""),
+    };
 
-        if let Some(inner) = standalone_braced_content(line_without_newline) {
-            if looks_like_mech_include(inner) {
-                let include_raw = inner.trim();
-                let parent = canonical_path.parent().unwrap_or(Path::new("."));
-                let include_path = parent.join(include_raw);
+    if let Some(inner) = standalone_braced_content(line_without_newline) {
+      if looks_like_mech_include(inner) {
+        let include_raw = inner.trim();
+        let parent = canonical_path.parent().unwrap_or(Path::new("."));
+        let include_path = parent.join(include_raw);
 
-                let include_canonical =
-                    canonicalize_source_path(&include_path).map_err(|error| {
-                        MechError::new(
-                            SourceIncludeReadFailed {
-                                path: canonical_path.display().to_string(),
-                                include: include_raw.to_string(),
-                                source: format!("{:?}", error),
-                            },
-                            None,
-                        )
-                    })?;
+        let include_canonical = canonicalize_source_path(&include_path)
+          .map_err(|error| {
+            MechError::new(
+              SourceIncludeReadFailed {
+                path: canonical_path.display().to_string(),
+                include: include_raw.to_string(),
+                source: format!("{:?}", error),
+              },
+              None,
+            )
+          })?;
 
-                let include_source = expand_mechdown_includes_inner(&include_canonical, active)?;
+        let include_source =
+          expand_mechdown_includes_inner(&include_canonical, active)?;
 
-                result.push_str(&include_source);
+        result.push_str(&include_source);
 
-                if !include_source.ends_with('\n') {
-                    result.push('\n');
-                }
-
-                result.push_str(newline);
-
-                continue;
-            }
+        if !include_source.ends_with('\n') {
+          result.push('\n');
         }
 
-        result.push_str(line);
+        result.push_str(newline);
+
+        continue;
+      }
     }
 
-    Ok(result)
+    result.push_str(line);
+  }
+
+  Ok(result)
 }
 
 fn looks_like_mech_include(content: &str) -> bool {
-    let trimmed = content.trim();
+  let trimmed = content.trim();
 
-    trimmed.ends_with(".mec") || trimmed.ends_with(".🤖")
+  trimmed.ends_with(".mec") || trimmed.ends_with(".🤖")
 }
 
 fn standalone_braced_content(line_without_newline: &str) -> Option<&str> {
-    let trimmed = line_without_newline.trim();
+  let trimmed = line_without_newline.trim();
 
-    if !(trimmed.starts_with('{') && trimmed.ends_with('}')) {
-        return None;
-    }
+  if !(trimmed.starts_with('{') && trimmed.ends_with('}')) {
+    return None;
+  }
 
-    Some(&trimmed[1..trimmed.len() - 1])
+  Some(&trimmed[1..trimmed.len() - 1])
 }
 
 fn canonicalize_source_path(path: &Path) -> MResult<PathBuf> {
-    path.canonicalize().map_err(|error| {
-        MechError::new(
-            SourceFileReadFailed {
-                path: path.display().to_string(),
-                source: error.to_string(),
-            },
-            None,
-        )
-    })
+  path.canonicalize().map_err(|error| {
+    MechError::new(
+      SourceFileReadFailed {
+        path: path.display().to_string(),
+        source: error.to_string(),
+      },
+      None,
+    )
+  })
 }
 
 fn file_uri(path: &Path) -> String {
-    let mut text = path.display().to_string();
+  let mut text = path.display().to_string();
 
-    if cfg!(windows) {
-        text = text.replace('\\', "/");
-    }
+  if cfg!(windows) {
+    text = text.replace('\\', "/");
+  }
 
-    format!("file://{}", text)
+  format!("file://{}", text)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
+  use super::*;
+  use std::time::{SystemTime, UNIX_EPOCH};
 
-    fn temp_root(name: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("{}-{}", name, nanos))
-    }
+  fn temp_root(name: &str) -> PathBuf {
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    std::env::temp_dir().join(format!("{}-{}", name, nanos))
+  }
 
-    #[test]
-    fn source_kind_classifies_mech_files() {
-        assert_eq!(SourceKind::from_extension("mec"), SourceKind::Mech,);
+  #[test]
+  fn source_kind_classifies_mech_files() {
+    assert_eq!(
+      SourceKind::from_extension("mec"),
+      SourceKind::Mech,
+    );
 
-        assert_eq!(SourceKind::from_extension("mecb"), SourceKind::MechBytecode,);
-    }
+    assert_eq!(
+      SourceKind::from_extension("mecb"),
+      SourceKind::MechBytecode,
+    );
+  }
 
-    #[test]
-    fn file_resolver_resolves_mec_file() {
-        let root = temp_root("mech-runtime-file-resolver-test");
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(&root).unwrap();
+  #[test]
+  fn file_resolver_resolves_mec_file() {
+    let root = temp_root("mech-runtime-file-resolver-test");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
 
-        let path = root.join("index.mec");
-        std::fs::write(&path, "x := 1").unwrap();
+    let path = root.join("index.mec");
+    std::fs::write(&path, "x := 1").unwrap();
 
-        let resolver = FileSourceResolver::new(&root);
-        let request = SourceRequest::new("index.mec");
+    let resolver = FileSourceResolver::new(&root);
+    let request = SourceRequest::new("index.mec");
 
-        let resolved = resolver.resolve(&request).unwrap().unwrap();
+    let resolved = resolver.resolve(&request).unwrap().unwrap();
 
-        assert_eq!(resolved.name, "index.mec");
-        assert_eq!(resolved.kind, SourceKind::Mech);
-        assert!(resolved.canonical_uri.starts_with("file://"));
-        assert!(resolved.is_executable_mech_source());
-    }
+    assert_eq!(resolved.name, "index.mec");
+    assert_eq!(resolved.kind, SourceKind::Mech);
+    assert!(resolved.canonical_uri.starts_with("file://"));
+    assert!(resolved.is_executable_mech_source());
+  }
 
-    #[test]
-    fn resolves_math_to_math_mec() {
-        let root = temp_root("resolve-math-mec");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::write(root.join("math.mec"), "x := 1").unwrap();
-        let resolver = FileSourceResolver::new(&root);
-        let resolved = resolver
-            .resolve(&SourceRequest::new("math"))
-            .unwrap()
-            .unwrap();
-        assert_eq!(resolved.name, "math.mec");
-    }
+  #[test]
+  fn resolves_math_to_math_mec() {
+    let root = temp_root("resolve-math-mec");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "x := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let resolved = resolver.resolve(&SourceRequest::new("math")).unwrap().unwrap();
+    assert_eq!(resolved.name, "math.mec");
+  }
 
-    #[test]
-    fn resolves_math_to_math_index_mec_when_no_math_mec() {
-        let root = temp_root("resolve-math-index");
-        std::fs::create_dir_all(root.join("math")).unwrap();
-        std::fs::write(root.join("math/index.mec"), "x := 1").unwrap();
-        let resolver = FileSourceResolver::new(&root);
-        let resolved = resolver
-            .resolve(&SourceRequest::new("math"))
-            .unwrap()
-            .unwrap();
-        assert_eq!(resolved.name, "index.mec");
-    }
+  #[test]
+  fn resolves_math_to_math_index_mec_when_no_math_mec() {
+    let root = temp_root("resolve-math-index");
+    std::fs::create_dir_all(root.join("math")).unwrap();
+    std::fs::write(root.join("math/index.mec"), "x := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let resolved = resolver.resolve(&SourceRequest::new("math")).unwrap().unwrap();
+    assert_eq!(resolved.name, "index.mec");
+  }
 
-    #[test]
-    fn resolves_math_sin_to_math_sin_mec() {
-        let root = temp_root("resolve-math-sin");
-        std::fs::create_dir_all(root.join("math")).unwrap();
-        std::fs::write(root.join("math/sin.mec"), "x := 1").unwrap();
-        let resolver = FileSourceResolver::new(&root);
-        let resolved = resolver
-            .resolve(&SourceRequest::new("math/sin"))
-            .unwrap()
-            .unwrap();
-        assert_eq!(resolved.name, "sin.mec");
-    }
+  #[test]
+  fn resolves_math_sin_to_math_sin_mec() {
+    let root = temp_root("resolve-math-sin");
+    std::fs::create_dir_all(root.join("math")).unwrap();
+    std::fs::write(root.join("math/sin.mec"), "x := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let resolved = resolver.resolve(&SourceRequest::new("math/sin")).unwrap().unwrap();
+    assert_eq!(resolved.name, "sin.mec");
+  }
 
-    #[test]
-    fn resolves_relative_import_from_referrer_parent() {
-        let root = temp_root("resolve-referrer-parent");
-        std::fs::create_dir_all(root.join("sub")).unwrap();
-        let referrer = root.join("sub/main.mec");
-        std::fs::write(root.join("sub/math.mec"), "x := 1").unwrap();
-        std::fs::write(&referrer, "+> ./math.mec").unwrap();
-        let resolver = FileSourceResolver::new(&root);
-        let request =
-            SourceRequest::new("./math.mec").with_referrer(referrer.to_string_lossy().to_string());
-        let resolved = resolver.resolve(&request).unwrap().unwrap();
-        assert_eq!(resolved.name, "math.mec");
-    }
+  #[test]
+  fn resolves_relative_import_from_referrer_parent() {
+    let root = temp_root("resolve-referrer-parent");
+    std::fs::create_dir_all(root.join("sub")).unwrap();
+    let referrer = root.join("sub/main.mec");
+    std::fs::write(root.join("sub/math.mec"), "x := 1").unwrap();
+    std::fs::write(&referrer, "+> ./math.mec").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let request = SourceRequest::new("./math.mec").with_referrer(referrer.to_string_lossy().to_string());
+    let resolved = resolver.resolve(&request).unwrap().unwrap();
+    assert_eq!(resolved.name, "math.mec");
+  }
+
 }

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -1,0 +1,326 @@
+use mech_core::{
+    ContextBase, ContextCapabilityScope, MechCode, Program, SectionElement, SourceRange, Statement,
+    Token,
+};
+
+use super::{
+    classify_import_specifier, SourceContextBase, SourceContextCapability,
+    SourceContextCapabilityScope, SourceContextDeclaration, SourceExportDeclaration,
+    SourceImportDeclaration,
+};
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SourceScope {
+    Program,
+    Interpreter(SourceInterpreterId),
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SourceInterpreterId {
+    pub namespace: u64,
+    pub namespace_str: String,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceOccurrence {
+    pub scope: SourceScope,
+    pub order: usize,
+    pub range: Option<SourceRange>,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopedSourceImportDeclaration {
+    pub occurrence: SourceOccurrence,
+    pub declaration: SourceImportDeclaration,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopedSourceExportDeclaration {
+    pub occurrence: SourceOccurrence,
+    pub declaration: SourceExportDeclaration,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopedSourceContextDeclaration {
+    pub occurrence: SourceOccurrence,
+    pub declaration: SourceContextDeclaration,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceDeclaration {
+    Import(ScopedSourceImportDeclaration),
+    Export(ScopedSourceExportDeclaration),
+    Context(ScopedSourceContextDeclaration),
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SourceIndex {
+    pub declarations: Vec<SourceDeclaration>,
+    pub imports: Vec<ScopedSourceImportDeclaration>,
+    pub exports: Vec<ScopedSourceExportDeclaration>,
+    pub contexts: Vec<ScopedSourceContextDeclaration>,
+}
+
+impl SourceIndex {
+    pub fn from_program(program: &Program) -> Self {
+        let mut index = Self::default();
+        let mut order = 0usize;
+
+        for section in &program.body.sections {
+            for element in &section.elements {
+                match element {
+                    SectionElement::MechCode(code_items) => {
+                        for (code, _) in code_items {
+                            if let MechCode::Statement(statement) = code {
+                                match statement {
+                                    Statement::ImportDeclaration(import) => {
+                                        index.push_import(
+                                            SourceScope::Program,
+                                            order,
+                                            declaration_range(import.tokens()),
+                                            classify_import_specifier(import.specifier.to_string()),
+                                        );
+                                        order += 1;
+                                    }
+                                    Statement::ExportDeclaration(export) => {
+                                        index.push_export(
+                                            SourceScope::Program,
+                                            order,
+                                            declaration_range(export.tokens()),
+                                            SourceExportDeclaration {
+                                                name: export.name.to_string(),
+                                            },
+                                        );
+                                        order += 1;
+                                    }
+                                    Statement::ContextDeclaration(context) => {
+                                        index.push_context(
+                                            SourceScope::Program,
+                                            order,
+                                            declaration_range(context.tokens()),
+                                            source_context_declaration(context),
+                                        );
+                                        order += 1;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                    SectionElement::FencedMechCode(fenced) => {
+                        let scope = SourceScope::Interpreter(SourceInterpreterId {
+                            namespace: fenced.config.namespace,
+                            namespace_str: fenced.config.namespace_str.clone(),
+                        });
+
+                        // TODO: Interleaving imports/exports/statements exactly as written in fenced code
+                        // requires parser ordering data; currently imports and exports preserve local vector order.
+                        for import in &fenced.imports {
+                            index.push_import(
+                                scope.clone(),
+                                order,
+                                declaration_range(import.tokens()),
+                                classify_import_specifier(import.specifier.to_string()),
+                            );
+                            order += 1;
+                        }
+
+                        for export in &fenced.exports {
+                            index.push_export(
+                                scope.clone(),
+                                order,
+                                declaration_range(export.tokens()),
+                                SourceExportDeclaration {
+                                    name: export.name.to_string(),
+                                },
+                            );
+                            order += 1;
+                        }
+
+                        for (code, _) in &fenced.code {
+                            if let MechCode::Statement(Statement::ContextDeclaration(context)) =
+                                code
+                            {
+                                index.push_context(
+                                    scope.clone(),
+                                    order,
+                                    declaration_range(context.tokens()),
+                                    source_context_declaration(context),
+                                );
+                                order += 1;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // TODO: index addressed paths from statements/expressions in a future PR.
+        index
+    }
+
+    pub fn all_imports(&self) -> Vec<SourceImportDeclaration> {
+        self.imports.iter().map(|x| x.declaration.clone()).collect()
+    }
+    pub fn all_exports(&self) -> Vec<SourceExportDeclaration> {
+        self.exports.iter().map(|x| x.declaration.clone()).collect()
+    }
+    pub fn all_contexts(&self) -> Vec<SourceContextDeclaration> {
+        self.contexts
+            .iter()
+            .map(|x| x.declaration.clone())
+            .collect()
+    }
+
+    pub fn program_imports(&self) -> Vec<SourceImportDeclaration> {
+        self.imports_for_scope(&SourceScope::Program)
+    }
+    pub fn program_exports(&self) -> Vec<SourceExportDeclaration> {
+        self.exports_for_scope(&SourceScope::Program)
+    }
+    pub fn program_contexts(&self) -> Vec<SourceContextDeclaration> {
+        self.contexts_for_scope(&SourceScope::Program)
+    }
+
+    pub fn imports_for_scope(&self, scope: &SourceScope) -> Vec<SourceImportDeclaration> {
+        self.imports
+            .iter()
+            .filter(|x| &x.occurrence.scope == scope)
+            .map(|x| x.declaration.clone())
+            .collect()
+    }
+
+    pub fn exports_for_scope(&self, scope: &SourceScope) -> Vec<SourceExportDeclaration> {
+        self.exports
+            .iter()
+            .filter(|x| &x.occurrence.scope == scope)
+            .map(|x| x.declaration.clone())
+            .collect()
+    }
+
+    pub fn contexts_for_scope(&self, scope: &SourceScope) -> Vec<SourceContextDeclaration> {
+        self.contexts
+            .iter()
+            .filter(|x| &x.occurrence.scope == scope)
+            .map(|x| x.declaration.clone())
+            .collect()
+    }
+
+    pub fn interpreter_scopes(&self) -> Vec<SourceInterpreterId> {
+        let mut scopes = Vec::new();
+        for declaration in &self.declarations {
+            let scope = match declaration {
+                SourceDeclaration::Import(import) => &import.occurrence.scope,
+                SourceDeclaration::Export(export) => &export.occurrence.scope,
+                SourceDeclaration::Context(context) => &context.occurrence.scope,
+            };
+            if let SourceScope::Interpreter(interpreter) = scope {
+                if !scopes.contains(interpreter) {
+                    scopes.push(interpreter.clone());
+                }
+            }
+        }
+        scopes
+    }
+
+    fn push_import(
+        &mut self,
+        scope: SourceScope,
+        order: usize,
+        range: Option<SourceRange>,
+        declaration: SourceImportDeclaration,
+    ) {
+        let scoped = ScopedSourceImportDeclaration {
+            occurrence: SourceOccurrence {
+                scope,
+                order,
+                range,
+            },
+            declaration,
+        };
+        self.declarations
+            .push(SourceDeclaration::Import(scoped.clone()));
+        self.imports.push(scoped);
+    }
+
+    fn push_export(
+        &mut self,
+        scope: SourceScope,
+        order: usize,
+        range: Option<SourceRange>,
+        declaration: SourceExportDeclaration,
+    ) {
+        let scoped = ScopedSourceExportDeclaration {
+            occurrence: SourceOccurrence {
+                scope,
+                order,
+                range,
+            },
+            declaration,
+        };
+        self.declarations
+            .push(SourceDeclaration::Export(scoped.clone()));
+        self.exports.push(scoped);
+    }
+
+    fn push_context(
+        &mut self,
+        scope: SourceScope,
+        order: usize,
+        range: Option<SourceRange>,
+        declaration: SourceContextDeclaration,
+    ) {
+        let scoped = ScopedSourceContextDeclaration {
+            occurrence: SourceOccurrence {
+                scope,
+                order,
+                range,
+            },
+            declaration,
+        };
+        self.declarations
+            .push(SourceDeclaration::Context(scoped.clone()));
+        self.contexts.push(scoped);
+    }
+}
+
+fn source_context_declaration(context: &mech_core::ContextDeclaration) -> SourceContextDeclaration {
+    let base = match &context.base {
+        ContextBase::ResourceUri(uri) => SourceContextBase::ResourceUri(uri.to_string()),
+        ContextBase::Context(name) => SourceContextBase::Context(name.to_string()),
+    };
+    let capabilities = context
+        .capabilities
+        .iter()
+        .map(|capability| {
+            let scope = match &capability.scope {
+                ContextCapabilityScope::Path(path) => {
+                    SourceContextCapabilityScope::Path(path.to_string())
+                }
+                ContextCapabilityScope::Wildcard(_) => SourceContextCapabilityScope::Wildcard,
+            };
+            SourceContextCapability {
+                operation: capability.operation.to_string(),
+                scope,
+            }
+        })
+        .collect();
+    SourceContextDeclaration {
+        name: context.name.to_string(),
+        base,
+        capabilities,
+    }
+}
+
+fn declaration_range(mut tokens: Vec<Token>) -> Option<SourceRange> {
+    Token::merge_tokens(&mut tokens).map(|token| token.src_range)
+}

--- a/src/runtime/src/resolver/mod.rs
+++ b/src/runtime/src/resolver/mod.rs
@@ -36,19 +36,19 @@ use crate::capability::CapabilityRequest;
 // Submodules
 // -----------------------------------------------------------------------------
 
-pub mod ast;
-pub mod file;
-pub mod imports;
-pub mod index;
 pub mod memory;
 pub mod source;
+pub mod file;
+pub mod imports;
+pub mod ast;
+pub mod index;
 
-pub use ast::*;
-pub use file::*;
-pub use imports::*;
-pub use index::*;
 pub use memory::*;
 pub use source::*;
+pub use file::*;
+pub use imports::*;
+pub use ast::*;
+pub use index::*;
 
 // -----------------------------------------------------------------------------
 // Source Request
@@ -75,61 +75,61 @@ pub use source::*;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SourceRequest {
-    pub specifier: String,
-    pub referrer: Option<String>,
-    pub kind_hint: Option<String>,
+  pub specifier: String,
+  pub referrer: Option<String>,
+  pub kind_hint: Option<String>,
 }
 
 impl SourceRequest {
-    pub fn new(specifier: impl Into<String>) -> Self {
-        Self {
-            specifier: specifier.into(),
-            referrer: None,
-            kind_hint: None,
-        }
+  pub fn new(specifier: impl Into<String>) -> Self {
+    Self {
+      specifier: specifier.into(),
+      referrer: None,
+      kind_hint: None,
+    }
+  }
+
+  pub fn with_referrer(mut self, referrer: impl Into<String>) -> Self {
+    self.referrer = Some(referrer.into());
+    self
+  }
+
+  pub fn with_kind_hint(mut self, kind_hint: impl Into<String>) -> Self {
+    self.kind_hint = Some(kind_hint.into());
+    self
+  }
+
+  pub fn validate(&self) -> MResult<()> {
+    if self.specifier.trim().is_empty() {
+      return invalid_source_request("specifier", "must not be empty");
     }
 
-    pub fn with_referrer(mut self, referrer: impl Into<String>) -> Self {
-        self.referrer = Some(referrer.into());
-        self
+    if let Some(referrer) = &self.referrer {
+      if referrer.trim().is_empty() {
+        return invalid_source_request("referrer", "must not be empty when present");
+      }
     }
 
-    pub fn with_kind_hint(mut self, kind_hint: impl Into<String>) -> Self {
-        self.kind_hint = Some(kind_hint.into());
-        self
+    if let Some(kind_hint) = &self.kind_hint {
+      if kind_hint.trim().is_empty() {
+        return invalid_source_request("kind_hint", "must not be empty when present");
+      }
     }
 
-    pub fn validate(&self) -> MResult<()> {
-        if self.specifier.trim().is_empty() {
-            return invalid_source_request("specifier", "must not be empty");
-        }
-
-        if let Some(referrer) = &self.referrer {
-            if referrer.trim().is_empty() {
-                return invalid_source_request("referrer", "must not be empty when present");
-            }
-        }
-
-        if let Some(kind_hint) = &self.kind_hint {
-            if kind_hint.trim().is_empty() {
-                return invalid_source_request("kind_hint", "must not be empty when present");
-            }
-        }
-
-        Ok(())
-    }
+    Ok(())
+  }
 }
 
 impl From<&str> for SourceRequest {
-    fn from(value: &str) -> Self {
-        Self::new(value)
-    }
+  fn from(value: &str) -> Self {
+    Self::new(value)
+  }
 }
 
 impl From<String> for SourceRequest {
-    fn from(value: String) -> Self {
-        Self::new(value)
-    }
+  fn from(value: String) -> Self {
+    Self::new(value)
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -156,158 +156,158 @@ impl From<String> for SourceRequest {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SourceImportKind {
-    Namespace,
-    Single { name: String },
-    Wildcard,
-    DependencyOnly,
+  Namespace,
+  Single { name: String },
+  Wildcard,
+  DependencyOnly,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceImportDeclaration {
-    pub specifier: String,
-    pub alias: Option<String>,
-    pub kind: SourceImportKind,
+  pub specifier: String,
+  pub alias: Option<String>,
+  pub kind: SourceImportKind,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceExportDeclaration {
-    pub name: String,
+  pub name: String,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceContextDeclaration {
-    pub name: String,
-    pub base: SourceContextBase,
-    pub capabilities: Vec<SourceContextCapability>,
+  pub name: String,
+  pub base: SourceContextBase,
+  pub capabilities: Vec<SourceContextCapability>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SourceContextBase {
-    ResourceUri(String),
-    Context(String),
+  ResourceUri(String),
+  Context(String),
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceContextCapability {
-    pub operation: String,
-    pub scope: SourceContextCapabilityScope,
+  pub operation: String,
+  pub scope: SourceContextCapabilityScope,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SourceContextCapabilityScope {
-    Path(String),
-    Wildcard,
+  Path(String),
+  Wildcard,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedSource {
-    pub name: String,
-    pub canonical_uri: String,
-    pub source: MechSourceCode,
-    pub kind: SourceKind,
-    pub imports: Vec<SourceImportDeclaration>,
-    pub exports: Vec<SourceExportDeclaration>,
-    pub contexts: Vec<SourceContextDeclaration>,
-    pub dependencies: Vec<SourceRequest>,
-    pub capability_requirements: Vec<CapabilityRequest>,
+  pub name: String,
+  pub canonical_uri: String,
+  pub source: MechSourceCode,
+  pub kind: SourceKind,
+  pub imports: Vec<SourceImportDeclaration>,
+  pub exports: Vec<SourceExportDeclaration>,
+  pub contexts: Vec<SourceContextDeclaration>,
+  pub dependencies: Vec<SourceRequest>,
+  pub capability_requirements: Vec<CapabilityRequest>,
 }
 
 impl ResolvedSource {
-    pub fn new(
-        name: impl Into<String>,
-        canonical_uri: impl Into<String>,
-        source: MechSourceCode,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            canonical_uri: canonical_uri.into(),
-            source,
-            kind: SourceKind::Unknown("".to_string()),
-            imports: Vec::new(),
-            exports: Vec::new(),
-            contexts: Vec::new(),
-            dependencies: Vec::new(),
-            capability_requirements: Vec::new(),
-        }
+  pub fn new(
+    name: impl Into<String>,
+    canonical_uri: impl Into<String>,
+    source: MechSourceCode,
+  ) -> Self {
+    Self {
+      name: name.into(),
+      canonical_uri: canonical_uri.into(),
+      source,
+      kind: SourceKind::Unknown("".to_string()),
+      imports: Vec::new(),
+      exports: Vec::new(),
+      contexts: Vec::new(),
+      dependencies: Vec::new(),
+      capability_requirements: Vec::new(),
+    }
+  }
+
+  pub fn with_kind(mut self, kind: SourceKind) -> Self {
+    self.kind = kind;
+    self
+  }
+
+  pub fn with_dependencies(mut self, dependencies: Vec<SourceRequest>) -> Self {
+    self.dependencies = dependencies;
+    self
+  }
+
+  pub fn with_imports(mut self, imports: Vec<SourceImportDeclaration>) -> Self {
+    self.imports = imports;
+    self
+  }
+
+  pub fn with_exports(mut self, exports: Vec<SourceExportDeclaration>) -> Self {
+    self.exports = exports;
+    self
+  }
+
+  pub fn with_contexts(mut self, contexts: Vec<SourceContextDeclaration>) -> Self {
+    self.contexts = contexts;
+    self
+  }
+
+  pub fn with_capability_requirements(
+    mut self,
+    capability_requirements: Vec<CapabilityRequest>,
+  ) -> Self {
+    self.capability_requirements = capability_requirements;
+    self
+  }
+
+  pub fn validate(&self) -> MResult<()> {
+    if self.name.trim().is_empty() {
+      return invalid_resolved_source("name", "must not be empty");
     }
 
-    pub fn with_kind(mut self, kind: SourceKind) -> Self {
-        self.kind = kind;
-        self
+    if self.canonical_uri.trim().is_empty() {
+      return invalid_resolved_source("canonical_uri", "must not be empty");
     }
 
-    pub fn with_dependencies(mut self, dependencies: Vec<SourceRequest>) -> Self {
-        self.dependencies = dependencies;
-        self
+    for import in &self.imports {
+      if import.specifier.trim().is_empty() {
+        return invalid_resolved_source("imports.specifier", "must not be empty");
+      }
     }
 
-    pub fn with_imports(mut self, imports: Vec<SourceImportDeclaration>) -> Self {
-        self.imports = imports;
-        self
+    for export in &self.exports {
+      if export.name.trim().is_empty() {
+        return invalid_resolved_source("exports.name", "must not be empty");
+      }
     }
 
-    pub fn with_exports(mut self, exports: Vec<SourceExportDeclaration>) -> Self {
-        self.exports = exports;
-        self
+    for dependency in &self.dependencies {
+      dependency.validate()?;
     }
 
-    pub fn with_contexts(mut self, contexts: Vec<SourceContextDeclaration>) -> Self {
-        self.contexts = contexts;
-        self
-    }
+    Ok(())
+  }
 
-    pub fn with_capability_requirements(
-        mut self,
-        capability_requirements: Vec<CapabilityRequest>,
-    ) -> Self {
-        self.capability_requirements = capability_requirements;
-        self
-    }
-
-    pub fn validate(&self) -> MResult<()> {
-        if self.name.trim().is_empty() {
-            return invalid_resolved_source("name", "must not be empty");
-        }
-
-        if self.canonical_uri.trim().is_empty() {
-            return invalid_resolved_source("canonical_uri", "must not be empty");
-        }
-
-        for import in &self.imports {
-            if import.specifier.trim().is_empty() {
-                return invalid_resolved_source("imports.specifier", "must not be empty");
-            }
-        }
-
-        for export in &self.exports {
-            if export.name.trim().is_empty() {
-                return invalid_resolved_source("exports.name", "must not be empty");
-            }
-        }
-
-        for dependency in &self.dependencies {
-            dependency.validate()?;
-        }
-
-        Ok(())
-    }
-
-    pub fn is_executable_mech_source(&self) -> bool {
-        matches!(
-            self.source,
-            MechSourceCode::String(_)
-                | MechSourceCode::Tree(_)
-                | MechSourceCode::ByteCode(_)
-                | MechSourceCode::Program(_)
-        )
-    }
+  pub fn is_executable_mech_source(&self) -> bool {
+    matches!(
+      self.source,
+      MechSourceCode::String(_)
+        | MechSourceCode::Tree(_)
+        | MechSourceCode::ByteCode(_)
+        | MechSourceCode::Program(_)
+    )
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -319,7 +319,7 @@ impl ResolvedSource {
 /// This trait is intentionally small. Filesystem, package-manager, database,
 /// embedded, network, and editor/workspace resolvers should all implement this.
 pub trait SourceResolver: std::fmt::Debug + Send {
-    fn resolve(&self, request: &SourceRequest) -> MResult<Option<ResolvedSource>>;
+  fn resolve(&self, request: &SourceRequest) -> MResult<Option<ResolvedSource>>;
 }
 
 /// Optional trait for resolvers that can accept in-memory source.
@@ -327,17 +327,17 @@ pub trait SourceResolver: std::fmt::Debug + Send {
 /// This is useful for editor buffers, tests, notebooks, and hosts that generate
 /// source dynamically.
 pub trait MutableSourceResolver: SourceResolver {
-    fn insert_source(
-        &mut self,
-        specifier: impl Into<String>,
-        source: ResolvedSource,
-    ) -> MResult<()>;
+  fn insert_source(
+    &mut self,
+    specifier: impl Into<String>,
+    source: ResolvedSource,
+  ) -> MResult<()>;
 
-    fn insert_string(
-        &mut self,
-        specifier: impl Into<String>,
-        source: impl Into<String>,
-    ) -> MResult<()>;
+  fn insert_string(
+    &mut self,
+    specifier: impl Into<String>,
+    source: impl Into<String>,
+  ) -> MResult<()>;
 }
 
 /// Optional trait for resolvers that can watch external sources.
@@ -345,7 +345,7 @@ pub trait MutableSourceResolver: SourceResolver {
 /// Filesystem resolvers should implement this. Package, database, or editor
 /// resolvers may also implement it later if they support change notifications.
 pub trait WatchableSourceResolver: SourceResolver {
-    fn watch_source(&mut self, specifier: &str) -> MResult<()>;
+  fn watch_source(&mut self, specifier: &str) -> MResult<()>;
 }
 
 // -----------------------------------------------------------------------------
@@ -354,54 +354,54 @@ pub trait WatchableSourceResolver: SourceResolver {
 
 #[derive(Debug, Clone)]
 pub struct InvalidSourceRequestError {
-    pub field: &'static str,
-    pub reason: &'static str,
+  pub field: &'static str,
+  pub reason: &'static str,
 }
 
 impl MechErrorKind for InvalidSourceRequestError {
-    fn name(&self) -> &str {
-        "InvalidSourceRequest"
-    }
+  fn name(&self) -> &str {
+    "InvalidSourceRequest"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "Invalid source request field `{}`: {}",
-            self.field, self.reason
-        )
-    }
+  fn message(&self) -> String {
+    format!("Invalid source request field `{}`: {}", self.field, self.reason)
+  }
 }
 
-fn invalid_source_request<T>(field: &'static str, reason: &'static str) -> MResult<T> {
-    Err(MechError::new(
-        InvalidSourceRequestError { field, reason },
-        None,
-    ))
+fn invalid_source_request<T>(
+  field: &'static str,
+  reason: &'static str,
+) -> MResult<T> {
+  Err(MechError::new(
+    InvalidSourceRequestError { field, reason },
+    None,
+  ))
 }
 
 #[derive(Debug, Clone)]
 pub struct InvalidResolvedSourceError {
-    pub field: &'static str,
-    pub reason: &'static str,
+  pub field: &'static str,
+  pub reason: &'static str,
 }
 
 impl MechErrorKind for InvalidResolvedSourceError {
-    fn name(&self) -> &str {
-        "InvalidResolvedSource"
-    }
+  fn name(&self) -> &str {
+    "InvalidResolvedSource"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "Invalid resolved source field `{}`: {}",
-            self.field, self.reason
-        )
-    }
+  fn message(&self) -> String {
+    format!("Invalid resolved source field `{}`: {}", self.field, self.reason)
+  }
 }
 
-fn invalid_resolved_source<T>(field: &'static str, reason: &'static str) -> MResult<T> {
-    Err(MechError::new(
-        InvalidResolvedSourceError { field, reason },
-        None,
-    ))
+fn invalid_resolved_source<T>(
+  field: &'static str,
+  reason: &'static str,
+) -> MResult<T> {
+  Err(MechError::new(
+    InvalidResolvedSourceError { field, reason },
+    None,
+  ))
 }
 
 // -----------------------------------------------------------------------------
@@ -410,41 +410,41 @@ fn invalid_resolved_source<T>(field: &'static str, reason: &'static str) -> MRes
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+  use super::*;
 
-    #[test]
-    fn source_request_validates_nonempty_specifier() {
-        let request = SourceRequest::new("");
-        assert!(request.validate().is_err());
-    }
+  #[test]
+  fn source_request_validates_nonempty_specifier() {
+    let request = SourceRequest::new("");
+    assert!(request.validate().is_err());
+  }
 
-    #[test]
-    fn source_request_from_str() {
-        let request = SourceRequest::from("main.mec");
-        assert_eq!(request.specifier, "main.mec");
-        assert_eq!(request.referrer, None);
-        assert_eq!(request.kind_hint, None);
-    }
+  #[test]
+  fn source_request_from_str() {
+    let request = SourceRequest::from("main.mec");
+    assert_eq!(request.specifier, "main.mec");
+    assert_eq!(request.referrer, None);
+    assert_eq!(request.kind_hint, None);
+  }
 
-    #[test]
-    fn resolved_source_validates_identity_fields() {
-        let source = ResolvedSource::new(
-            "main",
-            "memory:main",
-            MechSourceCode::String("x := 1".to_string()),
-        );
+  #[test]
+  fn resolved_source_validates_identity_fields() {
+    let source = ResolvedSource::new(
+      "main",
+      "memory:main",
+      MechSourceCode::String("x := 1".to_string()),
+    );
 
-        assert!(source.validate().is_ok());
-    }
+    assert!(source.validate().is_ok());
+  }
 
-    #[test]
-    fn resolved_source_detects_executable_mech_source() {
-        let source = ResolvedSource::new(
-            "main",
-            "memory:main",
-            MechSourceCode::String("x := 1".to_string()),
-        );
+  #[test]
+  fn resolved_source_detects_executable_mech_source() {
+    let source = ResolvedSource::new(
+      "main",
+      "memory:main",
+      MechSourceCode::String("x := 1".to_string()),
+    );
 
-        assert!(source.is_executable_mech_source());
-    }
+    assert!(source.is_executable_mech_source());
+  }
 }

--- a/src/runtime/src/resolver/mod.rs
+++ b/src/runtime/src/resolver/mod.rs
@@ -36,17 +36,19 @@ use crate::capability::CapabilityRequest;
 // Submodules
 // -----------------------------------------------------------------------------
 
-pub mod memory;
-pub mod source;
+pub mod ast;
 pub mod file;
 pub mod imports;
-pub mod ast;
+pub mod index;
+pub mod memory;
+pub mod source;
 
-pub use memory::*;
-pub use source::*;
+pub use ast::*;
 pub use file::*;
 pub use imports::*;
-pub use ast::*;
+pub use index::*;
+pub use memory::*;
+pub use source::*;
 
 // -----------------------------------------------------------------------------
 // Source Request
@@ -73,61 +75,61 @@ pub use ast::*;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SourceRequest {
-  pub specifier: String,
-  pub referrer: Option<String>,
-  pub kind_hint: Option<String>,
+    pub specifier: String,
+    pub referrer: Option<String>,
+    pub kind_hint: Option<String>,
 }
 
 impl SourceRequest {
-  pub fn new(specifier: impl Into<String>) -> Self {
-    Self {
-      specifier: specifier.into(),
-      referrer: None,
-      kind_hint: None,
-    }
-  }
-
-  pub fn with_referrer(mut self, referrer: impl Into<String>) -> Self {
-    self.referrer = Some(referrer.into());
-    self
-  }
-
-  pub fn with_kind_hint(mut self, kind_hint: impl Into<String>) -> Self {
-    self.kind_hint = Some(kind_hint.into());
-    self
-  }
-
-  pub fn validate(&self) -> MResult<()> {
-    if self.specifier.trim().is_empty() {
-      return invalid_source_request("specifier", "must not be empty");
+    pub fn new(specifier: impl Into<String>) -> Self {
+        Self {
+            specifier: specifier.into(),
+            referrer: None,
+            kind_hint: None,
+        }
     }
 
-    if let Some(referrer) = &self.referrer {
-      if referrer.trim().is_empty() {
-        return invalid_source_request("referrer", "must not be empty when present");
-      }
+    pub fn with_referrer(mut self, referrer: impl Into<String>) -> Self {
+        self.referrer = Some(referrer.into());
+        self
     }
 
-    if let Some(kind_hint) = &self.kind_hint {
-      if kind_hint.trim().is_empty() {
-        return invalid_source_request("kind_hint", "must not be empty when present");
-      }
+    pub fn with_kind_hint(mut self, kind_hint: impl Into<String>) -> Self {
+        self.kind_hint = Some(kind_hint.into());
+        self
     }
 
-    Ok(())
-  }
+    pub fn validate(&self) -> MResult<()> {
+        if self.specifier.trim().is_empty() {
+            return invalid_source_request("specifier", "must not be empty");
+        }
+
+        if let Some(referrer) = &self.referrer {
+            if referrer.trim().is_empty() {
+                return invalid_source_request("referrer", "must not be empty when present");
+            }
+        }
+
+        if let Some(kind_hint) = &self.kind_hint {
+            if kind_hint.trim().is_empty() {
+                return invalid_source_request("kind_hint", "must not be empty when present");
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl From<&str> for SourceRequest {
-  fn from(value: &str) -> Self {
-    Self::new(value)
-  }
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
 }
 
 impl From<String> for SourceRequest {
-  fn from(value: String) -> Self {
-    Self::new(value)
-  }
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -154,158 +156,158 @@ impl From<String> for SourceRequest {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SourceImportKind {
-  Namespace,
-  Single { name: String },
-  Wildcard,
-  DependencyOnly,
+    Namespace,
+    Single { name: String },
+    Wildcard,
+    DependencyOnly,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceImportDeclaration {
-  pub specifier: String,
-  pub alias: Option<String>,
-  pub kind: SourceImportKind,
+    pub specifier: String,
+    pub alias: Option<String>,
+    pub kind: SourceImportKind,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceExportDeclaration {
-  pub name: String,
+    pub name: String,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceContextDeclaration {
-  pub name: String,
-  pub base: SourceContextBase,
-  pub capabilities: Vec<SourceContextCapability>,
+    pub name: String,
+    pub base: SourceContextBase,
+    pub capabilities: Vec<SourceContextCapability>,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SourceContextBase {
-  ResourceUri(String),
-  Context(String),
+    ResourceUri(String),
+    Context(String),
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceContextCapability {
-  pub operation: String,
-  pub scope: SourceContextCapabilityScope,
+    pub operation: String,
+    pub scope: SourceContextCapabilityScope,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SourceContextCapabilityScope {
-  Path(String),
-  Wildcard,
+    Path(String),
+    Wildcard,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedSource {
-  pub name: String,
-  pub canonical_uri: String,
-  pub source: MechSourceCode,
-  pub kind: SourceKind,
-  pub imports: Vec<SourceImportDeclaration>,
-  pub exports: Vec<SourceExportDeclaration>,
-  pub contexts: Vec<SourceContextDeclaration>,
-  pub dependencies: Vec<SourceRequest>,
-  pub capability_requirements: Vec<CapabilityRequest>,
+    pub name: String,
+    pub canonical_uri: String,
+    pub source: MechSourceCode,
+    pub kind: SourceKind,
+    pub imports: Vec<SourceImportDeclaration>,
+    pub exports: Vec<SourceExportDeclaration>,
+    pub contexts: Vec<SourceContextDeclaration>,
+    pub dependencies: Vec<SourceRequest>,
+    pub capability_requirements: Vec<CapabilityRequest>,
 }
 
 impl ResolvedSource {
-  pub fn new(
-    name: impl Into<String>,
-    canonical_uri: impl Into<String>,
-    source: MechSourceCode,
-  ) -> Self {
-    Self {
-      name: name.into(),
-      canonical_uri: canonical_uri.into(),
-      source,
-      kind: SourceKind::Unknown("".to_string()),
-      imports: Vec::new(),
-      exports: Vec::new(),
-      contexts: Vec::new(),
-      dependencies: Vec::new(),
-      capability_requirements: Vec::new(),
-    }
-  }
-
-  pub fn with_kind(mut self, kind: SourceKind) -> Self {
-    self.kind = kind;
-    self
-  }
-
-  pub fn with_dependencies(mut self, dependencies: Vec<SourceRequest>) -> Self {
-    self.dependencies = dependencies;
-    self
-  }
-
-  pub fn with_imports(mut self, imports: Vec<SourceImportDeclaration>) -> Self {
-    self.imports = imports;
-    self
-  }
-
-  pub fn with_exports(mut self, exports: Vec<SourceExportDeclaration>) -> Self {
-    self.exports = exports;
-    self
-  }
-
-  pub fn with_contexts(mut self, contexts: Vec<SourceContextDeclaration>) -> Self {
-    self.contexts = contexts;
-    self
-  }
-
-  pub fn with_capability_requirements(
-    mut self,
-    capability_requirements: Vec<CapabilityRequest>,
-  ) -> Self {
-    self.capability_requirements = capability_requirements;
-    self
-  }
-
-  pub fn validate(&self) -> MResult<()> {
-    if self.name.trim().is_empty() {
-      return invalid_resolved_source("name", "must not be empty");
+    pub fn new(
+        name: impl Into<String>,
+        canonical_uri: impl Into<String>,
+        source: MechSourceCode,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            canonical_uri: canonical_uri.into(),
+            source,
+            kind: SourceKind::Unknown("".to_string()),
+            imports: Vec::new(),
+            exports: Vec::new(),
+            contexts: Vec::new(),
+            dependencies: Vec::new(),
+            capability_requirements: Vec::new(),
+        }
     }
 
-    if self.canonical_uri.trim().is_empty() {
-      return invalid_resolved_source("canonical_uri", "must not be empty");
+    pub fn with_kind(mut self, kind: SourceKind) -> Self {
+        self.kind = kind;
+        self
     }
 
-    for import in &self.imports {
-      if import.specifier.trim().is_empty() {
-        return invalid_resolved_source("imports.specifier", "must not be empty");
-      }
+    pub fn with_dependencies(mut self, dependencies: Vec<SourceRequest>) -> Self {
+        self.dependencies = dependencies;
+        self
     }
 
-    for export in &self.exports {
-      if export.name.trim().is_empty() {
-        return invalid_resolved_source("exports.name", "must not be empty");
-      }
+    pub fn with_imports(mut self, imports: Vec<SourceImportDeclaration>) -> Self {
+        self.imports = imports;
+        self
     }
 
-    for dependency in &self.dependencies {
-      dependency.validate()?;
+    pub fn with_exports(mut self, exports: Vec<SourceExportDeclaration>) -> Self {
+        self.exports = exports;
+        self
     }
 
-    Ok(())
-  }
+    pub fn with_contexts(mut self, contexts: Vec<SourceContextDeclaration>) -> Self {
+        self.contexts = contexts;
+        self
+    }
 
-  pub fn is_executable_mech_source(&self) -> bool {
-    matches!(
-      self.source,
-      MechSourceCode::String(_)
-        | MechSourceCode::Tree(_)
-        | MechSourceCode::ByteCode(_)
-        | MechSourceCode::Program(_)
-    )
-  }
+    pub fn with_capability_requirements(
+        mut self,
+        capability_requirements: Vec<CapabilityRequest>,
+    ) -> Self {
+        self.capability_requirements = capability_requirements;
+        self
+    }
+
+    pub fn validate(&self) -> MResult<()> {
+        if self.name.trim().is_empty() {
+            return invalid_resolved_source("name", "must not be empty");
+        }
+
+        if self.canonical_uri.trim().is_empty() {
+            return invalid_resolved_source("canonical_uri", "must not be empty");
+        }
+
+        for import in &self.imports {
+            if import.specifier.trim().is_empty() {
+                return invalid_resolved_source("imports.specifier", "must not be empty");
+            }
+        }
+
+        for export in &self.exports {
+            if export.name.trim().is_empty() {
+                return invalid_resolved_source("exports.name", "must not be empty");
+            }
+        }
+
+        for dependency in &self.dependencies {
+            dependency.validate()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn is_executable_mech_source(&self) -> bool {
+        matches!(
+            self.source,
+            MechSourceCode::String(_)
+                | MechSourceCode::Tree(_)
+                | MechSourceCode::ByteCode(_)
+                | MechSourceCode::Program(_)
+        )
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -317,7 +319,7 @@ impl ResolvedSource {
 /// This trait is intentionally small. Filesystem, package-manager, database,
 /// embedded, network, and editor/workspace resolvers should all implement this.
 pub trait SourceResolver: std::fmt::Debug + Send {
-  fn resolve(&self, request: &SourceRequest) -> MResult<Option<ResolvedSource>>;
+    fn resolve(&self, request: &SourceRequest) -> MResult<Option<ResolvedSource>>;
 }
 
 /// Optional trait for resolvers that can accept in-memory source.
@@ -325,17 +327,17 @@ pub trait SourceResolver: std::fmt::Debug + Send {
 /// This is useful for editor buffers, tests, notebooks, and hosts that generate
 /// source dynamically.
 pub trait MutableSourceResolver: SourceResolver {
-  fn insert_source(
-    &mut self,
-    specifier: impl Into<String>,
-    source: ResolvedSource,
-  ) -> MResult<()>;
+    fn insert_source(
+        &mut self,
+        specifier: impl Into<String>,
+        source: ResolvedSource,
+    ) -> MResult<()>;
 
-  fn insert_string(
-    &mut self,
-    specifier: impl Into<String>,
-    source: impl Into<String>,
-  ) -> MResult<()>;
+    fn insert_string(
+        &mut self,
+        specifier: impl Into<String>,
+        source: impl Into<String>,
+    ) -> MResult<()>;
 }
 
 /// Optional trait for resolvers that can watch external sources.
@@ -343,7 +345,7 @@ pub trait MutableSourceResolver: SourceResolver {
 /// Filesystem resolvers should implement this. Package, database, or editor
 /// resolvers may also implement it later if they support change notifications.
 pub trait WatchableSourceResolver: SourceResolver {
-  fn watch_source(&mut self, specifier: &str) -> MResult<()>;
+    fn watch_source(&mut self, specifier: &str) -> MResult<()>;
 }
 
 // -----------------------------------------------------------------------------
@@ -352,54 +354,54 @@ pub trait WatchableSourceResolver: SourceResolver {
 
 #[derive(Debug, Clone)]
 pub struct InvalidSourceRequestError {
-  pub field: &'static str,
-  pub reason: &'static str,
+    pub field: &'static str,
+    pub reason: &'static str,
 }
 
 impl MechErrorKind for InvalidSourceRequestError {
-  fn name(&self) -> &str {
-    "InvalidSourceRequest"
-  }
+    fn name(&self) -> &str {
+        "InvalidSourceRequest"
+    }
 
-  fn message(&self) -> String {
-    format!("Invalid source request field `{}`: {}", self.field, self.reason)
-  }
+    fn message(&self) -> String {
+        format!(
+            "Invalid source request field `{}`: {}",
+            self.field, self.reason
+        )
+    }
 }
 
-fn invalid_source_request<T>(
-  field: &'static str,
-  reason: &'static str,
-) -> MResult<T> {
-  Err(MechError::new(
-    InvalidSourceRequestError { field, reason },
-    None,
-  ))
+fn invalid_source_request<T>(field: &'static str, reason: &'static str) -> MResult<T> {
+    Err(MechError::new(
+        InvalidSourceRequestError { field, reason },
+        None,
+    ))
 }
 
 #[derive(Debug, Clone)]
 pub struct InvalidResolvedSourceError {
-  pub field: &'static str,
-  pub reason: &'static str,
+    pub field: &'static str,
+    pub reason: &'static str,
 }
 
 impl MechErrorKind for InvalidResolvedSourceError {
-  fn name(&self) -> &str {
-    "InvalidResolvedSource"
-  }
+    fn name(&self) -> &str {
+        "InvalidResolvedSource"
+    }
 
-  fn message(&self) -> String {
-    format!("Invalid resolved source field `{}`: {}", self.field, self.reason)
-  }
+    fn message(&self) -> String {
+        format!(
+            "Invalid resolved source field `{}`: {}",
+            self.field, self.reason
+        )
+    }
 }
 
-fn invalid_resolved_source<T>(
-  field: &'static str,
-  reason: &'static str,
-) -> MResult<T> {
-  Err(MechError::new(
-    InvalidResolvedSourceError { field, reason },
-    None,
-  ))
+fn invalid_resolved_source<T>(field: &'static str, reason: &'static str) -> MResult<T> {
+    Err(MechError::new(
+        InvalidResolvedSourceError { field, reason },
+        None,
+    ))
 }
 
 // -----------------------------------------------------------------------------
@@ -408,41 +410,41 @@ fn invalid_resolved_source<T>(
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn source_request_validates_nonempty_specifier() {
-    let request = SourceRequest::new("");
-    assert!(request.validate().is_err());
-  }
+    #[test]
+    fn source_request_validates_nonempty_specifier() {
+        let request = SourceRequest::new("");
+        assert!(request.validate().is_err());
+    }
 
-  #[test]
-  fn source_request_from_str() {
-    let request = SourceRequest::from("main.mec");
-    assert_eq!(request.specifier, "main.mec");
-    assert_eq!(request.referrer, None);
-    assert_eq!(request.kind_hint, None);
-  }
+    #[test]
+    fn source_request_from_str() {
+        let request = SourceRequest::from("main.mec");
+        assert_eq!(request.specifier, "main.mec");
+        assert_eq!(request.referrer, None);
+        assert_eq!(request.kind_hint, None);
+    }
 
-  #[test]
-  fn resolved_source_validates_identity_fields() {
-    let source = ResolvedSource::new(
-      "main",
-      "memory:main",
-      MechSourceCode::String("x := 1".to_string()),
-    );
+    #[test]
+    fn resolved_source_validates_identity_fields() {
+        let source = ResolvedSource::new(
+            "main",
+            "memory:main",
+            MechSourceCode::String("x := 1".to_string()),
+        );
 
-    assert!(source.validate().is_ok());
-  }
+        assert!(source.validate().is_ok());
+    }
 
-  #[test]
-  fn resolved_source_detects_executable_mech_source() {
-    let source = ResolvedSource::new(
-      "main",
-      "memory:main",
-      MechSourceCode::String("x := 1".to_string()),
-    );
+    #[test]
+    fn resolved_source_detects_executable_mech_source() {
+        let source = ResolvedSource::new(
+            "main",
+            "memory:main",
+            MechSourceCode::String("x := 1".to_string()),
+        );
 
-    assert!(source.is_executable_mech_source());
-  }
+        assert!(source.is_executable_mech_source());
+    }
 }


### PR DESCRIPTION
### Motivation
- Consolidate multiple AST walkers into a single queryable resolver index to represent semantic declarations extracted from parsed programs.
- Preserve existing flat resolver behavior while enabling future per-interpreter/module semantics and fewer independent traversals.
- Keep context extraction and metadata behavior (imports/exports/contexts/dependencies) unchanged at runtime.

### Description
- Add a new resolver module `resolver::index` (`src/runtime/src/resolver/index.rs`) that defines `SourceScope`, `SourceInterpreterId`, `SourceOccurrence`, scoped import/export/context declaration types, `SourceDeclaration`, and `SourceIndex`; and implements `SourceIndex::from_program` which performs a single traversal to collect declarations across program and fenced interpreter sections while preserving declaration order and optional source ranges.
- Implement query APIs on `SourceIndex`: `all_*`, `program_*`, `*_for_scope`, and `interpreter_scopes`, and internal helpers that push scoped declarations; declaration ranges use `Token::merge_tokens` when available and a TODO notes addressed-path indexing.
- Rework legacy AST helpers in `resolver::ast` to be thin wrappers around `SourceIndex::from_program` (`imports_from_program`, `exports_from_program`, `contexts_from_program`, `dependencies_from_program`) so existing callers keep flat/all-scope behavior.
- Update `FileSourceResolver` (`resolver::file`) to call `SourceIndex::from_program` once and populate `ResolvedSource.imports`, `.exports`, `.contexts`, and `.dependencies` from the index (using the `all_*` views) to preserve existing behavior.
- Register and re-export the new `resolver::index` module in `resolver::mod` and add resolver tests that exercise program-scope, fenced interpreter-scope, scope separation, legacy-helper parity, and file resolver parity.

### Testing
- Ran `cargo test -p mech-runtime --features default` and the mech-runtime test suite completed successfully (101 + additional module tests passed).
- Ran `cargo test -p mech-runtime module` and `cargo test -p mech-syntax` and `cargo test -p mech-core` and they all passed for the modified/respective packages.
- Added resolver tests (in `resolver::ast` test module) including `source_index_collects_program_declarations`, `source_index_collects_fenced_interpreter_declarations`, `source_index_keeps_program_and_interpreter_scopes_separate`, `legacy_helpers_match_source_index_all_views`, and `file_resolver_uses_index_without_behavior_change`, and they passed under the test runs above.
- Ran `cargo fmt --all` which reported failures due to pre-existing trailing whitespace in unrelated files; formatting errors are unrelated to the new index implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17a0534018832aaf2bcfbd9315706b)