### PR TITLE
Integrate mech-wasm with MechRuntime host boundary

### DIFF
--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -174,6 +174,62 @@ impl MechProgram {
     result
   }
 
+  pub fn out_string(&self) -> String {
+    self.interpreter.out.to_string()
+  }
+
+  pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
+    with_interpreter(&self.interpreter, interpreter_id, &mut |_| ()).is_some()
+  }
+
+  pub fn output_value_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<Value> {
+    with_interpreter(&self.interpreter, interpreter_id, &mut |interpreter| {
+      interpreter.out_values.borrow().get(&output_id).cloned()
+    })
+    .flatten()
+  }
+
+  pub fn symbol_name_for_interpreter_output(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<String> {
+    with_interpreter(&self.interpreter, interpreter_id, &mut |interpreter| {
+      interpreter.symbols().borrow().get_symbol_name_by_id(output_id)
+    })
+    .flatten()
+  }
+
+  pub fn symbol_values_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    names: &[String],
+  ) -> Option<Vec<(String, Value)>> {
+    with_interpreter(&self.interpreter, interpreter_id, &mut |interpreter| {
+      let symbols = interpreter.symbols();
+      let symbols_brrw = symbols.borrow();
+      symbol_rows(&symbols_brrw, names)
+    })
+  }
+
+  pub fn bind_ans_for_interpreter(
+    &mut self,
+    interpreter_id: u64,
+    value: &Value,
+  ) -> bool {
+    bind_ans_recursive(&mut self.interpreter, interpreter_id, value)
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn step(&mut self, count: u64) -> MResult<()> {
+    self.interpreter.step(count as usize, 1)?;
+    Ok(())
+  }
+
   pub fn run_source(&mut self, source: &MechSourceCode) -> MResult<Value> {
     match source {
       MechSourceCode::String(source) => self.run_string(source),
@@ -217,6 +273,97 @@ impl MechProgram {
   }
 }
 
+fn with_interpreter<T>(
+  interpreter: &Interpreter,
+  interpreter_id: u64,
+  f: &mut impl FnMut(&Interpreter) -> T,
+) -> Option<T> {
+  if interpreter_id == 0 || interpreter.id == interpreter_id {
+    return Some(f(interpreter));
+  }
+
+  let sub_interpreters = interpreter.sub_interpreters.borrow();
+  for sub_interpreter in sub_interpreters.values() {
+    if let Some(result) = with_interpreter(sub_interpreter.as_ref(), interpreter_id, f) {
+      return Some(result);
+    }
+  }
+
+  None
+}
+
+fn bind_ans_recursive(
+  interpreter: &mut Interpreter,
+  interpreter_id: u64,
+  value: &Value,
+) -> bool {
+  if interpreter_id == 0 || interpreter.id == interpreter_id {
+    bind_ans_on_interpreter(interpreter, value);
+    return true;
+  }
+
+  let child_ids = {
+    let sub_interpreters = interpreter.sub_interpreters.borrow();
+    sub_interpreters.keys().copied().collect::<Vec<_>>()
+  };
+
+  for child_id in child_ids {
+    let mut sub_interpreters = interpreter.sub_interpreters.borrow_mut();
+    let Some(child) = sub_interpreters.get_mut(&child_id) else {
+      continue;
+    };
+    if bind_ans_recursive(child.as_mut(), interpreter_id, value) {
+      return true;
+    }
+  }
+
+  false
+}
+
+fn bind_ans_on_interpreter(
+  interpreter: &mut Interpreter,
+  value: &Value,
+) {
+  let resolved_value = match value {
+    Value::MutableReference(reference) => reference.borrow().clone(),
+    _ => value.clone(),
+  };
+  let ans_id = hash_str("ans");
+  let symbols = interpreter.symbols();
+  let mut symbols_brrw = symbols.borrow_mut();
+  symbols_brrw.insert(ans_id, resolved_value, false);
+  symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
+  interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+}
+
+fn symbol_rows(symbol_table: &mech_core::SymbolTable, names: &[String]) -> Vec<(String, Value)> {
+  let dictionary = symbol_table.dictionary.borrow();
+  let mut rows = Vec::new();
+
+  if !names.is_empty() {
+    for target_name in names {
+      for (id, name) in dictionary.iter() {
+        if name == target_name {
+          if let Some(value_ref) = symbol_table.symbols.get(id) {
+            let value = value_ref.borrow();
+            rows.push((name.clone(), value.clone()));
+          }
+          break;
+        }
+      }
+    }
+  } else {
+    for (id, value_ref) in symbol_table.symbols.iter() {
+      if let Some(name) = dictionary.get(id) {
+        let value = value_ref.borrow();
+        rows.push((name.clone(), value.clone()));
+      }
+    }
+  }
+
+  rows
+}
+
 #[derive(Debug, Clone)]
 pub struct UnsupportedProgramSourceError {
   pub source_kind: String,
@@ -229,5 +376,72 @@ impl MechErrorKind for UnsupportedProgramSourceError {
 
   fn message(&self) -> String {
     format!("Unsupported program source: {}", self.source_kind)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn program_with_nested_interpreter(nested_id: u64, child_id: u64) -> MechProgram {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let mut child = program.interpreter().clone();
+    child.clear();
+    child.id = child_id;
+    let mut nested = program.interpreter().clone();
+    nested.clear();
+    nested.id = nested_id;
+    child
+      .sub_interpreters
+      .borrow_mut()
+      .insert(nested_id, Box::new(nested));
+    program
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, Box::new(child));
+    program
+  }
+
+  #[test]
+  fn program_has_interpreter_finds_nested_interpreter() {
+    let program = program_with_nested_interpreter(4242, 2424);
+    assert!(program.has_interpreter(4242));
+  }
+
+  #[test]
+  fn program_output_value_for_interpreter_finds_nested_interpreter() {
+    let nested_id = 4242;
+    let child_id = 2424;
+    let output_id = 101;
+    let mut program = program_with_nested_interpreter(nested_id, child_id);
+    {
+      let root = program.interpreter_mut();
+      let mut sub_interpreters = root.sub_interpreters.borrow_mut();
+      let child = sub_interpreters.get_mut(&child_id).unwrap();
+      let mut child_sub_interpreters = child.sub_interpreters.borrow_mut();
+      let nested = child_sub_interpreters.get_mut(&nested_id).unwrap();
+      nested
+        .out_values
+        .borrow_mut()
+        .insert(output_id, Value::U64(mech_core::Ref::new(42)));
+    }
+
+    assert!(program.output_value_for_interpreter(nested_id, output_id).is_some());
+  }
+
+  #[test]
+  fn program_bind_ans_for_interpreter_binds_ans() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let value = Value::U64(mech_core::Ref::new(42));
+    assert!(program.bind_ans_for_interpreter(0, &value));
+    let ans_id = hash_str("ans");
+    let bound = program
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(ans_id)
+      .map(|value| value.borrow().clone());
+    assert_eq!(bound, Some(value));
   }
 }

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -150,7 +150,6 @@ notify = ["dep:notify"]
 [dependencies]
 blake3 = "1.8.5"
 mech-program = { version = "0.3.5", default-features = false }
-mech-interpreter = { version = "0.3.5", default-features = false }
 mech-core = { version = "0.3.5", default-features = false }
 mech-syntax = { version = "0.3.5", default-features = false }
 serde = { version = "1.0.228", optional = true }

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -150,6 +150,7 @@ notify = ["dep:notify"]
 [dependencies]
 blake3 = "1.8.5"
 mech-program = { version = "0.3.5", default-features = false }
+mech-interpreter = { version = "0.3.5", default-features = false }
 mech-core = { version = "0.3.5", default-features = false }
 mech-syntax = { version = "0.3.5", default-features = false }
 serde = { version = "1.0.228", optional = true }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -187,6 +187,183 @@ impl MechRuntime {
     result
   }
 
+
+  pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
+    let mut context = self.runtime_context()?;
+    self.run_tree_with_context(&mut context, tree)
+  }
+
+  pub fn run_tree_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    tree: &mech_core::Program,
+  ) -> MResult<Value> {
+    context.validate()?;
+    context.charge_step()?;
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    let program_config = self.program.config.clone();
+    let mut program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config),
+    );
+
+    self.register_runtime_program_host_functions(
+      context,
+      &mut program,
+    )?;
+
+    let runtime_ptr: *mut MechRuntime = self;
+    let context_ptr: *mut RuntimeContext = context;
+
+    let previous_target = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(Some(RuntimeProgramHostTarget {
+        runtime: runtime_ptr,
+        context: context_ptr,
+      }))
+    });
+
+    let result = program.run_tree(tree);
+
+    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(previous_target);
+    });
+
+    self.program = program;
+
+    match &result {
+      Ok(_) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
+        )?;
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+      }
+    }
+
+    result
+  }
+
+  pub fn out_string(&self) -> String {
+    self.program.interpreter().out.to_string()
+  }
+
+  pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
+    let root = self.program.interpreter();
+    if interpreter_id == 0 || root.id == interpreter_id {
+      return true;
+    }
+    root.sub_interpreters.borrow().contains_key(&interpreter_id)
+  }
+
+  pub fn output_value_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<Value> {
+    let root = self.program.interpreter();
+    if interpreter_id == 0 || root.id == interpreter_id {
+      return root.out_values.borrow().get(&output_id).cloned();
+    }
+    root
+      .sub_interpreters
+      .borrow()
+      .get(&interpreter_id)
+      .and_then(|interpreter| interpreter.out_values.borrow().get(&output_id).cloned())
+  }
+
+  pub fn symbol_name_for_interpreter_output(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<String> {
+    let root = self.program.interpreter();
+    if interpreter_id == 0 || root.id == interpreter_id {
+      return root.symbols().borrow().get_symbol_name_by_id(output_id);
+    }
+    root
+      .sub_interpreters
+      .borrow()
+      .get(&interpreter_id)
+      .and_then(|interpreter| interpreter.symbols().borrow().get_symbol_name_by_id(output_id))
+  }
+
+  pub fn symbol_values_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    names: &[String],
+  ) -> Option<Vec<(String, Value)>> {
+    let root = self.program.interpreter();
+    if interpreter_id == 0 || root.id == interpreter_id {
+      let symbols = root.symbols();
+      let symbols_brrw = symbols.borrow();
+      return Some(symbol_rows(&symbols_brrw, names));
+    }
+    root
+      .sub_interpreters
+      .borrow()
+      .get(&interpreter_id)
+      .map(|interpreter| {
+        let symbols = interpreter.symbols();
+        let symbols_brrw = symbols.borrow();
+        symbol_rows(&symbols_brrw, names)
+      })
+  }
+
+  pub fn bind_ans_for_interpreter(
+    &mut self,
+    interpreter_id: u64,
+    value: &Value,
+  ) -> MResult<()> {
+    let resolved_value = match value {
+      Value::MutableReference(reference) => reference.borrow().clone(),
+      _ => value.clone(),
+    };
+    let ans_id = hash_str("ans");
+    let root = self.program.interpreter_mut();
+    if interpreter_id == 0 || root.id == interpreter_id {
+      let symbols = root.symbols();
+      let mut symbols_brrw = symbols.borrow_mut();
+      symbols_brrw.insert(ans_id, resolved_value, false);
+      symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
+      root.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+      return Ok(());
+    }
+
+    let mut sub_interpreters = root.sub_interpreters.borrow_mut();
+    let Some(interpreter) = sub_interpreters.get_mut(&interpreter_id) else {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "bind_ans_for_interpreter",
+          reason: format!("interpreter id {} not found", interpreter_id),
+        },
+        None,
+      ));
+    };
+    let symbols = interpreter.symbols();
+    let mut symbols_brrw = symbols.borrow_mut();
+    symbols_brrw.insert(ans_id, resolved_value, false);
+    symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
+    interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+    Ok(())
+  }
+
   pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
     let mut context = self.runtime_context()?
       .with_module_version(version);
@@ -583,6 +760,34 @@ impl MechRuntime {
   }
 }
 
