### PR TITLE
Generalize dynamic ABI kernel union and add UnaryF64ToF64 (math round provider)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
           mkdir -p target/mech-modules
           cp target/dynamic-modules/debug/libmech_combinatorics.so target/mech-modules/libmech_module_combinatorics.so
           MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"
+          cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"
+          cargo build --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module" --target-dir target/dynamic-modules
+          cp target/dynamic-modules/debug/libmech_math.so target/mech-modules/libmech_module_math.so
+          MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"
 
           # Runtime package tests.
           cargo test -p mech-runtime --lib --tests

--- a/machines/combinatorics/src/dynamic_module.rs
+++ b/machines/combinatorics/src/dynamic_module.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "dynamic-module")]
 
 use mech_abi::{
-    MechExportV1, MechKernelKindV1, MechStatusV1, MechStrV1, MECH_MODULE_ABI_VERSION_V1,
+    MechExportV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1, MechStrV1, MECH_MODULE_ABI_VERSION_V1,
 };
 
 const MODULE_NAME: &[u8] = b"combinatorics";
@@ -47,7 +47,9 @@ pub unsafe extern "C" fn mech_module_get_export_v1(
         *out = MechExportV1 {
             name: MechStrV1::from_static(EXPORT_NAME),
             kind: MechKernelKindV1::BinaryF64F64ToF64,
-            binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
+            function: MechKernelFnV1 {
+                binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
+            },
         };
     }
 
@@ -110,7 +112,9 @@ mod tests {
                 len: 0,
             },
             kind: MechKernelKindV1::BinaryF64F64ToF64,
-            binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
+            function: MechKernelFnV1 {
+                binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
+            },
         };
 
         let status = unsafe { mech_module_get_export_v1(1, &mut export) };
@@ -131,7 +135,9 @@ mod tests {
                 len: 0,
             },
             kind: MechKernelKindV1::BinaryF64F64ToF64,
-            binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
+            function: MechKernelFnV1 {
+                binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
+            },
         };
         let status = unsafe { mech_module_get_export_v1(0, &mut export) };
         let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };

--- a/machines/math/Cargo.toml
+++ b/machines/math/Cargo.toml
@@ -16,10 +16,10 @@ gitlab = { repository = "mech-lang/machines/math", branch = "main" }
 maintenance = { status = "actively-developed" }
 
 [lib]
-crate-type = ["rlib"]
+crate-type = ["rlib", "cdylib"]
 
 [features]
