### PR TITLE
Preserve wildcard source imports

### DIFF
--- a/src/runtime/src/resolver/imports.rs
+++ b/src/runtime/src/resolver/imports.rs
@@ -233,4 +233,18 @@ mod tests {
     let import = classify_import_specifier("math/*");
     assert_eq!(module_namespace_for_import(&import), Some("math".to_string()));
   }
+
+  #[test]
+  fn classifies_mec_wildcard_imports() {
+    for (specifier, expected_request) in [
+      ("dep.mec/*", "dep.mec"),
+      ("./dep.mec/*", "./dep.mec"),
+      ("fs://lib/dep.mec/*", "fs://lib/dep.mec"),
+    ] {
+      let import = classify_import_specifier(specifier);
+      assert_eq!(import.kind, SourceImportKind::Wildcard);
+      assert_eq!(import.specifier, expected_request);
+      assert_eq!(source_request_for_import(&import, None).specifier, expected_request);
+    }
+  }
 }

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -226,9 +226,8 @@ fn source_import_tail(input: ParseString) -> ParseResult<Token> {
 }
 
 fn source_wildcard_specifier_is_valid(specifier: &str) -> bool {
-  specifier != "*"
-    && !specifier.contains("/*/")
-    && (!specifier.contains('*') || specifier.ends_with("/*"))
+  let wildcard_count = specifier.matches('*').count();
+  wildcard_count == 0 || (wildcard_count == 1 && specifier.ends_with("/*"))
 }
 
 fn merge_source_tokens(start: SourceLocation, mut tokens: Vec<Token>) -> MechString {

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -225,6 +225,16 @@ fn source_import_tail(input: ParseString) -> ParseResult<Token> {
   Ok((input, token))
 }
 
+fn validate_source_wildcard_specifier(input: ParseString, specifier: &str) -> ParseResult<()> {
+  if specifier == "*"
+    || specifier.contains("/*/")
+    || specifier.contains('*') && !specifier.ends_with("/*")
+  {
+    return Err(nom::Err::Failure(ParseError::new(input, "Invalid wildcard placement in import specifier")));
+  }
+  Ok((input, ()))
+}
+
 fn merge_source_tokens(start: SourceLocation, mut tokens: Vec<Token>) -> MechString {
   let mut token = Token::merge_tokens(&mut tokens).unwrap_or(Token::default());
   token.kind = TokenKind::Any;
@@ -255,6 +265,11 @@ fn source_mec_path(input: ParseString) -> ParseResult<Vec<Token>> {
   Ok((input, tokens))
 }
 
+fn source_mec_path_wildcard_suffix(input: ParseString) -> ParseResult<Vec<Token>> {
+  let (input, suffix) = opt(nom_tuple((slash, asterisk)))(input)?;
+  Ok((input, suffix.map(|(slash, asterisk)| vec![slash, asterisk]).unwrap_or_default()))
+}
+
 fn relative_source_import_specifier(input: ParseString) -> ParseResult<MechString> {
   let start = input.loc();
   let (input, prefix) = alt((
@@ -262,8 +277,10 @@ fn relative_source_import_specifier(input: ParseString) -> ParseResult<MechStrin
     nom_map(nom_tuple((period, slash)), |(a, b)| vec![a, b]),
   ))(input)?;
   let (input, tail) = source_mec_path(input)?;
+  let (input, wildcard) = source_mec_path_wildcard_suffix(input)?;
   let mut tokens = prefix;
   tokens.extend(tail);
+  tokens.extend(wildcard);
   Ok((input, merge_source_tokens(start, tokens)))
 }
 
@@ -271,14 +288,19 @@ fn absolute_source_import_specifier(input: ParseString) -> ParseResult<MechStrin
   let start = input.loc();
   let (input, leading) = slash(input)?;
   let (input, tail) = source_mec_path(input)?;
+  let (input, wildcard) = source_mec_path_wildcard_suffix(input)?;
   let mut tokens = vec![leading];
   tokens.extend(tail);
+  tokens.extend(wildcard);
   Ok((input, merge_source_tokens(start, tokens)))
 }
 
 fn bare_source_import_specifier(input: ParseString) -> ParseResult<MechString> {
   let start = input.loc();
   let (input, tokens) = source_mec_path(input)?;
+  let (input, wildcard) = source_mec_path_wildcard_suffix(input)?;
+  let mut tokens = tokens;
+  tokens.extend(wildcard);
   Ok((input, merge_source_tokens(start, tokens)))
 }
 
@@ -321,6 +343,7 @@ pub fn import_declaration(input: ParseString) -> ParseResult<ImportDeclaration> 
   let (input, _) = module_import_sigil(input)?;
   let (input, _) = whitespace1(input)?;
   let (input, specifier) = source_import_specifier(input)?;
+  validate_source_wildcard_specifier(input.clone(), &specifier.to_string())?;
   Ok((input, ImportDeclaration { specifier }))
 }
 

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -225,14 +225,10 @@ fn source_import_tail(input: ParseString) -> ParseResult<Token> {
   Ok((input, token))
 }
 
