### PR TITLE
Harden generic context/resource host boundary

### DIFF
--- a/hosts/browser/src/provider.rs
+++ b/hosts/browser/src/provider.rs
@@ -69,6 +69,10 @@ impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B
     "browser"
   }
 
+  fn base_uris(&self) -> Vec<String> {
+    vec![BROWSER_DOM_PROVIDER_URI.to_string()]
+  }
+
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
     Self::validate_dom_base(&request.base_uri)?;
     let path = Self::dom_path(request.path)?;

--- a/src/core/src/module_manifest.rs
+++ b/src/core/src/module_manifest.rs
@@ -66,10 +66,15 @@ impl ModuleManifestConfig {
 impl ModuleManifestCatalog {
   pub fn new() -> Self { Self::default() }
 
-  pub fn with_builtin_browser() -> Self {
+  pub fn with_builtin_hosts() -> Self {
     let mut catalog = Self::new();
     let _ = catalog.register(builtin_browser_module_manifest());
+    let _ = catalog.register(builtin_cli_module_manifest());
     catalog
+  }
+
+  pub fn with_builtin_browser() -> Self {
+    Self::with_builtin_hosts()
   }
 
   pub fn register(&mut self, manifest: ModuleManifestConfig) -> MResult<()> {
@@ -107,5 +112,32 @@ pub fn builtin_browser_module_manifest() -> ModuleManifestConfig {
       base_uri: "browser://dom".to_string(),
       operations: vec!["read".to_string(), "write".to_string()],
     }],
+  }
+}
+
+
+pub fn builtin_cli_module_manifest() -> ModuleManifestConfig {
+  ModuleManifestConfig {
+    name: "cli".to_string(),
+    exports: vec![
+      ModuleManifestExportConfig {
+        name: "env".to_string(),
+        kind: ModuleManifestExportKind::Context,
+        base_uri: "cli://env".to_string(),
+        operations: vec!["read".to_string()],
+      },
+      ModuleManifestExportConfig {
+        name: "stdout".to_string(),
+        kind: ModuleManifestExportKind::Context,
+        base_uri: "cli://stdout".to_string(),
+        operations: vec!["write".to_string()],
+      },
+      ModuleManifestExportConfig {
+        name: "stderr".to_string(),
+        kind: ModuleManifestExportKind::Context,
+        base_uri: "cli://stderr".to_string(),
+        operations: vec!["write".to_string()],
+      },
+    ],
   }
 }

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -166,19 +166,23 @@ impl SourceIndex {
                         }
                     }
                     SectionElement::FencedMechCode(fenced) => {
-                        let interpreter = SourceInterpreterId {
-                            namespace: fenced.config.namespace,
-                            namespace_str: fenced.config.namespace_str.clone(),
+                        let scope = if fenced.config.namespace_str.is_empty() {
+                            SourceScope::Program
+                        } else {
+                            let interpreter = SourceInterpreterId {
+                                namespace: fenced.config.namespace,
+                                namespace_str: fenced.config.namespace_str.clone(),
+                            };
+                            fenced_interpreters
+                                .entry(interpreter.namespace_str.clone())
+                                .or_insert_with(|| {
+                                    index.address_target_interpreters.push(interpreter.clone());
+                                    let scope = SourceScope::Interpreter(interpreter);
+                                    index.push_scope(scope.clone());
+                                    scope
+                                })
+                                .clone()
                         };
-                        let scope = fenced_interpreters
-                            .entry(interpreter.namespace_str.clone())
-                            .or_insert_with(|| {
-                                index.address_target_interpreters.push(interpreter.clone());
-                                let scope = SourceScope::Interpreter(interpreter);
-                                index.push_scope(scope.clone());
-                                scope
-                            })
-                            .clone();
 
                         // TODO: Interleaving imports/exports/statements exactly as written in fenced code
                         // requires parser ordering data; currently imports and exports preserve local vector order.
@@ -843,4 +847,22 @@ fn source_context_declaration(context: &mech_core::ContextDeclaration) -> Source
 
 fn declaration_range(mut tokens: Vec<Token>) -> Option<SourceRange> {
     Token::merge_tokens(&mut tokens).map(|token| token.src_range)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_index_treats_unqualified_fenced_mech_as_program_scope() {
+        let tree = mech_syntax::parser::parse(
+            "```mech\n+> @env := cli/env\nhome := @env/HOME\n```\n",
+        ).unwrap();
+
+        let index = SourceIndex::from_program(&tree);
+
+        assert_eq!(index.imports.len(), 1);
+        assert_eq!(index.imports[0].occurrence.scope, SourceScope::Program);
+        assert!(index.interpreter_scopes().is_empty());
+    }
 }

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -211,6 +211,10 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
   }
 }
 
+pub fn resource_base_matches(base: &str, candidate: &str) -> bool {
+  candidate == base || candidate.strip_prefix(base).is_some_and(|suffix| suffix.starts_with('/'))
+}
+
 fn resource_uri_scheme(uri: &str) -> MResult<&str> {
   let Some((scheme, _rest)) = uri.split_once("://") else {
     return Err(MechError::new(

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -20,6 +20,8 @@ pub struct RuntimeResourceWriteRequest {
 pub trait RuntimeResourceProvider: std::fmt::Debug {
   fn scheme(&self) -> &str;
 
+  fn base_uris(&self) -> Vec<String> { Vec::new() }
+
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
 
   fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
@@ -70,6 +72,25 @@ impl RuntimeResourceRegistry {
 
   pub fn has_provider(&self, scheme: &str) -> bool {
     self.providers.contains_key(scheme)
+  }
+
+  pub fn provider_base_uri_for(&self, candidate: &str) -> MResult<Option<String>> {
+    let scheme = resource_uri_scheme(candidate)?.to_string();
+    let Some(provider) = self.providers.get(&scheme) else {
+      return Ok(None);
+    };
+
+    let mut matches = provider
+      .base_uris()
+      .into_iter()
+      .filter(|base| resource_base_matches(base, candidate))
+      .collect::<Vec<_>>();
+    matches.sort_by_key(|base| std::cmp::Reverse(base.len()));
+    if let Some(base) = matches.into_iter().next() {
+      return Ok(Some(base));
+    }
+
+    Ok(Some(resource_uri_origin(candidate)?.to_string()))
   }
 
   pub fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
@@ -158,6 +179,10 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
     "docs"
   }
 
+  fn base_uris(&self) -> Vec<String> {
+    self.documents.keys().cloned().collect()
+  }
+
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
     let Some(document) = self.documents.get(&request.base_uri) else {
       return Err(MechError::new(
@@ -213,6 +238,22 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
 
 pub fn resource_base_matches(base: &str, candidate: &str) -> bool {
   candidate == base || candidate.strip_prefix(base).is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn resource_uri_origin(uri: &str) -> MResult<&str> {
+  let scheme = resource_uri_scheme(uri)?;
+  let rest = &uri[scheme.len() + 3..];
+  let authority_end = rest.find('/').unwrap_or(rest.len());
+  if authority_end == 0 {
+    return Err(MechError::new(
+      RuntimeResourceInvalidUri {
+        uri: uri.to_string(),
+        reason: "resource URI authority cannot be empty".to_string(),
+      },
+      None,
+    ));
+  }
+  Ok(&uri[..scheme.len() + 3 + authority_end])
 }
 
 fn resource_uri_scheme(uri: &str) -> MResult<&str> {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -24,6 +24,20 @@ enum RuntimeAddressTarget {
   Unknown,
 }
 
+
+#[derive(Debug, Clone)]
+pub struct RuntimeAddressedAssignmentUnsupported {
+  pub target: String,
+}
+
+impl MechErrorKind for RuntimeAddressedAssignmentUnsupported {
+  fn name(&self) -> &str { "RuntimeAddressedAssignmentUnsupported" }
+
+  fn message(&self) -> String {
+    format!("addressed assignment is not supported for `{}`", self.target)
+  }
+}
+
 fn resolve_runtime_address_target(
   record: &ModuleVersionRecord,
   scope: &SourceScope,
@@ -165,7 +179,7 @@ fn bind_runtime_value_on_program(
 ) -> MResult<()> {
   if var.context.is_some() {
     return Err(MechError::new(
-      mech_core::GenericError { msg: "AddressedAssignmentUnsupported: addressed assignment is not supported yet".to_string() },
+      RuntimeAddressedAssignmentUnsupported { target: var.name.to_string() },
       None,
     ).with_compiler_loc().with_tokens(var.tokens()));
   }
@@ -185,45 +199,119 @@ fn resolve_runtime_value(value: Value) -> Value {
 }
 
 
-fn string_value_expression(value: String) -> MResult<mech_core::Expression> {
-  Ok(mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
-    text: mech_core::Token::new(
-      mech_core::TokenKind::String,
-      mech_core::SourceRange::default(),
-      value.chars().collect(),
-    ),
-  })))
-}
 
 impl MechRuntime {
 
-  fn bind_browser_resource_roots_from_program(
-    &mut self,
-    tree: &mech_core::Program,
-  ) -> MResult<()> {
-    let index = SourceIndex::from_program(tree);
-    for import in index.program_imports() {
-      let Some(SourceImportAlias::Context(alias)) = import.alias else {
+  fn context_declarations_from_index_scope(
+    &self,
+    index: &SourceIndex,
+    scope: &SourceScope,
+  ) -> MResult<Vec<crate::SourceContextDeclaration>> {
+    let mut declarations = index
+      .contexts
+      .iter()
+      .filter(|ctx| &ctx.occurrence.scope == scope)
+      .map(|ctx| ctx.declaration.clone())
+      .collect::<Vec<_>>();
+
+    for import in index.imports.iter().filter(|import| &import.occurrence.scope == scope) {
+      let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
         continue;
       };
-      let Some(module) = import.module.as_deref() else {
-        continue;
-      };
-      let Some(item) = import.item.as_deref() else {
-        continue;
-      };
-      self.bind_context_export(&alias, module, item)?;
+      let module = import.declaration.module.as_deref().ok_or_else(|| {
+        MechError::new(RuntimeInvalidOperationError {
+          operation: "materialize_direct_manifest_context_imports",
+          reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
+        }, None)
+      })?;
+      let item = import.declaration.item.as_deref().ok_or_else(|| {
+        MechError::new(RuntimeInvalidOperationError {
+          operation: "materialize_direct_manifest_context_imports",
+          reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
+        }, None)
+      })?;
+      let export = self.module_manifests.context_export(module, item)?;
+      declarations.push(crate::SourceContextDeclaration {
+        name: alias.clone(),
+        base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
+        capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
+          operation: operation.clone(),
+          scope: crate::SourceContextCapabilityScope::Wildcard,
+        }).collect(),
+      });
     }
 
-    for ctx in index.program_contexts() {
-      let crate::SourceContextBase::ResourceUri(uri) = &ctx.base else {
-        continue;
-      };
-      if uri.starts_with("browser://dom") {
-        self.bind_resource_root(ctx.name, uri)?;
-      }
+    Ok(declarations)
+  }
+
+  fn direct_context_registry_for_scope(
+    &self,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<RuntimeContextRegistry> {
+    let index = SourceIndex::from_program(tree);
+    let declarations = self.context_declarations_from_index_scope(&index, scope)?;
+    RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
+  }
+
+  fn read_context_resource(
+    &self,
+    binding: &RuntimeContextBinding,
+    path: &str,
+  ) -> MResult<Value> {
+    let base_uri = runtime_context_base_uri(binding);
+    if !runtime_context_allows_read(binding, path) {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: "read".to_string(),
+        path: path.to_string(),
+      }, None));
     }
-    Ok(())
+    self.resources.read(RuntimeResourceReadRequest {
+      base_uri,
+      path: path.to_string(),
+      context_name: binding.name.clone(),
+    })
+  }
+
+  fn write_context_resource(
+    &mut self,
+    binding: &RuntimeContextBinding,
+    path: &str,
+    value: Value,
+  ) -> MResult<()> {
+    let base_uri = runtime_context_base_uri(binding);
+    if !runtime_context_allows_write(binding, path) {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: "write".to_string(),
+        path: path.to_string(),
+      }, None));
+    }
+    self.resources.write(RuntimeResourceWriteRequest {
+      base_uri,
+      path: path.to_string(),
+      context_name: binding.name.clone(),
+      value,
+    })
+  }
+
+  fn expression_context_read(
+    &self,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<Option<Value>> {
+    let mech_core::Expression::Var(var) = expression else {
+      return Ok(None);
+    };
+    let Some(context) = &var.context else {
+      return Ok(None);
+    };
+    let target = context.to_string();
+    let Some(binding) = registry.get(&target) else {
+      return Ok(None);
+    };
+    Ok(Some(resolve_runtime_value(self.read_context_resource(binding, &var.name.to_string())?)))
   }
 
   fn run_tree_on_program(
@@ -232,62 +320,58 @@ impl MechRuntime {
     program: &mut MechProgram,
     tree: &mech_core::Program,
   ) -> MResult<Value> {
-    if !self.program_has_browser_resource_forms(tree) {
-      return program.run_tree(tree);
-    }
-
+    let registry = self.direct_context_registry_for_scope(tree, &SourceScope::Program)?;
     let mut result = Value::Empty;
     for (code, comment) in program_codes(tree) {
       match code {
-        mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(ctx))
-          if self.is_browser_dom_context_declaration(ctx) =>
-        {
+        mech_core::MechCode::Import(_)
+        | mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
+        | mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(_))
+        | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => {
           result = Value::Empty;
         }
-        mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def))
-          if self.variable_define_targets_browser_binding(var_def) =>
-        {
-          let expression = self.lower_browser_resource_reads_in_expression(&var_def.expression)?;
-          let value = self.evaluate_expression_on_program(program, &expression)?;
-          bind_runtime_value_on_program(program, &var_def.var, resolve_runtime_value(value.clone()), var_def.mutable)?;
-          result = value;
-        }
         mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-          let expression = self.lower_browser_resource_reads_in_expression(&var_def.expression)?;
-          let mut var_def = var_def.clone();
-          var_def.expression = expression;
-          let single = single_code_program(
-            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
-            comment.clone(),
-          );
-          result = program.run_tree(&single)?;
-        }
-        mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign))
-          if self.assignment_targets_browser_resource(assign) =>
-        {
-          let expression = self.lower_browser_resource_reads_in_expression(&assign.expression)?;
-          let value = self.evaluate_expression_on_program(program, &expression)?;
-          let binding = assign.target.context.as_ref().expect("checked browser binding").to_string();
-          self.write_bound_resource(
-            &binding,
-            &assign.target.name.to_string(),
-            &resolve_runtime_value(value.clone()),
-          )?;
-          result = value;
+          if let Some(context) = &var_def.var.context {
+            let target = context.to_string();
+            if let Some(binding) = registry.get(&target).cloned() {
+              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &var_def.expression)?);
+              self.write_context_resource(&binding, &var_def.var.name.to_string(), value.clone())?;
+              result = value;
+            } else {
+              let single = single_code_program(code.clone(), comment.clone());
+              result = program.run_tree(&single)?;
+            }
+          } else if let Some(value) = self.expression_context_read(&registry, &var_def.expression)? {
+            bind_runtime_value_on_program(program, &var_def.var, value.clone(), var_def.mutable)?;
+            result = value;
+          } else {
+            let single = single_code_program(code.clone(), comment.clone());
+            result = program.run_tree(&single)?;
+          }
         }
         mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-          let mut assign = assign.clone();
-          assign.expression = self.lower_browser_resource_reads_in_expression(&assign.expression)?;
-          let single = single_code_program(
-            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)),
-            comment.clone(),
-          );
-          result = program.run_tree(&single)?;
+          if let Some(context) = &assign.target.context {
+            let target = context.to_string();
+            if let Some(binding) = registry.get(&target).cloned() {
+              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &assign.expression)?);
+              self.write_context_resource(&binding, &assign.target.name.to_string(), value.clone())?;
+              result = value;
+            } else {
+              let single = single_code_program(code.clone(), comment.clone());
+              result = program.run_tree(&single)?;
+            }
+          } else {
+            let single = single_code_program(code.clone(), comment.clone());
+            result = program.run_tree(&single)?;
+          }
         }
         mech_core::MechCode::Expression(expression) => {
-          let expression = self.lower_browser_resource_reads_in_expression(expression)?;
-          let single = single_code_program(mech_core::MechCode::Expression(expression), comment.clone());
-          result = program.run_tree(&single)?;
+          if let Some(value) = self.expression_context_read(&registry, expression)? {
+            result = value;
+          } else {
+            let single = single_code_program(code.clone(), comment.clone());
+            result = program.run_tree(&single)?;
+          }
         }
         _ => {
           let single = single_code_program(code.clone(), comment.clone());
@@ -296,550 +380,6 @@ impl MechRuntime {
       }
     }
     Ok(result)
