### PR TITLE
Add filesystem capability command-line options

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -20,6 +20,8 @@ use crossterm::{
 };
 use ariadne::{Report, ReportKind, Label, Color, sources};
 use clap::{arg, command, value_parser, Arg, ArgAction, Command};
+#[cfg(feature = "serve")]
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use tabled::{
   builder::Builder,
@@ -150,6 +152,26 @@ fn path_is_recursive_capability_target(path: &Path) -> bool {
 }
 
 #[cfg(feature = "serve")]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CapabilityGrantKey {
+    path: PathBuf,
+    recursive: bool,
+}
+
+#[cfg(feature = "serve")]
+fn add_capability_grant(
+    grants: &mut BTreeMap<CapabilityGrantKey, BTreeSet<&'static str>>,
+    path: PathBuf,
+    recursive: bool,
+    operations: &[&'static str],
+) {
+    grants
+        .entry(CapabilityGrantKey { path, recursive })
+        .or_default()
+        .extend(operations.iter().copied());
+}
+
+#[cfg(feature = "serve")]
 fn grant_mech_filesystem_path(
     authority: &mut HostFilesystemAuthority,
     id_generator: &mut DefaultIdGenerator,
@@ -176,6 +198,7 @@ fn build_mech_filesystem_authority(
     let mut id_generator = DefaultIdGenerator::new();
     let kernel = SharedCapabilityKernel::new();
     let mut authority = HostFilesystemAuthority::new(MECH_TOOL_SUBJECT, kernel);
+    let mut grants = BTreeMap::<CapabilityGrantKey, BTreeSet<&'static str>>::new();
 
     let cap_roots = collect_capability_paths(matches, "cap_root");
     let allow_read = collect_capability_paths(matches, "allow_read");
@@ -190,14 +213,12 @@ fn build_mech_filesystem_authority(
 
     if !explicit {
         let root = std::env::current_dir()?.canonicalize()?;
-        grant_mech_filesystem_path(
-            &mut authority,
-            &mut id_generator,
-            badge,
-            &root,
+        add_capability_grant(
+            &mut grants,
+            root,
             true,
             &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
-        )?;
+        );
     }
 
     for path in cap_roots {
@@ -212,57 +233,55 @@ fn build_mech_filesystem_authority(
             )
             .into());
         }
-        grant_mech_filesystem_path(
-            &mut authority,
-            &mut id_generator,
-            badge,
-            &path,
+        add_capability_grant(
+            &mut grants,
+            path,
             true,
             &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
-        )?;
+        );
     }
 
     for path in allow_read {
         let path = resolve_capability_path(&path)?;
         let recursive = path_is_recursive_capability_target(&path);
-        let operations = if recursive {
-            &[FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT][..]
+        if recursive {
+            add_capability_grant(
+                &mut grants,
+                path,
+                true,
+                &[FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT],
+            );
         } else {
-            &[FS_READ, FS_RESOLVE, FS_IMPORT][..]
-        };
-        grant_mech_filesystem_path(
-            &mut authority,
-            &mut id_generator,
-            badge,
-            &path,
-            recursive,
-            operations,
-        )?;
+            add_capability_grant(
+                &mut grants,
+                path,
+                false,
+                &[FS_READ, FS_RESOLVE, FS_IMPORT],
+            );
+        }
     }
 
     for path in allow_watch {
         let path = resolve_capability_path(&path)?;
         let recursive = path_is_recursive_capability_target(&path);
-        grant_mech_filesystem_path(
-            &mut authority,
-            &mut id_generator,
-            badge,
-            &path,
-            recursive,
-            &[FS_WATCH],
-        )?;
+        add_capability_grant(&mut grants, path, recursive, &[FS_WATCH]);
     }
 
     for path in allow_serve {
         let path = resolve_capability_path(&path)?;
         let recursive = path_is_recursive_capability_target(&path);
+        add_capability_grant(&mut grants, path, recursive, &[FS_SERVE]);
+    }
+
+    for (key, operations) in grants {
+        let operations = operations.into_iter().collect::<Vec<_>>();
         grant_mech_filesystem_path(
             &mut authority,
             &mut id_generator,
             badge,
-            &path,
-            recursive,
-            &[FS_SERVE],
+            &key.path,
+            key.recursive,
+            &operations,
         )?;
     }
 
@@ -1261,6 +1280,38 @@ mod filesystem_capability_cli_tests {
                 .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_SERVE])
                 .is_err()
         );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn explicit_granular_grants_combine_for_normal_serve_directory() {
+        let root = temp_root("granular-combine");
+        let allowed = root.join("allowed");
+        std::fs::create_dir_all(&allowed).unwrap();
+        let allowed_arg = allowed.to_string_lossy();
+        let matches = capability_matches(&[
+            "mech",
+            "--allow-read",
+            &allowed_arg,
+            "--allow-watch",
+            &allowed_arg,
+            "--allow-serve",
+            &allowed_arg,
+            "serve",
+            &allowed_arg,
+        ]);
+        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        assert_eq!(authority.source_capabilities().len(), 1);
+        let mut ids = DefaultIdGenerator::new();
+        authority
+            .delegate_path_to(
+                &mut ids,
+                SERVE_HOST_SUBJECT,
+                &allowed,
+                true,
+                [FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+            )
+            .unwrap();
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -4,7 +4,7 @@ use mech::*;
 use mech_core::*;
 use mech_syntax::parser;
 #[cfg(feature = "serve")]
-use mech_runtime::{DefaultIdGenerator, HostFilesystemAuthority, SharedCapabilityKernel, IdGenerator, MECH_TOOL_SUBJECT, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH};
+use mech_runtime::{DefaultIdGenerator, HostFilesystemAuthority, SharedCapabilityKernel, MECH_TOOL_SUBJECT, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH};
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
 use std::time::Instant;
@@ -68,6 +68,209 @@ impl MechErrorKind for Utf8ConversionError {
   fn message(&self) -> String {
     format!("Failed to convert bytes into UTF-8 string: {}", self.source_error)
   }
+}
+
+#[cfg(feature = "serve")]
+fn add_filesystem_capability_args(command: Command) -> Command {
+    command
+        .arg(
+            Arg::new("cap_root")
+                .long("cap-root")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant full recursive filesystem capability authority under PATH."),
+        )
+        .arg(
+            Arg::new("allow_read")
+                .long("allow-read")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant filesystem read/list/resolve/import authority for PATH."),
+        )
+        .arg(
+            Arg::new("allow_watch")
+                .long("allow-watch")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant filesystem watch authority for PATH."),
+        )
+        .arg(
+            Arg::new("allow_serve")
+                .long("allow-serve")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant filesystem serve authority for PATH."),
+        )
+        .arg(
+            Arg::new("no_default_capabilities")
+                .long("no-default-capabilities")
+                .action(ArgAction::SetTrue)
+                .global(true)
+                .help(
+                    "Disable the default recursive current-directory filesystem capability grant.",
+                ),
+        )
+}
+
+#[cfg(feature = "serve")]
+fn collect_capability_paths(matches: &clap::ArgMatches, id: &str) -> Vec<PathBuf> {
+    matches
+        .get_many::<String>(id)
+        .into_iter()
+        .flatten()
+        .map(PathBuf::from)
+        .collect()
+}
+
+#[cfg(feature = "serve")]
+fn resolve_capability_path(path: &Path) -> MResult<PathBuf> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    if candidate.exists() {
+        Ok(candidate.canonicalize()?)
+    } else {
+        Ok(candidate)
+    }
+}
+
+#[cfg(feature = "serve")]
+fn path_is_recursive_capability_target(path: &Path) -> bool {
+    path.exists() && path.is_dir()
+}
+
+#[cfg(feature = "serve")]
+fn grant_mech_filesystem_path(
+    authority: &mut HostFilesystemAuthority,
+    id_generator: &mut DefaultIdGenerator,
+    badge: &ColoredString,
+    path: &Path,
+    recursive: bool,
+    operations: &[&'static str],
+) -> MResult<()> {
+    authority.grant_path(id_generator, path, recursive, operations.iter().copied())?;
+    println!(
+        "{badge} Capability grant: {} {} {} recursive={recursive}",
+        MECH_TOOL_SUBJECT,
+        operations.join(","),
+        mech_runtime::fs_resource_key(path)?,
+    );
+    Ok(())
+}
+
+#[cfg(feature = "serve")]
+fn build_mech_filesystem_authority(
+    matches: &clap::ArgMatches,
+    badge: &ColoredString,
+) -> MResult<HostFilesystemAuthority> {
+    let mut id_generator = DefaultIdGenerator::new();
+    let kernel = SharedCapabilityKernel::new();
+    let mut authority = HostFilesystemAuthority::new(MECH_TOOL_SUBJECT, kernel);
+
+    let cap_roots = collect_capability_paths(matches, "cap_root");
+    let allow_read = collect_capability_paths(matches, "allow_read");
+    let allow_watch = collect_capability_paths(matches, "allow_watch");
+    let allow_serve = collect_capability_paths(matches, "allow_serve");
+    let no_default = matches.get_flag("no_default_capabilities");
+    let explicit = no_default
+        || !cap_roots.is_empty()
+        || !allow_read.is_empty()
+        || !allow_watch.is_empty()
+        || !allow_serve.is_empty();
+
+    if !explicit {
+        let root = std::env::current_dir()?.canonicalize()?;
+        grant_mech_filesystem_path(
+            &mut authority,
+            &mut id_generator,
+            badge,
+            &root,
+            true,
+            &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+        )?;
+    }
+
+    for path in cap_roots {
+        let path = resolve_capability_path(&path)?;
+        if !path.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "--cap-root path must be an existing directory: {}",
+                    path.display()
+                ),
+            )
+            .into());
+        }
+        grant_mech_filesystem_path(
+            &mut authority,
+            &mut id_generator,
+            badge,
+            &path,
+            true,
+            &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+        )?;
+    }
+
+    for path in allow_read {
+        let path = resolve_capability_path(&path)?;
+        let recursive = path_is_recursive_capability_target(&path);
+        let operations = if recursive {
+            &[FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT][..]
+        } else {
+            &[FS_READ, FS_RESOLVE, FS_IMPORT][..]
+        };
+        grant_mech_filesystem_path(
+            &mut authority,
+            &mut id_generator,
+            badge,
+            &path,
+            recursive,
+            operations,
+        )?;
+    }
+
+    for path in allow_watch {
+        let path = resolve_capability_path(&path)?;
+        let recursive = path_is_recursive_capability_target(&path);
+        grant_mech_filesystem_path(
+            &mut authority,
+            &mut id_generator,
+            badge,
+            &path,
+            recursive,
+            &[FS_WATCH],
+        )?;
+    }
+
+    for path in allow_serve {
+        let path = resolve_capability_path(&path)?;
+        let recursive = path_is_recursive_capability_target(&path);
+        grant_mech_filesystem_path(
+            &mut authority,
+            &mut id_generator,
+            badge,
+            &path,
+            recursive,
+            &[FS_SERVE],
+        )?;
+    }
+
+    if authority.source_capabilities().is_empty() {
+        println!("{badge} Capability grant: {} <none>", MECH_TOOL_SUBJECT);
+    }
+
+    Ok(authority)
 }
 
 async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
