### PR TITLE
Harden manifest-backed context imports

### DIFF
--- a/src/core/src/module_manifest.rs
+++ b/src/core/src/module_manifest.rs
@@ -30,6 +30,39 @@ pub struct ModuleManifestCatalog {
   manifests: Vec<ModuleManifestConfig>,
 }
 
+impl ModuleManifestConfig {
+  pub fn validate(&self) -> MResult<()> {
+    if self.name.trim().is_empty() {
+      return Err(MechError::new(GenericError { msg: "Module manifest name must not be empty".to_string() }, None).with_compiler_loc());
+    }
+    let mut names = std::collections::HashSet::new();
+    for export in &self.exports {
+      if export.name.trim().is_empty() {
+        return Err(MechError::new(GenericError { msg: format!("Module manifest `{}` has an empty export name", self.name) }, None).with_compiler_loc());
+      }
+      if !names.insert(export.name.clone()) {
+        return Err(MechError::new(GenericError { msg: format!("Module manifest `{}` declares duplicate export `{}`", self.name, export.name) }, None).with_compiler_loc());
+      }
+      if !export.base_uri.contains("://") {
+        return Err(MechError::new(GenericError { msg: format!("Module manifest `{}` export `{}` has invalid base_uri `{}`", self.name, export.name, export.base_uri) }, None).with_compiler_loc());
+      }
+      if export.operations.is_empty() {
+        return Err(MechError::new(GenericError { msg: format!("Module manifest `{}` export `{}` must declare at least one operation", self.name, export.name) }, None).with_compiler_loc());
+      }
+      match export.kind {
+        ModuleManifestExportKind::Context => {
+          for operation in &export.operations {
+            if operation != "read" && operation != "write" {
+              return Err(MechError::new(GenericError { msg: format!("Module manifest `{}` context export `{}` has unsupported operation `{}`", self.name, export.name, operation) }, None).with_compiler_loc());
+            }
+          }
+        }
+      }
+    }
+    Ok(())
+  }
+}
+
 impl ModuleManifestCatalog {
   pub fn new() -> Self { Self::default() }
 
@@ -40,6 +73,7 @@ impl ModuleManifestCatalog {
   }
 
   pub fn register(&mut self, manifest: ModuleManifestConfig) -> MResult<()> {
+    manifest.validate()?;
     if self.manifest(&manifest.name).is_some() {
       return Err(MechError::new(GenericError { msg: format!("Module manifest `{}` is already registered", manifest.name) }, None).with_compiler_loc());
     }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -26,10 +26,16 @@ enum RuntimeAddressTarget {
 
 fn resolve_runtime_address_target(
   record: &ModuleVersionRecord,
-  _scope: &SourceScope,
+  scope: &SourceScope,
   context_registry: &RuntimeContextRegistry,
   target: &str,
 ) -> RuntimeAddressTarget {
+  if !matches!(scope, SourceScope::Program) {
+    if let Some(binding) = context_registry.get(target) {
+      return RuntimeAddressTarget::Context(binding.clone());
+    }
+  }
+
   for metadata in &record.scopes {
     if let SourceScope::Interpreter(interpreter) = &metadata.scope {
       if interpreter.namespace_str == target {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -12,6 +12,7 @@
 // Both methods have corresponding _with_context versions that accept a mutable reference to a RuntimeContext, allowing for execution within the context of an active transaction. This ensures that any changes made during execution are properly staged within the transaction that if an error occurs, the transaction can be rolled back to maintain consistency.
 
 use super::*;
+use crate::SourceIndex;
 
 const DEFAULT_RESOURCE_SUBJECT: &str = "task://main";
 
@@ -194,16 +195,26 @@ impl MechRuntime {
     &mut self,
     tree: &mech_core::Program,
   ) -> MResult<()> {
-    for (code, _) in program_codes(tree) {
-      let mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(ctx)) = code else {
+    let index = SourceIndex::from_program(tree);
+    for import in index.program_imports() {
+      let Some(SourceImportAlias::Context(alias)) = import.alias else {
         continue;
       };
-      let mech_core::ContextBase::ResourceUri(uri) = &ctx.base else {
+      let Some(module) = import.module.as_deref() else {
         continue;
       };
-      let uri = uri.to_string();
-      if uri.starts_with("browser://dom/") {
-        self.bind_resource_root(ctx.name.to_string(), uri)?;
+      let Some(item) = import.item.as_deref() else {
+        continue;
+      };
+      self.bind_context_export(&alias, module, item)?;
+    }
+
+    for ctx in index.program_contexts() {
+      let crate::SourceContextBase::ResourceUri(uri) = &ctx.base else {
+        continue;
+      };
+      if uri.starts_with("browser://dom") {
+        self.bind_resource_root(ctx.name, uri)?;
       }
     }
     Ok(())
@@ -404,9 +415,13 @@ impl MechRuntime {
 
   fn slice_reads_browser_resource(&self, slice: &mech_core::Slice) -> bool {
     slice
-      .subscript
-      .iter()
-      .any(|subscript| self.subscript_reads_browser_resource(subscript))
+      .context
+      .as_ref()
+      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
+      || slice
+        .subscript
+        .iter()
+        .any(|subscript| self.subscript_reads_browser_resource(subscript))
   }
 
   fn subscript_reads_browser_resource(&self, subscript: &mech_core::Subscript) -> bool {
@@ -646,6 +661,16 @@ impl MechRuntime {
     &mut self,
     slice: &mech_core::Slice,
   ) -> MResult<mech_core::Slice> {
+    if slice
+      .context
+      .as_ref()
+      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
+    {
+      return Err(browser_runtime_resource_error(
+        slice.name.to_string(),
+        "context-addressed slices are not supported for browser DOM resources in this PR",
+      ));
+    }
     Ok(mech_core::Slice {
       name: slice.name.clone(),
       context: slice.context.clone(),

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -76,7 +76,7 @@ use crate::id::{
 
 use crate::resolver::{
   InMemorySourceResolver, ResolvedSource, SourceRequest, SourceResolver,
-  SourceAddressReference, SourceExportDeclaration, SourceImportAlias, SourceImportDeclaration,
+  SourceAddressReference, SourceExportDeclaration, SourceImportAlias,
   SourceImportKind, SourceScope, module_namespace_for_import,
 };
 
@@ -482,33 +482,6 @@ impl MechRuntime {
     self.bind_resource_root(alias, &base_uri)
   }
 
-  pub fn bind_context_imports_from_source(
-    &mut self,
-    imports: &[SourceImportDeclaration],
-  ) -> MResult<()> {
-    for import in imports {
-      let Some(SourceImportAlias::Context(alias)) = &import.alias else {
-        continue;
-      };
-      let module = import.module.as_deref().ok_or_else(|| MechError::new(
-        RuntimeInvalidOperationError {
-          operation: "bind_context_imports_from_source",
-          reason: "context import is missing module metadata".to_string(),
-        },
-        None,
-      ))?;
-      let item = import.item.as_deref().ok_or_else(|| MechError::new(
-        RuntimeInvalidOperationError {
-          operation: "bind_context_imports_from_source",
-          reason: "context import is missing item metadata".to_string(),
-        },
-        None,
-      ))?;
-      self.bind_context_export(alias, module, item)?;
-    }
-    Ok(())
-  }
-
   pub fn bind_resource_root(
     &mut self,
     name: impl Into<String>,
@@ -895,25 +868,4 @@ fn validate_module_import_edges(record: &ModuleVersionRecord) -> MResult<()> {
       None,
     )
   })
-}
-
-#[cfg(test)]
-mod manifest_context_import_tests {
-  use super::*;
-
-  #[test]
-  fn runtime_binds_context_imports_from_source_metadata() {
-    let mut runtime = MechRuntime::builder().build().unwrap();
-    let imports = vec![SourceImportDeclaration {
-      specifier: "browser/dom".to_string(),
-      alias: Some(SourceImportAlias::Context("ui".to_string())),
-      module: Some("browser".to_string()),
-      item: Some("dom".to_string()),
-      kind: SourceImportKind::Single { name: "dom".to_string() },
-    }];
-
-    runtime.bind_context_imports_from_source(&imports).unwrap();
-
-    assert!(runtime.resolve_resource_path("ui", "counter/_text").is_ok());
-  }
 }

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -90,11 +90,11 @@ impl MechRuntime {
   fn validate_runtime_module_record_address_targets(
     record: &crate::RuntimeModuleRecord,
   ) -> MResult<()> {
-    let mut targets: HashMap<String, String> = HashMap::new();
+    let mut interpreter_targets: HashMap<String, String> = HashMap::new();
 
     for metadata in &record.scopes {
       if let SourceScope::Interpreter(interpreter) = &metadata.scope {
-        if let Some(first_kind) = targets.insert(interpreter.namespace_str.clone(), "interpreter".to_string()) {
+        if let Some(first_kind) = interpreter_targets.insert(interpreter.namespace_str.clone(), "interpreter".to_string()) {
           return Err(MechError::new(
             crate::resolver::AddressTargetNameConflict {
               name: interpreter.namespace_str.clone(),
@@ -105,9 +105,23 @@ impl MechRuntime {
           ));
         }
       }
+    }
+
+    for metadata in &record.scopes {
+      let mut scope_targets = HashMap::new();
+      match &metadata.scope {
+        SourceScope::Program => {
+          for (name, kind) in &interpreter_targets {
+            scope_targets.insert(name.clone(), kind.clone());
+          }
+        }
+        SourceScope::Interpreter(interpreter) => {
+          scope_targets.insert(interpreter.namespace_str.clone(), "interpreter".to_string());
+        }
+      }
 
       for context in &metadata.contexts {
-        if let Some(first_kind) = targets.insert(context.name.clone(), "context".to_string()) {
+        if let Some(first_kind) = scope_targets.insert(context.name.clone(), "context".to_string()) {
           return Err(MechError::new(
             crate::resolver::AddressTargetNameConflict {
               name: context.name.clone(),

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -328,7 +328,6 @@ impl MechRuntime {
 
       self.materialize_manifest_context_imports(&mut record)?;
       Self::validate_runtime_module_record_address_targets(&record)?;
-      self.bind_context_imports_from_source(&record.imports)?;
 
       let module = self.ensure_module(
         &record.name,

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2210,6 +2210,59 @@ fn manifest_context_import_in_fenced_scope_does_not_leak_to_program_scope() {
 }
 
 #[test]
+fn resolving_module_with_fenced_context_import_does_not_pollute_direct_runtime_bindings() {
+  let root = setup_modules(
+    "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n"
+  );
+
+  let mut runtime = runtime_with_root(&root);
+  runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  let result = runtime.run_string("x := @ui/counter/_text\n");
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+
+  assert!(
+    error.contains("UnknownAddressTarget") || error.contains("Undefined"),
+    "expected @ui not to exist in direct runtime scope, got {error}"
+  );
+  assert!(
+    !error.contains("RuntimeResourceProviderNotFound"),
+    "module resolution leaked @ui into global browser bindings: {error}"
+  );
+}
+
+#[test]
+fn fenced_context_alias_can_match_unrelated_interpreter_name_without_resolving_as_interpreter() {
+  let root = setup_modules(
+    "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\n+> @foo := browser/dom\nx := @foo/counter/_text\n~~~\n"
+  );
+
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  let result = runtime.run_module_scope(
+    version,
+    SourceScope::Interpreter(SourceInterpreterId {
+      namespace: hash_str("bar"),
+      namespace_str: "bar".to_string(),
+    }),
+  );
+
+  assert!(result.is_err(), "expected browser provider failure without browser provider");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeResourceProviderNotFound")
+      || error.contains("RuntimeCapabilityGrantDenied")
+      || error.contains("RuntimeResourceCapabilityDenied"),
+    "expected @foo in bar to resolve as context, not interpreter, got {error}"
+  );
+  assert!(
+    !error.contains("RuntimeModuleExportNotFound"),
+    "@foo in bar resolved as interpreter foo instead of local context: {error}"
+  );
+}
+#[test]
 fn direct_runtime_context_addressed_slice_is_rejected_explicitly() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
   let result = runtime.run_string("+> @ui := browser/dom\nx := @ui/counter[0]\n");

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,4 +1,4 @@
-use mech_core::{hash_str, MechSourceCode, Ref, Value};
+use mech_core::{hash_str, MechSourceCode, ModuleManifestConfig, ModuleManifestExportConfig, ModuleManifestExportKind, Ref, Value};
 use mech_runtime::*;
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
@@ -2166,4 +2166,71 @@ fn context_import_alias_is_not_bound_as_value_import() {
   assert!(result.is_err(), "context alias should not be available as a value binding");
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("Undefined") || error.contains("Variable"), "expected missing value binding error, got {error}");
+}
+
+#[test]
+fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lowering() {
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+  assert!(result.is_err(), "expected browser provider failure without a browser provider");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected browser provider lookup after recognizing @ui, got {error}");
+  assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
+}
+
+#[test]
+fn direct_runtime_manifest_context_import_write_reports_current_addressed_assignment_limit() {
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom
+@ui/counter/_text := \"hello\"
+");
+  assert!(result.is_err(), "direct addressed assignment is not yet supported by this runtime path");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressedAssignmentUnsupported"), "expected current direct assignment limit, got {error}");
+  assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
+}
+
+#[test]
+fn repeated_manifest_context_alias_in_separate_fenced_scopes_is_legal() {
+  let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\n~~~mech:bar\n+> @ui := browser/dom\nb := @ui/counter/_text\n~~~\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_ok(), "same context alias in separate fenced scopes should be legal: {result:?}");
+}
+
+#[test]
+fn manifest_context_import_in_fenced_scope_does_not_leak_to_program_scope() {
+  let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\nresult := @ui/counter/_text\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err(), "program scope should not see fenced @ui context import");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected scoped address-target failure, got {error}");
+}
+
+#[test]
+fn direct_runtime_context_addressed_slice_is_rejected_explicitly() {
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom\nx := @ui/counter[0]\n");
+  assert!(result.is_err(), "context-addressed browser slices should be explicit until semantics are defined");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("context-addressed slices are not supported"), "expected explicit slice error, got {error}");
+}
+
+#[test]
+fn module_manifest_catalog_validates_builder_manifests() {
+  let invalids = [
+    ModuleManifestConfig { name: "".to_string(), exports: vec![] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["read".to_string()] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["read".to_string()] }, ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["write".to_string()] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser-dom".to_string(), operations: vec!["read".to_string()] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec![] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["list".to_string()] }] },
+  ];
+
+  for manifest in invalids {
+    let result = RuntimeBuilder::new().module_manifest(manifest);
+    assert!(result.is_err(), "invalid manifest should be rejected by builder/catalog");
+  }
 }

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -216,6 +216,10 @@ fn source_import_tail(input: ParseString) -> ParseResult<Token> {
   )))(input)?;
   let mut tokens: Vec<Token> = matched.into_iter().map(|(_, token)| token).collect();
   let mut token = Token::merge_tokens(&mut tokens).unwrap_or(Token::default());
+  while token.chars.last().is_some_and(|ch| ch.is_whitespace()) {
+    token.chars.pop();
+    token.src_range.end.col = token.src_range.end.col.saturating_sub(1);
+  }
   token.kind = TokenKind::Any;
   token.src_range.start = start;
   Ok((input, token))

--- a/src/syntax/tests/module_imports.rs
+++ b/src/syntax/tests/module_imports.rs
@@ -235,3 +235,20 @@ fn source_and_module_imports_remain_separate() {
         assert!(parser::parse(invalid).is_err(), "expected parse failure for {invalid}");
     }
 }
+
+#[test]
+fn source_uri_import_specifiers_trim_trailing_whitespace() {
+    let stmts = statements("+> fs://lib/dep.mec   \n+> https://example.com/dep.mec   \n+> memory://scratch/dep   \n");
+    let specifiers: Vec<String> = stmts
+        .iter()
+        .map(|stmt| match stmt {
+            Statement::ImportDeclaration(import) => import.specifier.to_string(),
+            other => panic!("expected source import, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(specifiers, vec![
+        "fs://lib/dep.mec",
+        "https://example.com/dep.mec",
+        "memory://scratch/dep",
+    ]);
+}


### PR DESCRIPTION
### Motivation
- Ensure manifest-backed context imports (e.g. `+> @ui := browser/dom`) are recognized in direct runtime execution paths and do not rely solely on module-resolution flows.
- Make context import bindings scoped to their source scope so imports from fenced/interpreter scopes do not leak into unrelated scopes or modules.
- Correct address-target conflict validation to operate in the proper namespace semantics and avoid false positives across scopes.
- Prevent silent mistakes for context-addressed slices and normalize source-import URI specifiers and manifest validation earlier in the toolchain.

### Description
- Direct runtime imports: `bind_browser_resource_roots_from_program` now consults `SourceIndex::from_program` and materializes `SourceImportAlias::Context` entries via `ModuleManifestCatalog` before browser DOM lowering, so program-scope `+> @ui := browser/dom` is recognized by `run_string`/`run_tree` paths. 
- Scoped address-target validation: `validate_runtime_module_record_address_targets` was split to collect interpreter targets first and then validate context aliases per `SourceScope` so interpreter/context collisions are detected where visible while allowing identical aliases in unrelated fenced scopes. 
- Slice handling: browser detection now flags slice `context` usage in `slice_reads_browser_resource`, and `lower_browser_resource_reads_in_slice` returns an explicit runtime error for context-addressed slices in this PR instead of silently skipping lowering. 
- Manifest validation: introduced `ModuleManifestConfig::validate` and call it from `ModuleManifestCatalog::register` to enforce non-empty manifest and export names, duplicate-export checks, basic `://` URI shape, presence of operations, and allowed context operations (`read`/`write`). 
- Source-import trimming: `source_import_tail` now trims trailing whitespace from URI-style source import tokens so specifiers like `fs://lib/dep.mec   ` are normalized. 
- Tests and coverage: added direct runtime tests for manifest context imports, fenced-scope leakage/collision tests, an explicit rejection test for context-addressed slices, manifest/catalog validation tests, and a parser regression test for trailing whitespace on URI imports.

### Testing
- Ran `cargo test -p mech-syntax --test module_imports source_uri_import_specifiers_trim_trailing_whitespace -- --nocapture` and the targeted syntax tests passed. 
- Ran `cargo test -p mech-runtime --test module_smoke -- --nocapture` and `cargo test -p mech-runtime --test config_profile` and the runtime tests passed (including the new module_smoke cases added). 
- Ran `cargo test -p mech-host-browser --test module_manifest` and the host/browser manifest test passed. 
- Ran `cargo test -p mech-interpreter context_bindings` and the interpreter context-binding tests passed. 
- A full-workspace `cargo test --workspace` was attempted but failed due to an unrelated pre-existing compile error in `mech-combinatorics` (type `NChooseK<T>` not implementing the expected trait), which is outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31599bb080832a81f86eb785be8787)