### PR TITLE
Treat records as matrix cells and allow blank lines in matrix literals

### DIFF
--- a/src/interpreter/src/structures.rs
+++ b/src/interpreter/src/structures.rs
@@ -535,18 +535,34 @@ pub fn table_column(r: &TableColumn, env: Option<&Environment>, p: &Interpreter)
 // ----------------------------------------------------------------------------
 
 #[cfg(feature = "matrix")]
+fn is_composite_matrix_cell(value: &Value) -> bool {
+  match value {
+    #[cfg(feature = "record")]
+    Value::Record(_) => true,
+    #[cfg(feature = "map")]
+    Value::Map(_) => true,
+    #[cfg(feature = "tuple")]
+    Value::Tuple(_) => true,
+    #[cfg(feature = "set")]
+    Value::Set(_) => true,
+    #[cfg(feature = "table")]
+    Value::Table(_) => true,
+    Value::MatrixValue(_) => true,
+    _ => false,
+  }
+}
+
+#[cfg(feature = "matrix")]
 pub fn matrix(m: &Mat, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
   let plan = p.plan();
   let mut shape = vec![0, 0];
   let mut col: Vec<Value> = Vec::new();
-  let mut kind = ValueKind::Empty;
   #[cfg(feature = "matrix_horzcat")]
   {
     for row in &m.rows {
       let result = matrix_row(row, env, p)?;
       if shape == vec![0,0] {
         shape = result.shape();
-        kind = result.kind();
         col.push(result);
       } else if shape[1] == result.shape()[1] {
         col.push(result);
@@ -566,6 +582,38 @@ pub fn matrix(m: &Mat, env: Option<&Environment>, p: &Interpreter) -> MResult<Va
   }
   #[cfg(feature = "matrix_vertcat")]
   {
+    if col.iter().any(|value| matches!(value, Value::MatrixValue(_))) {
+      let mut values = Vec::new();
+      let mut expected_cols: Option<usize> = None;
+      let mut row_count = 0;
+
+      for row_value in col {
+        let row_matrix = match row_value {
+          Value::MatrixValue(matrix) => matrix,
+          other => Matrix::from_vec(vec![other], 1, 1),
+        };
+        let row_shape = row_matrix.shape();
+        let row_cols = row_shape[1];
+
+        match expected_cols {
+          Some(cols) if cols != row_cols => {
+            return Err(MechError::new(
+              DimensionMismatch { dims: vec![cols, row_cols] },
+              None
+            ).with_compiler_loc());
+          }
+          None => expected_cols = Some(row_cols),
+          _ => (),
+        }
+
+        row_count += row_shape[0];
+        values.extend(row_matrix.as_vec());
+      }
+
+      let cols = expected_cols.unwrap_or(0);
+      return Ok(Value::MatrixValue(Matrix::from_vec(values, row_count, cols)));
+    }
+
     let new_fxn = MatrixVertCat{}.compile(&col)?;
     new_fxn.solve();
     let out = new_fxn.out();
@@ -584,14 +632,12 @@ pub fn matrix_row(r: &MatrixRow, env: Option<&Environment>, p: &Interpreter) -> 
   let plan = p.plan();
   let mut row: Vec<Value> = Vec::new();
   let mut shape = vec![0, 0];
-  let mut kind = ValueKind::Empty;
   let mut saw_empty = false;
   for col in &r.columns {
     let result = matrix_column(col, env, p)?;
     saw_empty |= matches!(result.kind(), ValueKind::Empty);
     if shape == vec![0,0] {
       shape = result.shape();
-      kind = result.kind();
       row.push(result);
     } else if shape[0] == result.shape()[0] {
       row.push(result);
@@ -602,6 +648,10 @@ pub fn matrix_row(r: &MatrixRow, env: Option<&Environment>, p: &Interpreter) -> 
         ).with_compiler_loc()
       );
     }
+  }
+  if row.iter().any(is_composite_matrix_cell) {
+    let cols = row.len();
+    return Ok(Value::MatrixValue(Matrix::from_vec(row, 1, cols)));
   }
   if saw_empty && row.iter().all(|value| value.shape() == vec![1, 1]) {
     return Ok(Value::MatrixValue(Matrix::from_vec(row, 1, r.columns.len())));

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -92,9 +92,23 @@ pub fn matrix(input: ParseString) -> ParseResult<Matrix> {
       break;
     }
 
-    let (next_input, row) = matrix_row(input)?;
-    rows.push(row);
-    input = next_input;
+    match matrix_row(input.clone()) {
+      Ok((next_input, row)) => {
+        if next_input.cursor == input.cursor {
+          return Err(Failure(ParseError::new(
+            input,
+            "Internal parser error: matrix row parser made no progress",
+          )));
+        }
+
+        rows.push(row);
+        input = next_input;
+      }
+      Err(_) => {
+        let _ = label!(matrix_end, msg, r)(input)?;
+        unreachable!("matrix parser loop already ruled out matrix_end before attempting a row");
+      }
+    }
   }
 
   let (input, _) = whitespace0(input)?;

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -81,10 +81,22 @@ pub fn structure(input: ParseString) -> ParseResult<Structure> {
 // matrix := matrix-start, (box-drawing-char | whitespace)*, matrix-row*, box-drawing-char*, matrix-end ;
 pub fn matrix(input: ParseString) -> ParseResult<Matrix> {
   let msg = "Expects right bracket ']' to finish the matrix";
-  let (input, (_, r)) = range(matrix_start)(input)?;
-  let (input, _) = many0(alt((box_drawing_char,whitespace)))(input)?;
-  let (input, rows) = many0(matrix_row)(input)?;
-  let (input, _) = many0(alt((box_drawing_char,whitespace)))(input)?;
+  let (mut input, (_, r)) = range(matrix_start)(input)?;
+  let mut rows = Vec::new();
+
+  loop {
+    let (next_input, _) = many0(alt((box_drawing_char,whitespace)))(input)?;
+    input = next_input;
+
+    if peek(matrix_end)(input.clone()).is_ok() {
+      break;
+    }
+
+    let (next_input, row) = matrix_row(input)?;
+    rows.push(row);
+    input = next_input;
+  }
+
   let (input, _) = whitespace0(input)?;
   let (input, _) = match label!(matrix_end, msg, r)(input) {
     Ok(k) => k,

--- a/src/syntax/src/structures.rs
+++ b/src/syntax/src/structures.rs
@@ -104,9 +104,15 @@ pub fn matrix(input: ParseString) -> ParseResult<Matrix> {
         rows.push(row);
         input = next_input;
       }
-      Err(_) => {
+      Err(Err::Error(_)) => {
         let _ = label!(matrix_end, msg, r)(input)?;
         unreachable!("matrix parser loop already ruled out matrix_end before attempting a row");
+      }
+      Err(err @ Err::Failure(_)) => {
+        return Err(err);
+      }
+      Err(err @ Err::Incomplete(_)) => {
+        return Err(err);
       }
     }
   }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1030,6 +1030,16 @@ fn interpret_matrix_eof_after_whitespace_errors() {
   assert!(program.run_string(s).is_err());
 }
 
+
+#[test]
+fn interpret_matrix_record_bad_value_errors() {
+  let s = r##"dom := [
+  { path: }
+]"##;
+  let mut program = MechProgram::new(MechProgramConfig{name: "interpret_matrix_record_bad_value_errors".to_string(), environment: MechProgramEnvironment::default()});
+  assert!(program.run_string(s).is_err());
+}
+
 test_interpreter!(interpret_record,r#"{a: 1, b: "Hello"}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::String(Ref::new("Hello".to_string())))]))));
 test_interpreter!(interpret_define_custom_record, r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::F64(Ref::new(2.0)))]))));
 test_interpreter!(interpret_record_field_access,r#"a := {x: 1,  y: 2}; a.y"#, Value::F64(Ref::new(2.0)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -1009,6 +1009,27 @@ fn interpret_matrix_records_without_blank_line_are_column_cells() {
   assert!(matches!(values[1], Value::Record(_)));
 }
 
