### PR TITLE
Use prefix syntax for browser resource paths

### DIFF
--- a/examples/browser-dom-demo/README.md
+++ b/examples/browser-dom-demo/README.md
@@ -8,11 +8,11 @@ It shows a full DOM -> Mech -> DOM round trip:
 - `WasmMech.fromHostConfig()` initializes the browser runtime from the host-owned config projection.
 - The page fetches `/code/*.mec` encoded compiled payloads and executes them with `WasmMech.evalCompiled()`.
 - Mech code binds `@browser := browser://dom/`.
-- Mech reads the source input value from `body/content/mech-sandbox/input/_value@browser`.
+- Mech reads the source input value from `@browser/body/content/mech-sandbox/input/_value`.
 - Mech computes `greeting`, `roundtrip`, and `status` strings from that DOM value.
-- Mech writes the computed output back to `body/content/mech-sandbox/output/_value@browser`.
-- Mech writes DOM text to `body/content/mech-sandbox/title@browser` and `body/content/mech-sandbox/status@browser`.
-- Mech writes the `class` attribute through `body/content/mech-sandbox/status/_class@browser`.
+- Mech writes the computed output back to `@browser/body/content/mech-sandbox/output/_value`.
+- Mech writes DOM text to `@browser/body/content/mech-sandbox/title` and `@browser/body/content/mech-sandbox/status`.
+- Mech writes the `class` attribute through `@browser/body/content/mech-sandbox/status/_class`.
 - `denied.mec` attempts to write to the read-only source input and is rejected by config permissions.
 
 ## Files

--- a/examples/browser-dom-demo/demo.mec
+++ b/examples/browser-dom-demo/demo.mec
@@ -1,11 +1,11 @@
 @browser := browser://dom/
 
-name := body/content/mech-sandbox/input/_value@browser
+name := @browser/body/content/mech-sandbox/input/_value
 greeting := "Hello, " + name
 roundtrip := greeting + " — computed in Mech"
 status := "Read `" + name + "` from the DOM and wrote the computed result back."
 
-body/content/mech-sandbox/title@browser = greeting
-body/content/mech-sandbox/output/_value@browser = roundtrip
-body/content/mech-sandbox/status@browser = status
-body/content/mech-sandbox/status/_class@browser = "ready"
+@browser/body/content/mech-sandbox/title = greeting
+@browser/body/content/mech-sandbox/output/_value = roundtrip
+@browser/body/content/mech-sandbox/status = status
+@browser/body/content/mech-sandbox/status/_class = "ready"

--- a/examples/browser-dom-demo/denied.mec
+++ b/examples/browser-dom-demo/denied.mec
@@ -1,3 +1,3 @@
 @browser := browser://dom/
 
-body/content/mech-sandbox/input/_value@browser = "This should be denied"
+@browser/body/content/mech-sandbox/input/_value = "This should be denied"

--- a/examples/browser-dom-resource.mec
+++ b/examples/browser-dom-resource.mec
@@ -1,5 +1,5 @@
 @browser := browser://dom/
 
-body/content/mech-sandbox/title@browser = "Hello from Mech"
-body/content/mech-sandbox/status/_class@browser = "ready"
-input-value := body/content/mech-sandbox/input/_value@browser
+@browser/body/content/mech-sandbox/title = "Hello from Mech"
+@browser/body/content/mech-sandbox/status/_class = "ready"
+input-value := @browser/body/content/mech-sandbox/input/_value

