### PR TITLE
Finalize dynamic module smoke path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,16 @@ jobs:
 
           # Runtime package tests.
           cargo test -p mech-runtime --lib --tests
+
+  dynamic-modules:
+    name: Dynamic modules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run dynamic module smoke path
+        run: bash scripts/test-dynamic-modules.sh

--- a/docs/dynamic-modules.md
+++ b/docs/dynamic-modules.md
@@ -1,0 +1,48 @@
+# Dynamic module smoke path
+
+The dynamic module prototype can be validated with:
+
+```bash
+./scripts/test-dynamic-modules.sh
+```
+
+The script performs the full local smoke path:
+
+1. Checks the interpreter with `base dynamic-modules f64`.
+2. Tests and builds the math dynamic provider.
+3. Tests and builds the combinatorics dynamic provider.
+4. Stages provider artifacts under `target/mech-modules`.
+5. Runs dynamic math integration tests with `MECH_MODULE_PATH`.
+6. Runs dynamic combinatorics integration tests with `MECH_MODULE_PATH`.
+7. Runs dynamic module smoke tests with `MECH_MODULE_PATH`.
+
+The script does not install modules globally. It uses only repository-local build output.
+
+The staged module directory is:
+
+```text
+target/mech-modules
+```
+
+The provider build directory is:
+
+```text
+target/dynamic-modules
+```
+
+The current smoke path validates:
+
+```mech
++> math
++> math/sin
++> math/*
++> combinatorics/n-choose-k
+```
+
+It also validates missing module and missing item failures.
+
+This is a prototype validation path for the current narrow dynamic ABI. It is not a package manager, module installer, or dynamic dependency resolver.
+
+Do not document unimplemented behavior.
+
+Do not mention future features as working.

--- a/scripts/test-dynamic-modules.sh
+++ b/scripts/test-dynamic-modules.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+TARGET_DIR="${REPO_ROOT}/target/dynamic-modules"
+MODULE_DIR="${REPO_ROOT}/target/mech-modules"
+PROFILE_DIR="${TARGET_DIR}/debug"
+
+case "$(uname -s)" in
+Darwin*)
+DYLIB_PREFIX="lib"
+DYLIB_EXT="dylib"
+;;
+MINGW*|MSYS*|CYGWIN*)
+DYLIB_PREFIX=""
+DYLIB_EXT="dll"
+;;
+*)
+DYLIB_PREFIX="lib"
+DYLIB_EXT="so"
+;;
+esac
+
+stage_module() {
+local source_name="$1"
+local staged_name="$2"
+
+local source_path="${PROFILE_DIR}/${DYLIB_PREFIX}${source_name}.${DYLIB_EXT}"
+local staged_path="${MODULE_DIR}/${DYLIB_PREFIX}${staged_name}.${DYLIB_EXT}"
+
+if [[ ! -f "${source_path}" ]]; then
+echo "missing dynamic module artifact: ${source_path}" >&2
+exit 1
+fi
+
+cp "${source_path}" "${staged_path}"
+}
+
+echo "checking interpreter with dynamic modules enabled"
+cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"
+
+echo "testing math dynamic provider"
+cargo test --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module"
+
+echo "building math dynamic provider"
+cargo build --manifest-path machines/math/Cargo.toml --no-default-features --features "dynamic-module" --target-dir "${TARGET_DIR}"
+
+echo "testing combinatorics dynamic provider"
+cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module"
+
+echo "building combinatorics dynamic provider"
+cargo build --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module" --target-dir "${TARGET_DIR}"
+
+echo "staging dynamic modules"
+rm -rf "${MODULE_DIR}"
+mkdir -p "${MODULE_DIR}"
+
+stage_module "mech_math" "mech_module_math"
+stage_module "mech_combinatorics" "mech_module_combinatorics"
+
+echo "running dynamic math integration tests"
+MECH_MODULE_PATH="${MODULE_DIR}" cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"
+
+echo "running dynamic combinatorics integration tests"
+MECH_MODULE_PATH="${MODULE_DIR}" cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"
+
+echo "running dynamic module smoke tests"
+MECH_MODULE_PATH="${MODULE_DIR}" cargo test --test dynamic_modules --no-default-features --features "base dynamic-modules f64"
+
+echo "dynamic module smoke path passed"

