### PR TITLE
Add browser DOM resource demo example

### DIFF
--- a/examples/browser-dom-demo/README.md
+++ b/examples/browser-dom-demo/README.md
@@ -1,0 +1,36 @@
+# Browser DOM resource demo
+
+This example demonstrates browser DOM resources backed by runtime resource providers.
+
+It shows:
+
+- `WasmMech.fromConfig(...)` loading browser DOM grants from `demo.mcfg`.
+- Mech code binding `@browser := browser://dom/`.
+- A DOM read from `body/content/mech-sandbox/input/_value@browser`.
+- DOM writes to `body/content/mech-sandbox/title@browser`, `body/content/mech-sandbox/status@browser`, and `body/content/mech-sandbox/status/_class@browser`.
+- A denied write from `denied.mec` because the config grants read, but not write, on the input value.
+
+## Files
+
+- `index.html` — browser page that loads the WASM package and runs the demo.
+- `demo.mcfg` — runtime/browser config and DOM permissions.
+- `demo.mec` — allowed program that reads an input value and writes DOM output.
+- `denied.mec` — program that attempts a denied DOM write.
+
+## Running
+
+Build or copy the Mech WASM package into `examples/browser-dom-demo/pkg/` so the page can import:
+
+```text
+./pkg/mech_wasm.js
+./pkg/mech_wasm_bg.wasm
+```
+
+Then serve this directory with any static file server. For example:
+
+```text
+cd examples/browser-dom-demo
+python3 -m http.server 8080
+```
+
+Open `http://localhost:8080/` in a browser.

--- a/examples/browser-dom-demo/README.md
+++ b/examples/browser-dom-demo/README.md
@@ -2,19 +2,22 @@
 
 This example demonstrates browser DOM resources backed by runtime resource providers.
 
-It shows:
+It shows a full DOM -> Mech -> DOM round trip:
 
-- `WasmMech.fromConfig(...)` loading browser DOM grants from `demo.mcfg`.
-- Mech code binding `@browser := browser://dom/`.
-- A DOM read from `body/content/mech-sandbox/input/_value@browser`.
-- DOM writes to `body/content/mech-sandbox/title@browser`, `body/content/mech-sandbox/status@browser`, and `body/content/mech-sandbox/status/_class@browser`.
-- A denied write from `denied.mec` because the config grants read, but not write, on the input value.
+- `WasmMech.fromConfig(...)` loads browser DOM grants from `demo.mcfg`.
+- Mech code binds `@browser := browser://dom/`.
+- Mech reads the source input value from `body/content/mech-sandbox/input/_value@browser`.
+- Mech computes `greeting`, `roundtrip`, and `status` strings from that DOM value.
+- Mech writes the computed output back to `body/content/mech-sandbox/output/_value@browser`.
+- Mech writes DOM text to `body/content/mech-sandbox/title@browser` and `body/content/mech-sandbox/status@browser`.
+- Mech writes the `class` attribute through `body/content/mech-sandbox/status/_class@browser`.
+- `denied.mec` attempts to write to the read-only source input and is rejected by config permissions.
 
 ## Files
 
 - `index.html` — browser page that loads the WASM package and runs the demo.
-- `demo.mcfg` — runtime/browser config and DOM permissions.
-- `demo.mec` — allowed program that reads an input value and writes DOM output.
+- `demo.mcfg` — runtime/browser config and DOM read/write permissions.
+- `demo.mec` — allowed program that reads a DOM value, performs string logic in Mech, and writes DOM output.
 - `denied.mec` — program that attempts a denied DOM write.
 
 ## Running
@@ -34,3 +37,5 @@ python3 -m http.server 8080
 ```
 
 Open `http://localhost:8080/` in a browser.
+
+Change the `Source DOM input` field, click `Run round trip`, and observe that Mech reads the DOM value, computes new strings, and writes the computed result back into the page.

--- a/examples/browser-dom-demo/demo.mcfg
+++ b/examples/browser-dom-demo/demo.mcfg
@@ -1,0 +1,42 @@
+config := {
+  runtime: {
+    name: "browser-dom-demo"
+    diagnostics: {
+      debug-enabled: true
+      log-level: "info"
+    }
+  }
+
+  browser: {
+    dom: [
+      {
+        path: "body/content/mech-sandbox/input/_value"
+        selector: "#name-input"
+        property: "value"
+        allow: ["read"]
+      }
+
+      {
+        path: "body/content/mech-sandbox/title"
+        selector: "#title"
+        property: "text"
+        allow: ["write"]
+      }
+
+      {
+        path: "body/content/mech-sandbox/status/_class"
+        selector: "#status"
+        property: "attribute"
+        attribute: "class"
+        allow: ["write"]
+      }
+
+      {
+        path: "body/content/mech-sandbox/status"
+        selector: "#status"
+        property: "text"
+        allow: ["write"]
+      }
+    ]
+  }
+}

