### PR TITLE
Add static runtime workspace loading

### DIFF
--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -17,6 +17,7 @@ pub mod actor;
 pub mod service;
 pub mod actor_behavior;
 pub mod module;
+mod workspace;
 
 pub use self::id::*;
 pub use self::runtime::*;
@@ -35,3 +36,4 @@ pub use self::actor::*;
 pub use self::service::*;
 pub use self::actor_behavior::*;
 pub use self::module::*;
+pub use self::workspace::*;

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -398,4 +398,18 @@ impl MechRuntime {
     self.store.get_active_module_version(module)
   }
 
+  pub(crate) fn workspace_module_records(
+    &self,
+    version: ModuleVersionId,
+  ) -> MResult<Option<(ModuleRecord, ModuleVersionRecord)>> {
+    let Some(version_record) = self.store.get_module_version(version)? else {
+      return Ok(None);
+    };
+    let Some(module_record) = self.store.get_module(version_record.module)? else {
+      return Ok(None);
+    };
+
+    Ok(Some((module_record, version_record)))
+  }
+
 }

--- a/src/runtime/src/workspace.rs
+++ b/src/runtime/src/workspace.rs
@@ -173,7 +173,7 @@ impl RuntimeWorkspace {
     let mut loaded_versions = Vec::new();
 
     for target in &self.config.targets {
-      match runtime.resolve_and_store_module_source(target.specifier.as_str(), options) {
+      match runtime.resolve_and_store_module_source(target.specifier.as_str(), options.clone()) {
         Ok(Some(module_version)) => {
           let Some((module, _)) = runtime.workspace_module_records(module_version)? else {
             snapshot.diagnostics.push(target_diagnostic(
@@ -308,11 +308,87 @@ fn source_snapshot(
 }
 
 fn file_uri_path(canonical_uri: &str) -> Option<PathBuf> {
-  canonical_uri.strip_prefix("file://").map(PathBuf::from)
+  let rest = canonical_uri.strip_prefix("file://")?;
+
+  #[cfg(windows)]
+  {
+    file_uri_path_windows(rest)
+  }
+
+  #[cfg(not(windows))]
+  {
+    file_uri_path_unix(rest)
+  }
+}
+
+#[cfg(not(windows))]
+fn file_uri_path_unix(rest: &str) -> Option<PathBuf> {
+  if rest.is_empty() {
+    return None;
+  }
+  Some(PathBuf::from(rest))
+}
+
+#[cfg(windows)]
+fn file_uri_path_windows(rest: &str) -> Option<PathBuf> {
+  if rest.is_empty() {
+    return None;
+  }
+
+  if let Some(path) = rest.strip_prefix("//?/") {
+    return Some(PathBuf::from(format!(r"\\?\{}", path.replace('/', r"\"))));
+  }
+
+  if rest.len() >= 3
+    && rest.as_bytes()[0] == b'/'
+    && rest.as_bytes()[2] == b':'
+  {
+    return Some(PathBuf::from(rest[1..].replace('/', r"\")));
+  }
+
+  Some(PathBuf::from(rest.replace('/', r"\")))
 }
 
 fn hash_content(content: Vec<u8>) -> u64 {
   let mut hasher = DefaultHasher::new();
   content.hash(&mut hasher);
   hasher.finish()
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[cfg(not(windows))]
+  #[test]
+  fn file_uri_path_converts_unix_file_uri() {
+    assert_eq!(
+      file_uri_path("file:///tmp/project/main.mec").unwrap(),
+      PathBuf::from("/tmp/project/main.mec"),
+    );
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn file_uri_path_converts_windows_drive_file_uri() {
+    assert_eq!(
+      file_uri_path("file:///C:/Users/cmont/project/main.mec").unwrap(),
+      PathBuf::from(r"C:\Users\cmont\project\main.mec"),
+    );
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn file_uri_path_converts_windows_extended_file_uri() {
+    assert_eq!(
+      file_uri_path("file:////?/C:/Users/cmont/project/main.mec").unwrap(),
+      PathBuf::from(r"\\?\C:\Users\cmont\project\main.mec"),
+    );
+  }
+
+  #[test]
+  fn file_uri_path_rejects_non_file_uri() {
+    assert!(file_uri_path("http://example.com/main.mec").is_none());
+  }
 }

--- a/src/runtime/src/workspace.rs
+++ b/src/runtime/src/workspace.rs
@@ -1,0 +1,318 @@
+use std::{
+  collections::{BTreeMap, BTreeSet, VecDeque},
+  hash::{DefaultHasher, Hash, Hasher},
+  path::{Path, PathBuf},
+  time::SystemTime,
+};
+
+use mech_core::{MResult, MechError, MechErrorKind};
+
+use crate::{
+  MechRuntime,
+  ModuleBuildOptions,
+  ModuleVersionId,
+};
+
+#[derive(Clone, Debug)]
+pub struct RuntimeWorkspaceConfig {
+  pub root: PathBuf,
+  pub targets: Vec<RuntimeWorkspaceTarget>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeWorkspaceTarget {
+  pub name: String,
+  pub specifier: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeWorkspace {
+  config: RuntimeWorkspaceConfig,
+  snapshot: Option<RuntimeWorkspaceSnapshot>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RuntimeWorkspaceSnapshot {
+  pub root: PathBuf,
+  pub targets: BTreeMap<String, RuntimeWorkspaceTargetSnapshot>,
+  pub sources: BTreeMap<String, RuntimeWorkspaceSourceSnapshot>,
+  pub import_edges: Vec<RuntimeWorkspaceImportEdge>,
+  pub diagnostics: Vec<RuntimeWorkspaceDiagnostic>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeWorkspaceTargetSnapshot {
+  pub name: String,
+  pub specifier: String,
+  pub canonical_uri: String,
+  pub module_version: ModuleVersionId,
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeWorkspaceSourceSnapshot {
+  pub canonical_uri: String,
+  pub path: Option<PathBuf>,
+  pub module_version: Option<ModuleVersionId>,
+  pub content_hash: u64,
+  pub modified_time: Option<SystemTime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeWorkspaceImportEdge {
+  pub importer: ModuleVersionId,
+  pub dependency: ModuleVersionId,
+  pub specifier: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeWorkspaceDiagnosticSeverity {
+  Error,
+  Warning,
+  Info,
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeWorkspaceDiagnostic {
+  pub severity: RuntimeWorkspaceDiagnosticSeverity,
+  pub target: Option<String>,
+  pub canonical_uri: Option<String>,
+  pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeWorkspaceInvalidConfig {
+  pub reason: String,
+}
+
+impl MechErrorKind for RuntimeWorkspaceInvalidConfig {
+  fn name(&self) -> &str {
+    "RuntimeWorkspaceInvalidConfig"
+  }
+
+  fn message(&self) -> String {
+    format!("invalid runtime workspace config: {}", self.reason)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeWorkspaceTargetNotFound {
+  pub name: String,
+}
+
+impl MechErrorKind for RuntimeWorkspaceTargetNotFound {
+  fn name(&self) -> &str {
+    "RuntimeWorkspaceTargetNotFound"
+  }
+
+  fn message(&self) -> String {
+    format!("runtime workspace target `{}` was not found", self.name)
+  }
+}
+
+impl RuntimeWorkspaceConfig {
+  pub fn new(root: impl Into<PathBuf>) -> Self {
+    Self {
+      root: root.into(),
+      targets: Vec::new(),
+    }
+  }
+
+  pub fn target(
+    mut self,
+    name: impl Into<String>,
+    specifier: impl Into<String>,
+  ) -> Self {
+    self.targets.push(RuntimeWorkspaceTarget {
+      name: name.into(),
+      specifier: specifier.into(),
+    });
+    self
+  }
+}
+
+impl RuntimeWorkspace {
+  pub fn open(mut config: RuntimeWorkspaceConfig) -> MResult<Self> {
+    config.root = canonicalize_workspace_root(&config.root)?;
+
+    let mut target_names = BTreeSet::new();
+    for target in &config.targets {
+      if target.name.trim().is_empty() {
+        return invalid_config("target name must not be empty");
+      }
+      if target.specifier.trim().is_empty() {
+        return invalid_config("target specifier must not be empty");
+      }
+      if !target_names.insert(target.name.clone()) {
+        return invalid_config(format!("duplicate target name `{}`", target.name));
+      }
+    }
+
+    Ok(Self {
+      config,
+      snapshot: None,
+    })
+  }
+
+  pub fn config(&self) -> &RuntimeWorkspaceConfig {
+    &self.config
+  }
+
+  pub fn snapshot(&self) -> Option<&RuntimeWorkspaceSnapshot> {
+    self.snapshot.as_ref()
+  }
+
+  pub fn load(
+    &mut self,
+    runtime: &mut MechRuntime,
+    options: ModuleBuildOptions,
+  ) -> MResult<RuntimeWorkspaceSnapshot> {
+    let mut snapshot = RuntimeWorkspaceSnapshot {
+      root: self.config.root.clone(),
+      ..RuntimeWorkspaceSnapshot::default()
+    };
+    let mut loaded_versions = Vec::new();
+
+    for target in &self.config.targets {
+      match runtime.resolve_and_store_module_source(target.specifier.as_str(), options) {
+        Ok(Some(module_version)) => {
+          let Some((module, _)) = runtime.workspace_module_records(module_version)? else {
+            snapshot.diagnostics.push(target_diagnostic(
+              target,
+              format!("loaded module version `{}` was not found in the runtime store", module_version),
+            ));
+            continue;
+          };
+          snapshot.targets.insert(target.name.clone(), RuntimeWorkspaceTargetSnapshot {
+            name: target.name.clone(),
+            specifier: target.specifier.clone(),
+            canonical_uri: module.name,
+            module_version,
+          });
+          loaded_versions.push(module_version);
+        }
+        Ok(None) => snapshot.diagnostics.push(target_diagnostic(
+          target,
+          format!("workspace target `{}` could not resolve `{}`", target.name, target.specifier),
+        )),
+        Err(error) => snapshot.diagnostics.push(target_diagnostic(
+          target,
+          format!("workspace target `{}` failed to load `{}`: {:?}", target.name, target.specifier, error),
+        )),
+      }
+    }
+
+    collect_loaded_modules(runtime, &loaded_versions, &mut snapshot)?;
+
+    self.snapshot = Some(snapshot.clone());
+    Ok(snapshot)
+  }
+
+  pub fn target(
+    &self,
+    name: &str,
+  ) -> Option<&RuntimeWorkspaceTargetSnapshot> {
+    self.snapshot.as_ref()?.targets.get(name)
+  }
+}
+
+fn canonicalize_workspace_root(root: &Path) -> MResult<PathBuf> {
+  root.canonicalize().map_err(|error| {
+    MechError::new(
+      RuntimeWorkspaceInvalidConfig {
+        reason: format!("workspace root `{}` could not be canonicalized: {}", root.display(), error),
+      },
+      None,
+    )
+  })
+}
+
+fn invalid_config<T>(reason: impl Into<String>) -> MResult<T> {
+  Err(MechError::new(
+    RuntimeWorkspaceInvalidConfig {
+      reason: reason.into(),
+    },
+    None,
+  ))
+}
+
+fn target_diagnostic(
+  target: &RuntimeWorkspaceTarget,
+  message: String,
+) -> RuntimeWorkspaceDiagnostic {
+  RuntimeWorkspaceDiagnostic {
+    severity: RuntimeWorkspaceDiagnosticSeverity::Error,
+    target: Some(target.name.clone()),
+    canonical_uri: None,
+    message,
+  }
+}
+
+fn collect_loaded_modules(
+  runtime: &MechRuntime,
+  loaded_versions: &[ModuleVersionId],
+  snapshot: &mut RuntimeWorkspaceSnapshot,
+) -> MResult<()> {
+  let mut pending = VecDeque::from(loaded_versions.to_vec());
+  let mut visited = BTreeSet::new();
+
+  while let Some(module_version) = pending.pop_front() {
+    if !visited.insert(module_version) {
+      continue;
+    }
+
+    let Some((module, version)) = runtime.workspace_module_records(module_version)? else {
+      continue;
+    };
+
+    snapshot.sources.insert(
+      module.name.clone(),
+      source_snapshot(module.name, module_version),
+    );
+
+    for edge in &version.import_edges {
+      snapshot.import_edges.push(RuntimeWorkspaceImportEdge {
+        importer: module_version,
+        dependency: edge.dependency,
+        specifier: edge.import.specifier.clone(),
+      });
+    }
+
+    pending.extend(version.dependencies);
+  }
+
+  Ok(())
+}
+
+fn source_snapshot(
+  canonical_uri: String,
+  module_version: ModuleVersionId,
+) -> RuntimeWorkspaceSourceSnapshot {
+  let path = file_uri_path(&canonical_uri);
+  let content_hash = path
+    .as_ref()
+    .and_then(|path| std::fs::read(path).ok())
+    .map(hash_content)
+    .unwrap_or_default();
+  let modified_time = path
+    .as_ref()
+    .and_then(|path| std::fs::metadata(path).ok())
+    .and_then(|metadata| metadata.modified().ok());
+
+  RuntimeWorkspaceSourceSnapshot {
+    canonical_uri,
+    path,
+    module_version: Some(module_version),
+    content_hash,
+    modified_time,
+  }
+}
+
+fn file_uri_path(canonical_uri: &str) -> Option<PathBuf> {
+  canonical_uri.strip_prefix("file://").map(PathBuf::from)
+}
+
+fn hash_content(content: Vec<u8>) -> u64 {
+  let mut hasher = DefaultHasher::new();
+  content.hash(&mut hasher);
+  hasher.finish()
+}

--- a/src/runtime/src/workspace.rs
+++ b/src/runtime/src/workspace.rs
@@ -173,7 +173,27 @@ impl RuntimeWorkspace {
     let mut loaded_versions = Vec::new();
 
     for target in &self.config.targets {
-      match runtime.resolve_and_store_module_source(target.specifier.as_str(), options.clone()) {
+      let resolved_specifier = match workspace_target_specifier(
+        &self.config.root,
+        &target.specifier,
+      ) {
+        Ok(specifier) => specifier,
+        Err(error) => {
+          snapshot.diagnostics.push(target_diagnostic(
+            target,
+            format!(
+              "workspace target `{}` failed to resolve `{}` against root `{}`: {:?}",
+              target.name,
+              target.specifier,
+              self.config.root.display(),
+              error,
+            ),
+          ));
+          continue;
+        }
+      };
+
+      match runtime.resolve_and_store_module_source(resolved_specifier.as_str(), options.clone()) {
         Ok(Some(module_version)) => {
           let Some((module, _)) = runtime.workspace_module_records(module_version)? else {
             snapshot.diagnostics.push(target_diagnostic(
@@ -213,6 +233,51 @@ impl RuntimeWorkspace {
   ) -> Option<&RuntimeWorkspaceTargetSnapshot> {
     self.snapshot.as_ref()?.targets.get(name)
   }
+}
+
+fn workspace_target_specifier(
+  root: &Path,
+  specifier: &str,
+) -> MResult<String> {
+  if specifier.contains("://") {
+    return Ok(specifier.to_string());
+  }
+
+  let path = PathBuf::from(specifier);
+  let joined = if path.is_absolute() {
+    path
+  } else {
+    root.join(path)
+  };
+
+  let canonical = joined.canonicalize().map_err(|error| {
+    MechError::new(
+      RuntimeWorkspaceInvalidConfig {
+        reason: format!(
+          "workspace target `{}` could not be canonicalized against root `{}`: {}",
+          specifier,
+          root.display(),
+          error,
+        ),
+      },
+      None,
+    )
+  })?;
+
+  if !canonical.starts_with(root) {
+    return Err(MechError::new(
+      RuntimeWorkspaceInvalidConfig {
+        reason: format!(
+          "workspace target `{}` resolves outside workspace root `{}`",
+          specifier,
+          root.display(),
+        ),
+      },
+      None,
+    ));
+  }
+
+  Ok(canonical.to_string_lossy().to_string())
 }
 
 fn canonicalize_workspace_root(root: &Path) -> MResult<PathBuf> {
@@ -390,5 +455,34 @@ mod tests {
   #[test]
   fn file_uri_path_rejects_non_file_uri() {
     assert!(file_uri_path("http://example.com/main.mec").is_none());
+  }
+
+  #[test]
+  fn workspace_target_specifier_canonicalizes_absolute_local_path() {
+    let root = std::env::temp_dir().join(format!(
+      "mech-runtime-workspace-absolute-target-{}",
+      SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    let target = root.join("main.mec");
+    std::fs::write(&target, "result := true\n").unwrap();
+    let canonical_root = root.canonicalize().unwrap();
+    let canonical_target = target.canonicalize().unwrap();
+
+    assert_eq!(
+      workspace_target_specifier(&canonical_root, target.to_string_lossy().as_ref()).unwrap(),
+      canonical_target.to_string_lossy(),
+    );
+  }
+
+  #[test]
+  fn workspace_target_specifier_passes_through_uri() {
+    assert_eq!(
+      workspace_target_specifier(Path::new("unused"), "memory://main.mec").unwrap(),
+      "memory://main.mec",
+    );
   }
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1642,6 +1642,78 @@ fn workspace_load_target_with_local_import() {
 }
 
 #[test]
+fn workspace_load_relative_target_uses_workspace_root() {
+  let root_a = std::env::temp_dir().join(format!(
+    "mech-runtime-workspace-root-a-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  let root_b = std::env::temp_dir().join(format!(
+    "mech-runtime-workspace-root-b-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  std::fs::create_dir_all(&root_a).unwrap();
+  std::fs::create_dir_all(&root_b).unwrap();
+
+  std::fs::write(root_a.join("main.mec"), "result := false\n").unwrap();
+  std::fs::write(root_b.join("main.mec"), "result := true\n").unwrap();
+
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root_b))
+    .build()
+    .unwrap();
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root_a)
+      .target("main", "main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(snapshot.diagnostics.is_empty());
+
+  let target = snapshot.targets.get("main").unwrap();
+  assert_eq!(target.specifier, "main.mec");
+  let result = runtime.run_module(target.module_version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(!*value.borrow()),
+    other => panic!("expected false bool result from workspace root target, got {:?}", other),
+  }
+}
+
+#[test]
+fn workspace_load_target_outside_root_records_diagnostic() {
+  let parent = std::env::temp_dir().join(format!(
+    "mech-runtime-workspace-outside-root-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  let root = parent.join("workspace");
+  let outside = parent.join("outside");
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::create_dir_all(&outside).unwrap();
+  std::fs::write(outside.join("main.mec"), "result := true\n").unwrap();
+
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("outside", "../outside/main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(snapshot.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
+  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("outside"));
+  assert!(snapshot.diagnostics[0].message.contains("outside workspace root"));
+  assert!(!snapshot.targets.contains_key("outside"));
+}
+
+#[test]
 fn workspace_load_missing_target_records_diagnostic() {
   let root = setup_modules("result := true\n");
   let mut runtime = runtime_with_root(&root);

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,5 +1,5 @@
 use mech_core::{hash_str, MechSourceCode, Ref, Value};
-use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, InMemoryDocsProvider, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityGrantSpec, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeContextRegistry, RuntimeDocsEntrySpec, RuntimeInMemoryDocsResourceSpec, RuntimeResourceConfigSpec, SourceContextBase, SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest};
+use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, InMemoryDocsProvider, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityGrantSpec, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeContextRegistry, RuntimeDocsEntrySpec, RuntimeInMemoryDocsResourceSpec, RuntimeResourceConfigSpec, SourceContextBase, SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest, RuntimeWorkspace, RuntimeWorkspaceConfig, RuntimeWorkspaceDiagnosticSeverity};
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
@@ -1579,4 +1579,97 @@ fn invalid_grant_empty_path_fails_build() {
   let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
   assert!(error.contains("RuntimeCapabilityGrantInvalid"));
   assert!(error.contains("path"));
+}
+
+
+#[test]
+fn workspace_open_rejects_duplicate_targets() {
+  let root = setup_modules("result := true\n");
+  let config = RuntimeWorkspaceConfig::new(&root)
+    .target("main", "main.mec")
+    .target("main", "other.mec");
+
+  let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
+  assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
+  assert!(error.contains("duplicate target"));
+}
+
+#[test]
+fn workspace_open_rejects_empty_target_name() {
+  let root = setup_modules("result := true\n");
+  let config = RuntimeWorkspaceConfig::new(&root)
+    .target("", "main.mec");
+
+  let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
+  assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
+  assert!(error.contains("target name"));
+}
+
+#[test]
+fn workspace_load_target_without_imports() {
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(snapshot.diagnostics.is_empty());
+  let target = snapshot.targets.get("main").unwrap();
+  assert!(snapshot.sources.contains_key(&target.canonical_uri));
+  assert!(workspace.target("main").is_some());
+  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace target");
+}
+
+#[test]
+fn workspace_load_target_with_local_import() {
+  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+  std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(snapshot.diagnostics.is_empty());
+  let target = snapshot.targets.get("main").unwrap();
+  let main_uri = format!("file://{}", root.join("main.mec").canonicalize().unwrap().display());
+  let math_uri = format!("file://{}", root.join("math.mec").canonicalize().unwrap().display());
+  assert!(snapshot.sources.contains_key(&main_uri));
+  assert!(snapshot.sources.contains_key(&math_uri));
+  assert!(snapshot.import_edges.iter().any(|edge| edge.specifier == "./math.mec"));
+  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace imported target");
+}
+
+#[test]
+fn workspace_load_missing_target_records_diagnostic() {
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("missing", "missing.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(snapshot.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
+  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
+  assert!(snapshot.diagnostics[0].message.contains("missing.mec"));
+  assert!(!snapshot.targets.contains_key("missing"));
+}
+
+#[test]
+fn workspace_load_multiple_targets_continues_after_failure() {
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("missing", "missing.mec")
+      .target("main", "main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
+  let target = snapshot.targets.get("main").unwrap();
+  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace surviving target");
 }


### PR DESCRIPTION
### Motivation
- Provide the first runtime workspace layer so the server can own explicit targets, loaded source files, module versions, import edges, and diagnostics without adding file watching or config-file parsing.

### Description
- Add a crate-level workspace module in `src/runtime/src/workspace.rs` that defines `RuntimeWorkspaceConfig`, `RuntimeWorkspaceTarget`, `RuntimeWorkspace`, `RuntimeWorkspaceSnapshot`, `RuntimeWorkspaceTargetSnapshot`, `RuntimeWorkspaceSourceSnapshot`, `RuntimeWorkspaceImportEdge`, `RuntimeWorkspaceDiagnostic` and the requested error kinds, builder methods, and lifecycle APIs including `open`, `load`, `config`, `snapshot`, and `target`.
- Implement `RuntimeWorkspace::open` to canonicalize the workspace root and validate targets (reject empty names/specifiers and duplicate names) and `RuntimeWorkspace::load` to resolve/store targets via the runtime, continue after target failures while recording diagnostics, and populate a snapshot of targets, sources, import edges, and diagnostics without executing modules.
- Add minimal crate-private runtime accessor `pub(crate) fn workspace_module_records(&self, version: ModuleVersionId) -> MResult<Option<(ModuleRecord, ModuleVersionRecord)>>` to `MechRuntime` so the workspace can read module and module-version records for snapshot collection, and wire the workspace into `src/runtime/src/lib.rs` (`mod workspace; pub use self::workspace::*;`).
- Implement source snapshot collection for file-backed modules: canonical URI -> optional local `path`, `module_version`, `content_hash`, and `modified_time`, and collect import edges from stored `ModuleVersionRecord.import_edges`.
- Add focused smoke tests appended to `src/runtime/tests/module_smoke.rs` that exercise: duplicate/empty target validation, loading a standalone target, loading a target with a local `./math.mec` import (verifying source & import edge presence), missing-target diagnostic, and continuing after a failed target.

### Testing
- Ran `cargo test -p mech-runtime --test module_smoke`, which passed (all workspace and existing module smoke tests passed).
- Ran `cargo test -p mech-runtime --lib --tests`, which passed (runtime unit tests passed).
- Ran `cargo check -p mech-runtime`, which completed successfully (only pre-existing warnings reported).

All automated checks above passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c1f7a2974832a8a0430e8a3d541be)