### PR TITLE
Support stdlib module imports (+> ...) and lazy stdlib loading

### DIFF
--- a/examples/working/ekf.mec
+++ b/examples/working/ekf.mec
@@ -1,6 +1,7 @@
 Extended Kalman Filter State Estimation
 ===============================================================================
 section: Examples
++> math
 ===============================================================================
 
 %% The Extended Kalman Filter (EKF) is a mathematical algorithm used for estimating the state of a dynamic system from noisy measurements. It is an extension of the Kalman Filter that can handle non-linear systems by linearizing them around the current estimate. Unlike a Kalman Filter, which depends on linear dynamics and Gaussian noise, the EKF can be applied to a wider range of problems, including those with non-linear dynamics and non-Gaussian noise. Therefore, an EKF can be used to estimate the state of systems with inherently nonlinear dynamics, like a mobile robot with noisy sensor measurements. In this program we will introduce the Kalman Filter by deriving it and showing why it can't be used even for the simplest of robots. Then we will show how to relax the linear and Gaussian assumptions to derive the EKF. Finally, we will implement the EKF to estimate the state of a simple robot moving on a 2D plane, using noisy measurements from a camera.

--- a/examples/working/n-body.mec
+++ b/examples/working/n-body.mec
@@ -1,6 +1,8 @@
 N-Body Simulation
 ===============================================================================
 section: Examples