--- a/examples/browser-dom-demo/demo.mcfg
+++ b/examples/browser-dom-demo/demo.mcfg
@@ -17,6 +17,13 @@ config := {
       }
 
       {
+        path: "body/content/mech-sandbox/output/_value"
+        selector: "#roundtrip-output"
+        property: "value"
+        allow: ["write"]
+      }
+
+      {
         path: "body/content/mech-sandbox/title"
         selector: "#title"
         property: "text"

--- a/examples/browser-dom-demo/demo.mec
+++ b/examples/browser-dom-demo/demo.mec
@@ -1,7 +1,11 @@
 @browser := browser://dom/
 
 name := body/content/mech-sandbox/input/_value@browser
+greeting := "Hello, " + name
+roundtrip := greeting + " — computed in Mech"
+status := "Read `" + name + "` from the DOM and wrote the computed result back."
 
-body/content/mech-sandbox/title@browser = "Hello, " + name
-body/content/mech-sandbox/status@browser = "Updated by Mech"
+body/content/mech-sandbox/title@browser = greeting
+body/content/mech-sandbox/output/_value@browser = roundtrip
+body/content/mech-sandbox/status@browser = status
 body/content/mech-sandbox/status/_class@browser = "ready"

--- a/examples/browser-dom-demo/demo.mec
+++ b/examples/browser-dom-demo/demo.mec
@@ -1,0 +1,7 @@
+@browser := browser://dom/
+
+name := body/content/mech-sandbox/input/_value@browser
+
+body/content/mech-sandbox/title@browser = "Hello, " + name
+body/content/mech-sandbox/status@browser = "Updated by Mech"
+body/content/mech-sandbox/status/_class@browser = "ready"

--- a/examples/browser-dom-demo/denied.mec
+++ b/examples/browser-dom-demo/denied.mec
@@ -1,0 +1,3 @@
+@browser := browser://dom/
+
+body/content/mech-sandbox/input/_value@browser = "This should be denied"

--- a/examples/browser-dom-demo/index.html
+++ b/examples/browser-dom-demo/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Mech Browser DOM Resource Demo</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+      }
+
+      #mech-sandbox {
+        border: 1px solid #ccc;
+        padding: 1rem;
+        max-width: 520px;
+      }
+
+      #status {
+        margin-top: 1rem;
+        padding: 0.5rem;
+      }
+
+      #status.ready {
+        border: 1px solid green;
+      }
+
+      #status.error {
+        border: 1px solid red;
+      }
+
+      pre {
+        background: #f6f6f6;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Mech Browser DOM Resource Demo</h1>
+
+    <section id="mech-sandbox">
+      <label>
+        Name:
+        <input id="name-input" value="Ada" />
+      </label>
+
+      <h2 id="title">Not updated yet</h2>
+
+      <div id="status" class="idle">Idle</div>
+    </section>
+
+    <p>
+      <button id="run-ok">Run allowed Mech program</button>
+      <button id="run-denied">Run denied write</button>
+    </p>
+
+    <h3>Log</h3>
+    <pre id="log"></pre>
+
+    <script type="module">
+      import init, { WasmMech } from "./pkg/mech_wasm.js";
+
+      const logEl = document.getElementById("log");
+
+      function log(line) {
+        logEl.textContent += `${line}\n`;
+      }
+
+      async function loadText(path) {
+        const response = await fetch(path);
+        if (!response.ok) {
+          throw new Error(`Failed to load ${path}: ${response.status}`);
+        }
+        return response.text();
+      }
+
+      async function main() {
+        await init();
+
+        const configSource = await loadText("./demo.mcfg");
+        const demoSource = await loadText("./demo.mec");
+        const deniedSource = await loadText("./denied.mec");
+
+        const mech = WasmMech.fromConfig(configSource);
+
+        log(`browser grants: ${mech.browserGrantCount()}`);
+        log(`can read input value: ${mech.canReadDom("#name-input")}`);
+        log(`can write input value: ${mech.canWriteDom("#name-input")}`);
+        log(`can write title: ${mech.canWriteDom("#title")}`);
+        log("");
+
+        document.getElementById("run-ok").addEventListener("click", () => {
+          try {
+            const outputHtml = mech.eval(demoSource);
+            log("allowed program ran");
+            log(`runtime output: ${outputHtml}`);
+            log(`title text: ${document.getElementById("title").textContent}`);
+            log(`status text: ${document.getElementById("status").textContent}`);
+            log(`status class: ${document.getElementById("status").getAttribute("class")}`);
+            log("");
+          } catch (error) {
+            log(`unexpected error: ${error}`);
+          }
+        });
+
+        document.getElementById("run-denied").addEventListener("click", () => {
+          try {
+            const outputHtml = mech.eval(deniedSource);
+            log("unexpected success");
+            log(outputHtml);
+          } catch (error) {
+            log(`denied as expected: ${error}`);
+          }
+
+          log(`input value is still: ${document.getElementById("name-input").value}`);
+          log("");
+        });
+      }
+
+      main().catch((error) => {
+        log(`fatal: ${error}`);
+      });
+    </script>
+  </body>
+</html>

--- a/examples/browser-dom-demo/index.html
+++ b/examples/browser-dom-demo/index.html
@@ -12,7 +12,16 @@
       #mech-sandbox {
         border: 1px solid #ccc;
         padding: 1rem;
-        max-width: 520px;
+        max-width: 620px;
+      }
+
+      label {
+        display: block;
+        margin: 0.75rem 0;
+      }
+
+      input {
+        min-width: 24rem;
       }
 
       #status {