-  }
-
-  fn program_has_browser_resource_forms(&self, tree: &mech_core::Program) -> bool {
-    program_codes(tree).any(|(code, _)| match code {
-      mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(ctx)) => {
-        self.is_browser_dom_context_declaration(ctx)
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-        self.variable_define_targets_browser_binding(var_def)
-          || self.expression_reads_browser_resource(&var_def.expression)
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-        self.assignment_targets_browser_resource(assign)
-          || self.expression_reads_browser_resource(&assign.expression)
-      }
-      mech_core::MechCode::Expression(expression) => {
-        self.expression_reads_browser_resource(expression)
-      }
-      _ => false,
-    })
-  }
-
-  fn is_browser_dom_context_declaration(&self, ctx: &mech_core::ContextDeclaration) -> bool {
-    match &ctx.base {
-      mech_core::ContextBase::ResourceUri(uri) => uri.to_string().starts_with("browser://dom/"),
-      _ => false,
-    }
-  }
-
-  fn is_browser_dom_resource_binding(&self, binding: &str) -> bool {
-    self
-      .resource_bindings
-      .get(binding)
-      .is_some_and(|binding| binding.base_uri == BROWSER_DOM_PROVIDER_URI)
-  }
-
-  fn variable_define_targets_browser_binding(&self, var_def: &mech_core::VariableDefine) -> bool {
-    var_def
-      .var
-      .context
-      .as_ref()
-      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
-  }
-
-  fn assignment_targets_browser_resource(&self, assign: &mech_core::VariableAssign) -> bool {
-    assign
-      .target
-      .context
-      .as_ref()
-      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
-  }
-
-  fn expression_reads_browser_resource(&self, expression: &mech_core::Expression) -> bool {
-    match expression {
-      mech_core::Expression::Var(var) => var
-        .context
-        .as_ref()
-        .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string())),
-      mech_core::Expression::Formula(factor) => self.factor_reads_browser_resource(factor),
-      mech_core::Expression::FunctionCall(call) => call
-        .args
-        .iter()
-        .any(|(_, expression)| self.expression_reads_browser_resource(expression)),
-      mech_core::Expression::FsmPipe(pipe) => pipe
-        .start
-        .args
-        .as_ref()
-        .is_some_and(|args| args.iter().any(|(_, expression)| self.expression_reads_browser_resource(expression))),
-      mech_core::Expression::Literal(_) => false,
-      mech_core::Expression::Match(match_expression) => {
-        self.expression_reads_browser_resource(&match_expression.source)
-          || match_expression.arms.iter().any(|arm| {
-            arm
-              .guard
-              .as_ref()
-              .is_some_and(|guard| self.expression_reads_browser_resource(guard))
-              || self.expression_reads_browser_resource(&arm.expression)
-          })
-      }
-      mech_core::Expression::Range(range) => {
-        self.factor_reads_browser_resource(&range.start)
-          || range
-            .increment
-            .as_ref()
-            .is_some_and(|(_, increment)| self.factor_reads_browser_resource(increment))
-          || self.factor_reads_browser_resource(&range.terminal)
-      }
-      mech_core::Expression::Slice(slice) => self.slice_reads_browser_resource(slice),
-      mech_core::Expression::Structure(structure) => self.structure_reads_browser_resource(structure),
-      mech_core::Expression::SetComprehension(comprehension) => {
-        self.expression_reads_browser_resource(&comprehension.expression)
-          || comprehension
-            .qualifiers
-            .iter()
-            .any(|qualifier| self.comprehension_qualifier_reads_browser_resource(qualifier))
-      }
-      mech_core::Expression::MatrixComprehension(comprehension) => {
-        self.expression_reads_browser_resource(&comprehension.expression)
-          || comprehension
-            .qualifiers
-            .iter()
-            .any(|qualifier| self.comprehension_qualifier_reads_browser_resource(qualifier))
-      }
-    }
-  }
-
-  fn factor_reads_browser_resource(&self, factor: &mech_core::Factor) -> bool {
-    match factor {
-      mech_core::Factor::Expression(expression) => self.expression_reads_browser_resource(expression),
-      mech_core::Factor::Negate(factor)
-      | mech_core::Factor::Not(factor)
-      | mech_core::Factor::Parenthetical(factor)
-      | mech_core::Factor::Transpose(factor) => self.factor_reads_browser_resource(factor),
-      mech_core::Factor::Term(term) => {
-        self.factor_reads_browser_resource(&term.lhs)
-          || term
-            .rhs
-            .iter()
-            .any(|(_, factor)| self.factor_reads_browser_resource(factor))
-      }
-    }
-  }
-
-  fn slice_reads_browser_resource(&self, slice: &mech_core::Slice) -> bool {
-    slice
-      .context
-      .as_ref()
-      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
-      || slice
-        .subscript
-        .iter()
-        .any(|subscript| self.subscript_reads_browser_resource(subscript))
-  }
-
-  fn subscript_reads_browser_resource(&self, subscript: &mech_core::Subscript) -> bool {
-    match subscript {
-      mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
-        subscripts
-          .iter()
-          .any(|subscript| self.subscript_reads_browser_resource(subscript))
-      }
-      mech_core::Subscript::Formula(factor) => self.factor_reads_browser_resource(factor),
-      mech_core::Subscript::Range(range) => {
-        self.factor_reads_browser_resource(&range.start)
-          || range
-            .increment
-            .as_ref()
-            .is_some_and(|(_, increment)| self.factor_reads_browser_resource(increment))
-          || self.factor_reads_browser_resource(&range.terminal)
-      }
-      _ => false,
-    }
-  }
-
-  fn structure_reads_browser_resource(&self, structure: &mech_core::Structure) -> bool {
-    match structure {
-      mech_core::Structure::Empty => false,
-      mech_core::Structure::Map(map) => map.elements.iter().any(|mapping| {
-        self.expression_reads_browser_resource(&mapping.key)
-          || self.expression_reads_browser_resource(&mapping.value)
-      }),
-      mech_core::Structure::Matrix(matrix) => matrix.rows.iter().any(|row| {
-        row
-          .columns
-          .iter()
-          .any(|column| self.expression_reads_browser_resource(&column.element))
-      }),
-      mech_core::Structure::Record(record) => record
-        .bindings
-        .iter()
-        .any(|binding| self.expression_reads_browser_resource(&binding.value)),
-      mech_core::Structure::Set(set) => set
-        .elements
-        .iter()
-        .any(|expression| self.expression_reads_browser_resource(expression)),
-      mech_core::Structure::Table(table) => table.rows.iter().any(|row| {
-        row
-          .columns
-          .iter()
-          .any(|column| self.expression_reads_browser_resource(&column.element))
-      }),
-      mech_core::Structure::Tuple(tuple) => tuple
-        .elements
-        .iter()
-        .any(|expression| self.expression_reads_browser_resource(expression)),
-      mech_core::Structure::TupleStruct(tuple_struct) => {
-        self.expression_reads_browser_resource(&tuple_struct.value)
-      }
-    }
-  }
-
-  fn comprehension_qualifier_reads_browser_resource(
-    &self,
-    qualifier: &mech_core::ComprehensionQualifier,
-  ) -> bool {
-    match qualifier {
-      mech_core::ComprehensionQualifier::Generator((_, expression)) => {
-        self.expression_reads_browser_resource(expression)
-      }
-      mech_core::ComprehensionQualifier::Filter(expression) => {
-        self.expression_reads_browser_resource(expression)
-      }
-      mech_core::ComprehensionQualifier::Let(var_def) => {
-        self.expression_reads_browser_resource(&var_def.expression)
-      }
-    }
-  }
-
-  fn lower_browser_resource_reads_in_expression(
-    &mut self,
-    expression: &mech_core::Expression,
-  ) -> MResult<mech_core::Expression> {
-    match expression {
-      mech_core::Expression::Var(var) => {
-        let Some(context) = &var.context else {
-          return Ok(expression.clone());
-        };
-        let binding = context.to_string();
-        if !self.is_browser_dom_resource_binding(&binding) {
-          return Ok(expression.clone());
-        }
-        let value = resolve_runtime_value(
-          self.read_bound_resource(&binding, &var.name.to_string())?,
-        );
-        let Value::String(value) = value else {
-          return Err(browser_runtime_resource_error(
-            var.name.to_string(),
-            "browser DOM resource reads must return string values in this PR",
-          ));
-        };
-        string_value_expression(value.borrow().clone())
-      }
-      mech_core::Expression::Formula(factor) => {
-        Ok(mech_core::Expression::Formula(self.lower_browser_resource_reads_in_factor(factor)?))
-      }
-      mech_core::Expression::FunctionCall(call) => {
-        let args = call
-          .args
-          .iter()
-          .map(|(name, expression)| {
-            Ok((
-              name.clone(),
-              self.lower_browser_resource_reads_in_expression(expression)?,
-            ))
-          })
-          .collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall {
-          name: call.name.clone(),
-          args,
-        }))
-      }
-      mech_core::Expression::FsmPipe(pipe) => {
-        let mut pipe = pipe.clone();
-        if let Some(args) = &pipe.start.args {
-          pipe.start.args = Some(
-            args
-              .iter()
-              .map(|(name, expression)| {
-                Ok((
-                  name.clone(),
-                  self.lower_browser_resource_reads_in_expression(expression)?,
-                ))
-              })
-              .collect::<MResult<Vec<_>>>()?,
-          );
-        }
-        Ok(mech_core::Expression::FsmPipe(pipe))
-      }
-      mech_core::Expression::Literal(_) => Ok(expression.clone()),
-      mech_core::Expression::Match(match_expression) => {
-        let mut match_expression = match_expression.as_ref().clone();
-        match_expression.source = self.lower_browser_resource_reads_in_expression(&match_expression.source)?;
-        match_expression.arms = match_expression
-          .arms
-          .iter()
-          .map(|arm| {
-            Ok(mech_core::MatchArm {
-              pattern: arm.pattern.clone(),
-              guard: arm
-                .guard
-                .as_ref()
-                .map(|guard| self.lower_browser_resource_reads_in_expression(guard))
-                .transpose()?,
-              expression: self.lower_browser_resource_reads_in_expression(&arm.expression)?,
-            })
-          })
-          .collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::Match(Box::new(match_expression)))
-      }
-      mech_core::Expression::Range(range) => {
-        let mut range = range.as_ref().clone();
-        range.start = self.lower_browser_resource_reads_in_factor(&range.start)?;
-        range.increment = match &range.increment {
-          Some((operator, increment)) => Some((
-            operator.clone(),
-            self.lower_browser_resource_reads_in_factor(increment)?,
-          )),
-          None => None,
-        };
-        range.terminal = self.lower_browser_resource_reads_in_factor(&range.terminal)?;
-        Ok(mech_core::Expression::Range(Box::new(range)))
-      }
-      mech_core::Expression::Slice(slice) => {
-        Ok(mech_core::Expression::Slice(self.lower_browser_resource_reads_in_slice(slice)?))
-      }
-      mech_core::Expression::Structure(structure) => {
-        Ok(mech_core::Expression::Structure(self.lower_browser_resource_reads_in_structure(structure)?))
-      }
-      mech_core::Expression::SetComprehension(comprehension) => {
-        let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.lower_browser_resource_reads_in_expression(&comprehension.expression)?;
-        comprehension.qualifiers = comprehension
-          .qualifiers
-          .iter()
-          .map(|qualifier| self.lower_browser_resource_reads_in_comprehension_qualifier(qualifier))
-          .collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
-      }
-      mech_core::Expression::MatrixComprehension(comprehension) => {
-        let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.lower_browser_resource_reads_in_expression(&comprehension.expression)?;
-        comprehension.qualifiers = comprehension
-          .qualifiers
-          .iter()
-          .map(|qualifier| self.lower_browser_resource_reads_in_comprehension_qualifier(qualifier))
-          .collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
-      }
-    }
-  }
-
-  fn lower_browser_resource_reads_in_factor(
-    &mut self,
-    factor: &mech_core::Factor,
-  ) -> MResult<mech_core::Factor> {
-    match factor {
-      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(
-        self.lower_browser_resource_reads_in_expression(expression)?,
-      ))),
-      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(
-        self.lower_browser_resource_reads_in_factor(factor)?,
-      ))),
-      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(
-        self.lower_browser_resource_reads_in_factor(factor)?,
-      ))),
-      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(
-        self.lower_browser_resource_reads_in_factor(factor)?,
-      ))),
-      mech_core::Factor::Term(term) => {
-        let rhs = term
-          .rhs
-          .iter()
-          .map(|(operator, factor)| {
-            Ok((operator.clone(), self.lower_browser_resource_reads_in_factor(factor)?))
-          })
-          .collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
-          lhs: self.lower_browser_resource_reads_in_factor(&term.lhs)?,
-          rhs,
-        })))
-      }
-      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(
-        self.lower_browser_resource_reads_in_factor(factor)?,
-      ))),
-    }
-  }
-
-  fn lower_browser_resource_reads_in_slice(
-    &mut self,
-    slice: &mech_core::Slice,
-  ) -> MResult<mech_core::Slice> {
-    if slice
-      .context
-      .as_ref()
-      .is_some_and(|context| self.is_browser_dom_resource_binding(&context.to_string()))
-    {
-      return Err(browser_runtime_resource_error(
-        slice.name.to_string(),
-        "context-addressed slices are not supported for browser DOM resources in this PR",
-      ));
-    }
-    Ok(mech_core::Slice {
-      name: slice.name.clone(),
-      context: slice.context.clone(),
-      subscript: slice
-        .subscript
-        .iter()
-        .map(|subscript| self.lower_browser_resource_reads_in_subscript(subscript))
-        .collect::<MResult<Vec<_>>>()?,
-    })
-  }
-
-  fn lower_browser_resource_reads_in_subscript(
-    &mut self,
-    subscript: &mech_core::Subscript,
-  ) -> MResult<mech_core::Subscript> {
-    match subscript {
-      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(
-        subscripts
-          .iter()
-          .map(|subscript| self.lower_browser_resource_reads_in_subscript(subscript))
-          .collect::<MResult<Vec<_>>>()?,
-      )),
-      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(
-        subscripts
-          .iter()
-          .map(|subscript| self.lower_browser_resource_reads_in_subscript(subscript))
-          .collect::<MResult<Vec<_>>>()?,
-      )),
-      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(
-        self.lower_browser_resource_reads_in_factor(factor)?,
-      )),
-      mech_core::Subscript::Range(range) => {
-        let mut range = range.clone();
-        range.start = self.lower_browser_resource_reads_in_factor(&range.start)?;
-        range.increment = match &range.increment {
-          Some((operator, increment)) => Some((
-            operator.clone(),
-            self.lower_browser_resource_reads_in_factor(increment)?,
-          )),
-          None => None,
-        };
-        range.terminal = self.lower_browser_resource_reads_in_factor(&range.terminal)?;
-        Ok(mech_core::Subscript::Range(range))
-      }
-      _ => Ok(subscript.clone()),
-    }
-  }
-
-  fn lower_browser_resource_reads_in_structure(
-    &mut self,
-    structure: &mech_core::Structure,
-  ) -> MResult<mech_core::Structure> {
-    match structure {
-      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
-      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
-        elements: map
-          .elements
-          .iter()
-          .map(|mapping| {
-            Ok(mech_core::Mapping {
-              key: self.lower_browser_resource_reads_in_expression(&mapping.key)?,
-              value: self.lower_browser_resource_reads_in_expression(&mapping.value)?,
-            })
-          })
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
-        rows: matrix
-          .rows
-          .iter()
-          .map(|row| {
-            Ok(mech_core::MatrixRow {
-              columns: row
-                .columns
-                .iter()
-                .map(|column| {
-                  Ok(mech_core::MatrixColumn {
-                    element: self.lower_browser_resource_reads_in_expression(&column.element)?,
-                  })
-                })
-                .collect::<MResult<Vec<_>>>()?,
-            })
-          })
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
-        bindings: record
-          .bindings
-          .iter()
-          .map(|binding| {
-            Ok(mech_core::Binding {
-              name: binding.name.clone(),
-              kind: binding.kind.clone(),
-              value: self.lower_browser_resource_reads_in_expression(&binding.value)?,
-            })
-          })
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
-        elements: set
-          .elements
-          .iter()
-          .map(|expression| self.lower_browser_resource_reads_in_expression(expression))
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
-        header: table.header.clone(),
-        rows: table
-          .rows
-          .iter()
-          .map(|row| {
-            Ok(mech_core::TableRow {
-              columns: row
-                .columns
-                .iter()
-                .map(|column| {
-                  Ok(mech_core::TableColumn {
-                    element: self.lower_browser_resource_reads_in_expression(&column.element)?,
-                  })
-                })
-                .collect::<MResult<Vec<_>>>()?,
-            })
-          })
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
-        elements: tuple
-          .elements
-          .iter()
-          .map(|expression| self.lower_browser_resource_reads_in_expression(expression))
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::TupleStruct(tuple_struct) => {
-        Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
-          name: tuple_struct.name.clone(),
-          value: Box::new(self.lower_browser_resource_reads_in_expression(&tuple_struct.value)?),
-        }))
-      }
-    }
-  }
-
-  fn lower_browser_resource_reads_in_comprehension_qualifier(
-    &mut self,
-    qualifier: &mech_core::ComprehensionQualifier,
-  ) -> MResult<mech_core::ComprehensionQualifier> {
-    match qualifier {
-      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
-        Ok(mech_core::ComprehensionQualifier::Generator((
-          pattern.clone(),
-          self.lower_browser_resource_reads_in_expression(expression)?,
-        )))
-      }
-      mech_core::ComprehensionQualifier::Filter(expression) => {
-        Ok(mech_core::ComprehensionQualifier::Filter(
-          self.lower_browser_resource_reads_in_expression(expression)?,
-        ))
-      }
-      mech_core::ComprehensionQualifier::Let(var_def) => {
-        let mut var_def = var_def.clone();
-        var_def.expression = self.lower_browser_resource_reads_in_expression(&var_def.expression)?;
-        Ok(mech_core::ComprehensionQualifier::Let(var_def))
-      }
-    }
   }
 
   fn evaluate_expression_on_program(
@@ -871,8 +411,6 @@ impl MechRuntime {
     )?;
 
     let tree = mech_syntax::parser::parse(source.trim())?;
-    self.bind_browser_resource_roots_from_program(&tree)?;
-
     let program_config = self.program.config.clone();
     let mut program = std::mem::replace(
       &mut self.program,
@@ -945,8 +483,6 @@ impl MechRuntime {
         task_id: context.task,
       },
     )?;
-
-    self.bind_browser_resource_roots_from_program(tree)?;
 
     let program_config = self.program.config.clone();
     let mut program = std::mem::replace(
@@ -1260,8 +796,8 @@ impl MechRuntime {
 
     let result = match source {
       MechSourceCode::String(source) => {
-        let stripped = strip_module_declarations_for_execution(source);
-        program.run_source(&MechSourceCode::String(stripped))
+        let tree = mech_syntax::parser::parse(source.trim())?;
+        self.run_tree_on_program(context, program, &tree)
       }
       other => program.run_source(other),
     };
@@ -1583,16 +1119,7 @@ fn exports_for_scope<'a>(
     .unwrap_or(&[])
 }
 
-pub fn strip_module_declarations_for_execution(source: &str) -> String {
-  source
-    .lines()
-    .filter(|line| {
-      let trimmed = line.trim_start();
-      !(trimmed.starts_with("+>") || trimmed.starts_with("<+") || trimmed.starts_with("@"))
-    })
-    .collect::<Vec<_>>()
-    .join("\n")
-}
+
 
 
 #[cfg(test)]

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -38,6 +38,35 @@ impl MechErrorKind for RuntimeAddressedAssignmentUnsupported {
   }
 }
 
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedContextResourceRequest {
+  provider_base_uri: String,
+  provider_path: String,
+  context_path: String,
+}
+
+fn join_resource_paths(prefix: &str, child: &str) -> String {
+  let prefix = prefix.trim_matches('/');
+  let child = child.trim_matches('/');
+  match (prefix.is_empty(), child.is_empty()) {
+    (true, true) => String::new(),
+    (true, false) => child.to_string(),
+    (false, true) => prefix.to_string(),
+    (false, false) => format!("{}/{}", prefix, child),
+  }
+}
+
+fn identifier_from_str(name: &str) -> mech_core::Identifier {
+  mech_core::Identifier {
+    name: mech_core::Token::new(
+      mech_core::TokenKind::Identifier,
+      mech_core::SourceRange::default(),
+      name.chars().collect(),
+    ),
+  }
+}
+
 fn resolve_runtime_address_target(
   record: &ModuleVersionRecord,
   scope: &SourceScope,
@@ -137,20 +166,27 @@ fn runtime_context_allows_write(
 
 
 
-fn program_codes(
-  tree: &mech_core::Program,
-) -> impl Iterator<Item = (&mech_core::MechCode, &Option<mech_core::Comment>)> {
-  tree.body.sections.iter().flat_map(|section| {
-    section.elements.iter().flat_map(|element| match element {
+fn program_codes<'a>(
+  tree: &'a mech_core::Program,
+  scope: &'a SourceScope,
+) -> impl Iterator<Item = (&'a mech_core::MechCode, &'a Option<mech_core::Comment>)> + 'a {
+  tree.body.sections.iter().flat_map(move |section| {
+    section.elements.iter().flat_map(move |element| match element {
       mech_core::SectionElement::MechCode(codes) => codes
         .iter()
         .map(|(code, comment)| (code, comment))
         .collect::<Vec<_>>(),
-      mech_core::SectionElement::FencedMechCode(fenced) => fenced
+      mech_core::SectionElement::FencedMechCode(fenced) if match scope {
+        SourceScope::Program => fenced.config.namespace_str.is_empty(),
+        SourceScope::Interpreter(interpreter) => {
+          fenced.config.namespace_str == interpreter.namespace_str || fenced.config.namespace_str.is_empty()
+        }
+      } => fenced
         .code
         .iter()
         .map(|(code, comment)| (code, comment))
         .collect::<Vec<_>>(),
+      mech_core::SectionElement::FencedMechCode(_) => Vec::new(),
       _ => Vec::new(),
     })
   })
@@ -254,22 +290,56 @@ impl MechRuntime {
     RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
   }
 
+  fn resolve_context_resource_request(
+    &self,
+    binding: &RuntimeContextBinding,
+    requested_path: &str,
+  ) -> MResult<ResolvedContextResourceRequest> {
+    let context_base_uri = runtime_context_base_uri(binding).trim_end_matches('/').to_string();
+    let provider_base_uri = self
+      .resources
+      .provider_base_uri_for(&context_base_uri)?
+      .unwrap_or_else(|| context_base_uri.clone());
+    let context_root = context_base_uri
+      .strip_prefix(&provider_base_uri)
+      .unwrap_or_default()
+      .trim_matches('/');
+    Ok(ResolvedContextResourceRequest {
+      provider_base_uri,
+      provider_path: join_resource_paths(context_root, requested_path),
+      context_path: requested_path.trim_matches('/').to_string(),
+    })
+  }
+
   fn read_context_resource(
     &self,
     binding: &RuntimeContextBinding,
     path: &str,
   ) -> MResult<Value> {
-    let base_uri = runtime_context_base_uri(binding);
-    if !runtime_context_allows_read(binding, path) {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    if !runtime_context_allows_read(binding, &resolved.context_path) {
       return Err(MechError::new(RuntimeResourceCapabilityDenied {
         context_name: binding.name.clone(),
         operation: "read".to_string(),
-        path: path.to_string(),
+        path: resolved.context_path,
+      }, None));
+    }
+    if !self.grants.allows(
+      DEFAULT_RESOURCE_SUBJECT,
+      &resolved.provider_base_uri,
+      &RuntimeCapabilityOperation::Read,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: DEFAULT_RESOURCE_SUBJECT.to_string(),
+        resource: resolved.provider_base_uri,
+        operation: RuntimeCapabilityOperation::Read,
+        path: resolved.provider_path,
       }, None));
     }
     self.resources.read(RuntimeResourceReadRequest {
-      base_uri,
-      path: path.to_string(),
+      base_uri: resolved.provider_base_uri,
+      path: resolved.provider_path,
       context_name: binding.name.clone(),
     })
   }
@@ -280,38 +350,270 @@ impl MechRuntime {
     path: &str,
     value: Value,
   ) -> MResult<()> {
-    let base_uri = runtime_context_base_uri(binding);
-    if !runtime_context_allows_write(binding, path) {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    if !runtime_context_allows_write(binding, &resolved.context_path) {
       return Err(MechError::new(RuntimeResourceCapabilityDenied {
         context_name: binding.name.clone(),
         operation: "write".to_string(),
-        path: path.to_string(),
+        path: resolved.context_path,
+      }, None));
+    }
+    if !self.grants.allows(
+      DEFAULT_RESOURCE_SUBJECT,
+      &resolved.provider_base_uri,
+      &RuntimeCapabilityOperation::Write,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: DEFAULT_RESOURCE_SUBJECT.to_string(),
+        resource: resolved.provider_base_uri,
+        operation: RuntimeCapabilityOperation::Write,
+        path: resolved.provider_path,
       }, None));
     }
     self.resources.write(RuntimeResourceWriteRequest {
-      base_uri,
-      path: path.to_string(),
+      base_uri: resolved.provider_base_uri,
+      path: resolved.provider_path,
       context_name: binding.name.clone(),
       value,
     })
   }
 
-  fn expression_context_read(
+  fn bind_context_read_temp(
     &self,
+    program: &mut MechProgram,
+    target: &str,
+    path: &str,
+    value: Value,
+  ) -> MResult<mech_core::Expression> {
+    let name = format!("__mech_ctx_{}_{}", hash_str(target), hash_str(path));
+    let var = mech_core::Var {
+      name: identifier_from_str(&name),
+      context: None,
+      kind: None,
+    };
+    bind_runtime_value_on_program(program, &var, resolve_runtime_value(value), false)?;
+    Ok(mech_core::Expression::Var(var))
+  }
+
+  fn resolve_context_reads_in_expression(
+    &mut self,
+    program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
-  ) -> MResult<Option<Value>> {
-    let mech_core::Expression::Var(var) = expression else {
-      return Ok(None);
-    };
-    let Some(context) = &var.context else {
-      return Ok(None);
-    };
-    let target = context.to_string();
-    let Some(binding) = registry.get(&target) else {
-      return Ok(None);
-    };
-    Ok(Some(resolve_runtime_value(self.read_context_resource(binding, &var.name.to_string())?)))
+  ) -> MResult<mech_core::Expression> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        let Some(context) = &var.context else {
+          return Ok(expression.clone());
+        };
+        let target = context.to_string();
+        let Some(binding) = registry.get(&target) else {
+          return Ok(expression.clone());
+        };
+        let path = var.name.to_string();
+        let value = self.read_context_resource(binding, &path)?;
+        self.bind_context_read_temp(program, &target, &path, value)
+      }
+      mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
+        self.resolve_context_reads_in_factor(program, registry, factor)?,
+      )),
+      mech_core::Expression::FunctionCall(call) => {
+        let args = call.args.iter().map(|(name, expression)| {
+          Ok((name.clone(), self.resolve_context_reads_in_expression(program, registry, expression)?))
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        let mut pipe = pipe.clone();
+        if let Some(args) = &pipe.start.args {
+          pipe.start.args = Some(args.iter().map(|(name, expression)| {
+            Ok((name.clone(), self.resolve_context_reads_in_expression(program, registry, expression)?))
+          }).collect::<MResult<Vec<_>>>()?);
+        }
+        Ok(mech_core::Expression::FsmPipe(pipe))
+      }
+      mech_core::Expression::Literal(_) => Ok(expression.clone()),
+      mech_core::Expression::Match(match_expression) => {
+        let mut match_expression = match_expression.as_ref().clone();
+        match_expression.source = self.resolve_context_reads_in_expression(program, registry, &match_expression.source)?;
+        match_expression.arms = match_expression.arms.iter().map(|arm| {
+          Ok(mech_core::MatchArm {
+            pattern: arm.pattern.clone(),
+            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(program, registry, guard)).transpose()?,
+            expression: self.resolve_context_reads_in_expression(program, registry, &arm.expression)?,
+          })
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::Match(Box::new(match_expression)))
+      }
+      mech_core::Expression::Range(range) => {
+        let mut range = range.as_ref().clone();
+        range.start = self.resolve_context_reads_in_factor(program, registry, &range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(program, registry, increment)?)),
+          None => None,
+        };
+        range.terminal = self.resolve_context_reads_in_factor(program, registry, &range.terminal)?;
+        Ok(mech_core::Expression::Range(Box::new(range)))
+      }
+      mech_core::Expression::Slice(slice) => {
+        if slice
+          .context
+          .as_ref()
+          .is_some_and(|context| registry.contains(&context.to_string()))
+        {
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "context_read",
+            reason: "context-addressed slices are not supported".to_string(),
+          }, None));
+        }
+        Ok(mech_core::Expression::Slice(
+          self.resolve_context_reads_in_slice(program, registry, slice)?,
+        ))
+      }
+      mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
+        self.resolve_context_reads_in_structure(program, registry, structure)?,
+      )),
+      mech_core::Expression::SetComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.resolve_context_reads_in_expression(program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.resolve_context_reads_in_expression(program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
+      }
+    }
+  }
+
+  fn resolve_context_reads_in_factor(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<mech_core::Factor> {
+    match factor {
+      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(program, registry, expression)?))),
+      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
+      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
+      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
+      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
+      mech_core::Factor::Term(term) => {
+        let rhs = term.rhs.iter().map(|(operator, factor)| {
+          Ok((operator.clone(), self.resolve_context_reads_in_factor(program, registry, factor)?))
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
+          lhs: self.resolve_context_reads_in_factor(program, registry, &term.lhs)?,
+          rhs,
+        })))
+      }
+    }
+  }
+
+  fn resolve_context_reads_in_slice(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    slice: &mech_core::Slice,
+  ) -> MResult<mech_core::Slice> {
+    Ok(mech_core::Slice {
+      name: slice.name.clone(),
+      context: slice.context.clone(),
+      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
+    })
+  }
+
+  fn resolve_context_reads_in_subscript(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    subscript: &mech_core::Subscript,
+  ) -> MResult<mech_core::Subscript> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(program, registry, factor)?)),
+      mech_core::Subscript::Range(range) => {
+        let mut range = range.clone();
+        range.start = self.resolve_context_reads_in_factor(program, registry, &range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(program, registry, increment)?)),
+          None => None,
+        };
+        range.terminal = self.resolve_context_reads_in_factor(program, registry, &range.terminal)?;
+        Ok(mech_core::Subscript::Range(range))
+      }
+      _ => Ok(subscript.clone()),
+    }
+  }
+
+  fn resolve_context_reads_in_structure(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    structure: &mech_core::Structure,
+  ) -> MResult<mech_core::Structure> {
+    match structure {
+      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
+      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
+        elements: map.elements.iter().map(|mapping| Ok(mech_core::Mapping {
+          key: self.resolve_context_reads_in_expression(program, registry, &mapping.key)?,
+          value: self.resolve_context_reads_in_expression(program, registry, &mapping.value)?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
+        rows: matrix.rows.iter().map(|row| Ok(mech_core::MatrixRow {
+          columns: row.columns.iter().map(|column| Ok(mech_core::MatrixColumn {
+            element: self.resolve_context_reads_in_expression(program, registry, &column.element)?,
+          })).collect::<MResult<Vec<_>>>()?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
+        bindings: record.bindings.iter().map(|binding| Ok(mech_core::Binding {
+          name: binding.name.clone(),
+          kind: binding.kind.clone(),
+          value: self.resolve_context_reads_in_expression(program, registry, &binding.value)?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
+        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
+        header: table.header.clone(),
+        rows: table.rows.iter().map(|row| Ok(mech_core::TableRow {
+          columns: row.columns.iter().map(|column| Ok(mech_core::TableColumn {
+            element: self.resolve_context_reads_in_expression(program, registry, &column.element)?,
+          })).collect::<MResult<Vec<_>>>()?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
+        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::TupleStruct(tuple_struct) => Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
+        name: tuple_struct.name.clone(),
+        value: Box::new(self.resolve_context_reads_in_expression(program, registry, &tuple_struct.value)?),
+      })),
+    }
+  }
+
+  fn resolve_context_reads_in_comprehension_qualifier(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> MResult<mech_core::ComprehensionQualifier> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => Ok(mech_core::ComprehensionQualifier::Generator((pattern.clone(), self.resolve_context_reads_in_expression(program, registry, expression)?))),
+      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(program, registry, expression)?)),
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(program, registry, &var_def.expression)?;
+        Ok(mech_core::ComprehensionQualifier::Let(var_def))
+      }
+    }
   }
 
   fn run_tree_on_program(
@@ -319,33 +621,45 @@ impl MechRuntime {
     _context: &mut RuntimeContext,
     program: &mut MechProgram,
     tree: &mech_core::Program,
+    scope_hint: Option<&SourceScope>,
   ) -> MResult<Value> {
+    let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
     let registry = self.direct_context_registry_for_scope(tree, &SourceScope::Program)?;
     let mut result = Value::Empty;
-    for (code, comment) in program_codes(tree) {
+    for (code, comment) in program_codes(tree, execution_scope) {
       match code {
         mech_core::MechCode::Import(_)
         | mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
-        | mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(_))
         | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => {
           result = Value::Empty;
+        }
+        mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
+          let id = hash_str(&export.name.to_string());
+          if let Some(value) = program.interpreter().symbols().borrow().get(id) {
+            result = resolve_runtime_value(value.borrow().clone());
+          } else {
+            result = Value::Empty;
+          }
         }
         mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
           if let Some(context) = &var_def.var.context {
             let target = context.to_string();
             if let Some(binding) = registry.get(&target).cloned() {
-              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &var_def.expression)?);
+              let expression = self.resolve_context_reads_in_expression(program, &registry, &var_def.expression)?;
+              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
               self.write_context_resource(&binding, &var_def.var.name.to_string(), value.clone())?;
               result = value;
             } else {
               let single = single_code_program(code.clone(), comment.clone());
               result = program.run_tree(&single)?;
             }
-          } else if let Some(value) = self.expression_context_read(&registry, &var_def.expression)? {
-            bind_runtime_value_on_program(program, &var_def.var, value.clone(), var_def.mutable)?;
-            result = value;
           } else {
-            let single = single_code_program(code.clone(), comment.clone());
+            let mut var_def = var_def.clone();
+            var_def.expression = self.resolve_context_reads_in_expression(program, &registry, &var_def.expression)?;
+            let single = single_code_program(
+              mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
+              comment.clone(),
+            );
             result = program.run_tree(&single)?;
           }
         }
@@ -353,7 +667,8 @@ impl MechRuntime {
           if let Some(context) = &assign.target.context {
             let target = context.to_string();
             if let Some(binding) = registry.get(&target).cloned() {
-              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &assign.expression)?);
+              let expression = self.resolve_context_reads_in_expression(program, &registry, &assign.expression)?;
+              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
               self.write_context_resource(&binding, &assign.target.name.to_string(), value.clone())?;
               result = value;
             } else {
@@ -361,17 +676,19 @@ impl MechRuntime {
               result = program.run_tree(&single)?;
             }
           } else {
-            let single = single_code_program(code.clone(), comment.clone());
+            let mut assign = assign.clone();
+            assign.expression = self.resolve_context_reads_in_expression(program, &registry, &assign.expression)?;
+            let single = single_code_program(
+              mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)),
+              comment.clone(),
+            );
             result = program.run_tree(&single)?;
           }
         }
         mech_core::MechCode::Expression(expression) => {
-          if let Some(value) = self.expression_context_read(&registry, expression)? {
-            result = value;
-          } else {
-            let single = single_code_program(code.clone(), comment.clone());
-            result = program.run_tree(&single)?;
-          }
+          let expression = self.resolve_context_reads_in_expression(program, &registry, expression)?;
+          let single = single_code_program(mech_core::MechCode::Expression(expression), comment.clone());
+          result = program.run_tree(&single)?;
         }
         _ => {
           let single = single_code_program(code.clone(), comment.clone());
@@ -432,7 +749,7 @@ impl MechRuntime {
       }))
     });
 
