### PR TITLE
Reject context-send in function bodies and fix CLI provider feature

### DIFF
--- a/hosts/cli/Cargo.toml
+++ b/hosts/cli/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.92"
 
 [features]
 default = []
-provider = ["mech-runtime/default"]
+provider = ["mech-core/string"]
 
 [dependencies]
 mech-core = { version = "0.3.5", default-features = false }

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1966,7 +1966,7 @@ impl Value {
     match self {
       #[cfg(feature = "string")]
       Value::String(_) => true,
-      #[cfg(feature = "string")]
+      #[cfg(all(feature = "matrix", feature = "string"))]
       Value::MatrixString(_) => true,
       Value::MutableReference(val) => val.borrow().is_string(),
       _ => false,

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
 use mech_core::{hash_str, MechSourceCode, ModuleManifestConfig, ModuleManifestExportConfig, ModuleManifestExportKind, Ref, Value};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::*;
@@ -94,6 +97,26 @@ fn assert_bool_false(result: Value, label: &str) {
   }
 }
 
+
+
+#[test]
+fn direct_run_string_preserves_normal_imports() {
+  let root = setup_modules("+> ./math.mec
+ok := math/tau > 6.0
+");
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .build()
+    .unwrap();
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
+
+  let result = runtime.run_module(version).unwrap();
+
+  assert_bool_true(result, "direct run_string normal import");
+}
 
 #[test]
 fn in_memory_docs_provider_write_then_read_returns_value() {
@@ -2322,6 +2345,57 @@ fn module_manifest_catalog_validates_builder_manifests() {
   }
 }
 
+
+#[derive(Debug, Default)]
+struct RuntimeFakeCliState {
+  env: HashMap<String, String>,
+  stdout: Vec<String>,
+  stderr: Vec<String>,
+  env_reads: usize,
+  stdout_writes: usize,
+  stderr_writes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeFakeCliBackend {
+  state: Arc<Mutex<RuntimeFakeCliState>>,
+}
+
+impl RuntimeFakeCliBackend {
+  fn new(state: Arc<Mutex<RuntimeFakeCliState>>) -> Self {
+    Self { state }
+  }
+}
+
+impl CliBackend for RuntimeFakeCliBackend {
+  fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
+    let mut state = self.state.lock().unwrap();
+    state.env_reads += 1;
+    Ok(state.env.get(name).cloned())
+  }
+
+  fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
+    let mut state = self.state.lock().unwrap();
+    state.stdout_writes += 1;
+    state.stdout.push(text.to_string());
+    Ok(())
+  }
+
+  fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
+    let mut state = self.state.lock().unwrap();
+    state.stderr_writes += 1;
+    state.stderr.push(text.to_string());
+    Ok(())
+  }
+}
+
+fn runtime_with_fake_cli(state: Arc<Mutex<RuntimeFakeCliState>>) -> MechRuntime {
+  RuntimeBuilder::new()
+    .resource_provider(Box::new(CliResourceProvider::new(RuntimeFakeCliBackend::new(state))))
+    .build()
+    .unwrap()
+}
+
 #[derive(Debug, Clone, Default)]
 struct FakeCliBackend {
   env: std::collections::HashMap<String, String>,
@@ -2354,6 +2428,148 @@ impl CliBackend for FakeCliBackend {
     self.stderr.lock().unwrap().push(text.to_string());
     Ok(())
   }
+}
+
+
+#[test]
+fn cli_manifest_env_import_reads_through_runtime() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  state.lock().unwrap().env.insert("HOME".to_string(), "/tmp/home".to_string());
+
+  let mut runtime = runtime_with_fake_cli(state.clone());
+  runtime
+    .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+    .unwrap();
+
+  let result = runtime
+    .run_string("+> @env := cli/env
+@env/HOME
+")
+    .unwrap();
+
+  let result = match result {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  match result {
+    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/home"),
+    other => panic!("expected HOME string from cli env, got {:?}", other),
+  }
+
+  assert_eq!(state.lock().unwrap().env_reads, 1);
+}
+
+#[test]
+fn cli_manifest_stdout_send_line_writes_through_runtime() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
+
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
+
+  runtime
+    .run_string("+> @out := cli/stdout
+@out/line <- \"hello\"
+")
+    .unwrap();
+
+  let state = state.lock().unwrap();
+  assert_eq!(state.stdout, vec!["hello\n".to_string()]);
+  assert_eq!(state.stdout_writes, 1);
+}
+
+#[test]
+fn cli_manifest_stderr_send_text_writes_through_runtime() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
+
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text"))
+    .unwrap();
+
+  runtime
+    .run_string("+> @err := cli/stderr
+@err/text <- \"warning\"
+")
+    .unwrap();
+
+  let state = state.lock().unwrap();
+  assert_eq!(state.stderr, vec!["warning".to_string()]);
+  assert_eq!(state.stderr_writes, 1);
+}
+
+#[test]
+fn cli_stdout_assignment_errors_and_writes_nothing() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
+
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
+
+  let result = runtime.run_string("+> @out := cli/stdout
+@out/line = \"hello\"
+");
+
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert!(state.stdout.is_empty());
+  assert_eq!(state.stdout_writes, 0);
+}
+
+#[test]
+fn cli_stdout_define_errors_and_writes_nothing() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
+
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
+
+  let result = runtime.run_string("+> @out := cli/stdout
+@out/line := \"hello\"
+");
+
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert!(state.stdout.is_empty());
+  assert_eq!(state.stdout_writes, 0);
+}
+
+#[test]
+fn cli_env_send_errors() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
+
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
+    .unwrap();
+
+  let result = runtime.run_string("+> @env := cli/env
+@env/HOME <- \"x\"
+");
+
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert_eq!(state.env_reads, 0);
+  assert_eq!(state.stdout_writes, 0);
+  assert_eq!(state.stderr_writes, 0);
+}
+
+#[test]
+fn cli_stdout_missing_write_grant_fails_before_backend() {
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
+
+  let result = runtime.run_string("+> @out := cli/stdout
+@out/line <- \"hello\"
+");
+
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert!(state.stdout.is_empty());
+  assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]

--- a/src/syntax/src/functions.rs
+++ b/src/syntax/src/functions.rs
@@ -28,6 +28,20 @@ pub fn function_define(input: ParseString) -> ParseResult<FunctionDefine> {
   }
 }
 
+fn function_body_statement(input: ParseString) -> ParseResult<Statement> {
+  let start = input.clone();
+  let (input, statement) = statement(input)?;
+
+  if matches!(statement, Statement::ContextSend(_)) {
+    return Err(Failure(ParseError::new(
+      start,
+      "context sends are only supported at top level; functions cannot contain `<-` yet",
+    )));
+  }
+
+  Ok((input, statement))
+}
+
 fn function_define_statements(
   input: ParseString,
   name: Identifier,
@@ -37,7 +51,10 @@ fn function_define_statements(
   let ((input, _)) = whitespace0(input)?;
   let ((input, output)) = alt((function_out_args,function_out_arg))(input)?;
   let ((input, _)) = define_operator(input)?;
-  let ((input, statements)) = separated_list1(alt((whitespace1,statement_separator)), statement)(input)?;
+  let ((input, statements)) = separated_list1(
+    alt((whitespace1, statement_separator)),
+    function_body_statement,
+  )(input)?;
   let ((input, _)) = period(input)?;
   Ok((input,FunctionDefine{name,input: input_args,output,statements,match_arms: vec![]}))
 }

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -301,6 +301,17 @@ fn parses_context_send_statements() {
   }
 }
 
+
+#[test]
+fn rejects_context_send_inside_function_body() {
+  assert!(parser::parse("emit() = result<string> := @out/line <- \"hello\".").is_err());
+}
+
+#[test]
+fn function_body_without_context_send_still_parses() {
+  assert!(parser::parse("emit() = result<string> := result := \"hello\".").is_ok());
+}
+
 #[test]
 fn rejects_local_send_and_context_definitions() {
   assert!(parser::parse("x <- 5").is_err());


### PR DESCRIPTION
### Motivation

- Function bodies were parsed with the generic `statement` parser which now accepts `ContextSend`, but only top-level execution handles `<-`; functions must reject `<-` for now.
- The CLI host feature pulled in `mech-runtime/default` unnecessarily; the CLI provider feature only needs `Value::String` and should depend on `mech-core/string` instead.
- Add regression tests to lock down the intended parsing/runtime semantics and ensure direct imports still behave correctly.

### Description

- Change CLI feature wiring in `hosts/cli/Cargo.toml` to `provider = ["mech-core/string"]` so the CLI provider feature does not pull in `mech-runtime/default`.
- In `src/syntax/src/functions.rs` add `fn function_body_statement(...)` which parses a statement and returns a parsing failure if it is `Statement::ContextSend(_)`, and use it for function bodies instead of the generic `statement` parser so function bodies reject `<-` sends.
- Add syntax regression tests in `src/syntax/tests/context_parser.rs` that verify top-level `@out/line <- "hello"` still parses, that `@out/line <- "hello"` inside function bodies is rejected, and that normal function-body statements still parse.
- Add runtime tests and a small fake CLI backend in `src/runtime/tests/module_smoke.rs` to validate manifest-based CLI env reads and stdout/stderr sends go through the runtime path, that assignment/define to context paths error without writing, and that missing grants fail before calling the backend; also add a direct-import regression test that verifies `run_module`/direct execution import behavior.
- Small fix in `src/core/src/value.rs` to guard `Value::MatrixString` checks behind `#[cfg(all(feature = "matrix", feature = "string"))]` so the separate `mech-core/string` feature path builds correctly.

### Testing

- Ran `cargo test -p mech-syntax --test context_parser` and the parser suite passed (all tests OK).
- Ran `cargo test -p mech-host-cli --features provider --test provider` and the CLI provider tests passed (all tests OK).
- Ran `cargo test -p mech-host-cli --test module_manifest` and the CLI module manifest test passed (OK).
- Ran `cargo test -p mech-runtime --test module_smoke` and the runtime module smoke tests passed (all tests OK), including the new CLI runtime coverage and direct-import regression.
- Ran `cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli` and the workspace checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36db6a9cd4832a88e47973b7ae2c23)