@@ -41,8 +50,13 @@
 
     <section id="mech-sandbox">
       <label>
-        Name:
+        Source DOM input:
         <input id="name-input" value="Ada" />
+      </label>
+
+      <label>
+        Computed DOM output:
+        <input id="roundtrip-output" readonly value="Not updated yet" />
       </label>
 
       <h2 id="title">Not updated yet</h2>
@@ -51,7 +65,7 @@
     </section>
 
     <p>
-      <button id="run-ok">Run allowed Mech program</button>
+      <button id="run-ok">Run round trip</button>
       <button id="run-denied">Run denied write</button>
     </p>
 
@@ -85,19 +99,23 @@
         const mech = WasmMech.fromConfig(configSource);
 
         log(`browser grants: ${mech.browserGrantCount()}`);
-        log(`can read input value: ${mech.canReadDom("#name-input")}`);
-        log(`can write input value: ${mech.canWriteDom("#name-input")}`);
+        log(`can read source input: ${mech.canReadDom("#name-input")}`);
+        log(`can write source input: ${mech.canWriteDom("#name-input")}`);
+        log(`can write computed output: ${mech.canWriteDom("#roundtrip-output")}`);
         log(`can write title: ${mech.canWriteDom("#title")}`);
         log("");
 
         document.getElementById("run-ok").addEventListener("click", () => {
           try {
+            const sourceValue = document.getElementById("name-input").value;
             const outputHtml = mech.eval(demoSource);
-            log("allowed program ran");
-            log(`runtime output: ${outputHtml}`);
+            log("round trip program ran");
+            log(`DOM -> Mech source value: ${sourceValue}`);
+            log(`Mech -> DOM computed output: ${document.getElementById("roundtrip-output").value}`);
             log(`title text: ${document.getElementById("title").textContent}`);
             log(`status text: ${document.getElementById("status").textContent}`);
             log(`status class: ${document.getElementById("status").getAttribute("class")}`);
+            log(`runtime output: ${outputHtml}`);
             log("");
           } catch (error) {
             log(`unexpected error: ${error}`);
@@ -113,7 +131,7 @@
             log(`denied as expected: ${error}`);
           }
 
-          log(`input value is still: ${document.getElementById("name-input").value}`);
+          log(`source input value is still: ${document.getElementById("name-input").value}`);
           log("");
         });
       }


### PR DESCRIPTION
### Motivation

- Add a concrete browser example that demonstrates the new DOM resource provider flow.
- Show config-driven read/write permissions for DOM resources without exposing raw CSS selectors to Mech code.

### Description

- Add `examples/browser-dom-demo/demo.mcfg` with read-only permission for an input value and write permissions for title/status DOM resources.
- Add `examples/browser-dom-demo/demo.mec` showing `@browser := browser://dom/`, a DOM read from `body/content/mech-sandbox/input/_value@browser`, and DOM writes to title/status resources.
- Add `examples/browser-dom-demo/denied.mec` showing a denied write to the read-only input value.
- Add `examples/browser-dom-demo/index.html` that loads `WasmMech.fromConfig(...)`, runs the allowed program, and runs the denied program.
- Add `examples/browser-dom-demo/README.md` with run instructions.

### Testing

- Documentation/example-only change. Not run locally.