-    let result = self.run_tree_on_program(context, &mut program, &tree);
+    let result = self.run_tree_on_program(context, &mut program, &tree, None);
 
     ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
       slot.replace(previous_target);
@@ -505,7 +822,7 @@ impl MechRuntime {
       }))
     });
 
-    let result = self.run_tree_on_program(context, &mut program, tree);
+    let result = self.run_tree_on_program(context, &mut program, tree, None);
 
     ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
       slot.replace(previous_target);
@@ -725,7 +1042,7 @@ impl MechRuntime {
       RuntimeEventKind::ModuleExecutionStarted { module_version: version },
     )?;
     let scoped_source = module_source_for_scope(&source, scope)?;
-    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source);
+    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
     let result = match result {
       Ok(value) => value,
       Err(error) => {
@@ -774,6 +1091,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     program: &mut MechProgram,
     source: &MechSourceCode,
+    scope: &SourceScope,
   ) -> MResult<Value> {
     self.register_runtime_program_host_functions(context, program)?;
 
@@ -797,7 +1115,7 @@ impl MechRuntime {
     let result = match source {
       MechSourceCode::String(source) => {
         let tree = mech_syntax::parser::parse(source.trim())?;
-        self.run_tree_on_program(context, program, &tree)
+        self.run_tree_on_program(context, program, &tree, Some(scope))
       }
       other => program.run_source(other),
     };
@@ -861,38 +1179,7 @@ impl MechRuntime {
           requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
         }
         RuntimeAddressTarget::Context(binding) => {
-          let base_uri = runtime_context_base_uri(&binding);
-          if !runtime_context_allows_read(&binding, &reference.name) {
-            return Err(MechError::new(
-              RuntimeResourceCapabilityDenied {
-                context_name: binding.name.clone(),
-                operation: "read".to_string(),
-                path: reference.name.clone(),
-              },
-              None,
-            ));
-          }
-          if !self.grants.allows(
-            DEFAULT_RESOURCE_SUBJECT,
-            &base_uri,
-            &RuntimeCapabilityOperation::Read,
-            &reference.name,
-          ) {
-            return Err(MechError::new(
-              RuntimeCapabilityGrantDenied {
-                subject: DEFAULT_RESOURCE_SUBJECT.to_string(),
-                resource: base_uri,
-                operation: RuntimeCapabilityOperation::Read,
-                path: reference.name.clone(),
-              },
-              None,
-            ));
-          }
-          let value = self.resources.read(RuntimeResourceReadRequest {
-            base_uri,
-            path: reference.name.clone(),
-            context_name: binding.name.clone(),
-          })?;
+          let value = self.read_context_resource(&binding, &reference.name)?;
           bindings.insert(
             address_binding_key(&reference.target, &reference.name),
             Ref::new(value),

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -14,9 +14,6 @@
 use super::*;
 use crate::SourceIndex;
 
-const DEFAULT_RESOURCE_SUBJECT: &str = "task://main";
-
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
   Interpreter(SourceScope),
@@ -24,6 +21,26 @@ enum RuntimeAddressTarget {
   Unknown,
 }
 
+struct ActiveRuntimeProgramHostGuard {
+  previous: Option<RuntimeProgramHostTarget>,
+}
+
+impl ActiveRuntimeProgramHostGuard {
+  fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
+    let previous = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(Some(RuntimeProgramHostTarget { runtime, context }))
+    });
+    Self { previous }
+  }
+}
+
+impl Drop for ActiveRuntimeProgramHostGuard {
+  fn drop(&mut self) {
+    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(self.previous.take());
+    });
+  }
+}
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAddressedAssignmentUnsupported {
@@ -166,32 +183,6 @@ fn runtime_context_allows_write(
 
 
 
-fn program_codes<'a>(
-  tree: &'a mech_core::Program,
-  scope: &'a SourceScope,
-) -> impl Iterator<Item = (&'a mech_core::MechCode, &'a Option<mech_core::Comment>)> + 'a {
-  tree.body.sections.iter().flat_map(move |section| {
-    section.elements.iter().flat_map(move |element| match element {
-      mech_core::SectionElement::MechCode(codes) => codes
-        .iter()
-        .map(|(code, comment)| (code, comment))
-        .collect::<Vec<_>>(),
-      mech_core::SectionElement::FencedMechCode(fenced) if match scope {
-        SourceScope::Program => fenced.config.namespace_str.is_empty(),
-        SourceScope::Interpreter(interpreter) => {
-          fenced.config.namespace_str == interpreter.namespace_str || fenced.config.namespace_str.is_empty()
-        }
-      } => fenced
-        .code
-        .iter()
-        .map(|(code, comment)| (code, comment))
-        .collect::<Vec<_>>(),
-      mech_core::SectionElement::FencedMechCode(_) => Vec::new(),
-      _ => Vec::new(),
-    })
-  })
-}
-
 fn single_code_program(
   code: mech_core::MechCode,
   comment: Option<mech_core::Comment>,
@@ -313,6 +304,7 @@ impl MechRuntime {
 
   fn read_context_resource(
     &self,
+    context: &RuntimeContext,
     binding: &RuntimeContextBinding,
     path: &str,
   ) -> MResult<Value> {
@@ -325,13 +317,13 @@ impl MechRuntime {
       }, None));
     }
     if !self.grants.allows(
-      DEFAULT_RESOURCE_SUBJECT,
+      &context.subject,
       &resolved.provider_base_uri,
       &RuntimeCapabilityOperation::Read,
       &resolved.provider_path,
     ) {
       return Err(MechError::new(RuntimeCapabilityGrantDenied {
-        subject: DEFAULT_RESOURCE_SUBJECT.to_string(),
+        subject: context.subject.clone(),
         resource: resolved.provider_base_uri,
         operation: RuntimeCapabilityOperation::Read,
         path: resolved.provider_path,
@@ -346,6 +338,7 @@ impl MechRuntime {
 
   fn write_context_resource(
     &mut self,
+    context: &RuntimeContext,
     binding: &RuntimeContextBinding,
     path: &str,
     value: Value,
@@ -359,13 +352,13 @@ impl MechRuntime {
       }, None));
     }
     if !self.grants.allows(
-      DEFAULT_RESOURCE_SUBJECT,
+      &context.subject,
       &resolved.provider_base_uri,
       &RuntimeCapabilityOperation::Write,
       &resolved.provider_path,
     ) {
       return Err(MechError::new(RuntimeCapabilityGrantDenied {
-        subject: DEFAULT_RESOURCE_SUBJECT.to_string(),
+        subject: context.subject.clone(),
         resource: resolved.provider_base_uri,
         operation: RuntimeCapabilityOperation::Write,
         path: resolved.provider_path,
@@ -398,29 +391,30 @@ impl MechRuntime {
 
   fn resolve_context_reads_in_expression(
     &mut self,
+    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<mech_core::Expression> {
     match expression {
       mech_core::Expression::Var(var) => {
-        let Some(context) = &var.context else {
+        let Some(var_context) = &var.context else {
           return Ok(expression.clone());
         };
-        let target = context.to_string();
+        let target = var_context.to_string();
         let Some(binding) = registry.get(&target) else {
           return Ok(expression.clone());
         };
         let path = var.name.to_string();
-        let value = self.read_context_resource(binding, &path)?;
+        let value = self.read_context_resource(context, binding, &path)?;
         self.bind_context_read_temp(program, &target, &path, value)
       }
       mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
-        self.resolve_context_reads_in_factor(program, registry, factor)?,
+        self.resolve_context_reads_in_factor(context, program, registry, factor)?,
       )),
       mech_core::Expression::FunctionCall(call) => {
         let args = call.args.iter().map(|(name, expression)| {
-          Ok((name.clone(), self.resolve_context_reads_in_expression(program, registry, expression)?))
+          Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
         }).collect::<MResult<Vec<_>>>()?;
         Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
       }
@@ -428,7 +422,7 @@ impl MechRuntime {
         let mut pipe = pipe.clone();
         if let Some(args) = &pipe.start.args {
           pipe.start.args = Some(args.iter().map(|(name, expression)| {
-            Ok((name.clone(), self.resolve_context_reads_in_expression(program, registry, expression)?))
+            Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
           }).collect::<MResult<Vec<_>>>()?);
         }
         Ok(mech_core::Expression::FsmPipe(pipe))
@@ -436,24 +430,24 @@ impl MechRuntime {
       mech_core::Expression::Literal(_) => Ok(expression.clone()),
       mech_core::Expression::Match(match_expression) => {
         let mut match_expression = match_expression.as_ref().clone();
-        match_expression.source = self.resolve_context_reads_in_expression(program, registry, &match_expression.source)?;
+        match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
         match_expression.arms = match_expression.arms.iter().map(|arm| {
           Ok(mech_core::MatchArm {
             pattern: arm.pattern.clone(),
-            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(program, registry, guard)).transpose()?,
-            expression: self.resolve_context_reads_in_expression(program, registry, &arm.expression)?,
+            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
+            expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
           })
         }).collect::<MResult<Vec<_>>>()?;
         Ok(mech_core::Expression::Match(Box::new(match_expression)))
       }
       mech_core::Expression::Range(range) => {
         let mut range = range.as_ref().clone();
-        range.start = self.resolve_context_reads_in_factor(program, registry, &range.start)?;
+        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
         range.increment = match &range.increment {
-          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(program, registry, increment)?)),
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
           None => None,
         };
-        range.terminal = self.resolve_context_reads_in_factor(program, registry, &range.terminal)?;
+        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
         Ok(mech_core::Expression::Range(Box::new(range)))
       }
       mech_core::Expression::Slice(slice) => {
@@ -468,22 +462,22 @@ impl MechRuntime {
           }, None));
         }
         Ok(mech_core::Expression::Slice(
-          self.resolve_context_reads_in_slice(program, registry, slice)?,
+          self.resolve_context_reads_in_slice(context, program, registry, slice)?,
         ))
       }
       mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
-        self.resolve_context_reads_in_structure(program, registry, structure)?,
+        self.resolve_context_reads_in_structure(context, program, registry, structure)?,
       )),
       mech_core::Expression::SetComprehension(comprehension) => {
         let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.resolve_context_reads_in_expression(program, registry, &comprehension.expression)?;
-        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
         Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
       }
       mech_core::Expression::MatrixComprehension(comprehension) => {
         let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.resolve_context_reads_in_expression(program, registry, &comprehension.expression)?;
-        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
         Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
       }
     }
@@ -491,22 +485,23 @@ impl MechRuntime {
 
   fn resolve_context_reads_in_factor(
     &mut self,
+    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     factor: &mech_core::Factor,
   ) -> MResult<mech_core::Factor> {
     match factor {
-      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(program, registry, expression)?))),
-      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
-      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
-      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
-      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(program, registry, factor)?))),
+      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
+      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
       mech_core::Factor::Term(term) => {
         let rhs = term.rhs.iter().map(|(operator, factor)| {
-          Ok((operator.clone(), self.resolve_context_reads_in_factor(program, registry, factor)?))
+          Ok((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, factor)?))
         }).collect::<MResult<Vec<_>>>()?;
         Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
