### PR TITLE
Add runtime resource provider write plumbing

### DIFF
--- a/src/runtime/src/bin/address_target_diagnostics.rs
+++ b/src/runtime/src/bin/address_target_diagnostics.rs
@@ -1,5 +1,5 @@
 use mech_core::{Ref, Value};
-use mech_runtime::{FileSourceResolver, InMemoryDocsProvider, ModuleBuildOptions, RuntimeBuilder, SourceScope};
+use mech_runtime::{FileSourceResolver, InMemoryDocsProvider, ModuleBuildOptions, RuntimeBuilder, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteRequest, SourceScope};
 
 fn write_case(root: &std::path::Path, name: &str, source: &str) -> std::path::PathBuf {
   let case_root = root.join(name);
@@ -61,6 +61,17 @@ fn main() {
   let root = std::env::temp_dir().join(format!("mech-address-target-diagnostics-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
   std::fs::create_dir_all(&root).unwrap();
   println!("root path: {}", root.display());
+
+  let mut provider = InMemoryDocsProvider::new();
+  println!("provider write/read:");
+  println!("  write docs://manual intro/title = true");
+  provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: Value::Bool(Ref::new(true)) }).unwrap();
+  let value = provider.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
+  match value {
+    Value::Bool(value) => println!("  read result: Bool({})", value.borrow()),
+    other => println!("  read result: {:?}", other),
+  }
+  println!();
 
   run_case(
     &root,

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -9,9 +9,29 @@ pub struct RuntimeResourceReadRequest {
   pub context_name: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct RuntimeResourceWriteRequest {
+  pub base_uri: String,
+  pub path: String,
+  pub context_name: String,
+  pub value: Value,
+}
+
 pub trait RuntimeResourceProvider: std::fmt::Debug {
   fn scheme(&self) -> &str;
+
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    Err(MechError::new(
+      RuntimeResourceWriteUnsupported {
+        scheme: self.scheme().to_string(),
+        base_uri: request.base_uri,
+        path: request.path,
+      },
+      None,
+    ))
+  }
 }
 
 #[derive(Debug, Default)]
@@ -64,6 +84,20 @@ impl RuntimeResourceRegistry {
       ));
     };
     provider.read(request)
+  }
+
+  pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+    let Some(provider) = self.providers.get_mut(&scheme) else {
+      return Err(MechError::new(
+        RuntimeResourceProviderNotFound {
+          scheme,
+          uri: request.base_uri,
+        },
+        None,
+      ));
+    };
+    provider.write(request)
   }
 }
 
@@ -145,6 +179,36 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
     };
     Ok(value.clone())
   }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    let scheme = resource_uri_scheme(&request.base_uri)?;
+    if scheme != "docs" {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: request.base_uri,
+          reason: "in-memory docs resources require the `docs` scheme".to_string(),
+        },
+        None,
+      ));
+    }
+
+    if request.path.is_empty() {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: request.base_uri,
+          reason: "resource path cannot be empty".to_string(),
+        },
+        None,
+      ));
+    }
+
+    self.documents
+      .entry(request.base_uri)
+      .or_default()
+      .insert(request.path, request.value);
+
+    Ok(())
+  }
 }
 
 fn resource_uri_scheme(uri: &str) -> MResult<&str> {
@@ -201,6 +265,28 @@ impl MechErrorKind for RuntimeResourceProviderNotFound {
       "no runtime resource provider registered for scheme `{}` while reading `{}`",
       self.scheme,
       self.uri,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeResourceWriteUnsupported {
+  pub scheme: String,
+  pub base_uri: String,
+  pub path: String,
+}
+
+impl MechErrorKind for RuntimeResourceWriteUnsupported {
+  fn name(&self) -> &str {
+    "RuntimeResourceWriteUnsupported"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "runtime resource provider for scheme `{}` does not support writes to `{}` under `{}`",
+      self.scheme,
+      self.path,
+      self.base_uri,
     )
   }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -85,6 +85,32 @@ fn runtime_context_allows_read(
   })
 }
 
