### PR TITLE
Reject context sends in FSM transitions

### DIFF
--- a/src/syntax/src/state_machines.rs
+++ b/src/syntax/src/state_machines.rs
@@ -160,11 +160,31 @@ pub fn fsm_async_transition(input: ParseString) -> ParseResult<Transition> {
   Ok((input, Transition::Async(ptrn)))
 }
 
+fn fsm_transition_statement(input: ParseString) -> ParseResult<Statement> {
+  let start = input.clone();
+  let (input, statement) = statement(input)?;
+
+  if matches!(statement, Statement::ContextSend(_)) {
+    return Err(nom::Err::Failure(ParseError::new(
+      start,
+      "context sends are only supported at top level; FSM transitions cannot contain `<-` yet",
+    )));
+  }
+
+  Ok((input, statement))
+}
+
 // fsm_statement_transition := transition_operator, statement ;
 pub fn fsm_statement_transition(input: ParseString) -> ParseResult<Transition> {
   let (input, _) = transition_operator(input)?;
-  let (input, stmnt) = statement(input)?;
+  let (input, stmnt) = fsm_transition_statement(input)?;
   Ok((input, Transition::Statement(stmnt)))
+}
+
+fn fsm_code_block_contains_context_send(code: &[(MechCode, Option<Comment>)]) -> bool {
+  code.iter().any(|(node, _)| {
+    matches!(node, MechCode::Statement(Statement::ContextSend(_)))
+  })
 }
 
 // fsm_block_transition := transition_operator, left_brace, mech_code+, right_brace ;
@@ -173,6 +193,14 @@ pub fn fsm_block_transition(input: ParseString) -> ParseResult<Transition> {
   let (input, _) = left_brace(input)?;
   let (input, parsed) = mech_code(input)?;
   let code = parsed.code;
+
+  if fsm_code_block_contains_context_send(&code) {
+    return Err(nom::Err::Failure(ParseError::new(
+      input,
+      "context sends are only supported at top level; FSM transition blocks cannot contain `<-` yet",
+    )));
+  }
+
   let (input, _) = right_brace(input)?;
   Ok((input, Transition::CodeBlock(code)))
 }

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -301,6 +301,31 @@ fn parses_context_send_statements() {
   }
 }
 
+#[test]
+fn top_level_context_send_still_parses_after_fsm_rejection() {
+  assert!(parser::parse("@out/line <- \"hello\"").is_ok());
+}
+
+#[test]
+fn rejects_context_send_inside_fsm_statement_transition() {
+  assert!(
+    parser::parse(
+      "#machine(x) -> :start\n:start -> @out/line <- \"hello\"\n."
+    )
+    .is_err()
+  );
+}
+
+#[test]
+fn rejects_context_send_inside_fsm_block_transition() {
+  assert!(
+    parser::parse(
+      "#machine(x) -> :start\n:start -> { @out/line <- \"hello\" }\n."
+    )
+    .is_err()
+  );
+}
+
 
 #[test]
 fn rejects_context_send_inside_function_body() {


### PR DESCRIPTION
### Motivation
- FSM transitions currently accept any `statement`, which allows `ContextSend` (`<-`) to be parsed inside transitions even though the runtime does not execute nested context sends. This causes invalid programs to parse but fail at execution time.

### Description
- Add `fsm_transition_statement` to parse statements inside FSM transitions and reject `Statement::ContextSend(_)` with a clear parse error message, and wire it into `fsm_statement_transition` by replacing the direct call to `statement` with `fsm_transition_statement` in `src/syntax/src/state_machines.rs`.
- Add `fsm_code_block_contains_context_send` and validate parsed `mech_code` in `fsm_block_transition` to reject context sends inside FSM transition blocks before returning `Transition::CodeBlock` in `src/syntax/src/state_machines.rs`.
- Add parser tests in `src/syntax/tests/context_parser.rs` that assert (1) top-level context sends still parse, (2) context sends are rejected inside FSM statement transitions, and (3) context sends are rejected inside FSM block transitions.

### Testing
- Ran `cargo test -p mech-syntax --test context_parser` and the test binary completed with `27 passed; 0 failed`.
- Ran `cargo test -p mech-runtime --test module_smoke` and the smoke tests completed with `166 passed; 0 failed`.
- Ran `cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli` and the checks completed successfully (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36e5b1ed74832a92fb059b0ed7924c)