### PR TITLE
Implement browser DOM resource bindings

### DIFF
--- a/examples/browser-dom-resource.mcfg
+++ b/examples/browser-dom-resource.mcfg
@@ -1,0 +1,12 @@
+config := {
+  browser: {
+    dom: [
+      {
+        path: "body/content/mech-sandbox/*"
+        selector: "#mech-sandbox"
+        mode: "subtree"
+        allow: ["read", "write"]
+      }
+    ]
+  }
+}

--- a/examples/browser-dom-resource.mec
+++ b/examples/browser-dom-resource.mec
@@ -1,0 +1,5 @@
+@browser := browser://dom/
+
+body/content/mech-sandbox/title@browser = "Hello from Mech"
+body/content/mech-sandbox/status/_class@browser = "ready"
+input-value := body/content/mech-sandbox/input/_value@browser

--- a/src/core/src/browser.rs
+++ b/src/core/src/browser.rs
@@ -24,6 +24,7 @@ pub const BROWSER_STORAGE_PROVIDER_URI: &str = "browser://storage";
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BrowserAuthority {
     grants: Vec<BrowserCapabilityGrant>,
+    dom_manifest: Vec<BrowserDomManifestEntry>,
 }
 
 impl BrowserAuthority {
@@ -37,6 +38,30 @@ impl BrowserAuthority {
 
     pub fn grants(&self) -> &[BrowserCapabilityGrant] {
         &self.grants
+    }
+
+    pub fn dom_manifest(&self) -> &[BrowserDomManifestEntry] {
+        &self.dom_manifest
+    }
+
+    pub fn bind_dom_path(&mut self, entry: BrowserDomManifestEntry) {
+        if let Some(existing) = self
+            .dom_manifest
+            .iter_mut()
+            .find(|existing| existing.path == entry.path)
+        {
+            *existing = entry;
+        } else {
+            self.dom_manifest.push(entry);
+            self.dom_manifest
+                .sort_by(|left, right| left.path.cmp(&right.path));
+        }
+    }
+
+    pub fn dom_entry_for_path(&self, path: &BrowserDomPath) -> Option<&BrowserDomManifestEntry> {
+        self.dom_manifest
+            .iter()
+            .find(|entry| entry.path.matches(path))
     }
 
     pub fn grant(&mut self, grant: BrowserCapabilityGrant) {
@@ -271,6 +296,163 @@ impl fmt::Display for BrowserOperation {
             Self::Watch => "watch",
             Self::Invoke => "invoke",
         })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrowserDomManifestEntry {
+    pub path: BrowserDomPath,
+    pub selector: BrowserDomScope,
+    pub property: BrowserDomProperty,
+}
+
+impl BrowserDomManifestEntry {
+    pub fn new(
+        path: BrowserDomPath,
+        selector: BrowserDomScope,
+        property: BrowserDomProperty,
+    ) -> Self {
+        Self {
+            path,
+            selector,
+            property,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BrowserDomPath {
+    path: String,
+    wildcard: bool,
+}
+
+impl BrowserDomPath {
+    pub fn new(path: impl Into<String>) -> Result<Self, BrowserCapabilityError> {
+        let path = path.into();
+        validate_browser_dom_path(&path)?;
+        let wildcard = path.ends_with("/*");
+        Ok(Self { path, wildcard })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.path
+    }
+
+    pub fn is_wildcard(&self) -> bool {
+        self.wildcard
+    }
+
+    pub fn matches(&self, requested: &BrowserDomPath) -> bool {
+        if self.path == requested.path {
+            return true;
+        }
+
+        if !self.wildcard {
+            return false;
+        }
+
+        let prefix = self
+            .path
+            .strip_suffix("/*")
+            .expect("wildcard DOM path must end in /*");
+
+        requested
+            .path
+            .strip_prefix(prefix)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    }
+
+    pub fn join(&self, child: &str) -> Result<Self, BrowserCapabilityError> {
+        let base = self.path.trim_end_matches('/');
+        let child = child.trim_start_matches('/');
+        if base.is_empty() {
+            Self::new(child.to_string())
+        } else if child.is_empty() {
+            Self::new(base.to_string())
+        } else {
+            Self::new(format!("{base}/{child}"))
+        }
+    }
+
+    pub fn without_property_suffix(&self) -> &str {
+        let Some((base, leaf)) = self.path.rsplit_once('/') else {
+            return &self.path;
+        };
+        if leaf.starts_with('_') {
+            base
+        } else {
+            &self.path
+        }
+    }
+
+    pub fn dom_property(&self) -> BrowserDomProperty {
+        let Some((_, leaf)) = self.path.rsplit_once('/') else {
+            return BrowserDomProperty::Text;
+        };
+
+        BrowserDomProperty::from_path_segment(leaf)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BrowserDomProperty {
+    Text,
+    Value,
+    InnerHtml,
+    Attribute(String),
+}
+
+impl BrowserDomProperty {
+    pub fn from_path_segment(segment: &str) -> Self {
+        match segment {
+            "_text" => Self::Text,
+            "_value" => Self::Value,
+            "_html" => Self::InnerHtml,
+            segment if segment.starts_with('_') => {
+                Self::Attribute(segment.trim_start_matches('_').to_string())
+            }
+            _ => Self::Text,
+        }
+    }
+
+    pub fn parse_manifest(
+        property: Option<&str>,
+        attribute: Option<&str>,
+        path: &BrowserDomPath,
+    ) -> Result<Self, BrowserCapabilityError> {
+        match property {
+            Some("text") => Ok(Self::Text),
+            Some("value") => Ok(Self::Value),
+            Some("inner-html") | Some("innerHtml") | Some("html") => Ok(Self::InnerHtml),
+            Some("attribute") => {
+                let Some(attribute) = attribute else {
+                    return Err(BrowserCapabilityError::InvalidScope {
+                        resource: BrowserResourceKind::Dom,
+                        scope: path.as_str().to_string(),
+                        reason: "DOM property `attribute` requires an `attribute` name".to_string(),
+                    });
+                };
+                validate_dom_attribute_name(attribute)?;
+                Ok(Self::Attribute(attribute.to_string()))
+            }
+            Some(other) => Err(BrowserCapabilityError::InvalidScope {
+                resource: BrowserResourceKind::Dom,
+                scope: path.as_str().to_string(),
+                reason: format!(
+                    "DOM property `{other}` must be `text`, `value`, `inner-html`, or `attribute`"
+                ),
+            }),
+            None => {
+                let inferred = path.dom_property();
+                if matches!(inferred, Self::Attribute(_)) {
+                    if let Some(attribute) = attribute {
+                        validate_dom_attribute_name(attribute)?;
+                        return Ok(Self::Attribute(attribute.to_string()));
+                    }
+                }
+                Ok(inferred)
+            }
+        }
     }
 }
 
@@ -615,6 +797,72 @@ pub fn browser_capability_error(error: BrowserCapabilityError) -> MechError {
 
 pub fn browser_capability_result(result: Result<(), BrowserCapabilityError>) -> MResult<()> {
     result.map_err(browser_capability_error)
+}
+
+fn validate_browser_dom_path(path: &str) -> Result<(), BrowserCapabilityError> {
+    let invalid = |reason: &str| BrowserCapabilityError::InvalidScope {
+        resource: BrowserResourceKind::Dom,
+        scope: path.to_string(),
+        reason: reason.to_string(),
+    };
+
+    if path.trim() != path || path.is_empty() {
+        return Err(invalid(
+            "DOM resource paths must be non-empty and must not include surrounding whitespace",
+        ));
+    }
+
+    let segments: Vec<&str> = path.split('/').collect();
+    for (index, segment) in segments.iter().enumerate() {
+        if segment.is_empty() || *segment == "." || *segment == ".." {
+            return Err(invalid(
+                "DOM resource path segments must be non-empty normalized tokens",
+            ));
+        }
+
+        if *segment == "*" {
+            if index + 1 != segments.len() {
+                return Err(invalid(
+                    "DOM resource wildcard `*` is only allowed as the final segment",
+                ));
+            }
+            continue;
+        }
+
+        if segment.contains('*') {
+            return Err(invalid(
+                "DOM resource wildcard `*` must be its own final segment",
+            ));
+        }
+
+        if !segment
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+        {
+            return Err(invalid(
+                "DOM resource path segments may contain only ASCII letters, digits, `_`, or `-`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_dom_attribute_name(attribute: &str) -> Result<(), BrowserCapabilityError> {
+    if attribute.trim() != attribute
+        || attribute.is_empty()
+        || !attribute
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+    {
+        return Err(BrowserCapabilityError::InvalidScope {
+            resource: BrowserResourceKind::Dom,
+            scope: attribute.to_string(),
+            reason: "DOM attribute names must be non-empty simple tokens".to_string(),
+        });
+    }
+
+    Ok(())
 }
 
 fn browser_resource_allows_operation(

--- a/src/core/src/browser.rs
+++ b/src/core/src/browser.rs
@@ -59,9 +59,19 @@ impl BrowserAuthority {
     }
 
     pub fn dom_entry_for_path(&self, path: &BrowserDomPath) -> Option<&BrowserDomManifestEntry> {
-        self.dom_manifest
+        if let Some(exact) = self
+            .dom_manifest
             .iter()
-            .find(|entry| entry.path.matches(path))
+            .find(|entry| !entry.path.is_wildcard() && entry.path == *path)
+        {
+            return Some(exact);
+        }
+
+        self
+            .dom_manifest
+            .iter()
+            .filter(|entry| entry.path.is_wildcard() && entry.path.matches(path))
+            .max_by_key(|entry| entry.path.as_str().trim_end_matches("/*").len())
     }
 
     pub fn grant(&mut self, grant: BrowserCapabilityGrant) {
@@ -420,40 +430,52 @@ impl BrowserDomProperty {
         attribute: Option<&str>,
         path: &BrowserDomPath,
     ) -> Result<Self, BrowserCapabilityError> {
+        let invalid = |reason: String| BrowserCapabilityError::InvalidScope {
+            resource: BrowserResourceKind::Dom,
+            scope: path.as_str().to_string(),
+            reason,
+        };
+
         match property {
-            Some("text") => Ok(Self::Text),
-            Some("value") => Ok(Self::Value),
-            Some("inner-html") | Some("innerHtml") | Some("html") => Ok(Self::InnerHtml),
+            Some("text") => {
+                if attribute.is_some() {
+                    return Err(invalid("DOM property `text` cannot include `attribute`".to_string()));
+                }
+                Ok(Self::Text)
+            }
+            Some("value") => {
+                if attribute.is_some() {
+                    return Err(invalid("DOM property `value` cannot include `attribute`".to_string()));
+                }
+                Ok(Self::Value)
+            }
+            Some("inner-html") | Some("innerHtml") | Some("html") => {
+                if attribute.is_some() {
+                    return Err(invalid("DOM property `inner-html` cannot include `attribute`".to_string()));
+                }
+                Ok(Self::InnerHtml)
+            }
             Some("attribute") => {
                 let Some(attribute) = attribute else {
-                    return Err(BrowserCapabilityError::InvalidScope {
-                        resource: BrowserResourceKind::Dom,
-                        scope: path.as_str().to_string(),
-                        reason: "DOM property `attribute` requires an `attribute` name".to_string(),
-                    });
+                    return Err(invalid("DOM property `attribute` requires an `attribute` name".to_string()));
                 };
                 validate_dom_attribute_name(attribute)?;
                 Ok(Self::Attribute(attribute.to_string()))
             }
-            Some(other) => Err(BrowserCapabilityError::InvalidScope {
-                resource: BrowserResourceKind::Dom,
-                scope: path.as_str().to_string(),
-                reason: format!(
-                    "DOM property `{other}` must be `text`, `value`, `inner-html`, or `attribute`"
-                ),
-            }),
+            Some(other) => Err(invalid(format!(
+                "DOM property `{other}` must be `text`, `value`, `inner-html`, or `attribute`"
+            ))),
             None => {
-                let inferred = path.dom_property();
-                if matches!(inferred, Self::Attribute(_)) {
-                    if let Some(attribute) = attribute {
-                        validate_dom_attribute_name(attribute)?;
-                        return Ok(Self::Attribute(attribute.to_string()));
-                    }
+                if attribute.is_some() {
+                    return Err(invalid(
+                        "`attribute` is only valid when `property` is `attribute`; underscore path segments infer attributes directly".to_string(),
+                    ));
                 }
-                Ok(inferred)
+                Ok(path.dom_property())
             }
         }
     }
+
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -955,6 +977,62 @@ mod tests {
                 })
             ));
         }
+    }
+
+
+    #[test]
+    fn dom_manifest_exact_path_beats_wildcard() {
+        let mut authority = BrowserAuthority::default();
+        let wildcard_scope = BrowserDomScope::new("#wild").unwrap();
+        let exact_scope = BrowserDomScope::new("#exact").unwrap();
+        authority.bind_dom_path(BrowserDomManifestEntry::new(
+            BrowserDomPath::new("body/*").unwrap(),
+            wildcard_scope,
+            BrowserDomProperty::Text,
+        ));
+        authority.bind_dom_path(BrowserDomManifestEntry::new(
+            BrowserDomPath::new("body/title").unwrap(),
+            exact_scope,
+            BrowserDomProperty::Text,
+        ));
+        let entry = authority
+            .dom_entry_for_path(&BrowserDomPath::new("body/title").unwrap())
+            .unwrap();
+        assert_eq!(entry.selector.selector, "#exact");
+    }
+
+    #[test]
+    fn dom_manifest_longest_wildcard_wins() {
+        let mut authority = BrowserAuthority::default();
+        let short_scope = BrowserDomScope::new("#short").unwrap();
+        let long_scope = BrowserDomScope::new("#long").unwrap();
+        authority.bind_dom_path(BrowserDomManifestEntry::new(
+            BrowserDomPath::new("body/*").unwrap(),
+            short_scope,
+            BrowserDomProperty::Text,
+        ));
+        authority.bind_dom_path(BrowserDomManifestEntry::new(
+            BrowserDomPath::new("body/content/*").unwrap(),
+            long_scope,
+            BrowserDomProperty::Text,
+        ));
+        let entry = authority
+            .dom_entry_for_path(&BrowserDomPath::new("body/content/title").unwrap())
+            .unwrap();
+        assert_eq!(entry.selector.selector, "#long");
+    }
+
+    #[test]
+    fn dom_manifest_sibling_wildcard_does_not_match() {
+        let mut authority = BrowserAuthority::default();
+        authority.bind_dom_path(BrowserDomManifestEntry::new(
+            BrowserDomPath::new("body/content/*").unwrap(),
+            BrowserDomScope::new("#content").unwrap(),
+            BrowserDomProperty::Text,
+        ));
+        assert!(authority
+            .dom_entry_for_path(&BrowserDomPath::new("body/sidebar/title").unwrap())
+            .is_none());
     }
 
     #[test]

--- a/src/program/tests/program.rs
+++ b/src/program/tests/program.rs
@@ -1,49 +1,67 @@
-/*
-#[test]
-fn program_test() {
-  let mut runner = ProgramRunner::new("test");
-  let running = runner.run().unwrap();
-  running.send(RunLoopMessage::Code(MechCode::String("#data = [1 2 3 4 5]".to_string())));
-  running.send(RunLoopMessage::Stop);
+use mech_core::nodes::*;
 
+fn statements(src: &str) -> Vec<Statement> {
+  let program = mech_syntax::parser::parse(src).expect("parse failed");
+  let mut out = vec![];
+  for section in &program.body.sections {
+    for element in &section.elements {
+      if let SectionElement::MechCode(codes) = element {
+        for (node, _) in codes {
+          if let MechCode::Statement(stmt) = node {
+            out.push(stmt.clone());
+          }
+        }
+      }
+    }
+  }
+  out
 }
 
 #[test]
-fn load_module_with_program() {
-  let mut runner = ProgramRunner::new("test");
-  let running = runner.run().unwrap();
-  running.send(RunLoopMessage::Code(MechCode::String("#test = math/sin(angle: 0)".to_string())));
-  running.send(RunLoopMessage::GetValue((hash_str("test"),TableIndex::Index(1),TableIndex::Index(1))));
-  loop {
-    match running.receive() {
-      Ok(ClientMessage::Value(value)) => {
-          assert_eq!(value, Value::F32(F32::new(0.0)));
-          break;
-      },
-      message => (),
-    }
-  }
-}*/
-#[test]
 fn program_browser_resource_binding_declaration() {
-  let tree = mech_syntax::parser::parse("@browser := browser://dom/").unwrap();
-  assert!(!tree.body.sections.is_empty());
+  let stmts = statements("@browser := browser://dom/");
+  match &stmts[0] {
+    Statement::ContextDeclaration(ctx) => {
+      assert_eq!(ctx.name.to_string(), "browser");
+      assert!(ctx.capabilities.is_empty());
+      match &ctx.base {
+        ContextBase::ResourceUri(uri) => assert_eq!(uri.to_string(), "browser://dom/"),
+        _ => panic!("expected resource uri"),
+      }
+    }
+    _ => panic!("expected context declaration"),
+  }
 }
 
 #[test]
 fn program_browser_resource_read() {
-  let tree = mech_syntax::parser::parse("x := body/search/_value@browser").unwrap();
-  assert!(!tree.body.sections.is_empty());
+  let stmts = statements("x := body/search/_value@browser");
+  match &stmts[0] {
+    Statement::VariableDefine(v) => match &v.expression {
+      Expression::Var(var) => {
+        assert_eq!(var.name.to_string(), "body/search/_value");
+        assert_eq!(var.context.as_ref().unwrap().to_string(), "browser");
+      }
+      _ => panic!("expected addressed var expression"),
+    },
+    _ => panic!("expected variable define"),
+  }
 }
 
 #[test]
 fn program_browser_resource_write() {
-  let tree = mech_syntax::parser::parse("body/header/title@browser = \"Hello\"").unwrap();
-  assert!(!tree.body.sections.is_empty());
+  let stmts = statements("body/header/title@browser = \"Hello\"");
+  match &stmts[0] {
+    Statement::VariableAssign(assign) => {
+      assert_eq!(assign.target.name.to_string(), "body/header/title");
+      assert_eq!(assign.target.context.as_ref().unwrap().to_string(), "browser");
+    }
+    _ => panic!("expected variable assignment"),
+  }
 }
 
 #[test]
 fn program_browser_resource_define_does_not_write() {
-  let tree = mech_syntax::parser::parse("title@browser := \"Hello\"").unwrap();
-  assert!(!tree.body.sections.is_empty());
+  let stmts = statements("title@browser := \"Hello\"");
+  assert!(matches!(&stmts[0], Statement::VariableDefine(_)));
 }

--- a/src/program/tests/program.rs
+++ b/src/program/tests/program.rs
@@ -1,9 +1,3 @@
-extern crate mech_program;
-extern crate mech_utilities;
-extern crate mech_core;
-use mech_program::*;
-use mech_utilities::*;
-use mech_core::*;
 /*
 #[test]
 fn program_test() {
@@ -30,3 +24,26 @@ fn load_module_with_program() {
     }
   }
 }*/
+#[test]
+fn program_browser_resource_binding_declaration() {
+  let tree = mech_syntax::parser::parse("@browser := browser://dom/").unwrap();
+  assert!(!tree.body.sections.is_empty());
+}
+
+#[test]
+fn program_browser_resource_read() {
+  let tree = mech_syntax::parser::parse("x := body/search/_value@browser").unwrap();
+  assert!(!tree.body.sections.is_empty());
+}
+
+#[test]
+fn program_browser_resource_write() {
+  let tree = mech_syntax::parser::parse("body/header/title@browser = \"Hello\"").unwrap();
+  assert!(!tree.body.sections.is_empty());
+}
+
+#[test]
+fn program_browser_resource_define_does_not_write() {
+  let tree = mech_syntax::parser::parse("title@browser := \"Hello\"").unwrap();
+  assert!(!tree.body.sections.is_empty());
+}

--- a/src/runtime/src/browser.rs
+++ b/src/runtime/src/browser.rs
@@ -1,6 +1,7 @@
 pub use mech_core::{
     browser_capability_error, browser_capability_result, BrowserAuthority, BrowserBudget,
-    BrowserCapabilityError, BrowserCapabilityGrant, BrowserCapabilityRequest, BrowserDomScope,
+    BrowserCapabilityError, BrowserCapabilityGrant, BrowserCapabilityRequest,
+    BrowserDomManifestEntry, BrowserDomPath, BrowserDomProperty, BrowserDomScope,
     BrowserNetworkScope, BrowserOperation, BrowserResource, BrowserResourceKind,
     BrowserStorageBackend, BrowserStorageScope, BROWSER_CLIPBOARD_PROVIDER_URI,
     BROWSER_DOM_PROVIDER_URI, BROWSER_HOST_IDENTITY, BROWSER_NETWORK_PROVIDER_URI,

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -299,6 +299,12 @@ impl ConfigLowerer {
                 ));
             }
             let property = if matches!(mode.as_deref(), Some("subtree")) {
+                if property.is_some() {
+                    return invalid(format!("{where_}.property is not allowed when mode is `subtree`"));
+                }
+                if attribute.is_some() {
+                    return invalid(format!("{where_}.attribute is not allowed when mode is `subtree`"));
+                }
                 BrowserDomProperty::Text
             } else {
                 BrowserDomProperty::parse_manifest(

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -5,9 +5,9 @@ use mech_core::{MResult, MechError};
 
 use super::{ConfigValue, InvalidConfigField};
 use crate::{
-    BrowserAuthority, BrowserCapabilityGrant, BrowserDomScope, BrowserNetworkScope,
-    BrowserOperation, BrowserResource, BrowserResourceKind, BrowserStorageBackend,
-    BrowserStorageScope,
+    BrowserAuthority, BrowserCapabilityGrant, BrowserDomManifestEntry, BrowserDomPath,
+    BrowserDomProperty, BrowserDomScope, BrowserNetworkScope, BrowserOperation, BrowserResource,
+    BrowserResourceKind, BrowserStorageBackend, BrowserStorageScope,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -233,13 +233,25 @@ impl ConfigLowerer {
         for (idx, item) in expect_list("browser.dom", value)?.iter().enumerate() {
             let where_ = format!("browser.dom[{idx}]");
             let map = expect_map(&where_, item)?;
+            let mut path = None;
             let mut selector = None;
+            let mut property = None;
+            let mut attribute = None;
+            let mut mode = None;
             let mut allow = None;
             for (key, value) in map {
                 match key.as_str() {
+                    "path" => path = Some(expect_string(&format!("{where_}.path"), value)?),
                     "selector" => {
                         selector = Some(expect_string(&format!("{where_}.selector"), value)?)
                     }
+                    "property" => {
+                        property = Some(expect_string(&format!("{where_}.property"), value)?)
+                    }
+                    "attribute" => {
+                        attribute = Some(expect_string(&format!("{where_}.attribute"), value)?)
+                    }
+                    "mode" => mode = Some(expect_string(&format!("{where_}.mode"), value)?),
                     "allow" => {
                         allow = Some(expect_browser_operations_for_resource(
                             &format!("{where_}.allow"),
@@ -257,10 +269,46 @@ impl ConfigLowerer {
             let scope = BrowserDomScope::new(selector)
                 .map_err(|error| invalid_error(format!("{where_}.selector: {error}")))?;
             authority.grant(BrowserCapabilityGrant {
-                resource: BrowserResource::Dom(scope),
+                resource: BrowserResource::Dom(scope.clone()),
                 allow,
                 budget: None,
             });
+
+            let Some(path) = path else {
+                continue;
+            };
+            let path = BrowserDomPath::new(path)
+                .map_err(|error| invalid_error(format!("{where_}.path: {error}")))?;
+            let mode = match mode.as_deref() {
+                Some("node") | None => mode,
+                Some("subtree") => mode,
+                Some(other) => {
+                    return invalid(format!(
+                        "{where_}.mode must be `node` or `subtree`; got `{other}`"
+                    ))
+                }
+            };
+            if path.is_wildcard() && !matches!(mode.as_deref(), None | Some("subtree")) {
+                return invalid(format!(
+                    "{where_}.mode must be `subtree` when path ends in `/*`"
+                ));
+            }
+            if matches!(mode.as_deref(), Some("subtree")) && !path.is_wildcard() {
+                return invalid(format!(
+                    "{where_}.path must end in `/*` when mode is `subtree`"
+                ));
+            }
+            let property = if matches!(mode.as_deref(), Some("subtree")) {
+                BrowserDomProperty::Text
+            } else {
+                BrowserDomProperty::parse_manifest(
+                    property.as_deref(),
+                    attribute.as_deref(),
+                    &path,
+                )
+                .map_err(|error| invalid_error(format!("{where_}: {error}")))?
+            };
+            authority.bind_dom_path(BrowserDomManifestEntry::new(path, scope, property));
         }
         Ok(())
     }

--- a/src/runtime/src/host/browser_dom.rs
+++ b/src/runtime/src/host/browser_dom.rs
@@ -1,0 +1,16 @@
+use mech_core::{BrowserDomManifestEntry, BrowserDomPath, MResult};
+
+pub trait BrowserDomHost {
+  fn read_dom_string(
+    &self,
+    entry: &BrowserDomManifestEntry,
+    requested_path: &BrowserDomPath,
+  ) -> MResult<String>;
+
+  fn write_dom_string(
+    &mut self,
+    entry: &BrowserDomManifestEntry,
+    requested_path: &BrowserDomPath,
+    value: &str,
+  ) -> MResult<()>;
+}

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -31,9 +31,11 @@ use crate::service::RuntimeServices;
 
 pub mod actor;
 pub mod arg;
+pub mod browser_dom;
 
 pub use self::actor::*;
 pub use self::arg::*;
+pub use self::browser_dom::*;
 
 // -----------------------------------------------------------------------------
 // Host Function

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -115,124 +115,224 @@ fn runtime_context_allows_write(
 }
 
 
-fn split_resource_address(value: &str) -> Option<(&str, &str)> {
-  let (path, binding) = value.rsplit_once('@')?;
-  let path = path.trim();
-  let binding = binding.trim();
-  if path.is_empty() || binding.is_empty() {
-    return None;
-  }
-  if !binding
-    .bytes()
-    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
-  {
-    return None;
-  }
-  Some((path, binding))
+
+fn program_codes(
+  tree: &mech_core::Program,
+) -> impl Iterator<Item = (&mech_core::MechCode, &Option<mech_core::Comment>)> {
+  tree.body.sections.iter().flat_map(|section| {
+    section.elements.iter().flat_map(|element| match element {
+      mech_core::SectionElement::MechCode(codes) => codes
+        .iter()
+        .map(|(code, comment)| (code, comment))
+        .collect::<Vec<_>>(),
+      mech_core::SectionElement::FencedMechCode(fenced) => fenced
+        .code
+        .iter()
+        .map(|(code, comment)| (code, comment))
+        .collect::<Vec<_>>(),
+      _ => Vec::new(),
+    })
+  })
 }
 
-fn parse_mech_string_literal(value: &str) -> Option<String> {
-  let value = value.trim();
-  if !value.starts_with('"') || !value.ends_with('"') || value.len() < 2 {
-    return None;
+fn single_code_program(
+  code: mech_core::MechCode,
+  comment: Option<mech_core::Comment>,
+) -> mech_core::Program {
+  mech_core::Program {
+    title: None,
+    body: mech_core::Body {
+      sections: vec![mech_core::Section {
+        subtitle: None,
+        elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
+      }],
+    },
   }
-  let inner = &value[1..value.len() - 1];
-  let mut out = String::new();
-  let mut chars = inner.chars();
-  while let Some(ch) = chars.next() {
-    if ch != '\\' {
-      out.push(ch);
-      continue;
-    }
-    match chars.next()? {
-      'n' => out.push('\n'),
-      'r' => out.push('\r'),
-      't' => out.push('\t'),
-      '\\' => out.push('\\'),
-      '"' => out.push('"'),
-      other => {
-        out.push('\\');
-        out.push(other);
-      }
-    }
-  }
-  Some(out)
 }
 
-fn mech_string_literal(value: &str) -> String {
-  let escaped = value
-    .replace('\\', "\\\\")
-    .replace('"', "\\\"")
-    .replace('\n', "\\n")
-    .replace('\r', "\\r")
-    .replace('\t', "\\t");
-  format!("\"{escaped}\"")
+fn bind_runtime_value_on_program(
+  program: &mut MechProgram,
+  var: &mech_core::Var,
+  value: Value,
+  mutable: bool,
+) -> MResult<()> {
+  let (id, name) = match &var.context {
+    Some(context) => {
+      let name = format!("{}@{}", var.name.to_string(), context.to_string());
+      (hash_str(&name), name)
+    }
+    None => (var.name.hash(), var.name.to_string()),
+  };
+  let symbols = program.interpreter_mut().symbols();
+  let mut symbols = symbols.borrow_mut();
+  symbols.insert(id, value, mutable);
+  symbols.dictionary.borrow_mut().insert(id, name);
+  Ok(())
 }
+
+fn resolve_runtime_value(value: Value) -> Value {
+  match value {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  }
+}
+
 
 impl MechRuntime {
 
-
-  fn lower_browser_resource_source(&mut self, source: &str) -> MResult<String> {
-    let mut lowered = Vec::new();
-    for line in source.lines() {
-      let trimmed = line.trim();
-      if trimmed.is_empty() {
-        lowered.push(line.to_string());
+  fn bind_browser_resource_roots_from_program(
+    &mut self,
+    tree: &mech_core::Program,
+  ) -> MResult<()> {
+    for (code, _) in program_codes(tree) {
+      let mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(ctx)) = code else {
         continue;
+      };
+      let mech_core::ContextBase::ResourceUri(uri) = &ctx.base else {
+        continue;
+      };
+      let uri = uri.to_string();
+      if uri.starts_with("browser://dom/") {
+        self.bind_resource_root(ctx.name.to_string(), uri)?;
       }
-
-      if let Some(rest) = trimmed.strip_prefix('@') {
-        if let Some((name, uri)) = rest.split_once(":=") {
-          let name = name.trim();
-          let uri = uri.trim();
-          if uri.starts_with("browser://dom/") {
-            self.bind_resource_root(name, uri)?;
-            continue;
-          }
-        }
-      }
-
-      if let Some((target, rhs)) = trimmed.split_once(" = ") {
-        if !target.contains(":=") {
-          if let Some((path, binding)) = split_resource_address(target) {
-            let Some(value) = parse_mech_string_literal(rhs) else {
-              return Err(browser_runtime_resource_error(
-                target,
-                "browser DOM resource writes currently require a string literal value",
-              ));
-            };
-            self.write_browser_dom_resource(binding, path, &Value::String(Ref::new(value)))?;
-            continue;
-          }
-        }
-      }
-
-      if let Some((lhs, rhs)) = trimmed.split_once(":=") {
-        if let Some((path, binding)) = split_resource_address(rhs) {
-          if self.resource_bindings.contains_key(binding) {
-            let value = self.read_browser_dom_resource(binding, path)?;
-            let Value::String(value) = value else {
-              return Err(browser_runtime_resource_error(
-                rhs,
-                "browser DOM resource reads must return strings",
-              ));
-            };
-            lowered.push(format!("{} := {}", lhs.trim(), mech_string_literal(&value.borrow())));
-            continue;
-          }
-        }
-      }
-
-      lowered.push(line.to_string());
     }
-    Ok(lowered.join("\n"))
+    Ok(())
+  }
+
+  fn run_tree_on_program(
+    &mut self,
+    _context: &mut RuntimeContext,
+    program: &mut MechProgram,
+    tree: &mech_core::Program,
+  ) -> MResult<Value> {
+    if !self.program_has_browser_resource_forms(tree) {
+      return program.run_tree(tree);
+    }
+
+    let mut result = Value::Empty;
+    for (code, comment) in program_codes(tree) {
+      match code {
+        mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(ctx))
+          if self.is_browser_dom_context_declaration(ctx) =>
+        {
+          result = Value::Empty;
+        }
+        mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def))
+          if self.variable_define_reads_browser_resource(var_def) =>
+        {
+          result = self.read_browser_resource_variable_define(program, var_def)?;
+        }
+        mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def))
+          if self.variable_define_targets_browser_binding(var_def) =>
+        {
+          let value = self.evaluate_expression_on_program(program, &var_def.expression)?;
+          bind_runtime_value_on_program(program, &var_def.var, resolve_runtime_value(value.clone()), var_def.mutable)?;
+          result = value;
+        }
+        mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign))
+          if self.assignment_targets_browser_resource(assign) =>
+        {
+          let value = self.evaluate_expression_on_program(program, &assign.expression)?;
+          let binding = assign.target.context.as_ref().expect("checked browser binding").to_string();
+          self.write_browser_dom_resource(
+            &binding,
+            &assign.target.name.to_string(),
+            &resolve_runtime_value(value.clone()),
+          )?;
+          result = value;
+        }
+        _ => {
+          let single = single_code_program(code.clone(), comment.clone());
+          result = program.run_tree(&single)?;
+        }
+      }
+    }
+    Ok(result)
+  }
+
+  fn program_has_browser_resource_forms(&self, tree: &mech_core::Program) -> bool {
+    program_codes(tree).any(|(code, _)| match code {
+      mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(ctx)) => {
+        self.is_browser_dom_context_declaration(ctx)
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+        self.variable_define_reads_browser_resource(var_def)
+          || self.variable_define_targets_browser_binding(var_def)
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+        self.assignment_targets_browser_resource(assign)
+      }
+      _ => false,
+    })
+  }
+
+  fn is_browser_dom_context_declaration(&self, ctx: &mech_core::ContextDeclaration) -> bool {
+    match &ctx.base {
+      mech_core::ContextBase::ResourceUri(uri) => uri.to_string().starts_with("browser://dom/"),
+      _ => false,
+    }
+  }
+
+  fn is_browser_dom_resource_binding(&self, binding: &str) -> bool {
+    self
+      .resource_bindings
+      .get(binding)
+      .is_some_and(|binding| binding.provider == BROWSER_DOM_PROVIDER_URI)
+  }
+
+  fn variable_define_reads_browser_resource(&self, var_def: &mech_core::VariableDefine) -> bool {
+    let mech_core::Expression::Var(var) = &var_def.expression else {
+      return false;
+    };
+    var
+      .context
+      .as_ref()
+      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
+  }
+
+  fn variable_define_targets_browser_binding(&self, var_def: &mech_core::VariableDefine) -> bool {
+    var_def
+      .var
+      .context
+      .as_ref()
+      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
+  }
+
+  fn assignment_targets_browser_resource(&self, assign: &mech_core::VariableAssign) -> bool {
+    assign
+      .target
+      .context
+      .as_ref()
+      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
+  }
+
+  fn read_browser_resource_variable_define(
+    &mut self,
+    program: &mut MechProgram,
+    var_def: &mech_core::VariableDefine,
+  ) -> MResult<Value> {
+    let mech_core::Expression::Var(var) = &var_def.expression else {
+      unreachable!("checked resource variable read")
+    };
+    let binding = var.context.as_ref().expect("checked browser binding").to_string();
+    let value = self.read_browser_dom_resource(&binding, &var.name.to_string())?;
+    bind_runtime_value_on_program(program, &var_def.var, value.clone(), var_def.mutable)?;
+    Ok(value)
+  }
+
+  fn evaluate_expression_on_program(
+    &mut self,
+    program: &mut MechProgram,
+    expression: &mech_core::Expression,
+  ) -> MResult<Value> {
+    let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
+    program.run_tree(&single).map(resolve_runtime_value)
   }
 
   pub fn run_string(&mut self, source: &str) -> MResult<Value> {
     let mut context = self.runtime_context()?;
     self.run_string_with_context(&mut context, source)
   }
-
   pub fn run_string_with_context(
     &mut self,
     context: &mut RuntimeContext,
@@ -248,7 +348,8 @@ impl MechRuntime {
       },
     )?;
 
-    let source = self.lower_browser_resource_source(source)?;
+    let tree = mech_syntax::parser::parse(source.trim())?;
+    self.bind_browser_resource_roots_from_program(&tree)?;
 
     let program_config = self.program.config.clone();
     let mut program = std::mem::replace(
@@ -271,7 +372,7 @@ impl MechRuntime {
       }))
     });
 
-    let result = program.run_string(&source);
+    let result = self.run_tree_on_program(context, &mut program, &tree);
 
     ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
       slot.replace(previous_target);
@@ -323,6 +424,8 @@ impl MechRuntime {
       },
     )?;
 
+    self.bind_browser_resource_roots_from_program(tree)?;
+
     let program_config = self.program.config.clone();
     let mut program = std::mem::replace(
       &mut self.program,
@@ -344,7 +447,7 @@ impl MechRuntime {
       }))
     });
 
-    let result = program.run_tree(tree);
+    let result = self.run_tree_on_program(context, &mut program, tree);
 
     ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
       slot.replace(previous_target);

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -114,7 +114,119 @@ fn runtime_context_allows_write(
   })
 }
 
+
+fn split_resource_address(value: &str) -> Option<(&str, &str)> {
+  let (path, binding) = value.rsplit_once('@')?;
+  let path = path.trim();
+  let binding = binding.trim();
+  if path.is_empty() || binding.is_empty() {
+    return None;
+  }
+  if !binding
+    .bytes()
+    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+  {
+    return None;
+  }
+  Some((path, binding))
+}
+
+fn parse_mech_string_literal(value: &str) -> Option<String> {
+  let value = value.trim();
+  if !value.starts_with('"') || !value.ends_with('"') || value.len() < 2 {
+    return None;
+  }
+  let inner = &value[1..value.len() - 1];
+  let mut out = String::new();
+  let mut chars = inner.chars();
+  while let Some(ch) = chars.next() {
+    if ch != '\\' {
+      out.push(ch);
+      continue;
+    }
+    match chars.next()? {
+      'n' => out.push('\n'),
+      'r' => out.push('\r'),
+      't' => out.push('\t'),
+      '\\' => out.push('\\'),
+      '"' => out.push('"'),
+      other => {
+        out.push('\\');
+        out.push(other);
+      }
+    }
+  }
+  Some(out)
+}
+
+fn mech_string_literal(value: &str) -> String {
+  let escaped = value
+    .replace('\\', "\\\\")
+    .replace('"', "\\\"")
+    .replace('\n', "\\n")
+    .replace('\r', "\\r")
+    .replace('\t', "\\t");
+  format!("\"{escaped}\"")
+}
+
 impl MechRuntime {
+
+
+  fn lower_browser_resource_source(&mut self, source: &str) -> MResult<String> {
+    let mut lowered = Vec::new();
+    for line in source.lines() {
+      let trimmed = line.trim();
+      if trimmed.is_empty() {
+        lowered.push(line.to_string());
+        continue;
+      }
+
+      if let Some(rest) = trimmed.strip_prefix('@') {
+        if let Some((name, uri)) = rest.split_once(":=") {
+          let name = name.trim();
+          let uri = uri.trim();
+          if uri.starts_with("browser://dom/") {
+            self.bind_resource_root(name, uri)?;
+            continue;
+          }
+        }
+      }
+
+      if let Some((target, rhs)) = trimmed.split_once(" = ") {
+        if !target.contains(":=") {
+          if let Some((path, binding)) = split_resource_address(target) {
+            let Some(value) = parse_mech_string_literal(rhs) else {
+              return Err(browser_runtime_resource_error(
+                target,
+                "browser DOM resource writes currently require a string literal value",
+              ));
+            };
+            self.write_browser_dom_resource(binding, path, &Value::String(Ref::new(value)))?;
+            continue;
+          }
+        }
+      }
+
+      if let Some((lhs, rhs)) = trimmed.split_once(":=") {
+        if let Some((path, binding)) = split_resource_address(rhs) {
+          if self.resource_bindings.contains_key(binding) {
+            let value = self.read_browser_dom_resource(binding, path)?;
+            let Value::String(value) = value else {
+              return Err(browser_runtime_resource_error(
+                rhs,
+                "browser DOM resource reads must return strings",
+              ));
+            };
+            lowered.push(format!("{} := {}", lhs.trim(), mech_string_literal(&value.borrow())));
+            continue;
+          }
+        }
+      }
+
+      lowered.push(line.to_string());
+    }
+    Ok(lowered.join("\n"))
+  }
 
   pub fn run_string(&mut self, source: &str) -> MResult<Value> {
     let mut context = self.runtime_context()?;
@@ -135,6 +247,8 @@ impl MechRuntime {
         task_id: context.task,
       },
     )?;
+
+    let source = self.lower_browser_resource_source(source)?;
 
     let program_config = self.program.config.clone();
     let mut program = std::mem::replace(
@@ -157,7 +271,7 @@ impl MechRuntime {
       }))
     });
 
-    let result = program.run_string(source);
+    let result = program.run_string(&source);
 
     ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
       slot.replace(previous_target);

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -178,14 +178,14 @@ fn resolve_runtime_value(value: Value) -> Value {
 }
 
 
-fn string_value_expression(value: String) -> mech_core::Expression {
-  mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
+fn string_value_expression(value: String) -> MResult<mech_core::Expression> {
+  Ok(mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
     text: mech_core::Token::new(
       mech_core::TokenKind::String,
       mech_core::SourceRange::default(),
       value.chars().collect(),
     ),
-  }))
+  })))
 }
 
 impl MechRuntime {
@@ -505,7 +505,7 @@ impl MechRuntime {
             "browser DOM resource reads must return string values in this PR",
           ));
         };