++> combinatorics
++> stats
 ===============================================================================
 
 The program simulates the gravitational interactions between celestial bodies using numerical methods.

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -808,12 +808,41 @@ impl MDList {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ModuleImportKind {
+  Module,
+  Item,
+  Glob,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ModuleImport {
+  pub module: Identifier,
+  pub item: Option<Vec<Identifier>>,
+  pub kind: ModuleImportKind,
+}
+
+impl ModuleImport {
+  pub fn tokens(&self) -> Vec<Token> {
+    let mut tokens = self.module.tokens();
+    if let Some(item_path) = &self.item {
+      for item in item_path {
+        tokens.append(&mut item.tokens());
+      }
+    }
+    tokens
+  }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MechCode {
   Comment(Comment),
   Expression(Expression),
   FsmImplementation(FsmImplementation),
   FsmSpecification(FsmSpecification),
   FunctionDefine(FunctionDefine),
+  Import(ModuleImport),
   Statement(Statement),
   Error(Token, SourceRange),
 }
@@ -833,6 +862,7 @@ impl MechCode {
       MechCode::FsmSpecification(x) => x.tokens(),
       MechCode::FsmImplementation(x) => x.tokens(),
       MechCode::FunctionDefine(_) => vec![],
+      MechCode::Import(x) => x.tokens(),
       MechCode::Error(t,_) => vec![t.clone()],
     }
   }

--- a/src/interpreter/src/builtins.rs
+++ b/src/interpreter/src/builtins.rs
@@ -1,0 +1,389 @@
+use crate::*;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct ModuleExports {
+    pub module: &'static str,
+    pub exports: Vec<&'static str>,
+}
+
+const MATH_EXPORTS: &[&str] = &[
+    "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh", "tanh", "asinh", "acosh",
+    "atanh", "cot", "sec", "csc", "acot", "asec", "acsc", "sqrt", "abs",
+];
+const STATS_EXPORTS: &[&str] = &["sum/column", "sum/row"];
+const IO_EXPORTS: &[&str] = &["print", "println"];
+const STRING_EXPORTS: &[&str] = &["concat"];
+const COMBINATORICS_EXPORTS: &[&str] = &["n-choose-k"];
+
+fn public_exports(module: &str) -> Option<ModuleExports> {
+    match module {
+        "math" => Some(ModuleExports {
+            module: "math",
+            exports: MATH_EXPORTS.to_vec(),
+        }),
+        "stats" => Some(ModuleExports {
+            module: "stats",
+            exports: STATS_EXPORTS.to_vec(),
+        }),
+        "io" => Some(ModuleExports {
+            module: "io",
+            exports: IO_EXPORTS.to_vec(),
+        }),
+        "string" => Some(ModuleExports {
+            module: "string",
+            exports: STRING_EXPORTS.to_vec(),
+        }),
+        "combinatorics" => Some(ModuleExports {
+            module: "combinatorics",
+            exports: COMBINATORICS_EXPORTS.to_vec(),
+        }),
+        _ => None,
+    }
+}
+
+fn is_prelude_name(name: &str) -> bool {
+    const EXACT: &[&str] = &[
+        "assign",
+        "assign/value",
+        "assign/column",
+        "assign/add",
+        "assign/sub",
+        "assign/mul",
+        "assign/div",
+        "access/scalar",
+        "access/range",
+        "access/column",
+        "access/swizzle",
+        "convert",
+        "convert/kind",
+        "set/comprehension",
+        "matrix/comprehension",
+        "range/inclusive",
+        "range/exclusive",
+        "range/inclusive_increment",
+        "range/exclusive_increment",
+        "math/add",
+        "math/sub",
+        "math/mul",
+        "math/div",
+        "math/mod",
+        "math/pow",
+        "math/neg",
+        "math/add_assign",
+        "math/sub_assign",
+        "math/mul_assign",
+        "math/div_assign",
+        "math/add-assign",
+        "math/sub-assign",
+        "math/mul-assign",
+        "math/div-assign",
+        "math/add-assign/range",
+        "math/sub-assign/range",
+        "math/mul-assign/range",
+        "math/div-assign/range",
+        "math/add-assign/range-all",
+        "math/sub-assign/range-all",
+        "math/mul-assign/range-all",
+        "math/div-assign/range-all",
+        "compare/eq",
+        "compare/neq",
+        "compare/lt",
+        "compare/gt",
+        "compare/lte",
+        "compare/gte",
+        "logic/and",
+        "logic/or",
+        "logic/not",
+        "logic/xor",
+        "matrix/horzcat",
+        "matrix/vertcat",
+        "matrix/matmul",
+        "matrix/solve",
+        "matrix/dot",
+        "matrix/transpose",
+        "matrix/comprehension",
+        "set/element_of",
+        "set/not_element_of",
+        "set/insert",
+        "set/remove",
+        "set/cartesian_product",
+        "set/difference",
+        "set/intersection",
+        "set/powerset",
+        "set/symmetric_difference",
+        "set/union",
+        "set/disjoint",
+        "set/equals",
+        "set/not_equals",
+        "set/proper_subset",
+        "set/proper_superset",
+        "set/subset",
+        "set/superset",
+        "set/size",
+    ];
+    const PREFIXES: &[&str] = &[
+        "Assign",
+        "Access",
+        "Convert",
+        "Range",
+        "MathAdd",
+        "MathSub",
+        "MathMul",
+        "MathDiv",
+        "MathMod",
+        "MathPow",
+        "MathNegate",
+        "AddAssign",
+        "SubAssign",
+        "MulAssign",
+        "DivAssign",
+        "CompareEqual",
+        "CompareNotEqual",
+        "CompareLessThan",
+        "CompareGreaterThan",
+        "CompareLessThanEqual",
+        "CompareGreaterThanEqual",
+        "LogicAnd",
+        "LogicOr",
+        "LogicNot",
+        "LogicXor",
+        "MatrixHorzCat",
+        "MatrixVertCat",
+        "MatrixMatMul",
+        "MatrixSolve",
+        "MatrixDot",
+        "MatrixTranspose",
+        "ValueMatrixComprehension",
+        "ValueSetComprehension",
+        "SetElementOf",
+        "SetNotElementOf",
+        "SetInsert",
+        "SetRemove",
+        "SetCartesianProduct",
+        "SetDifference",
+        "SetIntersection",
+        "SetPowerset",
+        "SetSymmetricDifference",
+        "SetUnion",
+        "SetDisjoint",
+        "SetEquals",
+        "SetNotEquals",
+        "SetProperSubset",
+        "SetProperSuperset",
+        "SetSubset",
+        "SetSuperset",
+        "SetSize",
+        "Table",
+    ];
+    EXACT.contains(&name) || PREFIXES.iter().any(|prefix| name.starts_with(prefix))
+}
+
+fn module_export_for_name(name: &str) -> Option<(&'static str, &'static str)> {
+    let exact = match name {
+        "math/sin" => Some(("math", "sin")),
+        "math/cos" => Some(("math", "cos")),
+        "math/tan" => Some(("math", "tan")),
+        "math/asin" => Some(("math", "asin")),
+        "math/acos" => Some(("math", "acos")),
+        "math/atan" => Some(("math", "atan")),
+        "math/atan2" => Some(("math", "atan2")),
+        "math/sinh" => Some(("math", "sinh")),
+        "math/cosh" => Some(("math", "cosh")),
+        "math/tanh" => Some(("math", "tanh")),
+        "math/asinh" => Some(("math", "asinh")),
+        "math/acosh" => Some(("math", "acosh")),
+        "math/atanh" => Some(("math", "atanh")),
+        "math/cot" => Some(("math", "cot")),
+        "math/sec" => Some(("math", "sec")),
+        "math/csc" => Some(("math", "csc")),
+        "math/acot" => Some(("math", "acot")),
+        "math/asec" => Some(("math", "asec")),
+        "math/acsc" => Some(("math", "acsc")),
+        "math/sqrt" => Some(("math", "sqrt")),
+        "math/abs" => Some(("math", "abs")),
+        "stats/sum/column" => Some(("stats", "sum/column")),
+        "stats/sum/row" => Some(("stats", "sum/row")),
+        "io/print" => Some(("io", "print")),
+        "io/println" => Some(("io", "println")),
+        "string/concat" => Some(("string", "concat")),
+        "combinatorics/n_choose_k" => Some(("combinatorics", "n-choose-k")),
+        "combinatorics/n-choose-k" => Some(("combinatorics", "n-choose-k")),
+        "StatsSumColumn" => Some(("stats", "sum/column")),
+        "StatsSumRow" => Some(("stats", "sum/row")),
+        "MathSin" => Some(("math", "sin")),
+        "MathCos" => Some(("math", "cos")),
+        "MathTan" => Some(("math", "tan")),
+        "MathAsin" => Some(("math", "asin")),
+        "MathAcos" => Some(("math", "acos")),
+        "MathAtan" => Some(("math", "atan")),
+        "MathAtan2" => Some(("math", "atan2")),
+        "MathSinh" => Some(("math", "sinh")),
+        "MathCosh" => Some(("math", "cosh")),
+        "MathTanh" => Some(("math", "tanh")),
+        "MathAsinh" => Some(("math", "asinh")),
+        "MathAcosh" => Some(("math", "acosh")),
+        "MathAtanh" => Some(("math", "atanh")),
+        "MathCot" => Some(("math", "cot")),
+        "MathSec" => Some(("math", "sec")),
+        "MathCsc" => Some(("math", "csc")),
+        "MathAcot" => Some(("math", "acot")),
+        "MathAsec" => Some(("math", "asec")),
+        "MathAcsc" => Some(("math", "acsc")),
+        "MathSqrt" => Some(("math", "sqrt")),
+        "MathAbs" => Some(("math", "abs")),
+        _ => None,
+    };
+    if exact.is_some() {
+        return exact;
+    }
+    if name.starts_with("StatsSumColumn") {
+        return Some(("stats", "sum/column"));
+    }
+    if name.starts_with("StatsSumRow") {
+        return Some(("stats", "sum/row"));
+    }
+    const MATH_PREFIXES: &[(&str, (&str, &str))] = &[
+        ("MathAtan2", ("math", "atan2")),
+        ("MathAsinh", ("math", "asinh")),
+        ("MathAcosh", ("math", "acosh")),
+        ("MathAtanh", ("math", "atanh")),
+        ("MathSinh", ("math", "sinh")),
+        ("MathCosh", ("math", "cosh")),
+        ("MathTanh", ("math", "tanh")),
+        ("MathAcot", ("math", "acot")),
+        ("MathAsec", ("math", "asec")),
+        ("MathAcsc", ("math", "acsc")),
+        ("MathAsin", ("math", "asin")),
+        ("MathAcos", ("math", "acos")),
+        ("MathAtan", ("math", "atan")),
+        ("MathSin", ("math", "sin")),
+        ("MathCos", ("math", "cos")),
+        ("MathTan", ("math", "tan")),
+        ("MathCot", ("math", "cot")),
+        ("MathSec", ("math", "sec")),
+        ("MathCsc", ("math", "csc")),
+        ("MathSqrt", ("math", "sqrt")),
+        ("MathAbs", ("math", "abs")),
+    ];
+    MATH_PREFIXES
+        .iter()
+        .find(|(prefix, _)| name.starts_with(prefix))
+        .map(|(_, export)| *export)
+}
+
+fn canonical_qualified_name(module: &str, export: &str) -> String {
+    format!("{module}/{export}")
+}
+
+pub fn load_prelude(fxns: &mut Functions) {
+    for fxn_desc in inventory::iter::<FunctionDescriptor> {
+        if is_prelude_name(fxn_desc.name) {
+            fxns.insert_function(fxn_desc.clone());
+        }
+    }
+    for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
+        if is_prelude_name(fxn_comp.name) {
+            fxns.insert_function_compiler(
+                fxn_comp.name,
+                Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)),
+            );
+        }
+    }
+}
+
+pub fn load_module(fxns: &mut Functions, module: &str) -> MResult<ModuleExports> {
+    let exports = public_exports(module).ok_or_else(|| {
+        MechError::new(
+            MissingFunctionError {
+                function_id: hash_str(module),
+            },
+            None,
+        )
+        .with_compiler_loc()
+    })?;
+    for fxn_desc in inventory::iter::<FunctionDescriptor> {
+        if let Some((desc_module, desc_export)) = module_export_for_name(fxn_desc.name) {
+            if desc_module == exports.module {
+                fxns.functions.insert(hash_str(fxn_desc.name), fxn_desc.ptr);
+                fxns.dictionary
+                    .borrow_mut()
+                    .insert(hash_str(fxn_desc.name), fxn_desc.name.to_string());
+            }
+        }
+    }
+    for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
+        if let Some((desc_module, desc_export)) = module_export_for_name(fxn_comp.name) {
+            if desc_module == exports.module {
+                let qualified = canonical_qualified_name(desc_module, desc_export);
+                fxns.insert_function_compiler(
+                    qualified,
+                    Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)),
+                );
+            }
+        }
+    }
+    Ok(exports)
+}
+
+pub fn import_module_qualified(fxns: &mut Functions, module: &str) -> MResult<ModuleExports> {
+    load_module(fxns, module)
+}
+
+pub fn import_module_item(fxns: &mut Functions, module: &str, item: &str) -> MResult<()> {
+    let exports = load_module(fxns, module)?;
+    if !exports.exports.contains(&item) {
+        return Err(MechError::new(
+            MissingFunctionError {
+                function_id: hash_str(&format!("{module}/{item}")),
+            },
+            None,
+        )
+        .with_compiler_loc());
+    }
+    alias_module_item(fxns, module, item)
+}
+
+pub fn import_module_glob(fxns: &mut Functions, module: &str) -> MResult<()> {
+    let exports = load_module(fxns, module)?;
+    for item in exports.exports.iter() {
+        alias_module_item(fxns, module, item)?;
+    }
+    Ok(())
+}
+
+fn alias_module_item(fxns: &mut Functions, module: &str, item: &str) -> MResult<()> {
+    let qualified_name = format!("{module}/{item}");
+    let qualified_id = hash_str(&qualified_name);
+    let local_name = item.rsplit('/').next().unwrap_or(item);
+    let local_id = hash_str(local_name);
+    let mut found = false;
+
+    if let Some(ptr) = fxns.function_compilers.get(&qualified_id).cloned() {
+        fxns.function_compilers.insert(local_id, ptr);
+        fxns.dictionary
+            .borrow_mut()
+            .insert(local_id, local_name.to_string());
+        found = true;
+    }
+
+    if let Some(ptr) = fxns.functions.get(&qualified_id).copied() {
+        fxns.functions.insert(local_id, ptr);
+        fxns.dictionary
+            .borrow_mut()
+            .insert(local_id, local_name.to_string());
+        found = true;
+    }
+
+    if found {
+        Ok(())
+    } else {
+        Err(MechError::new(
+            MissingFunctionError {
+                function_id: qualified_id,
+            },
+            None,
+        )
+        .with_compiler_loc())
+    }
+}

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -92,7 +92,7 @@ impl Interpreter {
       state.dictionary.borrow_mut().insert(ans_id, "ans".to_string());
     }
     #[cfg(feature = "functions")]
