### PR TITLE
Implement bundle-web static bundling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ default = ["baselib", "pretty_print", "serde", "compiler", "program", "mika",
       "i8", "i16", "i32", "i64", "i128", 
       "f32", "f64", "c64", "r64",
       "statements_default", "subscript_default", "state_machines",
-      "formatter", "serve", "run", "test", "repl", "build", "whos", "async", "trace",
+      "formatter", "serve", "bundle_web", "run", "test", "repl", "build", "whos", "async", "trace",
       "mech-core/default", "mech-program/default", "mech-syntax/default",
       ]
 base = ["baselib", "pretty_print", "serde", "compiler", "program", "mika",
       "statements_default", "subscript_default", "state_machines",
-      "formatter", "serve", "run", "test", "repl", "build","whos", "async", "trace",
+      "formatter", "serve", "bundle_web", "run", "test", "repl", "build","whos", "async", "trace",
       "mech-core/base", "mech-program/base", "mech-syntax/base",
       ]
 build = ["compiler"]
@@ -46,7 +46,10 @@ repl = []
 run = ["mech-program/program"]
 test = ["variable_define", "invariant_define", "symbol_table", "bool"]
 cli = []
-serve = ["cli", "formatter", "mech-runtime", "mech-runtime/default", "ignore"]
+project = ["mech-runtime", "mech-runtime/default"]
+web_host = ["mech-runtime", "mech-runtime/default"]
+bundle_web = ["cli", "project", "web_host", "formatter", "serde", "mech-runtime", "mech-runtime/default"]
+serve = ["cli", "project", "web_host", "formatter", "mech-runtime", "mech-runtime/default", "ignore"]
 whos = ["pretty_print", "variables", "symbol_table"]
 formatter = ["mech-syntax/formatter"]
 async = []

--- a/examples/browser-dom-demo/README.md
+++ b/examples/browser-dom-demo/README.md
@@ -50,3 +50,24 @@ http://127.0.0.1:8081/
 `mech serve` loads the config, uses the `serve` section for the address, port, source paths, shim, and WASM package, and injects a derived host config as `window.__MECH_HOST_CONFIG`.
 
 Change the `Source DOM input` field, click `Run round trip`, and observe that Mech reads the DOM value, computes new strings, and writes the computed result back into the page.
+
+## Bundle as static web assets
+
+Build the browser wasm package, bundle the demo, and serve it with a plain static file server:
+
+```sh
+cd src/wasm
+wasm-pack build --target web
+cd ../..
+cargo run --bin mech -- bundle-web examples/browser-dom-demo --out dist/browser-dom-demo
+python -m http.server 9000 -d dist/browser-dom-demo
+```
+
+Then open:
+
+```text
+http://127.0.0.1:9000/
+```
+
+This uses a plain static file server, not `mech serve`, because browsers generally do not load wasm modules and fetched code payloads reliably from `file://`.
+

--- a/examples/browser-dom-demo/README.md
+++ b/examples/browser-dom-demo/README.md
@@ -69,5 +69,7 @@ Then open:
 http://127.0.0.1:9000/
 ```
 
+The shim used by `bundle-web` must use relative URLs for bundled Mech assets, such as `./pkg/mech_wasm.js` and `./code/demo.mec`. `bundle-web` rejects server-root Mech URLs like `/code/demo.mec` because those depend on `mech serve`.
+
 This uses a plain static file server, not `mech serve`, because browsers generally do not load wasm modules and fetched code payloads reliably from `file://`.
 

--- a/examples/browser-dom-demo/index.html
+++ b/examples/browser-dom-demo/index.html
@@ -92,8 +92,8 @@
       async function main() {
         await init();
 
-        const demoCode = await loadText("/code/demo.mec");
-        const deniedCode = await loadText("/code/denied.mec");
+        const demoCode = await loadText("./code/demo.mec");
+        const deniedCode = await loadText("./code/denied.mec");
 
         const mech = WasmMech.fromHostConfig();
 

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -69,6 +69,8 @@ impl MechErrorKind for Utf8ConversionError {
   }
 }
 
+#[cfg(feature = "bundle_web")]
+use mech::cli::bundle_web;
 #[cfg(feature = "serve")]
 use mech::cli::{capabilities, config};
 
@@ -285,11 +287,17 @@ async fn main() -> Result<(), MechError> {
         .help("Start REPL")
         .action(ArgAction::SetTrue));
 
+  #[cfg(feature = "bundle_web")]
+  let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
+
   #[cfg(feature = "serve")]
   let cli_command = capabilities::add_filesystem_capability_args(cli_command);
 
   #[cfg(feature = "serve")]
   let cli_command = config::add_config_args(cli_command);
+
+  #[cfg(all(feature = "bundle_web", not(feature = "serve")))]
+  let cli_command = bundle_web::add_config_args(cli_command);
 
   let cli_matches = cli_command.get_matches();
 
