### PR TITLE
Store scoped source declarations in module records

### DIFF
--- a/src/runtime/src/module/builder.rs
+++ b/src/runtime/src/module/builder.rs
@@ -117,6 +117,7 @@ impl ModuleBuilder {
       resolved.exports,
       resolved.imports,
       resolved.contexts,
+      resolved.scopes,
       dependency_versions.to_vec(),
       capability_requirements.to_vec(),
       capability_requirement_keys,

--- a/src/runtime/src/module/record.rs
+++ b/src/runtime/src/module/record.rs
@@ -7,6 +7,7 @@ use crate::{
   SourceExportDeclaration,
   SourceImportDeclaration,
   SourceKind,
+  ModuleScopeMetadata,
   CapabilityRequest
 };
 
@@ -25,6 +26,7 @@ pub struct RuntimeModuleRecord {
   pub exports: Vec<SourceExportDeclaration>,
   pub imports: Vec<SourceImportDeclaration>,
   pub contexts: Vec<SourceContextDeclaration>,
+  pub scopes: Vec<ModuleScopeMetadata>,
   pub dependency_versions: Vec<ModuleVersionId>,
   pub capability_requirements: Vec<CapabilityRequest>,
   pub capability_requirement_keys: Vec<String>,
@@ -45,6 +47,7 @@ impl RuntimeModuleRecord {
     exports: Vec<SourceExportDeclaration>,
     imports: Vec<SourceImportDeclaration>,
     contexts: Vec<SourceContextDeclaration>,
+    scopes: Vec<ModuleScopeMetadata>,
     dependency_versions: Vec<ModuleVersionId>,
     capability_requirements: Vec<CapabilityRequest>,
     capability_requirement_keys: Vec<String>,
@@ -63,6 +66,7 @@ impl RuntimeModuleRecord {
       exports,
       imports,
       contexts,
+      scopes,
       dependency_versions,
       capability_requirements,
       capability_requirement_keys,

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -115,6 +115,7 @@ impl SourceResolver for FileSourceResolver {
         let imports = index.all_imports();
         let exports = index.all_exports();
         let contexts = index.all_contexts();
+        let scopes = index.module_scopes();
         let dependencies = imports
           .iter()
           .map(|import| source_request_for_import(import, Some(&referrer)))
@@ -124,7 +125,8 @@ impl SourceResolver for FileSourceResolver {
           .with_imports(imports)
           .with_exports(exports)
           .with_contexts(contexts)
-          .with_dependencies(dependencies);
+          .with_dependencies(dependencies)
+          .with_scopes(scopes);
       }
     }
 

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -61,6 +61,15 @@ pub enum SourceDeclaration {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModuleScopeMetadata {
+    pub scope: SourceScope,
+    pub imports: Vec<SourceImportDeclaration>,
+    pub exports: Vec<SourceExportDeclaration>,
+    pub contexts: Vec<SourceContextDeclaration>,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SourceIndex {
     pub declarations: Vec<SourceDeclaration>,
@@ -166,6 +175,31 @@ impl SourceIndex {
 
         // TODO: index addressed paths from statements/expressions in a future PR.
         index
+    }
+
+    pub fn module_scopes(&self) -> Vec<ModuleScopeMetadata> {
+        let mut scopes: Vec<SourceScope> = Vec::new();
+
+        for declaration in &self.declarations {
+            let scope = match declaration {
+                SourceDeclaration::Import(import) => &import.occurrence.scope,
+                SourceDeclaration::Export(export) => &export.occurrence.scope,
+                SourceDeclaration::Context(context) => &context.occurrence.scope,
+            };
+            if !scopes.contains(scope) {
+                scopes.push(scope.clone());
+            }
+        }
+
+        scopes
+            .into_iter()
+            .map(|scope| ModuleScopeMetadata {
+                imports: self.imports_for_scope(&scope),
+                exports: self.exports_for_scope(&scope),
+                contexts: self.contexts_for_scope(&scope),
+                scope,
+            })
+            .collect()
     }
 
     pub fn all_imports(&self) -> Vec<SourceImportDeclaration> {

--- a/src/runtime/src/resolver/mod.rs
+++ b/src/runtime/src/resolver/mod.rs
@@ -215,6 +215,7 @@ pub struct ResolvedSource {
   pub imports: Vec<SourceImportDeclaration>,
   pub exports: Vec<SourceExportDeclaration>,
   pub contexts: Vec<SourceContextDeclaration>,
+  pub scopes: Vec<ModuleScopeMetadata>,
   pub dependencies: Vec<SourceRequest>,
   pub capability_requirements: Vec<CapabilityRequest>,
 }
@@ -233,6 +234,7 @@ impl ResolvedSource {
       imports: Vec::new(),
       exports: Vec::new(),
       contexts: Vec::new(),
+      scopes: Vec::new(),
       dependencies: Vec::new(),
       capability_requirements: Vec::new(),
     }
@@ -260,6 +262,11 @@ impl ResolvedSource {
 
   pub fn with_contexts(mut self, contexts: Vec<SourceContextDeclaration>) -> Self {
     self.contexts = contexts;
+    self
+  }
+
+  pub fn with_scopes(mut self, scopes: Vec<ModuleScopeMetadata>) -> Self {
+    self.scopes = scopes;
     self
   }
 

--- a/src/runtime/src/runtime.rs
+++ b/src/runtime/src/runtime.rs
@@ -1226,6 +1226,7 @@ impl MechRuntime {
       .with_exports(record.exports)
       .with_imports(record.imports)
       .with_contexts(record.contexts)
+      .with_scopes(record.scopes)
       .with_dependencies(record.dependency_versions)
       .with_import_edges(import_edges)
       .with_capability_requirements(record.capability_requirements);

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -28,7 +28,10 @@ use crate::id::{
   ActorId, CapabilityId, EventId, MessageId, ModuleId, ModuleVersionId,
   ObjectId, TaskId, TransactionId,
 };
-use crate::resolver::{SourceContextDeclaration, SourceExportDeclaration, SourceImportDeclaration};
+use crate::resolver::{
+  ModuleScopeMetadata, SourceContextDeclaration, SourceExportDeclaration,
+  SourceImportDeclaration,
+};
 
 // -----------------------------------------------------------------------------
 // Store Trait
@@ -196,6 +199,7 @@ pub struct ModuleVersionRecord {
   pub exports: Vec<SourceExportDeclaration>,
   pub imports: Vec<SourceImportDeclaration>,
   pub contexts: Vec<SourceContextDeclaration>,
+  pub scopes: Vec<ModuleScopeMetadata>,
   pub dependencies: Vec<ModuleVersionId>,
   pub import_edges: Vec<ModuleImportEdge>,
   pub capability_requirements: Vec<CapabilityRequest>,
@@ -212,6 +216,7 @@ impl ModuleVersionRecord {
       exports: Vec::new(),
       imports: Vec::new(),
       contexts: Vec::new(),
+      scopes: Vec::new(),
       dependencies: Vec::new(),
       import_edges: Vec::new(),
       capability_requirements: Vec::new(),
@@ -245,6 +250,11 @@ impl ModuleVersionRecord {
 
   pub fn with_contexts(mut self, contexts: Vec<SourceContextDeclaration>) -> Self {
     self.contexts = contexts;
+    self
+  }
+
+  pub fn with_scopes(mut self, scopes: Vec<ModuleScopeMetadata>) -> Self {
+    self.scopes = scopes;
     self
   }
 

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,5 +1,5 @@
 use mech_core::{Ref, Value};
-use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, ModuleBuildOptions, RuntimeBuilder, SourceRequest, SourceResolver};
+use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, ModuleBuildOptions, RuntimeBuilder, SourceRequest, SourceResolver, SourceScope};
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
@@ -22,6 +22,87 @@ fn resolver_metadata() {
 
   let dep = resolver.resolve(&main.dependencies[0]).unwrap().unwrap();
   assert!(dep.exports.iter().any(|e| e.name == "tau"));
+}
+
+#[test]
+fn module_records_store_scoped_source_declarations_without_execution_changes() {
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-scopes-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("foo.mec"), "foo-result := 1\n<+ foo-result\n").unwrap();
+  std::fs::write(root.join("bar.mec"), "bar-result := 2\n<+ bar-result\n").unwrap();
+  std::fs::write(
+    root.join("main.mec"),
+    "@program-db := db://program{:read(*)}\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n\n~~~mech:bar\n@bar-db := db://bar{:read(*)}\n+> ./bar.mec\n<+ bar-result\n~~~\n",
+  ).unwrap();
+
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+
+  assert_eq!(main.imports.len(), 3);
+  assert_eq!(main.exports.len(), 3);
+  assert_eq!(main.contexts.len(), 3);
+  assert_eq!(main.import_edges.len(), 3);
+
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert_eq!(program.imports.len(), 1);
+  assert_eq!(program.imports[0].specifier, "./math.mec");
+  assert_eq!(program.exports.len(), 1);
+  assert_eq!(program.exports[0].name, "ok");
+  assert_eq!(program.contexts.len(), 1);
+  assert_eq!(program.contexts[0].name, "program-db");
+
+  let foo = main.scopes.iter().find(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+    SourceScope::Program => false,
+  }).unwrap();
+  assert_eq!(foo.imports.len(), 1);
+  assert_eq!(foo.imports[0].specifier, "./foo.mec");
+  assert_eq!(foo.exports.len(), 1);
+  assert_eq!(foo.exports[0].name, "foo-result");
+  assert_eq!(foo.contexts.len(), 1);
+  assert_eq!(foo.contexts[0].name, "foo-db");
+
+  let bar = main.scopes.iter().find(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar",
+    SourceScope::Program => false,
+  }).unwrap();
+  assert_eq!(bar.imports.len(), 1);
+  assert_eq!(bar.imports[0].specifier, "./bar.mec");
+  assert_eq!(bar.exports.len(), 1);
+  assert_eq!(bar.exports[0].name, "bar-result");
+  assert_eq!(bar.contexts.len(), 1);
+  assert_eq!(bar.contexts[0].name, "bar-db");
+
+  assert!(!foo.imports.iter().any(|import| import.specifier == "./bar.mec"));
+  assert!(!foo.exports.iter().any(|export| export.name == "bar-result"));
+  assert!(!foo.contexts.iter().any(|context| context.name == "bar-db"));
+}
+
+#[test]
+fn run_module_keeps_flat_import_behavior_for_fenced_imports() {
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-flat-fenced-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\n~~~\nok := math/tau > 6.0\n").unwrap();
+
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.imports.len(), 1);
+  assert!(main.scopes.iter().any(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && scope.imports.len() == 1 && scope.imports[0].specifier == "./math.mec",
+    SourceScope::Program => false,
+  }));
+
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Record resolver-facing, per-scope declarations (Program vs Interpreter(namespace)) so later runtime work can create import environments per scope.
- Preserve existing flat `imports`/`exports`/`contexts`/`dependencies`/`import_edges` views for backwards compatibility and avoid changing execution semantics in this PR.
- Provide storage/metadata plumbing first so execution semantics can be scoped in a follow-up change.

### Description
- Add `ModuleScopeMetadata` and `SourceIndex::module_scopes()` to materialize imports/exports/contexts by `SourceScope` (Program or Interpreter). (files: `src/runtime/src/resolver/index.rs`)
- Extend `ResolvedSource`, `RuntimeModuleRecord`, and persisted `ModuleVersionRecord` with a `scopes: Vec<ModuleScopeMetadata>` field and builder helpers to carry scoped metadata. (files: `src/runtime/src/resolver/mod.rs`, `src/runtime/src/module/record.rs`, `src/runtime/src/store.rs`)
- Populate `ResolvedSource.scopes` during file resolution and thread `scopes` through module building and storage without removing or changing the existing flat lists. (files: `src/runtime/src/resolver/file.rs`, `src/runtime/src/module/builder.rs`, `src/runtime/src/runtime.rs`)
- Add tests in `module_smoke.rs` that assert scoped declarations land in `Program`, `Interpreter(foo)`, and `Interpreter(bar)` scopes, that scoped declarations do not mix across interpreters, and that existing flat `run_module` behavior remains unchanged. (file: `src/runtime/tests/module_smoke.rs`)

### Testing
- Ran `cargo test -p mech-runtime --test module_smoke` and the test suite for that target passed (module smoke tests passed).
- Ran full `cargo test -p mech-runtime` and all `mech-runtime` unit tests passed (no failures).
- The change preserves existing runtime behavior as verified by the added smoke tests which exercise both scoped storage and unchanged flat import semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184727d84c832a8f223551fbbeb69e)