### PR TITLE
Implement lazy stdlib module registration

### DIFF
--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -808,12 +808,39 @@ impl MDList {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ModuleImportKind {
+  Module,
+  Item,
+  Glob,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ModuleImport {
+  pub module: Identifier,
+  pub item: Option<Identifier>,
+  pub kind: ModuleImportKind,
+}
+
+impl ModuleImport {
+  pub fn tokens(&self) -> Vec<Token> {
+    let mut tokens = self.module.tokens();
+    if let Some(item) = &self.item {
+      tokens.append(&mut item.tokens());
+    }
+    tokens
+  }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MechCode {
   Comment(Comment),
   Expression(Expression),
   FsmImplementation(FsmImplementation),
   FsmSpecification(FsmSpecification),
   FunctionDefine(FunctionDefine),
+  Import(ModuleImport),
   Statement(Statement),
   Error(Token, SourceRange),
 }
@@ -833,6 +860,7 @@ impl MechCode {
       MechCode::FsmSpecification(x) => x.tokens(),
       MechCode::FsmImplementation(x) => x.tokens(),
       MechCode::FunctionDefine(_) => vec![],
+      MechCode::Import(x) => x.tokens(),
       MechCode::Error(t,_) => vec![t.clone()],
     }
   }

--- a/src/interpreter/src/builtins.rs
+++ b/src/interpreter/src/builtins.rs
@@ -1,0 +1,382 @@
+use crate::*;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct ModuleExports {
+    pub module: &'static str,
+    pub exports: Vec<&'static str>,
+}
+
+const MATH_EXPORTS: &[&str] = &[
+    "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh", "tanh", "asinh", "acosh",
+    "atanh", "cot", "sec", "csc", "acot", "asec", "acsc", "sqrt",
+];
+const STATS_EXPORTS: &[&str] = &["sum"];
+const IO_EXPORTS: &[&str] = &["print", "println"];
+const STRING_EXPORTS: &[&str] = &["concat"];
+const COMBINATORICS_EXPORTS: &[&str] = &["n_choose_k"];
+
+fn public_exports(module: &str) -> Option<ModuleExports> {
+    match module {
+        "math" => Some(ModuleExports {
+            module: "math",
+            exports: MATH_EXPORTS.to_vec(),
+        }),
+        "stats" => Some(ModuleExports {
+            module: "stats",
+            exports: STATS_EXPORTS.to_vec(),
+        }),
+        "io" => Some(ModuleExports {
+            module: "io",
+            exports: IO_EXPORTS.to_vec(),
+        }),
+        "string" => Some(ModuleExports {
+            module: "string",
+            exports: STRING_EXPORTS.to_vec(),
+        }),
+        "combinatorics" => Some(ModuleExports {
+            module: "combinatorics",
+            exports: COMBINATORICS_EXPORTS.to_vec(),
+        }),
+        _ => None,
+    }
+}
+
+fn is_prelude_name(name: &str) -> bool {
+    const EXACT: &[&str] = &[
+        "assign",
+        "assign/value",
+        "assign/column",
+        "assign/add",
+        "assign/sub",
+        "assign/mul",
+        "assign/div",
+        "access/scalar",
+        "access/range",
+        "access/column",
+        "access/swizzle",
+        "convert",
+        "convert/kind",
+        "set/comprehension",
+        "matrix/comprehension",
+        "range/inclusive",
+        "range/exclusive",
+        "range/inclusive_increment",
+        "range/exclusive_increment",
+        "math/add",
+        "math/sub",
+        "math/mul",
+        "math/div",
+        "math/mod",
+        "math/pow",
+        "math/neg",
+        "math/add_assign",
+        "math/sub_assign",
+        "math/mul_assign",
+        "math/div_assign",
+        "math/add-assign",
+        "math/sub-assign",
+        "math/mul-assign",
+        "math/div-assign",
+        "math/add-assign/range",
+        "math/sub-assign/range",
+        "math/mul-assign/range",
+        "math/div-assign/range",
+        "math/add-assign/range-all",
+        "math/sub-assign/range-all",
+        "math/mul-assign/range-all",
+        "math/div-assign/range-all",
+        "compare/eq",
+        "compare/neq",
+        "compare/lt",
+        "compare/gt",
+        "compare/lte",
+        "compare/gte",
+        "logic/and",
+        "logic/or",
+        "logic/not",
+        "logic/xor",
+        "matrix/horzcat",
+        "matrix/vertcat",
+        "matrix/matmul",
+        "matrix/solve",
+        "matrix/dot",
+        "matrix/transpose",
+        "matrix/comprehension",
+        "set/element_of",
+        "set/not_element_of",
+        "set/insert",
+        "set/remove",
+        "set/cartesian_product",
+        "set/difference",
+        "set/intersection",
+        "set/powerset",
+        "set/symmetric_difference",
+        "set/union",
+        "set/disjoint",
+        "set/equals",
+        "set/not_equals",
+        "set/proper_subset",
+        "set/proper_superset",
+        "set/subset",
+        "set/superset",
+        "set/size",
+    ];
+    const PREFIXES: &[&str] = &[
+        "Assign",
+        "Access",
+        "Convert",
+        "Range",
+        "MathAdd",
+        "MathSub",
+        "MathMul",
+        "MathDiv",
+        "MathMod",
+        "MathPow",
+        "MathNegate",
+        "AddAssign",
+        "SubAssign",
+        "MulAssign",
+        "DivAssign",
+        "CompareEqual",
+        "CompareNotEqual",
+        "CompareLessThan",
+        "CompareGreaterThan",
+        "CompareLessThanEqual",
+        "CompareGreaterThanEqual",
+        "LogicAnd",
+        "LogicOr",
+        "LogicNot",
+        "LogicXor",
+        "MatrixHorzCat",
+        "MatrixVertCat",
+        "MatrixMatMul",
+        "MatrixSolve",
+        "MatrixDot",
+        "MatrixTranspose",
+        "ValueMatrixComprehension",
+        "ValueSetComprehension",
+        "SetElementOf",
+        "SetNotElementOf",
+        "SetInsert",
+        "SetRemove",
+        "SetCartesianProduct",
+        "SetDifference",
+        "SetIntersection",
+        "SetPowerset",
+        "SetSymmetricDifference",
+        "SetUnion",
+        "SetDisjoint",
+        "SetEquals",
+        "SetNotEquals",
+        "SetProperSubset",
+        "SetProperSuperset",
+        "SetSubset",
+        "SetSuperset",
+        "SetSize",
+        "Table",
+    ];
+    EXACT.contains(&name) || PREFIXES.iter().any(|prefix| name.starts_with(prefix))
+}
+
+fn module_export_for_name(name: &str) -> Option<(&'static str, &'static str)> {
+    let exact = match name {
+        "math/sin" => Some(("math", "sin")),
+        "math/cos" => Some(("math", "cos")),
+        "math/tan" => Some(("math", "tan")),
+        "math/asin" => Some(("math", "asin")),
+        "math/acos" => Some(("math", "acos")),
+        "math/atan" => Some(("math", "atan")),
+        "math/atan2" => Some(("math", "atan2")),
+        "math/sinh" => Some(("math", "sinh")),
+        "math/cosh" => Some(("math", "cosh")),
+        "math/tanh" => Some(("math", "tanh")),
+        "math/asinh" => Some(("math", "asinh")),
+        "math/acosh" => Some(("math", "acosh")),
+        "math/atanh" => Some(("math", "atanh")),
+        "math/cot" => Some(("math", "cot")),
+        "math/sec" => Some(("math", "sec")),
+        "math/csc" => Some(("math", "csc")),
+        "math/acot" => Some(("math", "acot")),
+        "math/asec" => Some(("math", "asec")),
+        "math/acsc" => Some(("math", "acsc")),
+        "math/sqrt" => Some(("math", "sqrt")),
+        "stats/sum" => Some(("stats", "sum")),
+        "io/print" => Some(("io", "print")),
+        "io/println" => Some(("io", "println")),
+        "string/concat" => Some(("string", "concat")),
+        "combinatorics/n_choose_k" | "combinatorics/n-choose-k" => {
+            Some(("combinatorics", "n_choose_k"))
+        }
+        "MathSin" => Some(("math", "sin")),
+        "MathCos" => Some(("math", "cos")),
+        "MathTan" => Some(("math", "tan")),
+        "MathAsin" => Some(("math", "asin")),
+        "MathAcos" => Some(("math", "acos")),
+        "MathAtan" => Some(("math", "atan")),
+        "MathAtan2" => Some(("math", "atan2")),
+        "MathSinh" => Some(("math", "sinh")),
+        "MathCosh" => Some(("math", "cosh")),
+        "MathTanh" => Some(("math", "tanh")),
+        "MathAsinh" => Some(("math", "asinh")),
+        "MathAcosh" => Some(("math", "acosh")),
+        "MathAtanh" => Some(("math", "atanh")),
+        "MathCot" => Some(("math", "cot")),
+        "MathSec" => Some(("math", "sec")),
+        "MathCsc" => Some(("math", "csc")),
+        "MathAcot" => Some(("math", "acot")),
+        "MathAsec" => Some(("math", "asec")),
+        "MathAcsc" => Some(("math", "acsc")),
+        "MathSqrt" => Some(("math", "sqrt")),
+        _ => None,
+    };
+    if exact.is_some() {
+        return exact;
+    }
+    const MATH_PREFIXES: &[(&str, (&str, &str))] = &[
+        ("MathAtan2", ("math", "atan2")),
+        ("MathAsinh", ("math", "asinh")),
+        ("MathAcosh", ("math", "acosh")),
+        ("MathAtanh", ("math", "atanh")),
+        ("MathSinh", ("math", "sinh")),
+        ("MathCosh", ("math", "cosh")),
+        ("MathTanh", ("math", "tanh")),
+        ("MathAcot", ("math", "acot")),
+        ("MathAsec", ("math", "asec")),
+        ("MathAcsc", ("math", "acsc")),
+        ("MathAsin", ("math", "asin")),
+        ("MathAcos", ("math", "acos")),
+        ("MathAtan", ("math", "atan")),
+        ("MathSin", ("math", "sin")),
+        ("MathCos", ("math", "cos")),
+        ("MathTan", ("math", "tan")),
+        ("MathCot", ("math", "cot")),
+        ("MathSec", ("math", "sec")),
+        ("MathCsc", ("math", "csc")),
+        ("MathSqrt", ("math", "sqrt")),
+    ];
+    MATH_PREFIXES
+        .iter()
+        .find(|(prefix, _)| name.starts_with(prefix))
+        .map(|(_, export)| *export)
+}
+
+fn canonical_qualified_name(module: &str, export: &str) -> String {
+    format!("{module}/{export}")
+}
+
+pub fn load_prelude(fxns: &mut Functions) {
+    for fxn_desc in inventory::iter::<FunctionDescriptor> {
+        if is_prelude_name(fxn_desc.name) {
+            fxns.insert_function(fxn_desc.clone());
+        }
+    }
+    for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
+        if is_prelude_name(fxn_comp.name) {
+            fxns.insert_function_compiler(
+                fxn_comp.name,
+                Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)),
+            );
+        }
+    }
+}
+
+pub fn load_module(fxns: &mut Functions, module: &str) -> MResult<ModuleExports> {
+    let exports = public_exports(module).ok_or_else(|| {
+        MechError::new(
+            MissingFunctionError {
+                function_id: hash_str(module),
+            },
+            None,
+        )
+        .with_compiler_loc()
+    })?;
+    for fxn_desc in inventory::iter::<FunctionDescriptor> {
+        if let Some((desc_module, desc_export)) = module_export_for_name(fxn_desc.name) {
+            if desc_module == exports.module {
+                fxns.functions.insert(hash_str(fxn_desc.name), fxn_desc.ptr);
+                fxns.dictionary
+                    .borrow_mut()
+                    .insert(hash_str(fxn_desc.name), fxn_desc.name.to_string());
+                let qualified = canonical_qualified_name(desc_module, desc_export);
+                fxns.functions.insert(hash_str(&qualified), fxn_desc.ptr);
+                fxns.dictionary
+                    .borrow_mut()
+                    .insert(hash_str(&qualified), qualified);
+            }
+        }
+    }
+    for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
+        if let Some((desc_module, desc_export)) = module_export_for_name(fxn_comp.name) {
+            if desc_module == exports.module {
+                let qualified = canonical_qualified_name(desc_module, desc_export);
+                fxns.insert_function_compiler(
+                    qualified,
+                    Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)),
+                );
+            }
+        }
+    }
+    Ok(exports)
+}
+
+pub fn import_module_qualified(fxns: &mut Functions, module: &str) -> MResult<ModuleExports> {
+    load_module(fxns, module)
+}
+
+pub fn import_module_item(fxns: &mut Functions, module: &str, item: &str) -> MResult<()> {
+    let exports = load_module(fxns, module)?;
+    if !exports.exports.contains(&item) {
+        return Err(MechError::new(
+            MissingFunctionError {
+                function_id: hash_str(&format!("{module}/{item}")),
+            },
+            None,
+        )
+        .with_compiler_loc());
+    }
+    alias_module_item(fxns, module, item)
+}
+
+pub fn import_module_glob(fxns: &mut Functions, module: &str) -> MResult<()> {
+    let exports = load_module(fxns, module)?;
+    for item in exports.exports.iter() {
+        alias_module_item(fxns, module, item)?;
+    }
+    Ok(())
+}
+
+fn alias_module_item(fxns: &mut Functions, module: &str, item: &str) -> MResult<()> {
+    let qualified_name = format!("{module}/{item}");
+    let qualified_id = hash_str(&qualified_name);
+    let local_id = hash_str(item);
+    let mut found = false;
+
+    if let Some(ptr) = fxns.function_compilers.get(&qualified_id).cloned() {
+        fxns.function_compilers.insert(local_id, ptr);
+        fxns.dictionary
+            .borrow_mut()
+            .insert(local_id, item.to_string());
+        found = true;
+    }
+
+    if let Some(ptr) = fxns.functions.get(&qualified_id).copied() {
+        fxns.functions.insert(local_id, ptr);
+        fxns.dictionary
+            .borrow_mut()
+            .insert(local_id, item.to_string());
+        found = true;
+    }
+
+    if found {
+        Ok(())
+    } else {
+        Err(MechError::new(
+            MissingFunctionError {
+                function_id: qualified_id,
+            },
+            None,
+        )
+        .with_compiler_loc())
+    }
+}

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -92,7 +92,7 @@ impl Interpreter {
       state.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
     }
     #[cfg(feature = "functions")]
