### PR TITLE
Replace f64 slice ABI with shape-aware f64 view ABI

### DIFF
--- a/machines/math/src/dynamic_module.rs
+++ b/machines/math/src/dynamic_module.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "dynamic-module")]
 
 use mech_abi::{
-    MechExportV1, MechF64SliceMutV1, MechF64SliceV1, MechKernelFnV1, MechKernelKindV1,
-    MechStatusV1, MechStrV1,
+    MechExportV1, MechF64ViewMutV1, MechF64ViewV1, MechKernelFnV1, MechKernelKindV1, MechStatusV1,
+    MechStrV1,
 };
 
 const MODULE_NAME: &[u8] = b"math";
@@ -15,9 +15,9 @@ mech_abi::mech_dynamic_module_v1! {
             name: b"math/round",
             function: math_round_f64_v1,
         },
-        unary_f64_slice_to_f64_slice {
+        unary_f64_view_to_f64_view {
             name: b"math/round",
-            function: math_round_f64_slice_v1,
+            function: math_round_f64_view_v1,
         },
     ],
 }
@@ -36,11 +36,27 @@ pub unsafe extern "C" fn math_round_f64_v1(input: f64, out: *mut f64) -> MechSta
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_round_f64_slice_v1(
-    input: MechF64SliceV1,
-    out: MechF64SliceMutV1,
+pub unsafe extern "C" fn math_round_f64_view_v1(
+    input: MechF64ViewV1,
+    out: MechF64ViewMutV1,
 ) -> MechStatusV1 {
     if input.len != out.len {
+        return MechStatusV1::WrongShape;
+    }
+
+    if input.rows != out.rows || input.cols != out.cols {
+        return MechStatusV1::WrongShape;
+    }
+
+    let Some(input_cells) = input.rows.checked_mul(input.cols) else {
+        return MechStatusV1::WrongShape;
+    };
+
+    let Some(out_cells) = out.rows.checked_mul(out.cols) else {
+        return MechStatusV1::WrongShape;
+    };
+
+    if input.len != input_cells || out.len != out_cells {
         return MechStatusV1::WrongShape;
     }
 
@@ -55,7 +71,7 @@ pub unsafe extern "C" fn math_round_f64_slice_v1(
     let input_slice = unsafe { core::slice::from_raw_parts(input.ptr, input.len) };
     let out_slice = unsafe { core::slice::from_raw_parts_mut(out.ptr, out.len) };
 
-    crate::kernels::round::slice_f64(input_slice, out_slice);
+    crate::kernels::round::view_f64(input_slice, out_slice);
 
     MechStatusV1::Ok
 }
@@ -129,22 +145,22 @@ mod tests {
     }
 
     #[test]
-    fn export_metadata_describes_round_slice_kernel() {
+    fn export_metadata_describes_round_view_kernel() {
         let mut export = MechExportV1 {
             name: MechStrV1 {
                 ptr: core::ptr::null(),
                 len: 0,
             },
-            kind: MechKernelKindV1::UnaryF64SliceToF64Slice,
+            kind: MechKernelKindV1::UnaryF64ViewToF64View,
             function: MechKernelFnV1 {
-                unary_f64_slice_to_f64_slice: math_round_f64_slice_v1,
+                unary_f64_view_to_f64_view: math_round_f64_view_v1,
             },
         };
         let status = unsafe { mech_module_get_export_v1(1, &mut export) };
         let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
         assert_eq!(status, MechStatusV1::Ok);
         assert_eq!(name, EXPORT_NAME);
-        assert_eq!(export.kind, MechKernelKindV1::UnaryF64SliceToF64Slice);
+        assert_eq!(export.kind, MechKernelKindV1::UnaryF64ViewToF64View);
     }
 
     #[test]
@@ -162,19 +178,23 @@ mod tests {
     }
 
     #[test]
-    fn math_round_f64_slice_returns_expected_result() {
+    fn math_round_f64_view_returns_expected_result() {
         let input = [1.23, 2.7, 3.1];
         let mut out = [0.0, 0.0, 0.0];
 
         let status = unsafe {
-            math_round_f64_slice_v1(
-                MechF64SliceV1 {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
                     ptr: input.as_ptr(),
                     len: input.len(),
+                    rows: 1,
+                    cols: 3,
                 },
-                MechF64SliceMutV1 {
+                MechF64ViewMutV1 {
                     ptr: out.as_mut_ptr(),
                     len: out.len(),
+                    rows: 1,
+                    cols: 3,
                 },
             )
         };
@@ -184,18 +204,22 @@ mod tests {
     }
 
     #[test]
-    fn math_round_f64_slice_rejects_null_input() {
+    fn math_round_f64_view_rejects_null_input() {
         let mut out = [0.0, 0.0, 0.0];
 
         let status = unsafe {
-            math_round_f64_slice_v1(
-                MechF64SliceV1 {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
                     ptr: core::ptr::null(),
                     len: out.len(),
+                    rows: 1,
+                    cols: 3,
                 },
-                MechF64SliceMutV1 {
+                MechF64ViewMutV1 {
                     ptr: out.as_mut_ptr(),
                     len: out.len(),
+                    rows: 1,
+                    cols: 3,
                 },
             )
         };
@@ -204,18 +228,22 @@ mod tests {
     }
 
     #[test]
-    fn math_round_f64_slice_rejects_null_output() {
+    fn math_round_f64_view_rejects_null_output() {
         let input = [1.23, 2.7, 3.1];
 
         let status = unsafe {
-            math_round_f64_slice_v1(
-                MechF64SliceV1 {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
                     ptr: input.as_ptr(),
                     len: input.len(),
+                    rows: 1,
+                    cols: 3,
                 },
-                MechF64SliceMutV1 {
+                MechF64ViewMutV1 {
                     ptr: core::ptr::null_mut(),
                     len: input.len(),
+                    rows: 1,
+                    cols: 3,
                 },
             )
         };
@@ -224,19 +252,23 @@ mod tests {
     }
 
     #[test]
-    fn math_round_f64_slice_rejects_wrong_shape() {
+    fn math_round_f64_view_rejects_wrong_len() {
         let input = [1.23, 2.7, 3.1];
         let mut out = [0.0, 0.0];
 
         let status = unsafe {
-            math_round_f64_slice_v1(
-                MechF64SliceV1 {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
                     ptr: input.as_ptr(),
                     len: input.len(),
+                    rows: 1,
+                    cols: 3,
                 },
-                MechF64SliceMutV1 {
+                MechF64ViewMutV1 {
                     ptr: out.as_mut_ptr(),
                     len: out.len(),
+                    rows: 1,
+                    cols: 2,
                 },
             )
         };
@@ -245,16 +277,70 @@ mod tests {
     }
 
     #[test]
-    fn math_round_f64_slice_accepts_empty_slices() {
+    fn math_round_f64_view_rejects_mismatched_shape() {
+        let input = [1.23, 2.7, 3.1, 4.2];
+        let mut out = [0.0, 0.0, 0.0, 0.0];
+
         let status = unsafe {
-            math_round_f64_slice_v1(
-                MechF64SliceV1 {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
+                    ptr: input.as_ptr(),
+                    len: input.len(),
+                    rows: 2,
+                    cols: 2,
+                },
+                MechF64ViewMutV1 {
+                    ptr: out.as_mut_ptr(),
+                    len: out.len(),
+                    rows: 1,
+                    cols: 4,
+                },
+            )
+        };
+
+        assert_eq!(status, MechStatusV1::WrongShape);
+    }
+
+    #[test]
+    fn math_round_f64_view_rejects_len_shape_mismatch() {
+        let input = [1.23, 2.7, 3.1];
+        let mut out = [0.0, 0.0, 0.0];
+
+        let status = unsafe {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
+                    ptr: input.as_ptr(),
+                    len: input.len(),
+                    rows: 3,
+                    cols: 3,
+                },
+                MechF64ViewMutV1 {
+                    ptr: out.as_mut_ptr(),
+                    len: out.len(),
+                    rows: 3,
+                    cols: 3,
+                },
+            )
+        };
+
+        assert_eq!(status, MechStatusV1::WrongShape);
+    }
+
+    #[test]
+    fn math_round_f64_view_accepts_empty_views() {
+        let status = unsafe {
+            math_round_f64_view_v1(
+                MechF64ViewV1 {
                     ptr: core::ptr::null(),
                     len: 0,
+                    rows: 0,
+                    cols: 0,
                 },
-                MechF64SliceMutV1 {
+                MechF64ViewMutV1 {
                     ptr: core::ptr::null_mut(),
                     len: 0,
+                    rows: 0,
+                    cols: 0,
                 },
             )
         };

--- a/machines/math/src/kernels.rs
+++ b/machines/math/src/kernels.rs
@@ -4,7 +4,7 @@ pub mod round {
         libm::round(input)
     }
 
-    pub fn slice_f64(input: &[f64], out: &mut [f64]) {
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
         for (src, dst) in input.iter().zip(out.iter_mut()) {
             *dst = scalar_f64(*src);
         }

--- a/src/abi/src/lib.rs
+++ b/src/abi/src/lib.rs
@@ -28,18 +28,32 @@ pub struct MechStrV1 {
     pub len: usize,
 }
 
+/// Borrowed contiguous f64 view owned by the host.
+///
+/// The view is valid only for the duration of the ABI call.
+/// `len` must equal `rows * cols`.
+/// The dynamic module must not retain the pointer.
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MechF64SliceV1 {
+pub struct MechF64ViewV1 {
     pub ptr: *const f64,
     pub len: usize,
+    pub rows: usize,
+    pub cols: usize,
 }
 
+/// Mutable contiguous f64 view owned by the host.
+///
+/// The view is valid only for the duration of the ABI call.
+/// `len` must equal `rows * cols`.
+/// The dynamic module must not retain the pointer.
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MechF64SliceMutV1 {
+pub struct MechF64ViewMutV1 {
     pub ptr: *mut f64,
     pub len: usize,
+    pub rows: usize,
+    pub cols: usize,
 }
 
 impl MechStrV1 {
@@ -61,7 +75,7 @@ impl MechStrV1 {
 pub enum MechKernelKindV1 {
     UnaryF64ToF64 = 1,
     BinaryF64F64ToF64 = 2,
-    UnaryF64SliceToF64Slice = 3,
+    UnaryF64ViewToF64View = 3,
 }
 
 /// Kernel for a unary scalar f64 function.
@@ -72,8 +86,8 @@ pub enum MechKernelKindV1 {
 pub type MechUnaryF64ToF64KernelV1 =
     unsafe extern "C" fn(input: f64, out: *mut f64) -> MechStatusV1;
 
-pub type MechUnaryF64SliceToF64SliceKernelV1 =
-    unsafe extern "C" fn(input: MechF64SliceV1, out: MechF64SliceMutV1) -> MechStatusV1;
+pub type MechUnaryF64ViewToF64ViewKernelV1 =
+    unsafe extern "C" fn(input: MechF64ViewV1, out: MechF64ViewMutV1) -> MechStatusV1;
 
 /// Kernel for a binary scalar f64 function.
 ///
@@ -88,7 +102,7 @@ pub type MechBinaryF64F64ToF64KernelV1 =
 pub union MechKernelFnV1 {
     pub unary_f64_to_f64: MechUnaryF64ToF64KernelV1,
     pub binary_f64_f64_to_f64: MechBinaryF64F64ToF64KernelV1,
-    pub unary_f64_slice_to_f64_slice: MechUnaryF64SliceToF64SliceKernelV1,
+    pub unary_f64_view_to_f64_view: MechUnaryF64ViewToF64ViewKernelV1,
 }
 
 /// One exported Mech function/kernel.
@@ -202,12 +216,12 @@ macro_rules! mech_dynamic_module_v1 {
         }
     };
 
-    (@export unary_f64_slice_to_f64_slice, $export_name:expr, $function:path) => {
+    (@export unary_f64_view_to_f64_view, $export_name:expr, $function:path) => {
         $crate::MechExportV1 {
             name: $crate::MechStrV1::from_static($export_name),
-            kind: $crate::MechKernelKindV1::UnaryF64SliceToF64Slice,
+            kind: $crate::MechKernelKindV1::UnaryF64ViewToF64View,
             function: $crate::MechKernelFnV1 {
-                unary_f64_slice_to_f64_slice: $function,
+                unary_f64_view_to_f64_view: $function,
             },
         }
     };

--- a/src/interpreter/src/modules.rs
+++ b/src/interpreter/src/modules.rs
@@ -305,14 +305,14 @@ impl ModuleLoader for DynamicModuleLoader {
                         items.push(item);
                     }
                 }
-                mech_abi::MechKernelKindV1::UnaryF64SliceToF64Slice => {
-                    let kernel = unsafe { export.function.unary_f64_slice_to_f64_slice };
+                mech_abi::MechKernelKindV1::UnaryF64ViewToF64View => {
+                    let kernel = unsafe { export.function.unary_f64_view_to_f64_view };
                     let compiler_name = export_name.clone();
 
                     dynamic_compilers
                         .entry(compiler_name.clone())
                         .or_default()
-                        .push(Arc::new(DynamicUnaryF64SliceToF64SliceCompiler {
+                        .push(Arc::new(DynamicUnaryF64ViewToF64ViewCompiler {
                             name: compiler_name.clone(),
                             kernel,
                             _library: library.clone(),
@@ -370,9 +370,9 @@ unsafe extern "C" fn dynamic_null_unary_f64_to_f64(
 }
 
 #[cfg(feature = "dynamic-modules")]
-unsafe extern "C" fn dynamic_null_unary_f64_slice_to_f64_slice(
-    _input: mech_abi::MechF64SliceV1,
-    _out: mech_abi::MechF64SliceMutV1,
+unsafe extern "C" fn dynamic_null_unary_f64_view_to_f64_view(
+    _input: mech_abi::MechF64ViewV1,
+    _out: mech_abi::MechF64ViewMutV1,
 ) -> mech_abi::MechStatusV1 {
     mech_abi::MechStatusV1::Unsupported
 }
@@ -499,14 +499,14 @@ impl NativeFunctionCompiler for DynamicUnaryF64ToF64Compiler {
 }
 
 #[cfg(feature = "dynamic-modules")]
-struct DynamicUnaryF64SliceToF64SliceCompiler {
+struct DynamicUnaryF64ViewToF64ViewCompiler {
     name: String,
-    kernel: mech_abi::MechUnaryF64SliceToF64SliceKernelV1,
+    kernel: mech_abi::MechUnaryF64ViewToF64ViewKernelV1,
     _library: Arc<libloading::Library>,
 }
 
 #[cfg(feature = "dynamic-modules")]
-impl NativeFunctionCompiler for DynamicUnaryF64SliceToF64SliceCompiler {
+impl NativeFunctionCompiler for DynamicUnaryF64ViewToF64ViewCompiler {
     fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
         if arguments.len() != 1 {
             return Err(MechError::new(
@@ -525,11 +525,13 @@ impl NativeFunctionCompiler for DynamicUnaryF64SliceToF64SliceCompiler {
         let len = rows * cols;
         let out = Matrix::from_vec(vec![0.0; len], rows, cols);
 
-        Ok(Box::new(DynamicUnaryF64SliceToF64SliceFunction {
+        Ok(Box::new(DynamicUnaryF64ViewToF64ViewFunction {
             name: self.name.clone(),
             input,
             out,
             len,
+            rows,
+            cols,
             kernel: self.kernel,
             _library: self._library.clone(),
         }))
@@ -693,17 +695,19 @@ impl MechFunctionCompiler for DynamicUnaryF64ToF64Function {
 }
 
 #[cfg(feature = "dynamic-modules")]
-struct DynamicUnaryF64SliceToF64SliceFunction {
+struct DynamicUnaryF64ViewToF64ViewFunction {
     name: String,
     input: Matrix<f64>,
     out: Matrix<f64>,
     len: usize,
-    kernel: mech_abi::MechUnaryF64SliceToF64SliceKernelV1,
+    rows: usize,
+    cols: usize,
+    kernel: mech_abi::MechUnaryF64ViewToF64ViewKernelV1,
     _library: Arc<libloading::Library>,
 }
 
 #[cfg(feature = "dynamic-modules")]
-impl MechFunctionImpl for DynamicUnaryF64SliceToF64SliceFunction {
+impl MechFunctionImpl for DynamicUnaryF64ViewToF64ViewFunction {
     fn solve(&self) {
         let mut input_vec = Vec::with_capacity(self.len);
         for index in 1..=self.len {
@@ -714,13 +718,17 @@ impl MechFunctionImpl for DynamicUnaryF64SliceToF64SliceFunction {
 
         let status = unsafe {
             (self.kernel)(
-                mech_abi::MechF64SliceV1 {
+                mech_abi::MechF64ViewV1 {
                     ptr: input_vec.as_ptr(),
                     len: input_vec.len(),
+                    rows: self.rows,
+                    cols: self.cols,
                 },
-                mech_abi::MechF64SliceMutV1 {
+                mech_abi::MechF64ViewMutV1 {
                     ptr: out_vec.as_mut_ptr(),
                     len: out_vec.len(),
+                    rows: self.rows,
+                    cols: self.cols,
                 },
             )
         };
@@ -745,7 +753,7 @@ impl MechFunctionImpl for DynamicUnaryF64SliceToF64SliceFunction {
 }
 
 #[cfg(all(feature = "dynamic-modules", feature = "compiler"))]
-impl MechFunctionCompiler for DynamicUnaryF64SliceToF64SliceFunction {
+impl MechFunctionCompiler for DynamicUnaryF64ViewToF64ViewFunction {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
         Err(MechError::new(
             GenericError {

--- a/tests/dynamic_math.rs
+++ b/tests/dynamic_math.rs
@@ -1,7 +1,7 @@
 extern crate mech_core;
 
 use mech::program::{MechProgram, MechProgramConfig};
-use mech_core::{Value, structures::matrix::Matrix};
+use mech_core::{structures::matrix::Matrix, Value};
 
 fn run(source: &str) -> bool {
     let mut program = MechProgram::new(MechProgramConfig::default());


### PR DESCRIPTION
### Motivation
- Replaces temporary f64 slice ABI naming with f64 view ABI naming.
- Adds rows and cols to the ABI descriptor.
- Keeps dynamic math/round overloaded for scalar and `MatrixF64`.
- Does not introduce stride support, new Mech-facing names, or bump `MECH_MODULE_ABI_VERSION_V1`.

### Description
- Replaced `MechF64SliceV1`/`MechF64SliceMutV1` with `MechF64ViewV1`/`MechF64ViewMutV1` (fields: `ptr`, `len`, `rows`, `cols`) in `src/abi/src/lib.rs` and added documentation comments describing borrowing rules.
- Renamed the ABI kernel kind/typedef/union/macro arm to view names (`UnaryF64ViewToF64View`, `MechUnaryF64ViewToF64ViewKernelV1`, union field `unary_f64_view_to_f64_view`, and the `mech_dynamic_module_v1!` export arm) while keeping existing scalar/binary arms unchanged.
- Updated the interpreter dynamic loader and host wrappers in `src/interpreter/src/modules.rs` to register the new `UnaryF64ViewToF64View` compiler, pass `rows` and `cols` through the `DynamicUnaryF64ViewToF64ViewCompiler`/`DynamicUnaryF64ViewToF64ViewFunction`, and preserve the temporary `Vec<f64>` copy-through behavior for matrix arguments.
- Updated math machine code in `machines/math`: renamed `slice_f64` to `view_f64` in `machines/math/src/kernels.rs`, implemented `math_round_f64_view_v1` in `machines/math/src/dynamic_module.rs` with full shape validation (`len`, `rows`, `cols`) and null checks, adapted the module export to provide two overloads under the existing `math/round` name, and updated unit tests to the view-based names and expectations.

### Testing
- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` and it succeeded.
- Ran `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"`, built the math module, and ran `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"`, and all tests passed.
- Ran the combinatorics module tests and dynamic combinatorics dynamic tests using the provided build/copy/test sequence and all tests passed.
- Verified repository searches for `round-slice`, `MechF64Slice`, `SliceToF64Slice`, `slice_to_f64_slice`, and `math_round_f64_slice` returned no results; occurrences of `core::slice` and an unrelated test named `interpret_slice_f64` remain as expected and were not part of the allowed edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dadae9a88832a91747860eb72710b)