+
+#[test]
+fn interpret_matrix_record_missing_closing_bracket_errors() {
+  let s = r##"dom := [
+  {
+    path: "a"
+  }
+"##;
+  let mut program = MechProgram::new(MechProgramConfig{name: "interpret_matrix_record_missing_closing_bracket_errors".to_string(), environment: MechProgramEnvironment::default()});
+  assert!(program.run_string(s).is_err());
+}
+
+#[test]
+fn interpret_matrix_eof_after_whitespace_errors() {
+  let s = "dom := [
+  
+";
+  let mut program = MechProgram::new(MechProgramConfig{name: "interpret_matrix_eof_after_whitespace_errors".to_string(), environment: MechProgramEnvironment::default()});
+  assert!(program.run_string(s).is_err());
+}
+
 test_interpreter!(interpret_record,r#"{a: 1, b: "Hello"}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::String(Ref::new("Hello".to_string())))]))));
 test_interpreter!(interpret_define_custom_record, r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::F64(Ref::new(2.0)))]))));
 test_interpreter!(interpret_record_field_access,r#"a := {x: 1,  y: 2}; a.y"#, Value::F64(Ref::new(2.0)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -947,6 +947,68 @@ test_interpreter!(interpret_dot_index_table6, "x := | x<u32> y<f32> z<i8>|1 2 3|
 test_interpreter!(interpret_set_empty,"{_}", Value::Set(Ref::new(MechSet::from_vec(vec![]))));
 test_interpreter!(interpret_set_empty2,"{}", Value::Set(Ref::new(MechSet::from_vec(vec![]))));
 test_interpreter!(interpret_set, "{1,2,3}", Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))]))));