-    load_stdlib(&mut state.functions.borrow_mut());
+    load_prelude(&mut state.functions.borrow_mut());
     Self {
       id,
       ip: 0,
@@ -125,6 +125,18 @@ impl Interpreter {
 
   pub fn default() -> Self {
     Self::new(0, 10_000)
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn new_with_full_stdlib(id: u64) -> Self {
+    Self::new_with_full_stdlib_steps(id, 10_000)
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn new_with_full_stdlib_steps(id: u64, max_steps: usize) -> Self {
+    let intrp = Self::new(id, max_steps);
+    load_stdlib(&mut intrp.functions().borrow_mut());
+    intrp
   }
 
   #[cfg(feature = "symbol_table")]

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -95,6 +95,8 @@ use indexmap::set::IndexSet;
 use na::DMatrix;
 use std::time::Duration;
 
+#[cfg(feature = "functions")]
+pub mod builtins;
 pub mod expressions;
 #[cfg(feature = "functions")]
 pub mod functions;
@@ -111,6 +113,8 @@ pub mod tracing;
 
 pub use mech_core::*;
 
+#[cfg(feature = "functions")]
+pub use crate::builtins::*;
 pub use crate::expressions::*;
 #[cfg(feature = "functions")]
 pub use crate::functions::*;
@@ -194,8 +198,7 @@ pub fn load_stdlib(fxns: &mut Functions) {
   }
 
   for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
-    fxns.function_compilers
-      .insert(hash_str(fxn_comp.name), Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)));
+    fxns.insert_function_compiler(fxn_comp.name, Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)));
   }
 }
 

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -288,10 +288,34 @@ pub fn comment(cmmt: &Comment, p: &Interpreter) -> MResult<Value> {
   Ok(Value::Empty)
 }
 