-          lhs: self.resolve_context_reads_in_factor(program, registry, &term.lhs)?,
+          lhs: self.resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
           rhs,
         })))
       }
@@ -515,6 +510,7 @@ impl MechRuntime {
 
   fn resolve_context_reads_in_slice(
     &mut self,
+    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     slice: &mech_core::Slice,
@@ -522,28 +518,29 @@ impl MechRuntime {
     Ok(mech_core::Slice {
       name: slice.name.clone(),
       context: slice.context.clone(),
-      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
+      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
     })
   }
 
   fn resolve_context_reads_in_subscript(
     &mut self,
+    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     subscript: &mech_core::Subscript,
   ) -> MResult<mech_core::Subscript> {
     match subscript {
-      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
-      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
-      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(program, registry, factor)?)),
+      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(context, program, registry, factor)?)),
       mech_core::Subscript::Range(range) => {
         let mut range = range.clone();
-        range.start = self.resolve_context_reads_in_factor(program, registry, &range.start)?;
+        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
         range.increment = match &range.increment {
-          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(program, registry, increment)?)),
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
           None => None,
         };
-        range.terminal = self.resolve_context_reads_in_factor(program, registry, &range.terminal)?;
+        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
         Ok(mech_core::Subscript::Range(range))
       }
       _ => Ok(subscript.clone()),