+
+#[test]
+fn interpret_matrix_single_record_cell() {
+  let s = r##"dom := [
+  {
+    path: "body/content/mech-sandbox/input/_value"
+    selector: "#name-input"
+    property: "value"
+  }
+]"##;
+  let mut program = MechProgram::new(MechProgramConfig{name: "interpret_matrix_single_record_cell".to_string(), environment: MechProgramEnvironment::default()});
+  let result = program.run_string(s).unwrap();
+  let Value::MatrixValue(matrix) = result else { panic!("expected MatrixValue"); };
+  assert_eq!(matrix.shape(), vec![1, 1]);
+  let values = matrix.as_vec();
+  let Value::Record(record) = &values[0] else { panic!("expected record cell"); };
+  let record = record.borrow();
+  assert_eq!(record.data.len(), 3);
+  assert!(record.data.contains_key(&hash_str("path")));
+  assert!(record.data.contains_key(&hash_str("selector")));
+  assert!(record.data.contains_key(&hash_str("property")));
+}
+
+#[test]
+fn interpret_matrix_records_with_blank_line_are_column_cells() {
+  let s = r##"dom := [
+  {
+    path: "body/content/mech-sandbox/input/_value"
+    selector: "#name-input"
+    property: "value"
+  }
+
+  {
+    path: "body/content/mech-sandbox/output/_value"
+    selector: "#roundtrip-output"
+    property: "value"
+  }
+]"##;
+  let mut program = MechProgram::new(MechProgramConfig{name: "interpret_matrix_records_with_blank_line_are_column_cells".to_string(), environment: MechProgramEnvironment::default()});
+  let result = program.run_string(s).unwrap();
+  let Value::MatrixValue(matrix) = result else { panic!("expected MatrixValue"); };
+  assert_eq!(matrix.shape(), vec![2, 1]);
+  let values = matrix.as_vec();
+  assert!(matches!(values[0], Value::Record(_)));
+  assert!(matches!(values[1], Value::Record(_)));
+}
+
+#[test]
+fn interpret_matrix_records_without_blank_line_are_column_cells() {
+  let s = r##"dom := [
+  { path: "a" selector: "#x" property: "value" }
+  { path: "b" selector: "#y" property: "value" }
+]"##;
+  let mut program = MechProgram::new(MechProgramConfig{name: "interpret_matrix_records_without_blank_line_are_column_cells".to_string(), environment: MechProgramEnvironment::default()});
+  let result = program.run_string(s).unwrap();
+  let Value::MatrixValue(matrix) = result else { panic!("expected MatrixValue"); };
+  assert_eq!(matrix.shape(), vec![2, 1]);
+  let values = matrix.as_vec();
+  assert!(matches!(values[0], Value::Record(_)));
+  assert!(matches!(values[1], Value::Record(_)));
+}
+
 test_interpreter!(interpret_record,r#"{a: 1, b: "Hello"}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::String(Ref::new("Hello".to_string())))]))));
 test_interpreter!(interpret_define_custom_record, r#"<point2>:=<{a<f64>,b<f64>}>; p<point2>:={a:1.0,b:2.0}"#, Value::Record(Ref::new(MechRecord::from_vec(vec![((55170961230981453,"a".to_string()),Value::F64(Ref::new(1.0))),((44311847522083591,"b".to_string()),Value::F64(Ref::new(2.0)))]))));
 test_interpreter!(interpret_record_field_access,r#"a := {x: 1,  y: 2}; a.y"#, Value::F64(Ref::new(2.0)));


### PR DESCRIPTION
### Motivation
- Matrix literals with record rows were being parsed/handled incorrectly: the parser stopped at blank lines between rows and the interpreter forwarded `Record` values into `matrix/horzcat`, causing `UnhandledFunctionArgumentKindVarg` errors instead of producing a column-vector of record cells.
- The intended semantics are that each record in `[...]` is a single matrix cell and newline-separated records form a `N x 1` `MatrixValue` (a column vector).

### Description
- Update the syntax parser `matrix()` to consume inter-row whitespace/blank lines and loop until the closing `]` is seen, allowing newline-separated record rows to be parsed as separate `MatrixRow`s (file: `src/syntax/src/structures.rs`).
- Add `is_composite_matrix_cell()` to detect composite cells (`Record`, `Map`, `Tuple`, `Set`, `Table`, or `MatrixValue`) and short-circuit horizontal concatenation when a row contains any composite cell (file: `src/interpreter/src/structures.rs`).
- In `matrix_row()` return a `Value::MatrixValue` with shape `[1, cols]` when any composite cell is present so a single record becomes a `1 x 1` matrix cell.
- In `matrix()` detect when collected rows contain `MatrixValue`s and vertically concatenate their underlying matrices directly (preserving shape and failing on column-count mismatches), producing the final `MatrixValue` without calling `matrix/vertcat` (file: `src/interpreter/src/structures.rs`).
- Add regression tests verifying: a single-record literal yields shape `[1,1]`; two newline-separated records (with and without a blank line between them) yield shape `[2,1]` and that each cell is a `Record` (file: `tests/interpreter.rs`).

### Testing
- Ran `cargo test -p mech --test interpreter interpret_matrix_single_record_cell` and the new single-record test passed.
- Ran the record matrix tests via `cargo test -p mech --test interpreter interpret_matrix_records_` and both blank-line and no-blank-line record tests passed.
- Re-ran existing matrix row tests via `cargo test -p mech --test interpreter interpret_matrix_row` to verify primitive matrix behavior was unchanged and they passed.
- All targeted interpreter tests exercised and added in this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2560453a28832aa0e8d9e081fc1245)