### PR TITLE
Add documentation page template (include/docs.html + include/docs.css)

### DIFF
--- a/docs/mechdown/template-placeholders.mec
+++ b/docs/mechdown/template-placeholders.mec
@@ -18,6 +18,8 @@ This allows one Mechdown source document to be rendered into different layouts b
 - `{{AUTHOR}}` — Inline author paragraph from title front matter.
 - `{{DATE}}` — Inline date paragraph from title front matter.
 - `{{KICKER}}` — Inline kicker paragraph from title front matter.
+- `{{SECTION}}` — Inline section paragraph from title front matter.
+- `{{VERSION}}` — Current Mech package version from the renderer.
 - `{{NEXT}}` — Inline next-link paragraph from title front matter.
 - `{{PREVIOUS}}` — Inline previous-link paragraph from title front matter.
 - `{{HERO}}` — Hero media/content from the title block.

--- a/include/docs.css
+++ b/include/docs.css
@@ -687,11 +687,9 @@ body.narrow-content .mech-float .mech-image {
 }
 .toc a.active {
   color: var(--toc-accent);
-  font-weight: 700;
 }
 .toc a.active-path {
   color: var(--toc-accent);
-  font-weight: 650;
 }
 .toc > ul > li > a.active::before {
   content: "";

--- a/include/docs.css
+++ b/include/docs.css
@@ -1,0 +1,1904 @@
+:root {
+  /* ── Layout ── */
+  --header-height: 52px;
+  --console-width: 575px;
+  --toc-width: 260px;
+  --content-max-width: 1200px;
+
+  /* ── Base palette ── */
+  --bg-primary:    hsl(206, 24%, 6%);
+  --bg-secondary:  hsl(207, 23%, 8%);
+  --bg-accent:     hsl(205, 10%, 47%);
+  --bg-dark:       hsl(206, 24%, 3%);
+  --bg-elevated:   #151B21;
+  --mika-primary:  #f3c15c;
+  --accent-primary:#F2B63D;
+  --accent-hover:  #ecd7ad;
+  --accent-shadow: rgba(195, 146, 39);
+  --accent-soft:   #ffefc9;
+  --blue-primary:  #2F6FA3;
+  --blue-bright:   #3E86C1;
+  --border:        #35393d;
+  --border-strong: #35393d;
+  --text-primary:  #f3f3e6;
+  --text-secondary:#bebcaa;
+  --text-muted:    #827f6b;
+  --body-primary:  hsl(206, 24%, 90%);
+  --success:       #3FB950;
+  --error:         #F85149;
+  --console-bg:    rgb(2, 3, 3);
+  --console-text:  #E6EDF3;
+
+  --accent-secondary-teal-soft: hsl(163, 39%, 71%);
+  --accent-secondary-teal: hsl(164, 47%, 45%);
+  --accent-secondary-teal-hover: hsl(164, 47%, 35%);
+
+  --accent-secondary-coral-soft: rgb(205, 159, 141);
+  --accent-secondary-coral: rgb(224, 122, 82);
+  --accent-secondary-coral-hover: #C96840;
+
+  --accent-secondary-purple-soft: hsl(254, 12%, 58%);
+  --accent-secondary-purple: hsl(255, 22%, 54%);
+  --accent-secondary-purple-hover: hsl(255, 21%, 46%);
+
+  --title-underline-color: hsl(42, 89%, 70%);
+  --callout-background-color: #1f2533;
+  --accent-coral: hsl(10, 100%, 75%);
+  --accent-orange: hsl(29, 100%, 75%);
+  --accent-yellow: hsl(55, 100%, 75%);
+  --accent-green: hsl(128, 100%, 75%);
+  --accent-teal: hsl(168, 100%, 75%);
+  --accent-cyan: hsl(206, 100%, 75%);
+  --accent-blue: hsl(240, 100%, 75%);
+  --accent-indigo: hsl(253, 100%, 75%);
+  --accent-purple: hsl(272, 100%, 75%);
+  --accent-magenta: hsl(312, 100%, 75%);
+  --accent-rose: hsl(338, 100%, 75%);
+  --accent-red: hsl(0, 100%, 75%);
+
+  --nav-text-primary: var(--text-primary);
+  --nav-text-active: var(--text-primary);
+  --nav-text-hover: var(--accent-hover);
+  --nav-accent-active: var(--accent-primary);
+  --nav-accent-hover: var(--accent-hover);
+
+  --kicker-accent: var(--accent-teal);
+  --hero-accent: var(--accent-teal);
+  --hero-text-secondary: #aabebe;
+  --hero-text-primary: hsl(168 97% 95% / 1);
+  --toc-accent: hsl(308, 42%, 69%);
+  --toc-accent-soft: hsl(308, 42%, 59%);
+  --toc-text-secondary: hsl(308, 17%, 73%);
+  --toc-border: hsl(308, 17%, 73%);
+  /* ── Resize grip dimensions (non-color layout vars) ── */
+  --grip-width:          8px;
+  --grip-height:         50px;
+  --grip-radius:         2px;
+  --separator-grip-width:  8px;
+  --separator-grip-height: 50px;
+  --grip-notch-width:  2px;
+  --grip-notch-height: 24px;
+
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: Inter, system-ui, sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
+body {
+  position: relative;
+}
+
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
+  display: none;
+}
+
+body { min-height: 100vh; }
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.brand img {
+  width: auto;
+  height: 35px;
+}
+a { color: inherit; text-decoration: none; }
+
+/* ── Header ── */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  height: var(--header-height);
+  background: linear-gradient(90deg, var(--bg-primary), var(--bg-secondary));
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 4px 10px rgba(0,0,0,1);
+  display: flex;
+  align-items: center;
+  padding: 0 28px;
+  font-weight: 700;
+}
+
+.header-inner {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 34px;
+}
+
+.brand {
+  white-space: nowrap;
+  color: var(--accent-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.045em;
+  font-weight: 800;
+}
+
+.top-nav {
+  display: flex;
+  gap: 18px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--nav-text-primary);
+  align-self: stretch;
+  align-items: stretch;
+}
+
+.top-nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: 17px 2px 17px;
+  border-bottom: 2px solid transparent;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  font-size: 12px;
+  margin-bottom: -1px;
+}
+
+.top-nav a:hover {
+  color: var(--nav-text-hover);
+  border-bottom-color: var(--nav-accent-hover);
+
+}
+
+.top-nav a.active {
+  color: var(--nav-text-active);
+  border-bottom-color: var(--nav-accent-active);
+}
+
+.header-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+/* ── GitHub widget ── */
+.widget {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+}
+
+.widget .btn,
+.widget .social-count {
+  display: inline-flex;
+  align-items: center;
+  height: 30px;
+  border: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.widget .btn {
+  padding: 0 12px;
+  gap: 6px;
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border-radius: 8px 0 0 8px;
+}
+
+.widget .btn:hover {
+  border-color: var(--blue-primary);
+  background: var(--border-strong);
+}
+
+.widget .social-count {
+  padding: 0 10px;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border-left: 0;
+  border-radius: 0 8px 8px 0;
+}
+
+.widget .social-count:hover {
+  color: var(--text-primary);
+}
+
+/* ── Workspace grid ── */
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 8px var(--console-width);
+  min-height: calc(100vh - var(--header-height));
+}
+
+body.console-fullscreen .workspace {
+  grid-template-columns: 0 0 1fr !important;
+}
+
+/* ── Content shell ── */
+.content-shell {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  padding: 32px;
+  padding-bottom: 0px;
+  height: calc(100vh - var(--header-height));
+  overflow-y: auto;
+  position: sticky;
+  top: var(--header-height);
+  align-self: start;
+  scrollbar-width: thin;
+  scrollbar-color: var(--bg-accent) transparent;
+}
+
+.content-shell::-webkit-scrollbar {
+  width: 8px;
+}
+
+.content-shell::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.content-shell::-webkit-scrollbar-thumb {
+  background: var(--accent-primary);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.content-shell::-webkit-scrollbar-thumb:hover {
+  background: var(--accent-hover);
+  background-clip: content-box;
+}
+
+.content-shell {
+  overflow-x: hidden;
+  max-width: 100%;
+  width: 100%;
+}
+
+
+.content-column {
+  width: min(100%, var(--content-max-width));
+  max-width: var(--content-max-width);
+  min-width: 0;
+  container-type: inline-size;
+}
+
+/* ── Breadcrumbs ── */
+.breadcrumbs {
+  margin-bottom: 20px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.breadcrumbs .hero-kicker {
+  margin-bottom: inherit !important;
+  display: inherit !important;
+  flex-wrap: inherit !important;
+  gap: inherit !important;
+  text-transform: inherit !important;
+  letter-spacing: inherit !important;
+  color: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+}
+
+.breadcrumbs .sep { color: var(--accent-primary); }
+.breadcrumbs a:hover { color: var(--accent-primary); }
+
+/* ── Hero ── */
+.hero {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.78fr) minmax(380px, 1.45fr);
+  gap: 18px;
+  margin-bottom: 48px;
+  color: var(--text-primary);
+}
+
+.hero-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.hero-kicker {
+  margin: 0 0 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--kicker-accent);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(34px, 4vw, 64px);
+  line-height: 1.04;
+  color: var(--text-primary);
+  font-family: "IBM Plex Mono", "SFMono-Regular", ui-monospace, Menlo, monospace;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.mech-meta {
+  margin-top: 22px;
+  color: var(--hero-text-secondary);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mech-meta p {
+  color: inherit;
+  margin: 0px;
+  font-weight: 400;
+}
+
+.post-pagination{
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+  margin:32px 0 20px;
+  padding-top:14px;
+  border-top:1px dotted var(--border);
+}
+
+.post-pagination-prev,.post-pagination-next{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.post-pagination-next{
+  text-align:right;
+  align-items:flex-end;
+}
+
+.post-pagination-label{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:var(--text-secondary);
+}
+
+.post-pagination-next .post-pagination-label {
+  margin-right: 25px;
+}
+
+.post-pagination-prev .post-pagination-label {
+  margin-left: 25px;
+}
+
+.post-pagination .mech-previous,
+.post-pagination .mech-next{
+  margin:0;
+}
+
+.post-pagination a{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--text-primary);
+  font-size:16px;
+  text-decoration:none;
+}
+
+.post-pagination-prev a::before{
+  content:"⟨";
+  color:var(--accent-primary);
+  font-size:35px;
+  line-height:1;
+  margin-right:4px;
+  transform: translateY(-15px);
+}
+
+.post-pagination-next a::after{
+  content:"⟩";
+  color:var(--accent-primary);
+  font-size:35px;
+  line-height:1;
+  margin-left:4px;
+  transform: translateY(-15px);
+}
+
+.post-pagination a:hover{
+  color:var(--accent-soft);
+}
+
+.mech-summary {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px dotted var(--hero-accent);
+  color: var(--hero-text-secondary);
+  line-height: 1.75;
+}
+
+.mech-summary p {
+  margin-top: 0px;
+  line-height: inherit;
+  color: inherit;
+  font-weight: 400;
+}
+
+.hero-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hero-accent);
+  color: var(--bg-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+
+.mech-hero-img img,
+.mech-figure img,
+.mech-image {
+  width: 100%;
+  height: auto;
+}
+
+.mech-hero-img {
+  overflow: hidden;
+  border-radius: 12px;
+  min-height: 320px;
+  border: 1px solid var(--border);
+  /* remove any height: 100% if present */
+}
+
+.mech-hero-img figure {
+  display: block;
+  width: 100%;
+  height: 100%;
+  margin-block-start: 0px;
+  margin-block-end: 0px;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  padding-bottom: 0px;
+}
+
+.mech-hero-img figure img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mech-hero-img figure figcaption {
+  visibility: hidden;
+  display: none;
+}
+
+/* ── Intro / abstract (full-width) ── */
+.article-intro {
+  max-width: 100%;
+  margin: 0 0 52px;
+}
+
+.article-intro > .mech-intro > p {
+  margin: 0 0 18px;
+  line-height: 1.85;
+  color: var(--body-primary);
+  font-size: 1.06rem;
+}
+
+.article-intro .mech-code .mech-comment p {
+  margin: 0;
+  line-height: inherit;
+  font-size: inherit;
+}
+
+.mech-paragraph {
+  color: var(--body-primary);
+  font-size: 1.06rem;
+  line-height: 1.85;
+}
+
+.article-intro li p {
+  margin: 0 0 5px;
+}
+
+.article-intro  > .mech-intro >  p:first-of-type::first-letter {
+  float: left;
+  font-size: 4.5em;
+  line-height: 0.84;
+  padding-right: 12px;
+  margin-top: 0.15em;
+  color: var(--accent-primary);
+  font-weight: 700;
+}
+
+/* ── Article layout ── */
+.article-layout {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: var(--toc-width) minmax(0, 1fr);
+  gap: 48px;
+  align-items: start;
+}
+
+.article-layout.hide-toc { grid-template-columns: 1fr; }
+.article-layout.hide-toc .toc { display: none; }
+.article-layout.no-sections { display: block; }
+.article-layout.no-sections .toc { display: none; }
+.content-shell.hidden { display: none; }
+
+.main-content .mech-float {
+  width: min(48%, 520px);
+  max-width: 100%;
+}
+
+.main-content .mech-float .mech-image {
+  width: 100%;
+  height: auto;
+}
+
+.article-backmatter {
+  display: block;
+  width: 100%;
+  margin-top: 20px;
+  position: relative;
+}
+
+.backmatter-row + .backmatter-row {
+  margin-top: 18px;
+}
+
+.backmatter-body .mech-backmatter-heading {
+  margin: 30px 0 12px;
+  padding: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--text-primary);
+  border-bottom: 0;
+  counter-increment: none;
+  counter-reset: none;
+}
+
+.backmatter-body .mech-backmatter-heading::before {
+  content: none !important;
+}
+
+.backmatter-cited .mech-backmatter-heading {
+  column-span: all;
+}
+
+.backmatter-body {
+  padding: 12px 14px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  font-size: 14px;
+}
+
+.backmatter-cited .backmatter-body {
+  column-count: 2;
+  column-gap: 2rem;
+}
+
+.backmatter-body h1,
+.backmatter-body h2,
+.backmatter-body h3,
+.backmatter-body h4,
+.backmatter-body h5,
+.backmatter-body h6 {
+  all: unset;
+  display: block;
+}
+
+.backmatter-body ol,
+.backmatter-body ul {
+  margin: 0;
+  padding-left: 1.2em;
+}
+
+.backmatter-body li + li {
+  margin-top: 8px;
+}
+
+body.narrow-content .mech-float,
+body.narrow-content .mech-float.left,
+body.narrow-content .mech-float.right {
+  float: none !important;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin: 12px 0;
+  clear: both;
+}
+
+body.narrow-content .mech-float .mech-image {
+  max-height: min(60vh, 560px);
+  width: auto;
+  object-fit: contain;
+}
+
+/* ── TOC ── */
+.toc {
+  position: sticky;
+  top: 0px;
+  align-self: start;
+  max-height: calc(100vh - var(--header-height) - 32px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+/* ── TOC ── */
+
+.toc .toc-title {
+  font-size: 1.17em;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  margin-top: 0;
+  font-size: 14px;
+  text-transform: uppercase;
+  color: var(--toc-accent-soft);
+  letter-spacing: 0.08em;
+}
+
+.toc ul { list-style: none; padding: 0; margin: 0; }
+.toc li { margin-bottom: 12px; }
+.toc a {
+  color: var(--toc-text-secondary);
+  display: block;
+  padding: 4px 0 4px 10px;   /* add left padding to make room */
+  position: relative;
+}
+.toc a.active {
+  color: var(--toc-accent);
+  font-weight: 700;
+}
+.toc a.active-path {
+  color: var(--toc-accent);
+  font-weight: 650;
+}
+.toc > ul > li > a.active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--toc-accent-soft);
+}
+.toc .toc-sub { display: none; margin: 6px 0 0 14px; padding-left: 12px; border-left: 1px dotted var(--toc-accent-soft); }
+.toc li.expanded > .toc-sub { display: block; }
+.toc .toc-sub li { margin-bottom: 8px; }
+.toc .toc-sub a { font-size: 14px; }
+.toc .toc-sub .toc-sub { margin-top: 4px; }
+
+/* ── Main content ── */
+.main-content {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  counter-reset: section-index;
+}
+
+section { margin-bottom: 0px; }
+section h2 {
+  margin-top: 0;
+  font-size: 34px;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+  margin-left: -20px;
+}
+/* ── Editorial numbered headings ── */
+.main-content section {
+  counter-reset: sub3section-index sub4section-index sub5section-index sub6section-index;
+}
+
+.main-content section > h2,
+.main-content section > h3 {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25em;
+
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+  border-bottom: 0px dotted var(--title-underline-color);
+}
+
+.main-content section > h4,
+.main-content section > h5,
+.main-content section > h6 {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 0.5em;
+  margin-bottom: 0px;
+  padding-bottom: 0px;
+  border-bottom: 0px dotted var(--title-underline-color);
+}
+
+.main-content section > h2 {
+  counter-increment: section-index;
+}
+
+.main-content section > h3 {
+  counter-increment: sub3section-index;
+  counter-reset: sub4section-index sub5section-index sub6section-index;
+  margin-top: 30px;
+  margin-bottom: 12px;
+  font-size: 24px;
+}
+
+.main-content section > h4 {
+  counter-increment: sub4section-index;
+  counter-reset: sub5section-index sub6section-index;
+}
+
+.main-content section > h5 {
+  color: var(--accent-soft);
+  counter-increment: sub5section-index;
+  counter-reset: sub6section-index;
+}
+
+.main-content section > h6 {
+  color: var(--accent-soft);
+  counter-increment: sub6section-index;
+}
+
+.main-content section > h2::before,
+.main-content section > h3::before,
+.main-content section > h4::before,
+.main-content section > h5::before,
+.main-content section > h6::before {
+  flex-shrink: 0;
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.40em;
+  font-weight: 700;
+  letter-spacing: 0.21em;
+  line-height: 1;
+  color: var(--accent-primary);
+  text-transform: uppercase;
+}
+
+.main-content section > h2::before {
+  display: block;
+  content: "section " counter(section-index, decimal) "";
+}
+
+.main-content section > h3::before {
+  display: block;
+  font-size: 12px;
+  content: counter(section-index, decimal) "." counter(sub3section-index, decimal);
+}
+
+.main-content section > h4::before {
+  font-size: 10px;
+  content: counter(section-index, decimal) "." counter(sub3section-index, decimal) "." counter(sub4section-index, decimal);
+}
+
+.main-content section > h5::before {
+  display: none;
+  font-size: 10px;
+  content: counter(section-index, decimal) "." counter(sub3section-index, decimal) "." counter(sub4section-index, decimal) "." counter(sub5section-index, decimal);
+}
+
+.main-content section > h6::before {
+  font-size: 10px;
+  content: counter(section-index, decimal) "." counter(sub3section-index, decimal) "." counter(sub4section-index, decimal) "." counter(sub5section-index, decimal) "." counter(sub6section-index, decimal);
+}
+
+section p {
+  line-height: 1.7;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.main-content p strong {
+  overflow-wrap: anywhere;
+}
+section.active-section h2 {
+
+}
+section.active-section {
+  padding-left: 0px;
+  border-left: 0px solid var(--accent-primary);
+}
+
+.main-content section {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  border-bottom: 0px dotted var(--border);
+  padding-bottom: 30px;
+}
+
+/* ── Footer ── */
+.footer {
+  grid-column: 1 / -1;
+  margin-top: 0px;
+  border-top: 1px dotted var(--border);
+  background: linear-gradient(90deg, var(--bg-primary), var(--bg-dark), var(--bg-primary));
+  color: var(--text-secondary);
+}
+
+.footer-inner {
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+  padding: 0 32px;
+  container-type: inline-size;
+}
+
+/* Main layout */
+.footer-main {
+  display: grid;
+  grid-template-columns: 170px minmax(280px, 360px) minmax(340px, 1fr);
+  column-gap: 30px;
+  row-gap: 18px;
+  padding: 54px 0 36px;
+  align-items: start;
+}
+
+/* Robot */
+.footer-robot {
+  grid-column: 1;
+  grid-row: 1;
+  width: 230px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.footer-robot img {
+  width: 100%;
+  margin-left: 20px;
+  max-width: 230px;
+  filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.45));
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.mika-glyph {
+  display: inline-block;
+  margin: 0;
+  color: var(--text-primary);
+  opacity: 0;
+  transform: translateY(6px) scale(0.96);
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 220ms ease, transform 220ms ease, max-height 220ms ease;
+  pointer-events: none;
+}
+
+.mika-glyph-label {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.mika-glyph-art {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: 0.03em;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  text-shadow: 0 0 18px rgba(246, 202, 93, 0.22);
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.mika-glyph-art--mini,
+.mika-glyph-art--micro {
+  display: block;
+  grid-area: 1 / 1;
+}
+
+.mika-glyph-art-wrap {
+  display: grid;
+}
+
+.mika-glyph-art--mini {
+  opacity: 1;
+  font-size: 24px;
+  transform: scale(1);
+}
+
+.mika-glyph-art--micro {
+  opacity: 0;
+  transform: scale(0.86);
+}
+
+/* Links */
+.footer-links {
+  grid-column: 3;
+  grid-row: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(96px, 1fr));
+  gap: 24px;
+  align-content: start; /* FIX */
+}
+
+.footer-heading {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.footer-heading-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-primary);
+  border-bottom: 1px solid var(--accent-primary);
+  padding-bottom: 2px;
+}
+
+.footer-heading-text {
+  display: block;
+  flex: 1;
+  border-bottom: 1px solid #7f7f7f;
+  padding-bottom: 2px;
+}
+
+.footer-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.footer-group a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.footer-group a::after {
+  content: "›";
+  color: var(--text-muted);
+  font-size: 14px;
+  margin-left: auto;
+}
+
+.footer-group a:hover {
+  color: var(--accent-hover);
+}
+
+.footer-group a:hover::after {
+  color: var(--accent-hover);
+}
+
+/* Release panel */
+.footer-release {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-primary);
+}
+
+.release-grid-row {
+  display: grid;
+  grid-template-columns: 126px 1fr;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.release-grid-row:last-of-type {
+  border-bottom: 0;
+}
+
+.release-grid-label,
+.release-grid-value {
+  padding: 10px 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 14px;
+}
+
+.release-grid-label {
+  color: var(--text-primary);
+  border-right: 1px solid var(--border-strong);
+}
+
+.release-grid-value {
+  color: var(--text-secondary);
+}
+
+.release-downloads {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+}
+
+.release-downloads a,
+.release-grid-value a,
+.release-ack a {
+  color: var(--accent-soft);
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.release-ack {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--border-strong);
+  padding: 10px 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 14px;
+
+}
+
+.release-ack .footer-icon {
+  color: var(--accent-primary);
+}
+
+/* Bottom bar */
+.footer-meta {
+  border-top: 1px dotted var(--border);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 0;
+  font-size: 14px;
+  width: 100%;
+  text-align: center;
+}
+
+.footer-pride {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  margin-inline: auto;
+}
+
+/* ── Resize handle ── */
+.resize-handle {
+  position: sticky;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
+  align-self: start;
+  cursor: ew-resize;
+  z-index: 50;
+}
+
+.resize-handle::after,
+.edge-handle::after {
+  content: "";
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: var(--grip-radius);
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-shadow);
+  z-index: 0;
+}
+
+.resize-handle::after {
+  width: var(--separator-grip-width);
+  height: var(--separator-grip-height);
+}
+
+.edge-handle::after {
+  width: var(--grip-width);
+  height: var(--grip-height);
+}
+
+.resize-handle::before,
+.edge-handle::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--grip-notch-width);
+  height: var(--grip-notch-height);
+  border-radius: 999px;
+  background: var(--border);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.resize-handle::before {
+  left: 100%;
+}
+
+/* ── Edge handle ── */
+.edge-handle {
+  position: fixed;
+  top: calc(var(--header-height) + ((100vh - var(--header-height)) / 2));
+  right: -4px;
+  transform: translateY(-50%);
+  width: var(--grip-width);
+  height: var(--grip-height);
+  border-radius: var(--grip-radius) 0 0 var(--grip-radius);
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-hover);
+  cursor: ew-resize;
+  z-index: 1100;
+  display: none;
+  transition: right 140ms ease, left 140ms ease;
+}
+
+.edge-handle.left {
+  right: auto;
+  left: -4px;
+  border-radius: 0 var(--grip-radius) var(--grip-radius) 0;
+}
+
+.edge-handle:hover { right: 0; }
+.edge-handle.left:hover { left: 0; }
+.edge-handle::after { left: 60%; }
+.edge-handle.left::after { left: 40%; }
+
+body.edge-left .resize-handle,
+body.edge-right .resize-handle {
+  display: none !important;
+}
+
+body.is-resizing,
+body.is-resizing * {
+  cursor: ew-resize !important;
+}
+
+/* ── Console pane ── */
+.console-pane {
+  position: sticky;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--console-bg);
+  color: var(--console-text);
+  border-left: 1px solid var(--border-strong);
+}
+
+body.console-fullscreen .console-pane {
+  position: fixed;
+  top: var(--header-height);
+  right: 0;
+  width: 100vw;
+  height: calc(100vh - var(--header-height));
+  z-index: 900;
+}
+
+.console-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-strong);
+  background: none;
+}
+
+.console-tabs {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  align-self: stretch;
+}
+
+.console-tab {
+  display: inline-flex;
+  align-items: center;
+  align-self: stretch;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--nav-text-primary);
+  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 14px 2px 12px;
+  margin-bottom: -1px;
+  cursor: pointer;
+}
+
+.console-tab:hover {
+  color: var(--nav-text-hover);
+  border-bottom-color: var(--nav-accent-hover);
+}
+
+.console-tab.active {
+  color: var(--nav-text-active);
+  border-bottom-color: var(--nav-accent-active);
+}
+
+.console-fullscreen-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 0;
+  margin: 8px 0;
+  align-self: center;
+  cursor: pointer;
+}
+
+.console-fullscreen-toggle:hover {
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+.console-fullscreen-toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
+.console-fullscreen-toggle .icon-exit {
+  display: none;
+}
+
+body.console-fullscreen .console-fullscreen-toggle {
+  color: var(--accent-primary);
+  border-color: rgba(242, 182, 61, 0.35);
+}
+
+body.console-fullscreen .console-fullscreen-toggle .icon-enter {
+  display: none;
+}
+
+body.console-fullscreen .console-fullscreen-toggle .icon-exit {
+  display: inline;
+}
+
+.console-panels {
+  position: relative;
+  min-height: 0;
+  flex: 1;
+}
+
+.console-panel {
+  display: none;
+  height: 100%;
+}
+
+.console-panel.is-active {
+  display: block;
+}
+
+.console-scroll {
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px;
+  font-family: ui-monospace, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent-secondary-purple-soft) transparent;
+}
+
+.console-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.console-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.console-scroll::-webkit-scrollbar-thumb {
+  background: var(--accent-secondary-purple-soft);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.console-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--accent-secondary-purple-soft);
+  background-clip: content-box;
+}
+
+/* ── Responsive ── */
+@media (max-width: 700px) {
+  :root { --header-height: 156px; }
+
+  .site-header {
+    align-items: flex-start;
+    padding: 10px 16px;
+  }
+
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .top-nav {
+    width: 100%;
+    overflow-x: auto;
+    white-space: nowrap;
+    gap: 14px;
+  }
+
+  .header-actions { margin-left: 0; }
+}
+
+@media (max-width: 900px) {
+  .console-pane, .resize-handle, .edge-handle { display: none; }
+  .workspace { grid-template-columns: 1fr; }
+  .article-layout { grid-template-columns: 1fr; }
+  .toc { display: none; }
+  .footer-main {
+    grid-template-columns: max-content minmax(0, 1fr);
+    padding-top: 36px;
+    row-gap: 22px;
+  }
+  .footer-robot {
+    grid-column: 1;
+    width: auto;
+    grid-row: 1;
+    align-self: start;
+  }
+  .footer-release {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+  }
+  .footer-links {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: 100%;
+    grid-template-columns: repeat(3, minmax(88px, 1fr));
+  }
+  .footer-robot img {
+    opacity: 0;
+    transform: scale(0.75);
+    width: 0;
+    margin: 0;
+  }
+  .mika-glyph {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+    max-height: 120px;
+    margin-top: 8px;
+  }
+  .mika-glyph-art--mini {
+    opacity: 1;
+    margin-top: 20px;
+    transform: scale(1);
+  }
+  .footer-cta {
+    border-left: 0;
+    border-top: 1px solid var(--border-strong);
+    padding: 24px 0 0;
+  }
+  .footer-cta h3 {
+    font-size: clamp(30px, 8vw, 44px);
+  }
+  .footer-cta p {
+    font-size: 28px;
+  }
+}
+
+@media (max-width: 900px) {
+  .workspace {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    min-height: auto;
+    overflow-x: hidden;
+  }
+
+  .content-shell {
+    position: static;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    min-height: auto;
+    overflow-x: hidden;
+    overflow-y: visible;
+    padding: 18px;
+    padding-bottom: 0px;
+  }
+
+  .content-column,
+  .article-layout,
+  .main-content,
+  .article-intro,
+  .article-backmatter {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .toc,
+  .console-pane,
+  .resize-handle,
+  .edge-handle {
+    display: none !important;
+  }
+}
+
+@container (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .mech-hero-img figure img {
+    aspect-ratio: 5 / 3;
+  }
+
+  .footer-main {
+    grid-template-columns: max-content minmax(0, 1fr);
+    padding-top: 36px;
+    row-gap: 22px;
+  }
+  .footer-robot {
+    grid-column: 1;
+    width: auto;
+    grid-row: 1;
+    align-self: start;
+  }
+
+  .footer-links {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: 100%;
+    grid-template-columns: repeat(3, minmax(88px, 1fr));
+  }
+  .footer-release {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+  }
+
+  .footer-robot img {
+    opacity: 0;
+    transform: scale(0.75);
+    width: 0;
+    max-width: 0;
+    margin: 0;
+  }
+
+  .mika-glyph {
+    color: var(--accent-primary);
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+    max-height: 120px;
+    margin-top: 8px;
+  }
+
+  .mika-glyph-art--mini {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .footer-cta {
+    border-left: 0;
+    border-top: 1px solid var(--border-strong);
+    padding: 24px 0 0;
+  }
+
+  .hero h1 { font-size: clamp(34px, 7.5vw, 56px); }
+  .hero-visual { min-height: 280px; }
+}
+
+@container (max-width: 700px) {
+  .footer-main { gap: 18px 20px; }
+}
+
+@container (max-width: 680px) {
+  .footer-release {
+    margin-left: -75px;
+  }
+
+  .mika-glyph {
+    padding: 8px 9px;
+    margin-left: 0;
+  }
+
+  .mika-glyph-art--mini {
+    opacity: 0;
+    transform: scale(0.86);
+  }
+
+  .mika-glyph-art--micro {
+    opacity: 1;
+    transform: scale(1);
+    font-size: 20px;
+  }
+}
+
+.mech-inline-popup {
+    position: fixed;
+    top: 96px;
+    left: 24px;
+    z-index: 12000;
+    min-width: 220px;
+    max-width: min(460px, calc(100vw - 24px));
+    background: #111827;
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 12px 28px rgba(0,0,0,.45);
+    overflow: hidden;
+  }
+  .mech-inline-popup[hidden] { display:none !important; }
+  .mech-inline-popup__header {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:10px;
+    padding:8px 10px;
+    border-bottom:1px solid var(--border);
+    cursor:grab;
+    user-select:none;
+  }
+  .mech-inline-popup__header:active { cursor:grabbing; }
+  .mech-inline-popup__title { font-size:22px; letter-spacing:0; text-transform:none; color:inherit; }
+  .mech-inline-popup__content .mech-output-value { padding: 8px 6px 4px; }
+  .mech-inline-popup__close {
+    border:1px solid var(--border);
+    background:#1f2937;
+    color:var(--text-primary);
+    border-radius:5px;
+    width:24px;
+    height:24px;
+    line-height:20px;
+    cursor:pointer;
+    transition: background .15s ease, border-color .15s ease, color .15s ease;
+  }
+  .mech-inline-popup__close:hover {
+    background: #2d3a4f;
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+  }
+  .mech-inline-popup__content {
+    margin:0;
+    padding:10px;
+    max-height:40vh;
+    overflow:auto;
+    border-radius: 0 0 8px 8px;
+  }
+
+.mika-separator {
+  position: relative;
+  display: block;
+  width: 55%;
+  height: 0;
+  margin: 64px auto;
+  border-top: 1px dotted #d29a2e;
+}
+
+.mika-separator::before {
+  content: "⦿";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, -50%);
+  font-family: SF Mono, SF Mono Regular, Consolas, "Liberation Mono", "Courier New", monospace;
+  color: #d29a2e;
+  background: var(--bg-primary);
+  padding: 0 12px;
+  font-size: 22px;
+  line-height: 1;
+}
+
+@media (max-width: 700px) {
+  :root {
+    --header-height: 118px;
+  }
+
+  .site-header {
+    height: var(--header-height);
+    align-items: stretch;
+    padding: 8px 16px 0;
+  }
+
+  .header-inner {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "brand"
+      "nav";
+    justify-items: center;
+    align-items: start;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .brand {
+    grid-area: brand;
+    justify-self: center;
+    min-width: 0;
+  }
+
+  .brand img {
+    width: auto;
+    height: 42px;
+    max-width: min(70vw, 260px);
+    margin: 0 auto;
+  }
+
+  .header-actions {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-left: 0;
+    display: flex;
+    align-items: center;
+    z-index: 1;
+  }
+
+  .top-nav {
+    grid-area: nav;
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 14px;
+    overflow-x: visible;
+    white-space: normal;
+    align-items: center;
+  }
+
+  .top-nav a {
+    padding: 20px 0 22px;
+    font-size: 12px;
+  }
+
+  .widget .btn,
+  .widget .social-count {
+    height: 28px;
+    font-size: 12px;
+  }
+
+  .widget .btn {
+    padding: 0 9px;
+  }
+
+  .widget .social-count {
+    padding: 0 8px;
+  }
+}
+
+@media (max-width: 450px) {
+  .header-actions {
+    display: none !important;
+  }
+
+  .brand img {
+    max-width: 90vw;
+  }
+}
+
+@media (max-width: 900px) {
+  section h2 {
+    margin-left: 0;
+  }
+
+  .main-content section > h2,
+  .main-content section > h3 {
+    margin-left: 0;
+  }
+  .mika-separator {
+    margin: 48px auto;
+  }
+}
+
+@media (max-width: 500px) {
+  .backmatter-cited .backmatter-body {
+    column-count: 1;
+    column-gap: 0;
+  }
+  .mika-separator {
+    margin: 0px auto;
+  }
+  .footer-inner {
+    padding: 0px;
+  }
+}
+@media (max-width: 400px) {
+  .footer-inner {
+    padding: 0 16px;
+  }
+
+  .footer-main {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding-top: 28px;
+  }
+
+  .footer-robot {
+    display: none;
+  }
+
+  .footer-release {
+    grid-column: 1;
+    grid-row: 1;
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+  }
+
+  .footer-links {
+    grid-column: 1;
+    grid-row: 2;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 22px;
+    width: 100%;
+  }
+
+  .footer-group {
+    min-width: 0;
+  }
+
+  .footer-heading {
+    width: 100%;
+  }
+
+  .footer-group a {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .release-grid-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .release-grid-label {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-strong);
+    padding-bottom: 4px;
+  }
+
+  .release-grid-value {
+    padding-top: 6px;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .release-ack {
+    justify-content: center;
+  }
+
+  .footer-meta {
+    padding: 18px 0;
+  }
+
+  .footer-pride {
+    flex-wrap: wrap;
+  }
+}
+/* ── Documentation layout ── */
+.docs-layout {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: var(--toc-width) minmax(0, 1fr);
+  gap: 48px;
+  align-items: start;
+}
+
+.docs-header {
+  margin: 0 0 32px;
+  padding-bottom: 20px;
+  border-bottom: 1px dotted var(--border);
+}
+
+.docs-kicker {
+  margin: 0 0 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--kicker-accent);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.docs-header h1 {
+  margin: 0;
+  font-size: clamp(34px, 4vw, 56px);
+  line-height: 1.05;
+  color: var(--text-primary);
+  font-family: "IBM Plex Mono", "SFMono-Regular", ui-monospace, Menlo, monospace;
+  font-weight: 700;
+}
+
+.docs-version {
+  margin: 14px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.docs-intro {
+  margin: 0 0 40px;
+}
+
+.docs-intro > .mech-intro > p:first-of-type::first-letter {
+  float: none;
+  font-size: inherit;
+  line-height: inherit;
+  padding-right: 0;
+  margin-top: 0;
+  color: inherit;
+  font-weight: inherit;
+}
+
+/* Keep H2 and H3 navigation visible; reveal deeper branches on the active path. */
+.toc > ul,
+.toc > ul > li > .toc-sub {
+  display: block;
+}
+
+.toc > ul > li > .toc-sub > li > .toc-sub {
+  display: none;
+}
+
+.toc li.expanded > .toc-sub,
+.toc li.active-path > .toc-sub {
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .docs-layout {
+    grid-template-columns: 1fr;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+}

--- a/include/docs.css
+++ b/include/docs.css
@@ -1200,6 +1200,8 @@ body.is-resizing * {
   background: var(--console-bg);
   color: var(--console-text);
   border-left: 1px solid var(--border-strong);
+  min-width: 0;
+  width: 100%;
 }
 
 body.console-fullscreen .console-pane {
@@ -1301,12 +1303,14 @@ body.console-fullscreen .console-fullscreen-toggle .icon-exit {
 .console-panels {
   position: relative;
   min-height: 0;
+  min-width: 0;
   flex: 1;
 }
 
 .console-panel {
   display: none;
   height: 100%;
+  min-width: 0;
 }
 
 .console-panel.is-active {
@@ -1315,6 +1319,7 @@ body.console-fullscreen .console-fullscreen-toggle .icon-exit {
 
 .console-scroll {
   height: 100%;
+  min-width: 0;
   overflow-y: auto;
   padding: 24px;
   font-family: ui-monospace, monospace;

--- a/include/docs.css
+++ b/include/docs.css
@@ -1,7 +1,7 @@
 :root {
   /* ── Layout ── */
   --header-height: 52px;
-  --console-width: 575px;
+  --console-width: 50vw;
   --toc-width: 260px;
   --content-max-width: 1200px;
 

--- a/include/docs.css
+++ b/include/docs.css
@@ -691,7 +691,8 @@ body.narrow-content .mech-float .mech-image {
 .toc a.active-path {
   color: var(--toc-accent);
 }
-.toc > ul > li > a.active::before {
+.toc > ul > li > a.active::before,
+.toc > ul > li > a.active-path::before {
   content: "";
   position: absolute;
   left: 0;

--- a/include/docs.html
+++ b/include/docs.html
@@ -347,16 +347,10 @@ const COLLAPSE_THRESHOLD = 80;
 const HANDLE_WIDTH       = 8;
 const TOC_WIDTH          = 260;
 const TOC_GAP            = 48;
-const MIN_MAIN_CONTENT   = 640;
 const MIN_MAIN_WITH_TOC  = 760;
 const MIN_LEFT_WITH_TOC  = TOC_WIDTH + TOC_GAP + MIN_MAIN_WITH_TOC;
 const MIN_LEFT_WITH_FLOATS = 980;
 const DEFAULT_OPEN_WIDTH = 575;
-const HEADER_HEIGHT = parseInt(
-  getComputedStyle(document.documentElement).getPropertyValue("--header-height"),
-  10
-);
-
 let resizing = false;
 let lastNormalWidth = DEFAULT_OPEN_WIDTH;
 let dragStartX = 0;
@@ -427,8 +421,18 @@ function syncTocVisibility(availableWidth) {
 }
 
 function applyNonFullscreenLayout(viewport, consoleWidth) {
-  const maxConsoleForContent = Math.max(0, viewport - HANDLE_WIDTH - MIN_MAIN_CONTENT);
-  if (consoleWidth > maxConsoleForContent) consoleWidth = maxConsoleForContent;
+  const tocIsHidden = articleLayout.classList.contains("hide-toc");
+  const preferredLeftMin = tocIsHidden ? 420 : 560;
+  const minLeftPane = Math.min(preferredLeftMin, viewport * 0.50);
+  const maxConsoleForContent = Math.max(
+    MIN_CONSOLE_WIDTH,
+    viewport - HANDLE_WIDTH - minLeftPane
+  );
+
+  consoleWidth = Math.max(
+    MIN_CONSOLE_WIDTH,
+    Math.min(consoleWidth, maxConsoleForContent)
+  );
 
   const leftPaneWidth = viewport - HANDLE_WIDTH - consoleWidth;
   syncTocVisibility(leftPaneWidth);
@@ -627,8 +631,17 @@ if (!contentSections.length) {
   articleLayout.classList.add("no-sections", "hide-toc");
 }
 
+const sectionContainers = new Set(
+  tocTargets.map((entry) => entry.section.closest("section") || entry.section)
+);
+let lastActiveTocLink = null;
+let lastActiveSectionContainer = null;
+
 function setActiveTocSection(activeLink) {
   if (!tocRoot) return;
+  if (activeLink === lastActiveTocLink) return;
+  lastActiveTocLink = activeLink;
+
   tocRoot.querySelectorAll("a").forEach((link) => link.classList.remove("active", "active-path"));
   tocRoot.querySelectorAll("li").forEach((item) => item.classList.remove("expanded", "active-path"));
   if (!activeLink) return;
@@ -649,8 +662,8 @@ function updateTocOnScroll() {
   if (contentShell.classList.contains("hidden")) return;
   if (!tocTargets.length) return;
 
-  const viewportHeight = contentShell.clientHeight || window.innerHeight;
-  const activationLine = HEADER_HEIGHT + Math.min(viewportHeight * 0.30, 220);
+  const shellRect = contentShell.getBoundingClientRect();
+  const activationLine = shellRect.top + Math.min(contentShell.clientHeight * 0.30, 220);
   const nearBottom = contentShell.scrollTop + contentShell.clientHeight >= contentShell.scrollHeight - 2;
   let active = tocTargets[0];
 
@@ -662,8 +675,12 @@ function updateTocOnScroll() {
     });
   }
 
-  tocTargets.forEach((entry) => entry.section.classList.remove("active-section"));
-  active.section.classList.add("active-section");
+  const activeContainer = active.section.closest("section") || active.section;
+  if (activeContainer !== lastActiveSectionContainer) {
+    sectionContainers.forEach((container) => container.classList.remove("active-section"));
+    activeContainer.classList.add("active-section");
+    lastActiveSectionContainer = activeContainer;
+  }
   setActiveTocSection(active.link);
 }
 
@@ -678,7 +695,6 @@ function deferPostPaint(fn) {
   requestAnimationFrame(() => requestAnimationFrame(fn));
 }
 
-window.addEventListener("scroll", requestTocUpdate, { passive: true });
 contentShell.addEventListener("scroll", requestTocUpdate, { passive: true });
 window.addEventListener("resize", requestTocUpdate);
 

--- a/include/docs.html
+++ b/include/docs.html
@@ -52,6 +52,8 @@ onload="renderMathInElement(document.body);"></script>
         <span class="sep">⟩</span>
         <a href="https://docs.mech-lang.org">Docs</a>
         <span class="sep">⟩</span>
+        <span aria-current="page">{{SECTION}}</span>
+        <span class="sep">⟩</span>
         <span aria-current="page">{{TITLE}}</span>
       </nav>
       <div class="docs-layout article-layout" id="articleLayout">
@@ -63,6 +65,7 @@ onload="renderMathInElement(document.body);"></script>
             <p class="docs-version">Version {{VERSION}}</p>
           </header>
           <div class="article-intro docs-intro" id="articleIntro">
+            {{ABSTRACT}}
             {{INTRO}}
           </div>
           {{CONTENT}}

--- a/include/docs.html
+++ b/include/docs.html
@@ -1,0 +1,868 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js" integrity="sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"
+onload="renderMathInElement(document.body);"></script>
+
+<title>{{TITLE}}</title>
+<link rel="icon" href="https://gitlab.com/mech-lang/assets/-/raw/main/images/icons/favicon.ico?ref_type=heads" type="image/x-icon">
+<style>
+  {{STYLESHEET}}
+</style>
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <div class="brand">
+      <a href="https://mech-lang.org">
+        <img src="https://mech-lang.org/img/logo.png" alt="Mech Programming Language" height="35">
+      </a>
+    </div>
+    <nav class="top-nav" aria-label="Primary">
+      <a href="https://about.mech-lang.org">About</a>
+      <a href="/blog">Blog</a>
+      <a href="/community">Community</a>
+      <a href="https://docs.mech-lang.org" class="active" aria-current="page">Docs</a>
+      <a href="https://try.mech-lang.org">Explore</a>
+    </nav>
+    <div class="header-actions">
+      <div id="github">
+        <a class="github-button" href="https://github.com/mech-lang/mech" data-color-scheme="no-preference: light; light: light; dark: dark;" data-size="large" data-show-count="true" aria-label="Star mech-lang/mech on GitHub">Star</a>
+      </div>
+    </div>
+  </div>
+</header>
+
+<main class="workspace mech-root" id="workspace" mech-interpreter-id="0" aria-label="Documentation workspace">
+
+  <section class="content-shell" id="contentShell">
+    <div class="content-column">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/docs">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline; width:11px; height:11px; margin-top: -1px; vertical-align:middle;"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+        </a>
+        <span class="sep">⟩</span>
+        <a href="https://docs.mech-lang.org">Docs</a>
+        <span class="sep">⟩</span>
+        <span aria-current="page">{{TITLE}}</span>
+      </nav>
+      <div class="docs-layout article-layout" id="articleLayout">
+        {{TOC}}
+        <article class="main-content docs-content">
+          <header class="docs-header">
+            <p class="docs-kicker">{{SECTION}}</p>
+            <h1>{{TITLE}}</h1>
+            <p class="docs-version">Version {{VERSION}}</p>
+          </header>
+          <div class="article-intro docs-intro" id="articleIntro">
+            {{INTRO}}
+          </div>
+          {{CONTENT}}
+        </article>
+      </div>
+      <div class="mika-separator"></div>
+      <section class="article-backmatter" aria-label="Documentation notes">
+        <div class="backmatter-row backmatter-notes">
+          <div class="backmatter-body">
+            {{FOOTNOTES}}
+          </div>
+        </div>
+      </section>
+      <nav class="post-pagination" aria-label="Documentation navigation">
+        <div class="post-pagination-prev">
+          <span class="post-pagination-label">Previous section</span>
+          {{PREVIOUS}}
+        </div>
+        <div class="post-pagination-next">
+          <span class="post-pagination-label">Next section</span>
+          {{NEXT}}
+        </div>
+      </nav>
+      <footer class="footer">
+        <div class="footer-inner">
+
+          <div class="footer-main">
+
+            <!-- Left: Robot -->
+            <div class="footer-robot">
+              <img src="https://gitlab.com/mech-lang/assets/-/raw/main/images/mika/mika-pose-point.png?ref_type=heads" alt="Mika the Mech">
+              <div class="mika-glyph" aria-hidden="true">
+                <div class="mika-glyph-art-wrap">
+                  <pre class="mika-glyph-art mika-glyph-art--mini">╭(˙◯˙)─</pre>
+                  <pre class="mika-glyph-art mika-glyph-art--micro">╭⦿─</pre>
+                </div>
+              </div>
+            </div>
+
+            <!-- Middle: Links -->
+            <div class="footer-links">
+              <div class="footer-group">
+                <div class="footer-heading"><span class="footer-heading-icon"><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-package-icon lucide-package" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><polyline points="3.29 7 12 12 20.71 7"/><path d="m7.5 4.27 9 5.15"/></svg></span><span class="footer-heading-text">Documentation</span></div>
+                <a href="https://docs.mech-lang.org/getting-started/index.html">Getting Started</a>
+                <a href="https://docs.mech-lang.org/guides/index.html">Language Guide</a>
+                <a href="https://docs.mech-lang.org/reference/index.html">Reference</a>
+                <a href="https://docs.mech-lang.org/standard-library/index.html">Standard Library</a>
+              </div>
+
+              <div class="footer-group">
+                <div class="footer-heading"><span class="footer-heading-icon"><svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-users-icon lucide-users" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><path d="M16 3.128a4 4 0 0 1 0 7.744"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><circle cx="9" cy="7" r="4"/></svg></span><span class="footer-heading-text">Project</span></div>
+                <a href="https://about.mech-lang.org">About</a>
+                <a href="/blog">Blog</a>
+                <a href="https://github.com/mech-lang/mech/releases">Releases</a>
+                <a href="https://github.com/mech-lang">GitHub</a>
+              </div>
+
+              <div class="footer-group">
+                <div class="footer-heading"><span class="footer-heading-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="footer-icon lucide lucide-book-open-text-icon lucide-book-open-text"><path d="M12 7v14"/><path d="M16 12h2"/><path d="M16 8h2"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/><path d="M6 12h2"/><path d="M6 8h2"/></svg></span><span class="footer-heading-text">Community</span></div>
+                <a href="https://discord.gg/asqP25NNTH">Discord</a>
+                <a href="https://groups.google.com/g/mechtalk">Mailing List</a>
+                <a href="https://www.youtube.com/@MechLang">YouTube</a>
+                <a href="https://github.com/mech-lang/mech/blob/main/CONTRIBUTING.md">Contributing</a>
+              </div>
+            </div>
+
+            <!-- Right: Current documentation info -->
+            <div class="footer-release">
+              <div class="release-ack">
+                <svg xmlns="http://www.w3.org/2000/svg" class="footer-icon lucide lucide-rocket-icon lucide-rocket" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09"/><path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05"/></svg>
+                <a href="https://docs.mech-lang.org">Current Docs</a>
+              </div>
+              <div class="release-grid-row">
+                <div class="release-grid-label">Version:</div>
+                <div class="release-grid-value">{{VERSION}}</div>
+              </div>
+              <div class="release-grid-row">
+                <div class="release-grid-label">Channel:</div>
+                <div class="release-grid-value">Stable</div>
+              </div>
+              <div class="release-grid-row">
+                <div class="release-grid-label">Source:</div>
+                <div class="release-grid-value"><a href="https://github.com/mech-lang/mech">GitHub</a></div>
+              </div>
+
+            </div>
+
+          </div>
+
+          <div class="footer-meta">
+            <div class="footer-pride">
+              Built with
+              <span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline; width:18px; height:18px; margin-top: -2px; vertical-align:middle;">
+
+                  <defs>
+                    <radialGradient id="rainbowRadial" cx="12" cy="17" r="11" gradientUnits="userSpaceOnUse">
+                    <!-- pastel purple -->
+                    <stop offset="0%" stop-color="#8b6fd8"></stop>
+                    <stop offset="18%" stop-color="#8b6fd8"></stop>
+                    <!-- pastel blue -->
+                    <stop offset="18%" stop-color="#6fa8ff"></stop>
+                    <stop offset="38%" stop-color="#6fa8ff"></stop>
+                    <!-- pastel green -->
+                    <stop offset="38%" stop-color="#5DCF8D"></stop>
+                    <stop offset="53%" stop-color="#5DCF8D"></stop>
+                    <!-- pastel yellow -->
+                    <stop offset="53%" stop-color="#ffe873"></stop>
+                    <stop offset="72%" stop-color="#ffe873"></stop>
+                    <!-- pastel orange -->
+                    <stop offset="72%" stop-color="#ff9f5f"></stop>
+                    <stop offset="90%" stop-color="#ff9f5f"></stop>
+                    <!-- pastel red -->
+                    <stop offset="90%" stop-color="#ff6666"></stop>
+                    <stop offset="100%" stop-color="#ff6666"></stop>
+                    </radialGradient>
+                  </defs>
+
+                  <path d="M22 17a10 10 0 0 0-20 0" stroke="url(#rainbowRadial)"></path>
+                  <path d="M6 17a6 6 0 0 1 12 0" stroke="url(#rainbowRadial)"></path>
+                  <path d="M10 17a2 2 0 0 1 4 0" stroke="url(#rainbowRadial)"></path>
+                </svg>
+              </span> in Pennsylvania
+            </div>
+          </div>
+
+        </div>
+      </footer>
+    </div>
+  </section>
+
+  <div class="resize-handle" id="resizer"></div>
+  <div class="edge-handle" id="edgeHandle" aria-hidden="true"></div>
+
+  <aside class="console-pane">
+    <div class="console-topbar">
+      <div class="console-tabs" role="tablist" aria-label="Console sections">
+        <button class="console-tab active" type="button" role="tab" aria-selected="true" data-tab="console">console</button>
+        <button class="console-tab" type="button" role="tab" aria-selected="false" data-tab="output">output</button>
+        <button class="console-tab" type="button" role="tab" aria-selected="false" data-tab="errors">errors</button>
+      </div>
+      <button class="console-fullscreen-toggle" id="consoleFullscreenToggle" type="button" aria-pressed="false" aria-label="Enter fullscreen">
+        <svg class="icon-enter" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M3 7V5a2 2 0 0 1 2-2h2"></path>
+          <path d="M17 3h2a2 2 0 0 1 2 2v2"></path>
+          <path d="M21 17v2a2 2 0 0 1-2 2h-2"></path>
+          <path d="M7 21H5a2 2 0 0 1-2-2v-2"></path>
+          <rect width="10" height="8" x="7" y="8" rx="1"></rect>
+        </svg>
+        <svg class="icon-exit" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+          <path d="M15 3v18"></path>
+          <path d="m8 9 3 3-3 3"></path>
+        </svg>
+      </button>
+    </div>
+    <div class="console-panels">
+      <div class="console-panel is-active" data-panel="console">
+        {{REPL}}
+      </div>
+      <div class="console-panel" data-panel="output">
+        <div class="console-scroll">under construction</div>
+      </div>
+      <div class="console-panel" data-panel="errors">
+        <div class="console-scroll">under construction</div>
+      </div>
+    </div>
+  </aside>
+
+</main>
+
+<script type="module">
+let wasm_core;
+
+async function loadMechModule() {
+  const moduleCandidates = [
+    "/pkg/mech_wasm.js",
+    "https://docs.mech-lang.org/pkg/mech_wasm.js",
+  ];
+
+  let lastError = null;
+  for (const moduleUrl of moduleCandidates) {
+    try {
+      const mod = await import(moduleUrl);
+      return mod;
+    } catch (err) {
+      lastError = err;
+      console.error(`Failed to import ${moduleUrl}`, err);
+    }
+  }
+  throw lastError || new Error("Unable to load mech_wasm.js");
+}
+
+async function run() {
+  const { default: init, WasmMech } = await loadMechModule();
+  await init();
+  const prepareVarPlaceholders = () => {
+  const pattern = /\{\{VAR:([A-Za-z0-9\-_\/]+)(?:@([A-Za-z0-9\-_\/]+))?\}\}/g;
+  document.querySelectorAll("script, style, code, pre, textarea").forEach((el) => el.setAttribute("data-var-skip", "1"));
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const updates = [];
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (!node || !node.nodeValue || !pattern.test(node.nodeValue)) {
+      pattern.lastIndex = 0;
+      continue;
+    }
+    pattern.lastIndex = 0;
+    const parent = node.parentElement;
+    if (!parent || parent.closest("[data-var-skip='1']")) continue;
+    const nearestMechRoot = parent.closest(".mech-root");
+    const rootInterpreterId = Number(nearestMechRoot?.getAttribute("mech-interpreter-id") || "0");
+    const fragment = document.createDocumentFragment();
+    let lastIndex = 0;
+    node.nodeValue.replace(pattern, (match, varName, interpreterName, offset) => {
+      if (offset > lastIndex) {
+        fragment.appendChild(document.createTextNode(node.nodeValue.slice(lastIndex, offset)));
+      }
+      const span = document.createElement("span");
+      span.className = "mech-var-placeholder";
+      span.setAttribute("data-var-name", varName);
+      if (interpreterName) {
+        span.setAttribute("data-interpreter-name", interpreterName);
+      } else {
+        span.setAttribute("data-interpreter-id", String(rootInterpreterId));
+      }
+      span.textContent = "";
+      fragment.appendChild(span);
+      lastIndex = offset + match.length;
+      return match;
+    });
+    if (lastIndex < node.nodeValue.length) {
+      fragment.appendChild(document.createTextNode(node.nodeValue.slice(lastIndex)));
+    }
+    updates.push([node, fragment]);
+  }
+  updates.forEach(([node, fragment]) => node.parentNode.replaceChild(fragment, node));
+  };
+  const code = `{{CODE}}`;
+  wasm_core = new WasmMech();
+  const xhr = new XMLHttpRequest();
+  const codeUrl = `/code${window.location.pathname}`;
+  xhr.open('GET', codeUrl, true);
+  xhr.onload = function () {
+    if (xhr.readyState === 4) {
+      if (xhr.status === 200) {
+        wasm_core.run_program(xhr.responseText);
+      } else {
+        console.error('Defaulting to included program');
+        wasm_core.run_program(code);
+      }
+      prepareVarPlaceholders();
+      wasm_core.init();
+      wasm_core.render_inline_values();
+      wasm_core.render_codeblock_output_values();
+      wasm_core.attach_repl('mech-output');
+    }
+  };
+  xhr.onerror = function () {
+    console.error("I've been waiting for this error. Look me up in formatter.rs");
+    console.error(xhr.statusText);
+  };
+  xhr.send(null);
+}
+
+run();
+</script>
+
+<script>
+const handle        = document.getElementById("resizeHandle") || document.getElementById("resizer");
+const workspace     = document.getElementById("workspace");
+const articleLayout = document.getElementById("articleLayout");
+const contentShell  = document.getElementById("contentShell");
+const consolePane   = document.querySelector(".console-pane");
+const edgeHandle    = document.getElementById("edgeHandle");
+const tabButtons    = Array.from(document.querySelectorAll(".console-tab"));
+const tabPanels     = Array.from(document.querySelectorAll(".console-panel"));
+const fullscreenToggle = document.getElementById("consoleFullscreenToggle");
+
+const MIN_CONSOLE_WIDTH  = 320;
+const COLLAPSE_THRESHOLD = 80;
+const HANDLE_WIDTH       = 8;
+const TOC_WIDTH          = 260;
+const TOC_GAP            = 48;
+const MIN_MAIN_CONTENT   = 640;
+const MIN_MAIN_WITH_TOC  = 760;
+const MIN_LEFT_WITH_TOC  = TOC_WIDTH + TOC_GAP + MIN_MAIN_WITH_TOC;
+const MIN_LEFT_WITH_FLOATS = 980;
+const DEFAULT_OPEN_WIDTH = 575;
+const HEADER_HEIGHT = parseInt(
+  getComputedStyle(document.documentElement).getPropertyValue("--header-height"),
+  10
+);
+
+let resizing = false;
+let lastNormalWidth = DEFAULT_OPEN_WIDTH;
+let dragStartX = 0;
+let didDrag = false;
+let currentConsoleWidth = parseFloat(
+  document.documentElement.style.getPropertyValue("--console-width")
+) || DEFAULT_OPEN_WIDTH;
+
+function setActiveConsoleTab(tabName) {
+  tabButtons.forEach((button) => {
+    const isActive = button.dataset.tab === tabName;
+    button.classList.toggle("active", isActive);
+    button.setAttribute("aria-selected", String(isActive));
+  });
+  tabPanels.forEach((panel) => {
+    panel.classList.toggle("is-active", panel.dataset.panel === tabName);
+  });
+}
+
+function updateFullscreenToggleLabel() {
+  if (!fullscreenToggle) return;
+  const isFullscreen = document.body.classList.contains("console-fullscreen");
+  fullscreenToggle.setAttribute("aria-label", isFullscreen ? "Exit fullscreen" : "Enter fullscreen");
+  fullscreenToggle.setAttribute("aria-pressed", String(isFullscreen));
+}
+
+function setConsoleWidth(width) {
+  currentConsoleWidth = width;
+  document.documentElement.style.setProperty("--console-width", `${width}px`);
+}
+
+function setEdgeHandle(mode) {
+  if (!edgeHandle) return;
+  document.body.classList.remove("edge-left", "edge-right");
+  edgeHandle.classList.remove("left");
+
+  if (mode === "left") {
+    edgeHandle.style.display = "block";
+    edgeHandle.classList.add("left");
+    document.body.classList.add("edge-left");
+    handle.style.display = "none";
+  } else if (mode === "right") {
+    edgeHandle.style.display = "block";
+    document.body.classList.add("edge-right");
+    handle.style.display = "none";
+  } else {
+    edgeHandle.style.display = "none";
+    if (!document.body.classList.contains("console-fullscreen") && consolePane.style.display !== "none") {
+      handle.style.display = "";
+    }
+  }
+}
+
+function syncEdgeHandleOnLoad() {
+  if (window.innerWidth <= 900) { setEdgeHandle("none"); return; }
+  if (document.body.classList.contains("console-fullscreen")) {
+    setEdgeHandle("left");
+  } else if (consolePane.style.display === "none" || currentConsoleWidth <= COLLAPSE_THRESHOLD) {
+    setEdgeHandle("right");
+  } else {
+    setEdgeHandle("none");
+  }
+}
+
+function syncTocVisibility(availableWidth) {
+  articleLayout.classList.toggle("hide-toc", availableWidth < MIN_LEFT_WITH_TOC);
+  document.body.classList.toggle("narrow-content", availableWidth < MIN_LEFT_WITH_FLOATS);
+}
+
+function applyNonFullscreenLayout(viewport, consoleWidth) {
+  const maxConsoleForContent = Math.max(0, viewport - HANDLE_WIDTH - MIN_MAIN_CONTENT);
+  if (consoleWidth > maxConsoleForContent) consoleWidth = maxConsoleForContent;
+
+  const leftPaneWidth = viewport - HANDLE_WIDTH - consoleWidth;
+  syncTocVisibility(leftPaneWidth);
+
+  contentShell.classList.remove("hidden");
+  handle.style.display = "";
+  workspace.style.gridTemplateColumns = "";
+  setEdgeHandle("none");
+  lastNormalWidth = consoleWidth;
+  return consoleWidth;
+}
+
+function closeConsole() {
+  document.body.classList.remove("console-fullscreen");
+  consolePane.style.display = "none";
+  handle.style.display = "none";
+  contentShell.classList.remove("hidden");
+  syncTocVisibility(window.innerWidth);
+  setEdgeHandle("right");
+  setConsoleWidth(0);
+  updateFullscreenToggleLabel();
+}
+
+function openConsoleNormal() {
+  const viewport = window.innerWidth;
+  document.body.classList.remove("console-fullscreen");
+  consolePane.style.display = "";
+  contentShell.classList.remove("hidden");
+  handle.style.display = "";
+  let openWidth = Math.min(lastNormalWidth || DEFAULT_OPEN_WIDTH, viewport - HANDLE_WIDTH);
+  if (openWidth < MIN_CONSOLE_WIDTH) {
+    openWidth = Math.min(DEFAULT_OPEN_WIDTH, Math.max(MIN_CONSOLE_WIDTH, viewport * 0.36));
+  }
+  openWidth = applyNonFullscreenLayout(viewport, openWidth);
+  setConsoleWidth(openWidth);
+  updateFullscreenToggleLabel();
+}
+
+function enterConsoleFullscreen() {
+  if (window.innerWidth <= 900) return;
+  const viewport = window.innerWidth;
+  if (currentConsoleWidth > COLLAPSE_THRESHOLD) {
+    lastNormalWidth = currentConsoleWidth;
+  }
+  consolePane.style.display = "";
+  document.body.classList.add("console-fullscreen");
+  articleLayout.classList.add("hide-toc");
+  contentShell.classList.add("hidden");
+  handle.style.display = "none";
+  workspace.style.gridTemplateColumns = "";
+  setEdgeHandle("left");
+  setConsoleWidth(viewport);
+  updateFullscreenToggleLabel();
+}
+
+function cycleConsoleMode() {
+  const isFullscreen = document.body.classList.contains("console-fullscreen");
+  const isClosed = consolePane.style.display === "none" || currentConsoleWidth <= COLLAPSE_THRESHOLD;
+  if (isFullscreen || isClosed) {
+    openConsoleNormal();
+  } else {
+    lastNormalWidth = currentConsoleWidth;
+    closeConsole();
+  }
+}
+
+handle.addEventListener("mousedown", (e) => {
+  resizing = true; dragStartX = e.clientX; didDrag = false;
+  document.body.classList.add("is-resizing");
+  document.body.style.userSelect = "none";
+});
+
+edgeHandle.addEventListener("mousedown", (e) => {
+  resizing = true; dragStartX = e.clientX; didDrag = false;
+  document.body.classList.add("is-resizing");
+  document.body.style.userSelect = "none";
+});
+
+function onHandleClick(event) {
+  if (didDrag) { didDrag = false; return; }
+  const state = document.body.classList.contains("console-fullscreen") ? "fullscreen"
+    : (consolePane.style.display === "none" || currentConsoleWidth <= COLLAPSE_THRESHOLD) ? "closed" : "open";
+  if (state === "open" && event.type !== "dblclick") return;
+  cycleConsoleMode();
+}
+
+handle.addEventListener("click", onHandleClick);
+handle.addEventListener("dblclick", onHandleClick);
+edgeHandle.addEventListener("click", onHandleClick);
+
+window.addEventListener("mousemove", (e) => {
+  if (!resizing) return;
+  if (Math.abs(e.clientX - dragStartX) > 3) didDrag = true;
+
+  const viewport = window.innerWidth;
+  let consoleWidth = viewport - e.clientX;
+  const fullSnap = viewport * 0.92;
+
+  if (consoleWidth <= COLLAPSE_THRESHOLD) {
+    consoleWidth = 0;
+    document.body.classList.remove("console-fullscreen");
+    consolePane.style.display = "none";
+    handle.style.display = "none";
+    workspace.style.gridTemplateColumns = "";
+    syncTocVisibility(viewport);
+    contentShell.classList.remove("hidden");
+    setEdgeHandle("right");
+  } else {
+    document.body.classList.remove("console-fullscreen");
+    consolePane.style.display = "";
+    if (consoleWidth < MIN_CONSOLE_WIDTH) consoleWidth = MIN_CONSOLE_WIDTH;
+
+    if (consoleWidth >= fullSnap) {
+      articleLayout.classList.add("hide-toc");
+      consoleWidth = viewport;
+      contentShell.classList.add("hidden");
+      handle.style.display = "none";
+      workspace.style.gridTemplateColumns = "";
+      document.body.classList.add("console-fullscreen");
+      setEdgeHandle("left");
+    } else {
+      consoleWidth = applyNonFullscreenLayout(viewport, consoleWidth);
+    }
+  }
+
+  setConsoleWidth(consoleWidth);
+  updateFullscreenToggleLabel();
+});
+
+window.addEventListener("mouseup", () => {
+  resizing = false;
+  document.body.classList.remove("is-resizing");
+  document.body.style.userSelect = "";
+});
+
+window.addEventListener("resize", () => {
+  if (window.innerWidth <= 900) return;
+  const viewport = window.innerWidth;
+  let consoleWidth = currentConsoleWidth;
+
+  if (document.body.classList.contains("console-fullscreen")) {
+    setEdgeHandle("left");
+    setConsoleWidth(viewport);
+    updateFullscreenToggleLabel();
+    return;
+  }
+  if (consolePane.style.display === "none" || consoleWidth <= COLLAPSE_THRESHOLD) {
+    syncTocVisibility(viewport);
+    contentShell.classList.remove("hidden");
+    setEdgeHandle("right");
+    updateFullscreenToggleLabel();
+    return;
+  }
+
+  if (consoleWidth > viewport - HANDLE_WIDTH) consoleWidth = viewport - HANDLE_WIDTH;
+  if (consoleWidth < MIN_CONSOLE_WIDTH) consoleWidth = MIN_CONSOLE_WIDTH;
+  consoleWidth = applyNonFullscreenLayout(viewport, consoleWidth);
+  setConsoleWidth(consoleWidth);
+  updateFullscreenToggleLabel();
+});
+
+window.addEventListener("keydown", (e) => {
+  if (e.key !== "`") return;
+  const tag = document.activeElement?.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || document.activeElement?.isContentEditable) return;
+  e.preventDefault();
+  cycleConsoleMode();
+});
+
+tabButtons.forEach((button) => {
+  button.addEventListener("click", () => setActiveConsoleTab(button.dataset.tab));
+});
+
+fullscreenToggle?.addEventListener("click", () => {
+  if (document.body.classList.contains("console-fullscreen")) {
+    openConsoleNormal();
+  } else {
+    enterConsoleFullscreen();
+  }
+});
+
+updateFullscreenToggleLabel();
+
+/* ── Scrollspy ── */
+const tocRoot = document.querySelector(".toc");
+const tocLinks = tocRoot ? Array.from(tocRoot.querySelectorAll('a[href^="#"]')) : [];
+const tocTargets = tocLinks
+  .map((link) => {
+    const id = link.getAttribute("href")?.slice(1);
+    return { link, section: id ? document.getElementById(id) : null };
+  })
+  .filter((entry) => entry.section);
+
+const contentSections = Array.from(document.querySelectorAll(".main-content > section"));
+if (!contentSections.length) {
+  articleLayout.classList.add("no-sections", "hide-toc");
+}
+
+function setActiveTocSection(activeLink) {
+  if (!tocRoot) return;
+  tocRoot.querySelectorAll("a").forEach((link) => link.classList.remove("active", "active-path"));
+  tocRoot.querySelectorAll("li").forEach((item) => item.classList.remove("expanded", "active-path"));
+  if (!activeLink) return;
+
+  activeLink.classList.add("active", "active-path");
+  let item = activeLink.closest("li");
+  while (item) {
+    item.classList.add("expanded", "active-path");
+    const parentItem = item.parentElement?.closest("li");
+    const parentLink = parentItem?.querySelector(":scope > a");
+    if (parentLink) parentLink.classList.add("active-path");
+    item = parentItem;
+  }
+}
+
+function updateTocOnScroll() {
+  if (document.visibilityState !== "visible") return;
+  if (contentShell.classList.contains("hidden")) return;
+  if (!tocTargets.length) return;
+
+  const viewportHeight = contentShell.clientHeight || window.innerHeight;
+  const activationLine = HEADER_HEIGHT + Math.min(viewportHeight * 0.30, 220);
+  const nearBottom = contentShell.scrollTop + contentShell.clientHeight >= contentShell.scrollHeight - 2;
+  let active = tocTargets[0];
+
+  if (nearBottom) {
+    active = tocTargets[tocTargets.length - 1];
+  } else {
+    tocTargets.forEach((entry) => {
+      if (entry.section.getBoundingClientRect().top <= activationLine) active = entry;
+    });
+  }
+
+  tocTargets.forEach((entry) => entry.section.classList.remove("active-section"));
+  active.section.classList.add("active-section");
+  setActiveTocSection(active.link);
+}
+
+let tocTicking = false;
+function requestTocUpdate() {
+  if (tocTicking) return;
+  tocTicking = true;
+  requestAnimationFrame(() => { tocTicking = false; updateTocOnScroll(); });
+}
+
+function deferPostPaint(fn) {
+  requestAnimationFrame(() => requestAnimationFrame(fn));
+}
+
+window.addEventListener("scroll", requestTocUpdate, { passive: true });
+contentShell.addEventListener("scroll", requestTocUpdate, { passive: true });
+window.addEventListener("resize", requestTocUpdate);
+
+function syncInitialResponsiveLayout() {
+  if (window.innerWidth > 900) {
+    const initialWidth = Math.max(MIN_CONSOLE_WIDTH, Math.min(currentConsoleWidth, window.innerWidth - HANDLE_WIDTH));
+    setConsoleWidth(applyNonFullscreenLayout(window.innerWidth, initialWidth));
+  }
+  syncEdgeHandleOnLoad();
+  requestTocUpdate();
+}
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") deferPostPaint(syncInitialResponsiveLayout);
+});
+
+deferPostPaint(syncInitialResponsiveLayout);
+
+
+(function setupInlineValuePopups() {
+
+  function createPopup(varName, value, x, y, { isHtml = false } = {}) {
+    const popup = document.createElement("section");
+    popup.className = "mech-inline-popup";
+    popup.innerHTML = `
+      <div class="mech-inline-popup__header">
+        <span class="mech-inline-popup__title mech-var-name"></span>
+        <button type="button" class="mech-inline-popup__close" aria-label="Close popup">×</button>
+      </div>
+      <div class="mech-inline-popup__content mech-block-output"></div>
+    `;
+    document.body.appendChild(popup);
+
+    const header = popup.querySelector(".mech-inline-popup__header");
+    const title = popup.querySelector(".mech-inline-popup__title");
+    const closeBtn = popup.querySelector(".mech-inline-popup__close");
+    const content = popup.querySelector(".mech-inline-popup__content");
+
+    title.textContent = varName;
+    if (isHtml) content.innerHTML = value;
+    else content.textContent = value;
+
+    const pad = 12;
+    const width = popup.offsetWidth || 320;
+    const height = popup.offsetHeight || 120;
+    popup.style.left = `${Math.max(pad, Math.min(x, window.innerWidth - width - pad))}px`;
+    popup.style.top = `${Math.max(70, Math.min(y, window.innerHeight - height - pad))}px`;
+
+    closeBtn.addEventListener("click", () => popup.remove());
+
+    let dragging = false;
+    let dragOffsetX = 0;
+    let dragOffsetY = 0;
+    header.addEventListener("mousedown", (event) => {
+      dragging = true;
+      const rect = popup.getBoundingClientRect();
+      dragOffsetX = event.clientX - rect.left;
+      dragOffsetY = event.clientY - rect.top;
+      event.preventDefault();
+    });
+    const moveHandler = (event) => {
+      if (!dragging || !document.body.contains(popup)) return;
+      const maxX = window.innerWidth - popup.offsetWidth - 8;
+      const maxY = window.innerHeight - popup.offsetHeight - 8;
+      popup.style.left = `${Math.max(8, Math.min(event.clientX - dragOffsetX, maxX))}px`;
+      popup.style.top = `${Math.max(8, Math.min(event.clientY - dragOffsetY, maxY))}px`;
+    };
+    const upHandler = () => { dragging = false; };
+    window.addEventListener("mousemove", moveHandler);
+    window.addEventListener("mouseup", upHandler);
+  }
+  function consoleIsClosed() {
+    return consolePane.style.display === "none" || currentConsoleWidth <= COLLAPSE_THRESHOLD;
+  }
+
+  function resolvePopupData(source) {
+    const varName = (source.getAttribute("data-var")
+      || source.getAttribute("data-name")
+      || source.getAttribute("data-symbol")
+      || source.textContent
+      || "Inline Value").trim();
+
+    const nearbyValue = source.nextElementSibling?.classList?.contains("ans")
+      ? source.nextElementSibling.textContent
+      : source.closest(".mech-code")?.querySelector(".ans")?.textContent;
+
+    const value = (source.getAttribute("data-value")
+      || source.getAttribute("data-popup")
+      || source.getAttribute("title")
+      || source.getAttribute("aria-label")
+      || nearbyValue
+      || "(no value)").trim();
+
+    return { varName, value };
+  }
+
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") return;
+    document.querySelectorAll(".mech-inline-popup").forEach((el) => el.remove());
+  });
+
+  document.addEventListener("click", (event) => {
+    const target = event.target.closest(".mech-clickable, .ans, .mech-inline-expand");
+    if (!target) return;
+    if (!consoleIsClosed()) return;
+
+    const clickedAns = target.classList.contains("ans");
+    const source = clickedAns
+      ? target.previousElementSibling?.classList?.contains("mech-clickable") ? target.previousElementSibling : target
+      : target;
+
+    const { varName } = resolvePopupData(source);
+
+    if (clickedAns) {
+      const value = (target.innerHTML || target.textContent || "(no value)").trim();
+      createPopup(varName, value, event.clientX + 12, event.clientY + 12, { isHtml: true });
+      return;
+    }
+
+    window.setTimeout(() => {
+      const wasmModal = document.querySelector(".mech-modal:last-of-type");
+      let valueHtml = "";
+
+      if (wasmModal) {
+        valueHtml = (wasmModal.innerHTML || "").trim();
+        wasmModal.remove();
+      }
+
+      if (!valueHtml) {
+        const replResults = document.querySelectorAll("#mech-output .repl-result");
+        const lastResult = replResults[replResults.length - 1];
+        const kindHtml = lastResult?.querySelector(".mech-output-kind")?.outerHTML || "";
+        const bodyHtml = lastResult?.querySelector(".mech-output-value")?.outerHTML || lastResult?.innerHTML || "";
+        valueHtml = `${kindHtml}${bodyHtml}`.trim();
+      }
+
+      createPopup(varName, valueHtml || "(no value)", event.clientX + 12, event.clientY + 12, { isHtml: true });
+    }, 0);
+  });
+
+})();
+window.addEventListener("DOMContentLoaded", () => {
+
+  function renderEquations(root = document) {
+    const blockElements = root.querySelectorAll(".mech-equation");
+    blockElements.forEach(el => {
+      if (!el.getAttribute("data-rendered")) {
+        const eq = el.getAttribute("equation");
+        if (eq) {
+          katex.render(eq, el, { throwOnError: false });
+          el.setAttribute("data-rendered", "true");
+        }
+      }
+    });
+
+    const inlineElements = root.querySelectorAll(".mech-inline-equation");
+    inlineElements.forEach(el => {
+      if (!el.getAttribute("data-rendered")) {
+        const eq = el.getAttribute("equation");
+        if (eq) {
+          katex.render(eq, el, { throwOnError: false });
+          el.setAttribute("data-rendered", "true");
+        }
+      }
+    });
+  }
+
+  renderEquations();
+
+  // Set up a MutationObserver to watch for new elements
+  const mutationobserver = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          renderEquations(node);
+        }
+      }
+    }
+  });
+  mutationobserver.observe(document.body, { childList: true, subtree: true });
+
+});
+</script>
+
+</body>
+</html>

--- a/include/docs.html
+++ b/include/docs.html
@@ -350,14 +350,17 @@ const TOC_GAP            = 48;
 const MIN_MAIN_WITH_TOC  = 760;
 const MIN_LEFT_WITH_TOC  = TOC_WIDTH + TOC_GAP + MIN_MAIN_WITH_TOC;
 const MIN_LEFT_WITH_FLOATS = 980;
-const DEFAULT_OPEN_WIDTH = 575;
+const DEFAULT_OPEN_RATIO = 0.50;
+function defaultOpenWidth(viewport = window.innerWidth) {
+  return Math.max(MIN_CONSOLE_WIDTH, Math.round(viewport * DEFAULT_OPEN_RATIO));
+}
 let resizing = false;
-let lastNormalWidth = DEFAULT_OPEN_WIDTH;
+let lastNormalWidth = defaultOpenWidth();
 let dragStartX = 0;
 let didDrag = false;
 let currentConsoleWidth = parseFloat(
   document.documentElement.style.getPropertyValue("--console-width")
-) || DEFAULT_OPEN_WIDTH;
+) || lastNormalWidth;
 
 function setActiveConsoleTab(tabName) {
   tabButtons.forEach((button) => {
@@ -460,9 +463,10 @@ function openConsoleNormal() {
   consolePane.style.display = "";
   contentShell.classList.remove("hidden");
   handle.style.display = "";
-  let openWidth = Math.min(lastNormalWidth || DEFAULT_OPEN_WIDTH, viewport - HANDLE_WIDTH);
+  const defaultWidth = defaultOpenWidth(viewport);
+  let openWidth = Math.min(lastNormalWidth || defaultWidth, viewport - HANDLE_WIDTH);
   if (openWidth < MIN_CONSOLE_WIDTH) {
-    openWidth = Math.min(DEFAULT_OPEN_WIDTH, Math.max(MIN_CONSOLE_WIDTH, viewport * 0.36));
+    openWidth = Math.min(defaultWidth, Math.max(MIN_CONSOLE_WIDTH, viewport * DEFAULT_OPEN_RATIO));
   }
   openWidth = applyNonFullscreenLayout(viewport, openWidth);
   setConsoleWidth(openWidth);

--- a/include/docs.html
+++ b/include/docs.html
@@ -421,9 +421,7 @@ function syncTocVisibility(availableWidth) {
 }
 
 function applyNonFullscreenLayout(viewport, consoleWidth) {
-  const tocIsHidden = articleLayout.classList.contains("hide-toc");
-  const preferredLeftMin = tocIsHidden ? 420 : 560;
-  const minLeftPane = Math.min(preferredLeftMin, viewport * 0.50);
+  const minLeftPane = Math.min(560, viewport * 0.50);
   const maxConsoleForContent = Math.max(
     MIN_CONSOLE_WIDTH,
     viewport - HANDLE_WIDTH - minLeftPane
@@ -560,6 +558,16 @@ window.addEventListener("mousemove", (e) => {
 
   setConsoleWidth(consoleWidth);
   updateFullscreenToggleLabel();
+
+  console.log({
+    rawConsoleWidth: viewport - e.clientX,
+    appliedConsoleWidth: consoleWidth,
+    cssConsoleWidth: getComputedStyle(document.documentElement).getPropertyValue("--console-width"),
+    paneWidth: consolePane.getBoundingClientRect().width,
+    leftPaneWidth: viewport - HANDLE_WIDTH - consoleWidth,
+    hideToc: articleLayout.classList.contains("hide-toc"),
+    grid: getComputedStyle(workspace).gridTemplateColumns
+  });
 });
 
 window.addEventListener("mouseup", () => {

--- a/include/docs.html
+++ b/include/docs.html
@@ -563,15 +563,6 @@ window.addEventListener("mousemove", (e) => {
   setConsoleWidth(consoleWidth);
   updateFullscreenToggleLabel();
 
-  console.log({
-    rawConsoleWidth: viewport - e.clientX,
-    appliedConsoleWidth: consoleWidth,
-    cssConsoleWidth: getComputedStyle(document.documentElement).getPropertyValue("--console-width"),
-    paneWidth: consolePane.getBoundingClientRect().width,
-    leftPaneWidth: viewport - HANDLE_WIDTH - consoleWidth,
-    hideToc: articleLayout.classList.contains("hide-toc"),
-    grid: getComputedStyle(workspace).gridTemplateColumns
-  });
 });
 
 window.addEventListener("mouseup", () => {

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -311,6 +311,7 @@ pub struct Title {
   pub date: Option<Paragraph>,
   pub hero: Option<SectionElement>,
   pub kicker: Option<Paragraph>,
+  pub section: Option<Paragraph>,
   pub summary: Option<Paragraph>,
   pub next: Option<Paragraph>,
   pub previous: Option<Paragraph>,

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -11,6 +11,7 @@ struct TitleSlots {
   date: String,
   hero: String,
   kicker: String,
+  section: String,
   summary: String,
   next: String,
   previous: String,
@@ -199,6 +200,8 @@ impl Formatter {
         .replace("{{AUTHOR}}", &title_slots.author)
         .replace("{{DATE}}", &title_slots.date)
         .replace("{{KICKER}}", &title_slots.kicker)
+        .replace("{{SECTION}}", &title_slots.section)
+        .replace("{{VERSION}}", env!("CARGO_PKG_VERSION"))
         .replace("{{NEXT}}", &title_slots.next)
         .replace("{{PREVIOUS}}", &title_slots.previous)
         .replace("{{HERO}}", &title_slots.hero)
@@ -228,6 +231,7 @@ impl Formatter {
           date: title.date.as_ref().map(|p| self.inline_para_el(p, "mech-date")).unwrap_or_default(),
           hero: title.hero.as_ref().map(|h| self.hero_el(h)).unwrap_or_default(),
           kicker: title.kicker.as_ref().map(|p| self.inline_para_el(p, "hero-kicker")).unwrap_or_default(),
+          section: title.section.as_ref().map(|p| self.inline_para_el(p, "mech-section")).unwrap_or_default(),
           summary: title.summary.as_ref().map(|p| self.synopsis_el(p)).unwrap_or_default(),
           next: title.next.as_ref().map(|p| self.inline_para_el(p, "mech-next")).unwrap_or_default(),
           previous: title.previous.as_ref().map(|p| self.inline_para_el(p, "mech-previous")).unwrap_or_default(),

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -27,6 +27,7 @@ pub struct TitleFrontMatter {
   pub date: Option<Paragraph>,
   pub hero: Option<SectionElement>,
   pub kicker: Option<Paragraph>,
+  pub section: Option<Paragraph>,
   pub summary: Option<Paragraph>,
   pub next: Option<Paragraph>,
   pub previous: Option<Paragraph>,
@@ -51,6 +52,7 @@ pub fn title(input: ParseString) -> ParseResult<Title> {
     date: front_matter.date,
     hero: front_matter.hero,
     kicker: front_matter.kicker,
+    section: front_matter.section,
     summary: front_matter.summary,
     next: front_matter.next,
     previous: front_matter.previous,
@@ -89,6 +91,7 @@ pub fn title_front_matter(input: ParseString) -> ParseResult<TitleFrontMatter> {
       "author" => front_matter.author = Some(paragraph),
       "date" => front_matter.date = Some(paragraph),
       "kicker" => front_matter.kicker = Some(paragraph),
+      "section" => front_matter.section = Some(paragraph),
       "summary" => front_matter.summary = Some(paragraph),
       "next" => front_matter.next = Some(paragraph),
       "previous" => front_matter.previous = Some(paragraph),
@@ -1148,6 +1151,23 @@ mod tests {
     assert_eq!(fenced[1].exports.len(), 1);
     assert_eq!(fenced[1].imports[0].specifier.to_string(), "geometry/triangle-area");
     assert_eq!(fenced[1].exports[0].name.to_string(), "area");
+  }
+
+  #[test]
+  fn formatter_replaces_version_and_section_placeholders() {
+    let src = "Template Test\n==============\nsection: Guides\n==============\n\nIntro text.\n";
+    let tree = parser::parse(src).unwrap();
+    let mut formatter = Formatter::new();
+    let html = formatter.format_html(
+      &tree,
+      "".to_string(),
+      "<main>{{SECTION}} {{VERSION}} {{TITLE}}</main>".to_string(),
+    );
+    assert!(html.contains("mech-section"));
+    assert!(html.contains("Guides"));
+    assert!(html.contains(env!("CARGO_PKG_VERSION")));
+    assert!(!html.contains("{{SECTION}}"));
+    assert!(!html.contains("{{VERSION}}"));
   }
 
   #[test]


### PR DESCRIPTION
### Motivation

- Provide a documentation-oriented page template derived from the existing blog template so docs pages start with a persistent left TOC and a compact docs header instead of a blog hero. 
- Preserve interactive workspace features (resizable REPL/output pane, console tabs, fullscreen behavior, and inline value popups) so documentation pages keep the same developer experience as the blog pages. 
- Replace blog-specific editorial surfaces (hero, author/date, summary, drop-cap styling, and citation section) with neutral documentation semantics (section kicker, title, version, and generic documentation notes). 

### Description

- Added `include/docs.html` and `include/docs.css` as a parallel documentation template and stylesheet, leaving `include/blog.html` and `include/blog.css` unchanged. 
- Updated page semantics: the workspace `aria-label` is now `Documentation workspace`, the top nav marks `Docs` active and removes the `active`/`aria-current` from the Blog item, and pagination labels were changed to `Previous section` / `Next section`. 
- Replaced the blog `.hero` block by embedding a compact header inside the main article column and moved the intro into the main article flow so the TOC begins beside the docs header and intro (markup uses `div.docs-layout.article-layout`, `article.main-content.docs-content`, `header.docs-header`, `p.docs-kicker`, `p.docs-version`, and `div.article-intro.docs-intro`). 
- Added docs-specific CSS rules in `include/docs.css` including `.docs-layout`, `.docs-header`, `.docs-kicker`, `.docs-version`, and `.docs-intro`; neutralized blog-only hero rules and drop-cap styling so intros render like normal docs text; preserved responsive breakpoints and mobile single-column behavior. 
- Kept and preserved the workspace and console plumbing (elements and JS that reference `.workspace`, `.content-shell`, `#articleLayout`, `.resize-handle`, `.edge-handle`, `.console-pane`, console tabs, `#consoleFullscreenToggle`, and REPL/output/errors panels) so resizing/collapsing/fullscreen behaviors remain unchanged. 
- Improved the scrollspy logic to track all `.toc a[href^="#"]` links (resolve targets, pick the last target above the activation line, add `active`/`active-path` to links and `expanded` to ancestor `li` elements, and clear stale classes) so H2/H3 are visible by default and H4 is revealed only on the active branch. 
- Updated footer content to keep the Mika/robot visual while replacing the release panel with a docs-oriented panel and reorganizing footer groups into Documentation / Project / Community links; backmatter was renamed to `aria-label="Documentation notes"` and `{{CITED}}` was removed. 

### Testing

- Ran focused automated validation including `git diff --cached --check` for whitespace/format issues and fixed trailing whitespace in the new files. 
- Executed Python smoke assertions that verify template semantics (workspace label, nav active state, docs layout/markup, removed blog hero placeholders, pagination labels, footer groups, TOC hierarchy rules, and presence of console markup) and they passed. 
- Extracted inline scripts and ran `node --check` on the concatenated inline JS to validate syntax for the preserved interactive behaviors and it passed. 
- Verified CSS brace balance and responsive rules were present and that the TOC is sticky and independently scrollable; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aeb24d0e4832aba0117b2a5998ab1)