--- a/tests/dynamic_modules.rs
+++ b/tests/dynamic_modules.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "dynamic-modules")]
+
+use mech::program::{MechProgram, MechProgramConfig};
+
+fn run_ok(source: &str) {
+let mut program = MechProgram::new(MechProgramConfig::default());
+let result = program.run_string(source);
+assert!(result.is_ok(), "expected program to run successfully");
+}
+
+fn run_err(source: &str) {
+let mut program = MechProgram::new(MechProgramConfig::default());
+let result = program.run_string(source);
+assert!(result.is_err(), "expected program to fail");
+}
+
+#[test]
+fn dynamic_math_module_item_and_glob_imports_work() {
+run_ok(
+"+> math
++> math/sin
++> math/*
+a := math/sin(0.0)
+b := sin(0.0)
+c := cos(0.0)
+d := tan(0.0)
+",
+);
+}
+
+#[test]
+fn dynamic_combinatorics_item_import_works() {
+run_ok(
+"+> combinatorics/n-choose-k
+x := n-choose-k(5.0, 2.0)
+",
+);
+}
+
+#[test]
+fn dynamic_matrix_unary_math_import_works() {
+run_ok(
+"+> math/cos
+x := cos([0.0 0.0])
+",
+);
+}
+
+#[test]
+fn dynamic_binary_broadcast_import_works() {
+run_ok(
+"+> combinatorics/n-choose-k
+x := n-choose-k([10.0 20.0], 2.0)
+",
+);
+}
+
+#[test]
+fn dynamic_missing_module_errors() {
+run_err(
+"+> doesnotexist
+x := doesnotexist/thing(1.0)
+",
+);
+}
+
+#[test]
+fn dynamic_missing_item_errors() {
+run_err(
+"+> math/doesnotexist
+x := 1
+",
+);
+}
+
+#[test]
+fn dynamic_matrix_matrix_same_cells_different_shape_errors() {
+run_err(
+"+> combinatorics/n-choose-k
+x := n-choose-k([10.0 20.0 30.0 40.0], [2.0 3.0; 4.0 5.0])
+",
+);
+}


### PR DESCRIPTION
### Motivation

* Wrap up the current dynamic module prototype by making the end-to-end smoke path repeatable locally and in CI.
* Prove that dynamic module imports work through the existing loader, provider dylibs, ABI descriptors, host wrappers, and Mech programs without adding new ABI or standard-library surface area.

### Description

* Adds `scripts/test-dynamic-modules.sh`, an executable script that checks the interpreter, builds/tests the math and combinatorics dynamic providers, stages provider dylibs under `target/mech-modules`, sets `MECH_MODULE_PATH`, and runs the dynamic integration and smoke tests.
* Adds `tests/dynamic_modules.rs`, a focused smoke-test suite that covers module/item/glob imports, missing module/item errors, a dynamic matrix unary call, a dynamic binary broadcast call, and shape-mismatch failure cases.
* Adds `docs/dynamic-modules.md`, documenting how to run the local smoke path and the repository-local staging/build directories.
* Adds a Linux CI job `dynamic-modules` to `.github/workflows/ci.yml` that runs `bash scripts/test-dynamic-modules.sh` on `ubuntu-latest`.

### Testing

* Ran `./scripts/test-dynamic-modules.sh` and `bash scripts/test-dynamic-modules.sh`, which executed provider unit tests, built provider dylibs, staged artifacts, and ran `dynamic_math`, `dynamic_combinatorics`, and `dynamic_modules` integration tests; the full smoke path completed successfully.
* The script exercises the math and combinatorics provider tests and the new smoke tests under the `base dynamic-modules f64` feature set and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e1f7211c8832abd9404a41dbbfe39)