### PR TITLE
Address target namespace validation and runtime classification

### DIFF
--- a/src/runtime/src/bin/address_target_diagnostics.rs
+++ b/src/runtime/src/bin/address_target_diagnostics.rs
@@ -1,0 +1,88 @@
+use mech_runtime::{FileSourceResolver, ModuleBuildOptions, RuntimeBuilder};
+
+fn write_case(root: &std::path::Path, name: &str, source: &str) -> std::path::PathBuf {
+  let case_root = root.join(name);
+  std::fs::create_dir_all(&case_root).unwrap();
+  std::fs::write(case_root.join("main.mec"), source).unwrap();
+  case_root
+}
+
+fn run_case(root: &std::path::Path, name: &str, source: &str) {
+  let case_root = write_case(root, name, source);
+  println!("case: {name}");
+  println!("root path: {}", case_root.display());
+
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&case_root)).build().unwrap();
+  let options = ModuleBuildOptions::new("diagnostics", "v0.3", "native", &[], &[]);
+
+  match runtime.resolve_and_store_module_source("main.mec", options) {
+    Ok(Some(version)) => {
+      println!("main module version: {version}");
+      let record = runtime.store().get_module_version(version).unwrap().unwrap();
+      println!("scopes:");
+      for scope in &record.scopes {
+        println!("  - {:?}", scope.scope);
+      }
+      println!("scoped context declarations:");
+      for scope in &record.scopes {
+        for context in &scope.contexts {
+          println!("  - {:?}: {}", scope.scope, context.name);
+        }
+      }
+      println!("scoped address references:");
+      for scope in &record.scopes {
+        for reference in &scope.address_references {
+          println!("  - {:?}: {}@{}", scope.scope, reference.name, reference.target);
+        }
+      }
+      println!("run result: {:?}", runtime.run_module(version));
+    }
+    Ok(None) => {
+      println!("main module version: <none>");
+      println!("scopes: []");
+      println!("scoped context declarations: []");
+      println!("scoped address references: []");
+      println!("run result: no module resolved");
+    }
+    Err(error) => {
+      println!("main module version: <resolution failed>");
+      println!("scopes: <unavailable>");
+      println!("scoped context declarations: <unavailable>");
+      println!("scoped address references: <unavailable>");
+      println!("run result: resolution error: {:?}", error);
+    }
+  }
+  println!();
+}
+
+fn main() {
+  let root = std::env::temp_dir().join(format!("mech-address-target-diagnostics-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  println!("root path: {}", root.display());
+
+  run_case(
+    &root,
+    "ok@foo works",
+    "~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := ok@foo\n",
+  );
+  run_case(
+    &root,
+    "interpreter/context conflict fails resolution",
+    "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@foo := docs://foo{:read(ok)}\n",
+  );
+  run_case(
+    &root,
+    "context target returns ContextAddressReadUnsupported",
+    "@manual := docs://manual{:read(intro/title)}\n\nresult := intro/title@manual\n",
+  );
+  run_case(
+    &root,
+    "unknown target returns UnknownAddressTarget",
+    "result := ok@missing\n",
+  );
+  run_case(
+    &root,
+    "string/comment @bar does not execute bar",
+    "~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n-- @bar\n\nok := true\n",
+  );
+}

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -112,6 +112,7 @@ impl SourceResolver for FileSourceResolver {
         let tree = mech_syntax::parser::parse(source_text.trim())?;
         let referrer = path.to_string_lossy().to_string();
         let index = SourceIndex::from_program(&tree);
+        index.validate_address_targets()?;
         let imports = index.all_imports();
         let exports = index.all_exports();
         let contexts = index.all_contexts();

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -1,13 +1,13 @@
 use mech_core::{
     ComprehensionQualifier, ContextBase, ContextCapabilityScope, Expression, Factor, MechCode,
-    Pattern, Program, RangeExpression, SectionElement, SourceRange, Statement, Structure, Subscript,
-    Term, Token,
+    MResult, MechError, Pattern, Program, RangeExpression, SectionElement, SourceRange, Statement,
+    Structure, Subscript, Term, Token,
 };
 
 use super::{
-    classify_import_specifier, SourceAddressReference, SourceContextBase, SourceContextCapability,
-    SourceContextCapabilityScope, SourceContextDeclaration, SourceExportDeclaration,
-    SourceImportDeclaration,
+    classify_import_specifier, AddressTargetNameConflict, SourceAddressReference, SourceContextBase,
+    SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration,
+    SourceExportDeclaration, SourceImportDeclaration,
 };
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -88,6 +88,7 @@ pub struct SourceIndex {
     pub contexts: Vec<ScopedSourceContextDeclaration>,
     pub address_references: Vec<ScopedSourceAddressReference>,
     pub scopes: Vec<SourceScope>,
+    pub address_target_interpreters: Vec<SourceInterpreterId>,
 }
 
 impl SourceIndex {
@@ -153,10 +154,12 @@ impl SourceIndex {
                         }
                     }
                     SectionElement::FencedMechCode(fenced) => {
-                        let scope = SourceScope::Interpreter(SourceInterpreterId {
+                        let interpreter = SourceInterpreterId {
                             namespace: fenced.config.namespace,
                             namespace_str: fenced.config.namespace_str.clone(),
-                        });
+                        };
+                        index.address_target_interpreters.push(interpreter.clone());
+                        let scope = SourceScope::Interpreter(interpreter);
                         index.push_scope(scope.clone());
 
                         // TODO: Interleaving imports/exports/statements exactly as written in fenced code
@@ -216,6 +219,38 @@ impl SourceIndex {
         }
 
         index
+    }
+
+    pub fn validate_address_targets(&self) -> MResult<()> {
+        let mut targets: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+        for interpreter in &self.address_target_interpreters {
+            if let Some(first_kind) = targets.insert(interpreter.namespace_str.clone(), "interpreter".to_string()) {
+                return Err(MechError::new(
+                    AddressTargetNameConflict {
+                        name: interpreter.namespace_str.clone(),
+                        first_kind,
+                        second_kind: "interpreter".to_string(),
+                    },
+                    None,
+                ));
+            }
+        }
+
+        for context in &self.contexts {
+            if let Some(first_kind) = targets.insert(context.declaration.name.clone(), "context".to_string()) {
+                return Err(MechError::new(
+                    AddressTargetNameConflict {
+                        name: context.declaration.name.clone(),
+                        first_kind,
+                        second_kind: "context".to_string(),
+                    },
+                    None,
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     pub fn module_scopes(&self) -> Vec<ModuleScopeMetadata> {

--- a/src/runtime/src/resolver/mod.rs
+++ b/src/runtime/src/resolver/mod.rs
@@ -326,6 +326,42 @@ impl ResolvedSource {
       dependency.validate()?;
     }
 
+    self.validate_address_targets()?;
+
+    Ok(())
+  }
+
+  fn validate_address_targets(&self) -> MResult<()> {
+    let mut targets: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+    for metadata in &self.scopes {
+      if let ModuleScopeMetadata { scope: SourceScope::Interpreter(interpreter), .. } = metadata {
+        if let Some(first_kind) = targets.insert(interpreter.namespace_str.clone(), "interpreter".to_string()) {
+          return Err(MechError::new(
+            AddressTargetNameConflict {
+              name: interpreter.namespace_str.clone(),
+              first_kind,
+              second_kind: "interpreter".to_string(),
+            },
+            None,
+          ));
+        }
+      }
+
+      for context in &metadata.contexts {
+        if let Some(first_kind) = targets.insert(context.name.clone(), "context".to_string()) {
+          return Err(MechError::new(
+            AddressTargetNameConflict {
+              name: context.name.clone(),
+              first_kind,
+              second_kind: "context".to_string(),
+            },
+            None,
+          ));
+        }
+      }
+    }
+
     Ok(())
   }
 

--- a/src/runtime/src/resolver/mod.rs
+++ b/src/runtime/src/resolver/mod.rs
@@ -383,6 +383,28 @@ pub trait WatchableSourceResolver: SourceResolver {
 // -----------------------------------------------------------------------------
 
 #[derive(Debug, Clone)]
+pub struct AddressTargetNameConflict {
+  pub name: String,
+  pub first_kind: String,
+  pub second_kind: String,
+}
+
+impl MechErrorKind for AddressTargetNameConflict {
+  fn name(&self) -> &str {
+    "AddressTargetNameConflict"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "address target `{}` is declared more than once as `{}` and `{}`",
+      self.name,
+      self.first_kind,
+      self.second_kind,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
 pub struct InvalidSourceRequestError {
   pub field: &'static str,
   pub reason: &'static str,

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -97,6 +97,41 @@ impl MechErrorKind for RuntimeModuleExportNotFound {
 }
 
 #[derive(Debug, Clone)]
+pub struct UnknownAddressTarget {
+  pub target: String,
+}
+
+impl MechErrorKind for UnknownAddressTarget {
+  fn name(&self) -> &str {
+    "UnknownAddressTarget"
+  }
+
+  fn message(&self) -> String {
+    format!("unknown address target `{}`", self.target)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextAddressReadUnsupported {
+  pub target: String,
+  pub name: String,
+}
+
+impl MechErrorKind for ContextAddressReadUnsupported {
+  fn name(&self) -> &str {
+    "ContextAddressReadUnsupported"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "context-addressed read `{}@{}` is not supported yet",
+      self.name,
+      self.target,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
 pub struct RuntimeModuleImportConflict {
   pub binding: String,
   pub first_import: String,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -13,6 +13,36 @@
 
 use super::*;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RuntimeAddressTarget {
+  Interpreter(SourceScope),
+  Context(SourceContextDeclaration),
+  Unknown,
+}
+
+fn resolve_runtime_address_target(
+  record: &ModuleVersionRecord,
+  target: &str,
+) -> RuntimeAddressTarget {
+  for metadata in &record.scopes {
+    if let SourceScope::Interpreter(interpreter) = &metadata.scope {
+      if interpreter.namespace_str == target {
+        return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
+      }
+    }
+  }
+
+  if let Some(program_scope) = record.scopes.iter().find(|metadata| metadata.scope == SourceScope::Program) {
+    for context in &program_scope.contexts {
+      if context.name == target {
+        return RuntimeAddressTarget::Context(context.clone());
+      }
+    }
+  }
+
+  RuntimeAddressTarget::Unknown
+}
+
 impl MechRuntime {
 
   pub fn run_string(&mut self, source: &str) -> MResult<Value> {
@@ -338,21 +368,23 @@ impl MechRuntime {
       .map(|metadata| metadata.address_references.as_slice())
       .unwrap_or(&[]);
 
-    let mut bindings = HashMap::new();
-    for metadata in &record.scopes {
-      let SourceScope::Interpreter(interpreter) = &metadata.scope else {
-        continue;
-      };
-
-      let requested_refs = program_refs
-        .iter()
-        .filter(|reference| reference.target == interpreter.namespace_str)
-        .collect::<Vec<_>>();
-      if requested_refs.is_empty() {
-        continue;
+    let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> = HashMap::new();
+    for reference in program_refs {
+      match resolve_runtime_address_target(record, &reference.target) {
+        RuntimeAddressTarget::Interpreter(scope) => {
+          requested_by_scope.entry(scope).or_default().push(reference.clone());
+        }
+        RuntimeAddressTarget::Context(_context) => {
+          return Err(MechError::new(ContextAddressReadUnsupported { target: reference.target.clone(), name: reference.name.clone() }, None));
+        }
+        RuntimeAddressTarget::Unknown => {
+          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+        }
       }
+    }
 
-      let interpreter_scope = SourceScope::Interpreter(interpreter.clone());
+    let mut bindings = HashMap::new();
+    for (interpreter_scope, requested_refs) in requested_by_scope {
       let instance = self.execute_module_isolated_for_scope(
         context,
         version,
@@ -564,7 +596,7 @@ pub fn strip_module_declarations_for_execution(source: &str) -> String {
     .lines()
     .filter(|line| {
       let trimmed = line.trim_start();
-      !(trimmed.starts_with("+>") || trimmed.starts_with("<+"))
+      !(trimmed.starts_with("+>") || trimmed.starts_with("<+") || trimmed.starts_with("@"))
     })
     .collect::<Vec<_>>()
     .join("\n")

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -75,7 +75,7 @@ use crate::id::{
 
 use crate::resolver::{
   InMemorySourceResolver, ResolvedSource, SourceRequest, SourceResolver,
-  SourceExportDeclaration, SourceImportKind, SourceScope, module_namespace_for_import,
+  SourceAddressReference, SourceContextDeclaration, SourceExportDeclaration, SourceImportKind, SourceScope, module_namespace_for_import,
 };
 
 use crate::scheduler::{

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,5 +1,5 @@
-use mech_core::{hash_str, Ref, Value};
-use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, ModuleBuildOptions, RuntimeBuilder, SourceInterpreterId, SourceRequest, SourceResolver, SourceScope};
+use mech_core::{hash_str, MechSourceCode, Ref, Value};
+use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, SourceContextBase, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope};
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
@@ -53,6 +53,46 @@ fn duplicate_interpreter_address_target_fails_resolution() {
   let root = setup_modules("~~~mech:foo\n~~~\n\n~~~mech:foo\n~~~\n");
   let mut runtime = runtime_with_root(&root);
   let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+}
+
+#[test]
+fn resolved_source_scope_address_target_conflict_fails_validation() {
+  let foo = SourceInterpreterId {
+    namespace: hash_str("foo"),
+    namespace_str: "foo".to_string(),
+  };
+  let resolved = ResolvedSource::new(
+    "main.mec",
+    "memory:main.mec",
+    MechSourceCode::String("ok := true\n".to_string()),
+  )
+  .with_kind(SourceKind::Mech)
+  .with_scopes(vec![
+    ModuleScopeMetadata {
+      scope: SourceScope::Interpreter(foo),
+      imports: Vec::new(),
+      exports: Vec::new(),
+      contexts: Vec::new(),
+      address_references: Vec::new(),
+    },
+    ModuleScopeMetadata {
+      scope: SourceScope::Program,
+      imports: Vec::new(),
+      exports: Vec::new(),
+      contexts: vec![SourceContextDeclaration {
+        name: "foo".to_string(),
+        base: SourceContextBase::ResourceUri("docs://foo".to_string()),
+        capabilities: Vec::new(),
+      }],
+      address_references: Vec::new(),
+    },
+  ]);
+
+  let result = resolved.validate();
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -10,6 +10,110 @@ fn setup_modules(main_source: &str) -> std::path::PathBuf {
 }
 
 
+
+fn runtime_with_root(root: &std::path::Path) -> mech_runtime::MechRuntime {
+  RuntimeBuilder::new().source_resolver(FileSourceResolver::new(root)).build().unwrap()
+}
+
+fn module_options() -> ModuleBuildOptions<'static> {
+  ModuleBuildOptions::new("test", "v0.3", "native", &[], &[])
+}
+
+fn assert_bool_true(result: Value, label: &str) {
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from {label}, got {:?}", other),
+  }
+}
+
+#[test]
+fn interpreter_context_name_conflict_fails_resolution() {
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@foo := docs://foo{:read(ok)}\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+}
+
+#[test]
+fn duplicate_context_address_target_fails_resolution() {
+  let root = setup_modules("@foo := docs://a{:read(*)}\n@foo := docs://b{:read(*)}\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+}
+
+#[test]
+fn duplicate_interpreter_address_target_fails_resolution() {
+  let root = setup_modules("~~~mech:foo\n~~~\n\n~~~mech:foo\n~~~\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+}
+
+#[test]
+fn distinct_interpreter_and_context_names_pass() {
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@manual := docs://foo{:read(ok)}\n\nresult := ok@foo\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "distinct interpreter/context names");
+}
+
+#[test]
+fn context_address_read_is_explicitly_unsupported() {
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := intro/title@manual\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("ContextAddressReadUnsupported"), "expected context address error, got {error}");
+  assert!(error.contains("manual"), "expected context target in error, got {error}");
+  assert!(error.contains("intro/title"), "expected addressed name in error, got {error}");
+}
+
+#[test]
+fn unknown_address_target_is_explicit() {
+  let root = setup_modules("result := ok@missing\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target error, got {error}");
+  assert!(error.contains("missing"), "expected missing target in error, got {error}");
+}
+
+#[test]
+fn interpreter_address_still_works() {
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := ok@foo\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "interpreter address");
+}
+
+#[test]
+fn string_and_comment_address_text_are_not_targets() {
+  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n-- @bar\n\nok := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert!(program.address_references.is_empty(), "expected no program address references, got {:?}", program.address_references);
+  let result = runtime.run_module(version);
+  assert!(result.is_ok(), "expected string/comment @bar not to execute interpreter, got {result:?}");
+}
+
 fn foo_scope(runtime: &mech_runtime::MechRuntime, version: mech_runtime::ModuleVersionId) -> SourceScope {
   let main = runtime.store().get_module_version(version).unwrap().unwrap();
   main.scopes.iter().find_map(|metadata| match &metadata.scope {
@@ -216,8 +320,8 @@ fn program_unknown_interpreter_address_returns_error() {
   let result = runtime.run_module(version);
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"), "expected undefined variable error, got {error}");
-  assert!(error.contains("ok@missing"), "expected addressed symbol in error, got {error}");
+  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target error, got {error}");
+  assert!(error.contains("missing"), "expected missing target in error, got {error}");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Ensure modules have a single address-target namespace so interpreter scope names and context declaration names cannot conflict or be duplicated.
- Make runtime behavior for addressed reads explicit by classifying targets as interpreter/context/unknown and returning clear runtime errors for unsupported/unknown targets.
- Preserve existing interpreter addressing semantics (e.g. `ok@foo`) and keep addressed assignment rejection intact.

### Description
- Add resolver error `AddressTargetNameConflict` and implement `SourceIndex::validate_address_targets()` to detect duplicate interpreter names, duplicate context names, and interpreter/context name conflicts using a single `HashMap<String,String>` with kind labels `"interpreter"` and `"context"`.
- Run `index.validate_address_targets()?` immediately after `SourceIndex::from_program(&tree)` in `FileSourceResolver::resolve()` so invalid address namespaces fail during resolution/storage before execution.
- Add runtime classification via `RuntimeAddressTarget` and `resolve_runtime_address_target(record, target)` and replace implicit matching in `build_local_interpreter_address_environment` with classification-driven handling that returns `ContextAddressReadUnsupported` for context targets and `UnknownAddressTarget` for unknown targets, while still executing only requested interpreter scopes and binding requested exports as `"{name}@{target}"`.
- Add runtime errors `UnknownAddressTarget` and `ContextAddressReadUnsupported` and keep the existing `AddressedAssignmentUnsupported` behavior unchanged.
- Update `strip_module_declarations_for_execution` to ignore `@`-prefixed context declarations when stripping module declarations for runtime execution.
- Add/modify tests in `src/runtime/tests/module_smoke.rs` covering interpreter/context conflict resolution failure, duplicate context/interpreter detection, distinct interpreter+context success, explicit context-address read unsupported error, explicit unknown-address-target error, interpreter addressing still working, and proper non-indexing of `@` inside strings/comments.
- Add a compact diagnostics binary `src/runtime/src/bin/address_target_diagnostics.rs` that demonstrates the new behaviors.

### Testing
- Ran `cargo test -p mech-runtime --test module_smoke`, all tests passed (50 passed, 0 failed). 
- Ran `cargo test -p mech-runtime --lib --tests`, all runtime unit tests passed (106 passed, 0 failed).
- Ran the diagnostics binary `cargo run -p mech-runtime --bin address_target_diagnostics` which exercised success, resolution-failure, unsupported-context, unknown-target, and string/comment cases and produced expected outputs.
- Ran `cargo check -p mech-runtime` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1981969a6c832a850ccdf7d3114a16)