+#[cfg(feature = "functions")]
+pub fn module_import_runtime(import: &ModuleImport, p: &Interpreter) -> MResult<Value> {
+  let module = import.module.to_string();
+  match import.kind {
+    ModuleImportKind::Module => {
+      load_module(&mut p.functions().borrow_mut(), &module)?;
+      Ok(Value::Empty)
+    }
+    ModuleImportKind::Item => {
+      let item = import.item.as_ref().ok_or_else(|| {
+        MechError::new(MissingFunctionError { function_id: hash_str(&module) }, None).with_compiler_loc()
+      })?.to_string();
+      import_module_item(&mut p.functions().borrow_mut(), &module, &item)?;
+      Ok(Value::Empty)
+    }
+    ModuleImportKind::Glob => {
+      import_module_glob(&mut p.functions().borrow_mut(), &module)?;
+      Ok(Value::Empty)
+    }
+  }
+}
+
 pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
   let out = match &code {
     MechCode::Expression(expr) => expression(&expr, None, p),
     MechCode::Statement(stmt) => statement(&stmt, None, p),
+    #[cfg(feature = "functions")]
+    MechCode::Import(import) => module_import_runtime(import, p),
     #[cfg(feature = "state_machines")]
     MechCode::FsmSpecification(fsm_spec) => {
       crate::state_machines::register_fsm_specification(fsm_spec, p)?;

--- a/src/runtime/src/config_profile/compile.rs
+++ b/src/runtime/src/config_profile/compile.rs
@@ -27,6 +27,11 @@ impl ConfigCompiler {
                     items.push(ConfigItem::Function(self.compile_function(function)?));
                 }
                 MechCode::Statement(statement) => items.push(self.compile_statement(statement)?),
+                MechCode::Import(_) => {
+                    return Err(ConfigProfileViolation::error(
+                        "module imports are not allowed in Mech config",
+                    ));
+                }
                 MechCode::FsmSpecification(_) | MechCode::FsmImplementation(_) => {
                     return Err(ConfigProfileViolation::error(
                         "state machines are not allowed in Mech config",

--- a/src/runtime/src/resolver/imports.rs
+++ b/src/runtime/src/resolver/imports.rs
@@ -96,19 +96,17 @@ mod tests {
   }
 
   #[test]
-  fn classifies_single_import() {
+  fn stdlib_single_imports_are_not_source_imports() {
     let fenced = parse_fenced("~~~mech\n+> math/sin\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
-    assert_eq!(imports[0].specifier, "math");
-    assert_eq!(imports[0].kind, SourceImportKind::Single { name: "sin".to_string() });
+    assert!(imports.is_empty());
   }
 
   #[test]
-  fn classifies_wildcard_import() {
+  fn stdlib_wildcard_imports_are_not_source_imports() {
     let fenced = parse_fenced("~~~mech\n+> math/*\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
-    assert_eq!(imports[0].specifier, "math");
-    assert_eq!(imports[0].kind, SourceImportKind::Wildcard);
+    assert!(imports.is_empty());
   }
 
   #[test]
@@ -130,11 +128,8 @@ mod tests {
     let fenced = parse_fenced("~~~mech\n+> math\n+> math/sin\n+> math/*\n+> ./dep.mec\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
     let dependencies = import_dependencies(&imports);
-    assert_eq!(dependencies.len(), 4);
-    assert_eq!(dependencies[0].specifier, "math");
-    assert_eq!(dependencies[1].specifier, "math");
-    assert_eq!(dependencies[2].specifier, "math");
-    assert_eq!(dependencies[3].specifier, "./dep.mec");
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].specifier, "./dep.mec");
   }
 
   #[test]

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -684,6 +684,7 @@ impl Formatter {
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FunctionDefine(func_def) => self.function_define(func_def),
+        MechCode::Import(import) => self.module_import(import),
         MechCode::Statement(stmt) => self.statement(stmt),
         x => format!("{{{:?}}}", x)
       };
@@ -1544,6 +1545,7 @@ impl Formatter {
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FunctionDefine(func_def) => self.function_define(func_def),
+        MechCode::Import(import) => self.module_import(import),
         MechCode::Statement(stmt) => self.statement(stmt),
         MechCode::Error(token, range) => {
           if self.html {
@@ -1848,6 +1850,14 @@ impl Formatter {
       </div>"#,name,input,output,states)
     } else {
       format!("#{}({}){} {}\n{}", name, input, output, ":=", states)
+    }
+  }
+
+  pub fn module_import(&mut self, node: &ModuleImport) -> String {
+    match node.kind {
+      ModuleImportKind::Module => format!("+> {}", node.module.to_string()),
+      ModuleImportKind::Item => format!("+> {}/{}", node.module.to_string(), node.item.as_ref().unwrap().to_string()),
+      ModuleImportKind::Glob => format!("+> {}/*", node.module.to_string()),
     }
   }
 

--- a/src/syntax/src/imports.rs
+++ b/src/syntax/src/imports.rs
@@ -1,0 +1,93 @@
+#[macro_use]
+use crate::*;
+fn identifier_from_part(part: &str, range: SourceRange) -> Identifier {
+    Identifier {
+        name: Token {
+            kind: TokenKind::Identifier,
+            chars: part.chars().collect(),
+            src_range: range,
+        },
+    }
+}
+
+pub fn module_import(input: ParseString) -> ParseResult<ModuleImport> {
+    let original = input.clone();
+    let (input, _) = whitespace0(input)?;
+    let (input, _) = plus(input)?;
+    let (input, _) = right_angle(input)?;
+    let (input, _) = many0(space_tab)(input)?;
+    let start = input.loc();
+    let (input, raw_token) = skip_till_eol(input)?;
+    let raw = raw_token.to_string();
+    let path = raw.trim();
+
+    // Legacy file imports such as `+> ./dep.mec` remain statement imports.
+    if path.starts_with('.') || path.contains('.') {
+        return Err(nom::Err::Error(ParseError::new(
+            original,
+            "not a stdlib module import",
+        )));
+    }
+
+    let parts: Vec<&str> = path.split('/').collect();
+    let end = input.loc();
+    let range = SourceRange { start, end };
+
+    if path.is_empty() || parts.is_empty() || parts.len() > 2 {
+        return Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid module import path",
+        )));
+    }
+
+    let module = parts[0].trim();
+    if module.is_empty() || module == "*" {
+        return Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid module import module",
+        )));
+    }
+
+    let module = identifier_from_part(module, range.clone());
+    match parts.as_slice() {
+        [_] => Ok((
+            input,
+            ModuleImport {
+                module,
+                item: None,
+                kind: ModuleImportKind::Module,
+            },
+        )),
+        [_, item] => {
+            let item = item.trim();
+            if item.is_empty() {
+                return Err(nom::Err::Failure(ParseError::new(
+                    input,
+                    "Invalid empty module import item",
+                )));
+            }
+            if item == "*" {
+                return Ok((
+                    input,
+                    ModuleImport {
+                        module,
+                        item: None,
+                        kind: ModuleImportKind::Glob,
+                    },
+                ));
+            }
+            Ok((
+                input,
+                ModuleImport {
+                    module,
+                    item: Some(identifier_from_part(item, range)),
+                    kind: ModuleImportKind::Item,
+                },
+            ))
+        }
+        _ => Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid module import path",
+        ))),
+    }
+}

--- a/src/syntax/src/lib.rs
+++ b/src/syntax/src/lib.rs
@@ -41,6 +41,7 @@ use colored::*;
 
 //#[cfg(feature = "mechdown")]
 pub mod mechdown;
+pub mod imports;
 pub mod expressions;
 pub mod statements;
 pub mod structures;
@@ -57,6 +58,7 @@ pub mod state_machines;
 pub mod functions;
 pub mod repl;
 
+pub use crate::imports::*;
 pub use crate::parser::*;
 //#[cfg(feature = "mechdown")]
 pub use crate::mechdown::*;

--- a/src/syntax/src/parser.rs
+++ b/src/syntax/src/parser.rs
@@ -325,6 +325,7 @@ pub fn mech_code_alt(input: ParseString) -> ParseResult<MechCode> {
     ("fsm_specification", Box::new(|i| fsm_specification(i).map(|(i, v)| (i, MechCode::FsmSpecification(v))))),
     ("fsm_implementation", Box::new(|i| fsm_implementation(i).map(|(i, v)| (i, MechCode::FsmImplementation(v))))),
     ("function_define", Box::new(|i| function_define(i).map(|(i, v)| (i, MechCode::FunctionDefine(v))))),
+    ("module_import", Box::new(|i| module_import(i).map(|(i, v)| (i, MechCode::Import(v))))),
     ("statement",   Box::new(|i| statement(i).map(|(i, v)| (i, MechCode::Statement(v))))),
     ("expression",  Box::new(|i| expression(i).map(|(i, v)| (i, MechCode::Expression(v))))),
     ("comment",     Box::new(|i| comment(i).map(|(i, v)| (i, MechCode::Comment(v))))),

--- a/src/syntax/tests/module_imports.rs
+++ b/src/syntax/tests/module_imports.rs
@@ -1,0 +1,42 @@
+use mech_core::nodes::*;
+use mech_syntax::parser;
+
+fn imports(src: &str) -> Vec<ModuleImport> {
+    let program = parser::parse(src).expect("parse failed");
+    let mut out = vec![];
+    for section in &program.body.sections {
+        for element in &section.elements {
+            if let SectionElement::MechCode(codes) = element {
+                for (node, _) in codes {
+                    if let MechCode::Import(import) = node {
+                        out.push(import.clone());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn parses_module_item_and_glob_imports() {
+    let parsed = imports("+> math\n+> math/sin\n+> math/*");
+    assert_eq!(parsed.len(), 3);
+    assert_eq!(parsed[0].kind, ModuleImportKind::Module);
+    assert_eq!(parsed[0].module.to_string(), "math");
+    assert!(parsed[0].item.is_none());
+    assert_eq!(parsed[1].kind, ModuleImportKind::Item);
+    assert_eq!(parsed[1].module.to_string(), "math");
+    assert_eq!(parsed[1].item.as_ref().unwrap().to_string(), "sin");
+    assert_eq!(parsed[2].kind, ModuleImportKind::Glob);
+    assert_eq!(parsed[2].module.to_string(), "math");
+    assert!(parsed[2].item.is_none());
+}
+
+#[test]
+fn rejects_invalid_stdlib_import_paths() {
+    assert!(parser::parse("+> ").is_err());
+    assert!(parser::parse("+> */x").is_err());
+    assert!(parser::parse("+> math/").is_err());
+    assert!(parser::parse("+> math/*/x").is_err());
+}

--- a/tests/lazy_stdlib.rs
+++ b/tests/lazy_stdlib.rs
@@ -1,0 +1,44 @@
+use mech::program::{MechProgram, MechProgramConfig};
+
+fn run(source: &str) -> bool {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program.run_string(source).is_ok()
+}
+
+#[test]
+fn prelude_operators_work_without_imports() {
+    assert!(run("x := 1 + 1\ny := 1 > 2\nz := true && false"));
+}
+
+#[test]
+fn set_operators_work_without_imports() {
+    assert!(run("a := {1, 2}\nb := {2, 3}\nc := a ∪ b"));
+}
+
+#[test]
+fn matrix_operators_work_without_imports() {
+    assert!(run("a := [1 2]\nb := [3 4]\nc := a · b"));
+}
+
+#[test]
+fn named_math_functions_fail_without_imports() {
+    assert!(!run("x := sin(1.23)"));
+    assert!(!run("x := math/sin(1.23)"));
+}
+
+#[test]
+fn qualified_module_import_enables_only_qualified_calls() {
+    assert!(run("+> math\nx := math/sin(1.23)"));
+    assert!(!run("+> math\nx := sin(1.23)"));
+}
+
+#[test]
+fn item_import_enables_only_that_unqualified_item() {
+    assert!(run("+> math/sin\nx := sin(1.23)"));
+    assert!(!run("+> math/sin\nx := cos(1.23)"));
+}
+
+#[test]
+fn glob_import_enables_all_module_exports_unqualified() {
+    assert!(run("+> math/*\nx := sin(1.23)\ny := cos(1.23)"));
+}


### PR DESCRIPTION
### Motivation
- Reduce startup cost and separate core operator registration from named stdlib functions so builtin operators remain available without eagerly registering every stdlib descriptor.
- Provide a clear registration boundary so modules can be loaded on-demand via source-level import directives (`+> ...`).

### Description
- Add a new interpreter builtin policy in `src/interpreter/src/builtins.rs` that defines `ModuleExports`, `is_prelude_name`, `module_export_for_name`, `canonical_qualified_name`, `load_prelude`, `load_module`, `import_module_qualified`, `import_module_item`, and `import_module_glob`, plus aliasing logic that copies function table entries (no implementation duplication). 
- Change interpreter startup to call `load_prelude(&mut state.functions.borrow_mut())` by default and add `Interpreter::new_with_full_stdlib[_steps]` to restore the legacy eager `load_stdlib` behavior; expose the builtins module under the `functions` feature. 
- Add AST and parser support for module imports (`ModuleImport`, `ModuleImportKind`, `MechCode::Import`), implement `module_import` parser under `src/syntax/src/imports.rs`, wire it into `mech_code_alt`, and add formatter support for imports. 
- Add runtime handling that dispatches `MechCode::Import` to `module_import_runtime` which calls the appropriate `builtins` APIs to load a module, import a single named item (aliasing the qualified name to an unqualified name), or import all public exports (glob). 
- Adjust resolver/formatter/config code so stdlib module import directives are parsed as stdlib imports (not treated as source dependency imports), and reject module imports in Mech config profiles. 
- Tests and small helpers: new parser and interpreter tests were added to validate import parsing, prelude operator availability without imports, failing behavior before imports, and correct behavior for `+> module`, `+> module/item`, and `+> module/*`.

### Testing
- Ran `cargo check -p mech-interpreter` and `cargo check -p mech-interpreter --no-default-features`; both completed successfully. 
- Ran parser unit tests `cargo test -p mech-syntax --test module_imports`; tests passed. 
- Ran interpreter integration tests `cargo test --test lazy_stdlib`; tests passed and validated prelude, missing-named-functions, qualified/item/glob import behavior. 
- Ran runtime resolver tests `cargo test -p mech-runtime resolver::imports`; tests passed verifying resolver treats stdlib imports as non-source imports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e0689388832a9044c7ba88089329)