-        Ok(string_value_expression(value.borrow().clone()))
+        string_value_expression(value.borrow().clone())
       }
       mech_core::Expression::Formula(factor) => {
         Ok(mech_core::Expression::Formula(self.lower_browser_resource_reads_in_factor(factor)?))

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -178,6 +178,16 @@ fn resolve_runtime_value(value: Value) -> Value {
 }
 
 
+fn string_value_expression(value: String) -> mech_core::Expression {
+  mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
+    text: mech_core::Token::new(
+      mech_core::TokenKind::String,
+      mech_core::SourceRange::default(),
+      value.chars().collect(),
+    ),
+  }))
+}
+
 impl MechRuntime {
 
   fn bind_browser_resource_roots_from_program(
@@ -218,21 +228,28 @@ impl MechRuntime {
           result = Value::Empty;
         }
         mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def))
-          if self.variable_define_reads_browser_resource(var_def) =>
-        {
-          result = self.read_browser_resource_variable_define(program, var_def)?;
-        }
-        mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def))
           if self.variable_define_targets_browser_binding(var_def) =>
         {
-          let value = self.evaluate_expression_on_program(program, &var_def.expression)?;
+          let expression = self.lower_browser_resource_reads_in_expression(&var_def.expression)?;
+          let value = self.evaluate_expression_on_program(program, &expression)?;
           bind_runtime_value_on_program(program, &var_def.var, resolve_runtime_value(value.clone()), var_def.mutable)?;
           result = value;
+        }
+        mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+          let expression = self.lower_browser_resource_reads_in_expression(&var_def.expression)?;
+          let mut var_def = var_def.clone();
+          var_def.expression = expression;
+          let single = single_code_program(
+            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
+            comment.clone(),
+          );
+          result = program.run_tree(&single)?;
         }
         mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign))
           if self.assignment_targets_browser_resource(assign) =>
         {
-          let value = self.evaluate_expression_on_program(program, &assign.expression)?;
+          let expression = self.lower_browser_resource_reads_in_expression(&assign.expression)?;
+          let value = self.evaluate_expression_on_program(program, &expression)?;
           let binding = assign.target.context.as_ref().expect("checked browser binding").to_string();
           self.write_browser_dom_resource(
             &binding,
@@ -240,6 +257,20 @@ impl MechRuntime {
             &resolve_runtime_value(value.clone()),
           )?;
           result = value;
+        }
+        mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+          let mut assign = assign.clone();
+          assign.expression = self.lower_browser_resource_reads_in_expression(&assign.expression)?;
+          let single = single_code_program(
+            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)),
+            comment.clone(),
+          );
+          result = program.run_tree(&single)?;
+        }
+        mech_core::MechCode::Expression(expression) => {
+          let expression = self.lower_browser_resource_reads_in_expression(expression)?;
+          let single = single_code_program(mech_core::MechCode::Expression(expression), comment.clone());
+          result = program.run_tree(&single)?;
         }
         _ => {
           let single = single_code_program(code.clone(), comment.clone());
@@ -256,11 +287,15 @@ impl MechRuntime {
         self.is_browser_dom_context_declaration(ctx)
       }
       mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-        self.variable_define_reads_browser_resource(var_def)
-          || self.variable_define_targets_browser_binding(var_def)
+        self.variable_define_targets_browser_binding(var_def)
+          || self.expression_reads_browser_resource(&var_def.expression)
       }
       mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
         self.assignment_targets_browser_resource(assign)
