### PR TITLE
Wire mech.mcfg into serve CLI

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -311,14 +311,14 @@ async fn main() -> Result<(), MechError> {
     let badge = "[Mech Server]".truecolor(34, 204, 187);
     let error_badge = "[Error]".truecolor(246, 98, 78);
 
-    let config_doc = config::load_cli_config(serve_matches)?;
-    let effective = config::effective_serve_options(serve_matches, config_doc.as_ref());
+    let loaded_config = config::load_cli_config(serve_matches)?;
+    let effective = config::effective_serve_options(serve_matches, loaded_config.as_ref());
     let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
     let runtime_config = config::apply_runtime_config_patch(
       mech_runtime::RuntimeConfig::default(),
-      config_doc
+      loaded_config
         .as_ref()
-        .map(|doc| &doc.runtime)
+        .map(|loaded| &loaded.document.runtime)
         .unwrap_or(&default_runtime_patch),
     )?;
 
@@ -373,7 +373,7 @@ async fn main() -> Result<(), MechError> {
 
     let authority = capabilities::build_mech_filesystem_authority(
       serve_matches,
-      config_doc.as_ref(),
+      loaded_config.as_ref(),
       &badge,
     )?;
 

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -4,7 +4,6 @@ use mech::*;
 use mech_core::*;
 use mech_syntax::parser;
 #[cfg(feature = "serve")]
-use mech_runtime::{DefaultIdGenerator, HostFilesystemAuthority, SharedCapabilityKernel, MECH_TOOL_SUBJECT, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH};
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
 use std::time::Instant;
@@ -19,9 +18,7 @@ use crossterm::{
   terminal, cursor, style::Print,
 };
 use ariadne::{Report, ReportKind, Label, Color, sources};
-use clap::{arg, command, value_parser, Arg, ArgAction, Command};
-#[cfg(feature = "serve")]
-use std::collections::{BTreeMap, BTreeSet};
+use clap::{Arg, ArgAction, Command};
 use std::path::PathBuf;
 use tabled::{
   builder::Builder,
@@ -73,224 +70,15 @@ impl MechErrorKind for Utf8ConversionError {
 }
 
 #[cfg(feature = "serve")]
-fn add_filesystem_capability_args(command: Command) -> Command {
-    command
-        .arg(
-            Arg::new("cap_root")
-                .long("cap-root")
-                .value_name("PATH")
-                .num_args(1)
-                .action(ArgAction::Append)
-                .global(true)
-                .help("Grant full recursive filesystem capability authority under PATH."),
-        )
-        .arg(
-            Arg::new("allow_read")
-                .long("allow-read")
-                .value_name("PATH")
-                .num_args(1)
-                .action(ArgAction::Append)
-                .global(true)
-                .help("Grant filesystem read/list/resolve/import authority for PATH."),
-        )
-        .arg(
-            Arg::new("allow_watch")
-                .long("allow-watch")
-                .value_name("PATH")
-                .num_args(1)
-                .action(ArgAction::Append)
-                .global(true)
-                .help("Grant filesystem watch authority for PATH."),
-        )
-        .arg(
-            Arg::new("allow_serve")
-                .long("allow-serve")
-                .value_name("PATH")
-                .num_args(1)
-                .action(ArgAction::Append)
-                .global(true)
-                .help("Grant filesystem serve authority for PATH."),
-        )
-        .arg(
-            Arg::new("no_default_capabilities")
-                .long("no-default-capabilities")
-                .action(ArgAction::SetTrue)
-                .global(true)
-                .help(
-                    "Disable the default recursive current-directory filesystem capability grant.",
-                ),
-        )
-}
+#[path = "mech/config.rs"]
+mod config;
 
 #[cfg(feature = "serve")]
-fn collect_capability_paths(matches: &clap::ArgMatches, id: &str) -> Vec<PathBuf> {
-    matches
-        .get_many::<String>(id)
-        .into_iter()
-        .flatten()
-        .map(PathBuf::from)
-        .collect()
-}
+#[path = "mech/capabilities.rs"]
+mod capabilities;
 
-#[cfg(feature = "serve")]
-fn resolve_capability_path(path: &Path) -> MResult<PathBuf> {
-    let candidate = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()?.join(path)
-    };
-    if candidate.exists() {
-        Ok(candidate.canonicalize()?)
-    } else {
-        Ok(candidate)
-    }
-}
-
-#[cfg(feature = "serve")]
-fn path_is_recursive_capability_target(path: &Path) -> bool {
-    path.exists() && path.is_dir()
-}
-
-#[cfg(feature = "serve")]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct CapabilityGrantKey {
-    path: PathBuf,
-    recursive: bool,
-}
-
-#[cfg(feature = "serve")]
-fn add_capability_grant(
-    grants: &mut BTreeMap<CapabilityGrantKey, BTreeSet<&'static str>>,
-    path: PathBuf,
-    recursive: bool,
-    operations: &[&'static str],
-) {
-    grants
-        .entry(CapabilityGrantKey { path, recursive })
-        .or_default()
-        .extend(operations.iter().copied());
-}
-
-#[cfg(feature = "serve")]
-fn grant_mech_filesystem_path(
-    authority: &mut HostFilesystemAuthority,
-    id_generator: &mut DefaultIdGenerator,
-    badge: &ColoredString,
-    path: &Path,
-    recursive: bool,
-    operations: &[&'static str],
-) -> MResult<()> {
-    authority.grant_path(id_generator, path, recursive, operations.iter().copied())?;
-    println!(
-        "{badge} Capability grant: {} {} {} recursive={recursive}",
-        MECH_TOOL_SUBJECT,
-        operations.join(","),
-        mech_runtime::fs_resource_key(path)?,
-    );
-    Ok(())
-}
-
-#[cfg(feature = "serve")]
-fn build_mech_filesystem_authority(
-    matches: &clap::ArgMatches,
-    badge: &ColoredString,
-) -> MResult<HostFilesystemAuthority> {
-    let mut id_generator = DefaultIdGenerator::new();
-    let kernel = SharedCapabilityKernel::new();
-    let mut authority = HostFilesystemAuthority::new(MECH_TOOL_SUBJECT, kernel);
-    let mut grants = BTreeMap::<CapabilityGrantKey, BTreeSet<&'static str>>::new();
-
-    let cap_roots = collect_capability_paths(matches, "cap_root");
-    let allow_read = collect_capability_paths(matches, "allow_read");
-    let allow_watch = collect_capability_paths(matches, "allow_watch");
-    let allow_serve = collect_capability_paths(matches, "allow_serve");
-    let no_default = matches.get_flag("no_default_capabilities");
-    let explicit = no_default
-        || !cap_roots.is_empty()
-        || !allow_read.is_empty()
-        || !allow_watch.is_empty()
-        || !allow_serve.is_empty();
-
-    if !explicit {
-        let root = std::env::current_dir()?.canonicalize()?;
-        add_capability_grant(
-            &mut grants,
-            root,
-            true,
-            &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
-        );
-    }
-
-    for path in cap_roots {
-        let path = resolve_capability_path(&path)?;
-        if !path.is_dir() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "--cap-root path must be an existing directory: {}",
-                    path.display()
-                ),
-            )
-            .into());
-        }
-        add_capability_grant(
-            &mut grants,
-            path,
-            true,
-            &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
-        );
-    }
-
-    for path in allow_read {
-        let path = resolve_capability_path(&path)?;
-        let recursive = path_is_recursive_capability_target(&path);
-        if recursive {
-            add_capability_grant(
-                &mut grants,
-                path,
-                true,
-                &[FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT],
-            );
-        } else {
-            add_capability_grant(
-                &mut grants,
-                path,
-                false,
-                &[FS_READ, FS_RESOLVE, FS_IMPORT],
-            );
-        }
-    }
-
-    for path in allow_watch {
-        let path = resolve_capability_path(&path)?;
-        let recursive = path_is_recursive_capability_target(&path);
-        add_capability_grant(&mut grants, path, recursive, &[FS_WATCH]);
-    }
-
-    for path in allow_serve {
-        let path = resolve_capability_path(&path)?;
-        let recursive = path_is_recursive_capability_target(&path);
-        add_capability_grant(&mut grants, path, recursive, &[FS_SERVE]);
-    }
-
-    for (key, operations) in grants {
-        let operations = operations.into_iter().collect::<Vec<_>>();
-        grant_mech_filesystem_path(
-            &mut authority,
-            &mut id_generator,
-            badge,
-            &key.path,
-            key.recursive,
-            &operations,
-        )?;
-    }
-
-    if authority.source_capabilities().is_empty() {
-        println!("{badge} Capability grant: {} <none>", MECH_TOOL_SUBJECT);
-    }
-
-    Ok(authority)
-}
+#[cfg(all(test, feature = "serve"))]
+pub(crate) static CURRENT_DIR_LOCK: Mutex<()> = Mutex::new(());
 
 async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
   if paths.is_empty() {
@@ -496,7 +284,10 @@ async fn main() -> Result<(), MechError> {
         .action(ArgAction::SetTrue));
 
   #[cfg(feature = "serve")]
-  let cli_command = add_filesystem_capability_args(cli_command);
+  let cli_command = capabilities::add_filesystem_capability_args(cli_command);
+
+  #[cfg(feature = "serve")]
+  let cli_command = config::add_config_args(cli_command);
 
   let cli_matches = cli_command.get_matches();
 
@@ -520,41 +311,22 @@ async fn main() -> Result<(), MechError> {
     let badge = "[Mech Server]".truecolor(34, 204, 187);
     let error_badge = "[Error]".truecolor(246, 98, 78);
 
-    let port = serve_matches
-      .get_one::<String>("port")
-      .map(String::as_str)
-      .unwrap_or("8081");
+    let config_doc = config::load_cli_config(serve_matches)?;
+    let effective = config::effective_serve_options(serve_matches, config_doc.as_ref());
+    let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+    let runtime_config = config::apply_runtime_config_patch(
+      mech_runtime::RuntimeConfig::default(),
+      config_doc
+        .as_ref()
+        .map(|doc| &doc.runtime)
+        .unwrap_or(&default_runtime_patch),
+    )?;
 
-    let address = serve_matches
-      .get_one::<String>("address")
-      .map(String::as_str)
-      .unwrap_or("127.0.0.1");
-
-    let full_address = format!("{address}:{port}");
-
-    let mech_paths: Vec<String> = serve_matches
-      .get_many::<String>("mech_serve_file_paths")
-      .into_iter()
-      .flatten()
-      .cloned()
-      .collect();
-
-    let stylesheet_paths: Vec<String> = serve_matches
-      .get_many::<String>("stylesheet")
-      .into_iter()
-      .flatten()
-      .cloned()
-      .collect();
-
-    let wasm_pkg = serve_matches
-      .get_one::<String>("wasm")
-      .map(String::as_str)
-      .unwrap_or("");
-
-    let shim_path = serve_matches
-      .get_one::<String>("shim")
-      .map(String::as_str)
-      .unwrap_or("");
+    let full_address = format!("{}:{}", effective.address, effective.port);
+    let mech_paths = effective.paths;
+    let stylesheet_paths = effective.stylesheet_paths;
+    let wasm_pkg = effective.wasm_pkg.as_str();
+    let shim_path = effective.shim_path.as_str();
 
     let wasm_path = format!("{wasm_pkg}/mech_wasm_bg.wasm.br");
     let js_path = format!("{wasm_pkg}/mech_wasm.js");
@@ -599,9 +371,13 @@ async fn main() -> Result<(), MechError> {
     )
     .await?;
 
-    let authority = build_mech_filesystem_authority(serve_matches, &badge)?;
+    let authority = capabilities::build_mech_filesystem_authority(
+      serve_matches,
+      config_doc.as_ref(),
+      &badge,
+    )?;
 
-    let mut server = MechServer::new(
+    let mut server = MechServer::new_with_runtime_config(
       "Mech Server".to_string(),
       full_address,
       stylesheet_str,
@@ -609,6 +385,7 @@ async fn main() -> Result<(), MechError> {
       wasm,
       js,
       authority,
+      runtime_config,
     );
 
     server.init().await?;
@@ -1166,10 +943,10 @@ pub fn print_mech_error(err: &MechError) {
 #[cfg(all(test, feature = "serve"))]
 mod filesystem_capability_cli_tests {
     use super::*;
-    use mech_runtime::SERVE_HOST_SUBJECT;
+    use mech_runtime::{DefaultIdGenerator, SERVE_HOST_SUBJECT, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH};
 
     fn capability_matches(arguments: &[&str]) -> clap::ArgMatches {
-        add_filesystem_capability_args(Command::new("mech").subcommand(
+        capabilities::add_filesystem_capability_args(Command::new("mech").subcommand(
             Command::new("serve").arg(Arg::new("mech_serve_file_paths").action(ArgAction::Append)),
         ))
         .try_get_matches_from(arguments)
@@ -1198,7 +975,7 @@ mod filesystem_capability_cli_tests {
     #[test]
     fn default_grants_current_directory_when_no_capability_options_are_present() {
         let matches = capability_matches(&["mech", "serve", "."]);
-        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(
@@ -1222,7 +999,7 @@ mod filesystem_capability_cli_tests {
         let outside_arg = outside.to_string_lossy();
         let matches =
             capability_matches(&["mech", "--cap-root", &allowed_arg, "serve", &outside_arg]);
-        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         assert!(
             authority
@@ -1250,7 +1027,7 @@ mod filesystem_capability_cli_tests {
             "serve",
             root.to_str().unwrap(),
         ]);
-        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         assert!(
             authority
@@ -1270,7 +1047,7 @@ mod filesystem_capability_cli_tests {
             "--allow-read",
             root.to_str().unwrap(),
         ]);
-        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_READ])
@@ -1300,7 +1077,7 @@ mod filesystem_capability_cli_tests {
             "serve",
             &allowed_arg,
         ]);
-        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         assert_eq!(authority.source_capabilities().len(), 1);
         let mut ids = DefaultIdGenerator::new();
         authority
@@ -1325,7 +1102,7 @@ mod filesystem_capability_cli_tests {
             "--allow-serve",
             root.to_str().unwrap(),
         ]);
-        let authority = build_mech_filesystem_authority(&matches, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_SERVE])

--- a/src/bin/mech/capabilities.rs
+++ b/src/bin/mech/capabilities.rs
@@ -1,0 +1,460 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use clap::{Arg, ArgAction, Command};
+use colored::*;
+use mech::*;
+use mech_core::*;
+use mech_runtime::{
+    ConfigCapabilityKind, DefaultIdGenerator, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE,
+    FS_WATCH, HostFilesystemAuthority, MECH_TOOL_SUBJECT, MechConfigDocument,
+    SharedCapabilityKernel,
+};
+
+pub fn add_filesystem_capability_args(command: Command) -> Command {
+    command
+        .arg(
+            Arg::new("cap_root")
+                .long("cap-root")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant full recursive filesystem capability authority under PATH."),
+        )
+        .arg(
+            Arg::new("allow_read")
+                .long("allow-read")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant filesystem read/list/resolve/import authority for PATH."),
+        )
+        .arg(
+            Arg::new("allow_watch")
+                .long("allow-watch")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant filesystem watch authority for PATH."),
+        )
+        .arg(
+            Arg::new("allow_serve")
+                .long("allow-serve")
+                .value_name("PATH")
+                .num_args(1)
+                .action(ArgAction::Append)
+                .global(true)
+                .help("Grant filesystem serve authority for PATH."),
+        )
+        .arg(
+            Arg::new("no_default_capabilities")
+                .long("no-default-capabilities")
+                .action(ArgAction::SetTrue)
+                .global(true)
+                .help(
+                    "Disable the default recursive current-directory filesystem capability grant.",
+                ),
+        )
+}
+
+fn collect_capability_paths(matches: &clap::ArgMatches, id: &str) -> Vec<PathBuf> {
+    matches
+        .get_many::<String>(id)
+        .into_iter()
+        .flatten()
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn resolve_capability_path(path: &Path) -> MResult<PathBuf> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    if candidate.exists() {
+        Ok(candidate.canonicalize()?)
+    } else {
+        Ok(candidate)
+    }
+}
+
+fn path_is_recursive_capability_target(path: &Path) -> bool {
+    path.exists() && path.is_dir()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CapabilityGrantKey {
+    path: PathBuf,
+    recursive: bool,
+}
+
+fn add_capability_grant(
+    grants: &mut BTreeMap<CapabilityGrantKey, BTreeSet<&'static str>>,
+    path: PathBuf,
+    recursive: bool,
+    operations: &[&'static str],
+) {
+    grants
+        .entry(CapabilityGrantKey { path, recursive })
+        .or_default()
+        .extend(operations.iter().copied());
+}
+
+fn grant_mech_filesystem_path(
+    authority: &mut HostFilesystemAuthority,
+    id_generator: &mut DefaultIdGenerator,
+    badge: &ColoredString,
+    path: &Path,
+    recursive: bool,
+    operations: &[&'static str],
+) -> MResult<()> {
+    authority.grant_path(id_generator, path, recursive, operations.iter().copied())?;
+    println!(
+        "{badge} Capability grant: {} {} {} recursive={recursive}",
+        MECH_TOOL_SUBJECT,
+        operations.join(","),
+        mech_runtime::fs_resource_key(path)?,
+    );
+    Ok(())
+}
+
+fn add_config_capability_grant(
+    grants: &mut BTreeMap<CapabilityGrantKey, BTreeSet<&'static str>>,
+    grant: &mech_runtime::ConfigCapabilityGrant,
+) -> MResult<()> {
+    let path = resolve_capability_path(&grant.path)?;
+    match grant.kind {
+        ConfigCapabilityKind::CapRoot => {
+            if !path.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "config cap-root path must be an existing directory: {}",
+                        path.display()
+                    ),
+                )
+                .into());
+            }
+            add_capability_grant(
+                grants,
+                path,
+                grant.recursive.unwrap_or(true),
+                &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+            );
+        }
+        ConfigCapabilityKind::Read => {
+            let recursive = grant
+                .recursive
+                .unwrap_or_else(|| path_is_recursive_capability_target(&path));
+            if recursive {
+                add_capability_grant(
+                    grants,
+                    path,
+                    true,
+                    &[FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT],
+                );
+            } else {
+                add_capability_grant(grants, path, false, &[FS_READ, FS_RESOLVE, FS_IMPORT]);
+            }
+        }
+        ConfigCapabilityKind::Watch => {
+            let recursive = grant
+                .recursive
+                .unwrap_or_else(|| path_is_recursive_capability_target(&path));
+            add_capability_grant(grants, path, recursive, &[FS_WATCH]);
+        }
+        ConfigCapabilityKind::Serve => {
+            let recursive = grant
+                .recursive
+                .unwrap_or_else(|| path_is_recursive_capability_target(&path));
+            add_capability_grant(grants, path, recursive, &[FS_SERVE]);
+        }
+    }
+    Ok(())
+}
+
+pub fn build_mech_filesystem_authority(
+    matches: &clap::ArgMatches,
+    config: Option<&MechConfigDocument>,
+    badge: &ColoredString,
+) -> MResult<HostFilesystemAuthority> {
+    let mut id_generator = DefaultIdGenerator::new();
+    let kernel = SharedCapabilityKernel::new();
+    let mut authority = HostFilesystemAuthority::new(MECH_TOOL_SUBJECT, kernel);
+    let mut grants = BTreeMap::<CapabilityGrantKey, BTreeSet<&'static str>>::new();
+
+    let cap_roots = collect_capability_paths(matches, "cap_root");
+    let allow_read = collect_capability_paths(matches, "allow_read");
+    let allow_watch = collect_capability_paths(matches, "allow_watch");
+    let allow_serve = collect_capability_paths(matches, "allow_serve");
+    let no_default = matches.get_flag("no_default_capabilities");
+    let has_config_capabilities = config.is_some_and(|doc| !doc.capabilities.is_empty());
+    let explicit = no_default
+        || has_config_capabilities
+        || !cap_roots.is_empty()
+        || !allow_read.is_empty()
+        || !allow_watch.is_empty()
+        || !allow_serve.is_empty();
+
+    if !explicit {
+        let root = std::env::current_dir()?.canonicalize()?;
+        add_capability_grant(
+            &mut grants,
+            root,
+            true,
+            &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+        );
+    }
+
+    for path in cap_roots {
+        let path = resolve_capability_path(&path)?;
+        if !path.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "--cap-root path must be an existing directory: {}",
+                    path.display()
+                ),
+            )
+            .into());
+        }
+        add_capability_grant(
+            &mut grants,
+            path,
+            true,
+            &[FS_READ, FS_LIST, FS_WATCH, FS_RESOLVE, FS_IMPORT, FS_SERVE],
+        );
+    }
+
+    for path in allow_read {
+        let path = resolve_capability_path(&path)?;
+        let recursive = path_is_recursive_capability_target(&path);
+        if recursive {
+            add_capability_grant(
+                &mut grants,
+                path,
+                true,
+                &[FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT],
+            );
+        } else {
+            add_capability_grant(&mut grants, path, false, &[FS_READ, FS_RESOLVE, FS_IMPORT]);
+        }
+    }
+
+    for path in allow_watch {
+        let path = resolve_capability_path(&path)?;
+        let recursive = path_is_recursive_capability_target(&path);
+        add_capability_grant(&mut grants, path, recursive, &[FS_WATCH]);
+    }
+
+    for path in allow_serve {
+        let path = resolve_capability_path(&path)?;
+        let recursive = path_is_recursive_capability_target(&path);
+        add_capability_grant(&mut grants, path, recursive, &[FS_SERVE]);
+    }
+
+    if let Some(config) = config {
+        for grant in &config.capabilities {
+            add_config_capability_grant(&mut grants, grant)?;
+        }
+    }
+
+    for (key, operations) in grants {
+        let operations = operations.into_iter().collect::<Vec<_>>();
+        grant_mech_filesystem_path(
+            &mut authority,
+            &mut id_generator,
+            badge,
+            &key.path,
+            key.recursive,
+            &operations,
+        )?;
+    }
+
+    if authority.source_capabilities().is_empty() {
+        println!("{badge} Capability grant: {} <none>", MECH_TOOL_SUBJECT);
+    }
+
+    Ok(authority)
+}
+
+#[cfg(test)]
+mod filesystem_capability_tests {
+    use super::*;
+    use mech_runtime::{
+        ConfigProfileOptions, SERVE_HOST_SUBJECT, check_fs_capability, parse_config_document,
+    };
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct CurrentDirGuard {
+        previous: PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CurrentDirGuard {
+        fn enter(path: &Path) -> Self {
+            let lock = crate::CURRENT_DIR_LOCK.lock().unwrap();
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.previous).unwrap();
+        }
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mech-cli-capability-{name}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root.canonicalize().unwrap()
+    }
+
+    fn cli(args: &[&str]) -> clap::ArgMatches {
+        let command = crate::config::add_config_args(add_filesystem_capability_args(
+            Command::new("mech").subcommand(
+                Command::new("serve").arg(
+                    Arg::new("mech_serve_file_paths")
+                        .required(false)
+                        .action(ArgAction::Append),
+                ),
+            ),
+        ));
+        command.try_get_matches_from(args).unwrap()
+    }
+
+    fn parse_config(source: &str) -> MechConfigDocument {
+        parse_config_document(
+            "test.mcfg".to_string(),
+            source,
+            ConfigProfileOptions::default(),
+        )
+        .unwrap()
+    }
+
+    fn delegate_all(authority: &HostFilesystemAuthority, path: &Path) -> MResult<()> {
+        let mut ids = DefaultIdGenerator::new();
+        authority.delegate_path_to(
+            &mut ids,
+            SERVE_HOST_SUBJECT,
+            path,
+            true,
+            [FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT, FS_WATCH, FS_SERVE],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn config_capabilities_suppress_default_current_dir_grant() {
+        let root = temp_root("suppress-default");
+        let allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let _guard = CurrentDirGuard::enter(&root);
+        let config = parse_config(
+            r#"config := {capabilities: [{allow: "read", path: "allowed"} {allow: "watch", path: "allowed"} {allow: "serve", path: "allowed"}]}"#,
+        );
+        let matches = cli(&["mech", "serve"]);
+        let serve_matches = matches.subcommand_matches("serve").unwrap();
+        let badge = "[test]".normal();
+        let authority =
+            build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
+        assert!(delegate_all(&authority, &allowed).is_ok());
+        assert!(delegate_all(&authority, &outside).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn no_default_capabilities_does_not_suppress_config_grants() {
+        let root = temp_root("no-default-config");
+        let allowed = root.join("allowed");
+        std::fs::create_dir_all(&allowed).unwrap();
+        let _guard = CurrentDirGuard::enter(&root);
+        let config = parse_config(
+            r#"config := {capabilities: [{allow: "read", path: "allowed"} {allow: "watch", path: "allowed"} {allow: "serve", path: "allowed"}]}"#,
+        );
+        let matches = cli(&["mech", "--no-default-capabilities", "serve"]);
+        let serve_matches = matches.subcommand_matches("serve").unwrap();
+        let badge = "[test]".normal();
+        let authority =
+            build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
+        assert!(delegate_all(&authority, &allowed).is_ok());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn no_config_no_default_capabilities_grants_nothing() {
+        let root = temp_root("grants-nothing");
+        let allowed = root.join("allowed");
+        std::fs::create_dir_all(&allowed).unwrap();
+        let _guard = CurrentDirGuard::enter(&root);
+        let matches = cli(&[
+            "mech",
+            "--no-config",
+            "--no-default-capabilities",
+            "serve",
+            "allowed",
+        ]);
+        let serve_matches = matches.subcommand_matches("serve").unwrap();
+        let badge = "[test]".normal();
+        let authority = build_mech_filesystem_authority(serve_matches, None, &badge).unwrap();
+        assert!(delegate_all(&authority, &allowed).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_and_cli_capability_grants_aggregate() {
+        let root = temp_root("aggregate");
+        let allowed = root.join("allowed");
+        std::fs::create_dir_all(&allowed).unwrap();
+        let _guard = CurrentDirGuard::enter(&root);
+        let config =
+            parse_config(r#"config := {capabilities: [{allow: "read", path: "allowed"}]}"#);
+        let matches = cli(&[
+            "mech",
+            "--allow-watch",
+            "allowed",
+            "--allow-serve",
+            "allowed",
+            "serve",
+        ]);
+        let serve_matches = matches.subcommand_matches("serve").unwrap();
+        let badge = "[test]".normal();
+        let authority =
+            build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
+        assert!(delegate_all(&authority, &allowed).is_ok());
+        let mut kernel = authority.kernel().clone();
+        assert!(check_fs_capability(&mut kernel, MECH_TOOL_SUBJECT, FS_READ, &allowed).is_ok());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_cap_root_requires_existing_directory() {
+        let root = temp_root("cap-root-missing");
+        let _guard = CurrentDirGuard::enter(&root);
+        let config =
+            parse_config(r#"config := {capabilities: [{allow: "cap-root", path: "missing"}]}"#);
+        let matches = cli(&["mech", "serve"]);
+        let serve_matches = matches.subcommand_matches("serve").unwrap();
+        let badge = "[test]".normal();
+        assert!(build_mech_filesystem_authority(serve_matches, Some(&config), &badge).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/bin/mech/capabilities.rs
+++ b/src/bin/mech/capabilities.rs
@@ -8,8 +8,7 @@ use mech::*;
 use mech_core::*;
 use mech_runtime::{
     ConfigCapabilityKind, DefaultIdGenerator, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE,
-    FS_WATCH, HostFilesystemAuthority, MECH_TOOL_SUBJECT, MechConfigDocument,
-    SharedCapabilityKernel,
+    FS_WATCH, HostFilesystemAuthority, MECH_TOOL_SUBJECT, SharedCapabilityKernel,
 };
 
 pub fn add_filesystem_capability_args(command: Command) -> Command {
@@ -125,9 +124,11 @@ fn grant_mech_filesystem_path(
 
 fn add_config_capability_grant(
     grants: &mut BTreeMap<CapabilityGrantKey, BTreeSet<&'static str>>,
+    base_dir: &Path,
     grant: &mech_runtime::ConfigCapabilityGrant,
 ) -> MResult<()> {
-    let path = resolve_capability_path(&grant.path)?;
+    let path = crate::config::resolve_config_path(base_dir, &grant.path);
+    let path = resolve_capability_path(&path)?;
     match grant.kind {
         ConfigCapabilityKind::CapRoot => {
             if !path.is_dir() {
@@ -180,7 +181,7 @@ fn add_config_capability_grant(
 
 pub fn build_mech_filesystem_authority(
     matches: &clap::ArgMatches,
-    config: Option<&MechConfigDocument>,
+    config: Option<&crate::config::LoadedMechConfig>,
     badge: &ColoredString,
 ) -> MResult<HostFilesystemAuthority> {
     let mut id_generator = DefaultIdGenerator::new();
@@ -193,7 +194,8 @@ pub fn build_mech_filesystem_authority(
     let allow_watch = collect_capability_paths(matches, "allow_watch");
     let allow_serve = collect_capability_paths(matches, "allow_serve");
     let no_default = matches.get_flag("no_default_capabilities");
-    let has_config_capabilities = config.is_some_and(|doc| !doc.capabilities.is_empty());
+    let has_config_capabilities =
+        config.is_some_and(|loaded| !loaded.document.capabilities.is_empty());
     let explicit = no_default
         || has_config_capabilities
         || !cap_roots.is_empty()
@@ -258,9 +260,9 @@ pub fn build_mech_filesystem_authority(
         add_capability_grant(&mut grants, path, recursive, &[FS_SERVE]);
     }
 
-    if let Some(config) = config {
-        for grant in &config.capabilities {
-            add_config_capability_grant(&mut grants, grant)?;
+    if let Some(loaded) = config {
+        for grant in &loaded.document.capabilities {
+            add_config_capability_grant(&mut grants, &loaded.base_dir, grant)?;
         }
     }
 
@@ -339,13 +341,17 @@ mod filesystem_capability_tests {
         command.try_get_matches_from(args).unwrap()
     }
 
-    fn parse_config(source: &str) -> MechConfigDocument {
-        parse_config_document(
-            "test.mcfg".to_string(),
-            source,
-            ConfigProfileOptions::default(),
-        )
-        .unwrap()
+    fn parse_config(source: &str) -> crate::config::LoadedMechConfig {
+        crate::config::LoadedMechConfig {
+            path: PathBuf::from("test.mcfg"),
+            base_dir: PathBuf::new(),
+            document: parse_config_document(
+                "test.mcfg".to_string(),
+                source,
+                ConfigProfileOptions::default(),
+            )
+            .unwrap(),
+        }
     }
 
     fn delegate_all(authority: &HostFilesystemAuthority, path: &Path) -> MResult<()> {
@@ -367,17 +373,19 @@ mod filesystem_capability_tests {
         let outside = root.join("outside");
         std::fs::create_dir_all(&allowed).unwrap();
         std::fs::create_dir_all(&outside).unwrap();
-        let _guard = CurrentDirGuard::enter(&root);
-        let config = parse_config(
-            r#"config := {capabilities: [{allow: "read", path: "allowed"} {allow: "watch", path: "allowed"} {allow: "serve", path: "allowed"}]}"#,
-        );
-        let matches = cli(&["mech", "serve"]);
-        let serve_matches = matches.subcommand_matches("serve").unwrap();
-        let badge = "[test]".normal();
-        let authority =
-            build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
-        assert!(delegate_all(&authority, &allowed).is_ok());
-        assert!(delegate_all(&authority, &outside).is_err());
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let config = parse_config(
+                r#"config := {capabilities: [{allow: "read", path: "allowed"} {allow: "watch", path: "allowed"} {allow: "serve", path: "allowed"}]}"#,
+            );
+            let matches = cli(&["mech", "serve"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let badge = "[test]".normal();
+            let authority =
+                build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
+            assert!(delegate_all(&authority, &allowed).is_ok());
+            assert!(delegate_all(&authority, &outside).is_err());
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -386,16 +394,18 @@ mod filesystem_capability_tests {
         let root = temp_root("no-default-config");
         let allowed = root.join("allowed");
         std::fs::create_dir_all(&allowed).unwrap();
-        let _guard = CurrentDirGuard::enter(&root);
-        let config = parse_config(
-            r#"config := {capabilities: [{allow: "read", path: "allowed"} {allow: "watch", path: "allowed"} {allow: "serve", path: "allowed"}]}"#,
-        );
-        let matches = cli(&["mech", "--no-default-capabilities", "serve"]);
-        let serve_matches = matches.subcommand_matches("serve").unwrap();
-        let badge = "[test]".normal();
-        let authority =
-            build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
-        assert!(delegate_all(&authority, &allowed).is_ok());
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let config = parse_config(
+                r#"config := {capabilities: [{allow: "read", path: "allowed"} {allow: "watch", path: "allowed"} {allow: "serve", path: "allowed"}]}"#,
+            );
+            let matches = cli(&["mech", "--no-default-capabilities", "serve"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let badge = "[test]".normal();
+            let authority =
+                build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
+            assert!(delegate_all(&authority, &allowed).is_ok());
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -404,18 +414,20 @@ mod filesystem_capability_tests {
         let root = temp_root("grants-nothing");
         let allowed = root.join("allowed");
         std::fs::create_dir_all(&allowed).unwrap();
-        let _guard = CurrentDirGuard::enter(&root);
-        let matches = cli(&[
-            "mech",
-            "--no-config",
-            "--no-default-capabilities",
-            "serve",
-            "allowed",
-        ]);
-        let serve_matches = matches.subcommand_matches("serve").unwrap();
-        let badge = "[test]".normal();
-        let authority = build_mech_filesystem_authority(serve_matches, None, &badge).unwrap();
-        assert!(delegate_all(&authority, &allowed).is_err());
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = cli(&[
+                "mech",
+                "--no-config",
+                "--no-default-capabilities",
+                "serve",
+                "allowed",
+            ]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let badge = "[test]".normal();
+            let authority = build_mech_filesystem_authority(serve_matches, None, &badge).unwrap();
+            assert!(delegate_all(&authority, &allowed).is_err());
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -424,37 +436,153 @@ mod filesystem_capability_tests {
         let root = temp_root("aggregate");
         let allowed = root.join("allowed");
         std::fs::create_dir_all(&allowed).unwrap();
-        let _guard = CurrentDirGuard::enter(&root);
-        let config =
-            parse_config(r#"config := {capabilities: [{allow: "read", path: "allowed"}]}"#);
-        let matches = cli(&[
-            "mech",
-            "--allow-watch",
-            "allowed",
-            "--allow-serve",
-            "allowed",
-            "serve",
-        ]);
-        let serve_matches = matches.subcommand_matches("serve").unwrap();
-        let badge = "[test]".normal();
-        let authority =
-            build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
-        assert!(delegate_all(&authority, &allowed).is_ok());
-        let mut kernel = authority.kernel().clone();
-        assert!(check_fs_capability(&mut kernel, MECH_TOOL_SUBJECT, FS_READ, &allowed).is_ok());
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let config =
+                parse_config(r#"config := {capabilities: [{allow: "read", path: "allowed"}]}"#);
+            let matches = cli(&[
+                "mech",
+                "--allow-watch",
+                "allowed",
+                "--allow-serve",
+                "allowed",
+                "serve",
+            ]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let badge = "[test]".normal();
+            let authority =
+                build_mech_filesystem_authority(serve_matches, Some(&config), &badge).unwrap();
+            assert!(delegate_all(&authority, &allowed).is_ok());
+            let mut kernel = authority.kernel().clone();
+            assert!(check_fs_capability(&mut kernel, MECH_TOOL_SUBJECT, FS_READ, &allowed).is_ok());
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
     fn config_cap_root_requires_existing_directory() {
         let root = temp_root("cap-root-missing");
-        let _guard = CurrentDirGuard::enter(&root);
-        let config =
-            parse_config(r#"config := {capabilities: [{allow: "cap-root", path: "missing"}]}"#);
-        let matches = cli(&["mech", "serve"]);
-        let serve_matches = matches.subcommand_matches("serve").unwrap();
-        let badge = "[test]".normal();
-        assert!(build_mech_filesystem_authority(serve_matches, Some(&config), &badge).is_err());
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let config =
+                parse_config(r#"config := {capabilities: [{allow: "cap-root", path: "missing"}]}"#);
+            let matches = cli(&["mech", "serve"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let badge = "[test]".normal();
+            assert!(build_mech_filesystem_authority(serve_matches, Some(&config), &badge).is_err());
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_capability_paths_resolve_from_config_file_directory() {
+        let root = temp_root("relative-capabilities");
+        let subdir = root.join("subdir");
+        let config_allowed = subdir.join("allowed");
+        let cwd_allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&config_allowed).unwrap();
+        std::fs::create_dir_all(&cwd_allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(
+            subdir.join(mech_runtime::DEFAULT_CONFIG_FILENAME),
+            r#"config := {
+  capabilities: [
+    {allow: "read", path: "allowed"}
+    {allow: "watch", path: "allowed"}
+    {allow: "serve", path: "allowed"}
+  ]
+}
+"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = cli(&["mech", "--config", "subdir/mech.mcfg", "serve"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let loaded = crate::config::load_cli_config(serve_matches)
+                .unwrap()
+                .unwrap();
+            let badge = "[test]".normal();
+            let authority =
+                build_mech_filesystem_authority(serve_matches, Some(&loaded), &badge).unwrap();
+            assert!(delegate_all(&authority, &config_allowed).is_ok());
+            assert!(delegate_all(&authority, &cwd_allowed).is_err());
+            assert!(delegate_all(&authority, &outside).is_err());
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cli_capability_paths_remain_current_dir_relative() {
+        let root = temp_root("cli-capabilities-cwd-relative");
+        let subdir = root.join("subdir");
+        let config_allowed = subdir.join("allowed");
+        let cli_allowed = root.join("cli-allowed");
+        let accidental_subdir_cli_allowed = subdir.join("cli-allowed");
+        std::fs::create_dir_all(&config_allowed).unwrap();
+        std::fs::create_dir_all(&cli_allowed).unwrap();
+        std::fs::create_dir_all(&accidental_subdir_cli_allowed).unwrap();
+        std::fs::write(
+            subdir.join(mech_runtime::DEFAULT_CONFIG_FILENAME),
+            r#"config := {capabilities: [{allow: "read", path: "allowed"}]}"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = cli(&[
+                "mech",
+                "--config",
+                "subdir/mech.mcfg",
+                "--allow-watch",
+                "cli-allowed",
+                "--allow-serve",
+                "cli-allowed",
+                "serve",
+            ]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let loaded = crate::config::load_cli_config(serve_matches)
+                .unwrap()
+                .unwrap();
+            let badge = "[test]".normal();
+            let authority =
+                build_mech_filesystem_authority(serve_matches, Some(&loaded), &badge).unwrap();
+
+            let mut ids = DefaultIdGenerator::new();
+            assert!(
+                authority
+                    .delegate_path_to(
+                        &mut ids,
+                        SERVE_HOST_SUBJECT,
+                        &config_allowed,
+                        true,
+                        [FS_READ, FS_LIST, FS_RESOLVE, FS_IMPORT],
+                    )
+                    .is_ok()
+            );
+            assert!(
+                authority
+                    .delegate_path_to(
+                        &mut ids,
+                        SERVE_HOST_SUBJECT,
+                        &cli_allowed,
+                        true,
+                        [FS_WATCH, FS_SERVE],
+                    )
+                    .is_ok()
+            );
+            assert!(
+                authority
+                    .delegate_path_to(
+                        &mut ids,
+                        SERVE_HOST_SUBJECT,
+                        &accidental_subdir_cli_allowed,
+                        true,
+                        [FS_WATCH, FS_SERVE],
+                    )
+                    .is_err()
+            );
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/bin/mech/config.rs
+++ b/src/bin/mech/config.rs
@@ -1,0 +1,380 @@
+use std::path::PathBuf;
+
+use clap::{Arg, ArgAction, Command};
+use mech::*;
+use mech_core::*;
+use mech_runtime::{
+    ConfigProfileOptions, DEFAULT_CONFIG_FILENAME, LogLevel, MechConfigDocument, RuntimeConfig,
+    RuntimeConfigPatch,
+};
+
+pub fn add_config_args(command: Command) -> Command {
+    command
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .value_name("PATH")
+                .num_args(1)
+                .global(true)
+                .help("Load configuration from a Mech config file."),
+        )
+        .arg(
+            Arg::new("no_config")
+                .long("no-config")
+                .action(ArgAction::SetTrue)
+                .global(true)
+                .help("Disable automatic Mech config loading."),
+        )
+}
+
+pub fn load_cli_config(matches: &clap::ArgMatches) -> MResult<Option<MechConfigDocument>> {
+    if matches.get_flag("no_config") {
+        return Ok(None);
+    }
+
+    let path = if let Some(path) = matches.get_one::<String>("config") {
+        PathBuf::from(path)
+    } else {
+        let path = PathBuf::from(DEFAULT_CONFIG_FILENAME);
+        if !path.exists() {
+            return Ok(None);
+        }
+        path
+    };
+
+    let source = std::fs::read_to_string(&path)?;
+    let document = mech_runtime::parse_config_document(
+        path.display().to_string(),
+        &source,
+        ConfigProfileOptions::default(),
+    )?;
+    println!("[Mech Config] Loaded config: {}", path.display());
+    Ok(Some(document))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectiveServeOptions {
+    pub address: String,
+    pub port: String,
+    pub paths: Vec<String>,
+    pub stylesheet_paths: Vec<String>,
+    pub shim_path: String,
+    pub wasm_pkg: String,
+}
+
+pub fn effective_serve_options(
+    serve_matches: &clap::ArgMatches,
+    config: Option<&MechConfigDocument>,
+) -> EffectiveServeOptions {
+    let serve_config = config.and_then(|doc| doc.serve.as_ref());
+
+    let address = serve_matches
+        .get_one::<String>("address")
+        .cloned()
+        .or_else(|| serve_config.and_then(|serve| serve.address.clone()))
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+
+    let port = serve_matches
+        .get_one::<String>("port")
+        .cloned()
+        .or_else(|| serve_config.and_then(|serve| serve.port.map(|port| port.to_string())))
+        .unwrap_or_else(|| "8081".to_string());
+
+    let shim_path = serve_matches
+        .get_one::<String>("shim")
+        .cloned()
+        .or_else(|| {
+            serve_config.and_then(|serve| {
+                serve
+                    .shim
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string())
+            })
+        })
+        .unwrap_or_default();
+
+    let wasm_pkg = serve_matches
+        .get_one::<String>("wasm")
+        .cloned()
+        .or_else(|| {
+            serve_config.and_then(|serve| {
+                serve
+                    .wasm
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string())
+            })
+        })
+        .unwrap_or_default();
+
+    let mut stylesheet_paths: Vec<String> = serve_config
+        .map(|serve| {
+            serve
+                .stylesheets
+                .iter()
+                .map(|path| path.to_string_lossy().to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    stylesheet_paths.extend(
+        serve_matches
+            .get_many::<String>("stylesheet")
+            .into_iter()
+            .flatten()
+            .cloned(),
+    );
+
+    let cli_paths: Vec<String> = serve_matches
+        .get_many::<String>("mech_serve_file_paths")
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect();
+    let paths = if !cli_paths.is_empty() {
+        cli_paths
+    } else {
+        serve_config
+            .map(|serve| {
+                serve
+                    .paths
+                    .iter()
+                    .map(|path| path.to_string_lossy().to_string())
+                    .collect()
+            })
+            .filter(|paths: &Vec<String>| !paths.is_empty())
+            .unwrap_or_default()
+    };
+
+    EffectiveServeOptions {
+        address,
+        port,
+        paths,
+        stylesheet_paths,
+        shim_path,
+        wasm_pkg,
+    }
+}
+
+pub fn apply_runtime_config_patch(
+    mut base: RuntimeConfig,
+    patch: &RuntimeConfigPatch,
+) -> MResult<RuntimeConfig> {
+    if let Some(name) = &patch.name {
+        base.name = name.clone();
+    }
+
+    if let Some(value) = patch.limits.max_steps_per_turn {
+        base.limits.max_steps_per_turn = Some(value);
+    }
+    if let Some(value) = patch.limits.max_turn_duration_ms {
+        base.limits.max_turn_duration_ms = Some(value);
+    }
+    if let Some(value) = patch.limits.max_memory_bytes {
+        base.limits.max_memory_bytes = Some(value);
+    }
+    if let Some(value) = patch.limits.max_tasks {
+        base.limits.max_tasks = Some(value);
+    }
+    if let Some(value) = patch.limits.max_actors {
+        base.limits.max_actors = Some(value);
+    }
+    if let Some(value) = patch.limits.max_actor_mailbox_len {
+        base.limits.max_actor_mailbox_len = Some(value);
+    }
+    if let Some(value) = patch.limits.max_source_bytes {
+        base.limits.max_source_bytes = Some(value);
+    }
+    if let Some(value) = patch.limits.max_in_memory_events {
+        base.limits.max_in_memory_events = Some(value);
+    }
+
+    if let Some(value) = patch.diagnostics.trace_enabled {
+        base.diagnostics.trace_enabled = value;
+    }
+    if let Some(value) = patch.diagnostics.profile_enabled {
+        base.diagnostics.profile_enabled = value;
+    }
+    if let Some(value) = patch.diagnostics.debug_enabled {
+        base.diagnostics.debug_enabled = value;
+    }
+    if let Some(value) = &patch.diagnostics.log_level {
+        base.diagnostics.log_level = match value.as_str() {
+            "error" => LogLevel::Error,
+            "warn" => LogLevel::Warn,
+            "info" => LogLevel::Info,
+            "debug" => LogLevel::Debug,
+            "trace" => LogLevel::Trace,
+            _ => LogLevel::Info,
+        };
+    }
+
+    base.validate()?;
+    Ok(base)
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct CurrentDirGuard {
+        previous: PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CurrentDirGuard {
+        fn enter(path: &std::path::Path) -> Self {
+            let lock = crate::CURRENT_DIR_LOCK.lock().unwrap();
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.previous).unwrap();
+        }
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mech-cli-config-{name}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root.canonicalize().unwrap()
+    }
+
+    fn command() -> Command {
+        add_config_args(
+            Command::new("mech").subcommand(
+                Command::new("serve")
+                    .arg(
+                        Arg::new("mech_serve_file_paths")
+                            .required(false)
+                            .action(ArgAction::Append),
+                    )
+                    .arg(Arg::new("port").long("port").num_args(1))
+                    .arg(Arg::new("address").long("address").num_args(1))
+                    .arg(
+                        Arg::new("stylesheet")
+                            .long("stylesheet")
+                            .num_args(1..)
+                            .action(ArgAction::Append),
+                    )
+                    .arg(Arg::new("shim").long("shim").num_args(1))
+                    .arg(Arg::new("wasm").long("wasm").num_args(1)),
+            ),
+        )
+    }
+
+    fn matches(args: &[&str]) -> clap::ArgMatches {
+        command().try_get_matches_from(args).unwrap()
+    }
+
+    fn parse_config(source: &str) -> MechConfigDocument {
+        mech_runtime::parse_config_document(
+            "test.mcfg".to_string(),
+            source,
+            ConfigProfileOptions::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn explicit_config_loads() {
+        let root = temp_root("explicit");
+        let _guard = CurrentDirGuard::enter(&root);
+        std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
+        let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
+        let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(config.serve.unwrap().port, Some(9090));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn default_config_auto_loads() {
+        let root = temp_root("auto");
+        let _guard = CurrentDirGuard::enter(&root);
+        std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
+        let matches = matches(&["mech", "serve"]);
+        assert!(
+            load_cli_config(matches.subcommand_matches("serve").unwrap())
+                .unwrap()
+                .is_some()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn no_config_disables_auto_load() {
+        let root = temp_root("disabled");
+        let _guard = CurrentDirGuard::enter(&root);
+        std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
+        let matches = matches(&["mech", "--no-config", "serve"]);
+        assert!(
+            load_cli_config(matches.subcommand_matches("serve").unwrap())
+                .unwrap()
+                .is_none()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cli_scalar_options_override_config() {
+        let config = parse_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
+        let matches = matches(&["mech", "serve", "--address", "0.0.0.0", "--port", "9090"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
+        assert_eq!(effective.address, "0.0.0.0");
+        assert_eq!(effective.port, "9090");
+    }
+
+    #[test]
+    fn config_serve_paths_used_when_cli_paths_absent() {
+        let config = parse_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+        let matches = matches(&["mech", "serve"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
+        assert_eq!(effective.paths, vec!["docs/reference"]);
+    }
+
+    #[test]
+    fn cli_serve_paths_override_config_paths() {
+        let config = parse_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+        let matches = matches(&["mech", "serve", "examples/working"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
+        assert_eq!(effective.paths, vec!["examples/working"]);
+    }
+
+    #[test]
+    fn stylesheets_combine() {
+        let config = parse_config(r#"config := {serve: {stylesheets: ["a.css"]}}"#);
+        let matches = matches(&["mech", "serve", "--stylesheet", "b.css"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
+        assert_eq!(effective.stylesheet_paths, vec!["a.css", "b.css"]);
+    }
+
+    #[test]
+    fn runtime_config_patch_applies() {
+        let config = parse_config(
+            r#"config := {runtime: {name: "configured", limits: {max-steps-per-turn: 42}, diagnostics: {trace-enabled: true, log-level: "debug"}}}"#,
+        );
+        let runtime =
+            apply_runtime_config_patch(RuntimeConfig::default(), &config.runtime).unwrap();
+        assert_eq!(runtime.name, "configured");
+        assert_eq!(runtime.limits.max_steps_per_turn, Some(42));
+        assert!(runtime.diagnostics.trace_enabled);
+        assert_eq!(runtime.diagnostics.log_level, LogLevel::Debug);
+    }
+}

--- a/src/bin/mech/config.rs
+++ b/src/bin/mech/config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Arg, ArgAction, Command};
 use mech::*;
@@ -27,21 +27,36 @@ pub fn add_config_args(command: Command) -> Command {
         )
 }
 
-pub fn load_cli_config(matches: &clap::ArgMatches) -> MResult<Option<MechConfigDocument>> {
+#[derive(Clone, Debug)]
+pub struct LoadedMechConfig {
+    pub path: PathBuf,
+    pub base_dir: PathBuf,
+    pub document: MechConfigDocument,
+}
+
+pub fn load_cli_config(matches: &clap::ArgMatches) -> MResult<Option<LoadedMechConfig>> {
     if matches.get_flag("no_config") {
         return Ok(None);
     }
 
+    let current_dir = std::env::current_dir()?;
     let path = if let Some(path) = matches.get_one::<String>("config") {
-        PathBuf::from(path)
+        let path = PathBuf::from(path);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            current_dir.join(path)
+        };
+        path.canonicalize()?
     } else {
-        let path = PathBuf::from(DEFAULT_CONFIG_FILENAME);
+        let path = current_dir.join(DEFAULT_CONFIG_FILENAME);
         if !path.exists() {
             return Ok(None);
         }
-        path
+        path.canonicalize()?
     };
 
+    let base_dir = path.parent().unwrap_or(&current_dir).to_path_buf();
     let source = std::fs::read_to_string(&path)?;
     let document = mech_runtime::parse_config_document(
         path.display().to_string(),
@@ -49,7 +64,19 @@ pub fn load_cli_config(matches: &clap::ArgMatches) -> MResult<Option<MechConfigD
         ConfigProfileOptions::default(),
     )?;
     println!("[Mech Config] Loaded config: {}", path.display());
-    Ok(Some(document))
+    Ok(Some(LoadedMechConfig {
+        path,
+        base_dir,
+        document,
+    }))
+}
+
+pub fn resolve_config_path(base_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_dir.join(path)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,9 +91,14 @@ pub struct EffectiveServeOptions {
 
 pub fn effective_serve_options(
     serve_matches: &clap::ArgMatches,
-    config: Option<&MechConfigDocument>,
+    config: Option<&LoadedMechConfig>,
 ) -> EffectiveServeOptions {
-    let serve_config = config.and_then(|doc| doc.serve.as_ref());
+    let serve_config = config.and_then(|loaded| loaded.document.serve.as_ref());
+    let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
+        resolve_config_path(&loaded.base_dir, path)
+            .to_string_lossy()
+            .to_string()
+    };
 
     let address = serve_matches
         .get_one::<String>("address")
@@ -84,11 +116,13 @@ pub fn effective_serve_options(
         .get_one::<String>("shim")
         .cloned()
         .or_else(|| {
-            serve_config.and_then(|serve| {
-                serve
-                    .shim
-                    .as_ref()
-                    .map(|path| path.to_string_lossy().to_string())
+            config.and_then(|loaded| {
+                loaded.document.serve.as_ref().and_then(|serve| {
+                    serve
+                        .shim
+                        .as_ref()
+                        .map(|path| config_path_to_string(loaded, path))
+                })
             })
         })
         .unwrap_or_default();
@@ -97,22 +131,26 @@ pub fn effective_serve_options(
         .get_one::<String>("wasm")
         .cloned()
         .or_else(|| {
-            serve_config.and_then(|serve| {
-                serve
-                    .wasm
-                    .as_ref()
-                    .map(|path| path.to_string_lossy().to_string())
+            config.and_then(|loaded| {
+                loaded.document.serve.as_ref().and_then(|serve| {
+                    serve
+                        .wasm
+                        .as_ref()
+                        .map(|path| config_path_to_string(loaded, path))
+                })
             })
         })
         .unwrap_or_default();
 
-    let mut stylesheet_paths: Vec<String> = serve_config
-        .map(|serve| {
-            serve
-                .stylesheets
-                .iter()
-                .map(|path| path.to_string_lossy().to_string())
-                .collect()
+    let mut stylesheet_paths: Vec<String> = config
+        .and_then(|loaded| {
+            loaded.document.serve.as_ref().map(|serve| {
+                serve
+                    .stylesheets
+                    .iter()
+                    .map(|path| config_path_to_string(loaded, path))
+                    .collect()
+            })
         })
         .unwrap_or_default();
     stylesheet_paths.extend(
@@ -132,13 +170,15 @@ pub fn effective_serve_options(
     let paths = if !cli_paths.is_empty() {
         cli_paths
     } else {
-        serve_config
-            .map(|serve| {
-                serve
-                    .paths
-                    .iter()
-                    .map(|path| path.to_string_lossy().to_string())
-                    .collect()
+        config
+            .and_then(|loaded| {
+                loaded.document.serve.as_ref().map(|serve| {
+                    serve
+                        .paths
+                        .iter()
+                        .map(|path| config_path_to_string(loaded, path))
+                        .collect()
+                })
             })
             .filter(|paths: &Vec<String>| !paths.is_empty())
             .unwrap_or_default()
@@ -203,7 +243,13 @@ pub fn apply_runtime_config_patch(
             "info" => LogLevel::Info,
             "debug" => LogLevel::Debug,
             "trace" => LogLevel::Trace,
-            _ => LogLevel::Info,
+            other => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("unknown runtime.diagnostics.log-level `{other}`"),
+                )
+                .into());
+            }
         };
     }
 
@@ -278,7 +324,7 @@ mod config_tests {
         command().try_get_matches_from(args).unwrap()
     }
 
-    fn parse_config(source: &str) -> MechConfigDocument {
+    fn parse_document(source: &str) -> MechConfigDocument {
         mech_runtime::parse_config_document(
             "test.mcfg".to_string(),
             source,
@@ -287,50 +333,66 @@ mod config_tests {
         .unwrap()
     }
 
+    fn loaded_config(source: &str) -> LoadedMechConfig {
+        LoadedMechConfig {
+            path: PathBuf::from("test.mcfg"),
+            base_dir: PathBuf::new(),
+            document: parse_document(source),
+        }
+    }
+
     #[test]
     fn explicit_config_loads() {
         let root = temp_root("explicit");
-        let _guard = CurrentDirGuard::enter(&root);
-        std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
-        let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
-        let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(config.serve.unwrap().port, Some(9090));
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
+            let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
+            let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
+                .unwrap()
+                .unwrap();
+            assert_eq!(config.document.serve.unwrap().port, Some(9090));
+            assert_eq!(config.path, root.join("custom.mcfg"));
+            assert_eq!(config.base_dir, root);
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
     fn default_config_auto_loads() {
         let root = temp_root("auto");
-        let _guard = CurrentDirGuard::enter(&root);
-        std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
-        let matches = matches(&["mech", "serve"]);
-        assert!(
-            load_cli_config(matches.subcommand_matches("serve").unwrap())
-                .unwrap()
-                .is_some()
-        );
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
+            let matches = matches(&["mech", "serve"]);
+            assert!(
+                load_cli_config(matches.subcommand_matches("serve").unwrap())
+                    .unwrap()
+                    .is_some()
+            );
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
     fn no_config_disables_auto_load() {
         let root = temp_root("disabled");
-        let _guard = CurrentDirGuard::enter(&root);
-        std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
-        let matches = matches(&["mech", "--no-config", "serve"]);
-        assert!(
-            load_cli_config(matches.subcommand_matches("serve").unwrap())
-                .unwrap()
-                .is_none()
-        );
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
+            let matches = matches(&["mech", "--no-config", "serve"]);
+            assert!(
+                load_cli_config(matches.subcommand_matches("serve").unwrap())
+                    .unwrap()
+                    .is_none()
+            );
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
     fn cli_scalar_options_override_config() {
-        let config = parse_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
+        let config = loaded_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
         let matches = matches(&["mech", "serve", "--address", "0.0.0.0", "--port", "9090"]);
         let effective =
             effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
@@ -340,7 +402,7 @@ mod config_tests {
 
     #[test]
     fn config_serve_paths_used_when_cli_paths_absent() {
-        let config = parse_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+        let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
         let matches = matches(&["mech", "serve"]);
         let effective =
             effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
@@ -349,7 +411,7 @@ mod config_tests {
 
     #[test]
     fn cli_serve_paths_override_config_paths() {
-        let config = parse_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+        let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
         let matches = matches(&["mech", "serve", "examples/working"]);
         let effective =
             effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
@@ -358,7 +420,7 @@ mod config_tests {
 
     #[test]
     fn stylesheets_combine() {
-        let config = parse_config(r#"config := {serve: {stylesheets: ["a.css"]}}"#);
+        let config = loaded_config(r#"config := {serve: {stylesheets: ["a.css"]}}"#);
         let matches = matches(&["mech", "serve", "--stylesheet", "b.css"]);
         let effective =
             effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config));
@@ -366,12 +428,114 @@ mod config_tests {
     }
 
     #[test]
+    fn config_relative_serve_paths_resolve_from_config_file_directory() {
+        let root = temp_root("relative-serve-paths");
+        let subdir = root.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(
+            subdir.join(DEFAULT_CONFIG_FILENAME),
+            r#"config := {
+  serve: {
+    paths: ["app.mec"]
+    stylesheets: ["style.css"]
+    shim: "shim.html"
+    wasm: "pkg"
+  }
+}
+"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let config = load_cli_config(serve_matches).unwrap().unwrap();
+            let effective = effective_serve_options(serve_matches, Some(&config));
+            assert_eq!(
+                effective.paths,
+                vec![subdir.join("app.mec").to_string_lossy().to_string()]
+            );
+            assert_eq!(
+                effective.stylesheet_paths,
+                vec![subdir.join("style.css").to_string_lossy().to_string()]
+            );
+            assert_eq!(
+                effective.shim_path,
+                subdir.join("shim.html").to_string_lossy().to_string()
+            );
+            assert_eq!(
+                effective.wasm_pkg,
+                subdir.join("pkg").to_string_lossy().to_string()
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cli_paths_override_config_paths_and_remain_cwd_relative() {
+        let root = temp_root("cli-paths-cwd-relative");
+        let subdir = root.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(
+            subdir.join(DEFAULT_CONFIG_FILENAME),
+            r#"config := {serve: {paths: ["app.mec"]}}"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve", "other.mec"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let config = load_cli_config(serve_matches).unwrap().unwrap();
+            let effective = effective_serve_options(serve_matches, Some(&config));
+            assert_eq!(effective.paths, vec!["other.mec"]);
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cli_shim_and_wasm_override_config_and_remain_cwd_relative() {
+        let root = temp_root("cli-shim-wasm-cwd-relative");
+        let subdir = root.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(
+            subdir.join(DEFAULT_CONFIG_FILENAME),
+            r#"config := {serve: {shim: "shim.html", wasm: "pkg"}}"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&[
+                "mech",
+                "--config",
+                "subdir/mech.mcfg",
+                "serve",
+                "--shim",
+                "cli-shim.html",
+                "--wasm",
+                "cli-pkg",
+            ]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let config = load_cli_config(serve_matches).unwrap().unwrap();
+            let effective = effective_serve_options(serve_matches, Some(&config));
+            assert_eq!(effective.shim_path, "cli-shim.html");
+            assert_eq!(effective.wasm_pkg, "cli-pkg");
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn runtime_config_patch_rejects_unknown_log_level() {
+        let mut patch = RuntimeConfigPatch::default();
+        patch.diagnostics.log_level = Some("verbose".to_string());
+        assert!(apply_runtime_config_patch(RuntimeConfig::default(), &patch).is_err());
+    }
+    #[test]
     fn runtime_config_patch_applies() {
-        let config = parse_config(
+        let config = loaded_config(
             r#"config := {runtime: {name: "configured", limits: {max-steps-per-turn: 42}, diagnostics: {trace-enabled: true, log-level: "debug"}}}"#,
         );
         let runtime =
-            apply_runtime_config_patch(RuntimeConfig::default(), &config.runtime).unwrap();
+            apply_runtime_config_patch(RuntimeConfig::default(), &config.document.runtime).unwrap();
         assert_eq!(runtime.name, "configured");
         assert_eq!(runtime.limits.max_steps_per_turn, Some(42));
         assert!(runtime.diagnostics.trace_enabled);

--- a/src/runtime/src/service/workspace_session.rs
+++ b/src/runtime/src/service/workspace_session.rs
@@ -4,7 +4,7 @@ use mech_core::MResult;
 
 use crate::{
   DefaultIdGenerator, EventSink, FileSourceResolver, IdGenerator, MechRuntime, SharedCapabilityKernel,
-  ModuleBuildOptions, RuntimeBuilder, RuntimeEvent, RuntimeEventKind,
+  ModuleBuildOptions, RuntimeBuilder, RuntimeConfig, RuntimeEvent, RuntimeEventKind,
   RuntimeWorkspace, RuntimeWorkspaceConfig, RuntimeWorkspaceDiagnostic,
   RuntimeWorkspaceFolder, RuntimeWorkspaceRefresh, RuntimeWorkspaceSnapshot,
   RuntimeWorkspaceTarget, RuntimeWorkspaceWatcher, RuntimeWorkspaceWatchPoll,
@@ -56,9 +56,17 @@ impl ServerWorkspaceSession {
     root: impl Into<PathBuf>, targets: Vec<RuntimeWorkspaceTarget>, folders: Vec<RuntimeWorkspaceFolder>,
     options: ModuleBuildOptions, capability_kernel: SharedCapabilityKernel, capability_subject: impl Into<String>,
   ) -> MResult<Self> {
+    Self::open_with_capabilities_and_config(root, targets, folders, options, capability_kernel, capability_subject, RuntimeConfig::default())
+  }
+
+  pub fn open_with_capabilities_and_config(
+    root: impl Into<PathBuf>, targets: Vec<RuntimeWorkspaceTarget>, folders: Vec<RuntimeWorkspaceFolder>,
+    options: ModuleBuildOptions, capability_kernel: SharedCapabilityKernel, capability_subject: impl Into<String>, runtime_config: RuntimeConfig,
+  ) -> MResult<Self> {
     let root = root.into();
     let capability_subject = capability_subject.into();
     let mut runtime = RuntimeBuilder::new()
+      .config(runtime_config)
       .capability_kernel(capability_kernel.clone())
       .source_resolver(FileSourceResolver::new(&root).with_capabilities(capability_kernel, capability_subject.clone()))
       .build()?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -9,7 +9,7 @@ use colored::*;
 use ignore::WalkBuilder;
 use mech_core::*;
 use mech_runtime::{
-  EventId, EventSink, ModuleBuildOptions, RuntimeEvent, RuntimeWorkspaceFolder,
+  EventId, EventSink, ModuleBuildOptions, RuntimeConfig, RuntimeEvent, RuntimeWorkspaceFolder,
   RuntimeWorkspaceSnapshot, RuntimeWorkspaceTarget, RuntimeWorkspaceWatchEvent,
   ServerWorkspaceSession, HostFilesystemAuthority, DefaultIdGenerator, IdGenerator, SERVE_HOST_SUBJECT,
   FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH, MECH_TOOL_SUBJECT, check_fs_capability,
@@ -348,10 +348,15 @@ pub struct MechServer {
   wasm: Vec<u8>,
   authority: HostFilesystemAuthority,
   serve_subject: String,
+  runtime_config: RuntimeConfig,
 }
 
 impl MechServer {
   pub fn new(name: String, full_address: String, stylesheet: String, html_shim: String, wasm: Vec<u8>, js: Vec<u8>, authority: HostFilesystemAuthority) -> Self {
+    Self::new_with_runtime_config(name, full_address, stylesheet, html_shim, wasm, js, authority, RuntimeConfig::default())
+  }
+
+  pub fn new_with_runtime_config(name: String, full_address: String, stylesheet: String, html_shim: String, wasm: Vec<u8>, js: Vec<u8>, authority: HostFilesystemAuthority, runtime_config: RuntimeConfig) -> Self {
     Self {
       name,
       init: false,
@@ -366,6 +371,7 @@ impl MechServer {
       wasm,
       authority,
       serve_subject: SERVE_HOST_SUBJECT.to_string(),
+      runtime_config,
     }
   }
 
@@ -442,7 +448,7 @@ impl MechServer {
     println!("{} Static assets loaded in {:?}.", self.badge(), static_started.elapsed());
     let session_started = Instant::now();
     println!("{} Opening runtime workspace session…", self.badge());
-    let mut session = ServerWorkspaceSession::open_with_capabilities(&root, plan.targets, plan.folders, module_options(), self.authority.kernel().clone(), self.serve_subject.clone())?;
+    let mut session = ServerWorkspaceSession::open_with_capabilities_and_config(&root, plan.targets, plan.folders, module_options(), self.authority.kernel().clone(), self.serve_subject.clone(), self.runtime_config.clone())?;
     println!("{} Runtime workspace session opened in {:?}.", self.badge(), session_started.elapsed());
     for path in session.watcher().watched_paths() {
       println!("{} Watching: {}", self.badge(), path.display());


### PR DESCRIPTION
### Motivation
- Wire typed `mech.mcfg` config documents produced by the config-profile layer into the CLI and serve host so serve behavior and host capabilities can be configured declaratively.

### Description
- Adds global CLI args `--config <PATH>` and `--no-config` and auto-loads `./mech.mcfg` when present, logging `[Mech Config] Loaded config: <path>` on load.
- Introduces `src/bin/mech/config.rs` with `load_cli_config`, `EffectiveServeOptions`, `effective_serve_options`, and `apply_runtime_config_patch` to compute effective serve options and apply `RuntimeConfigPatch` to a `RuntimeConfig`.
- Adds `src/bin/mech/capabilities.rs` that refactors filesystem capability arg parsing and implements `build_mech_filesystem_authority(matches, config, badge)` to merge CLI flags and config `ConfigCapabilityGrant`s, validate `cap-root` directories, aggregate operations per resolved path+recursive key, and respect `--no-default-capabilities` semantics while preserving config grants.
- Wires the new flow into the `serve` command: load config via `config::load_cli_config`, compute `effective` via `config::effective_serve_options`, build `runtime_config` via `apply_runtime_config_patch`, build `authority` via `capabilities::build_mech_filesystem_authority`, and pass the patched `RuntimeConfig` into `MechServer` construction (added `MechServer::new_with_runtime_config` and `ServerWorkspaceSession::open_with_capabilities_and_config`).
- Preserves precedence rules: CLI scalar options override config scalars; CLI serve paths override config serve paths; stylesheets from config are appended before CLI `--stylesheet`; config and CLI capability grants are unioned/aggregated; config capabilities suppress the broad implicit current-directory grant unless no explicit sources exist or `--no-default-capabilities` is used (which only toggles the implicit grant).

### Testing
- Ran `cargo test --features serve config -- --nocapture` and `cargo test --features serve filesystem_capability -- --nocapture` and `cargo test --features serve`; the added CLI/config unit tests and capability tests passed (final run: all relevant tests passed).
- Ran `cargo check --features serve` and `cargo test -p mech-runtime config_profile -- --nocapture` plus `cargo test -p mech-runtime --lib --tests`; `mech-runtime` tests passed in the runs performed.
- Ran `rustfmt` on the new files and overall `cargo fmt`; an unrelated pre-existing trailing-whitespace issue in `src/wasm/*` caused `cargo fmt` to report failures but the new code was formatted and tests still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c03ae52c832a8441b587f6b2f516)