--- a/src/program/tests/program.rs
+++ b/src/program/tests/program.rs
@@ -35,11 +35,11 @@ fn program_browser_resource_binding_declaration() {
 
 #[test]
 fn program_browser_resource_read() {
-  let stmts = statements("x := body/search/_value@browser");
+  let stmts = statements("x := @browser/body/content/input/_value");
   match &stmts[0] {
     Statement::VariableDefine(v) => match &v.expression {
       Expression::Var(var) => {
-        assert_eq!(var.name.to_string(), "body/search/_value");
+        assert_eq!(var.name.to_string(), "body/content/input/_value");
         assert_eq!(var.context.as_ref().unwrap().to_string(), "browser");
       }
       _ => panic!("expected addressed var expression"),
@@ -50,10 +50,10 @@ fn program_browser_resource_read() {
 
 #[test]
 fn program_browser_resource_write() {
-  let stmts = statements("body/header/title@browser = \"Hello\"");
+  let stmts = statements("@browser/body/content/output/_value = \"Hello\"");
   match &stmts[0] {
     Statement::VariableAssign(assign) => {
-      assert_eq!(assign.target.name.to_string(), "body/header/title");
+      assert_eq!(assign.target.name.to_string(), "body/content/output/_value");
       assert_eq!(assign.target.context.as_ref().unwrap().to_string(), "browser");
     }
     _ => panic!("expected variable assignment"),
@@ -62,6 +62,6 @@ fn program_browser_resource_write() {
 
 #[test]
 fn program_browser_resource_define_does_not_write() {
-  let stmts = statements("title@browser := \"Hello\"");
+  let stmts = statements("@browser/title := \"Hello\"");
   assert!(matches!(&stmts[0], Statement::VariableDefine(_)));
 }

--- a/src/runtime/tests/browser_dom.rs
+++ b/src/runtime/tests/browser_dom.rs
@@ -220,7 +220,7 @@ fn program_browser_resource_write_uses_runtime_host() {
   );
 
   runtime
-    .run_string("@browser := browser://dom/\nbody/header/title@browser = \"Hello\"")
+    .run_string("@browser := browser://dom/\n@browser/body/header/title = \"Hello\"")
     .unwrap();
 
   assert_eq!(host.writes(), vec![("body/header/title".to_string(), "Hello".to_string())]);
@@ -237,7 +237,7 @@ fn program_browser_resource_read_uses_runtime_host() {
   );
 
   let value = runtime
-    .run_string("@browser := browser://dom/\nx := body/search/_value@browser")
+    .run_string("@browser := browser://dom/\nx := @browser/body/search/_value")
     .unwrap();
 
   assert_eq!(value.as_string().unwrap().borrow().as_str(), "query");
@@ -255,7 +255,7 @@ fn program_browser_resource_define_does_not_write() {
   );
 
   runtime
-    .run_string("@browser := browser://dom/\ntitle@browser := \"Hello\"")
+    .run_string("@browser := browser://dom/\n@browser/title := \"Hello\"")
     .unwrap();
 
   assert_eq!(host.write_count(), 0);
@@ -272,7 +272,7 @@ fn runtime_browser_resource_binding_applies_before_following_write() {
   );
 
   runtime
-    .run_string("@browser := browser://dom/\nbody/header/title@browser = \"Hello\"")
+    .run_string("@browser := browser://dom/\n@browser/body/header/title = \"Hello\"")
     .unwrap();
 
   assert_eq!(
@@ -294,7 +294,7 @@ fn program_browser_resource_write_accepts_string_variable() {
 
   runtime
     .run_string(
-      "@browser := browser://dom/\nsome-string-var := \"Hello\"\nbody/header/title@browser = some-string-var",
+      "@browser := browser://dom/\nsome-string-var := \"Hello\"\n@browser/body/header/title = some-string-var",
     )
     .unwrap();
 
@@ -313,7 +313,7 @@ fn program_browser_resource_read_inside_expression() {
 
   let value = runtime
     .run_string(r#"@browser := browser://dom/
-message := "Search: " + body/search/_value@browser"#)
+message := "Search: " + @browser/body/search/_value"#)
     .unwrap();
 
   assert_eq!(value.as_string().unwrap().borrow().as_str(), "Search: query");
@@ -342,7 +342,7 @@ fn program_browser_resource_write_rhs_reads_browser_resource() {
   runtime
     .run_string(
       "@browser := browser://dom/
-body/header/title@browser = body/search/_value@browser",
+@browser/body/header/title = @browser/body/search/_value",
     )
     .unwrap();
 
@@ -374,7 +374,7 @@ fn program_browser_resource_write_rhs_combines_string_and_resource() {
 
   runtime
     .run_string(r#"@browser := browser://dom/
-body/header/title@browser = "Search: " + body/search/_value@browser"#)
+@browser/body/header/title = "Search: " + @browser/body/search/_value"#)
     .unwrap();
 
   assert_eq!(host.read_count(), 1);
@@ -400,7 +400,7 @@ fn program_browser_resource_read_inside_expression_denied_before_host_access() {
 
   let result = runtime
     .run_string(r#"@browser := browser://dom/
-message := "Search: " + body/search/_value@browser"#);
+message := "Search: " + @browser/body/search/_value"#);
 
   assert!(result.is_err());
   assert_eq!(host.read_count(), 0);
@@ -421,4 +421,52 @@ fn runtime_browser_dom_uses_generic_resource_provider_dispatch() {
 
   assert_eq!(value.as_string().unwrap().borrow().as_str(), "Hello");
   assert_eq!(host.read_count(), 1);
+}
+
+#[test]
+fn program_browser_resource_roundtrip_uses_prefix_context_paths_and_denies_read_only_write() {
+  let mut authority = BrowserAuthority::default();
+  bind_authority_path(
+    &mut authority,
+    "body/content/mech-sandbox/input/_value",
+    "#name-input",
+    &[BrowserOperation::Read],
+  );
+  bind_authority_path(
+    &mut authority,
+    "body/content/mech-sandbox/output/_value",
+    "#roundtrip-output",
+    &[BrowserOperation::Write],
+  );
+  let mut runtime = runtime();
+  let host = FakeDomHost::default().with_value("body/content/mech-sandbox/input/_value", "Ada");
+  register_browser_provider(&mut runtime, authority, host.clone());
+
+  runtime
+    .run_string(
+      r#"@browser := browser://dom/
+name := @browser/body/content/mech-sandbox/input/_value
+@browser/body/content/mech-sandbox/output/_value = "Hello, " + name"#,
+    )
+    .unwrap();
+
+  assert_eq!(
+    runtime.resolve_resource_path("browser", "body/content/mech-sandbox/input/_value").unwrap().as_str(),
+    "body/content/mech-sandbox/input/_value"
+  );
+  assert_eq!(host.read_count(), 1);
+  assert_eq!(
+    host.writes(),
+    vec![(
+      "body/content/mech-sandbox/output/_value".to_string(),
+      "Hello, Ada".to_string(),
+    )]
+  );
+
+  let denied = runtime.run_string(
+    r#"@browser := browser://dom/
+@browser/body/content/mech-sandbox/input/_value = "This should be denied""#,
+  );
+  assert!(denied.is_err());
+  assert_eq!(host.write_count(), 1);
 }

--- a/src/syntax/src/expressions.rs
+++ b/src/syntax/src/expressions.rs
@@ -216,8 +216,36 @@ pub fn parenthetical_term(input: ParseString) -> ParseResult<Factor> {
   Ok((input, Factor::Parenthetical(Box::new(frmla))))
 }
 
-// var := identifier, ("@", identifier)?, ?kind-annotation ;
+fn identifier_from_string(name: &str) -> Identifier {
+  Identifier {
+    name: Token::new(TokenKind::Identifier, SourceRange::default(), name.chars().collect()),
+  }
+}
+
+fn split_prefix_context_identifier(identifier: Identifier) -> Option<(Identifier, Identifier)> {
+  let text = identifier.to_string();
+  let (context, path) = text.split_once('/')?;
+  if context.is_empty() || path.is_empty() {
+    return None;
+  }
+  Some((identifier_from_string(context), identifier_from_string(path)))
+}
+
+fn prefixed_context_path(input: ParseString) -> ParseResult<(Identifier, Identifier)> {
+  let (input, _) = at(input)?;
+  let (input, addressed) = identifier(input)?;
+  match split_prefix_context_identifier(addressed) {
+    Some((context, name)) => Ok((input, (context, name))),
+    None => Err(nom::Err::Error(ParseError::new(input, "context-prefixed resource paths require @context/path"))),
+  }
+}
+
+// var := ("@", identifier, "/", identifier) | identifier, ("@", identifier)?, ?kind-annotation ;
 pub fn var(input: ParseString) -> ParseResult<Var> {
+  if let Ok((input, (context, name))) = prefixed_context_path(input.clone()) {
+    let ((input, kind)) = opt(kind_annotation)(input)?;
+    return Ok((input, Var{ name, context: Some(context), kind }));
+  }
   let ((input, name)) = identifier(input)?;
   let ((input, context)) = opt(preceded(at, identifier))(input)?;
   let ((input, kind)) = opt(kind_annotation)(input)?;
@@ -743,16 +771,24 @@ pub fn subscript(input: ParseString) -> ParseResult<Vec<Subscript>> {
   Ok((input, subscripts))
 }
 
-// slice := identifier, subscript, ("@", identifier)? ;
+// slice := ("@", identifier, "/", identifier) | identifier, subscript, ("@", identifier)? ;
 pub fn slice(input: ParseString) -> ParseResult<Slice> {
+  if let Ok((input, (context, name))) = prefixed_context_path(input.clone()) {
+    let (input, ixes) = subscript(input)?;
+    return Ok((input, Slice{name, context: Some(context), subscript: ixes}));
+  }
   let (input, name) = identifier(input)?;
   let (input, ixes) = subscript(input)?;
   let (input, context) = opt(preceded(at, identifier))(input)?;
   Ok((input, Slice{name, context, subscript: ixes}))
 }
 
-// slice-ref := identifier, subscript?, ("@", identifier)? ;
+// slice-ref := ("@", identifier, "/", identifier) | identifier, subscript?, ("@", identifier)? ;
 pub fn slice_ref(input: ParseString) -> ParseResult<SliceRef> {
+  if let Ok((input, (context, name))) = prefixed_context_path(input.clone()) {
+    let (input, ixes) = opt(subscript)(input)?;
+    return Ok((input, SliceRef{name, context: Some(context), subscript: ixes}));
+  }
   let (input, name) = identifier(input)?;
   let (input, ixes) = opt(subscript)(input)?;
   let (input, context) = opt(preceded(at, identifier))(input)?;

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2217,11 +2217,16 @@ impl Formatter {
       },
       None => {},
     }
+    let display_name = if let Some(context) = &node.context {
+      format!("@{}/{}", context.to_string(), name)
+    } else {
+      name.clone()
+    };
     let id = format!("{}:{}",hash_str(&name),self.interpreter_id);
     if self.html {
-      format!("<span class=\"mech-slice-ref\"><span id=\"{}\" class=\"mech-var-name mech-clickable\">{}</span><span class=\"mech-subscript\">{}</span></span>",id,name,subscript)
+      format!("<span class=\"mech-slice-ref\"><span id=\"{}\" class=\"mech-var-name mech-clickable\">{}</span><span class=\"mech-subscript\">{}</span></span>",id,display_name,subscript)
     } else {
-      format!("{}{}", name, subscript)
+      format!("{}{}", display_name, subscript)
     }
   }
 
@@ -2504,15 +2509,20 @@ impl Formatter {
   pub fn slice(&mut self, node: &Slice) -> String {
     let name = node.name.to_string();
     let mut subscript = "".to_string();
-    for (i, sub) in node.subscript.iter().enumerate() {
+    for sub in node.subscript.iter() {
       let s = self.subscript(sub);
       subscript = format!("{}{}", subscript, s);
     }
+    let display_name = if let Some(context) = &node.context {
+      format!("@{}/{}", context.to_string(), name)
+    } else {
+      name.clone()
+    };
     let id = format!("{}:{}",hash_str(&name),self.interpreter_id);
     if self.html {
-      format!("<span class=\"mech-slice\"><span id=\"{}\" class=\"mech-var-name mech-clickable\">{}</span><span class=\"mech-subscript\">{}</span></span>",id,name,subscript)
+      format!("<span class=\"mech-slice\"><span id=\"{}\" class=\"mech-var-name mech-clickable\">{}</span><span class=\"mech-subscript\">{}</span></span>",id,display_name,subscript)
     } else {
-      format!("{}{}", name, subscript)
+      format!("{}{}", display_name, subscript)
     }
   }
 
@@ -2887,11 +2897,16 @@ pub fn matrix_column_elements(&mut self, column_elements: &[&MatrixColumn]) -> S
       "".to_string()
     };
     let name = &node.name.to_string();
+    let display_name = if let Some(context) = &node.context {
+      format!("@{}/{}", context.to_string(), name)
+    } else {
+      node.name.to_string()
+    };
     let id = format!("{}:{}",hash_str(&name),self.interpreter_id);
     if self.html {
-      format!("<span class=\"mech-var-name mech-clickable\" id=\"{}\">{}</span>{}", id, node.name.to_string(), annotation)
+      format!("<span class=\"mech-var-name mech-clickable\" id=\"{}\">{}</span>{}", id, display_name, annotation)
     } else {
-      format!("{}{}", node.name.to_string(), annotation)
+      format!("{}{}", display_name, annotation)
     }
   }
 

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -79,7 +79,7 @@ fn parses_context_declaration_with_wildcard_scope() {
 
 #[test]
 fn parses_addressed_path_expression() {
-  let stmts = statements("name := users/name@main");
+  let stmts = statements("name := @main/users/name");
   match &stmts[0] {
     Statement::VariableDefine(v) => match &v.expression {
       Expression::Var(var) => {
@@ -94,7 +94,7 @@ fn parses_addressed_path_expression() {
 
 #[test]
 fn parses_addressed_path_assignment_target() {
-  let stmts = statements("users/name@main = 1");
+  let stmts = statements("@main/users/name = 1");
   match &stmts[0] {
     Statement::VariableAssign(assign) => {
       assert_eq!(assign.target.name.to_string(), "users/name");
@@ -147,11 +147,11 @@ fn program_browser_resource_binding_declaration() {
 
 #[test]
 fn program_browser_resource_read() {
-  let stmts = statements("x := body/search/_value@browser");
+  let stmts = statements("x := @browser/body/content/input/_value");
   match &stmts[0] {
     Statement::VariableDefine(v) => match &v.expression {
       Expression::Var(var) => {
-        assert_eq!(var.name.to_string(), "body/search/_value");
+        assert_eq!(var.name.to_string(), "body/content/input/_value");
         assert_eq!(var.context.as_ref().unwrap().to_string(), "browser");
       }
       _ => panic!("expected addressed var expression"),
@@ -162,10 +162,10 @@ fn program_browser_resource_read() {
 
 #[test]
 fn program_browser_resource_write() {
-  let stmts = statements("body/header/title@browser = \"Hello\"");
+  let stmts = statements("@browser/body/content/output/_value = \"Hello\"");
   match &stmts[0] {
     Statement::VariableAssign(assign) => {
-      assert_eq!(assign.target.name.to_string(), "body/header/title");
+      assert_eq!(assign.target.name.to_string(), "body/content/output/_value");
       assert_eq!(assign.target.context.as_ref().unwrap().to_string(), "browser");
     }
     _ => panic!("expected variable assignment"),
@@ -174,6 +174,32 @@ fn program_browser_resource_write() {
 
 #[test]
 fn program_browser_resource_define_does_not_write() {
-  let stmts = statements("title@browser := \"Hello\"");
+  let stmts = statements("@browser/title := \"Hello\"");
   assert!(matches!(&stmts[0], Statement::VariableDefine(_)));
+}
+
+#[test]
+fn parses_prefix_browser_resource_read_inside_expression() {
+  let stmts = statements(
+    "@browser := browser://dom/\ngreeting := \"Hello, \" + @browser/body/content/input/_value",
+  );
+  match &stmts[1] {
+    Statement::VariableDefine(v) => match &v.expression {
+      Expression::Formula(factor) => match factor {
+        Factor::Term(term) => match &term.rhs[0].1 {
+          Factor::Expression(expr) => match &**expr {
+            Expression::Var(var) => {
+              assert_eq!(var.name.to_string(), "body/content/input/_value");
+              assert_eq!(var.context.as_ref().unwrap().to_string(), "browser");
+            }
+            _ => panic!("expected addressed var expression in formula rhs"),
+          },
+          _ => panic!("expected expression factor"),
+        },
+        _ => panic!("expected formula term"),
+      },
+      _ => panic!("expected formula expression"),
+    },
+    _ => panic!("expected variable define"),
+  }
 }

--- a/src/syntax/tests/formatter.rs
+++ b/src/syntax/tests/formatter.rs
@@ -81,3 +81,62 @@ fn fsm_declare_statement_formats_html_class() {
 
     assert!(formatter.statement(&statement).contains("mech-fsm-declare"));
 }
+
+#[test]
+fn formatter_renders_context_qualified_var_with_prefix_context() {
+    let mut formatter = Formatter::new();
+    let var = Var {
+        name: ident("body/content/input/_value"),
+        context: Some(ident("browser")),
+        kind: None,
+    };
+
+    assert_eq!(formatter.var(&var), "@browser/body/content/input/_value");
+}
+
+#[test]
+fn formatter_renders_context_qualified_assignment_target_with_prefix_context() {
+    let mut formatter = Formatter::new();
+    let assign = VariableAssign {
+        target: SliceRef {
+            name: ident("body/content/output/_value"),
+            context: Some(ident("browser")),
+            subscript: None,
+        },
+        expression: Expression::Literal(Literal::String(MechString { text: token(TokenKind::String, "hello") })),
+    };
+
+    assert_eq!(formatter.variable_assign(&assign), "@browser/body/content/output/_value = \"hello\"");
+}
+
+fn first_statement(src: &str) -> Statement {
+    let program = mech_syntax::parser::parse(src).expect("parse failed");
+    for section in &program.body.sections {
+        for element in &section.elements {
+            if let SectionElement::MechCode(codes) = element {
+                for (node, _) in codes {
+                    if let MechCode::Statement(statement) = node {
+                        return statement.clone();
+                    }
+                }
+            }
+        }
+    }
+    panic!("expected statement")
+}
+
+#[test]
+fn formatter_normalizes_old_suffix_context_resource_read_to_prefix_context() {
+    let mut formatter = Formatter::new();
+    let statement = first_statement("name := body/content/input/_value@browser");
+
+    assert_eq!(formatter.statement(&statement), "name := @browser/body/content/input/_value");
+}
+
+#[test]
+fn formatter_preserves_new_prefix_context_resource_read() {
+    let mut formatter = Formatter::new();
+    let statement = first_statement("name := @browser/body/content/input/_value");
+
+    assert_eq!(formatter.statement(&statement), "name := @browser/body/content/input/_value");
+}


### PR DESCRIPTION
### Motivation
- Make browser resource accesses use a prefix context form (`@browser/body/...`) instead of the older suffix form (`body/...@browser`) while keeping context declarations (`@browser := browser://dom/`) unchanged.
- Preserve runtime semantics: the parser must produce the same AST shape (`Var.context = Some(...)`, `Var.name = <child path>`) so the runtime continues to call `read_bound_resource` / `write_bound_resource` unchanged.
- Normalize formatted output and examples to the new prefix form for clarity and consistency.

### Description
- Parser: accept a new context-prefixed form `@context/path` in expression positions by adding `prefixed_context_path`, `split_prefix_context_identifier`, and integrating the parser branch into `var`, `slice`, and `slice_ref` so all produce `context = Some(...)` and `name = <child path>` as before (`src/syntax/src/expressions.rs`).
- Formatter: render context-qualified nodes in prefix form (`@browser/body/...`) and normalize suffix inputs to the prefix output in formatted source/HTML (`src/syntax/src/formatter.rs`).
- Examples/docs: updated browser DOM demo and README to use prefix access (`examples/browser-dom-demo/*`, `examples/browser-dom-resource.mec`).
- Tests: added and updated parser/formatter/program/runtime tests to cover prefix reads, assignments, expression reads, formatting normalization, and a browser round-trip + denied-write case (`src/syntax/tests/context_parser.rs`, `src/syntax/tests/formatter.rs`, `src/program/tests/program.rs`, `src/runtime/tests/browser_dom.rs`).
- Backwards compatibility: existing suffix parsing remains supported where it was already accepted and the formatter normalizes it to the new prefix form.

### Testing
- Ran `cargo test` for the whole workspace; all automated tests passed (unit, syntax, program, interpreter, runtime suites) during development.
- Ran `cargo test -p mech-syntax --test formatter` and the formatter unit tests passed.
- Ran targeted package tests `cargo test -p mech-program --test program` and `cargo test -p mech-runtime --test browser_dom`; updated browser DOM tests passed, including the new round-trip and denied-write test.
- Built the WASM package with `cd src/wasm && wasm-pack build --target web` (installed `wasm-pack` as needed) and compressed the resulting `.wasm` with `brotli -Z --force src/wasm/pkg/mech_wasm_bg.wasm`; the build steps completed in the test environment.
- Launched the server via `cargo run --bin mech -- serve examples/browser-dom-demo` (stopped with a timeout in CI); the server started and served the demo as expected in the non-interactive run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26dd8742e4832a98403b021411872e)