-fn validate_source_wildcard_specifier(input: ParseString, specifier: &str) -> ParseResult<()> {
-  if specifier == "*"
-    || specifier.contains("/*/")
-    || specifier.contains('*') && !specifier.ends_with("/*")
-  {
-    return Err(nom::Err::Failure(ParseError::new(input, "Invalid wildcard placement in import specifier")));
-  }
-  Ok((input, ()))
+fn source_wildcard_specifier_is_valid(specifier: &str) -> bool {
+  specifier != "*"
+    && !specifier.contains("/*/")
+    && (!specifier.contains('*') || specifier.ends_with("/*"))
 }
 
 fn merge_source_tokens(start: SourceLocation, mut tokens: Vec<Token>) -> MechString {
@@ -343,7 +339,9 @@ pub fn import_declaration(input: ParseString) -> ParseResult<ImportDeclaration> 
   let (input, _) = module_import_sigil(input)?;
   let (input, _) = whitespace1(input)?;
   let (input, specifier) = source_import_specifier(input)?;
-  validate_source_wildcard_specifier(input.clone(), &specifier.to_string())?;
+  if !source_wildcard_specifier_is_valid(&specifier.to_string()) {
+    return Err(nom::Err::Failure(ParseError::new(input, "Invalid wildcard placement in import specifier")));
+  }
   Ok((input, ImportDeclaration { specifier }))
 }
 

--- a/src/syntax/tests/module_imports.rs
+++ b/src/syntax/tests/module_imports.rs
@@ -249,6 +249,7 @@ fn source_wildcard_import_specifiers_reject_invalid_placements() {
         "+> dep.mec/*/foo",
         "+> ./lib/*/dep.mec",
         "+> fs://lib/dep.mec/**",
+        "+> fs://lib*/dep.mec/*",
         "+> https://example.com/dep.mec/*/foo",
         "+> s3://bucket/app.mec*",
     ] {

--- a/src/syntax/tests/module_imports.rs
+++ b/src/syntax/tests/module_imports.rs
@@ -216,6 +216,47 @@ fn source_imports_accept_generic_uris_bare_and_absolute_mec_paths() {
 }
 
 #[test]
+fn source_wildcard_import_specifiers_parse() {
+    let stmts = statements(
+        "+> dep.mec/*\n+> lib/dep.mec/*\n+> ./dep.mec/*\n+> ../lib/dep.mec/*\n+> /tmp/lib.mec/*\n+> fs://lib/dep.mec/*\n+> https://example.com/dep.mec/*\n",
+    );
+
+    let specifiers: Vec<String> = stmts
+        .iter()
+        .map(|stmt| match stmt {
+            Statement::ImportDeclaration(import) => import.specifier.to_string(),
+            other => panic!("expected source import, got {other:?}"),
+        })
+        .collect();
+
+    assert_eq!(specifiers, vec![
+        "dep.mec/*",
+        "lib/dep.mec/*",
+        "./dep.mec/*",
+        "../lib/dep.mec/*",
+        "/tmp/lib.mec/*",
+        "fs://lib/dep.mec/*",
+        "https://example.com/dep.mec/*",
+    ]);
+}
+
+#[test]
+fn source_wildcard_import_specifiers_reject_invalid_placements() {
+    for invalid in [
+        "+> *",
+        "+> dep.mec*",
+        "+> dep.mec/**",
+        "+> dep.mec/*/foo",
+        "+> ./lib/*/dep.mec",
+        "+> fs://lib/dep.mec/**",
+        "+> https://example.com/dep.mec/*/foo",
+        "+> s3://bucket/app.mec*",
+    ] {
+        assert!(parser::parse(invalid).is_err(), "expected parse failure for {invalid}");
+    }
+}
+
+#[test]
 fn source_and_module_imports_remain_separate() {
     let module_imports = imports("+> math/sin\n+> math/*\n+> combinatorics/n-choose-k\n+> browser/dom\n+> @ui := browser/dom\n");
     assert_eq!(module_imports.len(), 5);


### PR DESCRIPTION
### Motivation

Fix the remaining parser regression from PR #507: source imports with a final `/*` wildcard should remain valid for file-backed and URI-backed source imports.

### Description

- Accepts source wildcard imports such as:
  - `+> dep.mec/*`
  - `+> ./dep.mec/*`
  - `+> ../lib/dep.mec/*`
  - `+> /tmp/lib.mec/*`
  - `+> fs://lib/dep.mec/*`
  - `+> https://example.com/dep.mec/*`
- Rejects invalid wildcard placements such as:
  - `+> dep.mec*`
  - `+> dep.mec/**`
  - `+> dep.mec/*/foo`
  - `+> fs://lib/dep.mec/**`
  - `+> https://example.com/dep.mec/*/foo`
- Adds resolver coverage that `.mec/*` and URI `.mec/*` imports classify as `SourceImportKind::Wildcard` and normalize the source request to the underlying source specifier.

### Testing

Added parser and resolver tests for wildcard source import parsing, invalid wildcard placement, and wildcard classification.