### PR TITLE
Add host-side broadcasting for dynamic binary f64 kernels

### DIFF
--- a/src/interpreter/src/modules.rs
+++ b/src/interpreter/src/modules.rs
@@ -431,6 +431,30 @@ impl NativeFunctionCompiler for DynamicOverloadedCompiler {
 }
 
 #[cfg(feature = "dynamic-modules")]
+#[derive(Clone)]
+enum DynamicF64Arg {
+    Scalar(Ref<f64>),
+    Matrix(Matrix<f64>),
+}
+
+#[cfg(feature = "dynamic-modules")]
+impl DynamicF64Arg {
+    fn matrix_shape(&self) -> Option<(usize, usize)> {
+        match self {
+            DynamicF64Arg::Scalar(_) => None,
+            DynamicF64Arg::Matrix(matrix) => Some((matrix.rows(), matrix.cols())),
+        }
+    }
+
+    fn value_at(&self, index: usize) -> f64 {
+        match self {
+            DynamicF64Arg::Scalar(value) => unsafe { *value.as_ptr() },
+            DynamicF64Arg::Matrix(matrix) => matrix.index1d(index),
+        }
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
 struct DynamicBinaryF64F64ToF64Compiler {
     name: String,
     kernel: mech_abi::MechBinaryF64F64ToF64KernelV1,
@@ -451,17 +475,49 @@ impl NativeFunctionCompiler for DynamicBinaryF64F64ToF64Compiler {
             .with_compiler_loc());
         }
 
-        let n = dynamic_arg_as_f64_ref(&arguments[0], &self.name)?;
-        let k = dynamic_arg_as_f64_ref(&arguments[1], &self.name)?;
+        let lhs = dynamic_arg_as_f64_scalar_or_matrix(&arguments[0], &self.name)?;
+        let rhs = dynamic_arg_as_f64_scalar_or_matrix(&arguments[1], &self.name)?;
 
-        Ok(Box::new(DynamicBinaryF64F64ToF64Function {
-            name: self.name.clone(),
-            n,
-            k,
-            out: Ref::new(0.0),
-            kernel: self.kernel,
-            _library: self._library.clone(),
-        }))
+        match (&lhs, &rhs) {
+            (DynamicF64Arg::Scalar(n), DynamicF64Arg::Scalar(k)) => {
+                Ok(Box::new(DynamicBinaryF64F64ToF64Function {
+                    name: self.name.clone(),
+                    n: n.clone(),
+                    k: k.clone(),
+                    out: Ref::new(0.0),
+                    kernel: self.kernel,
+                    _library: self._library.clone(),
+                }))
+            }
+
+            _ => {
+                let (rows, cols) = dynamic_binary_broadcast_shape(&lhs, &rhs, &self.name)?;
+                let Some(len) = rows.checked_mul(cols) else {
+                    return Err(MechError::new(
+                        GenericError {
+                            msg: format!(
+                                "dynamic function `{}` broadcast shape overflowed: {} x {}",
+                                self.name, rows, cols
+                            ),
+                        },
+                        None,
+                    )
+                    .with_compiler_loc());
+                };
+
+                let out = Matrix::from_vec(vec![0.0; len], rows, cols);
+
+                Ok(Box::new(DynamicBinaryF64F64BroadcastFunction {
+                    name: self.name.clone(),
+                    lhs,
+                    rhs,
+                    out,
+                    len,
+                    kernel: self.kernel,
+                    _library: self._library.clone(),
+                }))
+            }
+        }
     }
 }
 
@@ -568,6 +624,84 @@ fn dynamic_arg_as_f64_ref(value: &Value, fxn_name: &str) -> MResult<Ref<f64>> {
 }
 
 #[cfg(feature = "dynamic-modules")]