@@ -140,7 +343,7 @@ async fn main() -> Result<(), MechError> {
   
   let about = format!("{}", text_logo);
 
-  let matches = Command::new("Mech")
+  let cli_command = Command::new("Mech")
     .version(VERSION)
     .author("Corey Montella corey@mech-lang.org")
     .about(about)
@@ -271,15 +474,19 @@ async fn main() -> Result<(), MechError> {
         .short('r')
         .long("repl")
         .help("Start REPL")
-        .action(ArgAction::SetTrue))
-    .get_matches();
+        .action(ArgAction::SetTrue));
 
-  let debug_flag = matches.get_flag("debug");
-  let tree_flag = matches.get_flag("tree");
-  let mut repl_flag = matches.get_flag("repl");
-  let time_flag = matches.get_flag("time");
-  let trace_flag = matches.get_flag("trace");
-  let rounds_per_step = matches.get_one::<String>("rounds-per-step").and_then(|s| s.parse::<usize>().ok()).unwrap_or(10_000);
+  #[cfg(feature = "serve")]
+  let cli_command = add_filesystem_capability_args(cli_command);
+
+  let cli_matches = cli_command.get_matches();
+
+  let debug_flag = cli_matches.get_flag("debug");
+  let tree_flag = cli_matches.get_flag("tree");
+  let mut repl_flag = cli_matches.get_flag("repl");
+  let time_flag = cli_matches.get_flag("time");
+  let trace_flag = cli_matches.get_flag("trace");
+  let rounds_per_step = cli_matches.get_one::<String>("rounds-per-step").and_then(|s| s.parse::<usize>().ok()).unwrap_or(10_000);
 
   let shim_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/shim.html".to_string();
   let stylesheet_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css".to_string();
