### PR TITLE
Reject context sends in FSM transitions

### DIFF
--- a/src/syntax/src/state_machines.rs
+++ b/src/syntax/src/state_machines.rs
@@ -161,13 +161,16 @@ pub fn fsm_async_transition(input: ParseString) -> ParseResult<Transition> {
 }
 
 fn fsm_transition_statement(input: ParseString) -> ParseResult<Statement> {
+  const FSM_CONTEXT_SEND_ERROR: &str =
+    "context sends are only supported at top level; FSM transitions cannot contain `<-` yet";
+
   let start = input.clone();
   let (input, statement) = statement(input)?;
 
   if matches!(statement, Statement::ContextSend(_)) {
     return Err(nom::Err::Failure(ParseError::new(
       start,
-      "context sends are only supported at top level; FSM transitions cannot contain `<-` yet",
+      FSM_CONTEXT_SEND_ERROR,
     )));
   }
 
@@ -189,6 +192,9 @@ fn fsm_code_block_contains_context_send(code: &[(MechCode, Option<Comment>)]) ->
 
 // fsm_block_transition := transition_operator, left_brace, mech_code+, right_brace ;
 pub fn fsm_block_transition(input: ParseString) -> ParseResult<Transition> {
+  const FSM_CONTEXT_SEND_BLOCK_ERROR: &str =
+    "context sends are only supported at top level; FSM transition blocks cannot contain `<-` yet";
+
   let (input, _) = transition_operator(input)?;
   let (input, _) = left_brace(input)?;
   let (input, parsed) = mech_code(input)?;
@@ -197,7 +203,7 @@ pub fn fsm_block_transition(input: ParseString) -> ParseResult<Transition> {
   if fsm_code_block_contains_context_send(&code) {
     return Err(nom::Err::Failure(ParseError::new(
       input,
-      "context sends are only supported at top level; FSM transition blocks cannot contain `<-` yet",
+      FSM_CONTEXT_SEND_BLOCK_ERROR,
     )));
   }
 

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -302,11 +302,6 @@ fn parses_context_send_statements() {
 }
 
 #[test]
-fn top_level_context_send_still_parses_after_fsm_rejection() {
-  assert!(parser::parse("@out/line <- \"hello\"").is_ok());
-}
-
-#[test]
 fn rejects_context_send_inside_fsm_statement_transition() {
   assert!(
     parser::parse(
@@ -326,6 +321,10 @@ fn rejects_context_send_inside_fsm_block_transition() {
   );
 }
 
+#[test]
+fn top_level_context_send_still_parses_after_fsm_rejection() {
+  assert!(parser::parse("@out/line <- \"hello\"").is_ok());
+}
 
 #[test]
 fn rejects_context_send_inside_function_body() {


### PR DESCRIPTION
### Motivation
- FSM transitions currently accepted `ContextSend` statements (nested `<-`) which are not implemented for execution, so the parser must reject them to avoid allowing unsupported syntax.
- The change keeps top-level context send syntax valid while preventing FSM-specific nested sends which would be unhandled by the runtime.

### Description
- Add `fsm_transition_statement` which parses a `statement` and fails if it is `Statement::ContextSend(_)`, and use it in `fsm_statement_transition` instead of calling `statement` directly. 
- Add `fsm_code_block_contains_context_send` to detect `MechCode::Statement(Statement::ContextSend(_))` entries and check parsed blocks in `fsm_block_transition`, returning a parse failure if any context send is present. 
- Introduce clear error messages for both statement and block FSM rejections and preserve top-level context send parsing behavior. 
- Add parser regression tests in `src/syntax/tests/context_parser.rs` exercising rejection of context sends inside FSM statement transitions and FSM block transitions and asserting top-level context sends still parse.

### Testing
- Ran `cargo test -p mech-syntax --test context_parser` and the test suite passed (all tests OK). 
- Ran `cargo test -p mech-runtime --test module_smoke` and the test suite passed (all tests OK). 
- Ran `cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli` which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ee421658832abec7a01e4797bab0)