@@ -304,6 +312,24 @@ async fn main() -> Result<(), MechError> {
   let stylesheet_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css".to_string();
   let wasm_backup_url = format!("https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm_bg.wasm.br", VERSION);
   let js_backup_url = format!("https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm.js", VERSION);
+
+  // --------------------------------------------------------------------------
+  // Bundle Web
+  // --------------------------------------------------------------------------
+  #[cfg(feature = "bundle_web")]
+  if let Some(bundle_matches) = cli_matches.subcommand_matches("bundle-web") {
+    let badge = "[Mech Bundle]".truecolor(34, 204, 187);
+
+    let loaded = bundle_web::load_bundle_web_config(bundle_matches)?;
+    println!("{badge} Loading config… {}", loaded.path.display());
+
+    let options = bundle_web::effective_bundle_web_options(bundle_matches, loaded)?;
+    let result = mech::bundle_web_project(options)?;
+
+    println!("{badge} Bundle written: {}", result.output_dir.display());
+    println!("{badge} Sources bundled: {}", result.source_count);
+    return Ok(());
+  }
 
   // --------------------------------------------------------------------------
   // Serve

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -37,13 +37,20 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
 
   let project_dir = options.project_dir.canonicalize()?;
   let base_dir = options.loaded_config.base_dir.canonicalize()?;
-  let output_dir = options.output_dir;
+  let wasm_pkg = options.wasm_pkg.canonicalize()?;
+  fs::create_dir_all(&options.output_dir)?;
+  let output_dir = options.output_dir.canonicalize()?;
   let stylesheet_string = read_stylesheets(&options.stylesheet_paths)?;
-  let shim_string = read_static_friendly_shim(&options.shim_path)?;
+  let shim_string = read_shim(&options.shim_path)?;
+  validate_static_web_shim(&shim_string)?;
 
-  fs::create_dir_all(&output_dir)?;
+  copy_project_static_assets(
+    &project_dir,
+    &output_dir,
+    &[output_dir.clone(), wasm_pkg.clone()],
+  )?;
   fs::write(output_dir.join("style.css"), &stylesheet_string)?;
-  copy_wasm_package(&options.wasm_pkg, &output_dir.join("pkg"))?;
+  copy_wasm_package(&wasm_pkg, &output_dir.join("pkg"))?;
 
   let runtime_config = crate::apply_runtime_config_patch(
     mech_runtime::RuntimeConfig::default(),
@@ -94,13 +101,136 @@ fn read_stylesheets(paths: &[PathBuf]) -> MResult<String> {
   Ok(combined)
 }
 
-fn read_static_friendly_shim(path: &Path) -> MResult<String> {
-  let shim = fs::read_to_string(path)?;
-  Ok(shim
-    .replace("\"/code/", "\"./code/")
-    .replace("\"/source/", "\"./source/")
-    .replace("\"/pkg/mech_wasm.js\"", "\"./pkg/mech_wasm.js\"")
-    .replace("\"/_mech/pkg/mech_wasm.js\"", "\"./pkg/mech_wasm.js\""))
+fn read_shim(path: &Path) -> MResult<String> {
+  Ok(fs::read_to_string(path)?)
+}
+
+fn validate_static_web_shim(shim: &str) -> MResult<()> {
+  for (pattern, url, fix) in [
+    ("\"/code/", "/code/", "./code/..."),
+    ("'/code/", "/code/", "./code/..."),
+    ("`/code/", "/code/", "./code/..."),
+    ("\"/source/", "/source/", "./source/..."),
+    ("'/source/", "/source/", "./source/..."),
+    ("`/source/", "/source/", "./source/..."),
+    ("\"/pkg/mech_wasm.js\"", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
+    ("'/pkg/mech_wasm.js'", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
+    ("`/pkg/mech_wasm.js`", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
+    ("\"/_mech/", "/_mech/", "./pkg/mech_wasm.js"),
+    ("'/_mech/", "/_mech/", "./pkg/mech_wasm.js"),
+    ("`/_mech/", "/_mech/", "./pkg/mech_wasm.js"),
+  ] {
+    if shim.contains(pattern) {
+      return Err(Error::new(
+        ErrorKind::InvalidInput,
+        format!(
+          "bundle-web shim contains server-root Mech URL `{url}`.\nUse a relative URL such as `{fix}` or `./pkg/mech_wasm.js`.",
+        ),
+      )
+      .into());
+    }
+  }
+
+  Ok(())
+}
+
+pub fn copy_project_static_assets(
+  project_dir: &Path,
+  output_dir: &Path,
+  excluded_dirs: &[PathBuf],
+) -> MResult<()> {
+  let project_dir = project_dir.canonicalize()?;
+  let output_dir = output_dir.canonicalize()?;
+  let excluded_dirs = excluded_dirs
+    .iter()
+    .filter_map(|path| path.canonicalize().ok())
+    .collect::<Vec<_>>();
+  copy_project_static_assets_inner(&project_dir, &project_dir, &output_dir, &excluded_dirs)
+}
+
+fn copy_project_static_assets_inner(
+  project_dir: &Path,
+  current_dir: &Path,
+  output_dir: &Path,
+  excluded_dirs: &[PathBuf],
+) -> MResult<()> {
+  for entry in fs::read_dir(current_dir)? {
+    let entry = entry?;
+    let path = entry.path();
+    let canonical_path = path.canonicalize()?;
+
+    if should_skip_static_asset_path(&canonical_path, output_dir, excluded_dirs) {
+      continue;
+    }
+
+    if canonical_path.is_dir() {
+      if should_skip_static_asset_dir(&canonical_path) {
+        continue;
+      }
+      copy_project_static_assets_inner(project_dir, &canonical_path, output_dir, excluded_dirs)?;
+      continue;
+    }
+
+    if !is_allowed_static_asset(&canonical_path) {
+      continue;
+    }
+
+    let relative = canonical_path.strip_prefix(project_dir).map_err(|error| {
+      Error::new(
+        ErrorKind::InvalidInput,
+        format!("bundle-web static asset is outside project root: {error}"),
+      )
+    })?;
+    validate_safe_relative_path(relative)?;
+    let output_path = output_dir.join(relative);
+    if let Some(parent) = output_path.parent() {
+      fs::create_dir_all(parent)?;
+    }
+    fs::copy(&canonical_path, output_path)?;
+  }
+
+  Ok(())
+}
+
+fn should_skip_static_asset_path(
+  path: &Path,
+  output_dir: &Path,
+  excluded_dirs: &[PathBuf],
+) -> bool {
+  path == output_dir
+    || path.starts_with(output_dir)
+    || excluded_dirs
+      .iter()
+      .any(|excluded| path == excluded || path.starts_with(excluded))
+}
+
+fn should_skip_static_asset_dir(path: &Path) -> bool {
+  matches!(
+    path.file_name().and_then(|name| name.to_str()),
+    Some("target" | "dist" | ".git")
+  )
+}
+
+fn is_allowed_static_asset(path: &Path) -> bool {
+  matches!(
+    path.extension().and_then(|extension| extension.to_str()),
+    Some(
+      "html"
+        | "htm"
+        | "css"
+        | "js"
+        | "wasm"
+        | "png"
+        | "jpg"
+        | "jpeg"
+        | "gif"
+        | "svg"
+        | "webp"
+        | "md"
+        | "csv"
+        | "json"
+    )
+  )
 }
 
 fn copy_wasm_package(wasm_pkg: &Path, output_pkg: &Path) -> MResult<()> {
@@ -200,7 +330,7 @@ mod tests {
     .unwrap();
     fs::write(
       root.join("index.html"),
-      r#"<!doctype html><html><head></head><body><script type="module">import init from "/pkg/mech_wasm.js"; const code = await fetch("/code/demo.mec");</script></body></html>"#,
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec");</script></body></html>"#,
     )
     .unwrap();
     fs::write(root.join("demo.mec"), "x := 1\n").unwrap();
@@ -278,6 +408,104 @@ mod tests {
 
     let index = fs::read_to_string(out.join("index.html")).unwrap();
     assert!(index.contains("window.__MECH_HOST_CONFIG"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_copies_static_assets() {
+    let root = temp_root("static-assets");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+    fs::write(root.join("app.js"), "console.log('app');\n").unwrap();
+    fs::create_dir_all(root.join("assets")).unwrap();
+    fs::write(root.join("assets/logo.svg"), "<svg></svg>\n").unwrap();
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    assert!(out.join("app.js").is_file());
+    assert!(out.join("assets/logo.svg").is_file());
+    assert!(!out.join("demo.mcfg").exists());
+    assert!(!out.join("demo.mec").exists());
+    assert!(out.join("source/demo.mec").is_file());
+    assert!(out.join("code/demo.mec").is_file());
+    assert!(out.join("html/demo.html").is_file());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_output_inside_project_does_not_copy_itself() {
+    let root = temp_root("output-inside-project");
+    let loaded = write_demo_project(&root);
+    let out = root.join("dist/bundle");
+    fs::create_dir_all(&out).unwrap();
+    fs::write(out.join("stale.js"), "console.log('stale');\n").unwrap();
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    assert!(out.join("stale.js").is_file());
+    assert!(!out.join("dist/bundle/stale.js").exists());
+    assert!(!out.join("bundle/stale.js").exists());
+    assert!(out.join("source/demo.mec").is_file());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_rejects_root_relative_code_url() {
+    let root = temp_root("root-code-url");
+    let loaded = write_demo_project(&root);
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script>fetch("/code/demo.mec")</script></body></html>"#,
+    )
+    .unwrap();
+    let out = root.join("out");
+
+    let error = format!("{:?}", bundle_web_project(options(&root, &out, loaded)).unwrap_err());
+
+    assert!(error.contains("bundle-web shim contains server-root Mech URL"));
+    assert!(error.contains("./code/"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_rejects_root_relative_pkg_url() {
+    let root = temp_root("root-pkg-url");
+    let loaded = write_demo_project(&root);
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "/pkg/mech_wasm.js";</script></body></html>"#,
+    )
+    .unwrap();
+    let out = root.join("out");
+
+    let error = format!("{:?}", bundle_web_project(options(&root, &out, loaded)).unwrap_err());
+
+    assert!(error.contains("bundle-web shim contains server-root Mech URL"));
+    assert!(error.contains("./pkg/mech_wasm.js"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_does_not_reject_ordinary_external_urls() {
+    let root = temp_root("external-urls");
+    let loaded = write_demo_project(&root);
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body>
+<a href="https://example.com/source/demo.mec">external</a>
+<a href="http://localhost:8081/code/demo.mec">local</a>
+<script src="//cdn.example.com/pkg/mech_wasm.js"></script>
+<a href="mailto:test@example.com">mail</a>
+<img src="data:image/svg+xml,%3Csvg%3E" />
+<script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec");</script>
+</body></html>"#,
+    )
+    .unwrap();
+    let out = root.join("out");
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    assert!(out.join("index.html").is_file());
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -1,0 +1,296 @@
+use std::fs;
+use std::io::{Error, ErrorKind};
+use std::path::{Component, Path, PathBuf};
+
+use mech_core::*;
+use mech_syntax::formatter::Formatter;
+use mech_syntax::parser;
+
+use crate::LoadedMechConfig;
+
+#[derive(Clone, Debug)]
+pub struct BundleWebOptions {
+  pub project_dir: PathBuf,
+  pub output_dir: PathBuf,
+  pub source_paths: Vec<PathBuf>,
+  pub shim_path: PathBuf,
+  pub stylesheet_paths: Vec<PathBuf>,
+  pub wasm_pkg: PathBuf,
+  pub loaded_config: LoadedMechConfig,
+}
+
+#[derive(Debug)]
+pub struct BundleWebResult {
+  pub output_dir: PathBuf,
+  pub index_html: PathBuf,
+  pub source_count: usize,
+}
+
+pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult> {
+  if options.source_paths.is_empty() {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      "bundle-web requires serve.paths in the project config",
+    )
+    .into());
+  }
+
+  let project_dir = options.project_dir.canonicalize()?;
+  let base_dir = options.loaded_config.base_dir.canonicalize()?;
+  let output_dir = options.output_dir;
+  let stylesheet_string = read_stylesheets(&options.stylesheet_paths)?;
+  let shim_string = read_static_friendly_shim(&options.shim_path)?;
+
+  fs::create_dir_all(&output_dir)?;
+  fs::write(output_dir.join("style.css"), &stylesheet_string)?;
+  copy_wasm_package(&options.wasm_pkg, &output_dir.join("pkg"))?;
+
+  let runtime_config = crate::apply_runtime_config_patch(
+    mech_runtime::RuntimeConfig::default(),
+    &options.loaded_config.document.runtime,
+  )?;
+  let host_config = mech_runtime::BrowserHostConfig::from_document_and_runtime(
+    &options.loaded_config.document,
+    &runtime_config,
+  );
+  let index_html = output_dir.join("index.html");
+  let shim_with_config = crate::inject_browser_host_config_script(&shim_string, &host_config)?;
+  fs::write(&index_html, shim_with_config)?;
+
+  for source_path in &options.source_paths {
+    let source_path = source_path.canonicalize()?;
+    let relative = relative_source_path(&source_path, &base_dir, &project_dir)?;
+    let source_text = fs::read_to_string(&source_path)?;
+    let tree = parser::parse(&source_text)?;
+
+    write_bundle_file(&output_dir, "source", &relative, source_text.as_bytes())?;
+
+    let encoded = compress_and_encode(&tree)
+      .map_err(|error| Error::new(ErrorKind::Other, error.to_string()))?;
+    write_bundle_file(&output_dir, "code", &relative, encoded.as_bytes())?;
+
+    let mut formatter = Formatter::new();
+    let html = formatter.format_html(&tree, stylesheet_string.clone(), shim_string.clone());
+    let html_relative = relative.with_extension("html");
+    write_bundle_file(&output_dir, "html", &html_relative, html.as_bytes())?;
+  }
+
+  Ok(BundleWebResult {
+    output_dir,
+    index_html,
+    source_count: options.source_paths.len(),
+  })
+}
+
+fn read_stylesheets(paths: &[PathBuf]) -> MResult<String> {
+  let mut combined = String::new();
+  for path in paths {
+    let stylesheet = fs::read_to_string(path)?;
+    if !combined.is_empty() {
+      combined.push('\n');
+    }
+    combined.push_str(&stylesheet);
+  }
+  Ok(combined)
+}
+
+fn read_static_friendly_shim(path: &Path) -> MResult<String> {
+  let shim = fs::read_to_string(path)?;
+  Ok(shim
+    .replace("\"/code/", "\"./code/")
+    .replace("\"/source/", "\"./source/")
+    .replace("\"/pkg/mech_wasm.js\"", "\"./pkg/mech_wasm.js\"")
+    .replace("\"/_mech/pkg/mech_wasm.js\"", "\"./pkg/mech_wasm.js\""))
+}
+
+fn copy_wasm_package(wasm_pkg: &Path, output_pkg: &Path) -> MResult<()> {
+  fs::create_dir_all(output_pkg)?;
+  fs::copy(wasm_pkg.join("mech_wasm.js"), output_pkg.join("mech_wasm.js"))?;
+  fs::copy(
+    wasm_pkg.join("mech_wasm_bg.wasm"),
+    output_pkg.join("mech_wasm_bg.wasm"),
+  )?;
+  Ok(())
+}
+
+fn relative_source_path(source: &Path, base_dir: &Path, project_dir: &Path) -> MResult<PathBuf> {
+  let relative = if let Ok(relative) = source.strip_prefix(base_dir) {
+    relative
+  } else if let Ok(relative) = source.strip_prefix(project_dir) {
+    relative
+  } else {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!("bundle-web source is outside project/config root: {}", source.display()),
+    )
+    .into());
+  };
+
+  validate_safe_relative_path(relative)?;
+  Ok(relative.to_path_buf())
+}
+
+fn validate_safe_relative_path(path: &Path) -> MResult<()> {
+  if path.is_absolute()
+    || path.components().any(|component| matches!(component, Component::ParentDir))
+  {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!("bundle-web rejected unsafe relative path: {}", path.display()),
+    )
+    .into());
+  }
+  Ok(())
+}
+
+fn write_bundle_file(output_dir: &Path, section: &str, relative: &Path, bytes: &[u8]) -> MResult<()> {
+  validate_safe_relative_path(relative)?;
+  let path = output_dir.join(section).join(relative);
+  if let Some(parent) = path.parent() {
+    fs::create_dir_all(parent)?;
+  }
+  fs::write(path, bytes)?;
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use mech_core::nodes::Program;
+  use std::time::{SystemTime, UNIX_EPOCH};
+
+  fn temp_root(name: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+      "mech-bundle-web-{name}-{}",
+      SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos(),
+    ));
+    fs::create_dir_all(&root).unwrap();
+    root.canonicalize().unwrap()
+  }
+
+  fn walk_has_mcfg(root: &Path) -> bool {
+    for entry in fs::read_dir(root).unwrap() {
+      let path = entry.unwrap().path();
+      if path.is_dir() && walk_has_mcfg(&path) {
+        return true;
+      }
+      if path.extension().map(|extension| extension == "mcfg").unwrap_or(false) {
+        return true;
+      }
+    }
+    false
+  }
+
+  fn write_demo_project(root: &Path) -> LoadedMechConfig {
+    fs::write(
+      root.join("demo.mcfg"),
+      r#"config := {
+  runtime: {name: "bundle-test"}
+  serve: {
+    paths: ["demo.mec"]
+    shim: "index.html"
+    wasm: "pkg"
+  }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "/pkg/mech_wasm.js"; const code = await fetch("/code/demo.mec");</script></body></html>"#,
+    )
+    .unwrap();
+    fs::write(root.join("demo.mec"), "x := 1\n").unwrap();
+    fs::create_dir_all(root.join("pkg")).unwrap();
+    fs::write(root.join("pkg/mech_wasm.js"), "export default async function init() {}\n").unwrap();
+    fs::write(root.join("pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    crate::load_mech_config_path(root.join("demo.mcfg"), Some(root.to_path_buf())).unwrap()
+  }
+
+  fn options(root: &Path, out: &Path, loaded: LoadedMechConfig) -> BundleWebOptions {
+    BundleWebOptions {
+      project_dir: root.to_path_buf(),
+      output_dir: out.to_path_buf(),
+      source_paths: vec![root.join("demo.mec")],
+      shim_path: root.join("index.html"),
+      stylesheet_paths: Vec::new(),
+      wasm_pkg: root.join("pkg"),
+      loaded_config: loaded,
+    }
+  }
+
+  #[test]
+  fn bundle_web_requires_source_paths() {
+    let root = temp_root("requires-source-paths");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+    let mut options = options(&root, &out, loaded);
+    options.source_paths.clear();
+
+    let error = format!("{:?}", bundle_web_project(options).unwrap_err());
+    assert!(error.contains("bundle-web requires serve.paths"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_writes_source_code_and_html() {
+    let root = temp_root("writes");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    assert!(out.join("index.html").is_file());
+    assert!(out.join("style.css").is_file());
+    assert!(out.join("pkg/mech_wasm.js").is_file());
+    assert!(out.join("pkg/mech_wasm_bg.wasm").is_file());
+    assert!(out.join("source/demo.mec").is_file());
+    assert!(out.join("code/demo.mec").is_file());
+    assert!(out.join("html/demo.html").is_file());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_code_payload_decodes() {
+    let root = temp_root("decodes");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    let source = fs::read_to_string(root.join("demo.mec")).unwrap();
+    let encoded = fs::read_to_string(out.join("code/demo.mec")).unwrap();
+    let decoded: Program = decode_and_decompress(&encoded).unwrap();
+    assert_eq!(decoded, parser::parse(&source).unwrap());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_injects_browser_host_config() {
+    let root = temp_root("host-config");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+    assert!(index.contains("window.__MECH_HOST_CONFIG"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_does_not_copy_config() {
+    let root = temp_root("no-config-copy");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    let has_config = walk_has_mcfg(&out);
+    assert!(!has_config);
+    fs::remove_dir_all(root).unwrap();
+  }
+}

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -40,6 +40,26 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
   let wasm_pkg = options.wasm_pkg.canonicalize()?;
   fs::create_dir_all(&options.output_dir)?;
   let output_dir = options.output_dir.canonicalize()?;
+  if output_dir == project_dir {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!(
+        "bundle-web output directory must not be the project root: {}. Use a subdirectory such as dist/<name>.",
+        output_dir.display(),
+      ),
+    )
+    .into());
+  }
+  if output_dir == base_dir {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!(
+        "bundle-web output directory must not be the config base directory: {}. Use a subdirectory such as dist/<name>.",
+        output_dir.display(),
+      ),
+    )
+    .into());
+  }
   let stylesheet_string = read_stylesheets(&options.stylesheet_paths)?;
   let shim_string = read_shim(&options.shim_path)?;
   validate_static_web_shim(&shim_string)?;
@@ -113,9 +133,9 @@ fn validate_static_web_shim(shim: &str) -> MResult<()> {
     ("\"/source/", "/source/", "./source/..."),
     ("'/source/", "/source/", "./source/..."),
     ("`/source/", "/source/", "./source/..."),
-    ("\"/pkg/mech_wasm.js\"", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
-    ("'/pkg/mech_wasm.js'", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
-    ("`/pkg/mech_wasm.js`", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
+    ("\"/pkg/mech_wasm.js", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
+    ("'/pkg/mech_wasm.js", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
+    ("`/pkg/mech_wasm.js", "/pkg/mech_wasm.js", "./pkg/mech_wasm.js"),
     ("\"/_mech/", "/_mech/", "./pkg/mech_wasm.js"),
     ("'/_mech/", "/_mech/", "./pkg/mech_wasm.js"),
     ("`/_mech/", "/_mech/", "./pkg/mech_wasm.js"),
@@ -450,6 +470,78 @@ mod tests {
   }
 
   #[test]
+  fn bundle_web_rejects_output_equal_project_root() {
+    let root = temp_root("output-project-root");
+    let loaded = write_demo_project(&root);
+    let original_index = fs::read_to_string(root.join("index.html")).unwrap();
+
+    let error = format!("{:?}", bundle_web_project(options(&root, &root, loaded)).unwrap_err());
+
+    assert!(error.contains("bundle-web output directory must not be the project root"));
+    assert_eq!(fs::read_to_string(root.join("index.html")).unwrap(), original_index);
+    assert!(!root.join("style.css").exists());
+    assert!(!root.join("source/demo.mec").exists());
+    assert!(!root.join("code/demo.mec").exists());
+    assert!(!root.join("html/demo.html").exists());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_rejects_output_equal_config_base_dir() {
+    let root = temp_root("output-config-base");
+    let app = root.join("app");
+    let config = root.join("config");
+    fs::create_dir_all(app.join("pkg")).unwrap();
+    fs::create_dir_all(&config).unwrap();
+    fs::write(
+      app.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec");</script></body></html>"#,
+    )
+    .unwrap();
+    fs::write(app.join("demo.mec"), "x := 1\n").unwrap();
+    fs::write(app.join("pkg/mech_wasm.js"), "export default async function init() {}\n").unwrap();
+    fs::write(app.join("pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    fs::write(
+      config.join("demo.mcfg"),
+      r#"config := {
+  runtime: {name: "bundle-config-base-test"}
+  serve: {
+    paths: ["../app/demo.mec"]
+    shim: "../app/index.html"
+    wasm: "../app/pkg"
+  }
+}
+"#,
+    )
+    .unwrap();
+    let loaded = crate::load_mech_config_path(
+      config.join("demo.mcfg"),
+      Some(config.clone()),
+    )
+    .unwrap();
+    let options = BundleWebOptions {
+      project_dir: app.clone(),
+      output_dir: config.clone(),
+      source_paths: vec![app.join("demo.mec")],
+      shim_path: app.join("index.html"),
+      stylesheet_paths: Vec::new(),
+      wasm_pkg: app.join("pkg"),
+      loaded_config: loaded,
+    };
+
+    let error = format!("{:?}", bundle_web_project(options).unwrap_err());
+
+    assert!(error.contains("bundle-web output directory must not be the config base directory"));
+    assert!(config.join("demo.mcfg").is_file());
+    assert!(!config.join("style.css").exists());
+    assert!(!config.join("source/demo.mec").exists());
+    assert!(!config.join("code/demo.mec").exists());
+    assert!(!config.join("html/demo.html").exists());
+    assert!(!config.join("pkg/mech_wasm.js").exists());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
   fn bundle_web_rejects_root_relative_code_url() {
     let root = temp_root("root-code-url");
     let loaded = write_demo_project(&root);
@@ -486,18 +578,54 @@ mod tests {
   }
 
   #[test]
+  fn bundle_web_rejects_root_relative_pkg_url_with_query() {
+    let root = temp_root("root-pkg-query-url");
+    let loaded = write_demo_project(&root);
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "/pkg/mech_wasm.js?v=123";</script></body></html>"#,
+    )
+    .unwrap();
+    let out = root.join("out");
+
+    let error = format!("{:?}", bundle_web_project(options(&root, &out, loaded)).unwrap_err());
+
+    assert!(error.contains("bundle-web shim contains server-root Mech URL"));
+    assert!(error.contains("./pkg/mech_wasm.js"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_rejects_root_relative_pkg_url_with_fragment() {
+    let root = temp_root("root-pkg-fragment-url");
+    let loaded = write_demo_project(&root);
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from '/pkg/mech_wasm.js#hash';</script></body></html>"#,
+    )
+    .unwrap();
+    let out = root.join("out");
+
+    let error = format!("{:?}", bundle_web_project(options(&root, &out, loaded)).unwrap_err());
+
+    assert!(error.contains("bundle-web shim contains server-root Mech URL"));
+    assert!(error.contains("./pkg/mech_wasm.js"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
   fn bundle_web_does_not_reject_ordinary_external_urls() {
     let root = temp_root("external-urls");
     let loaded = write_demo_project(&root);
     fs::write(
       root.join("index.html"),
       r#"<!doctype html><html><head></head><body>
-<a href="https://example.com/source/demo.mec">external</a>
+<a href="https://example.com/code/demo.mec">external</a>
 <a href="http://localhost:8081/code/demo.mec">local</a>
 <script src="//cdn.example.com/pkg/mech_wasm.js"></script>
 <a href="mailto:test@example.com">mail</a>
-<img src="data:image/svg+xml,%3Csvg%3E" />
-<script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec");</script>
+<img src="data:text/plain,hello" />
+<script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec"); const source = await fetch("./source/demo.mec");</script>
 </body></html>"#,
     )
     .unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,9 @@
+#[cfg(feature = "bundle_web")]
+pub mod bundle_web;
 #[cfg(feature = "serve")]
 pub mod capabilities;
 #[cfg(feature = "serve")]
 pub mod config;
 
-#[cfg(all(test, feature = "serve"))]
+#[cfg(all(test, any(feature = "serve", feature = "bundle_web")))]
 pub(crate) static CURRENT_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/src/cli/bundle_web.rs
+++ b/src/cli/bundle_web.rs
@@ -1,0 +1,425 @@
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+use clap::{Arg, ArgAction, Command};
+use mech_core::*;
+
+use crate::{
+  discover_project_config, load_mech_config_path, require_config_file, resolve_config_path,
+  resolve_project_dir_input, BundleWebOptions, LoadedMechConfig,
+};
+
+pub fn add_config_args(command: Command) -> Command {
+  command
+    .arg(
+      Arg::new("config")
+        .long("config")
+        .value_name("PATH")
+        .num_args(1)
+        .global(true)
+        .help("Load configuration from a Mech config file."),
+    )
+    .arg(
+      Arg::new("no_config")
+        .long("no-config")
+        .action(ArgAction::SetTrue)
+        .global(true)
+        .help("Disable automatic Mech config loading."),
+    )
+}
+
+pub fn bundle_web_command() -> clap::Command {
+  Command::new("bundle-web")
+    .about("Bundle a Mech browser project into static web assets.")
+    .arg(
+      Arg::new("project_path")
+        .help("Project directory to bundle.")
+        .required(true),
+    )
+    .arg(
+      Arg::new("out")
+        .short('o')
+        .long("out")
+        .value_name("OUTPUT_DIR")
+        .num_args(1)
+        .required(true)
+        .help("Destination directory for static bundle output."),
+    )
+    .arg(
+      Arg::new("shim")
+        .short('m')
+        .long("shim")
+        .value_name("PATH")
+        .num_args(1)
+        .help("HTML shim to use as the bundle index."),
+    )
+    .arg(
+      Arg::new("stylesheet")
+        .short('s')
+        .long("stylesheet")
+        .value_name("PATH")
+        .num_args(1..)
+        .action(ArgAction::Append)
+        .help("Additional stylesheet to include in the bundle."),
+    )
+    .arg(
+      Arg::new("wasm")
+        .short('w')
+        .long("wasm")
+        .value_name("PATH")
+        .num_args(1)
+        .help("Path to the wasm package directory."),
+    )
+}
+
+pub fn load_bundle_web_config(matches: &clap::ArgMatches) -> MResult<LoadedMechConfig> {
+  if matches.get_flag("no_config") {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      "bundle-web requires a config; remove --no-config or pass --config",
+    )
+    .into());
+  }
+
+  let current_dir = std::env::current_dir()?;
+  if let Some(path) = matches.get_one::<String>("config") {
+    let path = resolve_current_dir_path(&current_dir, Path::new(path));
+    return load_mech_config_path(path, None);
+  }
+
+  let project_path = matches
+    .get_one::<String>("project_path")
+    .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "bundle-web requires project_path"))?;
+  let project_dir = resolve_project_dir_input(project_path, &current_dir)?.ok_or_else(|| {
+    let path = resolve_current_dir_path(&current_dir, Path::new(project_path));
+    Error::new(
+      ErrorKind::InvalidInput,
+      format!("bundle-web project path must be an existing directory: {}", path.display()),
+    )
+  })?;
+
+  let discovery = discover_project_config(&project_dir)?.ok_or_else(|| {
+    Error::new(
+      ErrorKind::InvalidInput,
+      format!("bundle-web requires a project config in {}", project_dir.display()),
+    )
+  })?;
+
+  load_mech_config_path(discovery.config_path, Some(discovery.project_dir))
+}
+
+pub fn effective_bundle_web_options(
+  matches: &clap::ArgMatches,
+  loaded: LoadedMechConfig,
+) -> MResult<BundleWebOptions> {
+  let current_dir = std::env::current_dir()?;
+  let project_path = matches
+    .get_one::<String>("project_path")
+    .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "bundle-web requires project_path"))?;
+  let project_dir = resolve_current_dir_path(&current_dir, Path::new(project_path));
+  if !project_dir.is_dir() {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!("bundle-web project path must be an existing directory: {}", project_dir.display()),
+    )
+    .into());
+  }
+  let project_dir = project_dir.canonicalize()?;
+
+  let out = matches
+    .get_one::<String>("out")
+    .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "bundle-web requires --out"))?;
+  let output_dir = resolve_current_dir_path(&current_dir, Path::new(out));
+
+  let serve_config = loaded.document.serve.as_ref();
+  let source_paths = serve_config
+    .map(|serve| {
+      serve
+        .paths
+        .iter()
+        .map(|path| resolve_config_path(&loaded.base_dir, path))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  if source_paths.is_empty() {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      "bundle-web requires serve.paths in the project config",
+    )
+    .into());
+  }
+  for path in &source_paths {
+    require_file("serve.paths", path)?;
+  }
+
+  let shim_path = matches
+    .get_one::<String>("shim")
+    .map(|path| resolve_current_dir_path(&current_dir, Path::new(path)))
+    .or_else(|| {
+      serve_config
+        .and_then(|serve| serve.shim.as_ref())
+        .map(|path| resolve_config_path(&loaded.base_dir, path))
+    })
+    .ok_or_else(|| {
+      Error::new(
+        ErrorKind::InvalidInput,
+        "bundle-web requires a shim via --shim or serve.shim",
+      )
+    })?;
+  require_file("serve.shim", &shim_path)?;
+
+  let mut stylesheet_paths = serve_config
+    .map(|serve| {
+      serve
+        .stylesheets
+        .iter()
+        .map(|path| resolve_config_path(&loaded.base_dir, path))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  stylesheet_paths.extend(
+    matches
+      .get_many::<String>("stylesheet")
+      .into_iter()
+      .flatten()
+      .map(|path| resolve_current_dir_path(&current_dir, Path::new(path))),
+  );
+  for path in &stylesheet_paths {
+    require_config_file("serve.stylesheets", path)?;
+  }
+
+  let wasm_pkg = matches
+    .get_one::<String>("wasm")
+    .map(|path| resolve_current_dir_path(&current_dir, Path::new(path)))
+    .or_else(|| {
+      serve_config
+        .and_then(|serve| serve.wasm.as_ref())
+        .map(|path| resolve_config_path(&loaded.base_dir, path))
+    })
+    .ok_or_else(|| {
+      Error::new(
+        ErrorKind::InvalidInput,
+        "bundle-web requires a wasm package via --wasm or serve.wasm",
+      )
+    })?;
+  require_bundle_wasm_package(&wasm_pkg)?;
+
+  Ok(BundleWebOptions {
+    project_dir,
+    output_dir,
+    source_paths,
+    shim_path,
+    stylesheet_paths,
+    wasm_pkg,
+    loaded_config: loaded,
+  })
+}
+
+fn resolve_current_dir_path(current_dir: &Path, path: &Path) -> PathBuf {
+  if path.is_absolute() {
+    path.to_path_buf()
+  } else {
+    current_dir.join(path)
+  }
+}
+
+fn require_file(field: &str, path: &Path) -> MResult<()> {
+  if path.is_file() {
+    Ok(())
+  } else {
+    Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!("configuration error: {field} must be an existing file: {}", path.display()),
+    )
+    .into())
+  }
+}
+
+fn require_bundle_wasm_package(path: &Path) -> MResult<()> {
+  if !path.is_dir() {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      format!("configuration error: serve.wasm must be an existing directory: {}", path.display()),
+    )
+    .into());
+  }
+
+  for file in ["mech_wasm.js", "mech_wasm_bg.wasm"] {
+    let required = path.join(file);
+    if !required.is_file() {
+      return Err(Error::new(
+        ErrorKind::InvalidInput,
+        format!("configuration error: serve.wasm is missing required file: {}", required.display()),
+      )
+      .into());
+    }
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::cli::CURRENT_DIR_LOCK;
+  use std::time::{SystemTime, UNIX_EPOCH};
+
+  struct CurrentDirGuard {
+    previous: PathBuf,
+    _lock: std::sync::MutexGuard<'static, ()>,
+  }
+
+  impl CurrentDirGuard {
+    fn enter(path: &Path) -> Self {
+      let lock = CURRENT_DIR_LOCK.lock().unwrap();
+      let previous = std::env::current_dir().unwrap();
+      std::env::set_current_dir(path).unwrap();
+      Self {
+        previous,
+        _lock: lock,
+      }
+    }
+  }
+
+  impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+      std::env::set_current_dir(&self.previous).unwrap();
+    }
+  }
+
+  fn temp_root(name: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+      "mech-cli-bundle-web-{name}-{}",
+      SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos(),
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    root.canonicalize().unwrap()
+  }
+
+  fn command() -> Command {
+    add_config_args(Command::new("mech").subcommand(bundle_web_command()))
+  }
+
+  fn matches(args: &[&str]) -> clap::ArgMatches {
+    command().try_get_matches_from(args).unwrap()
+  }
+
+  fn bundle_matches(args: &[&str]) -> clap::ArgMatches {
+    matches(args)
+      .subcommand_matches("bundle-web")
+      .unwrap()
+      .clone()
+  }
+
+  fn write_project(root: &Path, name: &str, runtime_name: &str) -> PathBuf {
+    let project = root.join(name);
+    std::fs::create_dir_all(project.join("pkg")).unwrap();
+    std::fs::write(project.join("index.html"), "<html><head></head></html>").unwrap();
+    std::fs::write(project.join("demo.mec"), "x := 1\n").unwrap();
+    std::fs::write(project.join("style.css"), "body {}\n").unwrap();
+    std::fs::write(project.join("pkg/mech_wasm.js"), "export {};\n").unwrap();
+    std::fs::write(project.join("pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    std::fs::write(
+      project.join("demo.mcfg"),
+      format!(
+        r#"config := {{
+  runtime: {{name: "{runtime_name}"}}
+  serve: {{
+    paths: ["demo.mec"]
+    shim: "index.html"
+    stylesheets: ["style.css"]
+    wasm: "pkg"
+  }}
+}}
+"#,
+      ),
+    )
+    .unwrap();
+    project
+  }
+
+  #[test]
+  fn explicit_config_wins_over_discovered_project_config() {
+    let root = temp_root("explicit-wins");
+    let discovered = write_project(&root, "discovered", "discovered");
+    let explicit = write_project(&root, "explicit", "explicit");
+    let _guard = CurrentDirGuard::enter(&root);
+
+    let matches = bundle_matches(&[
+      "mech",
+      "--config",
+      "explicit/demo.mcfg",
+      "bundle-web",
+      "discovered",
+      "--out",
+      "out",
+    ]);
+    let loaded = load_bundle_web_config(&matches).unwrap();
+
+    assert_eq!(loaded.path, explicit.join("demo.mcfg").canonicalize().unwrap());
+    assert_ne!(loaded.path, discovered.join("demo.mcfg").canonicalize().unwrap());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn no_config_errors() {
+    let root = temp_root("no-config");
+    write_project(&root, "project", "project");
+    let _guard = CurrentDirGuard::enter(&root);
+
+    let matches = bundle_matches(&["mech", "--no-config", "bundle-web", "project", "--out", "out"]);
+    let error = format!("{:?}", load_bundle_web_config(&matches).unwrap_err());
+
+    assert!(error.contains("bundle-web requires a config"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn missing_project_config_errors() {
+    let root = temp_root("missing-config");
+    std::fs::create_dir_all(root.join("project")).unwrap();
+    let _guard = CurrentDirGuard::enter(&root);
+
+    let matches = bundle_matches(&["mech", "bundle-web", "project", "--out", "out"]);
+    let error = format!("{:?}", load_bundle_web_config(&matches).unwrap_err());
+
+    assert!(error.contains("bundle-web requires a project config"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn cli_shim_stylesheet_and_wasm_override_config_paths() {
+    let root = temp_root("overrides");
+    write_project(&root, "project", "project");
+    std::fs::create_dir_all(root.join("override-pkg")).unwrap();
+    std::fs::write(root.join("override.html"), "<html><head></head></html>").unwrap();
+    std::fs::write(root.join("override.css"), "html {}\n").unwrap();
+    std::fs::write(root.join("override-pkg/mech_wasm.js"), "export {};\n").unwrap();
+    std::fs::write(root.join("override-pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    let _guard = CurrentDirGuard::enter(&root);
+
+    let matches = bundle_matches(&[
+      "mech",
+      "bundle-web",
+      "project",
+      "--out",
+      "out",
+      "--shim",
+      "override.html",
+      "--stylesheet",
+      "override.css",
+      "--wasm",
+      "override-pkg",
+    ]);
+    let loaded = load_bundle_web_config(&matches).unwrap();
+    let options = effective_bundle_web_options(&matches, loaded).unwrap();
+
+    assert_eq!(options.shim_path, root.join("override.html"));
+    assert!(options.stylesheet_paths.contains(&root.join("override.css")));
+    assert_eq!(options.wasm_pkg, root.join("override-pkg"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,22 +58,26 @@ use std::collections::HashSet;
 mod repl;
 #[cfg(feature = "cli")]
 pub mod cli;
-#[cfg(feature = "serve")]
+#[cfg(feature = "bundle_web")]
+mod bundle_web;
+#[cfg(feature = "project")]
 mod project;
 #[cfg(feature = "serve")]
 mod serve;
-#[cfg(feature = "serve")]
+#[cfg(feature = "web_host")]
 mod web_host;
 #[cfg(feature = "test")]
 mod test;
 
 #[cfg(feature = "repl")]
 pub use self::repl::*;
-#[cfg(feature = "serve")]
+#[cfg(feature = "bundle_web")]
+pub use self::bundle_web::*;
+#[cfg(feature = "project")]
 pub use self::project::*;
 #[cfg(feature = "serve")]
 pub use self::serve::*;
-#[cfg(feature = "serve")]
+#[cfg(feature = "web_host")]
 pub use self::web_host::*;
 #[cfg(feature = "test")]
 pub use self::test::*;


### PR DESCRIPTION
### Motivation

- Provide a reusable library-backed `bundle-web` workflow to produce static browser bundles from a Mech project without enabling the HTTP server, while preserving existing `mech serve` behavior. 
- Expose the project/config and web-host features independently so bundling can reuse config discovery and host-config injection without pulling in the server implementation.
- Produce a deterministic static layout (`index.html`, `style.css`, `pkg/*`, `source/*`, `code/*`, `html/*`) suitable for serving via a plain static file server.

### Description

- Added feature boundaries in `Cargo.toml` (`project`, `web_host`, `bundle_web`) and adjusted the `serve` feature to depend on `project` and `web_host` so `bundle-web` can reuse config logic without the HTTP server. 
- Changed `src/lib.rs` gating to expose `project` and `web_host` behind their own features and added `bundle_web` export for the new library module. 
- Exposed a new CLI helper module in `src/cli.rs` and moved the `CURRENT_DIR_LOCK` test guard to include `bundle_web` tests where needed. 
- Implemented `src/bundle_web.rs` with `BundleWebOptions`, `BundleWebResult`, and `bundle_web_project` which: performs source relativization, parses `.mec` sources, writes `source/`, encodes compiled payloads to `code/`, formats HTML via the existing `Formatter` to `html/`, copies uncompressed wasm files to `pkg/`, concatenates stylesheets to `style.css`, rewrites dev-server shim URLs to static-friendly relative URLs, injects `window.__MECH_HOST_CONFIG` into the shim, and writes `index.html`. 
- Added `src/cli/bundle_web.rs` containing clap-only helpers, `bundle_web_command()`, `load_bundle_web_config()`, and `effective_bundle_web_options()` to validate/resolve CLI and config options (project path, `--out`, `--shim`, `--stylesheet`, `--wasm`) and to enforce the uncompressed wasm package requirement. 
- Wired the `bundle-web` subcommand into `src/bin/mech.rs` (behind `bundle_web`) and kept serve behavior unchanged. 
- Updated `examples/browser-dom-demo/index.html` to use static-friendly relative `./code/*` URLs and extended the example `README.md` with a `Bundle as static web assets` section documenting the `bundle-web` flow. 
- Added unit tests for library behavior (`src/bundle_web.rs`) and CLI helpers (`src/cli/bundle_web.rs`) covering missing `serve.paths`, output layout, code payload round-trip decoding, host-config injection, avoiding copying `.mcfg`, explicit `--config` precedence, `--no-config` failure, missing project config, and CLI overrides.

### Testing

- Ran the full test suite with default features via `cargo test` and all tests passed. 
- Ran the new bundle-web unit tests via `cargo test --features bundle_web bundle_web --lib` and they passed. 
- Performed feature checks with `cargo check --no-default-features --features bundle_web` and `cargo check --no-default-features --features serve`, both of which completed successfully. 
- Exercised the CLI path by running `cargo run --bin mech -- bundle-web examples/browser-dom-demo --out dist/browser-dom-demo --wasm <temporary fake wasm package>` which completed and produced the bundle (used a temporary wasm package because `wasm-pack` is not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2780f6ceec832aa812bd2849f106cf)