### PR TITLE
Make dynamic binary f64 broadcasting explicit

### DIFF
--- a/src/interpreter/src/modules.rs
+++ b/src/interpreter/src/modules.rs
@@ -438,6 +438,57 @@ enum DynamicF64Arg {
 }
 
 #[cfg(feature = "dynamic-modules")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DynamicF64BinaryBroadcastKind {
+    MatrixScalar,
+    ScalarMatrix,
+    MatrixMatrix,
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DynamicF64BinaryBroadcastPlan {
+    kind: DynamicF64BinaryBroadcastKind,
+    rows: usize,
+    cols: usize,
+    len: usize,
+}
+
+#[cfg(feature = "dynamic-modules")]
+impl DynamicF64BinaryBroadcastPlan {
+    fn new(
+        kind: DynamicF64BinaryBroadcastKind,
+        rows: usize,
+        cols: usize,
+        fxn_name: &str,
+    ) -> MResult<Self> {
+        let Some(len) = rows.checked_mul(cols) else {
+            return Err(MechError::new(
+                GenericError {
+                    msg: format!(
+                        "dynamic function `{}` broadcast shape overflowed: {} x {}",
+                        fxn_name, rows, cols
+                    ),
+                },
+                None,
+            )
+            .with_compiler_loc());
+        };
+
+        Ok(Self {
+            kind,
+            rows,
+            cols,
+            len,
+        })
+    }
+
+    fn new_output_matrix(&self) -> Matrix<f64> {
+        Matrix::from_vec(vec![0.0; self.len], self.rows, self.cols)
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
 impl DynamicF64Arg {
     fn matrix_shape(&self) -> Option<(usize, usize)> {
         match self {
@@ -491,28 +542,15 @@ impl NativeFunctionCompiler for DynamicBinaryF64F64ToF64Compiler {
             }
 
             _ => {
-                let (rows, cols) = dynamic_binary_broadcast_shape(&lhs, &rhs, &self.name)?;
-                let Some(len) = rows.checked_mul(cols) else {
-                    return Err(MechError::new(
-                        GenericError {
-                            msg: format!(
-                                "dynamic function `{}` broadcast shape overflowed: {} x {}",
-                                self.name, rows, cols
-                            ),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc());
-                };
-
-                let out = Matrix::from_vec(vec![0.0; len], rows, cols);
+                let plan = dynamic_binary_broadcast_plan(&lhs, &rhs, &self.name)?;
+                let out = plan.new_output_matrix();
 
                 Ok(Box::new(DynamicBinaryF64F64BroadcastFunction {
                     name: self.name.clone(),
                     lhs,
                     rhs,
                     out,
-                    len,
+                    plan,
                     kernel: self.kernel,
                     _library: self._library.clone(),
                 }))
@@ -664,20 +702,25 @@ fn dynamic_arg_as_f64_scalar_or_matrix(value: &Value, fxn_name: &str) -> MResult
 }
 
 #[cfg(feature = "dynamic-modules")]
-fn dynamic_binary_broadcast_shape(
+fn dynamic_binary_broadcast_plan(
     lhs: &DynamicF64Arg,
     rhs: &DynamicF64Arg,
     fxn_name: &str,
-) -> MResult<(usize, usize)> {
+) -> MResult<DynamicF64BinaryBroadcastPlan> {
     match (lhs.matrix_shape(), rhs.matrix_shape()) {
         (Some((lhs_rows, lhs_cols)), Some((rhs_rows, rhs_cols))) => {
             if lhs_rows == rhs_rows && lhs_cols == rhs_cols {
-                Ok((lhs_rows, lhs_cols))
+                DynamicF64BinaryBroadcastPlan::new(
+                    DynamicF64BinaryBroadcastKind::MatrixMatrix,
+                    lhs_rows,
+                    lhs_cols,
+                    fxn_name,
+                )
             } else {
                 Err(MechError::new(
                     GenericError {
                         msg: format!(
-                            "dynamic function `{}` cannot broadcast matrix shapes {}x{} and {}x{}",
+                            "dynamic function `{}` cannot broadcast matrix shapes {}x{} and {}x{}; exact shape match is required",
                             fxn_name, lhs_rows, lhs_cols, rhs_rows, rhs_cols
                         ),
                     },
@@ -686,12 +729,22 @@ fn dynamic_binary_broadcast_shape(
                 .with_compiler_loc())
             }
         }
-        (Some(shape), None) => Ok(shape),
-        (None, Some(shape)) => Ok(shape),
+        (Some((rows, cols)), None) => DynamicF64BinaryBroadcastPlan::new(
+            DynamicF64BinaryBroadcastKind::MatrixScalar,
+            rows,
+            cols,
+            fxn_name,
+        ),
+        (None, Some((rows, cols))) => DynamicF64BinaryBroadcastPlan::new(
+            DynamicF64BinaryBroadcastKind::ScalarMatrix,
+            rows,
+            cols,
+            fxn_name,
+        ),
         (None, None) => Err(MechError::new(
             GenericError {
                 msg: format!(
-                    "dynamic function `{}` expected at least one matrix argument for broadcast",
+                    "dynamic function `{}` does not need a broadcast plan for scalar/scalar arguments",
                     fxn_name
                 ),
             },
@@ -787,7 +840,7 @@ struct DynamicBinaryF64F64BroadcastFunction {
     lhs: DynamicF64Arg,
     rhs: DynamicF64Arg,
     out: Matrix<f64>,
-    len: usize,
+    plan: DynamicF64BinaryBroadcastPlan,
     kernel: mech_abi::MechBinaryF64F64ToF64KernelV1,
     _library: Arc<libloading::Library>,
 }
@@ -795,9 +848,9 @@ struct DynamicBinaryF64F64BroadcastFunction {
 #[cfg(feature = "dynamic-modules")]
 impl MechFunctionImpl for DynamicBinaryF64F64BroadcastFunction {
     fn solve(&self) {
-        let mut out_vec = Vec::with_capacity(self.len);
+        let mut out_vec = Vec::with_capacity(self.plan.len);
 
-        for index in 1..=self.len {
+        for index in 1..=self.plan.len {
             let lhs = self.lhs.value_at(index);
             let rhs = self.rhs.value_at(index);
             let mut out = 0.0;
@@ -1071,5 +1124,81 @@ fn alias_module_item(fxns: &mut Functions, module: &str, item: &str) -> MResult<
             None,
         )
         .with_compiler_loc())
+    }
+}
+
+#[cfg(all(test, feature = "dynamic-modules"))]
+mod dynamic_binary_broadcast_tests {
+    use super::*;
+
+    fn scalar(value: f64) -> DynamicF64Arg {
+        DynamicF64Arg::Scalar(Ref::new(value))
+    }
+
+    fn matrix(values: Vec<f64>, rows: usize, cols: usize) -> DynamicF64Arg {
+        DynamicF64Arg::Matrix(Matrix::from_vec(values, rows, cols))
+    }
+
+    #[test]
+    fn broadcast_plan_matrix_scalar() {
+        let lhs = matrix(vec![10.0, 20.0], 1, 2);
+        let rhs = scalar(2.0);
+
+        let plan = dynamic_binary_broadcast_plan(&lhs, &rhs, "test").unwrap();
+
+        assert_eq!(plan.kind, DynamicF64BinaryBroadcastKind::MatrixScalar);
+        assert_eq!(plan.rows, 1);
+        assert_eq!(plan.cols, 2);
+        assert_eq!(plan.len, 2);
+    }
+
+    #[test]
+    fn broadcast_plan_scalar_matrix() {
+        let lhs = scalar(10.0);
+        let rhs = matrix(vec![2.0, 3.0], 1, 2);
+
+        let plan = dynamic_binary_broadcast_plan(&lhs, &rhs, "test").unwrap();
+
+        assert_eq!(plan.kind, DynamicF64BinaryBroadcastKind::ScalarMatrix);
+        assert_eq!(plan.rows, 1);
+        assert_eq!(plan.cols, 2);
+        assert_eq!(plan.len, 2);
+    }
+
+    #[test]
+    fn broadcast_plan_same_shape_matrix_matrix() {
+        let lhs = matrix(vec![10.0, 20.0], 1, 2);
+        let rhs = matrix(vec![2.0, 3.0], 1, 2);
+
+        let plan = dynamic_binary_broadcast_plan(&lhs, &rhs, "test").unwrap();
+
+        assert_eq!(plan.kind, DynamicF64BinaryBroadcastKind::MatrixMatrix);
+        assert_eq!(plan.rows, 1);
+        assert_eq!(plan.cols, 2);
+        assert_eq!(plan.len, 2);
+    }
+
+    #[test]
+    fn broadcast_plan_rejects_different_lengths() {
+        let lhs = matrix(vec![10.0, 20.0], 1, 2);
+        let rhs = matrix(vec![2.0, 3.0, 4.0], 1, 3);
+
+        assert!(dynamic_binary_broadcast_plan(&lhs, &rhs, "test").is_err());
+    }
+
+    #[test]
+    fn broadcast_plan_rejects_same_len_different_shape() {
+        let lhs = matrix(vec![1.0, 2.0, 3.0, 4.0], 1, 4);
+        let rhs = matrix(vec![1.0, 2.0, 3.0, 4.0], 2, 2);
+
+        assert!(dynamic_binary_broadcast_plan(&lhs, &rhs, "test").is_err());
+    }
+
+    #[test]
+    fn broadcast_plan_rejects_scalar_scalar() {
+        let lhs = scalar(10.0);
+        let rhs = scalar(2.0);
+
+        assert!(dynamic_binary_broadcast_plan(&lhs, &rhs, "test").is_err());
     }
 }

--- a/tests/dynamic_combinatorics.rs
+++ b/tests/dynamic_combinatorics.rs
@@ -97,3 +97,14 @@ fn dynamic_combinatorics_matrix_matrix_shape_mismatch_errors() {
 
     assert!(result.is_err());
 }
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_combinatorics_matrix_matrix_same_cells_different_shape_errors() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let result = program.run_string(
+        "+> combinatorics/n-choose-k\nx := n-choose-k([10.0 20.0 30.0 40.0], [2.0 3.0; 4.0 5.0])\nx",
+    );
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
### Motivation

- Make the dynamic `BinaryF64F64ToF64` broadcasting rules explicit and unambiguous by moving from a shape-only helper to a host-side broadcast plan, and limit supported broadcast forms to the intended set.
- Prevent implicit or surprising broadcasts (row/column broadcasting, shape-only cell-count compatibility, implicit reshapes) by rejecting unsupported matrix/matrix shapes early on the host.

### Description

- Introduces `DynamicF64BinaryBroadcastKind` and `DynamicF64BinaryBroadcastPlan` with checked `len` computation and `new_output_matrix()` allocation and places them alongside `DynamicF64Arg` in `src/interpreter/src/modules.rs`.
- Replaces `dynamic_binary_broadcast_shape` with `dynamic_binary_broadcast_plan` which only accepts `MatrixScalar`, `ScalarMatrix`, or exact-shape `MatrixMatrix` (rejects differing rows/cols and scalar/scalar planning).
- Updates `DynamicBinaryF64F64ToF64Compiler::compile` to build the `DynamicF64BinaryBroadcastPlan` for matrix-containing calls and allocate `out` via `plan.new_output_matrix()`, while keeping scalar/scalar behavior unchanged (still returns `DynamicBinaryF64F64ToF64Function`).
- Changes `DynamicBinaryF64F64BroadcastFunction` to store the `plan` instead of a raw `len` and uses `self.plan.len` in `solve` without yet branching on `plan.kind`.
- Adds interpreter unit tests (`dynamic_binary_broadcast_tests`) validating accepted plans and rejecting unsupported cases, and an integration test in `tests/dynamic_combinatorics.rs` proving same-cell-count but different-shape matrices are rejected.

### Testing

- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` which completed successfully.
- Ran interpreter unit tests: `cargo test -p mech-interpreter --no-default-features --features "base dynamic-modules f64" dynamic_binary_broadcast_tests` and all tests passed (6 passed).
- Ran combinatorics module/unit and integration tests and built the dynamic module, then executed the dynamic combinatorics integration test with `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"`, and all tests passed (combinatorics tests and the added integration test passed).
- Ran dynamic math module/unit tests and the `dynamic_math` integration test via the same dynamic-module build + `MECH_MODULE_PATH` flow, and all tests passed (math tests passed).

All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de583fa84832a8b1ba7b472973c28)