### PR TITLE
Add declarative dynamic module export macro

### DIFF
--- a/machines/combinatorics/src/dynamic_module.rs
+++ b/machines/combinatorics/src/dynamic_module.rs
@@ -1,59 +1,18 @@
 #![cfg(feature = "dynamic-module")]
 
-use mech_abi::{
-    MechExportV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1, MechStrV1, MECH_MODULE_ABI_VERSION_V1,
-};
+use mech_abi::{MechExportV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1, MechStrV1};
 
 const MODULE_NAME: &[u8] = b"combinatorics";
 const EXPORT_NAME: &[u8] = b"combinatorics/n-choose-k";
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_abi_version_v1() -> u32 {
-    MECH_MODULE_ABI_VERSION_V1
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_name_v1(out: *mut MechStrV1) -> MechStatusV1 {
-    if out.is_null() {
-        return MechStatusV1::NullPointer;
-    }
-
-    unsafe {
-        *out = MechStrV1::from_static(MODULE_NAME);
-    }
-
-    MechStatusV1::Ok
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_export_count_v1() -> usize {
-    1
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_get_export_v1(
-    index: usize,
-    out: *mut MechExportV1,
-) -> MechStatusV1 {
-    if out.is_null() {
-        return MechStatusV1::NullPointer;
-    }
-
-    if index != 0 {
-        return MechStatusV1::InvalidIndex;
-    }
-
-    unsafe {
-        *out = MechExportV1 {
-            name: MechStrV1::from_static(EXPORT_NAME),
-            kind: MechKernelKindV1::BinaryF64F64ToF64,
-            function: MechKernelFnV1 {
-                binary_f64_f64_to_f64: combinatorics_n_choose_k_f64_v1,
-            },
-        };
-    }
-
-    MechStatusV1::Ok
+mech_abi::mech_dynamic_module_v1! {
+    module: b"combinatorics",
+    exports: [
+        binary_f64_f64_to_f64 {
+            name: b"combinatorics/n-choose-k",
+            function: combinatorics_n_choose_k_f64_v1,
+        },
+    ],
 }
 
 #[unsafe(no_mangle)]
@@ -96,6 +55,11 @@ mod tests {
 
         let name = unsafe { core::slice::from_raw_parts(module_name.ptr, module_name.len) };
         assert_eq!(name, MODULE_NAME);
+    }
+
+    #[test]
+    fn module_export_count_is_one() {
+        assert_eq!(unsafe { mech_module_export_count_v1() }, 1);
     }
 
     #[test]

--- a/machines/math/src/dynamic_module.rs
+++ b/machines/math/src/dynamic_module.rs
@@ -1,60 +1,18 @@
 #![cfg(feature = "dynamic-module")]
 
-use mech_abi::{
-    MechExportV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1, MechStrV1,
-    MECH_MODULE_ABI_VERSION_V1,
-};
+use mech_abi::{MechExportV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1, MechStrV1};
 
 const MODULE_NAME: &[u8] = b"math";
 const EXPORT_NAME: &[u8] = b"math/round";
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_abi_version_v1() -> u32 {
-    MECH_MODULE_ABI_VERSION_V1
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_name_v1(out: *mut MechStrV1) -> MechStatusV1 {
-    if out.is_null() {
-        return MechStatusV1::NullPointer;
-    }
-
-    unsafe {
-        *out = MechStrV1::from_static(MODULE_NAME);
-    }
-
-    MechStatusV1::Ok
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_export_count_v1() -> usize {
-    1
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mech_module_get_export_v1(
-    index: usize,
-    out: *mut MechExportV1,
-) -> MechStatusV1 {
-    if out.is_null() {
-        return MechStatusV1::NullPointer;
-    }
-
-    if index != 0 {
-        return MechStatusV1::InvalidIndex;
-    }
-
-    unsafe {
-        *out = MechExportV1 {
-            name: MechStrV1::from_static(EXPORT_NAME),
-            kind: MechKernelKindV1::UnaryF64ToF64,
-            function: MechKernelFnV1 {
-                unary_f64_to_f64: math_round_f64_v1,
-            },
-        };
-    }
-
-    MechStatusV1::Ok
+mech_abi::mech_dynamic_module_v1! {
+    module: b"math",
+    exports: [
+        unary_f64_to_f64 {
+            name: b"math/round",
+            function: math_round_f64_v1,
+        },
+    ],
 }
 
 #[unsafe(no_mangle)]
@@ -75,6 +33,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn module_name_null_pointer_returns_null_pointer() {
+        let status = unsafe { mech_module_name_v1(core::ptr::null_mut()) };
+        assert_eq!(status, MechStatusV1::NullPointer);
+    }
+
+    #[test]
     fn module_metadata_reports_module_name() {
         let mut module_name = MechStrV1 { ptr: core::ptr::null(), len: 0 };
         let status = unsafe { mech_module_name_v1(&mut module_name) };
@@ -86,6 +50,23 @@ mod tests {
     #[test]
     fn module_export_count_is_one() {
         assert_eq!(unsafe { mech_module_export_count_v1() }, 1);
+    }
+
+    #[test]
+    fn module_get_export_rejects_null_output() {
+        let status = unsafe { mech_module_get_export_v1(0, core::ptr::null_mut()) };
+        assert_eq!(status, MechStatusV1::NullPointer);
+    }
+
+    #[test]
+    fn module_get_export_rejects_invalid_index() {
+        let mut export = MechExportV1 {
+            name: MechStrV1 { ptr: core::ptr::null(), len: 0 },
+            kind: MechKernelKindV1::UnaryF64ToF64,
+            function: MechKernelFnV1 { unary_f64_to_f64: math_round_f64_v1 },
+        };
+        let status = unsafe { mech_module_get_export_v1(1, &mut export) };
+        assert_eq!(status, MechStatusV1::InvalidIndex);
     }
 
     #[test]

--- a/src/abi/src/lib.rs
+++ b/src/abi/src/lib.rs
@@ -89,3 +89,97 @@ pub type MechModuleNameFnV1 = unsafe extern "C" fn(out: *mut MechStrV1) -> MechS
 pub type MechModuleExportCountFnV1 = unsafe extern "C" fn() -> usize;
 pub type MechModuleGetExportFnV1 =
     unsafe extern "C" fn(index: usize, out: *mut MechExportV1) -> MechStatusV1;
+
+/// Generates the standard V1 dynamic module metadata and export symbols.
+///
+/// The generated ABI exposes only module metadata and typed scalar kernel
+/// pointers. Export order is the declaration order in the macro invocation.
+#[macro_export]
+macro_rules! mech_dynamic_module_v1 {
+    (
+        module: $module_name:expr,
+        exports: [
+            $(
+                $kind:ident {
+                    name: $export_name:expr,
+                    function: $function:path $(,)?
+                }
+            ),* $(,)?
+        ],
+    ) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn mech_module_abi_version_v1() -> u32 {
+            $crate::MECH_MODULE_ABI_VERSION_V1
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn mech_module_name_v1(
+            out: *mut $crate::MechStrV1,
+        ) -> $crate::MechStatusV1 {
+            if out.is_null() {
+                return $crate::MechStatusV1::NullPointer;
+            }
+
+            unsafe {
+                *out = $crate::MechStrV1::from_static($module_name);
+            }
+
+            $crate::MechStatusV1::Ok
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn mech_module_export_count_v1() -> usize {
+            <[()]>::len(&[$($crate::mech_dynamic_module_v1!(@unit $kind)),*])
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn mech_module_get_export_v1(
+            index: usize,
+            out: *mut $crate::MechExportV1,
+        ) -> $crate::MechStatusV1 {
+            if out.is_null() {
+                return $crate::MechStatusV1::NullPointer;
+            }
+
+            let exports: &[$crate::MechExportV1] = &[
+                $(
+                    $crate::mech_dynamic_module_v1!(
+                        @export $kind, $export_name, $function
+                    )
+                ),*
+            ];
+
+            let Some(export) = exports.get(index).copied() else {
+                return $crate::MechStatusV1::InvalidIndex;
+            };
+
+            unsafe {
+                *out = export;
+            }
+
+            $crate::MechStatusV1::Ok
+        }
+    };
+
+    (@unit $kind:ident) => { () };
+
+    (@export unary_f64_to_f64, $export_name:expr, $function:path) => {
+        $crate::MechExportV1 {
+            name: $crate::MechStrV1::from_static($export_name),
+            kind: $crate::MechKernelKindV1::UnaryF64ToF64,
+            function: $crate::MechKernelFnV1 {
+                unary_f64_to_f64: $function,
+            },
+        }
+    };
+
+    (@export binary_f64_f64_to_f64, $export_name:expr, $function:path) => {
+        $crate::MechExportV1 {
+            name: $crate::MechStrV1::from_static($export_name),
+            kind: $crate::MechKernelKindV1::BinaryF64F64ToF64,
+            function: $crate::MechKernelFnV1 {
+                binary_f64_f64_to_f64: $function,
+            },
+        }
+    };
+}


### PR DESCRIPTION
### Motivation
- Reduce repeated provider-side boilerplate by providing a declarative macro that emits the standard V1 dynamic-module ABI symbols. 
- Preserve the exact V1 ABI and runtime behavior while making provider code more concise and less error-prone.

### Description
- Add the exported macro `mech_dynamic_module_v1!` to `src/abi/src/lib.rs` which emits the four V1 symbols `mech_module_abi_version_v1`, `mech_module_name_v1`, `mech_module_export_count_v1`, and `mech_module_get_export_v1` using `$crate::` paths, null-pointer checks, invalid-index handling, and stable declaration-order exports, and supporting only the existing `UnaryF64ToF64` and `BinaryF64F64ToF64` kernel kinds.
- Replace handwritten module metadata/export implementations in `machines/combinatorics/src/dynamic_module.rs` and `machines/math/src/dynamic_module.rs` with `mech_abi::mech_dynamic_module_v1! { ... }` while keeping the actual scalar kernel functions (`combinatorics_n_choose_k_f64_v1` and `math_round_f64_v1`) unchanged.
- Update provider-side unit tests to exercise the macro-generated ABI (module name, export count, null-output checks, invalid-index behavior, and export metadata) while preserving existing kernel behavior tests.
- No runtime behavior changes, no new kernel kinds, no new view APIs or wrapper crates, and provider crates continue to avoid depending on `mech-core` in dynamic-module builds.

### Testing
- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` and it completed successfully.
- Ran `cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module"` and the combinatorics unit tests passed (`11 passed`).
- Built combinatorics with `cargo build --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module" --target-dir target/dynamic-modules` and the build succeeded.
- Ran `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"` and the math unit tests passed (`8 passed`).
- Built math with `cargo build --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module" --target-dir target/dynamic-modules` and the build succeeded.
- Executed integration tests by packaging dynamic libs into `target/mech-modules` and running `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"` and `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"`; both test suites passed.
- Verified dependency trees with `cargo tree` for both providers show `mech-abi` (and expected deps) and no `mech-core` in the dynamic-module builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d90ba60e0832a9f6a954a00d36281)