### PR TITLE
Add dynamic unary trig math exports

### DIFF
--- a/machines/math/src/dynamic_module.rs
+++ b/machines/math/src/dynamic_module.rs
@@ -11,6 +11,12 @@ const SQRT_EXPORT_NAME: &[u8] = b"math/sqrt";
 const FLOOR_EXPORT_NAME: &[u8] = b"math/floor";
 const CEIL_EXPORT_NAME: &[u8] = b"math/ceil";
 const ATAN2_EXPORT_NAME: &[u8] = b"math/atan2";
+const SIN_EXPORT_NAME: &[u8] = b"math/sin";
+const COS_EXPORT_NAME: &[u8] = b"math/cos";
+const TAN_EXPORT_NAME: &[u8] = b"math/tan";
+const ASIN_EXPORT_NAME: &[u8] = b"math/asin";
+const ACOS_EXPORT_NAME: &[u8] = b"math/acos";
+const ATAN_EXPORT_NAME: &[u8] = b"math/atan";
 
 macro_rules! define_unary_f64_dynamic_kernels {
     ($scalar_symbol:ident, $view_symbol:ident, $kernel_mod:ident) => {
@@ -81,6 +87,12 @@ math_dynamic_module_v1! {
         b"math/sqrt" => (math_sqrt_f64_v1, math_sqrt_f64_view_v1),
         b"math/floor" => (math_floor_f64_v1, math_floor_f64_view_v1),
         b"math/ceil" => (math_ceil_f64_v1, math_ceil_f64_view_v1),
+        b"math/sin" => (math_sin_f64_v1, math_sin_f64_view_v1),
+        b"math/cos" => (math_cos_f64_v1, math_cos_f64_view_v1),
+        b"math/tan" => (math_tan_f64_v1, math_tan_f64_view_v1),
+        b"math/asin" => (math_asin_f64_v1, math_asin_f64_view_v1),
+        b"math/acos" => (math_acos_f64_v1, math_acos_f64_view_v1),
+        b"math/atan" => (math_atan_f64_v1, math_atan_f64_view_v1),
     ],
     binary: [
         b"math/atan2" => math_atan2_f64_v1,
@@ -181,6 +193,42 @@ define_unary_f64_dynamic_kernels!(
     ceil
 );
 
+define_unary_f64_dynamic_kernels!(
+    math_sin_f64_v1,
+    math_sin_f64_view_v1,
+    sin
+);
+
+define_unary_f64_dynamic_kernels!(
+    math_cos_f64_v1,
+    math_cos_f64_view_v1,
+    cos
+);
+
+define_unary_f64_dynamic_kernels!(
+    math_tan_f64_v1,
+    math_tan_f64_view_v1,
+    tan
+);
+
+define_unary_f64_dynamic_kernels!(
+    math_asin_f64_v1,
+    math_asin_f64_view_v1,
+    asin
+);
+
+define_unary_f64_dynamic_kernels!(
+    math_acos_f64_v1,
+    math_acos_f64_view_v1,
+    acos
+);
+
+define_unary_f64_dynamic_kernels!(
+    math_atan_f64_v1,
+    math_atan_f64_view_v1,
+    atan
+);
+
 define_binary_f64_dynamic_kernel!(
     math_atan2_f64_v1,
     atan2
@@ -189,6 +237,30 @@ define_binary_f64_dynamic_kernel!(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_export_metadata(
+        index: usize,
+        expected_name: &[u8],
+        expected_kind: MechKernelKindV1,
+    ) {
+        let mut export = MechExportV1 {
+            name: MechStrV1 {
+                ptr: core::ptr::null(),
+                len: 0,
+            },
+            kind: MechKernelKindV1::UnaryF64ToF64,
+            function: MechKernelFnV1 {
+                unary_f64_to_f64: math_round_f64_v1,
+            },
+        };
+
+        let status = unsafe { mech_module_get_export_v1(index, &mut export) };
+        let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
+
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(name, expected_name);
+        assert_eq!(export.kind, expected_kind);
+    }
 
     #[test]
     fn module_name_null_pointer_returns_null_pointer() {
@@ -209,8 +281,8 @@ mod tests {
     }
 
     #[test]
-    fn module_export_count_is_nine() {
-        assert_eq!(unsafe { mech_module_export_count_v1() }, 9);
+    fn module_export_count_is_twenty_one() {
+        assert_eq!(unsafe { mech_module_export_count_v1() }, 21);
     }
 
     #[test]
@@ -231,8 +303,59 @@ mod tests {
                 unary_f64_to_f64: math_round_f64_v1,
             },
         };
-        let status = unsafe { mech_module_get_export_v1(9, &mut export) };
+        let status = unsafe { mech_module_get_export_v1(21, &mut export) };
         assert_eq!(status, MechStatusV1::InvalidIndex);
+    }
+
+    #[test]
+    fn export_metadata_describes_all_exported_kernels_in_order() {
+        assert_export_metadata(0, EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(1, EXPORT_NAME, MechKernelKindV1::UnaryF64ViewToF64View);
+
+        assert_export_metadata(2, SQRT_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(3, SQRT_EXPORT_NAME, MechKernelKindV1::UnaryF64ViewToF64View);
+
+        assert_export_metadata(4, FLOOR_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(
+            5,
+            FLOOR_EXPORT_NAME,
+            MechKernelKindV1::UnaryF64ViewToF64View,
+        );
+
+        assert_export_metadata(6, CEIL_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(7, CEIL_EXPORT_NAME, MechKernelKindV1::UnaryF64ViewToF64View);
+
+        assert_export_metadata(8, SIN_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(9, SIN_EXPORT_NAME, MechKernelKindV1::UnaryF64ViewToF64View);
+
+        assert_export_metadata(10, COS_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(11, COS_EXPORT_NAME, MechKernelKindV1::UnaryF64ViewToF64View);
+
+        assert_export_metadata(12, TAN_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(13, TAN_EXPORT_NAME, MechKernelKindV1::UnaryF64ViewToF64View);
+
+        assert_export_metadata(14, ASIN_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(
+            15,
+            ASIN_EXPORT_NAME,
+            MechKernelKindV1::UnaryF64ViewToF64View,
+        );
+
+        assert_export_metadata(16, ACOS_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(
+            17,
+            ACOS_EXPORT_NAME,
+            MechKernelKindV1::UnaryF64ViewToF64View,
+        );
+
+        assert_export_metadata(18, ATAN_EXPORT_NAME, MechKernelKindV1::UnaryF64ToF64);
+        assert_export_metadata(
+            19,
+            ATAN_EXPORT_NAME,
+            MechKernelKindV1::UnaryF64ViewToF64View,
+        );
+
+        assert_export_metadata(20, ATAN2_EXPORT_NAME, MechKernelKindV1::BinaryF64F64ToF64);
     }
 
     #[test]
@@ -323,7 +446,7 @@ mod tests {
                 binary_f64_f64_to_f64: math_atan2_f64_v1,
             },
         };
-        let status = unsafe { mech_module_get_export_v1(8, &mut export) };
+        let status = unsafe { mech_module_get_export_v1(20, &mut export) };
         let name = unsafe { core::slice::from_raw_parts(export.name.ptr, export.name.len) };
         assert_eq!(status, MechStatusV1::Ok);
         assert_eq!(name, ATAN2_EXPORT_NAME);
@@ -363,6 +486,54 @@ mod tests {
     }
 
     #[test]
+    fn math_sin_f64_returns_expected_result() {
+        let mut out = 1.0;
+        let status = unsafe { math_sin_f64_v1(0.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn math_cos_f64_returns_expected_result() {
+        let mut out = 0.0;
+        let status = unsafe { math_cos_f64_v1(0.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 1.0);
+    }
+
+    #[test]
+    fn math_tan_f64_returns_expected_result() {
+        let mut out = 1.0;
+        let status = unsafe { math_tan_f64_v1(0.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn math_asin_f64_returns_expected_result() {
+        let mut out = 1.0;
+        let status = unsafe { math_asin_f64_v1(0.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn math_acos_f64_returns_expected_result() {
+        let mut out = 1.0;
+        let status = unsafe { math_acos_f64_v1(1.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn math_atan_f64_returns_expected_result() {
+        let mut out = 1.0;
+        let status = unsafe { math_atan_f64_v1(0.0, &mut out) };
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
     fn math_atan2_f64_returns_expected_result() {
         let mut out = 1.0;
         let status = unsafe { math_atan2_f64_v1(0.0, 1.0, &mut out) };
@@ -392,6 +563,32 @@ mod tests {
         };
         assert_eq!(status, MechStatusV1::Ok);
         assert_eq!(out, [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn math_cos_f64_view_returns_expected_result() {
+        let input = [0.0, 0.0];
+        let mut out = [0.0, 0.0];
+
+        let status = unsafe {
+            math_cos_f64_view_v1(
+                MechF64ViewV1 {
+                    ptr: input.as_ptr(),
+                    len: input.len(),
+                    rows: 1,
+                    cols: 2,
+                },
+                MechF64ViewMutV1 {
+                    ptr: out.as_mut_ptr(),
+                    len: out.len(),
+                    rows: 1,
+                    cols: 2,
+                },
+            )
+        };
+
+        assert_eq!(status, MechStatusV1::Ok);
+        assert_eq!(out, [1.0, 1.0]);
     }
 
     #[test]

--- a/machines/math/src/kernels.rs
+++ b/machines/math/src/kernels.rs
@@ -56,3 +56,81 @@ pub mod atan2 {
         libm::atan2(lhs, rhs)
     }
 }
+
+#[cfg(any(feature = "sin", feature = "dynamic-module"))]
+pub mod sin {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::sin(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "cos", feature = "dynamic-module"))]
+pub mod cos {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::cos(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "tan", feature = "dynamic-module"))]
+pub mod tan {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::tan(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "asin", feature = "dynamic-module"))]
+pub mod asin {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::asin(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "acos", feature = "dynamic-module"))]
+pub mod acos {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::acos(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}
+
+#[cfg(any(feature = "atan", feature = "dynamic-module"))]
+pub mod atan {
+    pub fn scalar_f64(input: f64) -> f64 {
+        libm::atan(input)
+    }
+
+    pub fn view_f64(input: &[f64], out: &mut [f64]) {
+        for (src, dst) in input.iter().zip(out.iter_mut()) {
+            *dst = scalar_f64(*src);
+        }
+    }
+}

--- a/tests/dynamic_math.rs
+++ b/tests/dynamic_math.rs
@@ -1,7 +1,7 @@
 extern crate mech_core;
 
 use mech::program::{MechProgram, MechProgramConfig};
-use mech_core::{structures::matrix::Matrix, Value};
+use mech_core::{Value, structures::matrix::Matrix};
 
 fn run(source: &str) -> bool {
     let mut program = MechProgram::new(MechProgramConfig::default());
@@ -177,6 +177,104 @@ x",
     run_matrix_f64(
         "+> math/atan2
 x := atan2([0.0 0.0], [1.0 1.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_trig_item_import_works_for_scalar_and_matrix() {
+    run_scalar_f64(
+        "+> math/sin
+x := sin(0.0)
+x",
+        0.0,
+    );
+    run_matrix_f64(
+        "+> math/sin
+x := sin([0.0 0.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+
+    run_scalar_f64(
+        "+> math/cos
+x := cos(0.0)
+x",
+        1.0,
+    );
+    run_matrix_f64(
+        "+> math/cos
+x := cos([0.0 0.0])
+x",
+        vec![1.0, 1.0],
+        1,
+        2,
+    );
+
+    run_scalar_f64(
+        "+> math/tan
+x := tan(0.0)
+x",
+        0.0,
+    );
+    run_matrix_f64(
+        "+> math/tan
+x := tan([0.0 0.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+}
+
+#[cfg(feature = "dynamic-modules")]
+#[test]
+fn dynamic_math_inverse_trig_module_and_glob_import_work_for_scalar_and_matrix() {
+    run_scalar_f64(
+        "+> math
+x := math/asin(0.0)
+x",
+        0.0,
+    );
+    run_matrix_f64(
+        "+> math
+x := math/asin([0.0 0.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+
+    run_scalar_f64(
+        "+> math/*
+x := acos(1.0)
+x",
+        0.0,
+    );
+    run_matrix_f64(
+        "+> math/*
+x := acos([1.0 1.0])
+x",
+        vec![0.0, 0.0],
+        1,
+        2,
+    );
+
+    run_scalar_f64(
+        "+> math/atan
+x := atan(0.0)
+x",
+        0.0,
+    );
+    run_matrix_f64(
+        "+> math/atan
+x := atan([0.0 0.0])
 x",
         vec![0.0, 0.0],
         1,


### PR DESCRIPTION
### Motivation
- Expose the common unary trigonometric functions as dynamic exports so provider can offer `math/sin`, `math/cos`, `math/tan`, `math/asin`, `math/acos`, and `math/atan` to the host via the existing dynamic ABI.
- Keep the provider-local kernel shape and the ABI unchanged while reusing the existing provider macros and export patterns.

### Description
- Added provider-local kernel modules in `machines/math/src/kernels.rs` for `sin`, `cos`, `tan`, `asin`, `acos`, and `atan`, each implementing `scalar_f64` and `view_f64` using `libm`.
- Added export name constants and entries in `machines/math/src/dynamic_module.rs`, updated the `math_dynamic_module_v1!` table to include the six new unary exports (two overloads each) and kept `math/atan2` as the existing binary export, bringing the export count to 21.
- Inserted `define_unary_f64_dynamic_kernels!` invocations for each new function and kept the existing `define_binary_f64_dynamic_kernel!` for `atan2` to generate the exported symbols.
- Added provider-side metadata helper and tests in `machines/math/src/dynamic_module.rs` plus scalar and view behavior tests for the new kernels, and added interpreter-level dynamic tests in `tests/dynamic_math.rs` that cover scalar and `MatrixF64` usage and module/glob imports for the new functions.

### Testing
- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` which completed successfully.
- Ran provider unit tests with `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"` and all `machines/math` tests passed (`32 passed`).
- Built the math provider, ran the dynamic math integration tests with `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"` and all dynamic math tests passed (`12 passed`).
- Ran combinatorics provider tests as a regression check with `cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module"` and `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"`, and all combinatorics tests passed.
- Also executed the search cleanup checks (no `*-slice` symbols found) and `rg` queries for the new `math/*` names as described, all returning expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0462a28c832a821f03ee8a89b836)