@@ -552,6 +549,7 @@ impl MechRuntime {
 
   fn resolve_context_reads_in_structure(
     &mut self,
+    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     structure: &mech_core::Structure,
@@ -560,14 +558,14 @@ impl MechRuntime {
       mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
       mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
         elements: map.elements.iter().map(|mapping| Ok(mech_core::Mapping {
-          key: self.resolve_context_reads_in_expression(program, registry, &mapping.key)?,
-          value: self.resolve_context_reads_in_expression(program, registry, &mapping.value)?,
+          key: self.resolve_context_reads_in_expression(context, program, registry, &mapping.key)?,
+          value: self.resolve_context_reads_in_expression(context, program, registry, &mapping.value)?,
         })).collect::<MResult<Vec<_>>>()?,
       })),
       mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
         rows: matrix.rows.iter().map(|row| Ok(mech_core::MatrixRow {
           columns: row.columns.iter().map(|column| Ok(mech_core::MatrixColumn {
-            element: self.resolve_context_reads_in_expression(program, registry, &column.element)?,
+            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
           })).collect::<MResult<Vec<_>>>()?,
         })).collect::<MResult<Vec<_>>>()?,
       })),
@@ -575,127 +573,227 @@ impl MechRuntime {
         bindings: record.bindings.iter().map(|binding| Ok(mech_core::Binding {
           name: binding.name.clone(),
           kind: binding.kind.clone(),
-          value: self.resolve_context_reads_in_expression(program, registry, &binding.value)?,
+          value: self.resolve_context_reads_in_expression(context, program, registry, &binding.value)?,
         })).collect::<MResult<Vec<_>>>()?,
       })),
       mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
-        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
       })),
       mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
         header: table.header.clone(),
         rows: table.rows.iter().map(|row| Ok(mech_core::TableRow {
           columns: row.columns.iter().map(|column| Ok(mech_core::TableColumn {
-            element: self.resolve_context_reads_in_expression(program, registry, &column.element)?,
+            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
           })).collect::<MResult<Vec<_>>>()?,
         })).collect::<MResult<Vec<_>>>()?,
       })),
       mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
-        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
       })),
       mech_core::Structure::TupleStruct(tuple_struct) => Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
         name: tuple_struct.name.clone(),
-        value: Box::new(self.resolve_context_reads_in_expression(program, registry, &tuple_struct.value)?),
+        value: Box::new(self.resolve_context_reads_in_expression(context, program, registry, &tuple_struct.value)?),
       })),
     }
   }
 
   fn resolve_context_reads_in_comprehension_qualifier(
     &mut self,
+    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     qualifier: &mech_core::ComprehensionQualifier,
   ) -> MResult<mech_core::ComprehensionQualifier> {
     match qualifier {
-      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => Ok(mech_core::ComprehensionQualifier::Generator((pattern.clone(), self.resolve_context_reads_in_expression(program, registry, expression)?))),
-      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(program, registry, expression)?)),
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => Ok(mech_core::ComprehensionQualifier::Generator((pattern.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
+      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(context, program, registry, expression)?)),
       mech_core::ComprehensionQualifier::Let(var_def) => {
         let mut var_def = var_def.clone();
-        var_def.expression = self.resolve_context_reads_in_expression(program, registry, &var_def.expression)?;
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
         Ok(mech_core::ComprehensionQualifier::Let(var_def))
+      }
+    }
+  }
+
+  fn flush_direct_execution(
+    &mut self,
+    program: &mut MechProgram,
+    pending: &mut Vec<mech_core::SectionElement>,
+    result: &mut Value,
+  ) -> MResult<()> {
+    if pending.is_empty() {
+      return Ok(());
+    }
+    let tree = mech_core::Program {
+      title: None,
+      body: mech_core::Body {
+        sections: vec![mech_core::Section {
+          subtitle: None,
+          elements: std::mem::take(pending),
+        }],
+      },
+    };
+    *result = program.run_tree(&tree)?;
+    Ok(())
+  }
+
+  fn executable_fence_for_scope(
+    fenced: &mech_core::FencedMechCode,
+    scope: &SourceScope,
+  ) -> bool {
+    match scope {
+      SourceScope::Program => fenced.config.namespace_str.is_empty(),
+      SourceScope::Interpreter(interpreter) => fenced.config.namespace_str == interpreter.namespace_str,
+    }
+  }
+
+  fn push_direct_code(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pending: &mut Vec<mech_core::SectionElement>,
+    pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
+    result: &mut Value,
+    code: &mech_core::MechCode,
+    comment: &Option<mech_core::Comment>,
+  ) -> MResult<()> {
+    match code {
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
+      | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
+      mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
+        if !pending_codes.is_empty() {
+          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+        }
+        self.flush_direct_execution(program, pending, result)?;
+        let id = hash_str(&export.name.to_string());
+        if let Some(value) = program.interpreter().symbols().borrow().get(id) {
+          *result = resolve_runtime_value(value.borrow().clone());
+        } else {
+          *result = Value::Empty;
+        }
+        Ok(())
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+        if let Some(context_name) = &var_def.var.context {
+          let target = context_name.to_string();
+          if let Some(binding) = registry.get(&target).cloned() {
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+            }
+            self.flush_direct_execution(program, pending, result)?;
+            let expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+            let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
+            self.write_context_resource(context, &binding, &var_def.var.name.to_string(), value.clone())?;
+            *result = value;
+            return Ok(());
+          }
+        }
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+        pending_codes.push((
+          mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
+          comment.clone(),
+        ));
+        Ok(())
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+        if let Some(context_name) = &assign.target.context {
+          let target = context_name.to_string();
+          if let Some(binding) = registry.get(&target).cloned() {
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+            }
+            self.flush_direct_execution(program, pending, result)?;
+            let expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+            let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
+            self.write_context_resource(context, &binding, &assign.target.name.to_string(), value.clone())?;
+            *result = value;
+            return Ok(());
+          }
+        }
+        let mut assign = assign.clone();
+        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+        pending_codes.push((
+          mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)),
+          comment.clone(),
+        ));
+        Ok(())
+      }
+      mech_core::MechCode::Expression(expression) => {
+        let expression = self.resolve_context_reads_in_expression(context, program, registry, expression)?;
+        pending_codes.push((mech_core::MechCode::Expression(expression), comment.clone()));
+        Ok(())
+      }
+      _ => {
+        pending_codes.push((code.clone(), comment.clone()));
+        Ok(())
       }
     }
   }
 
   fn run_tree_on_program(
     &mut self,
-    _context: &mut RuntimeContext,
+    context: &mut RuntimeContext,
     program: &mut MechProgram,
     tree: &mech_core::Program,
     scope_hint: Option<&SourceScope>,
   ) -> MResult<Value> {
     let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
-    let registry = self.direct_context_registry_for_scope(tree, &SourceScope::Program)?;
+    let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
     let mut result = Value::Empty;
-    for (code, comment) in program_codes(tree, execution_scope) {
-      match code {
-        mech_core::MechCode::Import(_)
-        | mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
-        | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => {
-          result = Value::Empty;
-        }
-        mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
-          let id = hash_str(&export.name.to_string());
-          if let Some(value) = program.interpreter().symbols().borrow().get(id) {
-            result = resolve_runtime_value(value.borrow().clone());
-          } else {
-            result = Value::Empty;
-          }
-        }
-        mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-          if let Some(context) = &var_def.var.context {
-            let target = context.to_string();
-            if let Some(binding) = registry.get(&target).cloned() {
-              let expression = self.resolve_context_reads_in_expression(program, &registry, &var_def.expression)?;
-              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
-              self.write_context_resource(&binding, &var_def.var.name.to_string(), value.clone())?;
-              result = value;
-            } else {
-              let single = single_code_program(code.clone(), comment.clone());
-              result = program.run_tree(&single)?;
+    let mut pending = Vec::new();
+
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            let mut pending_codes = Vec::new();
+            for (code, comment) in codes {
+              self.push_direct_code(
+                context,
+                program,
+                &registry,
+                &mut pending,
+                &mut pending_codes,
+                &mut result,
+                code,
+                comment,
+              )?;
             }
-          } else {
-            let mut var_def = var_def.clone();
-            var_def.expression = self.resolve_context_reads_in_expression(program, &registry, &var_def.expression)?;
-            let single = single_code_program(
-              mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
-              comment.clone(),
-            );
-            result = program.run_tree(&single)?;
-          }
-        }
-        mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-          if let Some(context) = &assign.target.context {
-            let target = context.to_string();
-            if let Some(binding) = registry.get(&target).cloned() {
-              let expression = self.resolve_context_reads_in_expression(program, &registry, &assign.expression)?;
-              let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
-              self.write_context_resource(&binding, &assign.target.name.to_string(), value.clone())?;
-              result = value;
-            } else {
-              let single = single_code_program(code.clone(), comment.clone());
-              result = program.run_tree(&single)?;
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(pending_codes));
             }
-          } else {
-            let mut assign = assign.clone();
-            assign.expression = self.resolve_context_reads_in_expression(program, &registry, &assign.expression)?;
-            let single = single_code_program(
-              mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)),
-              comment.clone(),
-            );
-            result = program.run_tree(&single)?;
           }
