### PR TITLE
Refactor dynamic math kernel modules

### DIFF
--- a/machines/math/src/kernels.rs
+++ b/machines/math/src/kernels.rs
@@ -1,136 +1,40 @@
-#[cfg(any(feature = "round", feature = "dynamic-module"))]
-pub mod round {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::round(input)
-    }
+macro_rules! define_unary_f64_kernel_module {
+    ($module:ident, $feature:literal, $kernel:path) => {
+        #[cfg(any(feature = $feature, feature = "dynamic-module"))]
+        pub mod $module {
+            pub fn scalar_f64(input: f64) -> f64 {
+                $kernel(input)
+            }
 
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
+            pub fn view_f64(input: &[f64], out: &mut [f64]) {
+                for (src, dst) in input.iter().zip(out.iter_mut()) {
+                    *dst = scalar_f64(*src);
+                }
+            }
         }
-    }
+    };
 }
 
-#[cfg(any(feature = "sqrt", feature = "dynamic-module"))]
-pub mod sqrt {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::sqrt(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
+macro_rules! define_binary_f64_kernel_module {
+    ($module:ident, $feature:literal, $kernel:path) => {
+        #[cfg(any(feature = $feature, feature = "dynamic-module"))]
+        pub mod $module {
+            pub fn scalar_f64(lhs: f64, rhs: f64) -> f64 {
+                $kernel(lhs, rhs)
+            }
         }
-    }
+    };
 }
 
-#[cfg(any(feature = "floor", feature = "dynamic-module"))]
-pub mod floor {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::floor(input)
-    }
+define_unary_f64_kernel_module!(round, "round", libm::round);
+define_unary_f64_kernel_module!(sqrt, "sqrt", libm::sqrt);
+define_unary_f64_kernel_module!(floor, "floor", libm::floor);
+define_unary_f64_kernel_module!(ceil, "ceil", libm::ceil);
+define_unary_f64_kernel_module!(sin, "sin", libm::sin);
+define_unary_f64_kernel_module!(cos, "cos", libm::cos);
+define_unary_f64_kernel_module!(tan, "tan", libm::tan);
+define_unary_f64_kernel_module!(asin, "asin", libm::asin);
+define_unary_f64_kernel_module!(acos, "acos", libm::acos);
+define_unary_f64_kernel_module!(atan, "atan", libm::atan);
 
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "ceil", feature = "dynamic-module"))]
-pub mod ceil {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::ceil(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "atan2", feature = "dynamic-module"))]
-pub mod atan2 {
-    pub fn scalar_f64(lhs: f64, rhs: f64) -> f64 {
-        libm::atan2(lhs, rhs)
-    }
-}
-
-#[cfg(any(feature = "sin", feature = "dynamic-module"))]
-pub mod sin {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::sin(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "cos", feature = "dynamic-module"))]
-pub mod cos {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::cos(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "tan", feature = "dynamic-module"))]
-pub mod tan {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::tan(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "asin", feature = "dynamic-module"))]
-pub mod asin {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::asin(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "acos", feature = "dynamic-module"))]
-pub mod acos {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::acos(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
-
-#[cfg(any(feature = "atan", feature = "dynamic-module"))]
-pub mod atan {
-    pub fn scalar_f64(input: f64) -> f64 {
-        libm::atan(input)
-    }
-
-    pub fn view_f64(input: &[f64], out: &mut [f64]) {
-        for (src, dst) in input.iter().zip(out.iter_mut()) {
-            *dst = scalar_f64(*src);
-        }
-    }
-}
+define_binary_f64_kernel_module!(atan2, "atan2", libm::atan2);


### PR DESCRIPTION
### Motivation

- Reduce repetitive boilerplate in `machines/math/src/kernels.rs` by generating unary and binary f64 kernel modules with provider-local macros while preserving existing behavior and exports.

### Description

- Add two non-exported macros `define_unary_f64_kernel_module!` and `define_binary_f64_kernel_module!` at the top of `machines/math/src/kernels.rs` to generate provider-local kernel modules.
- Replace the hand-written unary kernel modules with `define_unary_f64_kernel_module!` invocations for `round`, `sqrt`, `floor`, `ceil`, `sin`, `cos`, `tan`, `asin`, `acos`, and `atan` in the specified order, keeping `scalar_f64` and `view_f64` signatures unchanged.
- Replace the hand-written `atan2` module with `define_binary_f64_kernel_module!` to generate `scalar_f64(lhs: f64, rhs: f64) -> f64` and omit `view_f64` as before.
- Only `machines/math/src/kernels.rs` was edited and no runtime-facing names, ABI symbols, dynamic exports, tests, Cargo, or CI were changed.

### Testing

- Ran `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"` which completed successfully.
- Ran `cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"` and unit tests passed (`32 passed`).
- Built the math provider, ran the dynamic math test `MECH_MODULE_PATH=target/mech-modules cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"`, and all dynamic math tests passed (`12 passed`).
- Ran combinatorics provider tests and dynamic combinatorics tests as a regression check and all tests passed (`11` and `10` passed respectively).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0ef89018832a8750a747537663ca)