-no_std = ["mech-core/no_std"]
+no_std = ["dep:mech-core", "mech-core/no_std"]
 
 default = ["baselib", "pretty_print", "serde", "compiler", "program",
           "u8", "u16", "u32", "u64", "u128", 
@@ -67,7 +67,8 @@ math_default = ["arithmetic_default", "bessel_default", "exponential_default", "
                 "gamma_default", "logarithm_default", "ops_default", "ops_assign_default",
                 "root_default", "rounding_default", "stat_error_default", "trig_default"] 
 
-math = ["num-traits", "libm", "functions"]
+math = ["dep:num-traits", "dep:libm", "functions"]
+dynamic-module = ["dep:mech-abi", "dep:libm"]
 arithmetic = ["math"]
 bessel = ["math"]
 exp = ["math"]
@@ -188,7 +189,7 @@ variable_assign = ["statements", "mech-core/variable_assign"]
 kind_define = ["kind_annotation", "statements", "mech-core/kind_define"]
 kind_annotation = ["functions", "mech-core/kind_annotation"]
 formulas = ["mech-core/formulas"]
-functions = ["symbol_table", "mech-core/functions"]
+functions = ["symbol_table", "mech-core/functions", "dep:inventory", "dep:paste"]
 symbol_table = ["mech-core/symbol_table"]
 
 bool = ["mech-core/bool"]
@@ -257,12 +258,13 @@ dot_indexing = ["subscript", "mech-core/dot_indexing"]
 swizzle = ["subscript", "mech-core/swizzle"]
 
 [dependencies]
-mech-core = {version = "0.3.5", default-features = false}
+mech-core = {version = "0.3.5", default-features = false, optional = true}
+mech-abi = { path = "../../src/abi", optional = true }
 
 libm = {version = "0.2.15", optional = true}
 simba = {version = "0.9.0", optional = true}
-paste = "1.0.15"
-inventory = "0.3.22"
+paste = { version = "1.0.15", optional = true }
+inventory = { version = "0.3.22", optional = true }
 nalgebra = {version="0.34.1", optional = true}
 
 [dependencies.num-traits]

--- a/machines/math/src/dynamic_module.rs
+++ b/machines/math/src/dynamic_module.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "dynamic-module")]
+
+use mech_abi::{
+    MechExportV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1, MechStrV1,
+    MECH_MODULE_ABI_VERSION_V1,
+};
+
+const MODULE_NAME: &[u8] = b"math";
+const EXPORT_NAME: &[u8] = b"math/round";
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mech_module_abi_version_v1() -> u32 {
+    MECH_MODULE_ABI_VERSION_V1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mech_module_name_v1(out: *mut MechStrV1) -> MechStatusV1 {
+    if out.is_null() {
+        return MechStatusV1::NullPointer;
+    }
+
+    unsafe {
+        *out = MechStrV1::from_static(MODULE_NAME);
+    }
+
+    MechStatusV1::Ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mech_module_export_count_v1() -> usize {
+    1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mech_module_get_export_v1(
+    index: usize,
+    out: *mut MechExportV1,
+) -> MechStatusV1 {
+    if out.is_null() {
+        return MechStatusV1::NullPointer;
+    }
+
+    if index != 0 {
+        return MechStatusV1::InvalidIndex;
+    }
+
+    unsafe {
+        *out = MechExportV1 {
+            name: MechStrV1::from_static(EXPORT_NAME),
+            kind: MechKernelKindV1::UnaryF64ToF64,
+            function: MechKernelFnV1 {
+                unary_f64_to_f64: math_round_f64_v1,
+            },
+        };
+    }
+
+    MechStatusV1::Ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_round_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
+    if out.is_null() {
+        return MechStatusV1::NullPointer;
+    }
+
+    unsafe {
+        *out = crate::kernels::round::scalar_f64(input);
+    }
+
+    MechStatusV1::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_metadata_reports_module_name() {
+        let mut module_name = MechStrV1 { ptr: core::ptr::null(), len: 0 };
+        let status = unsafe { mech_module_name_v1(&mut module_name) };
+        let name = unsafe { core::slice::from_raw_parts(module_name.ptr, module_name.len) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(name, MODULE_NAME);
+    }
+
+    #[test]
+    fn module_export_count_is_one() {
+        assert_eq!(unsafe { mech_module_export_count_v1() }, 1);
+    }
+
+    #[test]
+    fn export_metadata_describes_round_kernel() {
+        let mut export = MechExportV1 {
+            name: MechStrV1 { ptr: core::ptr::null(), len: 0 },
+            kind: MechKernelKindV1::UnaryF64ToF64,
+            function: MechKernelFnV1 { unary_f64_to_f64: math_round_f64_v1 },
+        };
+        let status = unsafe { mech_module_get_export_v1(0, &mut export) };
+        let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(name, EXPORT_NAME);
+        assert_eq!(export.kind, MechKernelKindV1::UnaryF64ToF64);
+    }
+
+    #[test]
+    fn math_round_f64_returns_expected_result() {
+        let mut out = 0.0;
+        let status = unsafe { math_round_f64_v1(1.23, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 1.0);
+    }
+
+    #[test]
+    fn math_round_f64_rejects_null_output() {
+        let status = unsafe { math_round_f64_v1(1.23, core::ptr::null_mut()) };
+        assert_eq!(status, MechStatusV1::NullPointer);
+    }
+}

--- a/machines/math/src/kernels.rs
+++ b/machines/math/src/kernels.rs
@@ -1,0 +1,6 @@
+#[cfg(any(feature = "round", feature = "dynamic-module"))]
+pub mod round {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::round(input)
+    }
+}

--- a/machines/math/src/lib.rs
+++ b/machines/math/src/lib.rs
@@ -1,12 +1,14 @@
-#![no_main]
+#![cfg_attr(not(test), no_main)]
 #![allow(warnings)]
 #![feature(where_clause_attrs)]
 
 #[cfg(feature = "matrix")]
 extern crate nalgebra as na;
 
+#[cfg(not(feature = "dynamic-module"))]
 use mech_core::*;
 
+#[cfg(not(feature = "dynamic-module"))]
 use paste::paste;
 
 #[cfg(feature = "vector2")]
@@ -43,6 +45,12 @@ use na::RowDVector;
 use std::ops::*;
 use std::fmt::{Display, Debug};
 use std::marker::PhantomData;
+
+#[cfg(any(feature = "round", feature = "dynamic-module"))]
+pub mod kernels;
+
+#[cfg(feature = "dynamic-module")]
+mod dynamic_module;
 
 #[cfg(feature = "arithmetic")]
 pub mod arithmetic;

--- a/src/abi/src/lib.rs
+++ b/src/abi/src/lib.rs
@@ -37,14 +37,25 @@ impl MechStrV1 {
     }
 }
 
-// This v1 prototype intentionally contains one kernel kind.
-// Add a #[repr(C)] union of typed kernel function pointers when the second
-// kernel kind is introduced.
+/// Scalar kernel shape exported by a dynamic module.
+///
+/// V1 supports scalar typed function pointers through `MechKernelFnV1`, a
+/// tagged union keyed by this enum. The host must read only the union field
+/// corresponding to `kind`.
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MechKernelKindV1 {
-    BinaryF64F64ToF64 = 1,
+    UnaryF64ToF64 = 1,
+    BinaryF64F64ToF64 = 2,
 }
+
+/// Kernel for a unary scalar f64 function.
+///
+/// The host owns all Mech runtime values. The module receives one copied
+/// scalar input and writes one scalar result into `out`.
+/// The module must not retain `out` after returning.
+pub type MechUnaryF64ToF64KernelV1 =
+    unsafe extern "C" fn(input: f64, out: *mut f64) -> MechStatusV1;
 
 /// Kernel for a binary scalar f64 function.
 ///
@@ -54,20 +65,23 @@ pub enum MechKernelKindV1 {
 pub type MechBinaryF64F64ToF64KernelV1 =
     unsafe extern "C" fn(n: f64, k: f64, out: *mut f64) -> MechStatusV1;
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union MechKernelFnV1 {
+    pub unary_f64_to_f64: MechUnaryF64ToF64KernelV1,
+    pub binary_f64_f64_to_f64: MechBinaryF64F64ToF64KernelV1,
+}
+
 /// One exported Mech function/kernel.
 ///
-/// V1 intentionally supports a single typed kernel function pointer.
-/// When a second kernel kind is added, replace the typed function field with
-/// a `#[repr(C)]` union of typed function pointers keyed by `kind`.
+/// V1 supports scalar typed function pointers through a tagged union. The host
+/// must read only the `function` union field corresponding to `kind`.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MechExportV1 {
     pub name: MechStrV1,
     pub kind: MechKernelKindV1,
-
-    // In v1 there is only one kernel kind, so keep this typed.
-    // When more kinds are added, replace this with a #[repr(C)] union.
-    pub binary_f64_f64_to_f64: MechBinaryF64F64ToF64KernelV1,
+    pub function: MechKernelFnV1,
 }
 
 pub type MechModuleAbiVersionFnV1 = unsafe extern "C" fn() -> u32;

--- a/src/interpreter/src/modules.rs
+++ b/src/interpreter/src/modules.rs
@@ -228,7 +228,9 @@ impl ModuleLoader for DynamicModuleLoader {
                     len: 0,
                 },
                 kind: mech_abi::MechKernelKindV1::BinaryF64F64ToF64,
-                binary_f64_f64_to_f64: dynamic_null_binary_f64_f64_to_f64,
+                function: mech_abi::MechKernelFnV1 {
+                    binary_f64_f64_to_f64: dynamic_null_binary_f64_f64_to_f64,
+                },
             };
             Self::call_status(
                 unsafe { get_export_fn(index, &mut export) },
@@ -258,12 +260,32 @@ impl ModuleLoader for DynamicModuleLoader {
 
             match export.kind {
                 mech_abi::MechKernelKindV1::BinaryF64F64ToF64 => {
-                    let kernel = export.binary_f64_f64_to_f64;
+                    let kernel = unsafe { export.function.binary_f64_f64_to_f64 };
                     let compiler_name = export_name.clone();
 
                     fxns.insert_function_compiler(
                         compiler_name.clone(),
                         Arc::new(DynamicBinaryF64F64ToF64Compiler {
+                            name: compiler_name.clone(),
+                            kernel,
+                            _library: library.clone(),
+                        }),
+                    );
+
+                    dynamic_trace(format!(
+                        "registered dynamic export `{}` as item `{}`",
+                        compiler_name, item
+                    ));
+
+                    items.push(item);
+                }
+                mech_abi::MechKernelKindV1::UnaryF64ToF64 => {
+                    let kernel = unsafe { export.function.unary_f64_to_f64 };
+                    let compiler_name = export_name.clone();
+
+                    fxns.insert_function_compiler(
+                        compiler_name.clone(),
+                        Arc::new(DynamicUnaryF64ToF64Compiler {
                             name: compiler_name.clone(),
                             kernel,
                             _library: library.clone(),
@@ -291,6 +313,14 @@ impl ModuleLoader for DynamicModuleLoader {
 unsafe extern "C" fn dynamic_null_binary_f64_f64_to_f64(
     _n: f64,
     _k: f64,
+    _out: *mut f64,
+) -> mech_abi::MechStatusV1 {
+    mech_abi::MechStatusV1::Unsupported
+}
+
+#[cfg(feature = "dynamic-modules")]
+unsafe extern "C" fn dynamic_null_unary_f64_to_f64(
+    _input: f64,
     _out: *mut f64,
 ) -> mech_abi::MechStatusV1 {
     mech_abi::MechStatusV1::Unsupported
@@ -347,6 +377,39 @@ impl NativeFunctionCompiler for DynamicBinaryF64F64ToF64Compiler {
             name: self.name.clone(),
             n,
             k,
+            out: Ref::new(0.0),
+            kernel: self.kernel,
+            _library: self._library.clone(),
+        }))
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
+struct DynamicUnaryF64ToF64Compiler {
+    name: String,
+    kernel: mech_abi::MechUnaryF64ToF64KernelV1,
+    _library: Arc<libloading::Library>,
+}
+
+#[cfg(feature = "dynamic-modules")]
+impl NativeFunctionCompiler for DynamicUnaryF64ToF64Compiler {
+    fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+        if arguments.len() != 1 {
+            return Err(MechError::new(
+                IncorrectNumberOfArguments {
+                    expected: 1,
+                    found: arguments.len(),
+                },
+                None,
+            )
+            .with_compiler_loc());
+        }
+
+        let input = dynamic_arg_as_f64_ref(&arguments[0], &self.name)?;
+
+        Ok(Box::new(DynamicUnaryF64ToF64Function {
+            name: self.name.clone(),
+            input,
             out: Ref::new(0.0),
             kernel: self.kernel,
             _library: self._library.clone(),
@@ -418,6 +481,53 @@ impl MechFunctionImpl for DynamicBinaryF64F64ToF64Function {
 
 #[cfg(all(feature = "dynamic-modules", feature = "compiler"))]
 impl MechFunctionCompiler for DynamicBinaryF64F64ToF64Function {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+        Err(MechError::new(
+            GenericError {
+                msg: format!(
+                    "bytecode compilation is not implemented for dynamic function `{}`",
+                    self.name
+                ),
+            },
+            None,
+        )
+        .with_compiler_loc())
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
+struct DynamicUnaryF64ToF64Function {
+    name: String,
+    input: Ref<f64>,
+    out: Ref<f64>,
+    kernel: mech_abi::MechUnaryF64ToF64KernelV1,
+    _library: Arc<libloading::Library>,
+}
+
+#[cfg(feature = "dynamic-modules")]
+impl MechFunctionImpl for DynamicUnaryF64ToF64Function {
+    fn solve(&self) {
+        let status = unsafe { (self.kernel)(*self.input.as_ptr(), self.out.as_mut_ptr()) };
+
+        if status != mech_abi::MechStatusV1::Ok {
+            dynamic_trace(format!(
+                "dynamic kernel `{}` returned status {:?}",
+                self.name, status
+            ));
+        }
+    }
+
+    fn out(&self) -> Value {
+        self.out.to_value()
+    }
+
+    fn to_string(&self) -> String {
+        format!("dynamic {}", self.name)
+    }
+}
+
+#[cfg(all(feature = "dynamic-modules", feature = "compiler"))]
+impl MechFunctionCompiler for DynamicUnaryF64ToF64Function {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
         Err(MechError::new(
             GenericError {

--- a/tests/dynamic_math.rs
+++ b/tests/dynamic_math.rs
@@ -1,0 +1,24 @@
+use mech::program::{MechProgram, MechProgramConfig};
+
+fn run(source: &str) -> bool {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program.run_string(source).is_ok()
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_item_import_works() {
+    assert!(run("+> math/round\nx := round(1.23)"));
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_module_import_works() {
+    assert!(run("+> math\nx := math/round(1.23)"));
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_glob_import_works() {
+    assert!(run("+> math/*\nx := round(1.23)"));
+}


### PR DESCRIPTION
### Motivation
- Generalize the narrow dynamic-module ABI so it can carry multiple scalar kernel shapes (unary and binary f64) without passing mech-core runtime types across the FFI boundary. 
- Add a simple unary provider (math/round) to exercise the new `UnaryF64ToF64` kernel kind and verify dynamic loading/dispatch for unary kernels. 

### Description
- Replace the single-typed kernel field in `MechExportV1` with a tagged union `MechKernelFnV1` and extend `MechKernelKindV1` with `UnaryF64ToF64` and `BinaryF64F64ToF64`, and add `MechUnaryF64ToF64KernelV1`. (`src/abi/src/lib.rs`).
- Update the dynamic module loader to initialize `MechExportV1.function` with a union default, read the correct union variant via `export.kind`, and register a new `DynamicUnaryF64ToF64Compiler` when `UnaryF64ToF64` is observed. (`src/interpreter/src/modules.rs`).
- Add host-owned unary wrappers: `DynamicUnaryF64ToF64Compiler` and `DynamicUnaryF64ToF64Function` that validate/convert arguments, call the provider kernel pointer, and keep Mech runtime state on the host. (`src/interpreter/src/modules.rs`).
- Update the combinatorics provider exports to populate the union field (`function: MechKernelFnV1 { binary_f64_f64_to_f64: ... }`) instead of the old typed field. (`machines/combinatorics/src/dynamic_module.rs`).
- Add a minimal `machines/math` dynamic provider for `math/round` with a provider-side pure kernel in `machines/math/src/kernels.rs`, a dynamic-module export in `machines/math/src/dynamic_module.rs`, and tests exercising metadata and kernel behavior. Adjust `machines/math/Cargo.toml` so `dynamic-module` builds without activating `mech-core` and produce a `cdylib`. (`machines/math/*`).
- Add interpreter-level integration tests for dynamic math imports (`tests/dynamic_math.rs`) and extend CI to build/test the math dynamic provider and run the dynamic-math smoke tests. (`.github/workflows/ci.yml`).

### Testing
- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` which completed successfully. 
- Ran `cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module"` and all combinatorics provider unit tests passed. 
- Built dynamic combinatorics and math providers and ran the runtime integration smoke tests by setting `MECH_MODULE_PATH=target/mech-modules`, and both `tests/dynamic_combinatorics` and `tests/dynamic_math` passed. 
- Verified dependency trees with `cargo tree` for both providers in `dynamic-module` mode and confirmed providers depend on `mech-abi` and `libm`/`num-traits` but not on `mech-core`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d86c1f948832a9d6a4cb55c0513e7)