### PR TITLE
Refactor browser DOM runtime to use generic RuntimeResourceProvider registry

### DIFF
--- a/src/runtime/src/host/browser_dom.rs
+++ b/src/runtime/src/host/browser_dom.rs
@@ -1,6 +1,11 @@
-use mech_core::{BrowserDomManifestEntry, BrowserDomPath, MResult};
+use mech_core::{
+  browser_capability_error, BrowserAuthority, BrowserDomManifestEntry, BrowserDomPath,
+  BrowserOperation, BROWSER_DOM_PROVIDER_URI, MResult, MechError, MechErrorKind, Ref, Value,
+};
 
-pub trait BrowserDomHost {
+use crate::{RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteRequest};
+
+pub trait BrowserDomBackend: std::fmt::Debug {
   fn read_dom_string(
     &self,
     entry: &BrowserDomManifestEntry,
@@ -13,4 +18,125 @@ pub trait BrowserDomHost {
     requested_path: &BrowserDomPath,
     value: &str,
   ) -> MResult<()>;
+}
+
+#[derive(Debug)]
+pub struct BrowserResourceProvider<B> {
+  authority: BrowserAuthority,
+  backend: B,
+}
+
+impl<B> BrowserResourceProvider<B> {
+  pub fn new(authority: BrowserAuthority, backend: B) -> Self {
+    Self { authority, backend }
+  }
+
+  pub fn authority(&self) -> &BrowserAuthority {
+    &self.authority
+  }
+
+  pub fn authority_mut(&mut self) -> &mut BrowserAuthority {
+    &mut self.authority
+  }
+
+  pub fn backend(&self) -> &B {
+    &self.backend
+  }
+
+  pub fn backend_mut(&mut self) -> &mut B {
+    &mut self.backend
+  }
+}
+
+impl<B: BrowserDomBackend> BrowserResourceProvider<B> {
+  fn validate_dom_base(base_uri: &str) -> MResult<()> {
+    if base_uri == BROWSER_DOM_PROVIDER_URI || base_uri == "browser://dom/" {
+      return Ok(());
+    }
+    Err(browser_resource_provider_error(
+      base_uri,
+      "browser provider base is unsupported in this PR; only browser://dom is supported",
+    ))
+  }
+
+  fn dom_path(path: String) -> MResult<BrowserDomPath> {
+    BrowserDomPath::new(path).map_err(browser_capability_error)
+  }
+}
+
+impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B> {
+  fn scheme(&self) -> &str {
+    "browser"
+  }
+
+  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+    Self::validate_dom_base(&request.base_uri)?;
+    let path = Self::dom_path(request.path)?;
+    let Some(entry) = self.authority.dom_entry_for_path(&path) else {
+      return Err(browser_resource_provider_error(
+        path.as_str(),
+        "no configured DOM manifest entry for path",
+      ));
+    };
+    self
+      .authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Read)
+      .map_err(browser_capability_error)?;
+    Ok(Value::String(Ref::new(self.backend.read_dom_string(entry, &path)?)))
+  }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    Self::validate_dom_base(&request.base_uri)?;
+    let path = Self::dom_path(request.path)?;
+    let entry = self
+      .authority
+      .dom_entry_for_path(&path)
+      .cloned()
+      .ok_or_else(|| {
+        browser_resource_provider_error(
+          path.as_str(),
+          "no configured DOM manifest entry for path",
+        )
+      })?;
+    self
+      .authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Write)
+      .map_err(browser_capability_error)?;
+    let Value::String(value) = request.value else {
+      return Err(browser_resource_provider_error(
+        path.as_str(),
+        "only string values can be written to browser DOM resources in this PR",
+      ));
+    };
+    self.backend.write_dom_string(&entry, &path, value.borrow().as_str())
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct BrowserResourceProviderError {
+  pub resource: String,
+  pub reason: String,
+}
+
+impl MechErrorKind for BrowserResourceProviderError {
+  fn name(&self) -> &str {
+    "BrowserResourceProvider"
+  }
+
+  fn message(&self) -> String {
+    format!("browser resource `{}` failed: {}", self.resource, self.reason)
+  }
+}
+
+fn browser_resource_provider_error(
+  resource: impl Into<String>,
+  reason: impl Into<String>,
+) -> MechError {
+  MechError::new(
+    BrowserResourceProviderError {
+      resource: resource.into(),
+      reason: reason.into(),
+    },
+    None,
+  )
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -251,7 +251,7 @@ impl MechRuntime {
           let expression = self.lower_browser_resource_reads_in_expression(&assign.expression)?;
           let value = self.evaluate_expression_on_program(program, &expression)?;
           let binding = assign.target.context.as_ref().expect("checked browser binding").to_string();
-          self.write_browser_dom_resource(
+          self.write_bound_resource(
             &binding,
             &assign.target.name.to_string(),
             &resolve_runtime_value(value.clone()),
@@ -312,7 +312,7 @@ impl MechRuntime {
     self
       .resource_bindings
       .get(binding)
-      .is_some_and(|binding| binding.provider == BROWSER_DOM_PROVIDER_URI)
+      .is_some_and(|binding| binding.base_uri == BROWSER_DOM_PROVIDER_URI)
   }
 
   fn variable_define_targets_browser_binding(&self, var_def: &mech_core::VariableDefine) -> bool {
@@ -497,7 +497,7 @@ impl MechRuntime {
           return Ok(expression.clone());
         }
         let value = resolve_runtime_value(
-          self.read_browser_dom_resource(&binding, &var.name.to_string())?,
+          self.read_bound_resource(&binding, &var.name.to_string())?,
         );
         let Value::String(value) = value else {
           return Err(browser_runtime_resource_error(

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -37,8 +37,8 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use mech_core::{
-  browser_capability_error, BrowserAuthority, BrowserDomPath, BrowserOperation,
-  BROWSER_DOM_PROVIDER_URI, MResult, MechError, MechErrorKind, MechSourceCode, Ref, Value,
+  browser_capability_error, BrowserDomPath, BROWSER_DOM_PROVIDER_URI, MResult, MechError,
+  MechErrorKind, MechSourceCode, Ref, Value,
   NativeFunctionCompiler, MechFunctionImpl, Register, CompileCtx, MechFunctionCompiler,
   hash_str,
 };
@@ -64,9 +64,8 @@ use crate::event::{
 };
 
 use crate::host::{
-  default_host_capability_request, BrowserDomHost, DefaultHostCallPolicy, HostCall,
-  HostCallPolicy, HostFunction, HostFunctionNotFoundError, HostRegistry,
-  InMemoryHostRegistry,
+  default_host_capability_request, DefaultHostCallPolicy, HostCall, HostCallPolicy, HostFunction,
+  HostFunctionNotFoundError, HostRegistry, InMemoryHostRegistry,
 };
 
 use crate::id::{
@@ -311,8 +310,6 @@ impl RuntimeBuilder {
       module_builder: self.module_builder,
       resources: RuntimeResourceRegistry::new(),
       grants: RuntimeCapabilityGrantRegistry::new(),
-      browser_dom_host: None,
-      browser_authority: BrowserAuthority::default(),
       resource_bindings: HashMap::new(),
     };
 
@@ -360,8 +357,6 @@ pub struct MechRuntime {
   module_builder: ModuleBuilder,
   resources: RuntimeResourceRegistry,
   grants: RuntimeCapabilityGrantRegistry,
-  browser_dom_host: Option<Box<dyn BrowserDomHost>>,
-  browser_authority: BrowserAuthority,
   resource_bindings: HashMap<String, RuntimeResourceBinding>,
 }
 
@@ -385,7 +380,6 @@ impl std::fmt::Debug for MechRuntime {
       .field("module_builder", &self.module_builder)
       .field("resources", &self.resources)
       .field("grants", &self.grants)
-      .field("browser_authority", &self.browser_authority)
       .field("resource_bindings", &self.resource_bindings)
       .finish()
   }
@@ -394,7 +388,7 @@ impl std::fmt::Debug for MechRuntime {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeResourceBinding {
   pub name: String,
-  pub provider: String,
+  pub base_uri: String,
   pub root_path: String,
 }
 
@@ -467,18 +461,6 @@ impl MechRuntime {
   }
 
 
-  pub fn set_browser_authority(&mut self, authority: BrowserAuthority) {
-    self.browser_authority = authority;
-  }
-
-  pub fn browser_authority(&self) -> &BrowserAuthority {
-    &self.browser_authority
-  }
-
-  pub fn set_browser_dom_host(&mut self, host: Box<dyn BrowserDomHost>) {
-    self.browser_dom_host = Some(host);
-  }
-
   pub fn bind_resource_root(
     &mut self,
     name: impl Into<String>,
@@ -493,14 +475,19 @@ impl MechRuntime {
     }
 
     let uri = uri.as_ref();
-    let prefix = "browser://dom/";
-    let Some(root_path) = uri.strip_prefix(prefix) else {
-      return Err(browser_runtime_resource_error(
-        uri,
-        "only browser://dom/ resource roots are supported in this PR",
-      ));
+    let (base_uri, root_path) = if uri == BROWSER_DOM_PROVIDER_URI {
+      (BROWSER_DOM_PROVIDER_URI.to_string(), String::new())
+    } else {
+      let prefix = "browser://dom/";
+      let Some(root_path) = uri.strip_prefix(prefix) else {
+        return Err(browser_runtime_resource_error(
+          uri,
+          "only browser://dom/ resource roots are supported in this PR",
+        ));
+      };
+      (BROWSER_DOM_PROVIDER_URI.to_string(), root_path.trim_matches('/').to_string())
     };
-    let root_path = root_path.trim_matches('/').to_string();
+
     if !root_path.is_empty() {
       BrowserDomPath::new(root_path.clone()).map_err(browser_capability_error)?;
     }
@@ -509,30 +496,24 @@ impl MechRuntime {
       name.clone(),
       RuntimeResourceBinding {
         name,
-        provider: BROWSER_DOM_PROVIDER_URI.to_string(),
+        base_uri,
         root_path,
       },
     );
     Ok(())
   }
 
-  pub fn resolve_resource_path(
+  fn resolve_bound_resource_parts(
     &self,
     binding: &str,
     child_path: &str,
-  ) -> MResult<BrowserDomPath> {
+  ) -> MResult<(String, String)> {
     let Some(binding_record) = self.resource_bindings.get(binding) else {
       return Err(browser_runtime_resource_error(
         binding,
         "unknown resource root binding",
       ));
     };
-    if binding_record.provider != BROWSER_DOM_PROVIDER_URI {
-      return Err(browser_runtime_resource_error(
-        binding,
-        "only browser DOM resource bindings are supported",
-      ));
-    }
 
     let child_path = child_path.trim_matches('/');
     let full_path = if binding_record.root_path.is_empty() {
@@ -542,7 +523,50 @@ impl MechRuntime {
     } else {
       format!("{}/{}", binding_record.root_path, child_path)
     };
+    Ok((binding_record.base_uri.clone(), full_path))
+  }
+
+  pub fn resolve_resource_path(
+    &self,
+    binding: &str,
+    child_path: &str,
+  ) -> MResult<BrowserDomPath> {
+    let (base_uri, full_path) = self.resolve_bound_resource_parts(binding, child_path)?;
+    if base_uri != BROWSER_DOM_PROVIDER_URI {
+      return Err(browser_runtime_resource_error(
+        binding,
+        "only browser DOM resource bindings are supported",
+      ));
+    }
     BrowserDomPath::new(full_path).map_err(browser_capability_error)
+  }
+
+  pub fn read_bound_resource(
+    &self,
+    binding: &str,
+    child_path: &str,
+  ) -> MResult<Value> {
+    let (base_uri, path) = self.resolve_bound_resource_parts(binding, child_path)?;
+    self.resources.read(RuntimeResourceReadRequest {
+      base_uri,
+      path,
+      context_name: binding.to_string(),
+    })
+  }
+
+  pub fn write_bound_resource(
+    &mut self,
+    binding: &str,
+    child_path: &str,
+    value: &Value,
+  ) -> MResult<()> {
+    let (base_uri, path) = self.resolve_bound_resource_parts(binding, child_path)?;
+    self.resources.write(RuntimeResourceWriteRequest {
+      base_uri,
+      path,
+      context_name: binding.to_string(),
+      value: value.clone(),
+    })
   }
 
   pub fn read_browser_dom_resource(
@@ -550,23 +574,7 @@ impl MechRuntime {
     binding: &str,
     child_path: &str,
   ) -> MResult<Value> {
-    let path = self.resolve_resource_path(binding, child_path)?;
-    let Some(entry) = self.browser_authority.dom_entry_for_path(&path) else {
-      return Err(browser_runtime_resource_error(
-        path.as_str(),
-        "no configured DOM manifest entry for path",
-      ));
-    };
-    self.browser_authority
-      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Read)
-      .map_err(browser_capability_error)?;
-    let Some(host) = self.browser_dom_host.as_ref() else {
-      return Err(browser_runtime_resource_error(
-        path.as_str(),
-        "no browser DOM host is registered",
-      ));
-    };
-    Ok(Value::String(Ref::new(host.read_dom_string(entry, &path)?)))
+    self.read_bound_resource(binding, child_path)
   }
 
   pub fn write_browser_dom_resource(
@@ -575,33 +583,7 @@ impl MechRuntime {
     child_path: &str,
     value: &Value,
   ) -> MResult<()> {
-    let path = self.resolve_resource_path(binding, child_path)?;
-    let entry = self
-      .browser_authority
-      .dom_entry_for_path(&path)
-      .cloned()
-      .ok_or_else(|| {
-        browser_runtime_resource_error(
-          path.as_str(),
-          "no configured DOM manifest entry for path",
-        )
-      })?;
-    self.browser_authority
-      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Write)
-      .map_err(browser_capability_error)?;
-    let Value::String(value) = value else {
-      return Err(browser_runtime_resource_error(
-        path.as_str(),
-        "only string values can be written to browser DOM resources in this PR",
-      ));
-    };
-    let Some(host) = self.browser_dom_host.as_mut() else {
-      return Err(browser_runtime_resource_error(
-        path.as_str(),
-        "no browser DOM host is registered",
-      ));
-    };
-    host.write_dom_string(&entry, &path, value.borrow().as_str())
+    self.write_bound_resource(binding, child_path, value)
   }
 
   pub fn apply_config_spec(

--- a/src/runtime/tests/browser_dom.rs
+++ b/src/runtime/tests/browser_dom.rs
@@ -5,14 +5,14 @@ use std::rc::Rc;
 use mech_core::Value;
 use mech_runtime::*;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct FakeDomState {
   values: BTreeMap<String, String>,
   reads: Vec<String>,
   writes: Vec<(String, String)>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 struct FakeDomHost {
   state: Rc<RefCell<FakeDomState>>,
 }
@@ -36,7 +36,7 @@ impl FakeDomHost {
   }
 }
 
-impl BrowserDomHost for FakeDomHost {
+impl BrowserDomBackend for FakeDomHost {
   fn read_dom_string(
     &self,
     _entry: &BrowserDomManifestEntry,
@@ -62,6 +62,16 @@ impl BrowserDomHost for FakeDomHost {
 
 fn runtime() -> MechRuntime {
   MechRuntime::new(RuntimeConfig::default()).unwrap()
+}
+
+fn register_browser_provider(
+  runtime: &mut MechRuntime,
+  authority: BrowserAuthority,
+  host: FakeDomHost,
+) {
+  runtime
+    .register_resource_provider(Box::new(BrowserResourceProvider::new(authority, host)))
+    .unwrap();
 }
 
 fn bind_authority_path(
@@ -113,8 +123,11 @@ fn runtime_resolves_child_path_under_narrow_root() {
 fn runtime_reads_configured_browser_dom_path() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Read]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default().with_value("body/title", "Hello")));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/title", "#title", &[BrowserOperation::Read]),
+    FakeDomHost::default().with_value("body/title", "Hello"),
+  );
   let value = runtime.read_browser_dom_resource("browser", "body/title").unwrap();
   assert_eq!(value.as_string().unwrap().borrow().as_str(), "Hello");
 }
@@ -123,8 +136,11 @@ fn runtime_reads_configured_browser_dom_path() {
 fn runtime_writes_configured_browser_dom_path() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Write]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/title", "#title", &[BrowserOperation::Write]),
+    FakeDomHost::default(),
+  );
   runtime.write_browser_dom_resource("browser", "body/title", &Value::from("Hello".to_string())).unwrap();
 }
 
@@ -132,8 +148,11 @@ fn runtime_writes_configured_browser_dom_path() {
 fn runtime_denies_browser_dom_read_without_read_grant() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Write]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/title", "#title", &[BrowserOperation::Write]),
+    FakeDomHost::default(),
+  );
   assert!(runtime.read_browser_dom_resource("browser", "body/title").is_err());
 }
 
@@ -141,8 +160,11 @@ fn runtime_denies_browser_dom_read_without_read_grant() {
 fn runtime_denies_browser_dom_write_without_write_grant() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Read]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/title", "#title", &[BrowserOperation::Read]),
+    FakeDomHost::default(),
+  );
   assert!(runtime.write_browser_dom_resource("browser", "body/title", &Value::from("Hello".to_string())).is_err());
 }
 
@@ -150,8 +172,11 @@ fn runtime_denies_browser_dom_write_without_write_grant() {
 fn runtime_rejects_unknown_browser_dom_path() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/title", "#title", &[BrowserOperation::Read]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/title", "#title", &[BrowserOperation::Read]),
+    FakeDomHost::default(),
+  );
   assert!(runtime.read_browser_dom_resource("browser", "body/other").is_err());
 }
 
@@ -159,8 +184,11 @@ fn runtime_rejects_unknown_browser_dom_path() {
 fn runtime_wildcard_dom_path_allows_child() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/content/*", "#content", &[BrowserOperation::Read]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default().with_value("body/content/title", "Hello")));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/content/*", "#content", &[BrowserOperation::Read]),
+    FakeDomHost::default().with_value("body/content/title", "Hello"),
+  );
   assert!(runtime.read_browser_dom_resource("browser", "body/content/title").is_ok());
 }
 
@@ -168,8 +196,11 @@ fn runtime_wildcard_dom_path_allows_child() {
 fn runtime_wildcard_dom_path_rejects_sibling() {
   let mut runtime = runtime();
   runtime.bind_resource_root("browser", "browser://dom/").unwrap();
-  runtime.set_browser_authority(authority("body/content/*", "#content", &[BrowserOperation::Read]));
-  runtime.set_browser_dom_host(Box::new(FakeDomHost::default()));
+  register_browser_provider(
+    &mut runtime,
+    authority("body/content/*", "#content", &[BrowserOperation::Read]),
+    FakeDomHost::default(),
+  );
   assert!(runtime.read_browser_dom_resource("browser", "body/sidebar/title").is_err());
 }
 
@@ -181,9 +212,12 @@ fn read_write_authority(path: &str, selector: &str) -> BrowserAuthority {
 #[test]
 fn program_browser_resource_write_uses_runtime_host() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(read_write_authority("body/header/title", "#title"));
   let host = FakeDomHost::default();
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    read_write_authority("body/header/title", "#title"),
+    host.clone(),
+  );
 
   runtime
     .run_string("@browser := browser://dom/\nbody/header/title@browser = \"Hello\"")
@@ -195,9 +229,12 @@ fn program_browser_resource_write_uses_runtime_host() {
 #[test]
 fn program_browser_resource_read_uses_runtime_host() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(read_write_authority("body/search/_value", "#search"));
   let host = FakeDomHost::default().with_value("body/search/_value", "query");
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    read_write_authority("body/search/_value", "#search"),
+    host.clone(),
+  );
 
   let value = runtime
     .run_string("@browser := browser://dom/\nx := body/search/_value@browser")
@@ -210,9 +247,12 @@ fn program_browser_resource_read_uses_runtime_host() {
 #[test]
 fn program_browser_resource_define_does_not_write() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(read_write_authority("title", "#title"));
   let host = FakeDomHost::default();
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    read_write_authority("title", "#title"),
+    host.clone(),
+  );
 
   runtime
     .run_string("@browser := browser://dom/\ntitle@browser := \"Hello\"")
@@ -224,9 +264,12 @@ fn program_browser_resource_define_does_not_write() {
 #[test]
 fn runtime_browser_resource_binding_applies_before_following_write() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(read_write_authority("body/header/title", "#title"));
   let host = FakeDomHost::default();
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    read_write_authority("body/header/title", "#title"),
+    host.clone(),
+  );
 
   runtime
     .run_string("@browser := browser://dom/\nbody/header/title@browser = \"Hello\"")
@@ -242,9 +285,12 @@ fn runtime_browser_resource_binding_applies_before_following_write() {
 #[test]
 fn program_browser_resource_write_accepts_string_variable() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(read_write_authority("body/header/title", "#title"));
   let host = FakeDomHost::default();
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    read_write_authority("body/header/title", "#title"),
+    host.clone(),
+  );
 
   runtime
     .run_string(
@@ -258,9 +304,12 @@ fn program_browser_resource_write_accepts_string_variable() {
 #[test]
 fn program_browser_resource_read_inside_expression() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(read_write_authority("body/search/_value", "#search"));
   let host = FakeDomHost::default().with_value("body/search/_value", "query");
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    read_write_authority("body/search/_value", "#search"),
+    host.clone(),
+  );
 
   let value = runtime
     .run_string(r#"@browser := browser://dom/
@@ -287,9 +336,8 @@ fn program_browser_resource_write_rhs_reads_browser_resource() {
     &[BrowserOperation::Write],
   );
   let mut runtime = runtime();
-  runtime.set_browser_authority(authority);
   let host = FakeDomHost::default().with_value("body/search/_value", "query");
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(&mut runtime, authority, host.clone());
 
   runtime
     .run_string(
@@ -321,9 +369,8 @@ fn program_browser_resource_write_rhs_combines_string_and_resource() {
     &[BrowserOperation::Write],
   );
   let mut runtime = runtime();
-  runtime.set_browser_authority(authority);
   let host = FakeDomHost::default().with_value("body/search/_value", "query");
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(&mut runtime, authority, host.clone());
 
   runtime
     .run_string(r#"@browser := browser://dom/
@@ -340,13 +387,16 @@ body/header/title@browser = "Search: " + body/search/_value@browser"#)
 #[test]
 fn program_browser_resource_read_inside_expression_denied_before_host_access() {
   let mut runtime = runtime();
-  runtime.set_browser_authority(authority(
-    "body/search/_value",
-    "#search",
-    &[BrowserOperation::Write],
-  ));
   let host = FakeDomHost::default().with_value("body/search/_value", "query");
-  runtime.set_browser_dom_host(Box::new(host.clone()));
+  register_browser_provider(
+    &mut runtime,
+    authority(
+      "body/search/_value",
+      "#search",
+      &[BrowserOperation::Write],
+    ),
+    host.clone(),
+  );
 
   let result = runtime
     .run_string(r#"@browser := browser://dom/
@@ -354,4 +404,21 @@ message := "Search: " + body/search/_value@browser"#);
 
   assert!(result.is_err());
   assert_eq!(host.read_count(), 0);
+}
+
+#[test]
+fn runtime_browser_dom_uses_generic_resource_provider_dispatch() {
+  let mut runtime = runtime();
+  runtime.bind_resource_root("browser", "browser://dom/").unwrap();
+  let host = FakeDomHost::default().with_value("body/title", "Hello");
+  register_browser_provider(
+    &mut runtime,
+    authority("body/title", "#title", &[BrowserOperation::Read]),
+    host.clone(),
+  );
+
+  let value = runtime.read_bound_resource("browser", "body/title").unwrap();
+
+  assert_eq!(value.as_string().unwrap().borrow().as_str(), "Hello");
+  assert_eq!(host.read_count(), 1);
 }

--- a/src/wasm/src/host/browser_host.rs
+++ b/src/wasm/src/host/browser_host.rs
@@ -61,21 +61,22 @@ mod tests {
     }
 }
 
-pub struct WasmBrowserDomHost;
+#[derive(Debug)]
+pub struct WasmBrowserDomBackend;
 
-impl WasmBrowserDomHost {
+impl WasmBrowserDomBackend {
   pub fn new() -> Self {
     Self
   }
 }
 
-impl Default for WasmBrowserDomHost {
+impl Default for WasmBrowserDomBackend {
   fn default() -> Self {
     Self::new()
   }
 }
 
-impl mech_runtime::BrowserDomHost for WasmBrowserDomHost {
+impl mech_runtime::BrowserDomBackend for WasmBrowserDomBackend {
   fn read_dom_string(
     &self,
     entry: &mech_core::BrowserDomManifestEntry,

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -6,13 +6,13 @@ use wasm_bindgen::prelude::*;
 use mech_core::*;
 use mech_syntax::*;
 use mech_runtime::{
-  ConfigProfileOptions, MechConfigDocument, MechRuntime, RuntimeConfig,
+  BrowserResourceProvider, ConfigProfileOptions, MechConfigDocument, MechRuntime, RuntimeConfig,
   parse_config_document,
 };
 use crate::host::{
   BrowserCapabilityRequest, BrowserDomScope, BrowserHost, BrowserHostError,
   BrowserNetworkScope, BrowserOperation, BrowserStorageBackend, BrowserStorageScope,
-  WasmBrowserDomHost,
+  WasmBrowserDomBackend,
 };
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlElement, HtmlInputElement, Node, Element, HashChangeEvent, HtmlTextAreaElement, Url};
@@ -143,11 +143,16 @@ fn runtime_from_config_document(document: Option<&MechConfigDocument>) -> MechRu
 
   let mut runtime = MechRuntime::new(config)
     .expect("failed to initialize MechRuntime for wasm");
-  match document {
-    Some(document) => runtime.set_browser_authority(document.browser.clone()),
-    None => runtime.set_browser_authority(mech_runtime::BrowserAuthority::default()),
-  }
-  runtime.set_browser_dom_host(Box::new(WasmBrowserDomHost::new()));
+  let authority = match document {
+    Some(document) => document.browser.clone(),
+    None => mech_runtime::BrowserAuthority::default(),
+  };
+  runtime
+    .register_resource_provider(Box::new(BrowserResourceProvider::new(
+      authority,
+      WasmBrowserDomBackend::new(),
+    )))
+    .expect("failed to register browser resource provider");
   runtime
     .bind_resource_root("browser", "browser://dom/")
     .expect("failed to bind default browser DOM resource root");
@@ -227,8 +232,12 @@ impl WasmMech {
   pub fn clear(&mut self) {
     let mut runtime = MechRuntime::new(self.runtime.config().clone())
       .expect("failed to reset MechRuntime for wasm");
-    runtime.set_browser_authority(self.browser_host.authority().clone());
-    runtime.set_browser_dom_host(Box::new(WasmBrowserDomHost::new()));
+    runtime
+      .register_resource_provider(Box::new(BrowserResourceProvider::new(
+        self.browser_host.authority().clone(),
+        WasmBrowserDomBackend::new(),
+      )))
+      .expect("failed to register browser resource provider");
     runtime
       .bind_resource_root("browser", "browser://dom/")
       .expect("failed to bind default browser DOM resource root");


### PR DESCRIPTION
### Motivation

- Replace bespoke `MechRuntime` browser fields and ad-hoc DOM host dispatch with the existing provider registry so browser resources are handled through the generic `RuntimeResourceProvider` API keyed by the `browser` scheme.
- Move browser-specific `BrowserAuthority` ownership and manifest checks into a provider so future `browser://...` bases can be routed from a single `browser` provider.

### Description

- Add `BrowserDomBackend` and `BrowserResourceProvider<B>` (implements `RuntimeResourceProvider`) in `src/runtime/src/host/browser_dom.rs` to own `BrowserAuthority` and a backend and to dispatch `browser://dom` reads/writes internally.
- Remove `browser_dom_host` and `browser_authority` from `MechRuntime` and change `RuntimeResourceBinding` to store `base_uri` plus `root_path`; add `read_bound_resource` and `write_bound_resource` that build `RuntimeResourceReadRequest`/`RuntimeResourceWriteRequest` and dispatch via `RuntimeResourceRegistry` (methods in `src/runtime/src/runtime/mod.rs`).
- Replace direct runtime DOM helper usage in execution and expression lowering to call `read_bound_resource` / `write_bound_resource` (changes in `src/runtime/src/runtime/execution.rs`) while keeping compatibility wrappers (`read_browser_dom_resource` / `write_browser_dom_resource`) as delegators.
- Update WASM integration to register the browser provider via `runtime.register_resource_provider(Box::new(BrowserResourceProvider::new(...)))` and adapt `WasmBrowserDomHost` → `WasmBrowserDomBackend` to implement the backend trait (changes in `src/wasm/src/lib.rs` and `src/wasm/src/host/browser_host.rs`).
- Update tests in `src/runtime/tests/browser_dom.rs` to register the generic `BrowserResourceProvider` and add a test verifying `read_bound_resource` dispatches through the provider; preserved original DOM semantics and wildcard safety comments.

### Testing

- Ran `cargo check -p mech-runtime` and `cargo check -p mech-wasm` which completed successfully.
- Ran unit and integration tests: `cargo test -p mech-runtime browser_dom`, `cargo test -p mech-runtime config_profile_browser_dom`, `cargo test -p mech-syntax browser_resource`, `cargo test -p mech-program browser_resource`, and `cargo test -p mech-runtime --test browser_dom`, all of which passed.
- Added a targeted test `runtime_browser_dom_uses_generic_resource_provider_dispatch` that asserts provider-backed reads are invoked; the test passed as part of the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a248362ed7c832a8fa30e158c800012)