### PR TITLE
Add dynamic math exports for sqrt floor ceil and atan2

### DIFF
--- a/machines/math/src/dynamic_module.rs
+++ b/machines/math/src/dynamic_module.rs
@@ -7,6 +7,10 @@ use mech_abi::{
 
 const MODULE_NAME: &[u8] = b"math";
 const EXPORT_NAME: &[u8] = b"math/round";
+const SQRT_EXPORT_NAME: &[u8] = b"math/sqrt";
+const FLOOR_EXPORT_NAME: &[u8] = b"math/floor";
+const CEIL_EXPORT_NAME: &[u8] = b"math/ceil";
+const ATAN2_EXPORT_NAME: &[u8] = b"math/atan2";
 
 mech_abi::mech_dynamic_module_v1! {
     module: b"math",
@@ -19,26 +23,70 @@ mech_abi::mech_dynamic_module_v1! {
             name: b"math/round",
             function: math_round_f64_view_v1,
         },
+        unary_f64_to_f64 {
+            name: b"math/sqrt",
+            function: math_sqrt_f64_v1,
+        },
+        unary_f64_view_to_f64_view {
+            name: b"math/sqrt",
+            function: math_sqrt_f64_view_v1,
+        },
+        unary_f64_to_f64 {
+            name: b"math/floor",
+            function: math_floor_f64_v1,
+        },
+        unary_f64_view_to_f64_view {
+            name: b"math/floor",
+            function: math_floor_f64_view_v1,
+        },
+        unary_f64_to_f64 {
+            name: b"math/ceil",
+            function: math_ceil_f64_v1,
+        },
+        unary_f64_view_to_f64_view {
+            name: b"math/ceil",
+            function: math_ceil_f64_view_v1,
+        },
+        binary_f64_f64_to_f64 {
+            name: b"math/atan2",
+            function: math_atan2_f64_v1,
+        },
     ],
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_round_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
+unsafe fn call_unary_f64(input: f64, out: *mut f64, kernel: fn(f64) -> f64) -> MechStatusV1 {
     if out.is_null() {
         return MechStatusV1::NullPointer;
     }
 
     unsafe {
-        *out = crate::kernels::round::scalar_f64(input);
+        *out = kernel(input);
     }
 
     MechStatusV1::Ok
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_round_f64_view_v1(
+unsafe fn call_binary_f64(
+    lhs: f64,
+    rhs: f64,
+    out: *mut f64,
+    kernel: fn(f64, f64) -> f64,
+) -> MechStatusV1 {
+    if out.is_null() {
+        return MechStatusV1::NullPointer;
+    }
+
+    unsafe {
+        *out = kernel(lhs, rhs);
+    }
+
+    MechStatusV1::Ok
+}
+
+unsafe fn call_unary_f64_view(
     input: MechF64ViewV1,
     out: MechF64ViewMutV1,
+    kernel: fn(&[f64], &mut [f64]),
 ) -> MechStatusV1 {
     if input.len != out.len {
         return MechStatusV1::WrongShape;
@@ -71,9 +119,66 @@ pub unsafe extern "C" fn math_round_f64_view_v1(
     let input_slice = unsafe { core::slice::from_raw_parts(input.ptr, input.len) };
     let out_slice = unsafe { core::slice::from_raw_parts_mut(out.ptr, out.len) };
 
-    crate::kernels::round::view_f64(input_slice, out_slice);
+    kernel(input_slice, out_slice);
 
     MechStatusV1::Ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_round_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
+    unsafe { call_unary_f64(input, out, crate::kernels::round::scalar_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_round_f64_view_v1(
+    input: MechF64ViewV1,
+    out: MechF64ViewMutV1,
+) -> MechStatusV1 {
+    unsafe { call_unary_f64_view(input, out, crate::kernels::round::view_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_sqrt_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
+    unsafe { call_unary_f64(input, out, crate::kernels::sqrt::scalar_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_sqrt_f64_view_v1(
+    input: MechF64ViewV1,
+    out: MechF64ViewMutV1,
+) -> MechStatusV1 {
+    unsafe { call_unary_f64_view(input, out, crate::kernels::sqrt::view_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_floor_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
+    unsafe { call_unary_f64(input, out, crate::kernels::floor::scalar_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_floor_f64_view_v1(
+    input: MechF64ViewV1,
+    out: MechF64ViewMutV1,
+) -> MechStatusV1 {
+    unsafe { call_unary_f64_view(input, out, crate::kernels::floor::view_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_ceil_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
+    unsafe { call_unary_f64(input, out, crate::kernels::ceil::scalar_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_ceil_f64_view_v1(
+    input: MechF64ViewV1,
+    out: MechF64ViewMutV1,
+) -> MechStatusV1 {
+    unsafe { call_unary_f64_view(input, out, crate::kernels::ceil::view_f64) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn math_atan2_f64_v1(lhs: f64, rhs: f64, out: *mut f64) -> MechStatusV1 {
+    unsafe { call_binary_f64(lhs, rhs, out, crate::kernels::atan2::scalar_f64) }
 }
 
 #[cfg(test)]
@@ -99,8 +204,8 @@ mod tests {
     }
 
     #[test]
-    fn module_export_count_is_two() {
-        assert_eq!(unsafe { mech_module_export_count_v1() }, 2);
+    fn module_export_count_is_nine() {
+        assert_eq!(unsafe { mech_module_export_count_v1() }, 9);
     }
 
     #[test]
@@ -121,7 +226,7 @@ mod tests {
                 unary_f64_to_f64: math_round_f64_v1,
             },
         };
-        let status = unsafe { mech_module_get_export_v1(2, &mut export) };
+        let status = unsafe { mech_module_get_export_v1(9, &mut export) };
         assert_eq!(status, MechStatusV1::InvalidIndex);
     }
 
@@ -164,11 +269,124 @@ mod tests {
     }
 
     #[test]
+    fn export_metadata_describes_sqrt_scalar_kernel() {
+        let mut export = MechExportV1 {
+            name: MechStrV1 {
+                ptr: core::ptr::null(),
+                len: 0,
+            },
+            kind: MechKernelKindV1::UnaryF64ToF64,
+            function: MechKernelFnV1 {
+                unary_f64_to_f64: math_sqrt_f64_v1,
+            },
+        };
+        let status = unsafe { mech_module_get_export_v1(2, &mut export) };
+        let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(name, SQRT_EXPORT_NAME);
+        assert_eq!(export.kind, MechKernelKindV1::UnaryF64ToF64);
+    }
+
+    #[test]
+    fn export_metadata_describes_sqrt_view_kernel() {
+        let mut export = MechExportV1 {
+            name: MechStrV1 {
+                ptr: core::ptr::null(),
+                len: 0,
+            },
+            kind: MechKernelKindV1::UnaryF64ViewToF64View,
+            function: MechKernelFnV1 {
+                unary_f64_view_to_f64_view: math_sqrt_f64_view_v1,
+            },
+        };
+        let status = unsafe { mech_module_get_export_v1(3, &mut export) };
+        let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(name, SQRT_EXPORT_NAME);
+        assert_eq!(export.kind, MechKernelKindV1::UnaryF64ViewToF64View);
+    }
+
+    #[test]
+    fn export_metadata_describes_atan2_kernel() {
+        let mut export = MechExportV1 {
+            name: MechStrV1 {
+                ptr: core::ptr::null(),
+                len: 0,
+            },
+            kind: MechKernelKindV1::BinaryF64F64ToF64,
+            function: MechKernelFnV1 {
+                binary_f64_f64_to_f64: math_atan2_f64_v1,
+            },
+        };
+        let status = unsafe { mech_module_get_export_v1(8, &mut export) };
+        let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(name, ATAN2_EXPORT_NAME);
+        assert_eq!(export.kind, MechKernelKindV1::BinaryF64F64ToF64);
+    }
+
+    #[test]
     fn math_round_f64_returns_expected_result() {
         let mut out = 0.0;
         let status = unsafe { math_round_f64_v1(1.23, &mut out) };
         assert_eq!(status, MechStatusV1::Ok);
         assert_eq!(out, 1.0);
+    }
+
+    #[test]
+    fn math_sqrt_f64_returns_expected_result() {
+        let mut out = 0.0;
+        let status = unsafe { math_sqrt_f64_v1(9.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 3.0);
+    }
+
+    #[test]
+    fn math_floor_f64_returns_expected_result() {
+        let mut out = 0.0;
+        let status = unsafe { math_floor_f64_v1(4.56, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 4.0);
+    }
+
+    #[test]
+    fn math_ceil_f64_returns_expected_result() {
+        let mut out = 0.0;
+        let status = unsafe { math_ceil_f64_v1(4.56, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 5.0);
+    }
+
+    #[test]
+    fn math_atan2_f64_returns_expected_result() {
+        let mut out = 1.0;
+        let status = unsafe { math_atan2_f64_v1(0.0, 1.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn math_sqrt_f64_view_returns_expected_result() {
+        let input = [1.0, 4.0, 9.0];
+        let mut out = [0.0, 0.0, 0.0];
+        let status = unsafe {
+            math_sqrt_f64_view_v1(
+                MechF64ViewV1 {
+                    ptr: input.as_ptr(),
+                    len: input.len(),
+                    rows: 1,
+                    cols: 3,
+                },
+                MechF64ViewMutV1 {
+                    ptr: out.as_mut_ptr(),
+                    len: out.len(),
+                    rows: 1,
+                    cols: 3,
+                },
+            )
+        };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, [1.0, 2.0, 3.0]);
     }
 
     #[test]

--- a/machines/math/src/kernels.rs
+++ b/machines/math/src/kernels.rs
@@ -10,3 +10,49 @@ pub mod round {
         }
     }
 }
+
+#[cfg(any(feature = "sqrt", feature = "dynamic-module"))]
+pub mod sqrt {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::sqrt(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "floor", feature = "dynamic-module"))]
+pub mod floor {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::floor(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "ceil", feature = "dynamic-module"))]
+pub mod ceil {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::ceil(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "atan2", feature = "dynamic-module"))]
+pub mod atan2 {
+    pub fn scalar_f64(lhs: f64, rhs: f64) -> f64 {
+        libm::atan2(lhs, rhs)
+    }
+}

--- a/tests/dynamic_math.rs
+++ b/tests/dynamic_math.rs
@@ -25,6 +25,38 @@ fn run_matrix_round(source: &str) {
 }
 
 #[cfg(feature = "dynamic-modules")]
+fn run_scalar_f64(source: &str, expected: f64) {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let result = program.run_string(source).unwrap();
+
+    let detached = match result {
+        Value::MutableReference(v) => v.borrow().clone(),
+        value => value,
+    };
+
+    match detached {
+        Value::F64(value) => assert_eq!(*value.borrow(), expected),
+        value => panic!("expected f64 result, got {:?}", value),
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
+fn run_matrix_f64(source: &str, expected: Vec<f64>, rows: usize, cols: usize) {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let result = program.run_string(source).unwrap();
+
+    let detached = match result {
+        Value::MutableReference(v) => v.borrow().clone(),
+        value => value,
+    };
+
+    assert_eq!(
+        detached,
+        Value::MatrixF64(Matrix::from_vec(expected, rows, cols))
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
 #[test]
 fn dynamic_math_item_import_works() {
     assert!(run("+> math/round\nx := round(1.23)"));
@@ -58,4 +90,96 @@ fn dynamic_math_round_module_import_accepts_matrix() {
 #[test]
 fn dynamic_math_round_glob_import_accepts_matrix() {
     run_matrix_round("+> math/*\nx := round([1.23 4.56])\nx");
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_sqrt_item_import_works_for_scalar_and_matrix() {
+    run_scalar_f64(
+        "+> math/sqrt
+x := sqrt(9.0)
+x",
+        3.0,
+    );
+    run_matrix_f64(
+        "+> math/sqrt
+x := sqrt([1.0 4.0 9.0])
+x",
+        vec![1.0, 2.0, 3.0],
+        1,
+        3,
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_floor_glob_import_works_for_scalar_and_matrix() {
+    run_scalar_f64(
+        "+> math/*
+x := floor(4.56)
+x",
+        4.0,
+    );
+    run_matrix_f64(
+        "+> math/*
+x := floor([1.23 4.56])
+x",
+        vec![1.0, 4.0],
+        1,
+        2,
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_ceil_module_import_works_for_scalar_and_matrix() {
+    run_scalar_f64(
+        "+> math
+x := math/ceil(4.56)
+x",
+        5.0,
+    );
+    run_matrix_f64(
+        "+> math
+x := math/ceil([1.23 4.56])
+x",
+        vec![2.0, 5.0],
+        1,
+        2,
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_atan2_item_import_works_for_scalar_and_matrix_broadcast() {
+    run_scalar_f64(
+        "+> math/atan2
+x := atan2(0.0, 1.0)
+x",
+        0.0,
+    );
+    run_matrix_f64(
+        "+> math/atan2
+x := atan2([0.0 0.0], 1.0)
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+    run_matrix_f64(
+        "+> math/atan2
+x := atan2(0.0, [1.0 1.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+    run_matrix_f64(
+        "+> math/atan2
+x := atan2([0.0 0.0], [1.0 1.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
 }


### PR DESCRIPTION
### Motivation

- Provide additional dynamic math kernels to the `math` provider using the existing scalar/view ABI so host-side dispatch and broadcasting remain unchanged.
- Demonstrate that adding new dynamic math functions is predominantly provider-side work and can reuse shared ABI helpers.

### Description

- Added new kernel modules in `machines/math/src/kernels.rs` for `sqrt`, `floor`, `ceil`, and `atan2` while keeping the existing `round` module intact.  
- Extended `machines/math/src/dynamic_module.rs` with export name constants and expanded the `mech_dynamic_module_v1!` export table to include `math/sqrt`, `math/floor`, `math/ceil` (each with scalar and view overloads) and `math/atan2` (scalar binary only).  
- Introduced private ABI helper functions `call_unary_f64`, `call_binary_f64`, and `call_unary_f64_view` and refactored the `math/round` exports to use them, then routed all new exports (`math_sqrt_f64_v1`, `math_sqrt_f64_view_v1`, `math_floor_f64_v1`, `math_floor_f64_view_v1`, `math_ceil_f64_v1`, `math_ceil_f64_view_v1`, `math_atan2_f64_v1`) through the helpers.  
- Added provider-side unit tests (export metadata and behavior) in `machines/math/src/dynamic_module.rs` and interpreter-level tests in `tests/dynamic_math.rs` to validate scalar and matrix usage and host-side broadcasting for `atan2`.

### Testing

- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` which completed successfully.  
- Ran `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"` and all provider unit tests passed (24 passed).  
- Built the dynamic module and ran the interpreter integration tests with `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"`, and all dynamic math tests passed (10 passed).  
- Verified dynamic combinatorics still passes by running `cargo test`/build for `machines/combinatorics` and `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics`, and all combinatorics tests passed (9 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dc9a9354c832a97eeb526b1b04a1f)