+          || self.expression_reads_browser_resource(&assign.expression)
+      }
+      mech_core::MechCode::Expression(expression) => {
+        self.expression_reads_browser_resource(expression)
       }
       _ => false,
     })
@@ -280,16 +315,6 @@ impl MechRuntime {
       .is_some_and(|binding| binding.provider == BROWSER_DOM_PROVIDER_URI)
   }
 
-  fn variable_define_reads_browser_resource(&self, var_def: &mech_core::VariableDefine) -> bool {
-    let mech_core::Expression::Var(var) = &var_def.expression else {
-      return false;
-    };
-    var
-      .context
-      .as_ref()
-      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
-  }
-
   fn variable_define_targets_browser_binding(&self, var_def: &mech_core::VariableDefine) -> bool {
     var_def
       .var
@@ -306,18 +331,484 @@ impl MechRuntime {
       .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
   }
 
-  fn read_browser_resource_variable_define(
+  fn expression_reads_browser_resource(&self, expression: &mech_core::Expression) -> bool {
+    match expression {
+      mech_core::Expression::Var(var) => var
+        .context
+        .as_ref()
+        .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string())),
+      mech_core::Expression::Formula(factor) => self.factor_reads_browser_resource(factor),
+      mech_core::Expression::FunctionCall(call) => call
+        .args
+        .iter()
+        .any(|(_, expression)| self.expression_reads_browser_resource(expression)),
+      mech_core::Expression::FsmPipe(pipe) => pipe
+        .start
+        .args
+        .as_ref()
+        .is_some_and(|args| args.iter().any(|(_, expression)| self.expression_reads_browser_resource(expression))),
+      mech_core::Expression::Literal(_) => false,
+      mech_core::Expression::Match(match_expression) => {
+        self.expression_reads_browser_resource(&match_expression.source)
+          || match_expression.arms.iter().any(|arm| {
+            arm
+              .guard
+              .as_ref()
+              .is_some_and(|guard| self.expression_reads_browser_resource(guard))
+              || self.expression_reads_browser_resource(&arm.expression)
+          })
+      }
+      mech_core::Expression::Range(range) => {
+        self.factor_reads_browser_resource(&range.start)
+          || range
+            .increment
+            .as_ref()
+            .is_some_and(|(_, increment)| self.factor_reads_browser_resource(increment))
+          || self.factor_reads_browser_resource(&range.terminal)
+      }
+      mech_core::Expression::Slice(slice) => self.slice_reads_browser_resource(slice),
+      mech_core::Expression::Structure(structure) => self.structure_reads_browser_resource(structure),
+      mech_core::Expression::SetComprehension(comprehension) => {
+        self.expression_reads_browser_resource(&comprehension.expression)
+          || comprehension
+            .qualifiers
+            .iter()
+            .any(|qualifier| self.comprehension_qualifier_reads_browser_resource(qualifier))
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        self.expression_reads_browser_resource(&comprehension.expression)
+          || comprehension
+            .qualifiers
+            .iter()
+            .any(|qualifier| self.comprehension_qualifier_reads_browser_resource(qualifier))
+      }
+    }
+  }
+
+  fn factor_reads_browser_resource(&self, factor: &mech_core::Factor) -> bool {
+    match factor {
+      mech_core::Factor::Expression(expression) => self.expression_reads_browser_resource(expression),
+      mech_core::Factor::Negate(factor)
+      | mech_core::Factor::Not(factor)
+      | mech_core::Factor::Parenthetical(factor)
+      | mech_core::Factor::Transpose(factor) => self.factor_reads_browser_resource(factor),
+      mech_core::Factor::Term(term) => {
+        self.factor_reads_browser_resource(&term.lhs)
+          || term
+            .rhs
+            .iter()
+            .any(|(_, factor)| self.factor_reads_browser_resource(factor))
+      }
+    }
+  }
+
+  fn slice_reads_browser_resource(&self, slice: &mech_core::Slice) -> bool {
+    slice
+      .subscript
+      .iter()
+      .any(|subscript| self.subscript_reads_browser_resource(subscript))
+  }
+
+  fn subscript_reads_browser_resource(&self, subscript: &mech_core::Subscript) -> bool {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
+        subscripts
+          .iter()
+          .any(|subscript| self.subscript_reads_browser_resource(subscript))
+      }
+      mech_core::Subscript::Formula(factor) => self.factor_reads_browser_resource(factor),
+      mech_core::Subscript::Range(range) => {
+        self.factor_reads_browser_resource(&range.start)
+          || range
+            .increment
+            .as_ref()
+            .is_some_and(|(_, increment)| self.factor_reads_browser_resource(increment))
+          || self.factor_reads_browser_resource(&range.terminal)
+      }
+      _ => false,
+    }
+  }
+
+  fn structure_reads_browser_resource(&self, structure: &mech_core::Structure) -> bool {
+    match structure {
+      mech_core::Structure::Empty => false,
+      mech_core::Structure::Map(map) => map.elements.iter().any(|mapping| {
+        self.expression_reads_browser_resource(&mapping.key)
+          || self.expression_reads_browser_resource(&mapping.value)
+      }),
+      mech_core::Structure::Matrix(matrix) => matrix.rows.iter().any(|row| {
+        row
+          .columns
+          .iter()
+          .any(|column| self.expression_reads_browser_resource(&column.element))
+      }),
+      mech_core::Structure::Record(record) => record
+        .bindings
+        .iter()
+        .any(|binding| self.expression_reads_browser_resource(&binding.value)),
+      mech_core::Structure::Set(set) => set
+        .elements
+        .iter()
+        .any(|expression| self.expression_reads_browser_resource(expression)),
+      mech_core::Structure::Table(table) => table.rows.iter().any(|row| {
+        row
+          .columns
+          .iter()
+          .any(|column| self.expression_reads_browser_resource(&column.element))
+      }),
+      mech_core::Structure::Tuple(tuple) => tuple
+        .elements
+        .iter()
+        .any(|expression| self.expression_reads_browser_resource(expression)),
+      mech_core::Structure::TupleStruct(tuple_struct) => {
+        self.expression_reads_browser_resource(&tuple_struct.value)
+      }
+    }
+  }
+
+  fn comprehension_qualifier_reads_browser_resource(
+    &self,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> bool {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((_, expression)) => {
+        self.expression_reads_browser_resource(expression)
+      }
+      mech_core::ComprehensionQualifier::Filter(expression) => {
+        self.expression_reads_browser_resource(expression)
+      }
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        self.expression_reads_browser_resource(&var_def.expression)
+      }
+    }
+  }
+
+  fn lower_browser_resource_reads_in_expression(
     &mut self,
-    program: &mut MechProgram,
-    var_def: &mech_core::VariableDefine,
-  ) -> MResult<Value> {
-    let mech_core::Expression::Var(var) = &var_def.expression else {
-      unreachable!("checked resource variable read")
-    };
-    let binding = var.context.as_ref().expect("checked browser binding").to_string();
-    let value = self.read_browser_dom_resource(&binding, &var.name.to_string())?;
-    bind_runtime_value_on_program(program, &var_def.var, value.clone(), var_def.mutable)?;
-    Ok(value)
+    expression: &mech_core::Expression,
+  ) -> MResult<mech_core::Expression> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        let Some(context) = &var.context else {
+          return Ok(expression.clone());
+        };
+        let binding = context.to_string();
+        if !self.is_browser_dom_resource_binding(&binding) {
+          return Ok(expression.clone());
+        }
+        let value = resolve_runtime_value(
+          self.read_browser_dom_resource(&binding, &var.name.to_string())?,
+        );
+        let Value::String(value) = value else {
+          return Err(browser_runtime_resource_error(
+            var.name.to_string(),
+            "browser DOM resource reads must return string values in this PR",
+          ));
+        };
+        Ok(string_value_expression(value.borrow().clone()))
+      }
+      mech_core::Expression::Formula(factor) => {
+        Ok(mech_core::Expression::Formula(self.lower_browser_resource_reads_in_factor(factor)?))
+      }
+      mech_core::Expression::FunctionCall(call) => {
+        let args = call
+          .args
+          .iter()
+          .map(|(name, expression)| {
+            Ok((
+              name.clone(),
+              self.lower_browser_resource_reads_in_expression(expression)?,
+            ))
+          })
+          .collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall {
+          name: call.name.clone(),
+          args,
+        }))
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        let mut pipe = pipe.clone();
+        if let Some(args) = &pipe.start.args {
+          pipe.start.args = Some(
+            args
+              .iter()
+              .map(|(name, expression)| {
+                Ok((
+                  name.clone(),
+                  self.lower_browser_resource_reads_in_expression(expression)?,
+                ))
+              })
+              .collect::<MResult<Vec<_>>>()?,
+          );
+        }
+        Ok(mech_core::Expression::FsmPipe(pipe))
+      }
+      mech_core::Expression::Literal(_) => Ok(expression.clone()),
+      mech_core::Expression::Match(match_expression) => {
+        let mut match_expression = match_expression.as_ref().clone();
+        match_expression.source = self.lower_browser_resource_reads_in_expression(&match_expression.source)?;
+        match_expression.arms = match_expression
+          .arms
+          .iter()
+          .map(|arm| {
+            Ok(mech_core::MatchArm {
+              pattern: arm.pattern.clone(),
+              guard: arm
+                .guard
+                .as_ref()
+                .map(|guard| self.lower_browser_resource_reads_in_expression(guard))
+                .transpose()?,
+              expression: self.lower_browser_resource_reads_in_expression(&arm.expression)?,
+            })
+          })
+          .collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::Match(Box::new(match_expression)))
+      }
+      mech_core::Expression::Range(range) => {
+        let mut range = range.as_ref().clone();
+        range.start = self.lower_browser_resource_reads_in_factor(&range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((
+            operator.clone(),
+            self.lower_browser_resource_reads_in_factor(increment)?,
+          )),
+          None => None,
+        };
+        range.terminal = self.lower_browser_resource_reads_in_factor(&range.terminal)?;
+        Ok(mech_core::Expression::Range(Box::new(range)))
+      }
+      mech_core::Expression::Slice(slice) => {
+        Ok(mech_core::Expression::Slice(self.lower_browser_resource_reads_in_slice(slice)?))
+      }
+      mech_core::Expression::Structure(structure) => {
+        Ok(mech_core::Expression::Structure(self.lower_browser_resource_reads_in_structure(structure)?))
+      }
+      mech_core::Expression::SetComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.lower_browser_resource_reads_in_expression(&comprehension.expression)?;
+        comprehension.qualifiers = comprehension
+          .qualifiers
+          .iter()
+          .map(|qualifier| self.lower_browser_resource_reads_in_comprehension_qualifier(qualifier))
+          .collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.lower_browser_resource_reads_in_expression(&comprehension.expression)?;
+        comprehension.qualifiers = comprehension
+          .qualifiers
+          .iter()
+          .map(|qualifier| self.lower_browser_resource_reads_in_comprehension_qualifier(qualifier))
+          .collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
+      }
+    }
+  }
+
+  fn lower_browser_resource_reads_in_factor(
+    &mut self,
+    factor: &mech_core::Factor,
+  ) -> MResult<mech_core::Factor> {
+    match factor {
+      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(
+        self.lower_browser_resource_reads_in_expression(expression)?,
+      ))),
+      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(
+        self.lower_browser_resource_reads_in_factor(factor)?,
+      ))),
+      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(
+        self.lower_browser_resource_reads_in_factor(factor)?,
+      ))),
+      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(
+        self.lower_browser_resource_reads_in_factor(factor)?,
+      ))),
+      mech_core::Factor::Term(term) => {
+        let rhs = term
+          .rhs
+          .iter()
+          .map(|(operator, factor)| {
+            Ok((operator.clone(), self.lower_browser_resource_reads_in_factor(factor)?))
+          })
+          .collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
+          lhs: self.lower_browser_resource_reads_in_factor(&term.lhs)?,
+          rhs,
+        })))
+      }
+      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(
+        self.lower_browser_resource_reads_in_factor(factor)?,
+      ))),
+    }
+  }
+
+  fn lower_browser_resource_reads_in_slice(
+    &mut self,
+    slice: &mech_core::Slice,
+  ) -> MResult<mech_core::Slice> {
+    Ok(mech_core::Slice {
+      name: slice.name.clone(),
+      context: slice.context.clone(),
+      subscript: slice
+        .subscript
+        .iter()
+        .map(|subscript| self.lower_browser_resource_reads_in_subscript(subscript))
+        .collect::<MResult<Vec<_>>>()?,
+    })
+  }
+
+  fn lower_browser_resource_reads_in_subscript(
+    &mut self,
+    subscript: &mech_core::Subscript,
+  ) -> MResult<mech_core::Subscript> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(
+        subscripts
+          .iter()
+          .map(|subscript| self.lower_browser_resource_reads_in_subscript(subscript))
+          .collect::<MResult<Vec<_>>>()?,
+      )),
+      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(
+        subscripts
+          .iter()
+          .map(|subscript| self.lower_browser_resource_reads_in_subscript(subscript))
+          .collect::<MResult<Vec<_>>>()?,
+      )),
+      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(
+        self.lower_browser_resource_reads_in_factor(factor)?,
+      )),
+      mech_core::Subscript::Range(range) => {
+        let mut range = range.clone();
+        range.start = self.lower_browser_resource_reads_in_factor(&range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((
+            operator.clone(),
+            self.lower_browser_resource_reads_in_factor(increment)?,
+          )),
+          None => None,
+        };
+        range.terminal = self.lower_browser_resource_reads_in_factor(&range.terminal)?;
+        Ok(mech_core::Subscript::Range(range))
+      }
+      _ => Ok(subscript.clone()),
+    }
+  }
+
+  fn lower_browser_resource_reads_in_structure(
+    &mut self,
+    structure: &mech_core::Structure,
+  ) -> MResult<mech_core::Structure> {
+    match structure {
+      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
+      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
+        elements: map
+          .elements
+          .iter()
+          .map(|mapping| {
+            Ok(mech_core::Mapping {
+              key: self.lower_browser_resource_reads_in_expression(&mapping.key)?,
+              value: self.lower_browser_resource_reads_in_expression(&mapping.value)?,
+            })
+          })
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
+        rows: matrix
+          .rows
+          .iter()
+          .map(|row| {
+            Ok(mech_core::MatrixRow {
+              columns: row
+                .columns
+                .iter()
+                .map(|column| {
+                  Ok(mech_core::MatrixColumn {
+                    element: self.lower_browser_resource_reads_in_expression(&column.element)?,
+                  })
+                })
+                .collect::<MResult<Vec<_>>>()?,
+            })
+          })
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
+        bindings: record
+          .bindings
+          .iter()
+          .map(|binding| {
+            Ok(mech_core::Binding {
+              name: binding.name.clone(),
+              kind: binding.kind.clone(),
+              value: self.lower_browser_resource_reads_in_expression(&binding.value)?,
+            })
+          })
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
+        elements: set
+          .elements
+          .iter()
+          .map(|expression| self.lower_browser_resource_reads_in_expression(expression))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
+        header: table.header.clone(),
+        rows: table
+          .rows
+          .iter()
+          .map(|row| {
+            Ok(mech_core::TableRow {
+              columns: row
+                .columns
+                .iter()
+                .map(|column| {
+                  Ok(mech_core::TableColumn {
+                    element: self.lower_browser_resource_reads_in_expression(&column.element)?,
+                  })
+                })
+                .collect::<MResult<Vec<_>>>()?,
+            })
+          })
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
+        elements: tuple
+          .elements
+          .iter()
+          .map(|expression| self.lower_browser_resource_reads_in_expression(expression))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::TupleStruct(tuple_struct) => {
+        Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
+          name: tuple_struct.name.clone(),
+          value: Box::new(self.lower_browser_resource_reads_in_expression(&tuple_struct.value)?),
+        }))
+      }
+    }
+  }
+
+  fn lower_browser_resource_reads_in_comprehension_qualifier(
+    &mut self,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> MResult<mech_core::ComprehensionQualifier> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+        Ok(mech_core::ComprehensionQualifier::Generator((
+          pattern.clone(),
+          self.lower_browser_resource_reads_in_expression(expression)?,
+        )))
+      }
+      mech_core::ComprehensionQualifier::Filter(expression) => {
+        Ok(mech_core::ComprehensionQualifier::Filter(
+          self.lower_browser_resource_reads_in_expression(expression)?,
+        ))
+      }
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.lower_browser_resource_reads_in_expression(&var_def.expression)?;
+        Ok(mech_core::ComprehensionQualifier::Let(var_def))
+      }
+    }
   }
 
   fn evaluate_expression_on_program(

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -37,8 +37,9 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use mech_core::{
-  MResult, MechError, MechErrorKind, MechSourceCode, Ref, Value, NativeFunctionCompiler, MechFunctionImpl,
-  Register, CompileCtx, MechFunctionCompiler,
+  browser_capability_error, BrowserAuthority, BrowserDomPath, BrowserOperation,
+  BROWSER_DOM_PROVIDER_URI, MResult, MechError, MechErrorKind, MechSourceCode, Ref, Value,
+  NativeFunctionCompiler, MechFunctionImpl, Register, CompileCtx, MechFunctionCompiler,
   hash_str,
 };
 
@@ -63,7 +64,7 @@ use crate::event::{
 };
 
 use crate::host::{
-  default_host_capability_request, DefaultHostCallPolicy, HostCall,
+  default_host_capability_request, BrowserDomHost, DefaultHostCallPolicy, HostCall,
   HostCallPolicy, HostFunction, HostFunctionNotFoundError, HostRegistry,
   InMemoryHostRegistry,
 };
@@ -310,6 +311,9 @@ impl RuntimeBuilder {
       module_builder: self.module_builder,
       resources: RuntimeResourceRegistry::new(),
       grants: RuntimeCapabilityGrantRegistry::new(),
+      browser_dom_host: None,
+      browser_authority: BrowserAuthority::default(),
+      resource_bindings: HashMap::new(),
     };
 
     for spec in &self.config_specs {
@@ -356,6 +360,9 @@ pub struct MechRuntime {
   module_builder: ModuleBuilder,
   resources: RuntimeResourceRegistry,
   grants: RuntimeCapabilityGrantRegistry,
+  browser_dom_host: Option<Box<dyn BrowserDomHost>>,
+  browser_authority: BrowserAuthority,
+  resource_bindings: HashMap<String, RuntimeResourceBinding>,
 }
 
 impl std::fmt::Debug for MechRuntime {
@@ -378,8 +385,53 @@ impl std::fmt::Debug for MechRuntime {
       .field("module_builder", &self.module_builder)
       .field("resources", &self.resources)
       .field("grants", &self.grants)
+      .field("browser_authority", &self.browser_authority)
+      .field("resource_bindings", &self.resource_bindings)
       .finish()
   }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeResourceBinding {
+  pub name: String,
+  pub provider: String,
+  pub root_path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BrowserRuntimeResourceError {
+  pub resource: String,
+  pub reason: String,
+}
+
+impl MechErrorKind for BrowserRuntimeResourceError {
+  fn name(&self) -> &str {
+    "BrowserRuntimeResource"
+  }
+
+  fn message(&self) -> String {
+    format!("browser runtime resource `{}` failed: {}", self.resource, self.reason)
+  }
+}
+
+fn browser_runtime_resource_error(
+  resource: impl Into<String>,
+  reason: impl Into<String>,
+) -> MechError {
+  MechError::new(
+    BrowserRuntimeResourceError {
+      resource: resource.into(),
+      reason: reason.into(),
+    },
+    None,
+  )
+}
+
+fn validate_resource_binding_name(name: &str) -> bool {
+  !name.is_empty()
+    && name
+      .bytes()
+      .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
 }
 
 #[derive(Clone, Debug)]
@@ -412,6 +464,144 @@ impl MechRuntime {
 
   pub fn program_mut(&mut self) -> &mut MechProgram {
     &mut self.program
+  }
+
+
+  pub fn set_browser_authority(&mut self, authority: BrowserAuthority) {
+    self.browser_authority = authority;
+  }
+
+  pub fn browser_authority(&self) -> &BrowserAuthority {
+    &self.browser_authority
+  }
+
+  pub fn set_browser_dom_host(&mut self, host: Box<dyn BrowserDomHost>) {
+    self.browser_dom_host = Some(host);
+  }
+
+  pub fn bind_resource_root(
+    &mut self,
+    name: impl Into<String>,
+    uri: impl AsRef<str>,
+  ) -> MResult<()> {
+    let name = name.into();
+    if !validate_resource_binding_name(&name) {
+      return Err(browser_runtime_resource_error(
+        name,
+        "resource binding names must be non-empty simple tokens",
+      ));
+    }
+
+    let uri = uri.as_ref();
+    let prefix = "browser://dom/";
+    let Some(root_path) = uri.strip_prefix(prefix) else {
+      return Err(browser_runtime_resource_error(
+        uri,
+        "only browser://dom/ resource roots are supported in this PR",
+      ));
+    };
+    let root_path = root_path.trim_matches('/').to_string();
+    if !root_path.is_empty() {
+      BrowserDomPath::new(root_path.clone()).map_err(browser_capability_error)?;
+    }
+
+    self.resource_bindings.insert(
+      name.clone(),
+      RuntimeResourceBinding {
+        name,
+        provider: BROWSER_DOM_PROVIDER_URI.to_string(),
+        root_path,
+      },
+    );
+    Ok(())
+  }
+
+  pub fn resolve_resource_path(
+    &self,
+    binding: &str,
+    child_path: &str,
+  ) -> MResult<BrowserDomPath> {
+    let Some(binding_record) = self.resource_bindings.get(binding) else {
+      return Err(browser_runtime_resource_error(
+        binding,
+        "unknown resource root binding",
+      ));
+    };
+    if binding_record.provider != BROWSER_DOM_PROVIDER_URI {
+      return Err(browser_runtime_resource_error(
+        binding,
+        "only browser DOM resource bindings are supported",
+      ));
+    }
+
+    let child_path = child_path.trim_matches('/');
+    let full_path = if binding_record.root_path.is_empty() {
+      child_path.to_string()
+    } else if child_path.is_empty() {
+      binding_record.root_path.clone()
+    } else {
+      format!("{}/{}", binding_record.root_path, child_path)
+    };
+    BrowserDomPath::new(full_path).map_err(browser_capability_error)
+  }
+
+  pub fn read_browser_dom_resource(
+    &self,
+    binding: &str,
+    child_path: &str,
+  ) -> MResult<Value> {
+    let path = self.resolve_resource_path(binding, child_path)?;
+    let Some(entry) = self.browser_authority.dom_entry_for_path(&path) else {
+      return Err(browser_runtime_resource_error(
+        path.as_str(),
+        "no configured DOM manifest entry for path",
+      ));
+    };
+    self.browser_authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Read)
+      .map_err(browser_capability_error)?;
+    let Some(host) = self.browser_dom_host.as_ref() else {
+      return Err(browser_runtime_resource_error(
+        path.as_str(),
+        "no browser DOM host is registered",
+      ));
+    };
+    Ok(Value::String(Ref::new(host.read_dom_string(entry, &path)?)))
+  }
+
+  pub fn write_browser_dom_resource(
+    &mut self,
+    binding: &str,
+    child_path: &str,
+    value: &Value,
+  ) -> MResult<()> {
+    let path = self.resolve_resource_path(binding, child_path)?;
+    let entry = self
+      .browser_authority
+      .dom_entry_for_path(&path)
+      .cloned()
+      .ok_or_else(|| {
+        browser_runtime_resource_error(
+          path.as_str(),
+          "no configured DOM manifest entry for path",
+        )
+      })?;
+    self.browser_authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Write)
+      .map_err(browser_capability_error)?;
+    let Value::String(value) = value else {
+      return Err(browser_runtime_resource_error(
+        path.as_str(),
+        "only string values can be written to browser DOM resources in this PR",
+      ));
+    };
+    let Some(host) = self.browser_dom_host.as_mut() else {
+      return Err(browser_runtime_resource_error(
+        path.as_str(),
+        "no browser DOM host is registered",
+      ));
+    };
+    host.write_dom_string(&entry, &path, value.borrow().as_str())
   }
 
   pub fn apply_config_spec(

--- a/src/runtime/tests/browser_dom.rs
+++ b/src/runtime/tests/browser_dom.rs
@@ -1,18 +1,38 @@
+use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::rc::Rc;
 
 use mech_core::Value;
 use mech_runtime::*;
 
 #[derive(Default)]
-struct FakeDomHost {
+struct FakeDomState {
   values: BTreeMap<String, String>,
+  reads: Vec<String>,
   writes: Vec<(String, String)>,
 }
 
+#[derive(Clone, Default)]
+struct FakeDomHost {
+  state: Rc<RefCell<FakeDomState>>,
+}
+
 impl FakeDomHost {
-  fn with_value(mut self, path: &str, value: &str) -> Self {
-    self.values.insert(path.to_string(), value.to_string());
+  fn with_value(self, path: &str, value: &str) -> Self {
+    self.state.borrow_mut().values.insert(path.to_string(), value.to_string());
     self
+  }
+
+  fn read_count(&self) -> usize {
+    self.state.borrow().reads.len()
+  }
+
+  fn write_count(&self) -> usize {
+    self.state.borrow().writes.len()
+  }
+
+  fn writes(&self) -> Vec<(String, String)> {
+    self.state.borrow().writes.clone()
   }
 }
 
@@ -22,7 +42,9 @@ impl BrowserDomHost for FakeDomHost {
     _entry: &BrowserDomManifestEntry,
     requested_path: &BrowserDomPath,
   ) -> mech_core::MResult<String> {
-    Ok(self.values.get(requested_path.as_str()).cloned().unwrap_or_default())
+    let mut state = self.state.borrow_mut();
+    state.reads.push(requested_path.as_str().to_string());
+    Ok(state.values.get(requested_path.as_str()).cloned().unwrap_or_default())
   }
 
   fn write_dom_string(
@@ -31,8 +53,9 @@ impl BrowserDomHost for FakeDomHost {
     requested_path: &BrowserDomPath,
     value: &str,
   ) -> mech_core::MResult<()> {
-    self.writes.push((requested_path.as_str().to_string(), value.to_string()));
-    self.values.insert(requested_path.as_str().to_string(), value.to_string());
+    let mut state = self.state.borrow_mut();
+    state.writes.push((requested_path.as_str().to_string(), value.to_string()));
+    state.values.insert(requested_path.as_str().to_string(), value.to_string());
     Ok(())
   }
 }
@@ -139,4 +162,86 @@ fn runtime_wildcard_dom_path_rejects_sibling() {
   runtime.set_browser_authority(authority("body/content/*", "#content", &[BrowserOperation::Read]));
   runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
   assert!(runtime.read_browser_dom_resource("browser", "body/sidebar/title").is_err());
+}
+
+
+fn read_write_authority(path: &str, selector: &str) -> BrowserAuthority {
+  authority(path, selector, &[BrowserOperation::Read, BrowserOperation::Write])
+}
+
+#[test]
+fn program_browser_resource_write_uses_runtime_host() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(read_write_authority("body/header/title", "#title"));
+  let host = FakeDomHost::default();
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  runtime
+    .run_string("@browser := browser://dom/\nbody/header/title@browser = \"Hello\"")
+    .unwrap();
+
+  assert_eq!(host.writes(), vec![("body/header/title".to_string(), "Hello".to_string())]);
+}
+
+#[test]
+fn program_browser_resource_read_uses_runtime_host() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(read_write_authority("body/search/_value", "#search"));
+  let host = FakeDomHost::default().with_value("body/search/_value", "query");
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  let value = runtime
+    .run_string("@browser := browser://dom/\nx := body/search/_value@browser")
+    .unwrap();
+
+  assert_eq!(value.as_string().unwrap().borrow().as_str(), "query");
+  assert_eq!(host.read_count(), 1);
+}
+
+#[test]
+fn program_browser_resource_define_does_not_write() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(read_write_authority("title", "#title"));
+  let host = FakeDomHost::default();
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  runtime
+    .run_string("@browser := browser://dom/\ntitle@browser := \"Hello\"")
+    .unwrap();
+
+  assert_eq!(host.write_count(), 0);
+}
+
+#[test]
+fn runtime_browser_resource_binding_applies_before_following_write() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(read_write_authority("body/header/title", "#title"));
+  let host = FakeDomHost::default();
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  runtime
+    .run_string("@browser := browser://dom/\nbody/header/title@browser = \"Hello\"")
+    .unwrap();
+
+  assert_eq!(
+    runtime.resolve_resource_path("browser", "body/header/title").unwrap().as_str(),
+    "body/header/title"
+  );
+  assert_eq!(host.write_count(), 1);
+}
+
+#[test]
+fn program_browser_resource_write_accepts_string_variable() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(read_write_authority("body/header/title", "#title"));
+  let host = FakeDomHost::default();
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  runtime
+    .run_string(
+      "@browser := browser://dom/\nsome-string-var := \"Hello\"\nbody/header/title@browser = some-string-var",
+    )
+    .unwrap();
+
+  assert_eq!(host.writes(), vec![("body/header/title".to_string(), "Hello".to_string())]);
 }

--- a/src/runtime/tests/browser_dom.rs
+++ b/src/runtime/tests/browser_dom.rs
@@ -338,7 +338,7 @@ body/header/title@browser = "Search: " + body/search/_value@browser"#)
 }
 
 #[test]