@@ -290,42 +497,42 @@ async fn main() -> Result<(), MechError> {
   // Serve
   // --------------------------------------------------------------------------
  #[cfg(feature = "serve")]
-  if let Some(matches) = matches.subcommand_matches("serve") {
+  if let Some(serve_matches) = cli_matches.subcommand_matches("serve") {
     let badge = "[Mech Server]".truecolor(34, 204, 187);
     let error_badge = "[Error]".truecolor(246, 98, 78);
 
-    let port = matches
+    let port = serve_matches
       .get_one::<String>("port")
       .map(String::as_str)
       .unwrap_or("8081");
 
-    let address = matches
+    let address = serve_matches
       .get_one::<String>("address")
       .map(String::as_str)
       .unwrap_or("127.0.0.1");
 
     let full_address = format!("{address}:{port}");
 
-    let mech_paths: Vec<String> = matches
+    let mech_paths: Vec<String> = serve_matches
       .get_many::<String>("mech_serve_file_paths")
       .into_iter()
       .flatten()
       .cloned()
       .collect();
 
-    let stylesheet_paths: Vec<String> = matches
+    let stylesheet_paths: Vec<String> = serve_matches
       .get_many::<String>("stylesheet")
       .into_iter()
       .flatten()
       .cloned()
       .collect();
 
-    let wasm_pkg = matches
+    let wasm_pkg = serve_matches
       .get_one::<String>("wasm")
       .map(String::as_str)
       .unwrap_or("");
 
-    let shim_path = matches
+    let shim_path = serve_matches
       .get_one::<String>("shim")
       .map(String::as_str)
       .unwrap_or("");
@@ -373,24 +580,7 @@ async fn main() -> Result<(), MechError> {
     )
     .await?;
 
-    let mut id_generator = DefaultIdGenerator::new();
-    let kernel = SharedCapabilityKernel::new();
-    let mut authority = HostFilesystemAuthority::new(MECH_TOOL_SUBJECT, kernel);
-
-    let root = std::env::current_dir()?.canonicalize()?;
-
-    authority.grant_path(
-      &mut id_generator,
-      &root,
-      true,
-      [FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
-    )?;
-
-    println!(
-      "{badge} Capability grant: {} :read,:list,:watch,:resolve,:import,:serve {} recursive=true",
-      MECH_TOOL_SUBJECT,
-      mech_runtime::fs_resource_key(&root)?,
-    );
+    let authority = build_mech_filesystem_authority(serve_matches, &badge)?;
 
     let mut server = MechServer::new(
       "Mech Server".to_string(),
@@ -418,7 +608,7 @@ async fn main() -> Result<(), MechError> {
   // Test
   // --------------------------------------------------------------------------
   #[cfg(all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool"))]
-  if let Some(matches) = matches.subcommand_matches("test") {
+  if let Some(matches) = cli_matches.subcommand_matches("test") {
     let mech_paths: Vec<String> = matches
       .get_many::<String>("mech_test_file_paths")
       .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
@@ -432,7 +622,7 @@ async fn main() -> Result<(), MechError> {
   // Build
   // --------------------------------------------------------------------------
   #[cfg(feature = "build")]
-  if let Some(matches) = matches.subcommand_matches("build") {
+  if let Some(matches) = cli_matches.subcommand_matches("build") {
     let mech_paths: Vec<String> = matches.get_many::<String>("mech_build_file_paths").map_or(vec![], |files| files.map(|file| file.to_string()).collect());
     let output_path = PathBuf::from(matches.get_one::<String>("output_path").cloned().unwrap_or(".".to_string()));
     let debug_flag = matches.get_flag("debug");
@@ -481,7 +671,7 @@ async fn main() -> Result<(), MechError> {
   // Format
   // --------------------------------------------------------------------------
   #[cfg(feature = "formatter")]
-  if let Some(matches) = matches.subcommand_matches("format") {
+  if let Some(matches) = cli_matches.subcommand_matches("format") {
     let badge = "[Mech Formatter]".truecolor(34, 204, 187);
     let html_flag = matches.get_flag("html");
     let stylesheet_paths: Vec<String> = matches
@@ -606,7 +796,7 @@ async fn main() -> Result<(), MechError> {
   program.configure(debug_flag, trace_flag, time_flag, rounds_per_step);
   #[cfg(feature = "run")]
   {
-    let mut paths = if let Some(m) = matches.get_many::<String>("mech_paths") {
+    let mut paths = if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
       m.map(|s| s.to_string()).collect()
     } else { repl_flag = true; vec![] };
 
@@ -953,3 +1143,142 @@ pub fn print_mech_error(err: &MechError) {
       println!("{:#?}", err);
   }
 } 
+
+#[cfg(all(test, feature = "serve"))]
+mod filesystem_capability_cli_tests {
+    use super::*;
+    use mech_runtime::SERVE_HOST_SUBJECT;
+
+    fn capability_matches(arguments: &[&str]) -> clap::ArgMatches {
+        add_filesystem_capability_args(Command::new("mech").subcommand(
+            Command::new("serve").arg(Arg::new("mech_serve_file_paths").action(ArgAction::Append)),
+        ))
+        .try_get_matches_from(arguments)
+        .unwrap()
+        .subcommand_matches("serve")
+        .unwrap()
+        .clone()
+    }
+
+    fn temp_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mech-cli-capability-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root.canonicalize().unwrap()
+    }
+
+    fn test_badge() -> ColoredString {
+        "[Mech Server]".normal()
+    }
+
+    #[test]
+    fn default_grants_current_directory_when_no_capability_options_are_present() {
+        let matches = capability_matches(&["mech", "serve", "."]);
+        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let mut ids = DefaultIdGenerator::new();
+        authority
+            .delegate_path_to(
+                &mut ids,
+                SERVE_HOST_SUBJECT,
+                &std::env::current_dir().unwrap(),
+                true,
+                [FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn cap_root_disables_default_current_directory_authority() {
+        let root = temp_root("cap-root");
+        let allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let allowed_arg = allowed.to_string_lossy();
+        let outside_arg = outside.to_string_lossy();
+        let matches =
+            capability_matches(&["mech", "--cap-root", &allowed_arg, "serve", &outside_arg]);
+        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let mut ids = DefaultIdGenerator::new();
+        assert!(
+            authority
+                .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &outside, true, [FS_READ])
+                .is_err()
+        );
+        authority
+            .delegate_path_to(
+                &mut ids,
+                SERVE_HOST_SUBJECT,
+                &allowed,
+                true,
+                [FS_READ, FS_SERVE],
+            )
+            .unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn no_default_capabilities_grants_nothing() {
+        let root = temp_root("none");
+        let matches = capability_matches(&[
+            "mech",
+            "--no-default-capabilities",
+            "serve",
+            root.to_str().unwrap(),
+        ]);
+        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let mut ids = DefaultIdGenerator::new();
+        assert!(
+            authority
+                .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_READ])
+                .is_err()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn allow_read_does_not_grant_serve() {
+        let root = temp_root("read-only");
+        let matches = capability_matches(&[
+            "mech",
+            "serve",
+            root.to_str().unwrap(),
+            "--allow-read",
+            root.to_str().unwrap(),
+        ]);
+        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let mut ids = DefaultIdGenerator::new();
+        authority
+            .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_READ])
+            .unwrap();
+        assert!(
+            authority
+                .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_SERVE])
+                .is_err()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn allow_serve_grants_serve() {
+        let root = temp_root("serve-only");
+        let matches = capability_matches(&[
+            "mech",
+            "serve",
+            root.to_str().unwrap(),
+            "--allow-serve",
+            root.to_str().unwrap(),
+        ]);
+        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let mut ids = DefaultIdGenerator::new();
+        authority
+            .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_SERVE])
+            .unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide users control over the host filesystem authority granted to `host://mech` from the CLI, allowing restriction or explicit granting of root authority instead of the previous unconditional current-dir grant.
- Ensure explicit capability flags disable the broad default grant so subcommands (notably `serve`) cannot escape user-provided limits while preserving existing server behavior.

### Description

- Add global CLI options to the root `Command` (with `.global(true)`): `--cap-root`, `--allow-read`, `--allow-watch`, `--allow-serve`, and `--no-default-capabilities`. These accept repeated `PATH` arguments or a boolean flag as specified. (changes in `src/bin/mech.rs`)
- Introduce helpers to collect and resolve capability paths, determine recursion, and build the host filesystem authority: `collect_capability_paths`, `resolve_capability_path`, `path_is_recursive_capability_target`, `grant_mech_filesystem_path`, and `build_mech_filesystem_authority` (all under `#[cfg(feature = "serve")]`).
- Replace the previous unconditional recursive `current_dir()` grant with `build_mech_filesystem_authority(...)` that: grants recursive current-dir authority only when no capability flags were supplied; rejects `--cap-root` paths that are not existing directories; grants directory/file-specific operations and recursion according to the rules; and logs normalized `fs://...` resources for each grant.
- Avoid shadowing root matches by building the root command first, augmenting it with the new global args, calling `get_matches()` into `cli_matches`, then reading the `serve` subcommand matches from `cli_matches` and passing them into `build_mech_filesystem_authority`.
- Add focused unit tests (under `#[cfg(all(test, feature = "serve"))]`) that exercise: default implicit grant behavior, `--cap-root` disabling the default grant, `--no-default-capabilities`, `--allow-read` (does not imply serve), and `--allow-serve` (implies serve). The tests use `HostFilesystemAuthority::delegate_path_to` assertions to validate grants.

### Testing

- Ran `cargo check --features serve` successfully.
- Ran `cargo test --features serve` and all tests passed, including the new CLI-focused tests (5 tests) added to `src/bin/mech.rs`.
- Ran `cargo test -p mech-runtime --lib --tests` and `cargo test -p mech-runtime --test module_smoke`, both completed successfully.
- Verified CLI help shows the new top-level/global capability flags for both `mech --help` and `mech serve --help`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecc076ea8832a9fce4977b5d89861)