-        }
-        mech_core::MechCode::Expression(expression) => {
-          let expression = self.resolve_context_reads_in_expression(program, &registry, expression)?;
-          let single = single_code_program(mech_core::MechCode::Expression(expression), comment.clone());
-          result = program.run_tree(&single)?;
-        }
-        _ => {
-          let single = single_code_program(code.clone(), comment.clone());
-          result = program.run_tree(&single)?;
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, execution_scope) =>
+          {
+            let mut pending_codes = Vec::new();
+            for (code, comment) in &fenced.code {
+              self.push_direct_code(
+                context,
+                program,
+                &registry,
+                &mut pending,
+                &mut pending_codes,
+                &mut result,
+                code,
+                comment,
+              )?;
+            }
+            if !pending_codes.is_empty() {
+              let mut fenced = fenced.clone();
+              fenced.code = pending_codes;
+              pending.push(mech_core::SectionElement::FencedMechCode(fenced));
+            }
+          }
+          _ => {}
         }
       }
     }
+
+    self.flush_direct_execution(program, &mut pending, &mut result)?;
     Ok(result)
   }
 
@@ -741,19 +839,9 @@ impl MechRuntime {
 
     let runtime_ptr: *mut MechRuntime = self;
     let context_ptr: *mut RuntimeContext = context;
-
-    let previous_target = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(Some(RuntimeProgramHostTarget {
-        runtime: runtime_ptr,
-        context: context_ptr,
-      }))
-    });
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
     let result = self.run_tree_on_program(context, &mut program, &tree, None);
-
-    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(previous_target);
-    });
 
     self.program = program;
 
@@ -814,19 +902,9 @@ impl MechRuntime {
 
     let runtime_ptr: *mut MechRuntime = self;
     let context_ptr: *mut RuntimeContext = context;
-
-    let previous_target = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(Some(RuntimeProgramHostTarget {
-        runtime: runtime_ptr,
-        context: context_ptr,
-      }))
-    });
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
     let result = self.run_tree_on_program(context, &mut program, tree, None);
-
-    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(previous_target);
-    });
 
     self.program = program;
 
@@ -1097,13 +1175,7 @@ impl MechRuntime {
 
     let runtime_ptr: *mut MechRuntime = self;
     let context_ptr: *mut RuntimeContext = context;
-
-    let previous_target = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(Some(RuntimeProgramHostTarget {
-        runtime: runtime_ptr,
-        context: context_ptr,
-      }))
-    });
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
     self.emit_event_to_context(
       context,
@@ -1114,15 +1186,11 @@ impl MechRuntime {
 
     let result = match source {
       MechSourceCode::String(source) => {
-        let tree = mech_syntax::parser::parse(source.trim())?;
-        self.run_tree_on_program(context, program, &tree, Some(scope))
+        mech_syntax::parser::parse(source.trim())
+          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(scope)))
       }
       other => program.run_source(other),
     };
-
-    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(previous_target);
-    });
 
     match &result {
       Ok(_) => {
@@ -1179,7 +1247,7 @@ impl MechRuntime {
           requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
         }
         RuntimeAddressTarget::Context(binding) => {
-          let value = self.read_context_resource(&binding, &reference.name)?;
+          let value = self.read_context_resource(context, &binding, &reference.name)?;
           bindings.insert(
             address_binding_key(&reference.target, &reference.name),
             Ref::new(value),

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -84,6 +84,14 @@ fn identifier_from_str(name: &str) -> mech_core::Identifier {
   }
 }
 
+
+fn execution_scope_for_extracted_module_source(scope: &SourceScope) -> SourceScope {
+  match scope {
+    SourceScope::Program => SourceScope::Program,
+    SourceScope::Interpreter(_) => SourceScope::Program,
+  }
+}
+
 fn resolve_runtime_address_target(
   record: &ModuleVersionRecord,
   scope: &SourceScope,
@@ -1184,10 +1192,17 @@ impl MechRuntime {
       },
     )?;
 
+    // Named interpreter scopes are extracted to bare source by module_source_for_scope.
+    // Once extracted, their declarations are indexed as SourceScope::Program in the
+    // reparsed tree, so direct context handling must use Program scope for that tree.
+    // The surrounding module execution still uses the original scope for imports,
+    // exports, address environment, and ModuleInstance identity.
+    let execution_scope = execution_scope_for_extracted_module_source(scope);
+
     let result = match source {
       MechSourceCode::String(source) => {
         mech_syntax::parser::parse(source.trim())
-          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(scope)))
+          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(&execution_scope)))
       }
       other => program.run_source(other),
     };

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -655,6 +655,44 @@ impl MechRuntime {
     }
   }
 
+  fn resolve_context_reads_in_statement(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    statement: &mech_core::Statement,
+  ) -> MResult<mech_core::Statement> {
+    match statement {
+      mech_core::Statement::VariableDefine(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+        Ok(mech_core::Statement::VariableDefine(var_def))
+      }
+      mech_core::Statement::VariableAssign(assign) => {
+        let mut assign = assign.clone();
+        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+        Ok(mech_core::Statement::VariableAssign(assign))
+      }
+      mech_core::Statement::OpAssign(op_assign) => {
+        let mut op_assign = op_assign.clone();
+        op_assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &op_assign.expression)?;
+        Ok(mech_core::Statement::OpAssign(op_assign))
+      }
+      mech_core::Statement::TupleDestructure(tuple_destructure) => {
+        let mut tuple_destructure = tuple_destructure.clone();
+        tuple_destructure.expression = self.resolve_context_reads_in_expression(context, program, registry, &tuple_destructure.expression)?;
+        Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
+      }
+      #[cfg(feature = "invariant_define")]
+      mech_core::Statement::InvariantDefine(invariant) => {
+        let mut invariant = invariant.clone();
+        invariant.expression = self.resolve_context_reads_in_expression(context, program, registry, &invariant.expression)?;
+        Ok(mech_core::Statement::InvariantDefine(invariant))
+      }
+      _ => Ok(statement.clone()),
+    }
+  }
+
   fn push_direct_code(
     &mut self,
     context: &RuntimeContext,
@@ -698,12 +736,13 @@ impl MechRuntime {
             return Ok(());
           }
         }
-        let mut var_def = var_def.clone();
-        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
-        pending_codes.push((
-          mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
-          comment.clone(),
-        ));
+        let statement = self.resolve_context_reads_in_statement(
+          context,
+          program,
+          registry,
+          &mech_core::Statement::VariableDefine(var_def.clone()),
+        )?;
+        pending_codes.push((mech_core::MechCode::Statement(statement), comment.clone()));
         Ok(())
       }
       mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
@@ -721,17 +760,23 @@ impl MechRuntime {
             return Ok(());
           }
         }
-        let mut assign = assign.clone();
-        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
-        pending_codes.push((
-          mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)),
-          comment.clone(),
-        ));
+        let statement = self.resolve_context_reads_in_statement(
+          context,
+          program,
+          registry,
+          &mech_core::Statement::VariableAssign(assign.clone()),
+        )?;
+        pending_codes.push((mech_core::MechCode::Statement(statement), comment.clone()));
         Ok(())
       }
       mech_core::MechCode::Expression(expression) => {
         let expression = self.resolve_context_reads_in_expression(context, program, registry, expression)?;
         pending_codes.push((mech_core::MechCode::Expression(expression), comment.clone()));
+        Ok(())
+      }
+      mech_core::MechCode::Statement(statement) => {
+        let statement = self.resolve_context_reads_in_statement(context, program, registry, statement)?;
+        pending_codes.push((mech_core::MechCode::Statement(statement), comment.clone()));
         Ok(())
       }
       _ => {
@@ -1261,12 +1306,9 @@ impl MechRuntime {
           }
           requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
         }
-        RuntimeAddressTarget::Context(binding) => {
-          let value = self.read_context_resource(context, &binding, &reference.name)?;
-          bindings.insert(
-            address_binding_key(&reference.target, &reference.name),
-            Ref::new(value),
-          );
+        RuntimeAddressTarget::Context(_) => {
+          // Context-addressed resource reads are resolved while executing source
+          // statements so reads observe earlier writes in the same module scope.
         }
         RuntimeAddressTarget::Unknown => {
           return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
@@ -1495,6 +1537,7 @@ fn exports_for_scope<'a>(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use mech_core::Ref;
 
   #[test]
   fn runtime_has_interpreter_finds_root_interpreter() {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -386,7 +386,7 @@ impl MechRuntime {
     path: &str,
     value: Value,
   ) -> MResult<mech_core::Expression> {
-    let name = format!("__mech_ctx_{}_{}", hash_str(target), hash_str(path));
+    let name = format!("mech-internal-context-{}-{}", hash_str(target), hash_str(path));
     let var = mech_core::Var {
       name: identifier_from_str(&name),
       context: None,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -655,6 +655,165 @@ impl MechRuntime {
     }
   }
 
+  fn resolve_context_reads_in_pattern(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<mech_core::Pattern> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+      )),
+      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
+        name: tuple_struct.name.clone(),
+        patterns: tuple_struct.patterns.iter()
+          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+        tuple.0.iter()
+          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      ))),
+      mech_core::Pattern::Array(array) => {
+        let spread = if let Some(spread) = &array.spread {
+          Some(mech_core::PatternArraySpread {
+            kind: spread.kind.clone(),
+            binding: spread.binding.as_ref()
+              .map(|binding| self.resolve_context_reads_in_pattern(context, program, registry, binding).map(Box::new))
+              .transpose()?,
+          })
+        } else {
+          None
+        };
+        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+          prefix: array.prefix.iter()
+            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+          spread,
+          suffix: array.suffix.iter()
+            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        }))
+      }
+      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+    }
+  }
+
+  fn resolve_context_reads_in_transition(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    transition: &mech_core::Transition,
+  ) -> MResult<mech_core::Transition> {
+    match transition {
+      mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
+        code_items.iter()
+          .map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone())))
+          .collect::<MResult<Vec<_>>>()?,
+      )),
+      mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
+        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+      )),
+    }
+  }
+
+  fn resolve_context_reads_in_fsm_implementation(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    fsm: &mech_core::FsmImplementation,
+  ) -> MResult<mech_core::FsmImplementation> {
+    let arms = fsm.arms.iter().map(|arm| {
+      match arm {
+        mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
+          self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+          guards.iter().map(|guard| Ok(mech_core::Guard {
+            condition: self.resolve_context_reads_in_pattern(context, program, registry, &guard.condition)?,
+            transitions: guard.transitions.iter()
+              .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+              .collect::<MResult<Vec<_>>>()?,
+          })).collect::<MResult<Vec<_>>>()?,
+        )),
+        mech_core::FsmArm::Transition(pattern, transitions) => Ok(mech_core::FsmArm::Transition(
+          self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+          transitions.iter()
+            .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+            .collect::<MResult<Vec<_>>>()?,
+        )),
+        mech_core::FsmArm::Comment(comment) => Ok(mech_core::FsmArm::Comment(comment.clone())),
+      }
+    }).collect::<MResult<Vec<_>>>()?;
+
+    Ok(mech_core::FsmImplementation {
+      name: fsm.name.clone(),
+      input: fsm.input.clone(),
+      start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
+      arms,
+    })
+  }
+
+  fn resolve_context_reads_in_function_define(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    function: &mech_core::FunctionDefine,
+  ) -> MResult<mech_core::FunctionDefine> {
+    Ok(mech_core::FunctionDefine {
+      name: function.name.clone(),
+      input: function.input.clone(),
+      output: function.output.clone(),
+      statements: function.statements.iter()
+        .map(|statement| self.resolve_context_reads_in_statement(context, program, registry, statement))
+        .collect::<MResult<Vec<_>>>()?,
+      match_arms: function.match_arms.iter().map(|arm| Ok(mech_core::FunctionMatchArm {
+        pattern: self.resolve_context_reads_in_pattern(context, program, registry, &arm.pattern)?,
+        expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
+      })).collect::<MResult<Vec<_>>>()?,
+    })
+  }
+
+  fn resolve_context_reads_in_mech_code(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    code: &mech_core::MechCode,
+  ) -> MResult<mech_core::MechCode> {
+    match code {
+      mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
+        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+      )),
+      mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
+        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+      )),
+      mech_core::MechCode::FsmImplementation(fsm) => Ok(mech_core::MechCode::FsmImplementation(
+        self.resolve_context_reads_in_fsm_implementation(context, program, registry, fsm)?,
+      )),
+      mech_core::MechCode::FsmSpecification(spec) => Ok(mech_core::MechCode::FsmSpecification(spec.clone())),
+      mech_core::MechCode::FunctionDefine(function) => Ok(mech_core::MechCode::FunctionDefine(
+        self.resolve_context_reads_in_function_define(context, program, registry, function)?,
+      )),
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Comment(_)
+      | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
+    }
+  }
+
   fn resolve_context_reads_in_statement(
     &mut self,
     context: &RuntimeContext,
@@ -736,13 +895,13 @@ impl MechRuntime {
             return Ok(());
           }
         }
-        let statement = self.resolve_context_reads_in_statement(
+        let code = self.resolve_context_reads_in_mech_code(
           context,
           program,
           registry,
-          &mech_core::Statement::VariableDefine(var_def.clone()),
+          &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def.clone())),
         )?;
-        pending_codes.push((mech_core::MechCode::Statement(statement), comment.clone()));
+        pending_codes.push((code, comment.clone()));
         Ok(())
       }
       mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
@@ -760,27 +919,18 @@ impl MechRuntime {
             return Ok(());
           }
         }
-        let statement = self.resolve_context_reads_in_statement(
+        let code = self.resolve_context_reads_in_mech_code(
           context,
           program,
           registry,
-          &mech_core::Statement::VariableAssign(assign.clone()),
+          &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign.clone())),
         )?;