+fn symbol_rows(symbol_table: &mech_core::SymbolTable, names: &[String]) -> Vec<(String, Value)> {
+  let dictionary = symbol_table.dictionary.borrow();
+  let mut rows = Vec::new();
+
+  if !names.is_empty() {
+    for target_name in names {
+      for (id, name) in dictionary.iter() {
+        if name == target_name {
+          if let Some(value_ref) = symbol_table.symbols.get(id) {
+            let value = value_ref.borrow();
+            rows.push((name.clone(), value.clone()));
+          }
+          break;
+        }
+      }
+    }
+  } else {
+    for (id, value_ref) in symbol_table.symbols.iter() {
+      if let Some(name) = dictionary.get(id) {
+        let value = value_ref.borrow();
+        rows.push((name.clone(), value.clone()));
+      }
+    }
+  }
+
+  rows
+}
+
 fn module_source_for_scope(
   source: &MechSourceCode,
   scope: &SourceScope,
@@ -708,4 +913,48 @@ pub fn strip_module_declarations_for_execution(source: &str) -> String {
     })
     .collect::<Vec<_>>()
     .join("\n")
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn runtime_has_interpreter_finds_root_interpreter() {
+    let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    assert!(runtime.has_interpreter(0));
+  }
+
+  #[test]
+  fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let source = "```mech
+1
+```";
+    let _ = runtime.run_string(source).unwrap();
+    let root_id = runtime.program().interpreter().id;
+    let output_id = {
+      let out_values = runtime.program().interpreter().out_values.borrow();
+      *out_values.keys().next().expect("expected output value after run_string")
+    };
+    let output = runtime.output_value_for_interpreter(root_id, output_id);
+    assert!(output.is_some());
+  }
+
+  #[test]
+  fn runtime_bind_ans_for_interpreter_binds_ans() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let value = Value::U64(Ref::new(42));
+    runtime.bind_ans_for_interpreter(0, &value).unwrap();
+    let ans_id = hash_str("ans");
+    let bound = runtime
+      .program()
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(ans_id)
+      .map(|value| value.borrow().clone());
+    assert_eq!(bound, Some(value));
+  }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -15,6 +15,47 @@ use super::*;
 
 const DEFAULT_RESOURCE_SUBJECT: &str = "task://main";
 
+
+macro_rules! with_interpreter {
+  ($interpreter:expr, $interpreter_id:expr, $name:ident, $body:block) => {{
+    let root = $interpreter;
+    let mut stack = vec![std::ptr::from_ref(root)];
+    let mut result = None;
+    while let Some(interpreter) = stack.pop() {
+      let $name = unsafe { &*interpreter };
+      if $interpreter_id == 0 || $name.id == $interpreter_id {
+        result = Some($body);
+        break;
+      }
+      let sub_interpreters = $name.sub_interpreters.borrow();
+      for sub_interpreter in sub_interpreters.values() {
+        stack.push(std::ptr::from_ref(sub_interpreter.as_ref()));
+      }
+    }
+    result
+  }};
+}
+
+macro_rules! with_interpreter_mut {
+  ($interpreter:expr, $interpreter_id:expr, $name:ident, $body:block) => {{
+    let root = $interpreter;
+    let mut stack = vec![std::ptr::from_mut(root)];
+    let mut result = None;
+    while let Some(interpreter) = stack.pop() {
+      let $name = unsafe { &mut *interpreter };
+      if $interpreter_id == 0 || $name.id == $interpreter_id {
+        result = Some($body);
+        break;
+      }
+      let mut sub_interpreters = $name.sub_interpreters.borrow_mut();
+      for sub_interpreter in sub_interpreters.values_mut() {
+        stack.push(std::ptr::from_mut(sub_interpreter.as_mut()));
+      }
+    }
+    result
+  }};
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
   Interpreter(SourceScope),
@@ -265,11 +306,7 @@ impl MechRuntime {
   }
 
   pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-    let root = self.program.interpreter();
-    if interpreter_id == 0 || root.id == interpreter_id {
-      return true;
-    }
-    root.sub_interpreters.borrow().contains_key(&interpreter_id)
+    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, { () }).is_some()
   }
 
   pub fn output_value_for_interpreter(
@@ -277,15 +314,10 @@ impl MechRuntime {
     interpreter_id: u64,
     output_id: u64,
   ) -> Option<Value> {
-    let root = self.program.interpreter();
-    if interpreter_id == 0 || root.id == interpreter_id {
-      return root.out_values.borrow().get(&output_id).cloned();
-    }
-    root
-      .sub_interpreters
-      .borrow()
-      .get(&interpreter_id)
-      .and_then(|interpreter| interpreter.out_values.borrow().get(&output_id).cloned())
+    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, {
+      interpreter.out_values.borrow().get(&output_id).cloned()
+    })
+    .flatten()
   }
 
   pub fn symbol_name_for_interpreter_output(
@@ -293,15 +325,10 @@ impl MechRuntime {
     interpreter_id: u64,
     output_id: u64,
   ) -> Option<String> {
-    let root = self.program.interpreter();
-    if interpreter_id == 0 || root.id == interpreter_id {
-      return root.symbols().borrow().get_symbol_name_by_id(output_id);
-    }
-    root
-      .sub_interpreters
-      .borrow()
-      .get(&interpreter_id)
-      .and_then(|interpreter| interpreter.symbols().borrow().get_symbol_name_by_id(output_id))
+    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, {
+      interpreter.symbols().borrow().get_symbol_name_by_id(output_id)
+    })
+    .flatten()
   }
 
   pub fn symbol_values_for_interpreter(
@@ -309,21 +336,11 @@ impl MechRuntime {
     interpreter_id: u64,
     names: &[String],
   ) -> Option<Vec<(String, Value)>> {
-    let root = self.program.interpreter();
-    if interpreter_id == 0 || root.id == interpreter_id {
-      let symbols = root.symbols();
+    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, {
+      let symbols = interpreter.symbols();
       let symbols_brrw = symbols.borrow();
-      return Some(symbol_rows(&symbols_brrw, names));
-    }
-    root
-      .sub_interpreters
-      .borrow()
-      .get(&interpreter_id)
-      .map(|interpreter| {
-        let symbols = interpreter.symbols();
-        let symbols_brrw = symbols.borrow();
-        symbol_rows(&symbols_brrw, names)
-      })
+      symbol_rows(&symbols_brrw, names)
+    })
   }
 
   pub fn bind_ans_for_interpreter(
@@ -331,36 +348,35 @@ impl MechRuntime {
     interpreter_id: u64,
     value: &Value,
   ) -> MResult<()> {
-    let resolved_value = match value {
-      Value::MutableReference(reference) => reference.borrow().clone(),
-      _ => value.clone(),
-    };
-    let ans_id = hash_str("ans");
-    let root = self.program.interpreter_mut();
-    if interpreter_id == 0 || root.id == interpreter_id {
-      let symbols = root.symbols();
+    let bound = with_interpreter_mut!(self.program.interpreter_mut(), interpreter_id, interpreter, {
+      let resolved_value = match value {
+        Value::MutableReference(reference) => reference.borrow().clone(),
+        _ => value.clone(),
+      };
+      let ans_id = hash_str("ans");
+      let symbols = interpreter.symbols();
       let mut symbols_brrw = symbols.borrow_mut();
       symbols_brrw.insert(ans_id, resolved_value, false);
       symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
-      root.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+      interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+    });
+
+    if bound.is_some() {
       return Ok(());
     }
 
-    let mut sub_interpreters = root.sub_interpreters.borrow_mut();
-    let Some(interpreter) = sub_interpreters.get_mut(&interpreter_id) else {
-      return Err(MechError::new(
-        RuntimeInvalidOperationError {
-          operation: "bind_ans_for_interpreter",
-          reason: format!("interpreter id {} not found", interpreter_id),
-        },
-        None,
-      ));
-    };
-    let symbols = interpreter.symbols();
-    let mut symbols_brrw = symbols.borrow_mut();
-    symbols_brrw.insert(ans_id, resolved_value, false);
-    symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
-    interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+    Err(MechError::new(
+      RuntimeInvalidOperationError {
+        operation: "bind_ans_for_interpreter",
+        reason: format!("interpreter id {} not found", interpreter_id),
+      },
+      None,
+    ))
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn step(&mut self, count: u64) -> MResult<()> {
+    self.program.interpreter_mut().step(count as usize, 1)?;
     Ok(())
   }
 
@@ -760,6 +776,7 @@ impl MechRuntime {
   }
 }
 
+
 fn symbol_rows(symbol_table: &mech_core::SymbolTable, names: &[String]) -> Vec<(String, Value)> {
   let dictionary = symbol_table.dictionary.borrow();
   let mut rows = Vec::new();
@@ -940,6 +957,61 @@ mod tests {
     };
     let output = runtime.output_value_for_interpreter(root_id, output_id);
     assert!(output.is_some());
+  }
+
+  #[test]
+  fn runtime_has_interpreter_finds_nested_interpreter() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let nested_id = 4242;
+    let child_id = 2424;
+    let mut child = runtime.program().interpreter().clone();
+    child.clear();
+    child.id = child_id;
+    let mut nested = runtime.program().interpreter().clone();
+    nested.clear();
+    nested.id = nested_id;
+    child
+      .sub_interpreters
+      .borrow_mut()
+      .insert(nested_id, Box::new(nested));
+    runtime
+      .program_mut()
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, Box::new(child));
+
+    assert!(runtime.has_interpreter(nested_id));
+  }
+
+  #[test]
+  fn runtime_output_value_for_interpreter_finds_nested_interpreter() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let nested_id = 4242;
+    let child_id = 2424;
+    let output_id = 101;
+    let mut child = runtime.program().interpreter().clone();
+    child.clear();
+    child.id = child_id;
+    let mut nested = runtime.program().interpreter().clone();
+    nested.clear();
+    nested.id = nested_id;
+    nested
+      .out_values
+      .borrow_mut()
+      .insert(output_id, Value::U64(Ref::new(42)));
+    child
+      .sub_interpreters
+      .borrow_mut()
+      .insert(nested_id, Box::new(nested));
+    runtime
+      .program_mut()
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, Box::new(child));
+
+    assert!(runtime.output_value_for_interpreter(nested_id, output_id).is_some());
   }
 
   #[test]

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -16,46 +16,6 @@ use super::*;
 const DEFAULT_RESOURCE_SUBJECT: &str = "task://main";
 
 
-macro_rules! with_interpreter {
-  ($interpreter:expr, $interpreter_id:expr, $name:ident, $body:block) => {{
-    let root = $interpreter;
-    let mut stack = vec![std::ptr::from_ref(root)];
-    let mut result = None;
-    while let Some(interpreter) = stack.pop() {
-      let $name = unsafe { &*interpreter };
-      if $interpreter_id == 0 || $name.id == $interpreter_id {
-        result = Some($body);
-        break;
-      }
-      let sub_interpreters = $name.sub_interpreters.borrow();
-      for sub_interpreter in sub_interpreters.values() {
-        stack.push(std::ptr::from_ref(sub_interpreter.as_ref()));
-      }
-    }
-    result
-  }};
-}
-
-macro_rules! with_interpreter_mut {
-  ($interpreter:expr, $interpreter_id:expr, $name:ident, $body:block) => {{
-    let root = $interpreter;
-    let mut stack = vec![std::ptr::from_mut(root)];
-    let mut result = None;
-    while let Some(interpreter) = stack.pop() {
-      let $name = unsafe { &mut *interpreter };
-      if $interpreter_id == 0 || $name.id == $interpreter_id {
-        result = Some($body);
-        break;
-      }
-      let mut sub_interpreters = $name.sub_interpreters.borrow_mut();
-      for sub_interpreter in sub_interpreters.values_mut() {
-        stack.push(std::ptr::from_mut(sub_interpreter.as_mut()));
-      }
-    }
-    result
-  }};
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
   Interpreter(SourceScope),
@@ -306,7 +266,7 @@ impl MechRuntime {
   }
 
   pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, { () }).is_some()
+    with_interpreter(self.program.interpreter(), interpreter_id, &mut |_| ()).is_some()
   }
 
   pub fn output_value_for_interpreter(
@@ -314,7 +274,7 @@ impl MechRuntime {
     interpreter_id: u64,
     output_id: u64,
   ) -> Option<Value> {
-    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, {
+    with_interpreter(self.program.interpreter(), interpreter_id, &mut |interpreter| {
       interpreter.out_values.borrow().get(&output_id).cloned()
     })
     .flatten()
@@ -325,7 +285,7 @@ impl MechRuntime {
     interpreter_id: u64,
     output_id: u64,
   ) -> Option<String> {
-    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, {
+    with_interpreter(self.program.interpreter(), interpreter_id, &mut |interpreter| {
       interpreter.symbols().borrow().get_symbol_name_by_id(output_id)
     })
     .flatten()
@@ -336,7 +296,7 @@ impl MechRuntime {
     interpreter_id: u64,
     names: &[String],
   ) -> Option<Vec<(String, Value)>> {
-    with_interpreter!(self.program.interpreter(), interpreter_id, interpreter, {
+    with_interpreter(self.program.interpreter(), interpreter_id, &mut |interpreter| {
       let symbols = interpreter.symbols();
       let symbols_brrw = symbols.borrow();
       symbol_rows(&symbols_brrw, names)
@@ -348,20 +308,7 @@ impl MechRuntime {
     interpreter_id: u64,
     value: &Value,
   ) -> MResult<()> {
-    let bound = with_interpreter_mut!(self.program.interpreter_mut(), interpreter_id, interpreter, {
-      let resolved_value = match value {
-        Value::MutableReference(reference) => reference.borrow().clone(),
-        _ => value.clone(),
-      };
-      let ans_id = hash_str("ans");
-      let symbols = interpreter.symbols();
-      let mut symbols_brrw = symbols.borrow_mut();
-      symbols_brrw.insert(ans_id, resolved_value, false);
-      symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
-      interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
-    });
-
-    if bound.is_some() {
+    if bind_ans_recursive(self.program.interpreter_mut(), interpreter_id, value) {
       return Ok(());
     }
 
@@ -776,6 +723,69 @@ impl MechRuntime {
   }
 }
 
+
+fn with_interpreter<T>(
+  interpreter: &mech_interpreter::Interpreter,
+  interpreter_id: u64,
+  f: &mut impl FnMut(&mech_interpreter::Interpreter) -> T,
+) -> Option<T> {
+  if interpreter_id == 0 || interpreter.id == interpreter_id {
+    return Some(f(interpreter));
+  }
+
+  let sub_interpreters = interpreter.sub_interpreters.borrow();
+  for sub_interpreter in sub_interpreters.values() {
+    if let Some(result) = with_interpreter(sub_interpreter.as_ref(), interpreter_id, f) {
+      return Some(result);
+    }
+  }
+
+  None
+}
+
+fn bind_ans_recursive(
+  interpreter: &mut mech_interpreter::Interpreter,
+  interpreter_id: u64,
+  value: &Value,
+) -> bool {
+  if interpreter_id == 0 || interpreter.id == interpreter_id {
+    bind_ans_on_interpreter(interpreter, value);
+    return true;
+  }
+
+  let child_ids = {
+    let sub_interpreters = interpreter.sub_interpreters.borrow();
+    sub_interpreters.keys().copied().collect::<Vec<_>>()
+  };
+
+  for child_id in child_ids {
+    let mut sub_interpreters = interpreter.sub_interpreters.borrow_mut();
+    let Some(child) = sub_interpreters.get_mut(&child_id) else {
+      continue;
+    };
+    if bind_ans_recursive(child.as_mut(), interpreter_id, value) {
+      return true;
+    }
+  }
+
+  false
+}
+
+fn bind_ans_on_interpreter(
+  interpreter: &mut mech_interpreter::Interpreter,
+  value: &Value,
+) {
+  let resolved_value = match value {
+    Value::MutableReference(reference) => reference.borrow().clone(),
+    _ => value.clone(),
+  };
+  let ans_id = hash_str("ans");
+  let symbols = interpreter.symbols();
+  let mut symbols_brrw = symbols.borrow_mut();
+  symbols_brrw.insert(ans_id, resolved_value, false);
+  symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
+  interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
+}
 
 fn symbol_rows(symbol_table: &mech_core::SymbolTable, names: &[String]) -> Vec<(String, Value)> {
   let dictionary = symbol_table.dictionary.borrow();

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -262,11 +262,11 @@ impl MechRuntime {
   }
 
   pub fn out_string(&self) -> String {
-    self.program.interpreter().out.to_string()
+    self.program.out_string()
   }
 
   pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-    with_interpreter(self.program.interpreter(), interpreter_id, &mut |_| ()).is_some()
+    self.program.has_interpreter(interpreter_id)
   }
 
   pub fn output_value_for_interpreter(
@@ -274,10 +274,7 @@ impl MechRuntime {
     interpreter_id: u64,
     output_id: u64,
   ) -> Option<Value> {
-    with_interpreter(self.program.interpreter(), interpreter_id, &mut |interpreter| {
-      interpreter.out_values.borrow().get(&output_id).cloned()
-    })
-    .flatten()
+    self.program.output_value_for_interpreter(interpreter_id, output_id)
   }
 
   pub fn symbol_name_for_interpreter_output(
@@ -285,10 +282,7 @@ impl MechRuntime {
     interpreter_id: u64,
     output_id: u64,
   ) -> Option<String> {
-    with_interpreter(self.program.interpreter(), interpreter_id, &mut |interpreter| {
-      interpreter.symbols().borrow().get_symbol_name_by_id(output_id)
-    })
-    .flatten()
+    self.program.symbol_name_for_interpreter_output(interpreter_id, output_id)
   }
 
   pub fn symbol_values_for_interpreter(
@@ -296,11 +290,7 @@ impl MechRuntime {
     interpreter_id: u64,
     names: &[String],
   ) -> Option<Vec<(String, Value)>> {
-    with_interpreter(self.program.interpreter(), interpreter_id, &mut |interpreter| {
-      let symbols = interpreter.symbols();
-      let symbols_brrw = symbols.borrow();
-      symbol_rows(&symbols_brrw, names)
-    })
+    self.program.symbol_values_for_interpreter(interpreter_id, names)
   }
 
   pub fn bind_ans_for_interpreter(
@@ -308,7 +298,7 @@ impl MechRuntime {
     interpreter_id: u64,
     value: &Value,
   ) -> MResult<()> {
-    if bind_ans_recursive(self.program.interpreter_mut(), interpreter_id, value) {
+    if self.program.bind_ans_for_interpreter(interpreter_id, value) {
       return Ok(());
     }
 
@@ -323,8 +313,7 @@ impl MechRuntime {
 
   #[cfg(feature = "functions")]
   pub fn step(&mut self, count: u64) -> MResult<()> {
-    self.program.interpreter_mut().step(count as usize, 1)?;
-    Ok(())
+    self.program.step(count)
   }
 
   pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
@@ -724,96 +713,6 @@ impl MechRuntime {
 }
 
 
-fn with_interpreter<T>(
-  interpreter: &mech_interpreter::Interpreter,
-  interpreter_id: u64,
-  f: &mut impl FnMut(&mech_interpreter::Interpreter) -> T,
-) -> Option<T> {
-  if interpreter_id == 0 || interpreter.id == interpreter_id {
-    return Some(f(interpreter));
-  }
-
-  let sub_interpreters = interpreter.sub_interpreters.borrow();
-  for sub_interpreter in sub_interpreters.values() {
-    if let Some(result) = with_interpreter(sub_interpreter.as_ref(), interpreter_id, f) {
-      return Some(result);
-    }
-  }
-
-  None
-}
-
-fn bind_ans_recursive(
-  interpreter: &mut mech_interpreter::Interpreter,
-  interpreter_id: u64,
-  value: &Value,
-) -> bool {
-  if interpreter_id == 0 || interpreter.id == interpreter_id {
-    bind_ans_on_interpreter(interpreter, value);
-    return true;
-  }
-
-  let child_ids = {
-    let sub_interpreters = interpreter.sub_interpreters.borrow();
-    sub_interpreters.keys().copied().collect::<Vec<_>>()
-  };
-
-  for child_id in child_ids {
-    let mut sub_interpreters = interpreter.sub_interpreters.borrow_mut();
-    let Some(child) = sub_interpreters.get_mut(&child_id) else {
-      continue;
-    };
-    if bind_ans_recursive(child.as_mut(), interpreter_id, value) {
-      return true;
-    }
-  }
-
-  false
-}
-
-fn bind_ans_on_interpreter(
-  interpreter: &mut mech_interpreter::Interpreter,
-  value: &Value,
-) {
-  let resolved_value = match value {
-    Value::MutableReference(reference) => reference.borrow().clone(),
-    _ => value.clone(),
-  };
-  let ans_id = hash_str("ans");
-  let symbols = interpreter.symbols();
-  let mut symbols_brrw = symbols.borrow_mut();
-  symbols_brrw.insert(ans_id, resolved_value, false);
-  symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
-  interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
-}
-
-fn symbol_rows(symbol_table: &mech_core::SymbolTable, names: &[String]) -> Vec<(String, Value)> {
-  let dictionary = symbol_table.dictionary.borrow();
-  let mut rows = Vec::new();
-
-  if !names.is_empty() {
-    for target_name in names {
-      for (id, name) in dictionary.iter() {
-        if name == target_name {
-          if let Some(value_ref) = symbol_table.symbols.get(id) {
-            let value = value_ref.borrow();
-            rows.push((name.clone(), value.clone()));
-          }
-          break;
-        }
-      }
-    }
-  } else {
-    for (id, value_ref) in symbol_table.symbols.iter() {
-      if let Some(name) = dictionary.get(id) {
-        let value = value_ref.borrow();
-        rows.push((name.clone(), value.clone()));
-      }
-    }
-  }
-
-  rows
-}
 
 fn module_source_for_scope(
   source: &MechSourceCode,
@@ -967,61 +866,6 @@ mod tests {
     };
     let output = runtime.output_value_for_interpreter(root_id, output_id);
     assert!(output.is_some());
-  }
-
-  #[test]
-  fn runtime_has_interpreter_finds_nested_interpreter() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let nested_id = 4242;
-    let child_id = 2424;
-    let mut child = runtime.program().interpreter().clone();
-    child.clear();
-    child.id = child_id;
-    let mut nested = runtime.program().interpreter().clone();
-    nested.clear();
-    nested.id = nested_id;
-    child
-      .sub_interpreters
-      .borrow_mut()
-      .insert(nested_id, Box::new(nested));
-    runtime
-      .program_mut()
-      .interpreter_mut()
-      .sub_interpreters
-      .borrow_mut()
-      .insert(child_id, Box::new(child));
-
-    assert!(runtime.has_interpreter(nested_id));
-  }
-
-  #[test]
-  fn runtime_output_value_for_interpreter_finds_nested_interpreter() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let nested_id = 4242;
-    let child_id = 2424;
-    let output_id = 101;
-    let mut child = runtime.program().interpreter().clone();
-    child.clear();
-    child.id = child_id;
-    let mut nested = runtime.program().interpreter().clone();
-    nested.clear();
-    nested.id = nested_id;
-    nested
-      .out_values
-      .borrow_mut()
-      .insert(output_id, Value::U64(Ref::new(42)));
-    child
-      .sub_interpreters
-      .borrow_mut()
-      .insert(nested_id, Box::new(nested));
-    runtime
-      .program_mut()
-      .interpreter_mut()
-      .sub_interpreters
-      .borrow_mut()
-      .insert(child_id, Box::new(child));
-
-    assert!(runtime.output_value_for_interpreter(nested_id, output_id).is_some());
   }
 
   #[test]

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -30,7 +30,7 @@ default = ["baselib", "pretty_print", "serde", "compiler", "program",
       "math_default", "matrix_default", "logic_default", "compare_default", "range_default", "set_default", "io_default", "stats_default", "combinatorics_default",      
       "run_program", "inline_output_values", "codeblock_output_values", "clickable_symbol_listeners",
       "eval", "repl", "whos", "help", "docs", "clc", "clear", "code",
-      "mech-core/default", "mech-interpreter/default", "mech-syntax/default",
+      "mech-core/default", "mech-interpreter/default", "mech-syntax/default", "mech-runtime/default",
       ]
 
 base = ["baselib", "pretty_print", "serde", "compiler", "program",
@@ -38,7 +38,7 @@ base = ["baselib", "pretty_print", "serde", "compiler", "program",
       "math_default", "matrix_default", "logic_default", "compare_default", "range_default", "set_default", "io_default", "stats_default", "combinatorics_default",
       "run_program", "inline_output_values", "codeblock_output_values", "clickable_symbol_listeners",
       "eval", "repl", "whos", "help", "docs", "clc", "clear", "code",
-      "mech-core/base", "mech-interpreter/base", "mech-syntax/base",
+      "mech-core/base", "mech-interpreter/base", "mech-syntax/base", "mech-runtime/base",
       ]
 
 statements_default = ["variable_assign","variable_define","invariant_define","kind_define"]
@@ -55,14 +55,14 @@ baselib = ["bool", "string",
       "kind_annotation", "variables",
       "functions", "formulas",
       "access", "assign", "convert",
-      "mech-core/baselib", "mech-syntax/baselib", "mech-interpreter/baselib"
+      "mech-core/baselib", "mech-syntax/baselib", "mech-interpreter/baselib", "mech-runtime/baselib"
     ]
 
 # core features
-compiler = ["mech-core/compiler", "mech-interpreter/compiler", "mech-syntax/compiler"]
-program = ["mech-core/program", "mech-interpreter/program", "mech-syntax/program"]
-pretty_print = ["mech-core/pretty_print", "mech-syntax/pretty_print"]
-serde = ["mech-core/serde", "mech-syntax/serde", "mech-interpreter/serde"]
+compiler = ["mech-core/compiler", "mech-interpreter/compiler", "mech-syntax/compiler", "mech-runtime/compiler"]
+program = ["mech-core/program", "mech-interpreter/program", "mech-syntax/program", "mech-runtime/program"]
+pretty_print = ["mech-core/pretty_print", "mech-syntax/pretty_print", "mech-runtime/pretty_print"]
+serde = ["mech-core/serde", "mech-syntax/serde", "mech-interpreter/serde", "mech-runtime/serde"]
 run_program = ["program"]
 inline_output_values = []
 codeblock_output_values = []
@@ -77,77 +77,77 @@ clear = []
 code = []
 
 # language features
-statements = ["mech-core/statements", "mech-interpreter/statements", "mech-syntax/statements"]
-variables = ["variable_define", "symbol_table", "mech-core/variables", "mech-interpreter/variables", "mech-syntax/variables"]
-variable_define = ["statements", "functions", "mech-core/variable_define", "mech-interpreter/variable_define", "mech-syntax/variable_define"]
-invariant_define = ["variable_define", "mech-core/invariant_define", "mech-interpreter/invariant_define", "mech-syntax/invariant_define"]
-variable_assign = ["statements", "mech-core/variable_assign", "mech-interpreter/variable_assign", "mech-syntax/variable_assign"]
-kind_define = ["kind_annotation", "statements", "mech-core/kind_define", "mech-interpreter/kind_define", "mech-syntax/kind_define"]
-kind_annotation = ["functions", "mech-core/kind_annotation", "mech-interpreter/kind_annotation", "mech-syntax/kind_annotation"]
-formulas = ["mech-core/formulas", "mech-interpreter/formulas", "mech-syntax/formulas"]
-functions = ["symbol_table", "mech-core/functions", "mech-interpreter/functions", "mech-syntax/functions"]
-symbol_table = ["mech-core/symbol_table", "mech-interpreter/symbol_table", "mech-syntax/symbol_table"]
+statements = ["mech-core/statements", "mech-interpreter/statements", "mech-syntax/statements", "mech-runtime/statements"]
+variables = ["variable_define", "symbol_table", "mech-core/variables", "mech-interpreter/variables", "mech-syntax/variables", "mech-runtime/variables"]
+variable_define = ["statements", "functions", "mech-core/variable_define", "mech-interpreter/variable_define", "mech-syntax/variable_define", "mech-runtime/variable_define"]
+invariant_define = ["variable_define", "mech-core/invariant_define", "mech-interpreter/invariant_define", "mech-syntax/invariant_define", "mech-runtime/invariant_define"]
+variable_assign = ["statements", "mech-core/variable_assign", "mech-interpreter/variable_assign", "mech-syntax/variable_assign", "mech-runtime/variable_assign"]
+kind_define = ["kind_annotation", "statements", "mech-core/kind_define", "mech-interpreter/kind_define", "mech-syntax/kind_define", "mech-runtime/kind_define"]
+kind_annotation = ["functions", "mech-core/kind_annotation", "mech-interpreter/kind_annotation", "mech-syntax/kind_annotation", "mech-runtime/kind_annotation"]
+formulas = ["mech-core/formulas", "mech-interpreter/formulas", "mech-syntax/formulas", "mech-runtime/formulas"]
+functions = ["symbol_table", "mech-core/functions", "mech-interpreter/functions", "mech-syntax/functions", "mech-runtime/functions"]
+symbol_table = ["mech-core/symbol_table", "mech-interpreter/symbol_table", "mech-syntax/symbol_table", "mech-runtime/symbol_table"]
 
 access = ["functions", "mech-interpreter/access"] 
 assign = ["functions", "mech-interpreter/assign"] 
 convert = ["functions", "mech-interpreter/convert"]
 
 # types
-bool = ["mech-core/bool", "mech-syntax/bool", "mech-interpreter/bool"]
-string = ["mech-core/string", "mech-syntax/string", "mech-interpreter/string"]
+bool = ["mech-core/bool", "mech-syntax/bool", "mech-interpreter/bool", "mech-runtime/bool"]
+string = ["mech-core/string", "mech-syntax/string", "mech-interpreter/string", "mech-runtime/string"]
 
 # Numbers
-numbers = ["mech-core/numbers", "mech-interpreter/numbers", "mech-syntax/numbers"]
-complex = ["f64", "numbers", "mech-core/complex", "mech-interpreter/complex", "mech-syntax/complex"]
-rational = ["i64", "numbers", "mech-core/rational", "mech-interpreter/rational", "mech-syntax/rational"]
-signed_ints = ["numbers", "mech-core/signed_ints", "mech-interpreter/signed_ints", "mech-syntax/signed_ints"]
-unsigned_ints = ["numbers", "mech-core/unsigned_ints", "mech-interpreter/unsigned_ints", "mech-syntax/unsigned_ints"]
-floats = ["numbers", "mech-core/floats", "mech-interpreter/floats", "mech-syntax/floats"]
-u8 = ["unsigned_ints", "mech-core/u8", "mech-interpreter/u8", "mech-syntax/u8"]
-u16 = ["unsigned_ints", "mech-core/u16", "mech-interpreter/u16", "mech-syntax/u16"]
-u32 = ["unsigned_ints", "mech-core/u32", "mech-interpreter/u32", "mech-syntax/u32"]
-u64 = ["unsigned_ints", "mech-core/u64", "mech-interpreter/u64", "mech-syntax/u64"]
-u128 = ["unsigned_ints", "mech-core/u128", "mech-interpreter/u128", "mech-syntax/u128"]
-i8 = ["signed_ints", "mech-core/i8", "mech-interpreter/i8", "mech-syntax/i8"]
-i16 = ["signed_ints", "mech-core/i16", "mech-interpreter/i16", "mech-syntax/i16"]
-i32 = ["signed_ints", "mech-core/i32", "mech-interpreter/i32", "mech-syntax/i32"]
-i64 = ["signed_ints", "mech-core/i64", "mech-interpreter/i64", "mech-syntax/i64"]
-i128 = ["signed_ints", "mech-core/i128", "mech-interpreter/i128", "mech-syntax/i128"]
-f32 = ["floats", "mech-core/f32", "mech-interpreter/f32", "mech-syntax/f32"]
-f64 = ["floats", "mech-core/f64", "mech-interpreter/f64", "mech-syntax/f64"]
-c64 = ["complex", "mech-core/c64", "mech-interpreter/c64", "mech-syntax/c64"]
-r64 = ["rational", "mech-core/r64", "mech-interpreter/r64", "mech-syntax/r64"]
+numbers = ["mech-core/numbers", "mech-interpreter/numbers", "mech-syntax/numbers", "mech-runtime/numbers"]
+complex = ["f64", "numbers", "mech-core/complex", "mech-interpreter/complex", "mech-syntax/complex", "mech-runtime/complex"]
+rational = ["i64", "numbers", "mech-core/rational", "mech-interpreter/rational", "mech-syntax/rational", "mech-runtime/rational"]
+signed_ints = ["numbers", "mech-core/signed_ints", "mech-interpreter/signed_ints", "mech-syntax/signed_ints", "mech-runtime/signed_ints"]
+unsigned_ints = ["numbers", "mech-core/unsigned_ints", "mech-interpreter/unsigned_ints", "mech-syntax/unsigned_ints", "mech-runtime/unsigned_ints"]
+floats = ["numbers", "mech-core/floats", "mech-interpreter/floats", "mech-syntax/floats", "mech-runtime/floats"]
+u8 = ["unsigned_ints", "mech-core/u8", "mech-interpreter/u8", "mech-syntax/u8", "mech-runtime/u8"]
+u16 = ["unsigned_ints", "mech-core/u16", "mech-interpreter/u16", "mech-syntax/u16", "mech-runtime/u16"]
+u32 = ["unsigned_ints", "mech-core/u32", "mech-interpreter/u32", "mech-syntax/u32", "mech-runtime/u32"]
+u64 = ["unsigned_ints", "mech-core/u64", "mech-interpreter/u64", "mech-syntax/u64", "mech-runtime/u64"]
+u128 = ["unsigned_ints", "mech-core/u128", "mech-interpreter/u128", "mech-syntax/u128", "mech-runtime/u128"]
+i8 = ["signed_ints", "mech-core/i8", "mech-interpreter/i8", "mech-syntax/i8", "mech-runtime/i8"]
+i16 = ["signed_ints", "mech-core/i16", "mech-interpreter/i16", "mech-syntax/i16", "mech-runtime/i16"]
+i32 = ["signed_ints", "mech-core/i32", "mech-interpreter/i32", "mech-syntax/i32", "mech-runtime/i32"]
+i64 = ["signed_ints", "mech-core/i64", "mech-interpreter/i64", "mech-syntax/i64", "mech-runtime/i64"]
+i128 = ["signed_ints", "mech-core/i128", "mech-interpreter/i128", "mech-syntax/i128", "mech-runtime/i128"]
+f32 = ["floats", "mech-core/f32", "mech-interpreter/f32", "mech-syntax/f32", "mech-runtime/f32"]
+f64 = ["floats", "mech-core/f64", "mech-interpreter/f64", "mech-syntax/f64", "mech-runtime/f64"]
+c64 = ["complex", "mech-core/c64", "mech-interpreter/c64", "mech-syntax/c64", "mech-runtime/c64"]
+r64 = ["rational", "mech-core/r64", "mech-interpreter/r64", "mech-syntax/r64", "mech-runtime/r64"]
 
 # structs
-set = ["mech-core/set", "mech-interpreter/set", "mech-syntax/set"]
-map = ["mech-core/map", "mech-interpreter/map", "mech-syntax/map"]
-table = ["vectord", "record", "kind_annotation", "mech-core/table", "mech-interpreter/table", "mech-syntax/table"]
-tuple = ["mech-core/tuple", "mech-interpreter/tuple", "mech-syntax/tuple"]
-enum = ["mech-core/enum", "mech-interpreter/enum", "mech-syntax/enum"]
-record = ["tuple", "kind_annotation", "mech-core/record", "mech-interpreter/record", "mech-syntax/record"]
-atom = ["mech-core/atom", "mech-interpreter/atom", "mech-syntax/atom"]
+set = ["mech-core/set", "mech-interpreter/set", "mech-syntax/set", "mech-runtime/set"]
+map = ["mech-core/map", "mech-interpreter/map", "mech-syntax/map", "mech-runtime/map"]
+table = ["vectord", "record", "kind_annotation", "mech-core/table", "mech-interpreter/table", "mech-syntax/table", "mech-runtime/table"]
+tuple = ["mech-core/tuple", "mech-interpreter/tuple", "mech-syntax/tuple", "mech-runtime/tuple"]
+enum = ["mech-core/enum", "mech-interpreter/enum", "mech-syntax/enum", "mech-runtime/enum"]
+record = ["tuple", "kind_annotation", "mech-core/record", "mech-interpreter/record", "mech-syntax/record", "mech-runtime/record"]
+atom = ["mech-core/atom", "mech-interpreter/atom", "mech-syntax/atom", "mech-runtime/atom"]
 
 # matrix
-matrix = ["mech-core/matrix", "mech-interpreter/matrix", "mech-syntax/matrix"]
-fixed_row_vector = ["row_vector4", "row_vector3", "row_vector2", "mech-core/fixed_row_vector", "mech-interpreter/fixed_row_vector", "mech-syntax/fixed_row_vector"]
-fixed_vector = ["vector4", "vector3", "vector2", "mech-core/fixed_vector", "mech-interpreter/fixed_vector", "mech-syntax/fixed_vector"]
-fixed_matrix = ["matrix4", "matrix3", "matrix2", "matrix1", "matrix2x3", "matrix3x2", "mech-core/fixed_matrix", "mech-interpreter/fixed_matrix", "mech-syntax/fixed_matrix"]
-dynamic_matrix = ["matrixd", "vectord", "row_vectord", "mech-core/dynamic_matrix", "mech-interpreter/dynamic_matrix", "mech-syntax/dynamic_matrix"]
-row_vector4 = ["matrix", "matrix_horzcat", "mech-core/row_vector4", "mech-interpreter/row_vector4", "mech-syntax/row_vector4"]
-row_vector3 = ["matrix", "matrix_horzcat", "mech-core/row_vector3", "mech-interpreter/row_vector3", "mech-syntax/row_vector3"]
-row_vector2 = ["matrix", "matrix_horzcat", "mech-core/row_vector2", "mech-interpreter/row_vector2", "mech-syntax/row_vector2"]
-vector4 = ["matrix", "matrix_vertcat", "mech-core/vector4", "mech-interpreter/vector4", "mech-syntax/vector4"]
-vector3 = ["matrix", "matrix_vertcat", "mech-core/vector3", "mech-interpreter/vector3", "mech-syntax/vector3"]
-vector2 = ["matrix", "matrix_vertcat", "mech-core/vector2", "mech-interpreter/vector2", "mech-syntax/vector2"]
-matrix4 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix4", "mech-interpreter/matrix4", "mech-syntax/matrix4"]
-matrix3 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix3", "mech-interpreter/matrix3", "mech-syntax/matrix3"]
-matrix2 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix2", "mech-interpreter/matrix2", "mech-syntax/matrix2"]
-matrix1 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix1", "mech-interpreter/matrix1", "mech-syntax/matrix1"]
-matrix2x3 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix2x3", "mech-interpreter/matrix2x3", "mech-syntax/matrix2x3"]
-matrix3x2 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix3x2", "mech-interpreter/matrix3x2", "mech-syntax/matrix3x2"]
+matrix = ["mech-core/matrix", "mech-interpreter/matrix", "mech-syntax/matrix", "mech-runtime/matrix"]
+fixed_row_vector = ["row_vector4", "row_vector3", "row_vector2", "mech-core/fixed_row_vector", "mech-interpreter/fixed_row_vector", "mech-syntax/fixed_row_vector", "mech-runtime/fixed_row_vector"]
+fixed_vector = ["vector4", "vector3", "vector2", "mech-core/fixed_vector", "mech-interpreter/fixed_vector", "mech-syntax/fixed_vector", "mech-runtime/fixed_vector"]
+fixed_matrix = ["matrix4", "matrix3", "matrix2", "matrix1", "matrix2x3", "matrix3x2", "mech-core/fixed_matrix", "mech-interpreter/fixed_matrix", "mech-syntax/fixed_matrix", "mech-runtime/fixed_matrix"]
+dynamic_matrix = ["matrixd", "vectord", "row_vectord", "mech-core/dynamic_matrix", "mech-interpreter/dynamic_matrix", "mech-syntax/dynamic_matrix", "mech-runtime/dynamic_matrix"]
+row_vector4 = ["matrix", "matrix_horzcat", "mech-core/row_vector4", "mech-interpreter/row_vector4", "mech-syntax/row_vector4", "mech-runtime/row_vector4"]
+row_vector3 = ["matrix", "matrix_horzcat", "mech-core/row_vector3", "mech-interpreter/row_vector3", "mech-syntax/row_vector3", "mech-runtime/row_vector3"]
+row_vector2 = ["matrix", "matrix_horzcat", "mech-core/row_vector2", "mech-interpreter/row_vector2", "mech-syntax/row_vector2", "mech-runtime/row_vector2"]
+vector4 = ["matrix", "matrix_vertcat", "mech-core/vector4", "mech-interpreter/vector4", "mech-syntax/vector4", "mech-runtime/vector4"]
+vector3 = ["matrix", "matrix_vertcat", "mech-core/vector3", "mech-interpreter/vector3", "mech-syntax/vector3", "mech-runtime/vector3"]
+vector2 = ["matrix", "matrix_vertcat", "mech-core/vector2", "mech-interpreter/vector2", "mech-syntax/vector2", "mech-runtime/vector2"]
+matrix4 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix4", "mech-interpreter/matrix4", "mech-syntax/matrix4", "mech-runtime/matrix4"]
+matrix3 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix3", "mech-interpreter/matrix3", "mech-syntax/matrix3", "mech-runtime/matrix3"]
+matrix2 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix2", "mech-interpreter/matrix2", "mech-syntax/matrix2", "mech-runtime/matrix2"]
+matrix1 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix1", "mech-interpreter/matrix1", "mech-syntax/matrix1", "mech-runtime/matrix1"]
+matrix2x3 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix2x3", "mech-interpreter/matrix2x3", "mech-syntax/matrix2x3", "mech-runtime/matrix2x3"]
+matrix3x2 = ["matrix", "matrix_horzcat", "matrix_vertcat", "mech-core/matrix3x2", "mech-interpreter/matrix3x2", "mech-syntax/matrix3x2", "mech-runtime/matrix3x2"]
 row_vectord =["matrix", "matrix_horzcat",  "mech-core/row_vectord", "mech-interpreter/row_vectord", "mech-syntax/row_vectord"]
-vectord = ["matrix", "matrix_vertcat",  "mech-core/vectord", "mech-interpreter/vectord", "mech-syntax/vectord"]
-matrixd = ["matrix", "matrix_horzcat", "matrix_vertcat",  "mech-core/matrixd", "mech-interpreter/matrixd", "mech-syntax/matrixd"]
+vectord = ["matrix", "matrix_vertcat",  "mech-core/vectord", "mech-interpreter/vectord", "mech-syntax/vectord", "mech-runtime/vectord"]
+matrixd = ["matrix", "matrix_horzcat", "matrix_vertcat",  "mech-core/matrixd", "mech-interpreter/matrixd", "mech-syntax/matrixd", "mech-runtime/matrixd"]
 
 # Libs
 # -----------------------------------------------------------------------------
@@ -276,18 +276,19 @@ set_union = ["set", "mech-interpreter/set_union"]
 set_cartesian_product = ["set", "mech-interpreter/set_cartesian_product"]
 
 # Subscripts
-subscript = ["mech-core/subscript", "mech-interpreter/subscript", "mech-syntax/subscript"]
-subscript_slice = ["subscript", "vectord", "mech-core/subscript_slice", "mech-interpreter/subscript_slice", "mech-syntax/subscript_slice"]
-subscript_range = ["subscript_slice","vectord", "mech-core/subscript_range", "mech-interpreter/subscript_range", "mech-syntax/subscript_range"]
-subscript_formula = ["subscript_slice","formulas", "mech-core/subscript_formula", "mech-interpreter/subscript_formula", "mech-syntax/subscript_formula"]
-logical_indexing = ["subscript","vectord","bool", "mech-core/logical_indexing", "mech-interpreter/logical_indexing", "mech-syntax/logical_indexing"]
-dot_indexing = ["subscript", "mech-core/dot_indexing", "mech-interpreter/dot_indexing", "mech-syntax/dot_indexing"]
-swizzle = ["subscript", "mech-core/swizzle", "mech-interpreter/swizzle", "mech-syntax/swizzle"]
+subscript = ["mech-core/subscript", "mech-interpreter/subscript", "mech-syntax/subscript", "mech-runtime/subscript"]
+subscript_slice = ["subscript", "vectord", "mech-core/subscript_slice", "mech-interpreter/subscript_slice", "mech-syntax/subscript_slice", "mech-runtime/subscript_slice"]
+subscript_range = ["subscript_slice","vectord", "mech-core/subscript_range", "mech-interpreter/subscript_range", "mech-syntax/subscript_range", "mech-runtime/subscript_range"]
+subscript_formula = ["subscript_slice","formulas", "mech-core/subscript_formula", "mech-interpreter/subscript_formula", "mech-syntax/subscript_formula", "mech-runtime/subscript_formula"]
+logical_indexing = ["subscript","vectord","bool", "mech-core/logical_indexing", "mech-interpreter/logical_indexing", "mech-syntax/logical_indexing", "mech-runtime/logical_indexing"]
+dot_indexing = ["subscript", "mech-core/dot_indexing", "mech-interpreter/dot_indexing", "mech-syntax/dot_indexing", "mech-runtime/dot_indexing"]
+swizzle = ["subscript", "mech-core/swizzle", "mech-interpreter/swizzle", "mech-syntax/swizzle", "mech-runtime/swizzle"]
 
 [dependencies]
 mech-core = {version = "0.3.5", default-features = false}
 mech-syntax = { version = "0.3.5", default-features = false}
 mech-interpreter = { version = "0.3.5", default-features = false}
+mech-runtime = { path = "../runtime", default-features = false }
 
 wasm-bindgen = "0.2.100"
 js-sys = "0.3.77"

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -5,7 +5,7 @@ pub mod host;
 use wasm_bindgen::prelude::*;
 use mech_core::*;
 use mech_syntax::*;
-use mech_interpreter::*;
+use mech_runtime::{MechRuntime, RuntimeConfig};
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlElement, HtmlInputElement, Node, Element, HashChangeEvent, HtmlTextAreaElement, Url};
 use js_sys::decode_uri_component;
@@ -40,191 +40,7 @@ macro_rules! log {
 }
 
 
-fn new_interpreter(id: u64) -> Interpreter {
 
-  let mut intrp = Interpreter::new(id, 10_000);
-
-  let fxns_ref = intrp.functions();
-  let mut fxns = fxns_ref.borrow_mut();
-      
-  // Preload combinatorics functions
-  #[cfg(feature = "combinatorics_n_choose_k")]
-  fxns.function_compilers.insert(hash_str("combinatorics/n-choose-k"), Arc::new(CombinatoricsNChooseK{}));
-
-  
-  // Preload stats functions
-  #[cfg(feature = "stats_sum")]
-  fxns.function_compilers.insert(hash_str("stats/sum/row"), Arc::new(StatsSumRow{}));
-  #[cfg(feature = "stats_sum")]
-  fxns.function_compilers.insert(hash_str("stats/sum/column"), Arc::new(StatsSumColumn{}));
-
-  // Preload ops functions
-  #[cfg(feature = "math_add")]
-  fxns.function_compilers.insert(hash_str("math/add"), Arc::new(MathAdd{}));
-  #[cfg(feature = "math_sub")]
-  fxns.function_compilers.insert(hash_str("math/sub"), Arc::new(MathSub{}));
-  #[cfg(feature = "math_mul")]
-  fxns.function_compilers.insert(hash_str("math/mul"), Arc::new(MathMul{}));
-  #[cfg(feature = "math_div")]
-  fxns.function_compilers.insert(hash_str("math/div"), Arc::new(MathDiv{}));
-  #[cfg(feature = "math_mod")]
-  fxns.function_compilers.insert(hash_str("math/mod"), Arc::new(MathMod{}));
-  #[cfg(feature = "math_pow")]
-  fxns.function_compilers.insert(hash_str("math/pow"), Arc::new(MathPow{}));
-  #[cfg(feature = "math_neg")]
-  fxns.function_compilers.insert(hash_str("math/neg"), Arc::new(MathNegate{}));
-  
-  // Preload math functions
-  #[cfg(feature = "math_sqrt")]
-  fxns.function_compilers.insert(hash_str("math/sqrt"), Arc::new(MathSqrt{}));
-  
-  // Preload trig functions
-  #[cfg(feature = "math_sin")]
-  fxns.function_compilers.insert(hash_str("math/sin"), Arc::new(MathSin{}));
-  #[cfg(feature = "math_cos")]
-  fxns.function_compilers.insert(hash_str("math/cos"), Arc::new(MathCos{}));
-  #[cfg(feature = "math_atan2")]
-  fxns.function_compilers.insert(hash_str("math/atan2"), Arc::new(MathAtan2{}));
-  #[cfg(feature = "math_atan")]
-  fxns.function_compilers.insert(hash_str("math/atan"), Arc::new(MathAtan{}));
-  #[cfg(feature = "math_acos")]
-  fxns.function_compilers.insert(hash_str("math/acos"), Arc::new(MathAcos{}));
-  #[cfg(feature = "math_acosh")]
-  fxns.function_compilers.insert(hash_str("math/acosh"), Arc::new(MathAcosh{}));
-  #[cfg(feature = "math_acot")]
-  fxns.function_compilers.insert(hash_str("math/acot"), Arc::new(MathAcot{}));
-  #[cfg(feature = "math_acsc")]
-  fxns.function_compilers.insert(hash_str("math/acsc"), Arc::new(MathAcsc{}));
-  #[cfg(feature = "math_asec")]
-  fxns.function_compilers.insert(hash_str("math/asec"), Arc::new(MathAsec{}));
-  #[cfg(feature = "math_asin")]
-  fxns.function_compilers.insert(hash_str("math/asin"), Arc::new(MathAsin{}));
-  #[cfg(feature = "math_sinh")]
-  fxns.function_compilers.insert(hash_str("math/sinh"), Arc::new(MathSinh{}));
-  #[cfg(feature = "math_cosh")]
-  fxns.function_compilers.insert(hash_str("math/cosh"), Arc::new(MathCosh{}));
-  #[cfg(feature = "math_tanh")]
-  fxns.function_compilers.insert(hash_str("math/tanh"), Arc::new(MathTanh{}));
-  #[cfg(feature = "math_atanh")]
-  fxns.function_compilers.insert(hash_str("math/atanh"), Arc::new(MathAtanh{}));
-  #[cfg(feature = "math_cot")]
-  fxns.function_compilers.insert(hash_str("math/cot"), Arc::new(MathCot{}));
-  #[cfg(feature = "math_csc")]
-  fxns.function_compilers.insert(hash_str("math/csc"), Arc::new(MathCsc{}));
-  #[cfg(feature = "math_sec")]
-  fxns.function_compilers.insert(hash_str("math/sec"), Arc::new(MathSec{}));
-  #[cfg(feature = "math_tan")]
-  fxns.function_compilers.insert(hash_str("math/tan"), Arc::new(MathTan{}));
-
-  // Preload io functions
-  //#[cfg(feature = "io_print")]
-  //fxns.function_compilers.insert(hash_str("io/print"), Arc::new(IoPrint{}));
-  //#[cfg(feature = "io_println")]
-  //fxns.function_compilers.insert(hash_str("io/println"), Arc::new(IoPrintln{}));
-
-  // Matrix functions
-  #[cfg(feature = "matrix_horzcat")]
-  fxns.function_compilers.insert(hash_str("matrix/horzcat"), Arc::new(MatrixHorzCat{}));
-  #[cfg(feature = "matrix_vertcat")]
-  fxns.function_compilers.insert(hash_str("matrix/vertcat"), Arc::new(MatrixVertCat{}));
-  #[cfg(feature = "matrix_transpose")]
-  fxns.function_compilers.insert(hash_str("matrix/transpose"), Arc::new(MatrixTranspose{}));
-  #[cfg(feature = "matrix_matmul")]
-  fxns.function_compilers.insert(hash_str("matrix/matmul"), Arc::new(MatrixMatMul{}));
-  #[cfg(feature = "matrix_dot")]
-  fxns.function_compilers.insert(hash_str("matrix/dot"), Arc::new(MatrixDot{}));
-  #[cfg(feature = "matrix_solve")]
-  fxns.function_compilers.insert(hash_str("matrix/solve"), Arc::new(MatrixSolve{}));
-  #[cfg(feature = "matrix_comprehensions")]
-  fxns.function_compilers.insert(hash_str("matrix/comprehension"), Arc::new(MatrixComprehensionDefine{}));
-
-  // Compare functions
-  #[cfg(feature = "compare_eq")]
-  fxns.function_compilers.insert(hash_str("compare/eq"), Arc::new(CompareEqual{}));
-  #[cfg(feature = "compare_neq")]
-  fxns.function_compilers.insert(hash_str("compare/neq"), Arc::new(CompareNotEqual{}));
-  #[cfg(feature = "compare_lte")]
-  fxns.function_compilers.insert(hash_str("compare/lte"), Arc::new(CompareLessThanEqual{}));
-  #[cfg(feature = "compare_gte")]
-  fxns.function_compilers.insert(hash_str("compare/gte"), Arc::new(CompareGreaterThanEqual{}));
-  #[cfg(feature = "compare_lt")]
-  fxns.function_compilers.insert(hash_str("compare/lt"), Arc::new(CompareLessThan{}));
-  #[cfg(feature = "compare_gt")]
-  fxns.function_compilers.insert(hash_str("compare/gt"), Arc::new(CompareGreaterThan{}));
-
-  // Logic functions
-  #[cfg(feature = "logic_and")]
-  fxns.function_compilers.insert(hash_str("logic/and"), Arc::new(LogicAnd{}));
-  #[cfg(feature = "logic_or")]
-  fxns.function_compilers.insert(hash_str("logic/or"), Arc::new(LogicOr{}));
-  #[cfg(feature = "logic_not")]
-  fxns.function_compilers.insert(hash_str("logic/not"), Arc::new(LogicNot{}));
-  #[cfg(feature = "logic_xor")]
-  fxns.function_compilers.insert(hash_str("logic/xor"), Arc::new(LogicXor{}));
-
-  // Set Functions
-  #[cfg(feature = "set_union")]
-  fxns.function_compilers.insert(hash_str("set/union"), Arc::new(SetUnion{}));
-  #[cfg(feature = "set_intersection")]
-  fxns.function_compilers.insert(hash_str("set/intersection"), Arc::new(SetIntersection{}));
-  #[cfg(feature = "set_difference")]
-  fxns.function_compilers.insert(hash_str("set/difference"), Arc::new(SetDifference{}));
-  #[cfg(feature = "set_subset")]
-  fxns.function_compilers.insert(hash_str("set/subset"), Arc::new(SetSubset{}));
-  #[cfg(feature = "set_superset")]
-  fxns.function_compilers.insert(hash_str("set/superset"), Arc::new(SetSuperset{}));
-  #[cfg(feature = "set_proper_subset")]
-  fxns.function_compilers.insert(hash_str("set/proper-subset"), Arc::new(SetProperSubset{}));
-  #[cfg(feature = "set_proper_superset")]
-  fxns.function_compilers.insert(hash_str("set/proper-superset"), Arc::new(SetProperSuperset{}));
-  #[cfg(feature = "set_element_of")]
-  fxns.function_compilers.insert(hash_str("set/element-of"), Arc::new(SetElementOf{}));
-  #[cfg(feature = "set_not_element_of")]
-  fxns.function_compilers.insert(hash_str("set/not-element-of"), Arc::new(SetNotElementOf{}));
-  #[cfg(feature = "set_comprehensions")]
-  fxns.function_compilers.insert(hash_str("set/comprehension"), Arc::new(SetComprehensionDefine{}));
-
-  intrp
-
-}
-
-struct WasmProgram<'a> {
-  interpreter: &'a mut Interpreter,
-}
-
-impl<'a> WasmProgram<'a> {
-  fn run_string(&mut self, source: &str) -> MResult<Value> {
-    let tree = parser::parse(source.trim())?;
-    self.interpreter.interpret(&tree)
-  }
-}
-
-fn find_out_values(interpreter: &Interpreter, interpreter_id: u64) -> Option<Ref<HashMap<u64, Value>>> {
-  if interpreter.id == interpreter_id {
-    return Some(interpreter.out_values.clone());
-  }
-  let sub_interpreters = interpreter.sub_interpreters.borrow();
-  for sub_interpreter in sub_interpreters.values() {
-    if let Some(out_values) = find_out_values(sub_interpreter, interpreter_id) {
-      return Some(out_values);
-    }
-  }
-  None
-}
-
-#[cfg(feature = "symbol_table")]
-fn find_symbols(interpreter: &Interpreter, interpreter_id: u64) -> Option<SymbolTableRef> {
-  if interpreter.id == interpreter_id {
-    return Some(interpreter.symbols());
-  }
-  let sub_interpreters = interpreter.sub_interpreters.borrow();
-  for sub_interpreter in sub_interpreters.values() {
-    if let Some(symbols) = find_symbols(sub_interpreter, interpreter_id) {
-      return Some(symbols);
-    }
-  }
-  None
-}
 
 fn format_output_value_html(output: &Value) -> String {
   #[cfg(any(feature = "string", feature = "variable_define"))]
@@ -252,26 +68,15 @@ pub fn main() -> Result<(), JsValue> {
   Ok(())
 }
 
-#[cfg(feature = "eval")]
-fn run_mech_code(intrp: &mut Interpreter, code: &Vec<(String,MechSourceCode)>) -> MResult<Value> {
-  let mut program = WasmProgram { interpreter: intrp };
-  for (file, source) in code {
-    match source {
-      MechSourceCode::String(s) => {
-        return program.run_string(s);
-      }
-      x => {
-        log!("Unsupported source code type: {:?}", x);
-        todo!();
-      },
-    }
-  }
-  Ok(Value::Empty)
+
+fn configure_browser_host(runtime: &mut MechRuntime) -> MResult<()> {
+  let _ = runtime;
+  Ok(())
 }
 
 #[wasm_bindgen]
 pub struct WasmMech {
-  interpreter: Interpreter,
+  runtime: MechRuntime,
   repl_history: Vec<String>,
   repl_history_index: Option<usize>,
   repl_id: Option<String>,
@@ -282,9 +87,18 @@ impl WasmMech {
 
   #[wasm_bindgen(constructor)]
   pub fn new() -> Self {
-    Self { 
-      interpreter: new_interpreter(0),
-      repl_history: Vec::new(), 
+    Self::with_default_runtime()
+  }
+
+  fn with_default_runtime() -> Self {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default())
+      .expect("failed to initialize MechRuntime for wasm");
+    configure_browser_host(&mut runtime)
+      .expect("failed to configure browser host for wasm");
+
+    Self {
+      runtime,
+      repl_history: Vec::new(),
       repl_history_index: None,
       repl_id: None,
     }
@@ -292,28 +106,13 @@ impl WasmMech {
 
   #[wasm_bindgen]
   pub fn out_string(&self) -> String {
-    self.interpreter.out.to_string()
+    self.runtime.out_string()
   }
 
   #[wasm_bindgen]
   pub fn clear(&mut self) {
-    self.interpreter = new_interpreter(0);
-  }
-
-  fn bind_ans_symbol_for_interpreter(&mut self, interpreter_id: u64, value: &Value) {
-    #[cfg(feature = "symbol_table")]
-    {
-      let resolved_value = match value {
-        Value::MutableReference(reference) => reference.borrow().clone(),
-        _ => value.clone(),
-      };
-      let ans_id = hash_str("ans");
-      let symbols = self.interpreter.symbols();
-      let mut symbols_brrw = symbols.borrow_mut();
-      symbols_brrw.insert(ans_id, resolved_value, false);
-      symbols_brrw.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
-      self.interpreter.dictionary().borrow_mut().insert(ans_id, "ans".to_string());
-    }
+    self.runtime = MechRuntime::new(RuntimeConfig::default())
+      .expect("failed to reset MechRuntime for wasm");
   }
 
 #[cfg(feature = "repl")]
@@ -667,27 +466,22 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         "REPL commands not supported. Rebuild with the 'repl' feature.".to_string()
       }
     } else {
-      let cmd = vec![("repl".to_string(),MechSourceCode::String(input.to_string()))];
-      CURRENT_MECH.with(|mech_ref| {
-        if let Some(ptr) = *mech_ref.borrow() {
-          unsafe {
-            let mut mech = &mut *ptr;
-            match run_mech_code(&mut mech.interpreter, &cmd)  {
-              Ok(output) => { 
-                let kind_str = html_escape(&format!("{}",output.kind()));
-                return format!("<div class=\"mech-output-kind\">{}</div><div class=\"mech-output-value\">{}</div>", kind_str, output.to_html());
-              },
-              Err(err) => {
-                return format!(
-                  "<div class=\"mech-output-kind\">Error</div><div class=\"mech-output-value\">{}</div>",
-                  err.to_html()
-                );
-              }
-            }
-          }
+      match self.runtime.run_string(input) {
+        Ok(output) => {
+          let kind_str = html_escape(&format!("{}", output.kind()));
+          format!(
+            "<div class=\"mech-output-kind\">{}</div><div class=\"mech-output-value\">{}</div>",
+            kind_str,
+            output.to_html()
+          )
         }
-        "Error: No interpreter found.".to_string()
-      })
+        Err(err) => {
+          format!(
+            "<div class=\"mech-output-kind\">Error</div><div class=\"mech-output-value\">{}</div>",
+            err.to_html()
+          )
+        }
+      }
     }
   }
 
@@ -741,14 +535,6 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         .get_attribute("data-var")
         .unwrap_or_else(|| symbol_text.clone());
 
-      let symbols = match find_symbols(&self.interpreter, interpreter_id) {
-        Some(symbols) => symbols,
-        None => {
-          log!("No sub interpreter found for id: {}", interpreter_id);
-          continue;
-        }
-      };
-
       // Create click closure
       let closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
         let window = web_sys::window().unwrap();
@@ -756,17 +542,38 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         let mech_output = document.get_element_by_id("mech-output").unwrap();
         let last_child = mech_output.last_child();
 
-        let output = {
-          let symbols_brrw = symbols.borrow();
-          symbols_brrw.get(element_id).map(|output| output.borrow().clone())
-        };
-        match output {
-          Some(output) => {
-            let symbol_name = if symbol_text.trim().is_empty() {
-              {
-                let symbols_brrw = symbols.borrow();
-                symbols_brrw.get_symbol_name_by_id(element_id)
+        CURRENT_MECH.with(|mech_ref| {
+          let Some(ptr) = *mech_ref.borrow() else {
+            log!("Clickable click: no current mech instance");
+            return;
+          };
+          unsafe {
+            let mech = &mut *ptr;
+            let output = match mech.runtime.output_value_for_interpreter(interpreter_id, element_id) {
+              Some(value) => value,
+              None => {
+                let error_message = format!("No value found for element id: {}", element_id);
+                log!(
+                  "Clickable click: missing symbol output for element_id={} interpreter_id={} id='{}'",
+                  element_id,
+                  interpreter_id,
+                  id
+                );
+                let result_line = document.create_element("div").unwrap();
+                result_line.set_class_name("repl-result");
+                result_line.set_inner_html(&error_message);
+                if let Some(last_child) = last_child {
+                  mech_output.insert_before(&result_line, Some(&last_child)).unwrap();
+                } else {
+                  mech_output.append_child(&result_line).unwrap();
+                }
+                return;
               }
+            };
+            let symbol_name = if symbol_text.trim().is_empty() {
+              mech
+                .runtime
+                .symbol_name_for_interpreter_output(interpreter_id, element_id)
                 .or_else(|| {
                   let trimmed = symbol_name_hint.trim();
                   if trimmed.is_empty() {
@@ -839,38 +646,12 @@ pub fn attach_repl(&mut self, repl_id: &str) {
             }
 
             // Update REPL history
-            CURRENT_MECH.with(|mech_ref| {
-              if let Some(ptr) = *mech_ref.borrow() {
-                unsafe { (*ptr).repl_history.push(symbol_name.clone()); }
-              }
-            });
+            mech.repl_history.push(symbol_name.clone());
 
             // Update variable "ans" with the value of the clicked symbol
-            CURRENT_MECH.with(|mech_ref| {
-              if let Some(ptr) = *mech_ref.borrow() {
-                unsafe { (*ptr).bind_ans_symbol_for_interpreter(interpreter_id, &output); }
-              }
-            });
-
-          },
-          None => {
-            let error_message = format!("No value found for element id: {}", element_id);
-            log!(
-              "Clickable click: missing symbol output for element_id={} interpreter_id={} id='{}'",
-              element_id,
-              interpreter_id,
-              id
-            );
-            let result_line = document.create_element("div").unwrap();
-            result_line.set_class_name("repl-result");
-            result_line.set_inner_html(&error_message);
-            if let Some(last_child) = last_child {
-              mech_output.insert_before(&result_line, Some(&last_child)).unwrap();
-            } else {
-              mech_output.append_child(&result_line).unwrap();
-            }
+            let _ = mech.runtime.bind_ans_for_interpreter(interpreter_id, &output);
           }
-        }
+        });
 
         mech_output.set_scroll_top(mech_output.scroll_height());
       }) as Box<dyn FnMut(_)>);
@@ -879,7 +660,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
       closure.forget();
     }
   }
-  
+
   #[wasm_bindgen]
   pub fn init(&self) {
     #[cfg(feature = "clickable_symbol_listeners")]
@@ -899,8 +680,8 @@ pub fn attach_repl(&mut self, repl_id: &str) {
   #[cfg(feature = "codeblock_output_values")]
   #[wasm_bindgen]
   pub fn render_codeblock_output_values(&mut self) {
-    let window = web_sys::window().expect("global window does not exists");    
-		let document = window.document().expect("expecting a document on window"); 
+    let window = web_sys::window().expect("global window does not exists");
+    let document = window.document().expect("expecting a document on window");
     // Get all elements with an attribute of "mech-interpreter-id"
     let programs = document.query_selector_all("[mech-interpreter-id]");
     if let Ok(programs) = programs {
@@ -913,12 +694,8 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         // Get the mech-interpreter-id attribute from the element
         let interpreter_id: String = program_el.get_attribute("mech-interpreter-id").unwrap();
         let interpreter_id: u64 = interpreter_id.parse().unwrap();
-        let root_interpreter_id = if interpreter_id == 0 {
-          self.interpreter.id
-        } else {
-          interpreter_id
-        };
-        if find_out_values(&self.interpreter, root_interpreter_id).is_none() {
+        let root_interpreter_id = interpreter_id;
+        if !self.runtime.has_interpreter(root_interpreter_id) {
           log!("No sub interpreter found for id: {}", root_interpreter_id);
           continue;
         }
@@ -945,17 +722,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
             } else {
               interpreter_id
             };
-            let out_values = match find_out_values(&self.interpreter, effective_interpreter_id) {
-              Some(out_values) => out_values,
-              None => {
-                log!("No sub interpreter found for id: {}", effective_interpreter_id);
-                continue;
-              }
-            };
-
-            // get the output id from the block id
-            let out_value_brrw = out_values.borrow();
-            let output = match out_value_brrw.get(&output_id) {
+            let output = match self.runtime.output_value_for_interpreter(effective_interpreter_id, output_id) {
               Some(value) => value,
               None => {
                 log!("No value found for output id: {}", output_id);
@@ -963,7 +730,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
               }
             };
             // set the inner html of the block to the output value html
-            block.set_inner_html(&format_output_value_html(output));
+            block.set_inner_html(&format_output_value_html(&output));
           }
         }
       }
@@ -973,8 +740,8 @@ pub fn attach_repl(&mut self, repl_id: &str) {
   #[cfg(feature = "inline_output_values")]
   #[wasm_bindgen]
   pub fn render_inline_values(&mut self) {
-    let window = web_sys::window().expect("global window does not exists");    
-		let document = window.document().expect("expecting a document on window"); 
+    let window = web_sys::window().expect("global window does not exists");
+    let document = window.document().expect("expecting a document on window");
     let inline_elements = document.get_elements_by_class_name("mech-inline-mech-code");
     for j in 0..inline_elements.length() {
       let inline_block = inline_elements.get_with_index(j).unwrap();
@@ -1004,16 +771,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
           continue;
         }
       };
-      let out_values = match find_out_values(&self.interpreter, inline_interpreter_id) {
-        Some(out_values) => out_values,
-        None => {
-          log!("No sub interpreter found for inline id: {}", inline_interpreter_id);
-          continue;
-        }
-      };
-      let out_values_brrw = out_values.borrow();
-
-      let inline_output = match out_values_brrw.get(&inline_output_id) {
+      let inline_output = match self.runtime.output_value_for_interpreter(inline_interpreter_id, inline_output_id) {
         Some(value) => value,
         None => {
           log!(
@@ -1081,23 +839,11 @@ pub fn attach_repl(&mut self, repl_id: &str) {
         Some(value) => hash_str(&value),
         None => match var_element.get_attribute("data-interpreter-id") {
           Some(value) => value.parse::<u64>().unwrap_or(0),
-          None => self.interpreter.id,
+          None => 0,
         },
       };
-      let symbols = match find_symbols(&self.interpreter, interpreter_id) {
-        Some(symbols) => symbols,
-        None => {
-          log!(
-            "VAR placeholder unresolved interpreter: {} (variable: {})",
-            interpreter_id,
-            var_name
-          );
-          continue;
-        }
-      };
-      let symbols_brrw = symbols.borrow();
-      let output = match symbols_brrw.get(var_id) {
-        Some(value) => value.borrow().clone(),
+      let output = match self.runtime.output_value_for_interpreter(interpreter_id, var_id) {
+        Some(value) => value,
         None => {
           log!(
             "VAR placeholder unresolved variable (yet?): {} (hash: {}, interpreter: {})",
@@ -1159,11 +905,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
           if let Some(ptr) = *mech_ref.borrow() {
             unsafe {
               let mech = &*ptr;
-              let out_values = match find_out_values(&mech.interpreter, interpreter_id) {
-                Some(out_values) => out_values,
-                None => return None,
-              };
-              return out_values.borrow().get(&output_id).cloned();
+              return mech.runtime.output_value_for_interpreter(interpreter_id, output_id);
             }
           }
           None
@@ -1176,7 +918,8 @@ pub fn attach_repl(&mut self, repl_id: &str) {
           CURRENT_MECH.with(|mech_ref| {
             if let Some(ptr) = *mech_ref.borrow() {
               unsafe {
-                (*ptr).bind_ans_symbol_for_interpreter(interpreter_id, &output_value);
+                let mech = &mut *ptr;
+                let _ = mech.runtime.bind_ans_for_interpreter(interpreter_id, &output_value);
               }
             }
           });
@@ -1284,7 +1027,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
 
   #[cfg(feature = "run_program")]
   fn interpret_with_runtime_error_handling(&mut self, tree: &Program) {
-    match catch_unwind(AssertUnwindSafe(|| self.interpreter.interpret(tree))) {
+    match catch_unwind(AssertUnwindSafe(|| self.runtime.run_tree(tree))) {
       Ok(Ok(result)) => {
         log!("{}", result.pretty_print());
       }
@@ -1308,7 +1051,7 @@ pub fn attach_repl(&mut self, repl_id: &str) {
 
   #[cfg(feature = "run_program")]
   #[wasm_bindgen]
-  pub fn run_program(&mut self, src: &str) { 
+  pub fn run_program(&mut self, src: &str) {
     // Decompress the string into a Program
     match decode_and_decompress(&src) {
       Ok(tree) => {
@@ -1347,8 +1090,14 @@ pub fn load_doc(doc: &str, element_id: String) {
         let mut formatter = Formatter::new();
         formatter.html = true;
         let doc_html = formatter.program(&tree);
-        let mut doc_intrp = new_interpreter(doc_hash);
-        let doc_result = doc_intrp.interpret(&tree);
+        CURRENT_MECH.with(|mech_ref| {
+          if let Some(ptr) = *mech_ref.borrow() {
+            unsafe {
+              let mech = &mut *ptr;
+              let _ = mech.runtime.run_string(&doc_mec);
+            }
+          }
+        });
         let output_element = document.get_element_by_id(&element_id).expect("REPL output element not found");
         // Get the second to last element of mech-output. It should be a repl-result from when teh user pressed enter.
         // Set the inner html of the repl result element to be the formatted doc.
@@ -1356,15 +1105,14 @@ pub fn load_doc(doc: &str, element_id: String) {
         let len = children.length();
         if len >= 2 {
             let repl_result = children.item(len - 2).expect("Failed to get second-to-last child");
-            repl_result.set_attribute("mech-interpreter-id", &format!("{}",doc_hash)).unwrap();
+            repl_result.set_attribute("mech-interpreter-id", "0").unwrap();
             let repl_html = repl_result.dyn_ref::<HtmlElement>().expect("Expected an HtmlElement");
             repl_html.class_list().add_1("compact").unwrap();
             repl_html.set_inner_html(&doc_html);
             CURRENT_MECH.with(|mech_ref| {
               if let Some(ptr) = *mech_ref.borrow() {
                 unsafe {
-                  let mut mech = &mut *ptr;
-                  mech.interpreter.sub_interpreters.borrow_mut().insert(doc_hash, Box::new(doc_intrp));
+                  let mech = &mut *ptr;
                   #[cfg(feature = "codeblock_output_values")]
                   mech.render_codeblock_output_values();
                 }

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -74,6 +74,14 @@ fn configure_browser_host(runtime: &mut MechRuntime) -> MResult<()> {
   Ok(())
 }
 
+fn new_wasm_runtime() -> MechRuntime {
+  let mut runtime = MechRuntime::new(RuntimeConfig::default())
+    .expect("failed to initialize MechRuntime for wasm");
+  configure_browser_host(&mut runtime)
+    .expect("failed to configure browser host for wasm");
+  runtime
+}
+
 #[wasm_bindgen]
 pub struct WasmMech {
   runtime: MechRuntime,
@@ -91,13 +99,8 @@ impl WasmMech {
   }
 
   fn with_default_runtime() -> Self {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default())
-      .expect("failed to initialize MechRuntime for wasm");
-    configure_browser_host(&mut runtime)
-      .expect("failed to configure browser host for wasm");
-
     Self {
-      runtime,
+      runtime: new_wasm_runtime(),
       repl_history: Vec::new(),
       repl_history_index: None,
       repl_id: None,
@@ -111,8 +114,7 @@ impl WasmMech {
 
   #[wasm_bindgen]
   pub fn clear(&mut self) {
-    self.runtime = MechRuntime::new(RuntimeConfig::default())
-      .expect("failed to reset MechRuntime for wasm");
+    self.runtime = new_wasm_runtime();
   }
 
 #[cfg(feature = "repl")]

--- a/src/wasm/src/repl.rs
+++ b/src/wasm/src/repl.rs
@@ -12,7 +12,7 @@ pub fn execute_repl_command(repl_cmd: ReplCommand) -> String {
         if let Some(ptr) = *mech_ref.borrow() {
           unsafe {
             let mut mech = &mut *ptr;
-            mech.interpreter.clear();
+            mech.clear();
           }
         }
       });
@@ -24,7 +24,7 @@ pub fn execute_repl_command(repl_cmd: ReplCommand) -> String {
         if let Some(ptr) = *mech_ref.borrow() {
           unsafe {
             let mut mech = &mut *ptr;
-            let window = web_sys::window().expect("global window does not exists");    
+            let window = web_sys::window().expect("global window does not exists");
             let document = window.document().expect("expecting a document on window");
             let output_element = document.get_element_by_id(&mech.repl_id.as_ref().unwrap().clone()).expect("REPL output element not found");
             // Remove all children
@@ -48,16 +48,20 @@ pub fn execute_repl_command(repl_cmd: ReplCommand) -> String {
         if let Some(ptr) = *mech_ref.borrow() {
           unsafe {
             let mut mech = &mut *ptr;
-            match run_mech_code(&mut mech.interpreter, &code)  {
-              Ok(output) => { 
-                let kind_str = html_escape(&format!("{}",output.kind()));
-                return format!("<div class=\"mech-output-kind\">{}</div><div class=\"mech-output-value\">{}</div>", kind_str, output.to_html());
-              },
-              Err(err) => {
-                return format!(
-                  "<div class=\"mech-output-kind\">Error</div><div class=\"mech-output-value\">{}</div>",
-                  err.to_html()
-                );
+            for (_, source) in code {
+              if let MechSourceCode::String(source) = source {
+                match mech.runtime.run_string(&source) {
+                  Ok(output) => {
+                    let kind_str = html_escape(&format!("{}", output.kind()));
+                    return format!("<div class=\"mech-output-kind\">{}</div><div class=\"mech-output-value\">{}</div>", kind_str, output.to_html());
+                  }
+                  Err(err) => {
+                    return format!(
+                      "<div class=\"mech-output-kind\">Error</div><div class=\"mech-output-value\">{}</div>",
+                      err.to_html()
+                    );
+                  }
+                }
               }
             }
           }
@@ -88,7 +92,7 @@ pub fn execute_repl_command(repl_cmd: ReplCommand) -> String {
         if let Some(ptr) = *mech_ref.borrow() {
           unsafe {
             let mut mech = &mut *ptr;
-            return whos_html(&mech.interpreter, names)
+            return whos_html(&mech.runtime, names)
           }
         }
         "Error: No interpreter found.".to_string()
@@ -114,7 +118,7 @@ pub fn execute_repl_command(repl_cmd: ReplCommand) -> String {
           format!("Fetching doc: {}…", d)
         },
         None => "Enter the name of a doc to load.".to_string(),
-      } 
+      }
     }
     x => format!("Command {:?} not implemented for wasm", x),
   }
@@ -133,12 +137,12 @@ pub fn help_html() -> String {
 └─┘     └─┘ └──────┘ └──────┘ └─┘  └─┘"#;
   let version = env!("CARGO_PKG_VERSION");
   let mut html = String::new();
-  
+
   html.push_str("<div class=\"mech-help\">");
-  html.push_str(&format!("<div class=\"mech-text-logo\">{}</div>", text_logo));  
+  html.push_str(&format!("<div class=\"mech-text-logo\">{}</div>", text_logo));
   html.push_str(&format!("<div class=\"mech-version\">Version: <a href=\"https://github.com/mech-lang/mech/releases/tag/v{}-beta\">{}</a></div>", version, version));
   html.push_str("<p>Welcome to the Mech REPL!</p>");
-  html.push_str("<p>Full documentation: <a href=\"https://docs.mech-lang.org\">docs.mech-lang.org</a>.</p>"); 
+  html.push_str("<p>Full documentation: <a href=\"https://docs.mech-lang.org\">docs.mech-lang.org</a>.</p>");
   html.push_str("<table class=\"mech-help-table\">");
     html.push_str("<thead><tr><th>Command</th><th>Short</th><th>Options</th><th>Description</th></tr></thead>");
     html.push_str("<tbody>");
@@ -155,35 +159,10 @@ pub fn help_html() -> String {
 }
 
 #[cfg(feature = "whos")]
-pub fn whos_html(intrp: &Interpreter, names: Vec<String>) -> String {
-  let state_brrw = intrp.state.borrow();
-  let symbol_table = state_brrw.symbol_table.borrow();
-  let dictionary = symbol_table.dictionary.borrow();
-
-  // Collect matching symbols into a vector
-  let mut rows = Vec::new();
-
-  if !names.is_empty() {
-    for target_name in &names {
-      for (id, name) in dictionary.iter() {
-        if *name == *target_name {
-          if let Some(value_ref) = symbol_table.symbols.get(id) {
-            let value = value_ref.borrow();
-            rows.push((name.clone(), value.clone()));
-          }
-          break;
-        }
-      }
-    }
-  } else {
-    // Show all symbols
-    for (id, value_ref) in symbol_table.symbols.iter() {
-      if let Some(name) = dictionary.get(id) {
-        let value = value_ref.borrow();
-        rows.push((name.clone(), value.clone()));
-      }
-    }
-  }
+pub fn whos_html(runtime: &MechRuntime, names: Vec<String>) -> String {
+  let rows = runtime
+    .symbol_values_for_interpreter(0, &names)
+    .unwrap_or_default();
 
   if rows.is_empty() {
     if names.is_empty() {

--- a/src/wasm/src/repl.rs
+++ b/src/wasm/src/repl.rs
@@ -79,8 +79,20 @@ pub fn execute_repl_command(repl_cmd: ReplCommand) -> String {
               Some(n) => n,
               None => 1,
             };
-            mech.interpreter.step(n as u64);
-            return format!("<div class=\"mech-output-kind\">Step</div><div class=\"mech-output-value\">Executed {} step(s).</div>",n);
+            match mech.runtime.step(n as u64) {
+              Ok(()) => {
+                return format!(
+                  "<div class=\"mech-output-kind\">Step</div><div class=\"mech-output-value\">Executed {} step(s).</div>",
+                  n
+                );
+              }
+              Err(err) => {
+                return format!(
+                  "<div class=\"mech-output-kind\">Error</div><div class=\"mech-output-value\">{}</div>",
+                  err.to_html()
+                );
+              }
+            }
           }
         }
         "Error: No interpreter found.".to_string()


### PR DESCRIPTION
### Motivation
- Remove direct interpreter ownership from the WASM layer so the browser-facing crate uses a `MechRuntime` host boundary instead of constructing or inspecting `Interpreter` internals.
- Provide a deterministic, feature-gated runtime construction and a hook for browser host configuration while keeping interpreter internals encapsulated in the runtime crate.

### Description
- Add `mech-runtime` as a local dependency in `src/wasm/Cargo.toml` and forward matching runtime features into WASM feature sets (including `default` and `base`).
- Replace all direct `Interpreter` usage in `src/wasm/src/lib.rs` with a `runtime: MechRuntime` field on `WasmMech`, add `with_default_runtime()` construction, a `configure_browser_host(&mut MechRuntime)` hook, and change `out_string`, `clear`, and `eval` paths to call runtime APIs instead of the interpreter.
- Remove `new_interpreter`, `WasmProgram`, `run_mech_code`, `find_out_values`, `find_symbols`, and `bind_ans_symbol_for_interpreter` from the WASM crate and update rendering and click handlers to call `MechRuntime` accessor methods instead.
- Add runtime-facing APIs in `src/runtime/src/runtime/execution.rs` on `impl MechRuntime`: `run_tree`, `out_string`, `has_interpreter`, `output_value_for_interpreter`, `symbol_name_for_interpreter_output`, `symbol_values_for_interpreter` (helper), and `bind_ans_for_interpreter`, plus a `symbol_rows` helper; keep their implementations internal to the runtime.
- Update `src/wasm/src/repl.rs` to use the runtime for `:clear`, code execution (`run_string`), and `:whos` output rendering via `symbol_values_for_interpreter`.
- Preserve existing WASM methods and feature gating (e.g., `attach_repl`, `eval`, `out_string`, `clear`, `add_clickable_event_listeners`, `init`, `render_values`, `render_codeblock_output_values`, `render_inline_values`) and avoid exposing interpreter internals from `mech-wasm`.

### Testing
- Ran `cargo check -p mech-runtime` and the check completed successfully with warnings only.
- Ran `cargo check -p mech-wasm` and the check completed successfully.
- Added and ran runtime tests: `runtime_output_value_for_interpreter_returns_value_after_run_string`, `runtime_bind_ans_for_interpreter_binds_ans`, and `runtime_has_interpreter_finds_root_interpreter` via `cargo test -p mech-runtime` and the tests passed.
- Ran `git diff --check` to verify trailing-space fixes; no blocking issues remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235a3aef5c832aa2530f8663a595ec)