+#[allow(dead_code)]
+fn runtime_context_allows_write(
+  binding: &RuntimeContextBinding,
+  path: &str,
+) -> bool {
+  binding.capabilities.iter().any(|capability| {
+    if capability.operation != "write" {
+      return false;
+    }
+
+    match &capability.scope {
+      RuntimeContextCapabilityScope::Wildcard => true,
+      RuntimeContextCapabilityScope::Path(exact) => {
+        if exact == path {
+          return true;
+        }
+        if let Some(prefix) = exact.strip_suffix("/*") {
+          let required_prefix = format!("{}/", prefix);
+          return path.starts_with(&required_prefix);
+        }
+        false
+      }
+    }
+  })
+}
+
 impl MechRuntime {
 
   pub fn run_string(&mut self, source: &str) -> MResult<Value> {

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -103,7 +103,7 @@ use crate::actor_behavior::{
 
 use crate::module::{ModuleBuilder, ModuleBuildOptions, ModuleDependencyGraph};
 
-use crate::{InMemoryDocsProvider, RuntimeResourceCapabilityDenied, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry};
+use crate::{InMemoryDocsProvider, RuntimeResourceCapabilityDenied, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest};
 
 thread_local! {
   static ACTIVE_RUNTIME_PROGRAM_HOST: RefCell<Option<RuntimeProgramHostTarget>> =
@@ -404,6 +404,20 @@ impl MechRuntime {
 
   pub fn has_resource_provider(&self, scheme: &str) -> bool {
     self.resources.has_provider(scheme)
+  }
+
+  pub fn write_resource(
+    &mut self,
+    request: RuntimeResourceWriteRequest,
+  ) -> MResult<()> {
+    self.resources.write(request)
+  }
+
+  pub fn read_resource(
+    &self,
+    request: RuntimeResourceReadRequest,
+  ) -> MResult<Value> {
+    self.resources.read(request)
   }
 
   pub fn store(&self) -> &dyn MechStore {

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,5 +1,5 @@
 use mech_core::{hash_str, MechSourceCode, Ref, Value};
-use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, InMemoryDocsProvider, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, RuntimeContextRegistry, SourceContextBase, SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope};
+use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, InMemoryDocsProvider, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, RuntimeContextRegistry, SourceContextBase, SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest};
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
@@ -38,6 +38,75 @@ fn assert_bool_true(result: Value, label: &str) {
     Value::Bool(value) => assert!(*value.borrow()),
     other => panic!("expected bool result from {label}, got {:?}", other),
   }
+}
+
+
+#[test]
+fn in_memory_docs_provider_write_then_read_returns_value() {
+  let mut provider = InMemoryDocsProvider::new();
+  provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true) }).unwrap();
+  let value = provider.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
+  assert_bool_true(value, "provider write then read");
+}
+
+#[test]
+fn resource_registry_write_then_read_returns_value() {
+  let mut registry = RuntimeResourceRegistry::new();
+  registry.register_provider(Box::new(InMemoryDocsProvider::new())).unwrap();
+  registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true) }).unwrap();
+  let value = registry.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
+  assert_bool_true(value, "registry write then read");
+}
+
+#[test]
+fn resource_registry_write_missing_provider_fails() {
+  let mut registry = RuntimeResourceRegistry::new();
+  let result = registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true) });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected missing provider error, got {error}");
+  assert!(error.contains("docs"), "expected scheme in error, got {error}");
+  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
+}
+
+#[test]
+fn in_memory_docs_write_invalid_scheme_fails() {
+  let mut provider = InMemoryDocsProvider::new();
+  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "db://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true) });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
+  assert!(error.contains("docs"), "expected docs scheme requirement, got {error}");
+}
+
+#[test]
+fn in_memory_docs_write_empty_path_fails() {
+  let mut provider = InMemoryDocsProvider::new();
+  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: String::new(), context_name: "manual".to_string(), value: bool_value(true) });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
+  assert!(error.contains("resource path cannot be empty"), "expected empty path error, got {error}");
+}
+
+#[derive(Debug)]
+struct ReadOnlyDocsProvider;
+
+impl RuntimeResourceProvider for ReadOnlyDocsProvider {
+  fn scheme(&self) -> &str { "docs" }
+  fn read(&self, _request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> { unreachable!("read is not needed for the default write behavior test") }
+}
+
+#[test]
+fn provider_default_write_is_unsupported() {
+  let mut provider = ReadOnlyDocsProvider;
+  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true) });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceWriteUnsupported"), "expected unsupported write error, got {error}");
+  assert!(error.contains("docs"), "expected provider scheme in error, got {error}");
+  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
+  assert!(error.contains("intro/title"), "expected path in error, got {error}");
 }
 
 #[test]
@@ -579,6 +648,18 @@ fn addressed_assignment_to_context_is_still_unsupported() {
   let root = setup_modules("@manual := docs://manual{:write(intro/title)}\n\nintro/title@manual := true\n");
 
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressedAssignmentUnsupported"), "expected addressed assignment error, got {error}");
+}
+
+#[test]
+fn addressed_assignment_with_docs_provider_is_still_unsupported() {
+  let root = setup_modules("@manual := docs://manual{:write(intro/title)}\n\nintro/title@manual := true\n");
+
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(InMemoryDocsProvider::new()).build().unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version);
   assert!(result.is_err());


### PR DESCRIPTION
### Motivation
- Extend the runtime resource provider surface so hosts can perform provider-level writes without changing Mech language semantics or enabling addressed assignment execution.
- Provide provider- and registry-level write dispatch and basic docs provider write support to enable future host integration and testing.

### Description
- Add `RuntimeResourceWriteRequest` to represent provider write requests and extend `RuntimeResourceProvider` with a default `write(...)` that returns a `RuntimeResourceWriteUnsupported` error.  
- Add `RuntimeResourceRegistry::write(...)` to dispatch write requests to the registered provider for the request scheme.  
- Implement `write(...)` for `InMemoryDocsProvider` with scheme validation and empty-path checks that store values in the provider's in-memory map.  
- Add the `runtime_context_allows_write(...)` helper (alongside the existing read helper) and host-facing runtime API methods `MechRuntime::write_resource(...)` and `MechRuntime::read_resource(...)` for direct runtime use without wiring addressed assignment.  
- Add provider/registry-level tests exercising successful write/read, missing provider, invalid-scheme, empty-path, and default-unsupported-write behavior, plus tests that addressed assignment remains unsupported even with a docs provider registered.  
- Include a small provider-level diagnostic snippet in `address_target_diagnostics` demonstrating a provider write/read round trip.

### Testing
- Ran the module smoke suite with `cargo test -p mech-runtime --test module_smoke` and all tests passed.  
- Ran runtime unit tests with `cargo test -p mech-runtime --lib --tests` and checks with `cargo check -p mech-runtime`; both completed successfully with warnings only.  
- Executed the diagnostics binary with `cargo run -p mech-runtime --bin address_target_diagnostics` which printed the provider write/read demonstration and the source-level diagnostics; it ran successfully.  
- `git diff --check` and the repository test commands were used to validate minimal whitespace/format changes and the focused patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3f9f73fc832a8d314a8fdc916307)