-        pending_codes.push((mech_core::MechCode::Statement(statement), comment.clone()));
-        Ok(())
-      }
-      mech_core::MechCode::Expression(expression) => {
-        let expression = self.resolve_context_reads_in_expression(context, program, registry, expression)?;
-        pending_codes.push((mech_core::MechCode::Expression(expression), comment.clone()));
-        Ok(())
-      }
-      mech_core::MechCode::Statement(statement) => {
-        let statement = self.resolve_context_reads_in_statement(context, program, registry, statement)?;
-        pending_codes.push((mech_core::MechCode::Statement(statement), comment.clone()));
+        pending_codes.push((code, comment.clone()));
         Ok(())
       }
       _ => {
-        pending_codes.push((code.clone(), comment.clone()));
+        let code = self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
+        pending_codes.push((code, comment.clone()));
         Ok(())
       }
     }

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -38,7 +38,7 @@ use std::collections::{HashMap, HashSet};
 
 use mech_core::{
   browser_capability_error, BrowserDomPath, BROWSER_DOM_PROVIDER_URI, MResult, MechError,
-  MechErrorKind, MechSourceCode, Ref, Value,
+  MechErrorKind, MechSourceCode, Value,
   NativeFunctionCompiler, MechFunctionImpl, Register, CompileCtx, MechFunctionCompiler,
   hash_str, ModuleManifestCatalog, ModuleManifestConfig,
 };

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -104,7 +104,7 @@ use crate::actor_behavior::{
 
 use crate::module::{ModuleBuilder, ModuleBuildOptions, ModuleDependencyGraph};
 
-use crate::{register_config_spec_grants, register_config_spec_resources, InMemoryDocsProvider, RuntimeCapabilityGrant, RuntimeCapabilityGrantInput, RuntimeCapabilityGrantRegistry, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeResourceCapabilityDenied, RuntimeCapabilityGrantDenied, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest};
+use crate::{register_config_spec_grants, register_config_spec_resources, InMemoryDocsProvider, RuntimeCapabilityGrant, RuntimeCapabilityGrantInput, RuntimeCapabilityGrantRegistry, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeResourceCapabilityDenied, RuntimeCapabilityGrantDenied, resource_base_matches, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceRegistry, RuntimeResourceWriteRequest};
 
 thread_local! {
   static ACTIVE_RUNTIME_PROGRAM_HOST: RefCell<Option<RuntimeProgramHostTarget>> =
@@ -169,7 +169,7 @@ impl Default for RuntimeBuilder {
       module_builder: ModuleBuilder::new(),
       config_specs: Vec::new(),
       resource_providers: Vec::new(),
-      module_manifests: ModuleManifestCatalog::with_builtin_browser(),
+      module_manifests: ModuleManifestCatalog::with_builtin_hosts(),
     }
   }
 }
@@ -495,22 +495,19 @@ impl MechRuntime {
       ));
     }
 
-    let uri = uri.as_ref();
-    let (base_uri, root_path) = if uri == BROWSER_DOM_PROVIDER_URI {
-      (BROWSER_DOM_PROVIDER_URI.to_string(), String::new())
-    } else {
-      let prefix = "browser://dom/";
-      let Some(root_path) = uri.strip_prefix(prefix) else {
-        return Err(browser_runtime_resource_error(
-          uri,
-          "only browser://dom/ resource roots are supported in this PR",
-        ));
-      };
-      (BROWSER_DOM_PROVIDER_URI.to_string(), root_path.trim_matches('/').to_string())
-    };
-
-    if !root_path.is_empty() {
-      BrowserDomPath::new(root_path.clone()).map_err(browser_capability_error)?;
+    let uri = uri.as_ref().trim_end_matches('/');
+    let mut base_uri = uri.to_string();
+    let mut root_path = String::new();
+    if resource_base_matches(BROWSER_DOM_PROVIDER_URI, uri) {
+      base_uri = BROWSER_DOM_PROVIDER_URI.to_string();
+      root_path = uri
+        .strip_prefix(BROWSER_DOM_PROVIDER_URI)
+        .unwrap_or_default()
+        .trim_matches('/')
+        .to_string();
+      if !root_path.is_empty() {
+        BrowserDomPath::new(root_path.clone()).map_err(browser_capability_error)?;
+      }
     }
 
     self.resource_bindings.insert(

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -32,10 +32,18 @@ fn read_grant(resource: &str, path: &str) -> RuntimeCapabilityGrantSpec {
 }
 
 fn runtime_read_grant(resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  runtime_grant(resource, RuntimeCapabilityOperation::Read, path)
+}
+
+fn runtime_write_grant(resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  runtime_grant(resource, RuntimeCapabilityOperation::Write, path)
+}
+
+fn runtime_grant(resource: &str, operation: RuntimeCapabilityOperation, path: &str) -> RuntimeCapabilityGrant {
   RuntimeCapabilityGrant {
     subject: "task://main".to_string(),
     resource: resource.to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
+    operations: vec![operation],
     paths: vec![path.to_string()],
   }
 }
@@ -2171,6 +2179,7 @@ fn context_import_alias_is_not_bound_as_value_import() {
 #[test]
 fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lowering() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
+  runtime.grant_capability(runtime_read_grant("browser://dom", "counter/_text")).unwrap();
   let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
   assert!(result.is_err(), "expected browser provider failure without a browser provider");
   let error = format!("{:?}", result.err().unwrap());
@@ -2181,6 +2190,7 @@ fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lower
 #[test]
 fn direct_runtime_manifest_context_import_write_uses_provider_lookup() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
+  runtime.grant_capability(runtime_write_grant("browser://dom", "counter/_text")).unwrap();
   let result = runtime.run_string("+> @ui := browser/dom
 @ui/counter/_text := \"hello\"
 ");
@@ -2305,6 +2315,10 @@ impl InMemoryCliProvider {
 impl RuntimeResourceProvider for InMemoryCliProvider {
   fn scheme(&self) -> &str { "cli" }
 
+  fn base_uris(&self) -> Vec<String> {
+    vec!["cli://env".to_string(), "cli://stdout".to_string(), "cli://stderr".to_string()]
+  }
+
   fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
     if request.base_uri != "cli://env" {
       return Err(mech_core::MechError::new(RuntimeResourceWriteUnsupported {
@@ -2336,6 +2350,7 @@ impl RuntimeResourceProvider for InMemoryCliProvider {
 fn cli_context_direct_read_uses_manifest_boundary() {
   let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/mech-home");
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
   runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
   let id = hash_str("home");
   let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
@@ -2350,6 +2365,7 @@ fn cli_context_direct_write_uses_manifest_boundary() {
   let provider = InMemoryCliProvider::default();
   let stdout = provider.stdout.clone();
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_write_grant("cli://stdout", "line")).unwrap();
   runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n").unwrap();
   assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
 }
@@ -2378,6 +2394,7 @@ fn cli_context_module_write_is_not_stripped() {
   let provider = InMemoryCliProvider::default();
   let stdout = provider.stdout.clone();
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_write_grant("cli://stdout", "line")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   runtime.run_module(version).unwrap();
   assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
@@ -2391,4 +2408,130 @@ fn cli_context_capabilities_are_enforced() {
   assert!(format!("{read_error:?}").contains("RuntimeResourceCapabilityDenied"));
   let write_error = runtime.run_string("+> @env := cli/env\n@env/HOME := \"nope\"\n").unwrap_err();
   assert!(format!("{write_error:?}").contains("RuntimeResourceCapabilityDenied"));
+}
+
+#[derive(Debug, Clone)]
+struct RecordingResourceProvider {
+  scheme: &'static str,
+  bases: Vec<String>,
+  values: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Value>>>,
+  writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
+}
+
+impl RecordingResourceProvider {
+  fn new(scheme: &'static str, bases: &[&str]) -> Self {
+    Self {
+      scheme,
+      bases: bases.iter().map(|base| base.to_string()).collect(),
+      values: Default::default(),
+      writes: Default::default(),
+    }
+  }
+
+  fn with_value(self, base: &str, path: &str, value: Value) -> Self {
+    self.values.lock().unwrap().insert(format!("{base}|{path}"), value);
+    self
+  }
+}
+
+impl RuntimeResourceProvider for RecordingResourceProvider {
+  fn scheme(&self) -> &str { self.scheme }
+
+  fn base_uris(&self) -> Vec<String> { self.bases.clone() }
+
+  fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
+    self.values
+      .lock()
+      .unwrap()
+      .get(&format!("{}|{}", request.base_uri, request.path))
+      .cloned()
+      .ok_or_else(|| mech_core::MechError::new(RuntimeResourcePathNotFound { base_uri: request.base_uri, path: request.path }, None))
+  }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
+    self.writes.lock().unwrap().push((request.base_uri.clone(), request.path.clone(), request.value.clone()));
+    self.values.lock().unwrap().insert(format!("{}|{}", request.base_uri, request.path), request.value);
+    Ok(())
+  }
+}
+
+fn assert_string_value(value: Value, expected: &str) {
+  let value = match value {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  match value {
+    Value::String(value) => assert_eq!(&*value.borrow(), expected),
+    other => panic!("expected string value `{expected}`, got {other:?}"),
+  }
+}
+
+#[test]
+fn cli_context_direct_read_resolves_inside_formula_expression() {
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  runtime.run_string("+> @env := cli/env\nmsg := \"HOME=\" + @env/HOME\n").unwrap();
+  let id = hash_str("msg");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "HOME=/tmp/home");
+}
+
+#[test]
+fn cli_context_standalone_expression_returns_env_value() {
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  let value = runtime.run_string("+> @env := cli/env\n@env/HOME\n").unwrap();
+  assert_string_value(value, "/tmp/home");
+}
+
+#[test]
+fn docs_context_write_requires_runtime_grant_before_provider_write() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  let result = runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := \"hello\"\n");
+  assert!(result.is_err(), "write without host grant should fail");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected host grant denial, got {error}");
+  assert!(writes.lock().unwrap().is_empty(), "provider write should not be called without grant");
+}
+
+#[test]
+fn docs_context_write_with_runtime_grant_reaches_provider() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_write_grant("docs://manual", "intro/title")).unwrap();
+  runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := \"hello\"\n").unwrap();
+  let writes = writes.lock().unwrap();
+  assert_eq!(writes.len(), 1);
+  assert_eq!(writes[0].0, "docs://manual");
+  assert_eq!(writes[0].1, "intro/title");
+  assert_string_value(writes[0].2.clone(), "hello");
+}
+
+#[test]
+fn browser_context_subroot_normalizes_to_provider_base_path() {
+  let provider = RecordingResourceProvider::new("browser", &["browser://dom"])
+    .with_value("browser://dom", "counter/text", Value::String(Ref::new("count".to_string())));
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_read_grant("browser://dom", "counter/text")).unwrap();
+  runtime.run_string("@ui := browser://dom/counter{:read(text)}\ntitle := @ui/text\n").unwrap();
+  let id = hash_str("title");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "count");
+}
+
+#[test]
+fn docs_context_subroot_normalizes_to_provider_base_path() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
+    .with_value("docs://manual", "intro/title", Value::String(Ref::new("Manual".to_string())));
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.run_string("@manual := docs://manual/intro{:read(title)}\ntitle := @manual/title\n").unwrap();
+  let id = hash_str("title");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "Manual");
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2179,14 +2179,14 @@ fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lower
 }
 
 #[test]
-fn direct_runtime_manifest_context_import_write_reports_current_addressed_assignment_limit() {
+fn direct_runtime_manifest_context_import_write_uses_provider_lookup() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
   let result = runtime.run_string("+> @ui := browser/dom
 @ui/counter/_text := \"hello\"
 ");
-  assert!(result.is_err(), "direct addressed assignment is not yet supported by this runtime path");
+  assert!(result.is_err(), "browser write should reach provider lookup without a browser provider");
   let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("AddressedAssignmentUnsupported"), "expected current direct assignment limit, got {error}");
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected provider lookup, got {error}");
   assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
 }
 
@@ -2286,4 +2286,109 @@ fn module_manifest_catalog_validates_builder_manifests() {
     let result = RuntimeBuilder::new().module_manifest(manifest);
     assert!(result.is_err(), "invalid manifest should be rejected by builder/catalog");
   }
+}
+
+#[derive(Debug, Clone, Default)]
+struct InMemoryCliProvider {
+  env: std::collections::HashMap<String, String>,
+  stdout: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+  stderr: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl InMemoryCliProvider {
+  fn with_env(mut self, name: &str, value: &str) -> Self {
+    self.env.insert(name.to_string(), value.to_string());
+    self
+  }
+}
+
+impl RuntimeResourceProvider for InMemoryCliProvider {
+  fn scheme(&self) -> &str { "cli" }
+
+  fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
+    if request.base_uri != "cli://env" {
+      return Err(mech_core::MechError::new(RuntimeResourceWriteUnsupported {
+        scheme: self.scheme().to_string(),
+        base_uri: request.base_uri,
+        path: request.path,
+      }, None));
+    }
+    let value = self.env.get(&request.path).cloned().unwrap_or_default();
+    Ok(Value::String(Ref::new(value)))
+  }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
+    let Value::String(value) = request.value else { return Ok(()); };
+    match request.base_uri.as_str() {
+      "cli://stdout" => self.stdout.lock().unwrap().push(value.borrow().clone()),
+      "cli://stderr" => self.stderr.lock().unwrap().push(value.borrow().clone()),
+      _ => return Err(mech_core::MechError::new(RuntimeResourceWriteUnsupported {
+        scheme: self.scheme().to_string(),
+        base_uri: request.base_uri,
+        path: request.path,
+      }, None)),
+    }
+    Ok(())
+  }
+}
+
+#[test]
+fn cli_context_direct_read_uses_manifest_boundary() {
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/mech-home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
+  let id = hash_str("home");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  match value {
+    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/mech-home"),
+    other => panic!("expected string home, got {other:?}"),
+  }
+}
+
+#[test]
+fn cli_context_direct_write_uses_manifest_boundary() {
+  let provider = InMemoryCliProvider::default();
+  let stdout = provider.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n").unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
+}
+
+#[test]
+fn cli_context_module_read_exports_value() {
+  let root = setup_modules("+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n");
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/module-home");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  let result = match result {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  match result {
+    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/module-home"),
+    other => panic!("expected string home, got {other:?}"),
+  }
+}
+
+#[test]
+fn cli_context_module_write_is_not_stripped() {
+  let root = setup_modules("+> @out := cli/stdout\n@out/line := \"hello\"\n");
+  let provider = InMemoryCliProvider::default();
+  let stdout = provider.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(provider)).build().unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  runtime.run_module(version).unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
+}
+
+#[test]
+fn cli_context_capabilities_are_enforced() {
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  let read_error = runtime.run_string("+> @out := cli/stdout\nvalue := @out/line\n").unwrap_err();
+  assert!(format!("{read_error:?}").contains("RuntimeResourceCapabilityDenied"));
+  let write_error = runtime.run_string("+> @env := cli/env\n@env/HOME := \"nope\"\n").unwrap_err();
+  assert!(format!("{write_error:?}").contains("RuntimeResourceCapabilityDenied"));
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2615,3 +2615,52 @@ home := @env/HOME
   let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
   assert_string_value(value, "/tmp/fenced-home");
 }
