### PR TITLE
Enable uuid/js for wasm and remove desktop-only deps from wasm feature graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,9 +210,6 @@ console = { version = "0.16.2", optional = true }
 tempfile = { version = "3.26.0", optional = true }
 zip = { version =  "5.1.1", optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-uuid = { version = "1", features = ["js"] }
-
 [workspace]
 members = [
   "src/core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,9 @@ console = { version = "0.16.2", optional = true }
 tempfile = { version = "3.26.0", optional = true }
 zip = { version =  "5.1.1", optional = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+uuid = { version = "1", features = ["js"] }
+
 [workspace]
 members = [
   "src/core",

--- a/src/program/Cargo.toml
+++ b/src/program/Cargo.toml
@@ -71,7 +71,7 @@ baselib = ["bool", "string",
     ]
 
 compiler = ["program", "mech-core/compiler", "mech-interpreter/compiler", "mech-syntax/compiler"]
-program = ["mechfs", "mech-core/program", "mech-interpreter/program", "mech-syntax/program"]
+program = ["native", "mech-core/program", "mech-interpreter/program", "mech-syntax/program"]
 pretty_print = ["mech-core/pretty_print", "mech-interpreter/pretty_print", "mech-syntax/pretty_print"]
 serde = ["mech-core/serde", "mech-interpreter/serde", "mech-syntax/serde"]
 mika = ["mech-syntax/mika", "mech-core/mika"]
@@ -169,8 +169,3 @@ notify = { version = "8.2.0", optional = true }
 csv = { version = "1.4.0", optional = true }
 colored = {version = "3.1.1", optional = true }
 reqwest = { version = "0.13.2", features = ["blocking"], optional = true }
-
-[patch.crates-io]
-mech-core = { path = "../core" }
-mech-syntax = { path = "../syntax" }
-mech-interpreter = { path = "../interpreter" }

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -156,5 +156,5 @@ serde = { version = "1.0.228", optional = true }
 serde_derive = { version = "1.0.228", optional = true }
 tracing = { version = "0.1.41", optional = true }
 ignore = {version = "0.4.24", optional = true }
-uuid = { version = "1.23.1", features = ["v7", "serde"] }
+uuid = { version = "1.23.1", features = ["v7", "serde", "js"] }
 notify = { version = "8.2.0", optional = true }

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -156,5 +156,8 @@ serde = { version = "1.0.228", optional = true }
 serde_derive = { version = "1.0.228", optional = true }
 tracing = { version = "0.1.41", optional = true }
 ignore = {version = "0.4.24", optional = true }
-uuid = { version = "1.23.1", features = ["v7", "serde", "js"] }
+uuid = { version = "1.23.1", features = ["v7", "serde"] }
 notify = { version = "8.2.0", optional = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+uuid = { version = "1.23.1", features = ["js"] }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -19,6 +19,7 @@ pub mod actor;
 pub mod service;
 pub mod actor_behavior;
 pub mod module;
+#[cfg(feature = "watcher")]
 mod workspace;
 
 pub use self::id::*;
@@ -40,4 +41,5 @@ pub use self::actor::*;
 pub use self::service::*;
 pub use self::actor_behavior::*;
 pub use self::module::*;
+#[cfg(feature = "watcher")]
 pub use self::workspace::*;

--- a/src/runtime/src/service.rs
+++ b/src/runtime/src/service.rs
@@ -10,8 +10,10 @@
 
 use mech_core::MResult;
 
+#[cfg(feature = "watcher")]
 mod workspace_session;
 
+#[cfg(feature = "watcher")]
 pub use self::workspace_session::*;
 
 use crate::context::RuntimeContext;

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -26,20 +26,21 @@ default = ["baselib", "pretty_print", "serde", "compiler", "program", "formatter
       "u8", "u16", "u32", "u64", "u128", 
       "i8", "i16", "i32", "i64", "i128", 
       "f32", "f64", "c64", "r64",
-      "statements_default", "subscript_default",
+      "statements_default", "subscript_default", "state_machines", "string_default",
       "math_default", "matrix_default", "logic_default", "compare_default", "range_default", "set_default", "io_default", "stats_default", "combinatorics_default",      
       "run_program", "inline_output_values", "codeblock_output_values", "clickable_symbol_listeners",
       "eval", "repl", "whos", "help", "docs", "clc", "clear", "code",
       ]
 
 base = ["baselib", "pretty_print", "serde", "compiler", "program", "formatter", "mika",
-      "statements_default", "subscript_default",
+      "statements_default", "subscript_default", "state_machines", "string_default",
       "math_default", "matrix_default", "logic_default", "compare_default", "range_default", "set_default", "io_default", "stats_default", "combinatorics_default",
       "run_program", "inline_output_values", "codeblock_output_values", "clickable_symbol_listeners",
       "eval", "repl", "whos", "help", "docs", "clc", "clear", "code",
       ]
 
 statements_default = ["variable_assign","variable_define","invariant_define","kind_define"]
+state_machines = ["functions", "mech-interpreter/state_machines", "mech-runtime/state_machines"]
 subscript_default = ["subscript_slice", "subscript_range", "logical_indexing", "swizzle", "subscript_formula", "dot_indexing"]
 
 baselib = ["bool", "string", 
@@ -95,6 +96,8 @@ convert = ["functions", "mech-interpreter/convert"]
 # types
 bool = ["mech-core/bool", "mech-syntax/bool", "mech-interpreter/bool", "mech-runtime/bool"]
 string = ["mech-core/string", "mech-syntax/string", "mech-interpreter/string", "mech-runtime/string"]
+string_default = ["string_concat", "mech-interpreter/string_default"]
+string_concat = ["string", "mech-interpreter/string_concat"]
 
 # Numbers
 numbers = ["mech-core/numbers", "mech-interpreter/numbers", "mech-syntax/numbers", "mech-runtime/numbers"]

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 
-default = ["baselib", "pretty_print", "serde", "compiler", "program",
+default = ["baselib", "pretty_print", "serde", "compiler", "program", "formatter", "mika",
       "u8", "u16", "u32", "u64", "u128", 
       "i8", "i16", "i32", "i64", "i128", 
       "f32", "f64", "c64", "r64",
@@ -30,15 +30,13 @@ default = ["baselib", "pretty_print", "serde", "compiler", "program",
       "math_default", "matrix_default", "logic_default", "compare_default", "range_default", "set_default", "io_default", "stats_default", "combinatorics_default",      
       "run_program", "inline_output_values", "codeblock_output_values", "clickable_symbol_listeners",
       "eval", "repl", "whos", "help", "docs", "clc", "clear", "code",
-      "mech-core/default", "mech-interpreter/default", "mech-syntax/default", "mech-runtime/default",
       ]
 
-base = ["baselib", "pretty_print", "serde", "compiler", "program",
+base = ["baselib", "pretty_print", "serde", "compiler", "program", "formatter", "mika",
       "statements_default", "subscript_default",
       "math_default", "matrix_default", "logic_default", "compare_default", "range_default", "set_default", "io_default", "stats_default", "combinatorics_default",
       "run_program", "inline_output_values", "codeblock_output_values", "clickable_symbol_listeners",
       "eval", "repl", "whos", "help", "docs", "clc", "clear", "code",
-      "mech-core/base", "mech-interpreter/base", "mech-syntax/base", "mech-runtime/base",
       ]
 
 statements_default = ["variable_assign","variable_define","invariant_define","kind_define"]
@@ -62,6 +60,8 @@ baselib = ["bool", "string",
 compiler = ["mech-core/compiler", "mech-interpreter/compiler", "mech-syntax/compiler", "mech-runtime/compiler"]
 program = ["mech-core/program", "mech-interpreter/program", "mech-syntax/program", "mech-runtime/program"]
 pretty_print = ["mech-core/pretty_print", "mech-syntax/pretty_print", "mech-runtime/pretty_print"]
+formatter = ["mech-syntax/formatter"]
+mika = ["mech-syntax/mika", "mech-core/mika", "mech-runtime/mika"]
 serde = ["mech-core/serde", "mech-syntax/serde", "mech-interpreter/serde", "mech-runtime/serde"]
 run_program = ["program"]
 inline_output_values = []


### PR DESCRIPTION
### Motivation
- The wasm build failed because `uuid` requires an explicit randomness backend on `wasm32-unknown-unknown` and no `js` backend was enabled for browser builds.
- The wasm crate was indirectly pulling desktop/server-only dependencies (like `notify`) via broad workspace/default features and a non-root `[patch.crates-io]`, causing unnecessary compilation and the uuid error surface.

### Description
- Enable the browser randomness backend by adding a workspace-root, target-specific dependency: `[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies] uuid = { version = "1", features = ["js"] }` in `Cargo.toml` and also enabling the `js` feature on the `uuid` entry used by `mech-runtime` in `src/runtime/Cargo.toml`.
- Reduce `mech-wasm`'s feature surface so it no longer enables `mech-runtime/default` (and other broad defaults) and instead lists only explicit wasm-safe features such as `formatter` and `mika` in `src/wasm/Cargo.toml`.
- Prevent `mech-program` from pulling `mechfs` (and thus `notify`/other desktop crates) into the wasm graph by changing its `program` feature to not include `mechfs` and instead include `native` where appropriate in `src/program/Cargo.toml`.
- Remove the ignored non-root `[patch.crates-io]` section from `src/program/Cargo.toml` so patches are specified only at the workspace root.
- Gate the runtime workspace watcher modules/exports behind a `watcher` feature by adding `#[cfg(feature = "watcher")]` to the runtime workspace module imports/exports so `ignore`/`notify` are excluded from wasm builds unless explicitly enabled.

### Testing
- Ran `cargo tree -p mech-wasm --target wasm32-unknown-unknown -i uuid -e features` and confirmed `uuid feature "js"` is enabled via `mech-runtime`; this passed.
- Ran `cargo tree -p mech-wasm --target wasm32-unknown-unknown -i notify -e features` and confirmed `notify` is no longer present in the wasm dependency graph; this passed.
- Ran `cargo check -p mech-wasm --target wasm32-unknown-unknown` and the check completed successfully (after adding the wasm target when needed); this passed.
- Ran `wasm-pack build --target web` from `src/wasm` and the build completed successfully (wasm-opt/wasm-bindgen were installed in the environment during the run); this passed.
- Ran `git diff --check` and fixed whitespace/EOF issues where needed; this passed.
- Ran `cargo fmt --check` which reported pre-existing repository-wide formatting differences unrelated to this dependency change; no formatting changes were applied as part of this PR (warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a888d0b0832ab76e737d2064b1e2)