### PR TITLE
Refactor dynamic math provider boilerplate

### DIFF
--- a/machines/math/src/dynamic_module.rs
+++ b/machines/math/src/dynamic_module.rs
@@ -12,45 +12,78 @@ const FLOOR_EXPORT_NAME: &[u8] = b"math/floor";
 const CEIL_EXPORT_NAME: &[u8] = b"math/ceil";
 const ATAN2_EXPORT_NAME: &[u8] = b"math/atan2";
 
-mech_abi::mech_dynamic_module_v1! {
-    module: b"math",
-    exports: [
-        unary_f64_to_f64 {
-            name: b"math/round",
-            function: math_round_f64_v1,
-        },
-        unary_f64_view_to_f64_view {
-            name: b"math/round",
-            function: math_round_f64_view_v1,
-        },
-        unary_f64_to_f64 {
-            name: b"math/sqrt",
-            function: math_sqrt_f64_v1,
-        },
-        unary_f64_view_to_f64_view {
-            name: b"math/sqrt",
-            function: math_sqrt_f64_view_v1,
-        },
-        unary_f64_to_f64 {
-            name: b"math/floor",
-            function: math_floor_f64_v1,
-        },
-        unary_f64_view_to_f64_view {
-            name: b"math/floor",
-            function: math_floor_f64_view_v1,
-        },
-        unary_f64_to_f64 {
-            name: b"math/ceil",
-            function: math_ceil_f64_v1,
-        },
-        unary_f64_view_to_f64_view {
-            name: b"math/ceil",
-            function: math_ceil_f64_view_v1,
-        },
-        binary_f64_f64_to_f64 {
-            name: b"math/atan2",
-            function: math_atan2_f64_v1,
-        },
+macro_rules! define_unary_f64_dynamic_kernels {
+    ($scalar_symbol:ident, $view_symbol:ident, $kernel_mod:ident) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $scalar_symbol(input: f64, out: *mut f64) -> MechStatusV1 {
+            unsafe { call_unary_f64(input, out, crate::kernels::$kernel_mod::scalar_f64) }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $view_symbol(
+            input: MechF64ViewV1,
+            out: MechF64ViewMutV1,
+        ) -> MechStatusV1 {
+            unsafe { call_unary_f64_view(input, out, crate::kernels::$kernel_mod::view_f64) }
+        }
+    };
+}
+
+macro_rules! define_binary_f64_dynamic_kernel {
+    ($symbol:ident, $kernel_mod:ident) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $symbol(lhs: f64, rhs: f64, out: *mut f64) -> MechStatusV1 {
+            unsafe { call_binary_f64(lhs, rhs, out, crate::kernels::$kernel_mod::scalar_f64) }
+        }
+    };
+}
+
+macro_rules! math_dynamic_module_v1 {
+    (
+        unary: [
+            $(
+                $unary_name:expr => ($unary_scalar:path, $unary_view:path)
+            ),* $(,)?
+        ],
+        binary: [
+            $(
+                $binary_name:expr => $binary_scalar:path
+            ),* $(,)?
+        ],
+    ) => {
+        mech_abi::mech_dynamic_module_v1! {
+            module: b"math",
+            exports: [
+                $(
+                    unary_f64_to_f64 {
+                        name: $unary_name,
+                        function: $unary_scalar,
+                    },
+                    unary_f64_view_to_f64_view {
+                        name: $unary_name,
+                        function: $unary_view,
+                    },
+                )*
+                $(
+                    binary_f64_f64_to_f64 {
+                        name: $binary_name,
+                        function: $binary_scalar,
+                    },
+                )*
+            ],
+        }
+    };
+}
+
+math_dynamic_module_v1! {
+    unary: [
+        b"math/round" => (math_round_f64_v1, math_round_f64_view_v1),
+        b"math/sqrt" => (math_sqrt_f64_v1, math_sqrt_f64_view_v1),
+        b"math/floor" => (math_floor_f64_v1, math_floor_f64_view_v1),
+        b"math/ceil" => (math_ceil_f64_v1, math_ceil_f64_view_v1),
+    ],
+    binary: [
+        b"math/atan2" => math_atan2_f64_v1,
     ],
 }
 
@@ -124,62 +157,34 @@ unsafe fn call_unary_f64_view(
     MechStatusV1::Ok
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_round_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
-    unsafe { call_unary_f64(input, out, crate::kernels::round::scalar_f64) }
-}
+define_unary_f64_dynamic_kernels!(
+    math_round_f64_v1,
+    math_round_f64_view_v1,
+    round
+);
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_round_f64_view_v1(
-    input: MechF64ViewV1,
-    out: MechF64ViewMutV1,
-) -> MechStatusV1 {
-    unsafe { call_unary_f64_view(input, out, crate::kernels::round::view_f64) }
-}
+define_unary_f64_dynamic_kernels!(
+    math_sqrt_f64_v1,
+    math_sqrt_f64_view_v1,
+    sqrt
+);
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_sqrt_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
-    unsafe { call_unary_f64(input, out, crate::kernels::sqrt::scalar_f64) }
-}
+define_unary_f64_dynamic_kernels!(
+    math_floor_f64_v1,
+    math_floor_f64_view_v1,
+    floor
+);
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_sqrt_f64_view_v1(
-    input: MechF64ViewV1,
-    out: MechF64ViewMutV1,
-) -> MechStatusV1 {
-    unsafe { call_unary_f64_view(input, out, crate::kernels::sqrt::view_f64) }
-}
+define_unary_f64_dynamic_kernels!(
+    math_ceil_f64_v1,
+    math_ceil_f64_view_v1,
+    ceil
+);
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_floor_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
-    unsafe { call_unary_f64(input, out, crate::kernels::floor::scalar_f64) }
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_floor_f64_view_v1(
-    input: MechF64ViewV1,
-    out: MechF64ViewMutV1,
-) -> MechStatusV1 {
-    unsafe { call_unary_f64_view(input, out, crate::kernels::floor::view_f64) }
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_ceil_f64_v1(input: f64, out: *mut f64) -> MechStatusV1 {
-    unsafe { call_unary_f64(input, out, crate::kernels::ceil::scalar_f64) }
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_ceil_f64_view_v1(
-    input: MechF64ViewV1,
-    out: MechF64ViewMutV1,
-) -> MechStatusV1 {
-    unsafe { call_unary_f64_view(input, out, crate::kernels::ceil::view_f64) }
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn math_atan2_f64_v1(lhs: f64, rhs: f64, out: *mut f64) -> MechStatusV1 {
-    unsafe { call_binary_f64(lhs, rhs, out, crate::kernels::atan2::scalar_f64) }
-}
+define_binary_f64_dynamic_kernel!(
+    math_atan2_f64_v1,
+    atan2
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
### Motivation

- Reduce repetitive boilerplate in the math dynamic provider so exported kernels are easier to extend and add consistently. 
- Preserve existing ABI and runtime behavior for the `math` dynamic exports (no observable changes to callers or export order).

### Description

- Add provider-local macros `define_unary_f64_dynamic_kernels!`, `define_binary_f64_dynamic_kernel!`, and `math_dynamic_module_v1!` immediately after the export-name constants to centralize export boilerplate. 
- Replace the direct `mech_abi::mech_dynamic_module_v1!` invocation with the provider-local `math_dynamic_module_v1! { ... }` call that lists `math/round`, `math/sqrt`, `math/floor`, `math/ceil`, and `math/atan2` in the original order. 
- Remove the hand-written exported kernel function definitions and replace them with macro invocations that generate the same exported symbol names. 
- Preserve the existing `mech_abi` imports, the export-name constants, and the helper functions `call_unary_f64`, `call_binary_f64`, and `call_unary_f64_view` (including their validation behavior) unchanged.

### Testing

- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` and it completed successfully. 
- Ran math provider unit tests with `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"` and all tests passed. 
- Built the math provider and executed the dynamic integration tests (`cargo build --manifest-path machines/math/Cargo.toml ...` + `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"`) and all dynamic math tests passed. 
- Ran combinatorics provider unit and dynamic integration tests (`cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module"` and `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df17a6850832a93c897c9ef318d7a)