+
+#[test]
+fn named_fenced_context_import_write_uses_context_registry() {
+  let root = setup_modules("~~~mech:bar\n+> @out := cli/stdout\n@out/line := \"hello\"\n~~~\n");
+  let provider = InMemoryCliProvider::default();
+  let stdout = provider.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  runtime.run_module_scope(
+    version,
+    SourceScope::Interpreter(SourceInterpreterId {
+      namespace: hash_str("bar"),
+      namespace_str: "bar".to_string(),
+    }),
+  ).unwrap();
+
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
+}
+
+#[test]
+fn named_fenced_context_import_read_exports_value() {
+  let root = setup_modules("~~~mech:bar\n+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n~~~\n");
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/named-fence-home");
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  let result = runtime.run_module_scope(
+    version,
+    SourceScope::Interpreter(SourceInterpreterId {
+      namespace: hash_str("bar"),
+      namespace_str: "bar".to_string(),
+    }),
+  ).unwrap();
+
+  assert_string_value(result, "/tmp/named-fence-home");
+}

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -931,7 +931,7 @@ fn addressed_assignment_is_unsupported() {
 
 #[test]
 fn addressed_assignment_to_context_is_still_unsupported() {
-  let root = setup_modules("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
 
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
@@ -944,7 +944,7 @@ fn addressed_assignment_to_context_is_still_unsupported() {
 
 #[test]
 fn addressed_assignment_with_docs_provider_is_still_unsupported() {
-  let root = setup_modules("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
 
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(InMemoryDocsProvider::new()).build().unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
@@ -2663,4 +2663,68 @@ fn named_fenced_context_import_read_exports_value() {
   ).unwrap();
 
   assert_string_value(result, "/tmp/named-fence-home");
+}
+
+#[test]
+fn module_context_read_after_context_write_uses_execution_order() {
+  let root = setup_modules(
+    "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title := \"hello\"\nresult := @manual/intro/title\n<+ result\nresult\n",
+  );
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+
+  assert_string_value(result, "hello");
+}
+
+#[test]
+fn module_context_read_after_context_write_ignores_stale_provider_value() {
+  let root = setup_modules(
+    "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title := \"new\"\nresult := @manual/intro/title\n<+ result\nresult\n",
+  );
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
+    .with_value("docs://manual", "intro/title", Value::String(Ref::new("old".to_string())));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+
+  assert_string_value(result, "new");
+}
+
+#[test]
+fn direct_context_read_resolves_inside_op_assign() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://numbers"])
+    .with_value("docs://numbers", "increment", Value::F64(Ref::new(2.0)));
+  let mut runtime = RuntimeBuilder::new()
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://numbers", "increment")).unwrap();
+
+  runtime.run_string("@numbers := docs://numbers{:read(increment)}\n~total := 1.0\ntotal += @numbers/increment\n").unwrap();
+
+  let id = hash_str("total");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  match value {
+    Value::F64(value) => assert_eq!(*value.borrow(), 3.0),
+    other => panic!("expected f64 total, got {other:?}"),
+  }
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -31,21 +31,37 @@ fn read_grant(resource: &str, path: &str) -> RuntimeCapabilityGrantSpec {
     .with_path(path)
 }
 
-fn runtime_read_grant(resource: &str, path: &str) -> RuntimeCapabilityGrant {
-  runtime_grant(resource, RuntimeCapabilityOperation::Read, path)
-}
-
-fn runtime_write_grant(resource: &str, path: &str) -> RuntimeCapabilityGrant {
-  runtime_grant(resource, RuntimeCapabilityOperation::Write, path)
-}
-
-fn runtime_grant(resource: &str, operation: RuntimeCapabilityOperation, path: &str) -> RuntimeCapabilityGrant {
+fn runtime_write_grant_for(subject: &str, resource: &str, path: &str) -> RuntimeCapabilityGrant {
   RuntimeCapabilityGrant {
-    subject: "task://main".to_string(),
+    subject: subject.to_string(),
     resource: resource.to_string(),
-    operations: vec![operation],
+    operations: vec![RuntimeCapabilityOperation::Write],
     paths: vec![path.to_string()],
   }
+}
+
+fn runtime_read_grant_for(subject: &str, resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  RuntimeCapabilityGrant {
+    subject: subject.to_string(),
+    resource: resource.to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec![path.to_string()],
+  }
+}
+
+fn runtime_context_read_grant(runtime: &MechRuntime, resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime_read_grant_for(&subject, resource, path)
+}
+
+fn runtime_context_write_grant(runtime: &MechRuntime, resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime_write_grant_for(&subject, resource, path)
+}
+
+fn run_module_as_main(runtime: &mut MechRuntime, version: ModuleVersionId) -> mech_core::MResult<Value> {
+  let mut context = runtime.runtime_context()?.with_subject("task://main");
+  runtime.run_module_with_context(&mut context, version)
 }
 
 fn bool_value(value: bool) -> Value {
@@ -282,7 +298,7 @@ fn context_docs_read_returns_value() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version).unwrap();
   assert_bool_true(result, "context docs read");
@@ -303,7 +319,7 @@ fn config_spec_registers_in_memory_docs_resource() {
     .build()
     .unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "config spec docs read");
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "config spec docs read");
 }
 
 #[test]
@@ -326,7 +342,7 @@ fn config_spec_merges_multiple_docs_bases_into_one_provider() {
     .build()
     .unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "merged config spec docs bases");
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "merged config spec docs bases");
 }
 
 #[test]
@@ -347,7 +363,7 @@ fn config_spec_multiple_entries_same_base() {
     .build()
     .unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "config spec docs entries under one base");
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "config spec docs entries under one base");
 }
 
 #[test]
@@ -366,7 +382,7 @@ fn config_spec_later_duplicate_path_overwrites_earlier() {
     .build()
     .unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "later duplicate config spec docs path");
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "later duplicate config spec docs path");
 }
 
 #[test]
@@ -426,7 +442,7 @@ fn direct_provider_registration_still_works() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   assert_bool_true(runtime.run_module(version).unwrap(), "direct docs provider registration");
 }
@@ -446,7 +462,7 @@ fn apply_config_spec_after_build_registers_docs() {
     .unwrap();
   runtime.apply_config_spec(spec).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "applied config spec docs read");
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "applied config spec docs read");
 }
 
 #[test]
@@ -522,7 +538,7 @@ fn interpreter_scope_named(runtime: &mech_runtime::MechRuntime, version: mech_ru
 fn context_docs_read_without_provider_fails() {
   let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
   let mut runtime = runtime_with_root(&root);
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version);
   assert!(result.is_err());
@@ -540,7 +556,7 @@ fn context_docs_read_missing_path_fails() {
     .in_memory_docs(InMemoryDocsProvider::new())
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version);
   assert!(result.is_err());
@@ -559,7 +575,7 @@ fn context_docs_read_denied_by_capability_fails() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version);
   assert!(result.is_err());
@@ -579,7 +595,7 @@ fn context_docs_read_prefix_wildcard_allows_nested_path() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/*")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/*")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version).unwrap();
   assert_bool_true(result, "context docs prefix wildcard");
@@ -594,7 +610,7 @@ fn context_docs_read_prefix_wildcard_does_not_match_sibling() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version);
   assert!(result.is_err());
@@ -624,7 +640,7 @@ fn interpreter_scope_context_docs_read_returns_value() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let foo = foo_scope(&runtime, version);
   let result = runtime.run_module_scope(version, foo).unwrap();
@@ -1501,7 +1517,7 @@ fn run_docs_config_read(spec: RuntimeConfigSpec) -> Result<Value, mech_core::Mec
     .build()
     .unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  runtime.run_module(version)
+  run_module_as_main(&mut runtime, version)
 }
 
 #[test]
@@ -1588,8 +1604,9 @@ fn direct_provider_read_with_runtime_grant_still_works() {
     .in_memory_docs(provider)
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
-  assert!(runtime.has_capability_grant("task://main", "docs://manual", &RuntimeCapabilityOperation::Read, "intro/title"));
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(runtime_read_grant_for(&subject, "docs://manual", "intro/title")).unwrap();
+  assert!(runtime.has_capability_grant(&subject, "docs://manual", &RuntimeCapabilityOperation::Read, "intro/title"));
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   assert_bool_true(runtime.run_module(version).unwrap(), "runtime grant");
 }
@@ -1605,7 +1622,7 @@ fn apply_config_spec_after_build_registers_resources_and_grants() {
     .unwrap();
   runtime.apply_config_spec(spec).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "apply spec");
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "apply spec");
 }
 
 #[test]
@@ -2179,7 +2196,7 @@ fn context_import_alias_is_not_bound_as_value_import() {
 #[test]
 fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lowering() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
-  runtime.grant_capability(runtime_read_grant("browser://dom", "counter/_text")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/_text")).unwrap();
   let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
   assert!(result.is_err(), "expected browser provider failure without a browser provider");
   let error = format!("{:?}", result.err().unwrap());
@@ -2190,7 +2207,7 @@ fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lower
 #[test]
 fn direct_runtime_manifest_context_import_write_uses_provider_lookup() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
-  runtime.grant_capability(runtime_write_grant("browser://dom", "counter/_text")).unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "browser://dom", "counter/_text")).unwrap();
   let result = runtime.run_string("+> @ui := browser/dom
 @ui/counter/_text := \"hello\"
 ");
@@ -2350,7 +2367,7 @@ impl RuntimeResourceProvider for InMemoryCliProvider {
 fn cli_context_direct_read_uses_manifest_boundary() {
   let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/mech-home");
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
   runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
   let id = hash_str("home");
   let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
@@ -2365,7 +2382,7 @@ fn cli_context_direct_write_uses_manifest_boundary() {
   let provider = InMemoryCliProvider::default();
   let stdout = provider.stdout.clone();
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_write_grant("cli://stdout", "line")).unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
   runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n").unwrap();
   assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
 }
@@ -2375,7 +2392,7 @@ fn cli_context_module_read_exports_value() {
   let root = setup_modules("+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n");
   let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/module-home");
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   let result = runtime.run_module(version).unwrap();
   let result = match result {
@@ -2394,7 +2411,7 @@ fn cli_context_module_write_is_not_stripped() {
   let provider = InMemoryCliProvider::default();
   let stdout = provider.stdout.clone();
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_write_grant("cli://stdout", "line")).unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
   let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
   runtime.run_module(version).unwrap();
   assert_eq!(stdout.lock().unwrap().as_slice(), &["hello".to_string()]);
@@ -2470,7 +2487,7 @@ fn assert_string_value(value: Value, expected: &str) {
 fn cli_context_direct_read_resolves_inside_formula_expression() {
   let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/home");
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
   runtime.run_string("+> @env := cli/env\nmsg := \"HOME=\" + @env/HOME\n").unwrap();
   let id = hash_str("msg");
   let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
@@ -2481,7 +2498,7 @@ fn cli_context_direct_read_resolves_inside_formula_expression() {
 fn cli_context_standalone_expression_returns_env_value() {
   let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/home");
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_read_grant("cli://env", "HOME")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
   let value = runtime.run_string("+> @env := cli/env\n@env/HOME\n").unwrap();
   assert_string_value(value, "/tmp/home");
 }
@@ -2503,7 +2520,7 @@ fn docs_context_write_with_runtime_grant_reaches_provider() {
   let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
   let writes = provider.writes.clone();
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_write_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := \"hello\"\n").unwrap();
   let writes = writes.lock().unwrap();
   assert_eq!(writes.len(), 1);
@@ -2517,7 +2534,7 @@ fn browser_context_subroot_normalizes_to_provider_base_path() {
   let provider = RecordingResourceProvider::new("browser", &["browser://dom"])
     .with_value("browser://dom", "counter/text", Value::String(Ref::new("count".to_string())));
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_read_grant("browser://dom", "counter/text")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/text")).unwrap();
   runtime.run_string("@ui := browser://dom/counter{:read(text)}\ntitle := @ui/text\n").unwrap();
   let id = hash_str("title");
   let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
@@ -2529,9 +2546,72 @@ fn docs_context_subroot_normalizes_to_provider_base_path() {
   let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
     .with_value("docs://manual", "intro/title", Value::String(Ref::new("Manual".to_string())));
   let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_read_grant("docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
   runtime.run_string("@manual := docs://manual/intro{:read(title)}\ntitle := @manual/title\n").unwrap();
   let id = hash_str("title");
   let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
   assert_string_value(value, "Manual");
+}
+
+
+#[test]
+fn context_write_uses_active_runtime_context_subject() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("task://custom");
+
+  runtime.grant_capability(runtime_write_grant_for("task://custom", "docs://manual", "intro/title")).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := \"hello\"\n",
+  ).unwrap();
+
+  assert_eq!(writes.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn context_write_does_not_accept_grant_for_default_subject_when_context_subject_differs() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_write_grant_for("task://main", "docs://manual", "intro/title")).unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("task://custom");
+
+  let result = runtime.run_string_with_context(
+    &mut context,
+    "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title := \"hello\"\n",
+  );
+
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"));
+  assert!(writes.lock().unwrap().is_empty());
+}
+
+#[test]
+fn unqualified_fenced_context_import_is_available_to_program_execution() {
+  let provider = InMemoryCliProvider::default().with_env("HOME", "/tmp/fenced-home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("task://fenced");
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject: "task://fenced".to_string(),
+    resource: "cli://env".to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec!["HOME".to_string()],
+  }).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "```mech
++> @env := cli/env
+home := @env/HOME
+```
+",
+  ).unwrap();
+
+  let id = hash_str("home");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "/tmp/fenced-home");
 }


### PR DESCRIPTION
### Motivation
- Remove browser-specific execution special-cases and string-prefix declaration stripping and replace them with a generic manifest-backed context/resource boundary so host modules (browser, CLI, etc.) share the same runtime path.
- Ensure module and direct runtime execution use the same semantics (parse -> source index -> manifest normalization -> scoped context registry -> execution) so manifest context imports are materialized into scope before execution.
- Provide a small second host module (`cli`) to prove the provider/manifest boundary is generic and to exercise read/write capability checks via in-memory providers.

### Description
- Removed raw source-line declaration stripping and browser-only lowering; `run_string`/`run_tree` now parse source and execute via `run_tree_on_program` which skips declarations by AST variant rather than text prefixes.
- Introduced scoped manifest materialization and a `RuntimeContextRegistry` build path for direct runtime with `context_declarations_from_index_scope` and `direct_context_registry_for_scope`, and unified `expression_context_read`, `read_context_resource`, and `write_context_resource` helpers to drive provider calls.
- Added `resource_base_matches` helper and wired resource-root resolution so providers match base URIs precisely (not naive starts-with checks), and moved browser-specific binding logic into provider/manifest-facing code.
- Added `cli` builtin module manifest (`cli/env`, `cli/stdout`, `cli/stderr`) to the manifest catalog and provided an in-memory `InMemoryCliProvider` for tests; tests prove reads, writes, capability enforcement, and that manifest context imports do not create source dependency edges.
- Replaced ad-hoc generic string error for addressed assignment with a typed error `RuntimeAddressedAssignmentUnsupported` and returned typed `RuntimeResourceCapabilityDenied` where capability checks fail.

### Testing
- Ran `cargo test -p mech-syntax --test module_imports` which passed.
- Ran `cargo test -p mech-syntax --test context_parser` which passed, and `cargo test -p mech-runtime --test module_smoke manifest_context -- --nocapture` and `cargo test -p mech-runtime --test module_smoke cli_context -- --nocapture` which passed; also ran `cargo test -p mech-runtime resolver::imports --lib` and `cargo test -p mech-host-browser module_manifest` which passed, and `cargo check -p mech-runtime` which completed successfully.
- Ran the workspace test `cargo test --workspace` which revealed an unrelated pre-existing compilation failure in `mech-combinatorics` (`NChooseK<T>` does not satisfy `mech_core::MechFunction`); that workspace failure is not caused by this PR and does not block the runtime-specific changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3463b163dc832a869a513798b45ee9)