-fn program_browser_resource_read_inside_expression_denied_before_eval() {
+fn program_browser_resource_read_inside_expression_denied_before_host_access() {
   let mut runtime = runtime();
   runtime.set_browser_authority(authority(
     "body/search/_value",

--- a/src/runtime/tests/browser_dom.rs
+++ b/src/runtime/tests/browser_dom.rs
@@ -1,0 +1,142 @@
+use std::collections::BTreeMap;
+
+use mech_core::Value;
+use mech_runtime::*;
+
+#[derive(Default)]
+struct FakeDomHost {
+  values: BTreeMap<String, String>,
+  writes: Vec<(String, String)>,
+}
+
+impl FakeDomHost {
+  fn with_value(mut self, path: &str, value: &str) -> Self {
+    self.values.insert(path.to_string(), value.to_string());
+    self
+  }
+}
+
+impl BrowserDomHost for FakeDomHost {
+  fn read_dom_string(
+    &self,
+    _entry: &BrowserDomManifestEntry,
+    requested_path: &BrowserDomPath,
+  ) -> mech_core::MResult<String> {
+    Ok(self.values.get(requested_path.as_str()).cloned().unwrap_or_default())
+  }
+
+  fn write_dom_string(
+    &mut self,
+    _entry: &BrowserDomManifestEntry,
+    requested_path: &BrowserDomPath,
+    value: &str,
+  ) -> mech_core::MResult<()> {
+    self.writes.push((requested_path.as_str().to_string(), value.to_string()));
+    self.values.insert(requested_path.as_str().to_string(), value.to_string());
+    Ok(())
+  }
+}
+
+fn runtime() -> MechRuntime {
+  MechRuntime::new(RuntimeConfig::default()).unwrap()
+}
+
+fn authority(path: &str, selector: &str, allow: &[BrowserOperation]) -> BrowserAuthority {
+  let mut authority = BrowserAuthority::default();
+  let scope = BrowserDomScope::new(selector).unwrap();
+  authority.grant(BrowserCapabilityGrant::new(
+    BrowserResource::Dom(scope.clone()),
+    allow.iter().copied(),
+  ));
+  authority.bind_dom_path(BrowserDomManifestEntry::new(
+    BrowserDomPath::new(path).unwrap(),
+    scope,
+    BrowserDomProperty::Text,
+  ));
+  authority
+}
+
+#[test]
+fn runtime_binds_browser_resource_root() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  assert_eq!(runtime.resolve_resource_path("browser", "body/title").unwrap().as_str(), "body/title");
+}
+
+#[test]
+fn runtime_resolves_child_path_under_browser_root() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  assert_eq!(runtime.resolve_resource_path("browser", "body/header/title").unwrap().as_str(), "body/header/title");
+}
+
+#[test]
+fn runtime_resolves_child_path_under_narrow_root() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("head", "browser://dom/body/header/").unwrap();
+  assert_eq!(runtime.resolve_resource_path("head", "title").unwrap().as_str(), "body/header/title");
+}
+
+#[test]
+fn runtime_reads_configured_browser_dom_path() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Read]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default().with_value("body/title", "Hello")));
+  let value = runtime.read_browser_dom_resource("browser", "body/title").unwrap();
+  assert_eq!(value.as_string().unwrap().borrow().as_str(), "Hello");
+}
+
+#[test]
+fn runtime_writes_configured_browser_dom_path() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Write]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  runtime.write_browser_dom_resource("browser", "body/title", &Value::from("Hello".to_string())).unwrap();
+}
+
+#[test]
+fn runtime_denies_browser_dom_read_without_read_grant() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Write]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  assert!(runtime.read_browser_dom_resource("browser", "body/title").is_err());
+}
+
+#[test]
+fn runtime_denies_browser_dom_write_without_write_grant() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Read]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  assert!(runtime.write_browser_dom_resource("browser", "body/title", &Value::from("Hello".to_string())).is_err());
+}
+
+#[test]
+fn runtime_rejects_unknown_browser_dom_path() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Read]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  assert!(runtime.read_browser_dom_resource("browser", "body/other").is_err());
+}
+
+#[test]
+fn runtime_wildcard_dom_path_allows_child() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/content/*", "#content", &[BrowserOperation::Read]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default().with_value("body/content/title", "Hello")));
+  assert!(runtime.read_browser_dom_resource("browser", "body/content/title").is_ok());
+}
+
+#[test]
+fn runtime_wildcard_dom_path_rejects_sibling() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  runtime.set_browser_authority(authority("body/content/*", "#content", &[BrowserOperation::Read]));
+  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  assert!(runtime.read_browser_dom_resource("browser", "body/sidebar/title").is_err());
+}

--- a/src/runtime/tests/browser_dom.rs
+++ b/src/runtime/tests/browser_dom.rs
@@ -64,8 +64,12 @@ fn runtime() -> MechRuntime {
   MechRuntime::new(RuntimeConfig::default()).unwrap()
 }
 
-fn authority(path: &str, selector: &str, allow: &[BrowserOperation]) -> BrowserAuthority {
-  let mut authority = BrowserAuthority::default();
+fn bind_authority_path(
+  authority: &mut BrowserAuthority,
+  path: &str,
+  selector: &str,
+  allow: &[BrowserOperation],
+) {
   let scope = BrowserDomScope::new(selector).unwrap();
   authority.grant(BrowserCapabilityGrant::new(
     BrowserResource::Dom(scope.clone()),
@@ -76,6 +80,11 @@ fn authority(path: &str, selector: &str, allow: &[BrowserOperation]) -> BrowserA
     scope,
     BrowserDomProperty::Text,
   ));
+}
+
+fn authority(path: &str, selector: &str, allow: &[BrowserOperation]) -> BrowserAuthority {
+  let mut authority = BrowserAuthority::default();
+  bind_authority_path(&mut authority, path, selector, allow);
   authority
 }
 
@@ -244,4 +253,105 @@ fn program_browser_resource_write_accepts_string_variable() {
     .unwrap();
 
   assert_eq!(host.writes(), vec![("body/header/title".to_string(), "Hello".to_string())]);
+}
+
+#[test]
+fn program_browser_resource_read_inside_expression() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(read_write_authority("body/search/_value", "#search"));
+  let host = FakeDomHost::default().with_value("body/search/_value", "query");
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  let value = runtime
+    .run_string(r#"@browser := browser://dom/
+message := "Search: " + body/search/_value@browser"#)
+    .unwrap();
+
+  assert_eq!(value.as_string().unwrap().borrow().as_str(), "Search: query");
+  assert_eq!(host.read_count(), 1);
+}
+
+#[test]
+fn program_browser_resource_write_rhs_reads_browser_resource() {
+  let mut authority = BrowserAuthority::default();
+  bind_authority_path(
+    &mut authority,
+    "body/search/_value",
+    "#search",
+    &[BrowserOperation::Read],
+  );
+  bind_authority_path(
+    &mut authority,
+    "body/header/title",
+    "#title",
+    &[BrowserOperation::Write],
+  );
+  let mut runtime = runtime();
+  runtime.set_browser_authority(authority);
+  let host = FakeDomHost::default().with_value("body/search/_value", "query");
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  runtime
+    .run_string(
+      "@browser := browser://dom/
+body/header/title@browser = body/search/_value@browser",
+    )
+    .unwrap();
+
+  assert_eq!(host.read_count(), 1);
+  assert_eq!(
+    host.writes(),
+    vec![("body/header/title".to_string(), "query".to_string())]
+  );
+}
+
+#[test]
+fn program_browser_resource_write_rhs_combines_string_and_resource() {
+  let mut authority = BrowserAuthority::default();
+  bind_authority_path(
+    &mut authority,
+    "body/search/_value",
+    "#search",
+    &[BrowserOperation::Read],
+  );
+  bind_authority_path(
+    &mut authority,
+    "body/header/title",
+    "#title",
+    &[BrowserOperation::Write],
+  );
+  let mut runtime = runtime();
+  runtime.set_browser_authority(authority);
+  let host = FakeDomHost::default().with_value("body/search/_value", "query");
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  runtime
+    .run_string(r#"@browser := browser://dom/
+body/header/title@browser = "Search: " + body/search/_value@browser"#)
+    .unwrap();
+
+  assert_eq!(host.read_count(), 1);
+  assert_eq!(
+    host.writes(),
+    vec![("body/header/title".to_string(), "Search: query".to_string())]
+  );
+}
+
+#[test]
+fn program_browser_resource_read_inside_expression_denied_before_eval() {
+  let mut runtime = runtime();
+  runtime.set_browser_authority(authority(
+    "body/search/_value",
+    "#search",
+    &[BrowserOperation::Write],
+  ));
+  let host = FakeDomHost::default().with_value("body/search/_value", "query");
+  runtime.set_browser_dom_host(Box::new(host.clone()));
+
+  let result = runtime
+    .run_string(r#"@browser := browser://dom/
+message := "Search: " + body/search/_value@browser"#);
+
+  assert!(result.is_err());
+  assert_eq!(host.read_count(), 0);
 }

--- a/src/runtime/tests/config_profile.rs
+++ b/src/runtime/tests/config_profile.rs
@@ -536,3 +536,46 @@ fn config_profile_browser_dom_duplicate_path_last_wins() {
     assert_eq!(doc.browser.dom_manifest().len(), 1);
     assert_eq!(doc.browser.dom_manifest()[0].selector.selector, "#new");
 }
+
+#[test]
+fn config_profile_browser_dom_text_property_rejects_attribute() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/status", selector: "#status", property: "text", attribute: "class", allow: ["read"]}]}}"##);
+    assert!(msg.contains("cannot include `attribute`"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_attribute_without_property_rejected() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/status/_class", selector: "#status", attribute: "class", allow: ["read"]}]}}"##);
+    assert!(msg.contains("`attribute` is only valid when `property` is `attribute`"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_value_path_infers_value() {
+    let doc = parse(r##"config := {browser: {dom: [{path: "body/search/_value", selector: "#search", allow: ["read"]}]}}"##).unwrap();
+    assert_eq!(doc.browser.dom_manifest()[0].property, BrowserDomProperty::Value);
+}
+
+#[test]
+fn config_profile_browser_dom_html_path_infers_inner_html() {
+    let doc = parse(r##"config := {browser: {dom: [{path: "body/content/_html", selector: "#content", allow: ["read"]}]}}"##).unwrap();
+    assert_eq!(doc.browser.dom_manifest()[0].property, BrowserDomProperty::InnerHtml);
+}
+
+#[test]
+fn config_profile_browser_dom_subtree_rejects_property() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/content/*", selector: "#content", mode: "subtree", property: "text", allow: ["read"]}]}}"##);
+    assert!(msg.contains("property is not allowed"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_subtree_rejects_attribute() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/content/*", selector: "#content", mode: "subtree", attribute: "class", allow: ["read"]}]}}"##);
+    assert!(msg.contains("attribute is not allowed"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_subtree_with_wildcard_path_accepted() {
+    let doc = parse(r##"config := {browser: {dom: [{path: "body/content/*", selector: "#content", mode: "subtree", allow: ["read"]}]}}"##).unwrap();
+    assert_eq!(doc.browser.dom_manifest()[0].path.as_str(), "body/content/*");
+    assert_eq!(doc.browser.dom_manifest()[0].property, BrowserDomProperty::Text);
+}

--- a/src/runtime/tests/config_profile.rs
+++ b/src/runtime/tests/config_profile.rs
@@ -487,3 +487,52 @@ fn config_profile_browser_storage_recursive_scope_is_explicit() {
         Err(BrowserCapabilityError::NoMatchingGrant { .. })
     ));
 }
+
+#[test]
+fn config_profile_browser_dom_path_manifest_lowers() {
+    let doc = parse(r##"config := {browser: {dom: [{path: "body/header/title", selector: "#title", property: "text", allow: ["read", "write"]}]}}"##).unwrap();
+    let entry = &doc.browser.dom_manifest()[0];
+    assert_eq!(entry.path.as_str(), "body/header/title");
+    assert_eq!(entry.selector.selector, "#title");
+    assert_eq!(entry.property, BrowserDomProperty::Text);
+}
+
+#[test]
+fn config_profile_browser_dom_path_infers_text_property() {
+    let doc = parse(r##"config := {browser: {dom: [{path: "body/header/title", selector: "#title", allow: ["read"]}]}}"##).unwrap();
+    assert_eq!(doc.browser.dom_manifest()[0].property, BrowserDomProperty::Text);
+}
+
+#[test]
+fn config_profile_browser_dom_attribute_path_infers_attribute() {
+    let doc = parse(r##"config := {browser: {dom: [{path: "body/status/_class", selector: "#status", allow: ["read"]}]}}"##).unwrap();
+    assert_eq!(doc.browser.dom_manifest()[0].property, BrowserDomProperty::Attribute("class".to_string()));
+}
+
+#[test]
+fn config_profile_browser_dom_attribute_property_requires_attribute() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/status", selector: "#status", property: "attribute", allow: ["read"]}]}}"##);
+    assert!(msg.contains("requires an `attribute` name"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_subtree_requires_wildcard_path() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/content", selector: "#content", mode: "subtree", allow: ["read"]}]}}"##);
+    assert!(msg.contains("must end in `/*`"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_wildcard_path_requires_final_star() {
+    let msg = err_text(r##"config := {browser: {dom: [{path: "body/*/title", selector: "#content", allow: ["read"]}]}}"##);
+    assert!(msg.contains("wildcard `*` must be its own final segment") || msg.contains("only allowed as the final segment"), "{msg}");
+}
+
+#[test]
+fn config_profile_browser_dom_duplicate_path_last_wins() {
+    let doc = parse(r##"config := {browser: {dom: [
+      {path: "body/title", selector: "#old", allow: ["read"]}
+      {path: "body/title", selector: "#new", allow: ["read"]}
+    ]}}"##).unwrap();
+    assert_eq!(doc.browser.dom_manifest().len(), 1);
+    assert_eq!(doc.browser.dom_manifest()[0].selector.selector, "#new");
+}