+fn dynamic_arg_as_f64_scalar_or_matrix(value: &Value, fxn_name: &str) -> MResult<DynamicF64Arg> {
+    match value {
+        #[cfg(feature = "f64")]
+        Value::F64(v) => Ok(DynamicF64Arg::Scalar(v.clone())),
+
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Ok(DynamicF64Arg::Matrix(matrix.clone())),
+
+        Value::MutableReference(v) => {
+            let borrowed = v.borrow();
+            match &*borrowed {
+                #[cfg(feature = "f64")]
+                Value::F64(inner) => Ok(DynamicF64Arg::Scalar(inner.clone())),
+
+                #[cfg(all(feature = "matrix", feature = "f64"))]
+                Value::MatrixF64(matrix) => Ok(DynamicF64Arg::Matrix(matrix.clone())),
+
+                x => Err(MechError::new(
+                    UnhandledFunctionArgumentKind1 {
+                        arg: x.kind(),
+                        fxn_name: fxn_name.to_string(),
+                    },
+                    None,
+                )
+                .with_compiler_loc()),
+            }
+        }
+
+        x => Err(MechError::new(
+            UnhandledFunctionArgumentKind1 {
+                arg: x.kind(),
+                fxn_name: fxn_name.to_string(),
+            },
+            None,
+        )
+        .with_compiler_loc()),
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
+fn dynamic_binary_broadcast_shape(
+    lhs: &DynamicF64Arg,
+    rhs: &DynamicF64Arg,
+    fxn_name: &str,
+) -> MResult<(usize, usize)> {
+    match (lhs.matrix_shape(), rhs.matrix_shape()) {
+        (Some((lhs_rows, lhs_cols)), Some((rhs_rows, rhs_cols))) => {
+            if lhs_rows == rhs_rows && lhs_cols == rhs_cols {
+                Ok((lhs_rows, lhs_cols))
+            } else {
+                Err(MechError::new(
+                    GenericError {
+                        msg: format!(
+                            "dynamic function `{}` cannot broadcast matrix shapes {}x{} and {}x{}",
+                            fxn_name, lhs_rows, lhs_cols, rhs_rows, rhs_cols
+                        ),
+                    },
+                    None,
+                )
+                .with_compiler_loc())
+            }
+        }
+        (Some(shape), None) => Ok(shape),
+        (None, Some(shape)) => Ok(shape),
+        (None, None) => Err(MechError::new(
+            GenericError {
+                msg: format!(
+                    "dynamic function `{}` expected at least one matrix argument for broadcast",
+                    fxn_name
+                ),
+            },
+            None,
+        )
+        .with_compiler_loc()),
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
 fn dynamic_arg_as_f64_matrix(value: &Value, fxn_name: &str) -> MResult<Matrix<f64>> {
     match value {
         #[cfg(all(feature = "matrix", feature = "f64"))]
@@ -633,6 +767,68 @@ impl MechFunctionImpl for DynamicBinaryF64F64ToF64Function {
 
 #[cfg(all(feature = "dynamic-modules", feature = "compiler"))]
 impl MechFunctionCompiler for DynamicBinaryF64F64ToF64Function {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+        Err(MechError::new(
+            GenericError {
+                msg: format!(
+                    "bytecode compilation is not implemented for dynamic function `{}`",
+                    self.name
+                ),
+            },
+            None,
+        )
+        .with_compiler_loc())
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
+struct DynamicBinaryF64F64BroadcastFunction {
+    name: String,
+    lhs: DynamicF64Arg,
+    rhs: DynamicF64Arg,
+    out: Matrix<f64>,
+    len: usize,
+    kernel: mech_abi::MechBinaryF64F64ToF64KernelV1,
+    _library: Arc<libloading::Library>,
+}
+
+#[cfg(feature = "dynamic-modules")]
+impl MechFunctionImpl for DynamicBinaryF64F64BroadcastFunction {
+    fn solve(&self) {
+        let mut out_vec = Vec::with_capacity(self.len);
+
+        for index in 1..=self.len {
+            let lhs = self.lhs.value_at(index);
+            let rhs = self.rhs.value_at(index);
+            let mut out = 0.0;
+
+            let status = unsafe { (self.kernel)(lhs, rhs, &mut out as *mut f64) };
+
+            if status != mech_abi::MechStatusV1::Ok {
+                dynamic_trace(format!(
+                    "dynamic kernel `{}` returned status {:?}",
+                    self.name, status
+                ));
+                return;
+            }
+
+            out_vec.push(out);
+        }
+
+        self.out.set(out_vec);
+    }
+
+    fn out(&self) -> Value {
+        Value::MatrixF64(self.out.clone())
+    }
+
+    fn to_string(&self) -> String {
+        format!("dynamic {}", self.name)
+    }
+}
+
+#[cfg(all(feature = "dynamic-modules", feature = "compiler"))]
+impl MechFunctionCompiler for DynamicBinaryF64F64BroadcastFunction {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
         Err(MechError::new(
             GenericError {

--- a/tests/dynamic_combinatorics.rs
+++ b/tests/dynamic_combinatorics.rs
@@ -1,8 +1,24 @@
+extern crate mech_core;
+
 use mech::program::{MechProgram, MechProgramConfig};
+use mech_core::{Value, structures::matrix::Matrix};
 
 fn run(source: &str) -> bool {
     let mut program = MechProgram::new(MechProgramConfig::default());
     program.run_string(source).is_ok()
+}
+
+#[cfg(feature = "dynamic-modules")]
+fn run_matrix_n_choose_k(source: &str, expected: Vec<f64>) {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let result = program.run_string(source).unwrap();
+
+    let detached = match result {
+        Value::MutableReference(v) => v.borrow().clone(),
+        value => value,
+    };
+
+    assert_eq!(detached, Value::MatrixF64(Matrix::from_vec(expected, 1, 2)));
 }
 
 #[cfg(feature = "dynamic-modules")]
@@ -25,4 +41,59 @@ fn dynamic_combinatorics_module_import_works() {
 #[test]
 fn dynamic_combinatorics_glob_import_works() {
     assert!(run("+> combinatorics/*\nx := n-choose-k(10.0, 2.0)"));
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_matrix_scalar_broadcast_works() {
+    run_matrix_n_choose_k(
+        "+> combinatorics/n-choose-k\nx := n-choose-k([10.0 20.0], 2.0)\nx",
+        vec![45.0, 190.0],
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_scalar_matrix_broadcast_works() {
+    run_matrix_n_choose_k(
+        "+> combinatorics/n-choose-k\nx := n-choose-k(10.0, [2.0 3.0])\nx",
+        vec![45.0, 120.0],
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_matrix_matrix_broadcast_works() {
+    run_matrix_n_choose_k(
+        "+> combinatorics/n-choose-k\nx := n-choose-k([10.0 20.0], [2.0 3.0])\nx",
+        vec![45.0, 1140.0],
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_module_import_matrix_broadcast_works() {
+    run_matrix_n_choose_k(
+        "+> combinatorics\nx := combinatorics/n-choose-k([10.0 20.0], 2.0)\nx",
+        vec![45.0, 190.0],
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_glob_import_matrix_broadcast_works() {
+    run_matrix_n_choose_k(
+        "+> combinatorics/*\nx := n-choose-k([10.0 20.0], 2.0)\nx",
+        vec![45.0, 190.0],
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_matrix_matrix_shape_mismatch_errors() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let result = program
+        .run_string("+> combinatorics/n-choose-k\nx := n-choose-k([10.0 20.0], [2.0 3.0 4.0])\nx");
+
+    assert!(result.is_err());
 }


### PR DESCRIPTION
### Motivation

- Enable host-side scalar/matrix broadcasting for dynamic `BinaryF64F64ToF64` kernels so providers can remain scalar-only while the host implements broadcasting semantics. 
- Use the existing `combinatorics/n-choose-k` dynamic provider as a proof-of-concept implementation without changing ABI, provider exports, or Mech-facing names.

### Description

- Adds a `DynamicF64Arg` enum and helpers to accept either scalar `F64` or `MatrixF64` arguments and to read per-element values via `value_at` and `matrix_shape`.
- Replaces `DynamicBinaryF64F64ToF64Compiler::compile` to parse both arguments with `dynamic_arg_as_f64_scalar_or_matrix` and dispatch to the original scalar wrapper for scalar/scalar or to a new broadcast wrapper for any matrix-containing combination.
- Adds `dynamic_binary_broadcast_shape` to validate broadcast shapes (matrix+matrix requires identical rows and cols) and to handle overflow checks when allocating the output matrix.
- Implements `DynamicBinaryF64F64BroadcastFunction` which iterates elements, invokes the existing scalar ABI kernel for each pair, accumulates results into a `MatrixF64` output, and exposes a `MechFunctionCompiler` stub that returns an error for bytecode compilation.
- Adds tests in `tests/dynamic_combinatorics.rs` covering matrix/scalar, scalar/matrix, same-shape matrix/matrix, import variants, and a shape-mismatch error case; only `src/interpreter/src/modules.rs` and `tests/dynamic_combinatorics.rs` were modified.
- Intentionally does not add new ABI kinds, provider exports, Mech-facing names, row/column broadcasting, or zero-copy views.

### Testing

- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` which completed successfully.
- Built and ran the combinatorics module and unit tests with `cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module"` and `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"`, and all combinatorics tests passed.
- Built and ran the math dynamic module and `dynamic_math` tests with `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"` and `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"`, and all math dynamic tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dc1580b00832ab6cbf93fa53f7167)