-    load_stdlib(&mut state.functions.borrow_mut());
+    load_prelude(&mut state.functions.borrow_mut());
     Self {
       id,
       ip: 0,
@@ -125,6 +125,18 @@ impl Interpreter {
 
   pub fn default() -> Self {
     Self::new(0, 10_000)
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn new_with_full_stdlib(id: u64) -> Self {
+    Self::new_with_full_stdlib_steps(id, 10_000)
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn new_with_full_stdlib_steps(id: u64, max_steps: usize) -> Self {
+    let intrp = Self::new(id, max_steps);
+    load_stdlib(&mut intrp.functions().borrow_mut());
+    intrp
   }
 
   #[cfg(feature = "symbol_table")]

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -95,6 +95,8 @@ use indexmap::set::IndexSet;
 use na::DMatrix;
 use std::time::Duration;
 
+#[cfg(feature = "functions")]
+pub mod builtins;
 pub mod expressions;
 #[cfg(feature = "functions")]
 pub mod functions;
@@ -111,6 +113,8 @@ pub mod tracing;
 
 pub use mech_core::*;
 
+#[cfg(feature = "functions")]
+pub use crate::builtins::*;
 pub use crate::expressions::*;
 #[cfg(feature = "functions")]
 pub use crate::functions::*;
@@ -194,8 +198,7 @@ pub fn load_stdlib(fxns: &mut Functions) {
   }
 
   for fxn_comp in inventory::iter::<FunctionCompilerDescriptor> {
-    fxns.function_compilers
-      .insert(hash_str(fxn_comp.name), Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)));
+    fxns.insert_function_compiler(fxn_comp.name, Arc::new(StaticNativeFunctionCompiler::new(fxn_comp.ptr)));
   }
 }
 

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -288,10 +288,34 @@ pub fn comment(cmmt: &Comment, p: &Interpreter) -> MResult<Value> {
   Ok(Value::Empty)
 }
 
+#[cfg(feature = "functions")]
+pub fn module_import_runtime(import: &ModuleImport, p: &Interpreter) -> MResult<Value> {
+  let module = import.module.to_string();
+  match import.kind {
+    ModuleImportKind::Module => {
+      load_module(&mut p.functions().borrow_mut(), &module)?;
+      Ok(Value::Empty)
+    }
+    ModuleImportKind::Item => {
+      let item = import.item.as_ref().ok_or_else(|| {
+        MechError::new(MissingFunctionError { function_id: hash_str(&module) }, None).with_compiler_loc()
+      })?.iter().map(|id| id.to_string()).collect::<Vec<_>>().join("/");
+      import_module_item(&mut p.functions().borrow_mut(), &module, &item)?;
+      Ok(Value::Empty)
+    }
+    ModuleImportKind::Glob => {
+      import_module_glob(&mut p.functions().borrow_mut(), &module)?;
+      Ok(Value::Empty)
+    }
+  }
+}
+
 pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
   let out = match &code {
     MechCode::Expression(expr) => expression(&expr, None, p),
     MechCode::Statement(stmt) => statement(&stmt, None, p),
+    #[cfg(feature = "functions")]
+    MechCode::Import(import) => module_import_runtime(import, p),
     #[cfg(feature = "state_machines")]
     MechCode::FsmSpecification(fsm_spec) => {
       crate::state_machines::register_fsm_specification(fsm_spec, p)?;

--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -63,6 +63,11 @@ impl MechProgram {
     }
   }
 
+  #[cfg(feature = "functions")]
+  pub fn load_full_stdlib(&mut self) {
+    mech_interpreter::load_stdlib(&mut self.interpreter.functions().borrow_mut());
+  }
+
   pub fn register_native_function_compiler(
     &mut self,
     name: impl Into<String>,

--- a/src/runtime/src/config_profile/compile.rs
+++ b/src/runtime/src/config_profile/compile.rs
@@ -27,6 +27,11 @@ impl ConfigCompiler {
                     items.push(ConfigItem::Function(self.compile_function(function)?));
                 }
                 MechCode::Statement(statement) => items.push(self.compile_statement(statement)?),
+                MechCode::Import(_) => {
+                    return Err(ConfigProfileViolation::error(
+                        "module imports are not allowed in Mech config",
+                    ));
+                }
                 MechCode::FsmSpecification(_) | MechCode::FsmImplementation(_) => {
                     return Err(ConfigProfileViolation::error(
                         "state machines are not allowed in Mech config",

--- a/src/runtime/src/resolver/imports.rs
+++ b/src/runtime/src/resolver/imports.rs
@@ -61,6 +61,23 @@ pub fn source_request_for_import(
   request
 }
 
+
+pub(crate) fn module_import_specifier(import: &mech_core::ModuleImport) -> String {
+  let module = import.module.to_string();
+  match import.kind {
+    mech_core::ModuleImportKind::Module => module,
+    mech_core::ModuleImportKind::Glob => format!("{module}/*"),
+    mech_core::ModuleImportKind::Item => {
+      let item = import
+        .item
+        .as_ref()
+        .map(|path| path.iter().map(|id| id.to_string()).collect::<Vec<_>>().join("/"))
+        .unwrap_or_default();
+      format!("{module}/{item}")
+    }
+  }
+}
+
 pub fn import_dependencies(imports: &[SourceImportDeclaration]) -> Vec<SourceRequest> {
   imports
     .iter()
@@ -96,24 +113,22 @@ mod tests {
   }
 
   #[test]
-  fn classifies_single_import() {
+  fn stdlib_single_imports_are_not_source_imports() {
     let fenced = parse_fenced("~~~mech\n+> math/sin\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
-    assert_eq!(imports[0].specifier, "math");
-    assert_eq!(imports[0].kind, SourceImportKind::Single { name: "sin".to_string() });
+    assert!(imports.is_empty());
   }
 
   #[test]
-  fn classifies_wildcard_import() {
+  fn stdlib_wildcard_imports_are_not_source_imports() {
     let fenced = parse_fenced("~~~mech\n+> math/*\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
-    assert_eq!(imports[0].specifier, "math");
-    assert_eq!(imports[0].kind, SourceImportKind::Wildcard);
+    assert!(imports.is_empty());
   }
 
   #[test]
   fn classifies_dependency_only_imports() {
-    let fenced = parse_fenced("~~~mech\n+> ./dep.mec\n+> fs://lib/dep.mec\n+> file:///tmp/dep.mec\n+> memory://scratch/dep\n+> https://example.com/dep.mec\n~~~\n");
+    let fenced = parse_fenced("~~~mech\n+> ./dep.mec\n+> ../lib/dep.mec\n+> fs://lib/dep.mec\n+> file:///tmp/dep.mec\n+> memory://scratch/dep\n+> https://example.com/dep.mec\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
     assert!(imports.iter().all(|imp| imp.kind == SourceImportKind::DependencyOnly));
   }
@@ -130,11 +145,8 @@ mod tests {
     let fenced = parse_fenced("~~~mech\n+> math\n+> math/sin\n+> math/*\n+> ./dep.mec\n~~~\n");
     let imports = imports_from_fenced_code(&fenced);
     let dependencies = import_dependencies(&imports);
-    assert_eq!(dependencies.len(), 4);
-    assert_eq!(dependencies[0].specifier, "math");
-    assert_eq!(dependencies[1].specifier, "math");
-    assert_eq!(dependencies[2].specifier, "math");
-    assert_eq!(dependencies[3].specifier, "./dep.mec");
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].specifier, "./dep.mec");
   }
 
   #[test]

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -5,7 +5,7 @@ use mech_core::{
 };
 
 use super::{
-    classify_import_specifier, AddressTargetNameConflict, SourceAddressReference, SourceContextBase,
+    classify_import_specifier, module_import_specifier, AddressTargetNameConflict, SourceAddressReference, SourceContextBase,
     SourceContextCapability, SourceContextCapabilityScope, SourceContextDeclaration,
     SourceExportDeclaration, SourceImportDeclaration,
 };
@@ -104,6 +104,15 @@ impl SourceIndex {
                     SectionElement::MechCode(code_items) => {
                         for (code, _) in code_items {
                             match code {
+                                MechCode::Import(import) => {
+                                    index.push_import(
+                                        SourceScope::Program,
+                                        order,
+                                        declaration_range(import.tokens()),
+                                        classify_import_specifier(module_import_specifier(import)),
+                                    );
+                                    order += 1;
+                                }
                                 MechCode::Statement(statement) => {
                                     match statement {
                                         Statement::ImportDeclaration(import) => {
@@ -195,6 +204,15 @@ impl SourceIndex {
 
                         for (code, _) in &fenced.code {
                             match code {
+                                MechCode::Import(import) => {
+                                    index.push_import(
+                                        scope.clone(),
+                                        order,
+                                        declaration_range(import.tokens()),
+                                        classify_import_specifier(module_import_specifier(import)),
+                                    );
+                                    order += 1;
+                                }
                                 MechCode::Statement(Statement::ContextDeclaration(context)) => {
                                     index.push_context(
                                         scope.clone(),
@@ -591,6 +609,15 @@ fn index_expression_address_references(
                     mech_core::Transition::CodeBlock(code_items) => {
                         for (code, _) in code_items {
                             match code {
+                                MechCode::Import(import) => {
+                                    index.push_import(
+                                        scope.clone(),
+                                        *order,
+                                        declaration_range(import.tokens()),
+                                        classify_import_specifier(module_import_specifier(import)),
+                                    );
+                                    *order += 1;
+                                }
                                 MechCode::Statement(statement) => {
                                     index_statement_address_references(index, scope, order, statement);
                                 }

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -684,6 +684,7 @@ impl Formatter {
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FunctionDefine(func_def) => self.function_define(func_def),
+        MechCode::Import(import) => self.module_import(import),
         MechCode::Statement(stmt) => self.statement(stmt),
         x => format!("{{{:?}}}", x)
       };
@@ -1544,6 +1545,7 @@ impl Formatter {
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FunctionDefine(func_def) => self.function_define(func_def),
+        MechCode::Import(import) => self.module_import(import),
         MechCode::Statement(stmt) => self.statement(stmt),
         MechCode::Error(token, range) => {
           if self.html {
@@ -1848,6 +1850,17 @@ impl Formatter {
       </div>"#,name,input,output,states)
     } else {
       format!("#{}({}){} {}\n{}", name, input, output, ":=", states)
+    }
+  }
+
+  pub fn module_import(&mut self, node: &ModuleImport) -> String {
+    match node.kind {
+      ModuleImportKind::Module => format!("+> {}", node.module.to_string()),
+      ModuleImportKind::Item => {
+        let item = node.item.as_ref().unwrap().iter().map(|id| id.to_string()).collect::<Vec<_>>().join("/");
+        format!("+> {}/{}", node.module.to_string(), item)
+      }
+      ModuleImportKind::Glob => format!("+> {}/*", node.module.to_string()),
     }
   }
 

--- a/src/syntax/src/imports.rs
+++ b/src/syntax/src/imports.rs
@@ -1,0 +1,118 @@
+#[macro_use]
+use crate::*;
+
+const STDLIB_MODULE_ROOTS: &[&str] = &["math", "stats", "io", "string", "combinatorics"];
+
+fn identifier_from_part(part: &str, range: SourceRange) -> Identifier {
+    Identifier {
+        name: Token {
+            kind: TokenKind::Identifier,
+            chars: part.chars().collect(),
+            src_range: range,
+        },
+    }
+}
+
+fn is_source_import_path(path: &str) -> bool {
+    path.contains("://")
+        || path.starts_with("./")
+        || path.starts_with("../")
+        || path.ends_with(".mec")
+        || path.contains('.')
+}
+
+pub fn module_import(input: ParseString) -> ParseResult<ModuleImport> {
+    let original = input.clone();
+    let (input, _) = whitespace0(input)?;
+    let (input, _) = plus(input)?;
+    let (input, _) = right_angle(input)?;
+    let (input, _) = many0(space_tab)(input)?;
+    let start = input.loc();
+    let (input, raw_token) = skip_till_eol(input)?;
+    let raw = raw_token.to_string();
+    let path = raw.trim();
+
+    if is_source_import_path(path) {
+        return Err(nom::Err::Error(ParseError::new(
+            original,
+            "not a stdlib module import",
+        )));
+    }
+
+    if path.is_empty() {
+        return Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid empty module import path",
+        )));
+    }
+
+    let parts: Vec<&str> = path.split('/').map(str::trim).collect();
+    let end = input.loc();
+    let range = SourceRange { start, end };
+    let module = parts[0];
+
+    if module.is_empty() || module == "*" {
+        return Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid module import module",
+        )));
+    }
+
+    if !STDLIB_MODULE_ROOTS.contains(&module) {
+        return Err(nom::Err::Error(ParseError::new(
+            original,
+            "not a known stdlib module import",
+        )));
+    }
+
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid empty module import item",
+        )));
+    }
+
+    let item_parts = &parts[1..];
+    if let Some(star_ix) = item_parts.iter().position(|part| *part == "*") {
+        if item_parts.len() == 1 && star_ix == 0 {
+            return Ok((
+                input,
+                ModuleImport {
+                    module: identifier_from_part(module, range),
+                    item: None,
+                    kind: ModuleImportKind::Glob,
+                },
+            ));
+        }
+        return Err(nom::Err::Failure(ParseError::new(
+            input,
+            "Invalid wildcard placement in module import path",
+        )));
+    }
+
+    let module = identifier_from_part(module, range.clone());
+    if item_parts.is_empty() {
+        Ok((
+            input,
+            ModuleImport {
+                module,
+                item: None,
+                kind: ModuleImportKind::Module,
+            },
+        ))
+    } else {
+        Ok((
+            input,
+            ModuleImport {
+                module,
+                item: Some(
+                    item_parts
+                        .iter()
+                        .map(|part| identifier_from_part(part, range.clone()))
+                        .collect(),
+                ),
+                kind: ModuleImportKind::Item,
+            },
+        ))
+    }
+}

--- a/src/syntax/src/lib.rs
+++ b/src/syntax/src/lib.rs
@@ -41,6 +41,7 @@ use colored::*;
 
 //#[cfg(feature = "mechdown")]
 pub mod mechdown;
+pub mod imports;
 pub mod expressions;
 pub mod statements;
 pub mod structures;
@@ -57,6 +58,7 @@ pub mod state_machines;
 pub mod functions;
 pub mod repl;
 
+pub use crate::imports::*;
 pub use crate::parser::*;
 //#[cfg(feature = "mechdown")]
 pub use crate::mechdown::*;

--- a/src/syntax/src/parser.rs
+++ b/src/syntax/src/parser.rs
@@ -325,6 +325,7 @@ pub fn mech_code_alt(input: ParseString) -> ParseResult<MechCode> {
     ("fsm_specification", Box::new(|i| fsm_specification(i).map(|(i, v)| (i, MechCode::FsmSpecification(v))))),
     ("fsm_implementation", Box::new(|i| fsm_implementation(i).map(|(i, v)| (i, MechCode::FsmImplementation(v))))),
     ("function_define", Box::new(|i| function_define(i).map(|(i, v)| (i, MechCode::FunctionDefine(v))))),
+    ("module_import", Box::new(|i| module_import(i).map(|(i, v)| (i, MechCode::Import(v))))),
     ("statement",   Box::new(|i| statement(i).map(|(i, v)| (i, MechCode::Statement(v))))),
     ("expression",  Box::new(|i| expression(i).map(|(i, v)| (i, MechCode::Expression(v))))),
     ("comment",     Box::new(|i| comment(i).map(|(i, v)| (i, MechCode::Comment(v))))),

--- a/src/syntax/tests/module_imports.rs
+++ b/src/syntax/tests/module_imports.rs
@@ -1,0 +1,92 @@
+use mech_core::nodes::*;
+use mech_syntax::parser;
+
+fn imports(src: &str) -> Vec<ModuleImport> {
+    let program = parser::parse(src).expect("parse failed");
+    let mut out = vec![];
+    for section in &program.body.sections {
+        for element in &section.elements {
+            if let SectionElement::MechCode(codes) = element {
+                for (node, _) in codes {
+                    if let MechCode::Import(import) = node {
+                        out.push(import.clone());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn statements(src: &str) -> Vec<Statement> {
+    let program = parser::parse(src).expect("parse failed");
+    let mut out = vec![];
+    for section in &program.body.sections {
+        for element in &section.elements {
+            if let SectionElement::MechCode(codes) = element {
+                for (node, _) in codes {
+                    if let MechCode::Statement(stmt) = node {
+                        out.push(stmt.clone());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn item_path(import: &ModuleImport) -> Vec<String> {
+    import
+        .item
+        .as_ref()
+        .unwrap()
+        .iter()
+        .map(|id| id.to_string())
+        .collect()
+}
+
+#[test]
+fn parses_module_item_glob_and_nested_item_imports() {
+    let parsed = imports("+> math\n+> math/sin\n+> math/*\n+> stats/sum/column");
+    assert_eq!(parsed.len(), 4);
+    assert_eq!(parsed[0].kind, ModuleImportKind::Module);
+    assert_eq!(parsed[0].module.to_string(), "math");
+    assert!(parsed[0].item.is_none());
+    assert_eq!(parsed[1].kind, ModuleImportKind::Item);
+    assert_eq!(parsed[1].module.to_string(), "math");
+    assert_eq!(item_path(&parsed[1]), vec!["sin"]);
+    assert_eq!(parsed[2].kind, ModuleImportKind::Glob);
+    assert_eq!(parsed[2].module.to_string(), "math");
+    assert!(parsed[2].item.is_none());
+    assert_eq!(parsed[3].kind, ModuleImportKind::Item);
+    assert_eq!(parsed[3].module.to_string(), "stats");
+    assert_eq!(item_path(&parsed[3]), vec!["sum", "column"]);
+}
+
+#[test]
+fn preserves_source_import_declarations() {
+    let stmts = statements(
+        "+> ./dep.mec\n+> ../lib/dep.mec\n+> fs://lib/dep.mec\n+> file:///tmp/dep.mec\n+> memory://scratch/dep\n+> https://example.com/dep.mec",
+    );
+    assert_eq!(stmts.len(), 6);
+    assert!(stmts
+        .iter()
+        .all(|stmt| matches!(stmt, Statement::ImportDeclaration(_))));
+}
+
+#[test]
+fn unknown_module_roots_fall_back_to_source_imports() {
+    let stmts = statements("+> userlib\n+> userlib/tool");
+    assert_eq!(stmts.len(), 2);
+    assert!(stmts
+        .iter()
+        .all(|stmt| matches!(stmt, Statement::ImportDeclaration(_))));
+}
+
+#[test]
+fn rejects_invalid_stdlib_import_paths() {
+    assert!(parser::parse("+> ").is_err());
+    assert!(parser::parse("+> */x").is_err());
+    assert!(parser::parse("+> math/").is_err());
+    assert!(parser::parse("+> math/*/x").is_err());
+}

--- a/tests/bytecode.rs
+++ b/tests/bytecode.rs
@@ -24,6 +24,8 @@ macro_rules! bytecode_test {
       let prog = ParsedProgram::from_bytes(&bytecode)
         .unwrap_or_else(|err| panic!("Deserialize error: {:?}", err));
 
+      prgrm.load_full_stdlib();
+
       let result = prgrm.run_bytecode_program(&prog)
         .unwrap_or_else(|err| panic!("Runtime error: {:?}", err));
 
@@ -52,23 +54,23 @@ bytecode_test!(bytecode_math_div_assign_vr, "~x := [10 20]; y := [1 2]; z := [10
 bytecode_test!(bytecode_matrix_rowvector3,"[1 2 3]",Value::MatrixF64(Matrix::from_vec(vec![1.0,2.0,3.0], 1, 3)));
 bytecode_test!(bytecode_matrix_vector2,"[1; 2]",Value::MatrixF64(Matrix::from_vec(vec![1.0,2.0], 2, 1)));
 bytecode_test!(bytecode_matrix_matrix2x2,"[1 2; 3 4]",Value::MatrixF64(Matrix::from_vec(vec![1.0,3.0,2.0,4.0], 2, 2)));
-bytecode_test!(bytecode_combinatorics_n_choose_k,"combinatorics/n-choose-k(10,2)",Value::F64(Ref::new(45.0)));
+bytecode_test!(bytecode_combinatorics_n_choose_k,"+> combinatorics\ncombinatorics/n-choose-k(10,2)",Value::F64(Ref::new(45.0)));
 bytecode_test!(bytecode_compare_gt,"1 > 2",Value::Bool(Ref::new(false)));
 bytecode_test!(bytecode_compare_eq,r#""foo" == "bar""#,Value::Bool(Ref::new(false)));
 bytecode_test!(bytecode_logic_and,"true && false",Value::Bool(Ref::new(false)));
 bytecode_test!(bytecode_logic_or,"true || false",Value::Bool(Ref::new(true)));
 bytecode_test!(bytecode_logic_not,"!true",Value::Bool(Ref::new(false)));
-bytecode_test!(bytecode_math_cos,"math/cos(0)",Value::F64(Ref::new(1.0)));
-bytecode_test!(bytecode_math_sin,"math/sin(0)",Value::F64(Ref::new(0.0)));
-bytecode_test!(bytecode_math_atan2,"math/atan2(1, 1)",Value::F64(Ref::new(std::f64::consts::FRAC_PI_4)));
-bytecode_test!(bytecode_math_atan22,"math/atan(1, 1)",Value::F64(Ref::new(std::f64::consts::FRAC_PI_4)));
+bytecode_test!(bytecode_math_cos,"+> math\nmath/cos(0)",Value::F64(Ref::new(1.0)));
+bytecode_test!(bytecode_math_sin,"+> math\nmath/sin(0)",Value::F64(Ref::new(0.0)));
+bytecode_test!(bytecode_math_atan2,"+> math\nmath/atan2(1, 1)",Value::F64(Ref::new(std::f64::consts::FRAC_PI_4)));
+bytecode_test!(bytecode_math_atan22,"+> math\nmath/atan(1, 1)",Value::F64(Ref::new(std::f64::consts::FRAC_PI_4)));
 bytecode_test!(bytecode_matrix_matmul_transpose,"[1 2 3] ** [4 5 6]'",Value::MatrixF64(Matrix::from_vec(vec![32.0], 1, 1)));
-bytecode_test!(bytecode_matrix_dot,"matrix/dot([1 2 3],[4 5 6])",Value::F64(Ref::new(32.0)));
+bytecode_test!(bytecode_matrix_dot,"[1 2 3] \u{00b7} [4 5 6]",Value::F64(Ref::new(32.0)));
 bytecode_test!(bytecode_range_inclusive,"1..=4",Value::MatrixF64(Matrix::from_vec(vec![1.0,2.0,3.0,4.0], 1, 4)));
 bytecode_test!(bytecode_range_inclusive_d,"1..=5",Value::MatrixF64(Matrix::from_vec(vec![1.0,2.0,3.0,4.0,5.0], 1, 5)));
 bytecode_test!(bytecode_range_inclusive_refs,"a := 1; b :=4 ; a..=b",Value::MatrixF64(Matrix::from_vec(vec![1.0,2.0,3.0,4.0], 1, 4)));
 bytecode_test!(bytecode_range_exclusive,"1..5",Value::MatrixF64(Matrix::from_vec(vec![1.0,2.0,3.0,4.0], 1, 4)));
-bytecode_test!(bytecode_stats_sum_column,"stats/sum/column([1 2 3])",Value::MatrixF64(Matrix::from_vec(vec![6.0], 1, 1)));
+bytecode_test!(bytecode_stats_sum_column,"+> stats\nstats/sum/column([1 2 3])",Value::MatrixF64(Matrix::from_vec(vec![6.0], 1, 1)));
 bytecode_test!(bytecode_matrix_index_assign,"~x := [1 2 3]; x[1] = 10",Value::MatrixF64(Matrix::from_vec(vec![10.0,2.0,3.0], 1, 3)));
 bytecode_test!(bytecode_matrix_index_assign_bool,"~x := [1 2 3]; x[[true false true]] = [4 5 6]",Value::MatrixF64(Matrix::from_vec(vec![4.0,2.0,6.0], 1, 3)));
 bytecode_test!(bytecode_matrix_index_assign_bool_all,"~x := [1 2 3]; x[true] = [4 5 6]",Value::MatrixF64(Matrix::from_vec(vec![4.0,5.0,6.0], 1, 3)));
@@ -109,10 +111,10 @@ bytecode_test!(bytecode_matrix_index_2d_vbb3, r#"x := [1 2 3; 4 5 6; 7 8 9]; x[[
 bytecode_test!(bytecode_matrix_index_2d_vbb4, r#"x := [1 2 3; 4 5 6; 7 8 9]; x[[true false true],[true false true]]"#, Value::MatrixF64(Matrix::from_vec(vec![1.0,7.0,3.0,9.0], 2, 2)));
 bytecode_test!(bytecode_matrix_index_2d_vub, r#"ix := [false, false, true]; x := [1 2 3; 4 5 6; 7 8 9]; x[[1,2,3,3],ix]"#, Value::MatrixF64(Matrix::from_vec(vec![3.0,6.0,9.0,9.0], 4, 1)));
 bytecode_test!(bytecode_matrix_index_2d_vbu, r#"ix1 := [false, false, true]; ix2 := [1,2,3,3]; x := [1 2 3; 4 5 6; 7 8 9]; x[ix1,ix2]"#, Value::MatrixF64(Matrix::from_vec(vec![7.0,8.0,9.0,9.0], 1, 4)));
-bytecode_test!(bytecode_math_sqrt,"math/sqrt(9)",Value::F64(Ref::new(3.0)));
+bytecode_test!(bytecode_math_sqrt,"+> math\nmath/sqrt(9)",Value::F64(Ref::new(3.0)));
 bytecode_test!(bytecode_define_set,"x := {1 2 3 4}", Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0)), Value::F64(Ref::new(4.0))]))));
 bytecode_test!(bytecode_set,"{1 2 3 3 4}", Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0)), Value::F64(Ref::new(4.0))]))));
-bytecode_test!(bytecode_math_abs,"math/abs(-10)", Value::F64(Ref::new(10.0)));
+bytecode_test!(bytecode_math_abs,"+> math\nmath/abs(-10)", Value::F64(Ref::new(10.0)));
 bytecode_test!(bytecode_define_table, "x := |x<f64> y<u64>| 1 2 | 3 4 |", Value::Table(Ref::new(MechTable::new_table(
   vec!["x".to_string(), "y".to_string()],
   vec![ValueKind::F64, ValueKind::U64],

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -18,6 +18,7 @@ macro_rules! test_interpreter {
     fn $func() {
       let s = $input;
       let mut program = MechProgram::new(MechProgramConfig{name: "test".to_string(), environment: MechProgramEnvironment::default()});
+      program.load_full_stdlib();
       match program.run_string(s) {
         Ok(result) => assert_eq!(result, $expected),
         Err(err) => panic!("{:?}", err),

--- a/tests/lazy_stdlib.rs
+++ b/tests/lazy_stdlib.rs
@@ -1,0 +1,51 @@
+use mech::program::{MechProgram, MechProgramConfig};
+
+fn run(source: &str) -> bool {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program.run_string(source).is_ok()
+}
+
+#[test]
+fn prelude_operators_work_without_imports() {
+    assert!(run("x := 1 + 1\ny := 1 > 2\nz := true && false"));
+}
+
+#[test]
+fn set_operators_work_without_imports() {
+    assert!(run("a := {1, 2}\nb := {2, 3}\nc := a ∪ b"));
+}
+
+#[test]
+fn matrix_operators_work_without_imports() {
+    assert!(run("a := [1 2]\nb := [3 4]\nc := a · b"));
+}
+
+#[test]
+fn named_math_functions_fail_without_imports() {
+    assert!(!run("x := sin(1.23)"));
+    assert!(!run("x := math/sin(1.23)"));
+}
+
+#[test]
+fn qualified_module_import_enables_only_qualified_calls() {
+    assert!(run("+> math\nx := math/sin(1.23)"));
+    assert!(!run("+> math\nx := sin(1.23)"));
+}
+
+#[test]
+fn item_import_enables_only_that_unqualified_item() {
+    assert!(run("+> math/sin\nx := sin(1.23)"));
+    assert!(!run("+> math/sin\nx := cos(1.23)"));
+}
+
+#[test]
+fn glob_import_enables_all_module_exports_unqualified() {
+    assert!(run("+> math/*\nx := sin(1.23)\ny := cos(1.23)"));
+}
+
+#[test]
+fn nested_stats_imports_work_and_require_imports() {
+    assert!(!run("x := stats/sum/column([1 2 3])"));
+    assert!(run("+> stats\nx := stats/sum/column([1 2 3])"));
+    assert!(run("+> stats/sum/column\nx := column([1 2 3])"));
+}


### PR DESCRIPTION
### Motivation

- Introduce a concise directive for importing standard-library modules (e.g. `+> math`, `+> math/sin`, `+> math/*`) and enable lazy loading of builtin functions instead of eagerly populating the full stdlib.
- Differentiate between source/file imports and stdlib/module imports so resolver and dependency analysis treat them appropriately.

### Description

- Added a `ModuleImportKind` and `ModuleImport` AST node and extended `MechCode` with an `Import` variant in `src/core` to represent `+>` module imports.
- Implemented parsing of module import directives in `src/syntax` by adding `module_import` parser, exposing it from the syntax crate, and integrating it into `mech_code_alt` and tests in `src/syntax/tests/module_imports.rs`.
- Implemented lazy builtin/module handling in `src/interpreter` with a new `builtins` module providing `load_prelude`, `load_module`, `import_module_item`, `import_module_glob`, and `import_module_qualified`, and wired runtime execution via `mechdown::module_import_runtime` to perform imports at runtime when `MechCode::Import` is executed.
- Switched interpreter initialization to load only the prelude (`load_prelude`) by default and added helpers `new_with_full_stdlib` / `new_with_full_stdlib_steps` and `MechProgram::load_full_stdlib` to populate the full stdlib when needed.
- Updated the formatter to render `ModuleImport` nodes and updated the resolver/indexing logic to treat stdlib imports as non-source dependencies (using `module_import_specifier`) so only file imports create dependency edges.
- Added `src/syntax/src/imports.rs`, `src/interpreter/src/builtins.rs`, related runtime helpers and many test adaptations to reflect the new import semantics and lazy stdlib behavior.

### Testing

- Ran the unit and integration test suite, including `src/syntax` parser tests (`module_imports.rs`), interpreter tests (`tests/interpreter.rs`), bytecode tests (`tests/bytecode.rs`), and the new `tests/lazy_stdlib.rs` suite via `cargo test`, and all tests passed.
- Verified that stdlib directives are parsed (`module_import`), that prelude operators work without imports, and that qualified/item/glob imports enable the expected names at runtime via the added tests, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e0689388832a9044c7ba88089329)