--- a/src/syntax/src/base.rs
+++ b/src/syntax/src/base.rs
@@ -340,7 +340,7 @@ pub fn symbol(input: ParseString) -> ParseResult<Token> {
 
 // identifier-symbol := ampersand | dollar | bar | percent | slash | hashtag | backslash | tilde | plus | dash | asterisk | caret ;
 pub fn identifier_symbol(input: ParseString) -> ParseResult<Token> {
-  let (input, symbol) = alt((ampersand, dollar, percent, slash, hashtag, backslash, tilde, plus, dash, asterisk, caret))(input)?;
+  let (input, symbol) = alt((ampersand, dollar, percent, slash, hashtag, backslash, tilde, plus, dash, asterisk, caret, underscore))(input)?;
   Ok((input, symbol))
 }
 
@@ -439,7 +439,7 @@ pub fn enum_separator(input: ParseString) -> ParseResult<()> {
 
 // identifier := (alpha | emoji), (alpha | digit | identifier_symbol | emoji)* ;
 pub fn identifier(input: ParseString) -> ParseResult<Identifier> {
-  let (input, (first, mut rest)) = nom_tuple((alt((alpha_token, emoji)), many0(alt((alpha_token, digit_token, identifier_symbol, emoji)))))(input)?;
+  let (input, (first, mut rest)) = nom_tuple((alt((alpha_token, emoji, underscore)), many0(alt((alpha_token, digit_token, identifier_symbol, emoji)))))(input)?;
   let mut tokens = vec![first];
   tokens.append(&mut rest);
   let mut merged = Token::merge_tokens(&mut tokens).unwrap();

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -238,18 +238,21 @@ pub fn export_declaration(input: ParseString) -> ParseResult<ExportDeclaration> 
   Ok((input, ExportDeclaration { name }))
 }
 
-// context-declaration := "@", identifier, define-operator, context-base, "{", list1(list-separator, context-capability-declaration), list-separator?, "}" ;
+// context-declaration := "@", identifier, define-operator, context-base, ("{", list1(list-separator, context-capability-declaration), list-separator?, "}")? ;
 pub fn context_declaration(input: ParseString) -> ParseResult<ContextDeclaration> {
   let (input, _) = whitespace0(input)?;
   let (input, _) = at(input)?;
   let (input, name) = identifier(input)?;
   let (input, _) = define_operator(input)?;
   let (input, base) = alt((context_base_resource_uri, context_base_context))(input)?;
-  let (input, _) = left_brace(input)?;
-  let (input, capabilities) = separated_list1(list_separator, context_capability_declaration)(input)?;
-  let (input, _) = opt(list_separator)(input)?;
-  let (input, _) = right_brace(input)?;
-  Ok((input, ContextDeclaration { name, base, capabilities }))
+  let (input, capabilities) = opt(|input| {
+    let (input, _) = left_brace(input)?;
+    let (input, capabilities) = separated_list1(list_separator, context_capability_declaration)(input)?;
+    let (input, _) = opt(list_separator)(input)?;
+    let (input, _) = right_brace(input)?;
+    Ok((input, capabilities))
+  })(input)?;
+  Ok((input, ContextDeclaration { name, base, capabilities: capabilities.unwrap_or_default() }))
 }
 
 // context-base-context := "@", identifier ;

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -128,3 +128,52 @@ fn context_declaration_does_not_break_import_export() {
 fn bare_capability_operation_is_rejected() {
   assert!(parser::parse("@main := db://main{:write}").is_err());
 }
+
+#[test]
+fn program_browser_resource_binding_declaration() {
+  let stmts = statements("@browser := browser://dom/");
+  match &stmts[0] {
+    Statement::ContextDeclaration(ctx) => {
+      assert_eq!(ctx.name.to_string(), "browser");
+      assert!(ctx.capabilities.is_empty());
+      match &ctx.base {
+        ContextBase::ResourceUri(uri) => assert_eq!(uri.to_string(), "browser://dom/"),
+        _ => panic!("expected resource uri"),
+      }
+    }
+    _ => panic!("expected context declaration"),
+  }
+}
+
+#[test]
+fn program_browser_resource_read() {
+  let stmts = statements("x := body/search/_value@browser");
+  match &stmts[0] {
+    Statement::VariableDefine(v) => match &v.expression {
+      Expression::Var(var) => {
+        assert_eq!(var.name.to_string(), "body/search/_value");
+        assert_eq!(var.context.as_ref().unwrap().to_string(), "browser");
+      }
+      _ => panic!("expected addressed var expression"),
+    },
+    _ => panic!("expected variable define"),
+  }
+}
+
+#[test]
+fn program_browser_resource_write() {
+  let stmts = statements("body/header/title@browser = \"Hello\"");
+  match &stmts[0] {
+    Statement::VariableAssign(assign) => {
+      assert_eq!(assign.target.name.to_string(), "body/header/title");
+      assert_eq!(assign.target.context.as_ref().unwrap().to_string(), "browser");
+    }
+    _ => panic!("expected variable assignment"),
+  }
+}
+
+#[test]
+fn program_browser_resource_define_does_not_write() {
+  let stmts = statements("title@browser := \"Hello\"");
+  assert!(matches!(&stmts[0], Statement::VariableDefine(_)));
+}

--- a/src/wasm/src/host/browser_host.rs
+++ b/src/wasm/src/host/browser_host.rs
@@ -171,6 +171,9 @@ fn resolve_dom_element(
       if segment.starts_with('_') {
         break;
       }
+      // Safe because BrowserDomPath validation restricts path segments to
+      // ASCII alphanumeric, `_`, and `-`, and wildcard traversal never accepts
+      // raw CSS selectors from Mech code.
       let selector = format!(r#"[data-mech-node="{}"]"#, segment);
       element = element
         .query_selector(&selector)

--- a/src/wasm/src/host/browser_host.rs
+++ b/src/wasm/src/host/browser_host.rs
@@ -60,3 +60,123 @@ mod tests {
         );
     }
 }
+
+pub struct WasmBrowserDomHost;
+
+impl WasmBrowserDomHost {
+  pub fn new() -> Self {
+    Self
+  }
+}
+
+impl Default for WasmBrowserDomHost {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl mech_runtime::BrowserDomHost for WasmBrowserDomHost {
+  fn read_dom_string(
+    &self,
+    entry: &mech_core::BrowserDomManifestEntry,
+    requested_path: &mech_core::BrowserDomPath,
+  ) -> mech_core::MResult<String> {
+    let (element, property) = resolve_dom_element(entry, requested_path)?;
+    match property {
+      mech_core::BrowserDomProperty::Text => Ok(element.text_content().unwrap_or_default()),
+      mech_core::BrowserDomProperty::Value => {
+        let Some(input) = wasm_bindgen::JsCast::dyn_ref::<web_sys::HtmlInputElement>(&element) else {
+          return Err(browser_dom_error(requested_path.as_str(), "DOM _value requires an input element"));
+        };
+        Ok(input.value())
+      }
+      mech_core::BrowserDomProperty::InnerHtml => Ok(element.inner_html()),
+      mech_core::BrowserDomProperty::Attribute(attribute) => {
+        Ok(element.get_attribute(&attribute).unwrap_or_default())
+      }
+    }
+  }
+
+  fn write_dom_string(
+    &mut self,
+    entry: &mech_core::BrowserDomManifestEntry,
+    requested_path: &mech_core::BrowserDomPath,
+    value: &str,
+  ) -> mech_core::MResult<()> {
+    let (element, property) = resolve_dom_element(entry, requested_path)?;
+    match property {
+      mech_core::BrowserDomProperty::Text => element.set_text_content(Some(value)),
+      mech_core::BrowserDomProperty::Value => {
+        let Some(input) = wasm_bindgen::JsCast::dyn_ref::<web_sys::HtmlInputElement>(&element) else {
+          return Err(browser_dom_error(requested_path.as_str(), "DOM _value requires an input element"));
+        };
+        input.set_value(value);
+      }
+      mech_core::BrowserDomProperty::InnerHtml => element.set_inner_html(value),
+      mech_core::BrowserDomProperty::Attribute(attribute) => element
+        .set_attribute(&attribute, value)
+        .map_err(|_| browser_dom_error(requested_path.as_str(), "failed to set DOM attribute"))?,
+    }
+    Ok(())
+  }
+}
+
+fn browser_dom_error(resource: impl Into<String>, reason: impl Into<String>) -> mech_core::MechError {
+  mech_core::MechError::new(
+    mech_runtime::BrowserRuntimeResourceError {
+      resource: resource.into(),
+      reason: reason.into(),
+    },
+    None,
+  )
+}
+
+fn browser_document() -> mech_core::MResult<web_sys::Document> {
+  web_sys::window()
+    .and_then(|window| window.document())
+    .ok_or_else(|| browser_dom_error("browser://dom", "window.document is unavailable"))
+}
+
+fn resolve_dom_element(
+  entry: &mech_core::BrowserDomManifestEntry,
+  requested_path: &mech_core::BrowserDomPath,
+) -> mech_core::MResult<(web_sys::Element, mech_core::BrowserDomProperty)> {
+  let document = browser_document()?;
+  let root = document
+    .query_selector(entry.selector.selector.as_str())
+    .map_err(|_| browser_dom_error(requested_path.as_str(), "configured DOM selector is invalid"))?
+    .ok_or_else(|| browser_dom_error(requested_path.as_str(), "configured DOM selector did not match an element"))?;
+
+  if !entry.path.is_wildcard() {
+    return Ok((root, entry.property.clone()));
+  }
+
+  let prefix = entry
+    .path
+    .as_str()
+    .strip_suffix("/*")
+    .expect("wildcard DOM path must end in /*");
+  let relative = requested_path
+    .as_str()
+    .strip_prefix(prefix)
+    .and_then(|suffix| suffix.strip_prefix('/'))
+    .ok_or_else(|| browser_dom_error(requested_path.as_str(), "requested path is outside wildcard DOM root"))?;
+  let requested_relative = mech_core::BrowserDomPath::new(relative.to_string())
+    .map_err(mech_core::browser_capability_error)?;
+  let property = requested_relative.dom_property();
+  let node_path = requested_relative.without_property_suffix();
+  let mut element = root;
+  if !node_path.is_empty() && !node_path.starts_with('_') {
+    for segment in node_path.split('/') {
+      if segment.starts_with('_') {
+        break;
+      }
+      let selector = format!(r#"[data-mech-node="{}"]"#, segment);
+      element = element
+        .query_selector(&selector)
+        .map_err(|_| browser_dom_error(requested_path.as_str(), "failed to query data-mech-node descendant"))?
+        .ok_or_else(|| browser_dom_error(requested_path.as_str(), format!("missing data-mech-node descendant `{segment}`")))?;
+    }
+  }
+  Ok((element, property))
+}

--- a/src/wasm/src/host/resource.rs
+++ b/src/wasm/src/host/resource.rs
@@ -1,5 +1,6 @@
 pub use mech_core::{
-    BrowserCapabilityGrant, BrowserCapabilityRequest, BrowserDomScope, BrowserNetworkScope,
+    BrowserCapabilityGrant, BrowserCapabilityRequest, BrowserDomManifestEntry, BrowserDomPath,
+    BrowserDomProperty, BrowserDomScope, BrowserNetworkScope,
     BrowserOperation, BrowserResource, BrowserResourceKind, BrowserStorageBackend,
     BrowserStorageScope, BROWSER_CLIPBOARD_PROVIDER_URI, BROWSER_DOM_PROVIDER_URI,
     BROWSER_HOST_IDENTITY, BROWSER_NETWORK_PROVIDER_URI, BROWSER_STORAGE_PROVIDER_URI,

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -12,6 +12,7 @@ use mech_runtime::{
 use crate::host::{
   BrowserCapabilityRequest, BrowserDomScope, BrowserHost, BrowserHostError,
   BrowserNetworkScope, BrowserOperation, BrowserStorageBackend, BrowserStorageScope,
+  WasmBrowserDomHost,
 };
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlElement, HtmlInputElement, Node, Element, HashChangeEvent, HtmlTextAreaElement, Url};
@@ -140,8 +141,17 @@ fn runtime_from_config_document(document: Option<&MechConfigDocument>) -> MechRu
     None => RuntimeConfig::default(),
   };
 
-  MechRuntime::new(config)
-    .expect("failed to initialize MechRuntime for wasm")
+  let mut runtime = MechRuntime::new(config)
+    .expect("failed to initialize MechRuntime for wasm");
+  match document {
+    Some(document) => runtime.set_browser_authority(document.browser.clone()),
+    None => runtime.set_browser_authority(mech_runtime::BrowserAuthority::default()),
+  }
+  runtime.set_browser_dom_host(Box::new(WasmBrowserDomHost::new()));
+  runtime
+    .bind_resource_root("browser", "browser://dom/")
+    .expect("failed to bind default browser DOM resource root");
+  runtime
 }
 
 fn wasm_parts_from_config_document(
@@ -215,8 +225,14 @@ impl WasmMech {
 
   #[wasm_bindgen]
   pub fn clear(&mut self) {
-    self.runtime = MechRuntime::new(self.runtime.config().clone())
+    let mut runtime = MechRuntime::new(self.runtime.config().clone())
       .expect("failed to reset MechRuntime for wasm");
+    runtime.set_browser_authority(self.browser_host.authority().clone());
+    runtime.set_browser_dom_host(Box::new(WasmBrowserDomHost::new()));
+    runtime
+      .bind_resource_root("browser", "browser://dom/")
+      .expect("failed to bind default browser DOM resource root");
+    self.runtime = runtime;
   }
 
   #[wasm_bindgen(js_name = "readDomText")]


### PR DESCRIPTION
### Motivation
- Add structured DOM resource support so Mech programs can read/write configured browser DOM resources via resource root bindings instead of raw selectors.
- Provide manifest-backed mapping from normalized DOM paths to host selectors/properties and enforce permissions at runtime.
- Wire runtime and WASM host layers so reads/writes flow through `MechRuntime` and a `BrowserDomHost` trait without adding interpreter dependency to WASM.

### Description
- Introduce `BrowserDomPath`, `BrowserDomProperty`, and `BrowserDomManifestEntry` types and validators in `core` and expose manifest lookup on `BrowserAuthority` via `dom_manifest`, `bind_dom_path`, and `dom_entry_for_path`.
- Extend config lowering in `lower_browser_dom` to accept optional `path`, `property`, `attribute`, and `mode` fields, create selector grants, infer properties, validate wildcard/subtree rules, and call `authority.bind_dom_path(...)` for entries (see `src/runtime/src/config_profile/lower.rs`).
- Add runtime resource root bindings and APIs on `MechRuntime`: `bind_resource_root`, `resolve_resource_path`, `read_browser_dom_resource`, and `write_browser_dom_resource`, plus supporting `RuntimeResourceBinding` and error helpers; runtime enforces manifest existence and permission checks before host access (see `src/runtime/src/runtime/mod.rs` and `src/runtime/src/runtime/execution.rs`).
- Add a `BrowserDomHost` trait (string-only host interface) and a `WasmBrowserDomHost` implementation that resolves configured selectors, supports wildcard subtree traversal via `data-mech-node`, and reads/writes text/value/html/attribute (see `src/runtime/src/host/browser_dom.rs` and `src/wasm/src/host/browser_host.rs`).
- Lower simple source forms that declare resource roots and inline `path@binding` reads/writes in `MechRuntime::lower_browser_resource_source`, routing `@name := browser://dom/...`, `path@binding = "..."`, and `x := path@binding` through the runtime APIs (see `src/runtime/src/runtime/execution.rs`).
- Update syntax to accept `@binding := resource-uri` context declarations with optional capability list and permit addressed `path@binding` forms; add small parser/program tests and examples (see `src/syntax/src/*`, `src/program/tests/*`, and `examples/browser-dom-resource.*`).

### Testing
- Ran `cargo check -p mech-core` and it succeeded.
- Ran `cargo check -p mech-runtime` and `cargo test -p mech-runtime browser_dom` and `cargo test -p mech-runtime config_profile_browser_dom`, all succeeded.
- Ran `cargo check -p mech-wasm` and it succeeded, and the WASM host wiring compiles.
- Ran `cargo test -p mech-syntax browser_resource` and `cargo test -p mech-program browser_resource`, and both test sets passed.
- Executed broader runtime tests including `cargo test -p mech-runtime runtime_` and validated `git diff --check`; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2453d4afdc832ab5bc2300487b9a0a)