### PR TITLE
Add runtime workspace polling refresh

### DIFF
--- a/src/runtime/src/workspace.rs
+++ b/src/runtime/src/workspace.rs
@@ -41,6 +41,29 @@ pub struct RuntimeWorkspaceSnapshot {
 }
 
 #[derive(Clone, Debug)]
+pub struct RuntimeWorkspaceRefresh {
+  pub snapshot: RuntimeWorkspaceSnapshot,
+  pub changes: Vec<RuntimeWorkspaceChange>,
+  pub affected_targets: Vec<String>,
+  pub diagnostics: Vec<RuntimeWorkspaceDiagnostic>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeWorkspaceChangeKind {
+  Modified,
+  Removed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeWorkspaceChange {
+  pub canonical_uri: String,
+  pub path: Option<PathBuf>,
+  pub kind: RuntimeWorkspaceChangeKind,
+  pub previous_hash: Option<u64>,
+  pub current_hash: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
 pub struct RuntimeWorkspaceTargetSnapshot {
   pub name: String,
   pub specifier: String,
@@ -77,6 +100,19 @@ pub struct RuntimeWorkspaceDiagnostic {
   pub target: Option<String>,
   pub canonical_uri: Option<String>,
   pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeWorkspaceNotLoaded;
+
+impl MechErrorKind for RuntimeWorkspaceNotLoaded {
+  fn name(&self) -> &str {
+    "RuntimeWorkspaceNotLoaded"
+  }
+
+  fn message(&self) -> String {
+    "runtime workspace must be loaded before it can be refreshed".to_string()
+  }
 }
 
 #[derive(Debug, Clone)]
@@ -166,65 +202,77 @@ impl RuntimeWorkspace {
     runtime: &mut MechRuntime,
     options: ModuleBuildOptions,
   ) -> MResult<RuntimeWorkspaceSnapshot> {
-    let mut snapshot = RuntimeWorkspaceSnapshot {
-      root: self.config.root.clone(),
-      ..RuntimeWorkspaceSnapshot::default()
-    };
-    let mut loaded_versions = Vec::new();
+    let mut targets = BTreeMap::new();
+    let mut diagnostics = Vec::new();
 
     for target in &self.config.targets {
-      let resolved_specifier = match workspace_target_specifier(
-        &self.config.root,
-        &target.specifier,
-      ) {
-        Ok(specifier) => specifier,
-        Err(error) => {
-          snapshot.diagnostics.push(target_diagnostic(
-            target,
-            format!(
-              "workspace target `{}` failed to resolve `{}` against root `{}`: {:?}",
-              target.name,
-              target.specifier,
-              self.config.root.display(),
-              error,
-            ),
-          ));
-          continue;
+      match load_target(&self.config.root, runtime, target, options.clone())? {
+        Ok(snapshot) => {
+          targets.insert(target.name.clone(), snapshot);
         }
-      };
-
-      match runtime.resolve_and_store_module_source(resolved_specifier.as_str(), options.clone()) {
-        Ok(Some(module_version)) => {
-          let Some((module, _)) = runtime.workspace_module_records(module_version)? else {
-            snapshot.diagnostics.push(target_diagnostic(
-              target,
-              format!("loaded module version `{}` was not found in the runtime store", module_version),
-            ));
-            continue;
-          };
-          snapshot.targets.insert(target.name.clone(), RuntimeWorkspaceTargetSnapshot {
-            name: target.name.clone(),
-            specifier: target.specifier.clone(),
-            canonical_uri: module.name,
-            module_version,
-          });
-          loaded_versions.push(module_version);
-        }
-        Ok(None) => snapshot.diagnostics.push(target_diagnostic(
-          target,
-          format!("workspace target `{}` could not resolve `{}`", target.name, target.specifier),
-        )),
-        Err(error) => snapshot.diagnostics.push(target_diagnostic(
-          target,
-          format!("workspace target `{}` failed to load `{}`: {:?}", target.name, target.specifier, error),
-        )),
+        Err(diagnostic) => diagnostics.push(diagnostic),
       }
     }
 
-    collect_loaded_modules(runtime, &loaded_versions, &mut snapshot)?;
-
+    let snapshot = collect_snapshot(runtime, self.config.root.clone(), targets, diagnostics)?;
     self.snapshot = Some(snapshot.clone());
     Ok(snapshot)
+  }
+
+  pub fn refresh(
+    &mut self,
+    runtime: &mut MechRuntime,
+    options: ModuleBuildOptions,
+  ) -> MResult<RuntimeWorkspaceRefresh> {
+    let Some(previous) = self.snapshot.clone() else {
+      return Err(MechError::new(RuntimeWorkspaceNotLoaded, None));
+    };
+    let changes = changed_sources(&previous);
+    if changes.is_empty() {
+      return Ok(RuntimeWorkspaceRefresh {
+        snapshot: previous,
+        changes,
+        affected_targets: Vec::new(),
+        diagnostics: Vec::new(),
+      });
+    }
+
+    let affected_targets = affected_targets(&previous, &changes);
+    let affected = affected_targets.iter().cloned().collect::<BTreeSet<_>>();
+    let mut targets = previous
+      .targets
+      .into_iter()
+      .filter(|(name, _)| !affected.contains(name))
+      .collect::<BTreeMap<_, _>>();
+    let mut diagnostics = Vec::new();
+
+    for target in self
+      .config
+      .targets
+      .iter()
+      .filter(|target| affected.contains(&target.name))
+    {
+      match load_target(&self.config.root, runtime, target, options.clone())? {
+        Ok(snapshot) => {
+          targets.insert(target.name.clone(), snapshot);
+        }
+        Err(diagnostic) => diagnostics.push(diagnostic),
+      }
+    }
+
+    let snapshot = collect_snapshot(
+      runtime,
+      self.config.root.clone(),
+      targets,
+      diagnostics.clone(),
+    )?;
+    self.snapshot = Some(snapshot.clone());
+    Ok(RuntimeWorkspaceRefresh {
+      snapshot,
+      changes,
+      affected_targets,
+      diagnostics,
+    })
   }
 
   pub fn target(
@@ -235,10 +283,159 @@ impl RuntimeWorkspace {
   }
 }
 
-fn workspace_target_specifier(
+fn load_target(
   root: &Path,
-  specifier: &str,
-) -> MResult<String> {
+  runtime: &mut MechRuntime,
+  target: &RuntimeWorkspaceTarget,
+  options: ModuleBuildOptions,
+) -> MResult<Result<RuntimeWorkspaceTargetSnapshot, RuntimeWorkspaceDiagnostic>> {
+  let resolved_specifier = match workspace_target_specifier(root, &target.specifier) {
+    Ok(specifier) => specifier,
+    Err(error) => return Ok(Err(target_diagnostic(
+      target,
+      format!(
+        "workspace target `{}` failed to resolve `{}` against root `{}`: {:?}",
+        target.name,
+        target.specifier,
+        root.display(),
+        error,
+      ),
+    ))),
+  };
+
+  let module_version = match runtime.resolve_and_store_module_source(resolved_specifier.as_str(), options) {
+    Ok(Some(module_version)) => module_version,
+    Ok(None) => return Ok(Err(target_diagnostic(
+      target,
+      format!("workspace target `{}` could not resolve `{}`", target.name, target.specifier),
+    ))),
+    Err(error) => return Ok(Err(target_diagnostic(
+      target,
+      format!("workspace target `{}` failed to load `{}`: {:?}", target.name, target.specifier, error),
+    ))),
+  };
+  let Some((module, _)) = runtime.workspace_module_records(module_version)? else {
+    return Ok(Err(target_diagnostic(
+      target,
+      format!("loaded module version `{}` was not found in the runtime store", module_version),
+    )));
+  };
+
+  Ok(Ok(RuntimeWorkspaceTargetSnapshot {
+    name: target.name.clone(),
+    specifier: target.specifier.clone(),
+    canonical_uri: module.name,
+    module_version,
+  }))
+}
+
+fn collect_snapshot(
+  runtime: &MechRuntime,
+  root: PathBuf,
+  targets: BTreeMap<String, RuntimeWorkspaceTargetSnapshot>,
+  diagnostics: Vec<RuntimeWorkspaceDiagnostic>,
+) -> MResult<RuntimeWorkspaceSnapshot> {
+  let loaded_versions = targets
+    .values()
+    .map(|target| target.module_version)
+    .collect::<Vec<_>>();
+  let mut snapshot = RuntimeWorkspaceSnapshot {
+    root,
+    targets,
+    diagnostics,
+    ..RuntimeWorkspaceSnapshot::default()
+  };
+  collect_loaded_modules(runtime, &loaded_versions, &mut snapshot)?;
+  Ok(snapshot)
+}
+
+fn changed_sources(snapshot: &RuntimeWorkspaceSnapshot) -> Vec<RuntimeWorkspaceChange> {
+  snapshot
+    .sources
+    .values()
+    .filter_map(|source| {
+      let path = source.path.as_ref()?;
+      if !path.exists() {
+        return Some(RuntimeWorkspaceChange {
+          canonical_uri: source.canonical_uri.clone(),
+          path: Some(path.clone()),
+          kind: RuntimeWorkspaceChangeKind::Removed,
+          previous_hash: Some(source.content_hash),
+          current_hash: None,
+        });
+      }
+
+      let current_hash = std::fs::read(path).ok().map(hash_content)?;
+      if current_hash == source.content_hash {
+        return None;
+      }
+      Some(RuntimeWorkspaceChange {
+        canonical_uri: source.canonical_uri.clone(),
+        path: Some(path.clone()),
+        kind: RuntimeWorkspaceChangeKind::Modified,
+        previous_hash: Some(source.content_hash),
+        current_hash: Some(current_hash),
+      })
+    })
+    .collect()
+}
+
+fn affected_targets(
+  snapshot: &RuntimeWorkspaceSnapshot,
+  changes: &[RuntimeWorkspaceChange],
+) -> Vec<String> {
+  let changed_uris = changes
+    .iter()
+    .map(|change| change.canonical_uri.as_str())
+    .collect::<BTreeSet<_>>();
+  let changed_versions = snapshot
+    .sources
+    .values()
+    .filter(|source| changed_uris.contains(source.canonical_uri.as_str()))
+    .filter_map(|source| source.module_version)
+    .collect::<BTreeSet<_>>();
+
+  snapshot
+    .targets
+    .values()
+    .filter_map(|target| {
+      if changed_uris.contains(target.canonical_uri.as_str())
+        || import_closure_contains(snapshot, target.module_version, &changed_versions)
+      {
+        Some(target.name.clone())
+      } else {
+        None
+      }
+    })
+    .collect()
+}
+
+fn import_closure_contains(
+  snapshot: &RuntimeWorkspaceSnapshot,
+  root: ModuleVersionId,
+  versions: &BTreeSet<ModuleVersionId>,
+) -> bool {
+  let mut pending = VecDeque::from([root]);
+  let mut visited = BTreeSet::new();
+  while let Some(module_version) = pending.pop_front() {
+    if !visited.insert(module_version) {
+      continue;
+    }
+    if versions.contains(&module_version) {
+      return true;
+    }
+    pending.extend(
+      snapshot
+        .import_edges
+        .iter()
+        .filter(|edge| edge.importer == module_version)
+        .map(|edge| edge.dependency),
+    );
+  }
+  false
+}
+
+fn workspace_target_specifier(root: &Path, specifier: &str) -> MResult<String> {
   if specifier.contains("://") {
     return Ok(specifier.to_string());
   }

--- a/src/runtime/src/workspace.rs
+++ b/src/runtime/src/workspace.rs
@@ -45,7 +45,7 @@ pub struct RuntimeWorkspaceRefresh {
   pub snapshot: RuntimeWorkspaceSnapshot,
   pub changes: Vec<RuntimeWorkspaceChange>,
   pub affected_targets: Vec<String>,
-  pub diagnostics: Vec<RuntimeWorkspaceDiagnostic>,
+  pub refresh_diagnostics: Vec<RuntimeWorkspaceDiagnostic>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -214,7 +214,12 @@ impl RuntimeWorkspace {
       }
     }
 
-    let snapshot = collect_snapshot(runtime, self.config.root.clone(), targets, diagnostics)?;
+    let snapshot = collect_snapshot(
+      runtime,
+      self.config.root.clone(),
+      targets,
+      diagnostics,
+    )?;
     self.snapshot = Some(snapshot.clone());
     Ok(snapshot)
   }
@@ -227,24 +232,41 @@ impl RuntimeWorkspace {
     let Some(previous) = self.snapshot.clone() else {
       return Err(MechError::new(RuntimeWorkspaceNotLoaded, None));
     };
+
     let changes = changed_sources(&previous);
     if changes.is_empty() {
       return Ok(RuntimeWorkspaceRefresh {
         snapshot: previous,
         changes,
         affected_targets: Vec::new(),
-        diagnostics: Vec::new(),
+        refresh_diagnostics: Vec::new(),
       });
     }
 
     let affected_targets = affected_targets(&previous, &changes);
-    let affected = affected_targets.iter().cloned().collect::<BTreeSet<_>>();
+    let affected = affected_targets
+      .iter()
+      .cloned()
+      .collect::<BTreeSet<_>>();
+
+    let retained_diagnostics = previous
+      .diagnostics
+      .iter()
+      .filter(|diagnostic| match diagnostic.target.as_deref() {
+        Some(target) => !affected.contains(target),
+        None => true,
+      })
+      .cloned()
+      .collect::<Vec<_>>();
+
     let mut targets = previous
       .targets
-      .into_iter()
-      .filter(|(name, _)| !affected.contains(name))
+      .iter()
+      .filter(|(name, _)| !affected.contains(*name))
+      .map(|(name, target)| (name.clone(), target.clone()))
       .collect::<BTreeMap<_, _>>();
-    let mut diagnostics = Vec::new();
+
+    let mut refresh_diagnostics = Vec::new();
 
     for target in self
       .config
@@ -256,22 +278,27 @@ impl RuntimeWorkspace {
         Ok(snapshot) => {
           targets.insert(target.name.clone(), snapshot);
         }
-        Err(diagnostic) => diagnostics.push(diagnostic),
+        Err(diagnostic) => refresh_diagnostics.push(diagnostic),
       }
     }
+
+    let mut snapshot_diagnostics = retained_diagnostics;
+    snapshot_diagnostics.extend(refresh_diagnostics.clone());
 
     let snapshot = collect_snapshot(
       runtime,
       self.config.root.clone(),
       targets,
-      diagnostics.clone(),
+      snapshot_diagnostics,
     )?;
+
     self.snapshot = Some(snapshot.clone());
+
     Ok(RuntimeWorkspaceRefresh {
       snapshot,
       changes,
       affected_targets,
-      diagnostics,
+      refresh_diagnostics,
     })
   }
 
@@ -303,21 +330,37 @@ fn load_target(
     ))),
   };
 
-  let module_version = match runtime.resolve_and_store_module_source(resolved_specifier.as_str(), options) {
+  let module_version = match runtime.resolve_and_store_module_source(
+    resolved_specifier.as_str(),
+    options,
+  ) {
     Ok(Some(module_version)) => module_version,
     Ok(None) => return Ok(Err(target_diagnostic(
       target,
-      format!("workspace target `{}` could not resolve `{}`", target.name, target.specifier),
+      format!(
+        "workspace target `{}` could not resolve `{}`",
+        target.name,
+        target.specifier,
+      ),
     ))),
     Err(error) => return Ok(Err(target_diagnostic(
       target,
-      format!("workspace target `{}` failed to load `{}`: {:?}", target.name, target.specifier, error),
+      format!(
+        "workspace target `{}` failed to load `{}`: {:?}",
+        target.name,
+        target.specifier,
+        error,
+      ),
     ))),
   };
+
   let Some((module, _)) = runtime.workspace_module_records(module_version)? else {
     return Ok(Err(target_diagnostic(
       target,
-      format!("loaded module version `{}` was not found in the runtime store", module_version),
+      format!(
+        "loaded module version `{}` was not found in the runtime store",
+        module_version,
+      ),
     )));
   };
 
@@ -339,13 +382,16 @@ fn collect_snapshot(
     .values()
     .map(|target| target.module_version)
     .collect::<Vec<_>>();
+
   let mut snapshot = RuntimeWorkspaceSnapshot {
     root,
     targets,
     diagnostics,
     ..RuntimeWorkspaceSnapshot::default()
   };
+
   collect_loaded_modules(runtime, &loaded_versions, &mut snapshot)?;
+
   Ok(snapshot)
 }
 
@@ -355,6 +401,7 @@ fn changed_sources(snapshot: &RuntimeWorkspaceSnapshot) -> Vec<RuntimeWorkspaceC
     .values()
     .filter_map(|source| {
       let path = source.path.as_ref()?;
+
       if !path.exists() {
         return Some(RuntimeWorkspaceChange {
           canonical_uri: source.canonical_uri.clone(),
@@ -369,6 +416,7 @@ fn changed_sources(snapshot: &RuntimeWorkspaceSnapshot) -> Vec<RuntimeWorkspaceC
       if current_hash == source.content_hash {
         return None;
       }
+
       Some(RuntimeWorkspaceChange {
         canonical_uri: source.canonical_uri.clone(),
         path: Some(path.clone()),
@@ -388,6 +436,7 @@ fn affected_targets(
     .iter()
     .map(|change| change.canonical_uri.as_str())
     .collect::<BTreeSet<_>>();
+
   let changed_versions = snapshot
     .sources
     .values()
@@ -417,13 +466,16 @@ fn import_closure_contains(
 ) -> bool {
   let mut pending = VecDeque::from([root]);
   let mut visited = BTreeSet::new();
+
   while let Some(module_version) = pending.pop_front() {
     if !visited.insert(module_version) {
       continue;
     }
+
     if versions.contains(&module_version) {
       return true;
     }
+
     pending.extend(
       snapshot
         .import_edges
@@ -432,10 +484,14 @@ fn import_closure_contains(
         .map(|edge| edge.dependency),
     );
   }
+
   false
 }
 
-fn workspace_target_specifier(root: &Path, specifier: &str) -> MResult<String> {
+fn workspace_target_specifier(
+  root: &Path,
+  specifier: &str,
+) -> MResult<String> {
   if specifier.contains("://") {
     return Ok(specifier.to_string());
   }
@@ -481,7 +537,11 @@ fn canonicalize_workspace_root(root: &Path) -> MResult<PathBuf> {
   root.canonicalize().map_err(|error| {
     MechError::new(
       RuntimeWorkspaceInvalidConfig {
-        reason: format!("workspace root `{}` could not be canonicalized: {}", root.display(), error),
+        reason: format!(
+          "workspace root `{}` could not be canonicalized: {}",
+          root.display(),
+          error,
+        ),
       },
       None,
     )
@@ -598,7 +658,10 @@ fn file_uri_path_windows(rest: &str) -> Option<PathBuf> {
   }
 
   if let Some(path) = rest.strip_prefix("//?/") {
-    return Some(PathBuf::from(format!(r"\\?\{}", path.replace('/', r"\"))));
+    return Some(PathBuf::from(format!(
+      r"\\?\{}",
+      path.replace('/', r"\"),
+    )));
   }
 
   if rest.len() >= 3
@@ -616,7 +679,6 @@ fn hash_content(content: Vec<u8>) -> u64 {
   content.hash(&mut hasher);
   hasher.finish()
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -670,7 +732,10 @@ mod tests {
     let canonical_target = target.canonicalize().unwrap();
 
     assert_eq!(
-      workspace_target_specifier(&canonical_root, target.to_string_lossy().as_ref()).unwrap(),
+      workspace_target_specifier(
+        &canonical_root,
+        target.to_string_lossy().as_ref(),
+      ).unwrap(),
       canonical_target.to_string_lossy(),
     );
   }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1632,6 +1632,7 @@ fn workspace_load_target_without_imports() {
 fn workspace_load_target_with_local_import() {
   let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
   std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+
   let mut runtime = runtime_with_root(&root);
   let mut workspace = RuntimeWorkspace::open(
     RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
@@ -1639,6 +1640,7 @@ fn workspace_load_target_with_local_import() {
 
   let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
   assert!(snapshot.diagnostics.is_empty());
+
   let target = snapshot.targets.get("main").unwrap();
   let main_path = root.join("main.mec").canonicalize().unwrap();
   let math_path = root.join("math.mec").canonicalize().unwrap();
@@ -1657,6 +1659,15 @@ fn workspace_load_target_with_local_import() {
     }),
     "workspace snapshot should contain math.mec source; sources: {:?}",
     snapshot.sources,
+  );
+
+  assert!(snapshot.import_edges.iter().any(|edge| {
+    edge.specifier == "./math.mec"
+  }));
+
+  assert_bool_true(
+    runtime.run_module(target.module_version).unwrap(),
+    "workspace imported target",
   );
 }
 
@@ -1817,9 +1828,11 @@ fn workspace_refresh_modified_dependency_reloads_target() {
 }
 
 #[test]
+#[test]
 fn workspace_refresh_removed_dependency_records_diagnostic() {
   let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
   std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+
   let mut runtime = runtime_with_root(&root);
   let mut workspace = RuntimeWorkspace::open(
     RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
@@ -1829,13 +1842,27 @@ fn workspace_refresh_removed_dependency_records_diagnostic() {
   std::fs::remove_file(root.join("math.mec")).unwrap();
 
   let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+
   assert_eq!(refresh.changes.len(), 1);
   assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
   assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
   assert_eq!(refresh.affected_targets, vec!["main"]);
+
   assert_eq!(refresh.refresh_diagnostics.len(), 1);
-  assert_eq!(refresh.refresh_diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
-  assert_eq!(refresh.refresh_diagnostics[0].target.as_deref(), Some("main"));
+  assert_eq!(
+    refresh.refresh_diagnostics[0].severity,
+    RuntimeWorkspaceDiagnosticSeverity::Error,
+  );
+  assert_eq!(
+    refresh.refresh_diagnostics[0].target.as_deref(),
+    Some("main"),
+  );
+
+  assert_eq!(refresh.snapshot.diagnostics.len(), 1);
+  assert_eq!(
+    refresh.snapshot.diagnostics[0].target.as_deref(),
+    Some("main"),
+  );
   assert!(!refresh.snapshot.targets.contains_key("main"));
 }
 
@@ -1858,4 +1885,41 @@ fn workspace_refresh_modified_target_reloads_target() {
   assert_eq!(refresh.affected_targets, vec!["main"]);
   assert!(refresh.refresh_diagnostics.is_empty());
   assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace target");
+}
+
+#[test]
+fn workspace_refresh_preserves_unaffected_diagnostics() {
+  let root = setup_modules("result := false\n");
+
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("missing", "missing.mec")
+      .target("main", "main.mec"),
+  ).unwrap();
+
+  let initial = workspace.load(&mut runtime, module_options()).unwrap();
+
+  assert_eq!(initial.diagnostics.len(), 1);
+  assert_eq!(initial.diagnostics[0].target.as_deref(), Some("missing"));
+  assert!(initial.targets.contains_key("main"));
+
+  std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
+
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert!(refresh.refresh_diagnostics.is_empty());
+
+  assert_eq!(refresh.snapshot.diagnostics.len(), 1);
+  assert_eq!(
+    refresh.snapshot.diagnostics[0].target.as_deref(),
+    Some("missing"),
+  );
+
+  let target = refresh.snapshot.targets.get("main").unwrap();
+  assert_bool_true(
+    runtime.run_module(target.module_version).unwrap(),
+    "refreshed workspace target with retained diagnostic",
+  );
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1640,12 +1640,24 @@ fn workspace_load_target_with_local_import() {
   let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
   assert!(snapshot.diagnostics.is_empty());
   let target = snapshot.targets.get("main").unwrap();
-  let main_uri = format!("file://{}", root.join("main.mec").canonicalize().unwrap().display());
-  let math_uri = format!("file://{}", root.join("math.mec").canonicalize().unwrap().display());
-  assert!(snapshot.sources.contains_key(&main_uri));
-  assert!(snapshot.sources.contains_key(&math_uri));
-  assert!(snapshot.import_edges.iter().any(|edge| edge.specifier == "./math.mec"));
-  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace imported target");
+  let main_path = root.join("main.mec").canonicalize().unwrap();
+  let math_path = root.join("math.mec").canonicalize().unwrap();
+
+  assert!(
+    snapshot.sources.values().any(|source| {
+      source.path.as_ref() == Some(&main_path)
+    }),
+    "workspace snapshot should contain main.mec source; sources: {:?}",
+    snapshot.sources,
+  );
+
+  assert!(
+    snapshot.sources.values().any(|source| {
+      source.path.as_ref() == Some(&math_path)
+    }),
+    "workspace snapshot should contain math.mec source; sources: {:?}",
+    snapshot.sources,
+  );
 }
 
 #[test]
@@ -1778,7 +1790,7 @@ fn workspace_refresh_without_changes_is_empty() {
   let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
   assert!(refresh.changes.is_empty());
   assert!(refresh.affected_targets.is_empty());
-  assert!(refresh.diagnostics.is_empty());
+  assert!(refresh.refresh_diagnostics.is_empty());
   assert!(refresh.snapshot.targets.contains_key("main"));
 }
 
@@ -1800,7 +1812,7 @@ fn workspace_refresh_modified_dependency_reloads_target() {
   assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
   assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
   assert_eq!(refresh.affected_targets, vec!["main"]);
-  assert!(refresh.diagnostics.is_empty());
+  assert!(refresh.refresh_diagnostics.is_empty());
   assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace dependency");
 }
 
@@ -1821,9 +1833,9 @@ fn workspace_refresh_removed_dependency_records_diagnostic() {
   assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
   assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
   assert_eq!(refresh.affected_targets, vec!["main"]);
-  assert_eq!(refresh.diagnostics.len(), 1);
-  assert_eq!(refresh.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
-  assert_eq!(refresh.diagnostics[0].target.as_deref(), Some("main"));
+  assert_eq!(refresh.refresh_diagnostics.len(), 1);
+  assert_eq!(refresh.refresh_diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
+  assert_eq!(refresh.refresh_diagnostics[0].target.as_deref(), Some("main"));
   assert!(!refresh.snapshot.targets.contains_key("main"));
 }
 
@@ -1844,6 +1856,6 @@ fn workspace_refresh_modified_target_reloads_target() {
   assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
   assert!(refresh.changes[0].canonical_uri.ends_with("/main.mec"));
   assert_eq!(refresh.affected_targets, vec!["main"]);
-  assert!(refresh.diagnostics.is_empty());
+  assert!(refresh.refresh_diagnostics.is_empty());
   assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace target");
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,5 +1,5 @@
 use mech_core::{hash_str, MechSourceCode, Ref, Value};
-use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, InMemoryDocsProvider, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityGrantSpec, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeContextRegistry, RuntimeDocsEntrySpec, RuntimeInMemoryDocsResourceSpec, RuntimeResourceConfigSpec, SourceContextBase, SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest, RuntimeWorkspace, RuntimeWorkspaceConfig, RuntimeWorkspaceDiagnosticSeverity};
+use mech_runtime::{BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, ClosureHostFunction, FileSourceResolver, InMemoryDocsProvider, ModuleScopeMetadata, ModuleBuildOptions, ResolvedSource, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityGrantSpec, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeContextRegistry, RuntimeDocsEntrySpec, RuntimeInMemoryDocsResourceSpec, RuntimeResourceConfigSpec, SourceContextBase, SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration, SourceInterpreterId, SourceKind, SourceRequest, SourceResolver, SourceScope, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest, RuntimeWorkspace, RuntimeWorkspaceChangeKind, RuntimeWorkspaceConfig, RuntimeWorkspaceDiagnosticSeverity};
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
@@ -58,6 +58,13 @@ fn module_options() -> ModuleBuildOptions<'static> {
 fn assert_bool_true(result: Value, label: &str) {
   match result {
     Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from {label}, got {:?}", other),
+  }
+}
+
+fn assert_bool_false(result: Value, label: &str) {
+  match result {
+    Value::Bool(value) => assert!(!*value.borrow()),
     other => panic!("expected bool result from {label}, got {:?}", other),
   }
 }
@@ -1744,4 +1751,99 @@ fn workspace_load_multiple_targets_continues_after_failure() {
   assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
   let target = snapshot.targets.get("main").unwrap();
   assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace surviving target");
+}
+
+
+#[test]
+fn workspace_refresh_before_load_fails() {
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  let error = format!("{:?}", workspace.refresh(&mut runtime, module_options()).err().unwrap());
+  assert!(error.contains("RuntimeWorkspaceNotLoaded"));
+}
+
+#[test]
+fn workspace_refresh_without_changes_is_empty() {
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  workspace.load(&mut runtime, module_options()).unwrap();
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert!(refresh.changes.is_empty());
+  assert!(refresh.affected_targets.is_empty());
+  assert!(refresh.diagnostics.is_empty());
+  assert!(refresh.snapshot.targets.contains_key("main"));
+}
+
+#[test]
+fn workspace_refresh_modified_dependency_reloads_target() {
+  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+  std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_bool_false(runtime.run_module(snapshot.targets["main"].module_version).unwrap(), "initial workspace dependency");
+  std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert_eq!(refresh.changes.len(), 1);
+  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
+  assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert!(refresh.diagnostics.is_empty());
+  assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace dependency");
+}
+
+#[test]
+fn workspace_refresh_removed_dependency_records_diagnostic() {
+  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+  std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  workspace.load(&mut runtime, module_options()).unwrap();
+  std::fs::remove_file(root.join("math.mec")).unwrap();
+
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert_eq!(refresh.changes.len(), 1);
+  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
+  assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert_eq!(refresh.diagnostics.len(), 1);
+  assert_eq!(refresh.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
+  assert_eq!(refresh.diagnostics[0].target.as_deref(), Some("main"));
+  assert!(!refresh.snapshot.targets.contains_key("main"));
+}
+
+#[test]
+fn workspace_refresh_modified_target_reloads_target() {
+  let root = setup_modules("result := false\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_bool_false(runtime.run_module(snapshot.targets["main"].module_version).unwrap(), "initial workspace target");
+  std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
+
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert_eq!(refresh.changes.len(), 1);
+  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
+  assert!(refresh.changes[0].canonical_uri.ends_with("/main.mec"));
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert!(refresh.diagnostics.is_empty());
+  assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace target");
 }


### PR DESCRIPTION
### Motivation

- Provide a polling-based workspace refresh API so a loaded workspace can detect changed or removed file-backed sources and update only affected targets without adding a file watcher or changing resolver semantics.
- Surface a clear error when `refresh` is called before an initial `load` so callers must initialize the workspace snapshot first.

### Description

- Added `RuntimeWorkspaceRefresh`, `RuntimeWorkspaceChange`, and `RuntimeWorkspaceChangeKind` types and a `RuntimeWorkspaceNotLoaded` error to `workspace.rs` to model refresh results and pre-load failure.
- Implemented `RuntimeWorkspace::refresh(&mut self, runtime: &mut MechRuntime, options: ModuleBuildOptions) -> MResult<RuntimeWorkspaceRefresh>` which computes removed/modified sources by file-path/hash, determines affected targets using stored `import_edges`, reloads only affected targets, preserves unaffected targets, and produces a rebuilt snapshot and diagnostics.
- Extracted small helpers `load_target`, `collect_snapshot`, `changed_sources`, `affected_targets`, and `import_closure_contains` to avoid duplicating `load` logic and to keep resolution anchored to the workspace root.
- Updated `module_smoke.rs` tests to add `workspace_refresh_before_load_fails`, `workspace_refresh_without_changes_is_empty`, `workspace_refresh_modified_dependency_reloads_target`, `workspace_refresh_removed_dependency_records_diagnostic`, and `workspace_refresh_modified_target_reloads_target`, and added a `assert_bool_false` helper used by those tests.

### Testing

- Ran `cargo test -p mech-runtime --test module_smoke` and all module smoke tests passed (including the new refresh tests).
- Ran `cargo test -p mech-runtime --lib --tests` and the runtime unit tests passed.
- Ran `cargo check -p mech-runtime` and compilation succeeded with existing warnings; `git diff --check` was also clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c32ff2850832aa38d6a42ef75c03a)