### PR TITLE
Harden CLI host send semantics and provider boundaries

### DIFF
--- a/hosts/cli/src/provider.rs
+++ b/hosts/cli/src/provider.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::{env::VarError, io::Write};
 
 use mech_core::{MResult, MechError, MechErrorKind, Ref, Value};
 use mech_runtime::{
@@ -17,31 +17,30 @@ pub struct StdCliBackend;
 
 impl CliBackend for StdCliBackend {
     fn env_var(&self, name: &str) -> MResult<Option<String>> {
-        Ok(std::env::var(name).ok())
+        match std::env::var(name) {
+            Ok(value) => Ok(Some(value)),
+            Err(VarError::NotPresent) => Ok(None),
+            Err(VarError::NotUnicode(_)) => Err(cli_error(
+                "cli://env".to_string(),
+                format!("environment variable `{name}` exists but is not valid Unicode"),
+            )),
+        }
     }
 
     fn write_stdout(&mut self, text: &str) -> MResult<()> {
-        std::io::stdout().write_all(text.as_bytes()).map_err(|err| {
-            MechError::new(
-                CliResourceProviderError {
-                    resource: "cli://stdout".to_string(),
-                    reason: err.to_string(),
-                },
-                None,
-            )
-        })
+        let mut out = std::io::stdout().lock();
+        out.write_all(text.as_bytes())
+            .map_err(|err| cli_error("cli://stdout".to_string(), err.to_string()))?;
+        out.flush()
+            .map_err(|err| cli_error("cli://stdout".to_string(), err.to_string()))
     }
 
     fn write_stderr(&mut self, text: &str) -> MResult<()> {
-        std::io::stderr().write_all(text.as_bytes()).map_err(|err| {
-            MechError::new(
-                CliResourceProviderError {
-                    resource: "cli://stderr".to_string(),
-                    reason: err.to_string(),
-                },
-                None,
-            )
-        })
+        let mut err = std::io::stderr().lock();
+        err.write_all(text.as_bytes())
+            .map_err(|err| cli_error("cli://stderr".to_string(), err.to_string()))?;
+        err.flush()
+            .map_err(|err| cli_error("cli://stderr".to_string(), err.to_string()))
     }
 }
 
@@ -105,6 +104,8 @@ impl<B: CliBackend> RuntimeResourceProvider for CliResourceProvider<B> {
                 "cli env is read-only and does not support writes or sends",
             )),
             "cli://stdout" | "cli://stderr" => {
+                // The manifest grants stdout/stderr `write`; the provider currently accepts only
+                // send intents because context sends are represented as resource write requests.
                 if request.intent != RuntimeResourceWriteIntent::Send {
                     return Err(cli_error(
                         request.base_uri,

--- a/hosts/cli/tests/provider.rs
+++ b/hosts/cli/tests/provider.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use mech_core::{MResult, Ref, Value};
+use mech_core::{MResult, MechError, MechErrorKind, Ref, Value};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::{
     RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
@@ -10,12 +10,21 @@ use mech_runtime::{
 #[derive(Debug, Default)]
 struct FakeCliBackend {
     env: HashMap<String, String>,
+    env_error: Option<String>,
     stdout: Vec<String>,
     stderr: Vec<String>,
 }
 
 impl CliBackend for FakeCliBackend {
     fn env_var(&self, name: &str) -> MResult<Option<String>> {
+        if let Some(reason) = &self.env_error {
+            return Err(MechError::new(
+                FakeCliBackendError {
+                    reason: reason.clone(),
+                },
+                None,
+            ));
+        }
         Ok(self.env.get(name).cloned())
     }
     fn write_stdout(&mut self, text: &str) -> MResult<()> {
@@ -25,6 +34,21 @@ impl CliBackend for FakeCliBackend {
     fn write_stderr(&mut self, text: &str) -> MResult<()> {
         self.stderr.push(text.to_string());
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FakeCliBackendError {
+    reason: String,
+}
+
+impl MechErrorKind for FakeCliBackendError {
+    fn name(&self) -> &str {
+        "FakeCliBackend"
+    }
+
+    fn message(&self) -> String {
+        self.reason.clone()
     }
 }
 
@@ -56,6 +80,39 @@ fn env_read_returns_fake_value_and_missing_errors() {
             })
             .is_err()
     );
+}
+
+#[test]
+fn env_read_rejects_invalid_env_keys() {
+    let provider = CliResourceProvider::new(FakeCliBackend::default());
+
+    for path in ["", "1HOME", "HOME/PATH", "HOME-PATH"] {
+        let result = provider.read(RuntimeResourceReadRequest {
+            base_uri: "cli://env".to_string(),
+            path: path.to_string(),
+            context_name: "env".to_string(),
+        });
+        assert!(result.is_err(), "expected invalid env path to fail: {path}");
+    }
+}
+
+#[test]
+fn env_read_propagates_backend_errors() {
+    let provider = CliResourceProvider::new(FakeCliBackend {
+        env_error: Some("host env decode failed".to_string()),
+        ..FakeCliBackend::default()
+    });
+
+    let result = provider.read(RuntimeResourceReadRequest {
+        base_uri: "cli://env".to_string(),
+        path: "HOME".to_string(),
+        context_name: "env".to_string(),
+    });
+
+    assert!(result.is_err());
+    let message = result.unwrap_err().display_message();
+    assert!(message.contains("host env decode failed"), "{message}");
+    assert!(!message.contains("is not set"), "{message}");
 }
 
 #[test]

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -916,6 +916,9 @@ impl MechRuntime {
         Ok(())
       }
       mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+        // Context sends are executed only at module top level for now. Parser paths
+        // intentionally reject nested sends until interpreter/effect execution can
+        // support them in functions and state machines.
         let Some(context_name) = &send.target.context else {
           return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: send.target.name.to_string() }, None));
         };

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -146,6 +146,9 @@ pub fn context_send(input: ParseString) -> ParseResult<ContextSend> {
   if target.context.is_none() {
     return Err(nom::Err::Error(ParseError::new(input, "send target must be an addressed context path")));
   }
+  if target.kind.is_some() {
+    return Err(nom::Err::Error(ParseError::new(input, "send targets cannot have kind annotations")));
+  }
   let (input, _) = send_operator(input)?;
   let (input, expression) = label!(expression, msg2)(input)?;
   Ok((input, ContextSend { target, expression }))

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -302,6 +302,23 @@ fn parses_context_send_statements() {
 }
 
 #[test]
+fn rejects_kind_annotations_on_context_send_targets() {
+  assert!(parser::parse("@out/line<string> <- \"hello\"").is_err());
+}
+
+#[test]
+fn parses_deep_context_send_path() {
+  let stmts = statements("@ui/counter/_text <- \"hello\"");
+  match &stmts[0] {
+    Statement::ContextSend(send) => {
+      assert_eq!(send.target.context.as_ref().unwrap().to_string(), "ui");
+      assert_eq!(send.target.name.to_string(), "counter/_text");
+    }
+    other => panic!("expected context send, got {other:?}"),
+  }
+}
+
+#[test]
 fn rejects_context_send_inside_fsm_statement_transition() {
   assert!(
     parser::parse(


### PR DESCRIPTION
### Motivation

- Preserve real host errors when reading environment variables by distinguishing “not present” from “not valid Unicode” so a host decode failure is not reported as “missing.”
- Make stdout/stderr writes deterministic and less racy by locking the stream, writing, and flushing so write+flush failures are reported consistently.
- Remove ambiguous/meaningless syntax by rejecting kind annotations on send-only context targets so constructs like `@out/line<string> <- "x"` are explicit errors.
- Document and enforce the current top-level-only execution model for context sends to avoid accidentally reintroducing nested send execution before the interpreter/effect model supports it.

### Description

- Change `StdCliBackend::env_var` to match on `std::env::var(name)` and handle `VarError` explicitly, returning `Ok(None)` for `NotPresent` and a `CliResourceProviderError` for `NotUnicode(_)` (preserving host decode errors).
- Replace direct `std::io::stdout().write_all(...)` / `stderr().write_all(...)` with locked handles and explicit `write_all` + `flush`, mapping both write and flush errors through the existing CLI error helper (`cli_error`).
- Reject kind annotations on send targets by adding a check in the parser `context_send` that returns an error if `target.kind.is_some()`; deep addressed context paths remain accepted.
- Add a clarifying comment in the runtime `ContextSend` handling explaining that context sends are executed only at module top-level for now and that parser paths intentionally reject nested sends until interpreter/effect execution supports them.
- Add/extend tests and a small fake-backend scaffolding: new tests in `hosts/cli/tests/provider.rs` verify invalid env paths are rejected and backend env errors propagate (not converted into “not set”), and tests in `src/syntax/tests/context_parser.rs` assert that kind annotations on send targets are rejected and that deep context-send paths still parse.
- Kept the change narrow: no new host architecture, no capability-model rewrite, and no nested send execution implementation.

### Testing

- Ran formatting and build checks with `cargo fmt` and `cargo check -p mech-host-cli --no-default-features` which succeeded.
- Ran unit/test suites: `cargo test -p mech-host-cli --features provider`, `cargo test -p mech-syntax --test context_parser`, `cargo test -p mech-runtime --test module_smoke`, and `cargo test -p mech-runtime -p mech-host-browser -p mech-host-cli`, all of which completed successfully with the added tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a373f8abd70832abc86daa7cabaeb6b)