### PR TITLE
Add attenuable CLI host capabilities

### DIFF
--- a/scripts/test-dynamic-modules.sh
+++ b/scripts/test-dynamic-modules.sh
@@ -10,6 +10,8 @@ TARGET_DIR="${REPO_ROOT}/target/dynamic-modules"
 MODULE_DIR="${REPO_ROOT}/target/mech-modules"
 PROFILE_DIR="${TARGET_DIR}/debug"
 
+export CARGO_HTTP_MULTIPLEXING=false
+
 case "$(uname -s)" in
 Darwin*)
 DYLIB_PREFIX="lib"

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -80,7 +80,7 @@ use mech::cli::capabilities;
 use mech::cli::config;
 #[cfg(feature = "run")]
 use mech::cli::run::{
-  cli_host_capability_args, cli_host_capability_path_values, cli_host_capability_selection,
+  cli_host_capability_args, cli_host_capability_selection,
   effective_run_runtime_config, new_cli_runtime, run_cli_source,
 };
 
@@ -251,7 +251,7 @@ async fn main() -> Result<(), MechError> {
         .help("Print verbose pass/fail details.")
         .action(ArgAction::SetTrue)
         .required(false)))
-    .subcommand(add_cli_host_capability_args(Command::new("run")
+    .subcommand(Command::new("run")
       .about("Run Mech source files, project inputs, or inline Mech code.")
       .arg(Arg::new("mech_run_paths")
         .help("Source .mec files, project folders, or inline Mech code.")
@@ -275,7 +275,7 @@ async fn main() -> Result<(), MechError> {
       .arg(Arg::new("trace")
         .long("trace")
         .help("Print trace output for state-machine arms and function calls")
-        .action(ArgAction::SetTrue))))
+        .action(ArgAction::SetTrue)))
     .subcommand(Command::new("serve")
       .about("Serve Mech program over an HTTP server.")
       .arg(Arg::new("mech_serve_file_paths")
@@ -333,8 +333,7 @@ async fn main() -> Result<(), MechError> {
         .short('r')
         .long("repl")
         .help("Start REPL")
-        .action(ArgAction::SetTrue))
-    .args(cli_host_capability_args());
+        .action(ArgAction::SetTrue));
 
   let cli_command = add_cli_host_capability_args(cli_command);
 
@@ -702,14 +701,17 @@ async fn main() -> Result<(), MechError> {
     let mut run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
       run_matches
         .get_many::<String>("mech_run_paths")
-        .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
+        .map_or(vec![], |files| {
+          files
+            .filter(|file| !file.starts_with(':'))
+            .map(|file| file.to_string())
+            .collect()
+        })
     } else if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
       m.map(|s| s.to_string()).collect()
     } else {
       vec![]
     };
-    run_inputs.extend(cli_host_capability_path_values(&cli_matches, run_matches));
-
     let run_debug_flag = debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
     let run_trace_flag = trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
     let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -80,7 +80,8 @@ use mech::cli::capabilities;
 use mech::cli::config;
 #[cfg(feature = "run")]
 use mech::cli::run::{
-  cli_host_capability_args, effective_run_runtime_config, new_cli_runtime, run_cli_source,
+  cli_host_capability_args, cli_host_capability_selection, effective_run_runtime_config,
+  new_cli_runtime, run_cli_source,
 };
 
 
@@ -699,12 +700,6 @@ async fn main() -> Result<(), MechError> {
     let run_debug_flag = debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
     let run_trace_flag = trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
     let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);
-    let run_deny_cli_env = cli_matches.get_flag("deny_cli_env")
-      || run_matches.map(|m| m.get_flag("deny_cli_env")).unwrap_or(false);
-    let run_deny_cli_stdout = cli_matches.get_flag("deny_cli_stdout")
-      || run_matches.map(|m| m.get_flag("deny_cli_stdout")).unwrap_or(false);
-    let run_deny_cli_stderr = cli_matches.get_flag("deny_cli_stderr")
-      || run_matches.map(|m| m.get_flag("deny_cli_stderr")).unwrap_or(false);
     let run_rounds_per_step = run_matches
       .and_then(|m| m.get_one::<String>("rounds-per-step"))
       .and_then(|s| s.parse::<usize>().ok())
@@ -725,13 +720,10 @@ async fn main() -> Result<(), MechError> {
     )?;
     repl_runtime_config = Some(runtime_config.clone());
 
+    let cli_capability_selection = cli_host_capability_selection(&cli_matches, run_matches);
     let cli_grants = config::effective_cli_host_grants(
       loaded_config.as_ref(),
-      config::CliHostGrantAttenuation {
-        deny_env: run_deny_cli_env,
-        deny_stdout: run_deny_cli_stdout,
-        deny_stderr: run_deny_cli_stderr,
-      },
+      cli_capability_selection,
     )?;
 
     let mut runtime = new_cli_runtime(runtime_config, &cli_grants)?;

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -2,42 +2,45 @@
 #![allow(warnings)]
 use mech::*;
 use mech_core::*;
+use mech_syntax::parser;
 #[cfg(feature = "run")]
 use mech_host_cli::{CliResourceProvider, StdCliBackend};
-use mech_syntax::parser;
 
 #[cfg(feature = "run")]
 use mech_runtime::{
-    MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
-    RuntimeEvent, RuntimeEventKind,
+  MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
+  RuntimeEvent, RuntimeEventKind,
 };
 #[cfg(feature = "serve")]
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
-use std::env;
-use std::fs;
-use std::io;
 use std::time::Instant;
+use std::fs;
+use std::env;
+use std::io;
 
-use ariadne::{Color, Label, Report, ReportKind, sources};
-use clap::{Arg, ArgAction, Command};
 use colored::*;
-use crossterm::{ExecutableCommand, QueueableCommand, cursor, style::Print, terminal};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use serde_json;
-use std::ffi::OsStr;
-use std::io::{BufReader, BufWriter, Write, stdout};
-use std::panic;
-use std::path::Path;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
-use tabled::{
-    Tabled,
-    builder::Builder,
-    settings::{Alignment, Modify, Panel, Span, Style, object::Rows},
+use std::io::{Write, BufReader, BufWriter, stdout};
+use crossterm::{
+  ExecutableCommand, QueueableCommand,
+  terminal, cursor, style::Print,
 };
+use ariadne::{Report, ReportKind, Label, Color, sources};
+use clap::{Arg, ArgAction, Command};
+use std::path::PathBuf;
+use tabled::{
+  builder::Builder,
+  settings::{object::Rows,Panel, Span, Alignment, Modify, Style},
+  Tabled,
+};
+use indicatif::{ProgressBar, ProgressStyle, MultiProgress};
+use serde_json;
+use std::panic;
+use std::sync::{Arc, Mutex};
+use std::path::Path;
+use std::ffi::OsStr;
+use std::time::Duration;
+use std::thread;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -63,18 +66,15 @@ static STYLESHEET: &str = "No Embedded Stylesheet";
 
 #[derive(Debug, Clone)]
 pub struct Utf8ConversionError {
-    pub source_error: String,
+  pub source_error: String
 }
 impl MechErrorKind for Utf8ConversionError {
-    fn name(&self) -> &str {
-        "Utf8ConversionError"
-    }
-    fn message(&self) -> String {
-        format!(
-            "Failed to convert bytes into UTF-8 string: {}",
-            self.source_error
-        )
-    }
+  fn name(&self) -> &str {
+    "Utf8ConversionError"
+  }
+  fn message(&self) -> String {
+    format!("Failed to convert bytes into UTF-8 string: {}", self.source_error)
+  }
 }
 
 #[cfg(feature = "bundle_web")]
@@ -85,195 +85,182 @@ use mech::cli::capabilities;
 #[cfg(any(feature = "serve", feature = "run"))]
 use mech::cli::config;
 
-async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
-    if paths.is_empty() {
-        let stylesheet = read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?;
-        return String::from_utf8(stylesheet).map_err(|e| {
-            MechError::new(
-                Utf8ConversionError {
-                    source_error: e.to_string(),
-                },
-                None,
-            )
-            .with_compiler_loc()
-        });
-    }
 
-    let mut combined = String::new();
-    for path in paths {
-        let stylesheet = match std::fs::read(path) {
-            Ok(content) => {
-                println!("Using stylesheet: {}", path);
-                content
-            }
-            Err(_) => {
-                println!("\nStylesheet not found:\n  {}", path);
-                read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?
-            }
-        };
-        let stylesheet_str = String::from_utf8(stylesheet).map_err(|e| {
-            MechError::new(
-                Utf8ConversionError {
-                    source_error: e.to_string(),
-                },
-                None,
-            )
-            .with_compiler_loc()
-        })?;
-        if !combined.is_empty() {
-            combined.push('\n');
-        }
-        combined.push_str(&stylesheet_str);
+async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
+  if paths.is_empty() {
+    let stylesheet = read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?;
+    return String::from_utf8(stylesheet)
+      .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc());
+  }
+
+  let mut combined = String::new();
+  for path in paths {
+    let stylesheet = match std::fs::read(path) {
+      Ok(content) => {
+        println!("Using stylesheet: {}", path);
+        content
+      }
+      Err(_) => {
+        println!("\nStylesheet not found:\n  {}", path);
+        read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?
+      }
+    };
+    let stylesheet_str = String::from_utf8(stylesheet)
+      .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc())?;
+    if !combined.is_empty() {
+      combined.push('\n');
     }
-    Ok(combined)
+    combined.push_str(&stylesheet_str);
+  }
+  Ok(combined)
 }
 
 #[cfg(feature = "run")]
 fn new_cli_runtime(
-    config: RuntimeConfig,
-    cli_grants: &config::EffectiveCliHostGrants,
+  config: RuntimeConfig,
+  cli_grants: &config::EffectiveCliHostGrants,
 ) -> MResult<MechRuntime> {
-    let mut runtime = RuntimeBuilder::new()
-        .config(config)
-        .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
-        .build()?;
+  let mut runtime = RuntimeBuilder::new()
+    .config(config)
+    .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
+    .build()?;
 
-    grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
+  grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
 
-    Ok(runtime)
+  Ok(runtime)
 }
 
 #[cfg(feature = "run")]
 fn effective_run_runtime_config(
-    loaded_config: Option<&mech::LoadedMechConfig>,
-    name: String,
-    debug_enabled: bool,
-    trace_enabled: bool,
-    profile_enabled: bool,
-    rounds_per_step: Option<usize>,
+  loaded_config: Option<&mech::LoadedMechConfig>,
+  name: String,
+  debug_enabled: bool,
+  trace_enabled: bool,
+  profile_enabled: bool,
+  rounds_per_step: Option<usize>,
 ) -> MResult<RuntimeConfig> {
-    let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+  let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
 
-    let mut config = mech::apply_runtime_config_patch(
-        RuntimeConfig::default(),
-        loaded_config
-            .as_ref()
-            .map(|loaded| &loaded.document.runtime)
-            .unwrap_or(&default_runtime_patch),
-    )?;
+  let mut config = mech::apply_runtime_config_patch(
+    RuntimeConfig::default(),
+    loaded_config
+      .as_ref()
+      .map(|loaded| &loaded.document.runtime)
+      .unwrap_or(&default_runtime_patch),
+  )?;
 
-    config.name = name;
+  config.name = name;
 
-    if debug_enabled {
-        config.diagnostics.debug_enabled = true;
-    }
+  if debug_enabled {
+    config.diagnostics.debug_enabled = true;
+  }
 
-    if trace_enabled {
-        config.diagnostics.trace_enabled = true;
-    }
+  if trace_enabled {
+    config.diagnostics.trace_enabled = true;
+  }
 
-    if profile_enabled {
-        config.diagnostics.profile_enabled = true;
-    }
+  if profile_enabled {
+    config.diagnostics.profile_enabled = true;
+  }
 
-    if let Some(rounds_per_step) = rounds_per_step {
-        config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
-    }
+  if let Some(rounds_per_step) = rounds_per_step {
+    config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
+  }
 
-    config.validate()?;
-    Ok(config)
+  config.validate()?;
+  Ok(config)
 }
 
 #[cfg(feature = "run")]
 fn print_run_runtime_events(events: &[RuntimeEvent]) {
-    for event in events {
-        match &event.kind {
-            RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
-                println!("Cycle Time: {} ns", duration_ns);
-            }
-            _ => {}
-        }
+  for event in events {
+    match &event.kind {
+      RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
+        println!("Cycle Time: {} ns", duration_ns);
+      }
+      _ => {}
     }
+  }
 }
 
 #[cfg(feature = "run")]
 fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
-    let mut context = runtime.runtime_context()?;
-    let result = runtime.run_string_with_context(&mut context, source);
-    print_run_runtime_events(&context.events);
-    result
+  let mut context = runtime.runtime_context()?;
+  let result = runtime.run_string_with_context(&mut context, source);
+  print_run_runtime_events(&context.events);
+  result
 }
 
 #[cfg(feature = "run")]
 fn grant_cli_runner_capabilities(
-    runtime: &mut MechRuntime,
-    grants: &config::EffectiveCliHostGrants,
+  runtime: &mut MechRuntime,
+  grants: &config::EffectiveCliHostGrants,
 ) -> MResult<()> {
-    let subject = runtime.runtime_context()?.subject;
+  let subject = runtime.runtime_context()?.subject;
 
-    if !grants.env_read_paths.is_empty() {
-        runtime.grant_capability(RuntimeCapabilityGrant {
-            subject: subject.clone(),
-            resource: "cli://env".to_string(),
-            operations: vec![RuntimeCapabilityOperation::Read],
-            paths: grants.env_read_paths.clone(),
-        })?;
-    }
+  if !grants.env_read_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://env".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: grants.env_read_paths.clone(),
+    })?;
+  }
 
-    if !grants.stdout_write_paths.is_empty() {
-        runtime.grant_capability(RuntimeCapabilityGrant {
-            subject: subject.clone(),
-            resource: "cli://stdout".to_string(),
-            operations: vec![RuntimeCapabilityOperation::Write],
-            paths: grants.stdout_write_paths.clone(),
-        })?;
-    }
+  if !grants.stdout_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://stdout".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stdout_write_paths.clone(),
+    })?;
+  }
 
-    if !grants.stderr_write_paths.is_empty() {
-        runtime.grant_capability(RuntimeCapabilityGrant {
-            subject,
-            resource: "cli://stderr".to_string(),
-            operations: vec![RuntimeCapabilityOperation::Write],
-            paths: grants.stderr_write_paths.clone(),
-        })?;
-    }
+  if !grants.stderr_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://stderr".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stderr_write_paths.clone(),
+    })?;
+  }
 
-    Ok(())
+  Ok(())
 }
 
 fn cli_host_capability_args() -> Vec<Arg> {
-    vec![
-        Arg::new("deny_cli_env")
-            .long("deny-cli-env")
-            .help("Deny cli://env read grants for this run")
-            .action(ArgAction::SetTrue),
-        Arg::new("deny_cli_stdout")
-            .long("deny-cli-stdout")
-            .help("Deny cli://stdout write grants for this run")
-            .action(ArgAction::SetTrue),
-        Arg::new("deny_cli_stderr")
-            .long("deny-cli-stderr")
-            .help("Deny cli://stderr write grants for this run")
-            .action(ArgAction::SetTrue),
-    ]
+  vec![
+    Arg::new("deny_cli_env")
+      .long("deny-cli-env")
+      .help("Deny cli://env read grants for this run")
+      .action(ArgAction::SetTrue),
+    Arg::new("deny_cli_stdout")
+      .long("deny-cli-stdout")
+      .help("Deny cli://stdout write grants for this run")
+      .action(ArgAction::SetTrue),
+    Arg::new("deny_cli_stderr")
+      .long("deny-cli-stderr")
+      .help("Deny cli://stderr write grants for this run")
+      .action(ArgAction::SetTrue),
+  ]
 }
 
 #[tokio::main]
 async fn main() -> Result<(), MechError> {
-    /*panic::set_hook(Box::new(|panic_info| {
-      // do nothing.
-    }));*/
+  /*panic::set_hook(Box::new(|panic_info| {
+    // do nothing.
+  }));*/
 
-    let text_logo = r#"
+  let text_logo = r#"
   ┌─────────┐ ┌──────┐ ┌─┐ ┌──┐ ┌─┐  ┌─┐
   └───┐ ┌───┘ └──────┘ │ │ └┐ │ │ │  │ │
   ┌─┐ │ │ ┌─┐ ┌──────┐ │ │  └─┘ │ └─┐│ │
   │ │ │ │ │ │ │ ┌────┘ │ │  ┌─┐ │ ┌─┘│ │
   │ │ └─┘ │ │ │ └────┐ │ └──┘ │ │ │  │ │
-  └─┘     └─┘ └──────┘ └──────┘ └─┘  └─┘"#
-        .truecolor(246, 192, 78);
+  └─┘     └─┘ └──────┘ └──────┘ └─┘  └─┘"#.truecolor(246,192,78);
 
-    let super_3D_logo = r#"
+
+  let super_3D_logo = r#"
           _____                      _____                     _____                     _____
          ╱╲    ╲                    ╱╲    ╲                   ╱╲    ╲                   ╱╲    ╲
         ╱┊┊╲    ╲                  ╱┊┊╲    ╲                 ╱┊┊╲____╲                 ╱┊┊╲____╲
@@ -296,18 +283,19 @@ async fn main() -> Result<(), MechError> {
         ╲┊┊╱    ╱                  ╲╱____╱                   ╲╱____╱                   ╲╱____╱
          ╲╱____╱"#.truecolor(246,192,78);
 
-    let micromika = "╭◉╮".truecolor(246, 192, 78);
-    let micromika_point = "╭◉─".truecolor(246, 192, 78);
-    let micromika_hello = "╭◉╯".truecolor(246, 192, 78);
-    let help_cmd = ":help".bright_yellow();
-    let quit_cmd = ":quit".bright_yellow();
-    let ctrlc_cmd = ":ctrl+c".bright_yellow();
-    let mika_open = "⸢".bright_yellow();
-    let mika_close = "⸥".bright_yellow();
 
-    let about = format!("{}", text_logo);
+  let micromika = "╭◉╮".truecolor(246,192,78);
+  let micromika_point = "╭◉─".truecolor(246,192,78);
+  let micromika_hello = "╭◉╯".truecolor(246,192,78);
+  let help_cmd = ":help".bright_yellow();
+  let quit_cmd = ":quit".bright_yellow();
+  let ctrlc_cmd = ":ctrl+c".bright_yellow();
+  let mika_open = "⸢".bright_yellow();
+  let mika_close = "⸥".bright_yellow();
 
-    let cli_command = Command::new("Mech")
+  let about = format!("{}", text_logo);
+
+  let cli_command = Command::new("Mech")
     .subcommand_precedence_over_arg(true)
     .version(VERSION)
     .author("Corey Montella corey@mech-lang.org")
@@ -469,965 +457,825 @@ async fn main() -> Result<(), MechError> {
         .action(ArgAction::SetTrue))
     .args(cli_host_capability_args());
 
-    #[cfg(feature = "bundle_web")]
-    let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
+  #[cfg(feature = "bundle_web")]
+  let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
 
-    #[cfg(feature = "serve")]
-    let cli_command = capabilities::add_filesystem_capability_args(cli_command);
+  #[cfg(feature = "serve")]
+  let cli_command = capabilities::add_filesystem_capability_args(cli_command);
 
-    #[cfg(any(feature = "serve", feature = "run"))]
-    let cli_command = config::add_config_args(cli_command);
+  #[cfg(any(feature = "serve", feature = "run"))]
+  let cli_command = config::add_config_args(cli_command);
 
-    #[cfg(all(feature = "bundle_web", not(feature = "serve")))]
-    let cli_command = bundle_web::add_config_args(cli_command);
+  #[cfg(all(feature = "bundle_web", not(feature = "serve")))]
+  let cli_command = bundle_web::add_config_args(cli_command);
 
-    let cli_matches = cli_command.get_matches();
+  let cli_matches = cli_command.get_matches();
 
-    let debug_flag = cli_matches.get_flag("debug");
-    let tree_flag = cli_matches.get_flag("tree");
-    let mut repl_flag = cli_matches.get_flag("repl");
-    let time_flag = cli_matches.get_flag("time");
-    let trace_flag = cli_matches.get_flag("trace");
-    let root_rounds_per_step = cli_matches
-        .get_one::<String>("rounds-per-step")
-        .and_then(|s| s.parse::<usize>().ok());
+  let debug_flag = cli_matches.get_flag("debug");
+  let tree_flag = cli_matches.get_flag("tree");
+  let mut repl_flag = cli_matches.get_flag("repl");
+  let time_flag = cli_matches.get_flag("time");
+  let trace_flag = cli_matches.get_flag("trace");
+  let root_rounds_per_step = cli_matches.get_one::<String>("rounds-per-step").and_then(|s| s.parse::<usize>().ok());
 
-    let shim_backup_url =
-        "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/shim.html"
-            .to_string();
-    let stylesheet_backup_url =
-        "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css"
-            .to_string();
-    let wasm_backup_url = format!(
-        "https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm_bg.wasm.br",
-        VERSION
+  let shim_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/shim.html".to_string();
+  let stylesheet_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css".to_string();
+  let wasm_backup_url = format!("https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm_bg.wasm.br", VERSION);
+  let js_backup_url = format!("https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm.js", VERSION);
+
+  // --------------------------------------------------------------------------
+  // Bundle Web
+  // --------------------------------------------------------------------------
+  #[cfg(feature = "bundle_web")]
+  if let Some(bundle_matches) = cli_matches.subcommand_matches("bundle-web") {
+    let badge = "[Mech Bundle]".truecolor(34, 204, 187);
+
+    let loaded = bundle_web::load_bundle_web_config(bundle_matches)?;
+    println!("{badge} Loading config… {}", loaded.path.display());
+
+    let options = bundle_web::effective_bundle_web_options(bundle_matches, loaded)?;
+    let result = mech::bundle_web_project(options)?;
+
+    println!("{badge} Bundle written: {}", result.output_dir.display());
+    println!("{badge} Sources bundled: {}", result.source_count);
+    return Ok(());
+  }
+
+  // --------------------------------------------------------------------------
+  // Serve
+  // --------------------------------------------------------------------------
+  #[cfg(feature = "serve")]
+  if let Some(serve_matches) = cli_matches.subcommand_matches("serve") {
+    let badge = "[Mech Server]".truecolor(34, 204, 187);
+    let error_badge = "[Error]".truecolor(246, 98, 78);
+
+    let loaded_config = config::load_cli_config(serve_matches)?;
+    let effective = config::effective_serve_options(serve_matches, loaded_config.as_ref())?;
+    let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+    let runtime_config = mech::apply_runtime_config_patch(
+      mech_runtime::RuntimeConfig::default(),
+      loaded_config
+        .as_ref()
+        .map(|loaded| &loaded.document.runtime)
+        .unwrap_or(&default_runtime_patch),
+    )?;
+    let host_config = loaded_config
+      .as_ref()
+      .map(|loaded| mech_host_browser::BrowserHostConfig::from_document_and_runtime(
+        &loaded.document,
+        &runtime_config,
+      ));
+    let config_shim_at_root = loaded_config
+      .as_ref()
+      .and_then(|loaded| loaded.document.serve.as_ref())
+      .and_then(|serve| serve.shim.as_ref())
+      .is_some()
+      && serve_matches.get_one::<String>("shim").is_none();
+    if let Some(loaded) = loaded_config.as_ref() {
+      println!("{badge} Loaded browser config grants: {}", loaded.document.browser.grants().len());
+    }
+
+    let full_address = format!("{}:{}", effective.address, effective.port);
+    #[cfg(feature = "host_delegation_signing")]
+    let host_config_injection = serve_host_delegation_injection(
+      serve_matches,
+      loaded_config.as_ref(),
+      &runtime_config,
+      &full_address,
+    )?;
+    #[cfg(not(feature = "host_delegation_signing"))]
+    let host_config_injection = None;
+    let mech_paths = effective.paths;
+    let stylesheet_paths = effective.stylesheet_paths;
+    let wasm_pkg = effective.wasm_pkg.as_str();
+    let shim_path = effective.shim_path.as_str();
+
+    let wasm_path = format!("{wasm_pkg}/mech_wasm_bg.wasm.br");
+    let js_path = format!("{wasm_pkg}/mech_wasm.js");
+
+    println!("{badge} Loading resources…");
+
+    print!("{badge} Loading stylesheet…");
+    let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
+
+    print!("{badge} Loading HTML shim…");
+    let shim = read_or_download(
+      shim_path,
+      &shim_backup_url,
+      Some(SHIMHTML.as_bytes()),
+    )
+    .await?;
+
+    let shim_str = String::from_utf8(shim)
+      .map_err(|e| {
+        MechError::new(
+          Utf8ConversionError {
+            source_error: e.to_string(),
+          },
+          None,
+        )
+        .with_compiler_loc()
+      })?;
+
+    print!("{badge} Loading WASM…");
+    let wasm = read_or_download(
+      &wasm_path,
+      &wasm_backup_url,
+      Some(MECHWASM),
+    )
+    .await?;
+
+    print!("{badge} Loading JS…");
+    let js = read_or_download(
+      &js_path,
+      &js_backup_url,
+      Some(MECHJS),
+    )
+    .await?;
+
+    let authority = capabilities::build_mech_filesystem_authority(
+      serve_matches,
+      loaded_config.as_ref(),
+      &badge,
+    )?;
+
+    let mut server = MechServer::new_with_runtime_config_and_host_config(
+      "Mech Server".to_string(),
+      full_address,
+      stylesheet_str,
+      shim_str,
+      wasm,
+      js,
+      authority,
+      runtime_config,
+      host_config,
+      host_config_injection,
+      config_shim_at_root,
     );
-    let js_backup_url = format!(
-        "https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm.js",
-        VERSION
-    );
 
-    // --------------------------------------------------------------------------
-    // Bundle Web
-    // --------------------------------------------------------------------------
-    #[cfg(feature = "bundle_web")]
-    if let Some(bundle_matches) = cli_matches.subcommand_matches("bundle-web") {
-        let badge = "[Mech Bundle]".truecolor(34, 204, 187);
+    server.init().await?;
 
-        let loaded = bundle_web::load_bundle_web_config(bundle_matches)?;
-        println!("{badge} Loading config… {}", loaded.path.display());
-
-        let options = bundle_web::effective_bundle_web_options(bundle_matches, loaded)?;
-        let result = mech::bundle_web_project(options)?;
-
-        println!("{badge} Bundle written: {}", result.output_dir.display());
-        println!("{badge} Sources bundled: {}", result.source_count);
-        return Ok(());
+    if let Err(err) = server.load_workspace(&mech_paths) {
+      println!("{error_badge} {err:#?}");
+      std::process::exit(1);
     }
 
-    // --------------------------------------------------------------------------
-    // Serve
-    // --------------------------------------------------------------------------
-    #[cfg(feature = "serve")]
-    if let Some(serve_matches) = cli_matches.subcommand_matches("serve") {
-        let badge = "[Mech Server]".truecolor(34, 204, 187);
-        let error_badge = "[Error]".truecolor(246, 98, 78);
+    println!("{badge} Sources loaded.");
 
-        let loaded_config = config::load_cli_config(serve_matches)?;
-        let effective = config::effective_serve_options(serve_matches, loaded_config.as_ref())?;
-        let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
-        let runtime_config = mech::apply_runtime_config_patch(
-            mech_runtime::RuntimeConfig::default(),
-            loaded_config
-                .as_ref()
-                .map(|loaded| &loaded.document.runtime)
-                .unwrap_or(&default_runtime_patch),
-        )?;
-        let host_config = loaded_config.as_ref().map(|loaded| {
-            mech_host_browser::BrowserHostConfig::from_document_and_runtime(
-                &loaded.document,
-                &runtime_config,
-            )
-        });
-        let config_shim_at_root = loaded_config
-            .as_ref()
-            .and_then(|loaded| loaded.document.serve.as_ref())
-            .and_then(|serve| serve.shim.as_ref())
-            .is_some()
-            && serve_matches.get_one::<String>("shim").is_none();
-        if let Some(loaded) = loaded_config.as_ref() {
-            println!(
-                "{badge} Loaded browser config grants: {}",
-                loaded.document.browser.grants().len()
-            );
+    server.serve().await?;
+  }
+
+  // --------------------------------------------------------------------------
+  // Test
+  // --------------------------------------------------------------------------
+  #[cfg(all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool"))]
+  if let Some(matches) = cli_matches.subcommand_matches("test") {
+    let mech_paths: Vec<String> = matches
+      .get_many::<String>("mech_test_file_paths")
+      .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
+    let output_path = matches.get_one::<String>("output_path").cloned();
+    let verbose = matches.get_flag("verbose");
+    let exit_code = run_mech_tests(mech_paths, tree_flag, debug_flag, time_flag, trace_flag, output_path, verbose)?;
+    std::process::exit(exit_code);
+  }
+
+  // --------------------------------------------------------------------------
+  // Build
+  // --------------------------------------------------------------------------
+  #[cfg(feature = "build")]
+  if let Some(matches) = cli_matches.subcommand_matches("build") {
+    let mech_paths: Vec<String> = matches.get_many::<String>("mech_build_file_paths").map_or(vec![], |files| files.map(|file| file.to_string()).collect());
+    let output_path = PathBuf::from(matches.get_one::<String>("output_path").cloned().unwrap_or(".".to_string()));
+    let debug_flag = matches.get_flag("debug");
+    let rounds_per_step = matches.get_one::<String>("rounds-per-step").and_then(|s| s.parse::<usize>().ok()).unwrap_or(10_000);
+    // Create the directory html_output_path
+    if output_path != PathBuf::from(".") {
+      match fs::create_dir_all(&output_path) {
+        Ok(_) => {
+          println!("{} Directory created: {}", "[Created]".truecolor(153,221,85), output_path.display());
         }
-
-        let full_address = format!("{}:{}", effective.address, effective.port);
-        #[cfg(feature = "host_delegation_signing")]
-        let host_config_injection = serve_host_delegation_injection(
-            serve_matches,
-            loaded_config.as_ref(),
-            &runtime_config,
-            &full_address,
-        )?;
-        #[cfg(not(feature = "host_delegation_signing"))]
-        let host_config_injection = None;
-        let mech_paths = effective.paths;
-        let stylesheet_paths = effective.stylesheet_paths;
-        let wasm_pkg = effective.wasm_pkg.as_str();
-        let shim_path = effective.shim_path.as_str();
-
-        let wasm_path = format!("{wasm_pkg}/mech_wasm_bg.wasm.br");
-        let js_path = format!("{wasm_pkg}/mech_wasm.js");
-
-        println!("{badge} Loading resources…");
-
-        print!("{badge} Loading stylesheet…");
-        let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
-
-        print!("{badge} Loading HTML shim…");
-        let shim = read_or_download(shim_path, &shim_backup_url, Some(SHIMHTML.as_bytes())).await?;
-
-        let shim_str = String::from_utf8(shim).map_err(|e| {
-            MechError::new(
-                Utf8ConversionError {
-                    source_error: e.to_string(),
-                },
-                None,
-            )
-            .with_compiler_loc()
-        })?;
-
-        print!("{badge} Loading WASM…");
-        let wasm = read_or_download(&wasm_path, &wasm_backup_url, Some(MECHWASM)).await?;
-
-        print!("{badge} Loading JS…");
-        let js = read_or_download(&js_path, &js_backup_url, Some(MECHJS)).await?;
-
-        let authority = capabilities::build_mech_filesystem_authority(
-            serve_matches,
-            loaded_config.as_ref(),
-            &badge,
-        )?;
-
-        let mut server = MechServer::new_with_runtime_config_and_host_config(
-            "Mech Server".to_string(),
-            full_address,
-            stylesheet_str,
-            shim_str,
-            wasm,
-            js,
-            authority,
-            runtime_config,
-            host_config,
-            host_config_injection,
-            config_shim_at_root,
-        );
-
-        server.init().await?;
-
-        if let Err(err) = server.load_workspace(&mech_paths) {
-            println!("{error_badge} {err:#?}");
-            std::process::exit(1);
+        Err(err) => {
+          println!("Error creating directory: {:?}", err);
         }
-
-        println!("{badge} Sources loaded.");
-
-        server.serve().await?;
+      }
     }
 
-    // --------------------------------------------------------------------------
-    // Test
-    // --------------------------------------------------------------------------
-    #[cfg(all(
-        feature = "run",
-        feature = "variable_define",
-        feature = "invariant_define",
-        feature = "symbol_table",
-        feature = "bool"
-    ))]
-    if let Some(matches) = cli_matches.subcommand_matches("test") {
-        let mech_paths: Vec<String> = matches
-            .get_many::<String>("mech_test_file_paths")
-            .map_or(vec![".".to_string()], |files| {
-                files.map(|file| file.to_string()).collect()
-            });
-        let output_path = matches.get_one::<String>("output_path").cloned();
-        let verbose = matches.get_flag("verbose");
-        let exit_code = run_mech_tests(
-            mech_paths,
-            tree_flag,
-            debug_flag,
-            time_flag,
-            trace_flag,
-            output_path,
-            verbose,
-        )?;
-        std::process::exit(exit_code);
-    }
-
-    // --------------------------------------------------------------------------
-    // Build
-    // --------------------------------------------------------------------------
-    #[cfg(feature = "build")]
-    if let Some(matches) = cli_matches.subcommand_matches("build") {
-        let mech_paths: Vec<String> = matches
-            .get_many::<String>("mech_build_file_paths")
-            .map_or(vec![], |files| files.map(|file| file.to_string()).collect());
-        let output_path = PathBuf::from(
-            matches
-                .get_one::<String>("output_path")
-                .cloned()
-                .unwrap_or(".".to_string()),
-        );
-        let debug_flag = matches.get_flag("debug");
-        let rounds_per_step = matches
-            .get_one::<String>("rounds-per-step")
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(10_000);
-        // Create the directory html_output_path
-        if output_path != PathBuf::from(".") {
-            match fs::create_dir_all(&output_path) {
-                Ok(_) => {
-                    println!(
-                        "{} Directory created: {}",
-                        "[Created]".truecolor(153, 221, 85),
-                        output_path.display()
-                    );
-                }
-                Err(err) => {
-                    println!("Error creating directory: {:?}", err);
-                }
-            }
-        }
-
-        let uuid = generate_uuid();
-        let mut program = MechProgram::new(MechProgramConfig {
-            name: format!("program-{}", uuid),
-            environment: MechProgramEnvironment::default(),
-        });
-        let _ = tree_flag;
-        let _ = trace_flag;
-        program.configure(debug_flag, trace_flag, time_flag, rounds_per_step);
-        for path in mech_paths {
-            let source = std::fs::read_to_string(&path)?;
-            let _ = program.run_string(&source)?;
-        }
-
-        let bytecode = program.interpreter_mut().compile()?;
-
-        let mut output_file = output_path.join("output.mecb");
-
-        let mut f = std::fs::File::create(&output_file)?;
-        f.write_all(&bytecode)?;
-        f.flush()?;
-
-        // print debug info for the context
-        if debug_flag {
-            println!(
-                "{} Bytecode Size: {:#?} bytes",
-                "[Debug]".truecolor(246, 192, 78),
-                &program.interpreter().context
-            );
-        }
-
-        println!(
-            "{} Mech bytecode written to: {}",
-            "[Output]".truecolor(153, 221, 85),
-            output_file.display()
-        );
-
-        return Ok(());
-    }
-
-    // --------------------------------------------------------------------------
-    // Format
-    // --------------------------------------------------------------------------
-    #[cfg(feature = "formatter")]
-    if let Some(matches) = cli_matches.subcommand_matches("format") {
-        let badge = "[Mech Formatter]".truecolor(34, 204, 187);
-        let html_flag = matches.get_flag("html");
-        let stylesheet_paths: Vec<String> = matches
-            .get_many::<String>("stylesheet")
-            .map_or(vec![], |paths| paths.map(|path| path.to_string()).collect());
-
-        let shim_path = matches
-            .get_one::<String>("shim")
-            .cloned()
-            .unwrap_or("".to_string());
-
-        let output_path = PathBuf::from(
-            matches
-                .get_one::<String>("output_path")
-                .cloned()
-                .unwrap_or(".".to_string()),
-        );
-        let is_output_file = output_path.extension().is_some();
-
-        let mech_paths: Vec<String> = matches
-            .get_many::<String>("mech_format_file_paths")
-            .map_or(vec![], |files| files.map(|file| file.to_string()).collect());
-
-        // If the user provided exactly one path
-        if mech_paths.len() == 1 {
-            let input_path = PathBuf::from(&mech_paths[0]);
-            if input_path.is_dir() && is_output_file {
-                eprintln!(
-                    "{} Cannot write directory `{}` into single output file `{}`. Provide a directory for --out instead.",
-                    "[Error]".truecolor(246, 98, 78),
-                    input_path.display(),
-                    output_path.display()
-                );
-                return Ok(());
-            }
-        }
-        println!("{} Loading resources…", badge);
-
-        // Load stylesheet
-        print!("{} Loading stylesheet…", badge);
-        let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
-
-        // Load shim HTML
-        print!("{} Loading HTML shim…", badge);
-        let shim =
-            read_or_download(&shim_path, &shim_backup_url, Some(SHIMHTML.as_bytes())).await?;
-        let shim_str = String::from_utf8(shim).map_err(|e| {
-            MechError::new(
-                Utf8ConversionError {
-                    source_error: e.to_string(),
-                },
-                None,
-            )
-            .with_compiler_loc()
-        })?;
-
-        let mut loaded_sources: Vec<(PathBuf, MechSourceCode)> = Vec::new();
-        for path in mech_paths {
-            let pb = PathBuf::from(&path);
-            let source = std::fs::read_to_string(&pb)?;
-            let code = match pb.extension().and_then(|e| e.to_str()) {
-                Some("html") => MechSourceCode::Html(source),
-                _ => MechSourceCode::String(source),
-            };
-            loaded_sources.push((pb, code));
-        }
-
-        // Only create directory if output_path is not a file
-        if !is_output_file && output_path != PathBuf::from(".") {
-            match fs::create_dir_all(&output_path) {
-                Ok(_) => println!(
-                    "{} Directory created: {}",
-                    "[Created]".truecolor(153, 221, 85),
-                    output_path.display()
-                ),
-                Err(err) => println!("Error creating directory: {:?}", err),
-            }
-        }
-
-        // HTML mode
-        if html_flag {
-            let html_items: Vec<_> = loaded_sources
-                .iter()
-                .filter_map(|(p, src)| {
-                    if let MechSourceCode::Html(content) = src {
-                        Some((p, content))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let is_single_html = html_items.len() == 1;
-
-            if is_output_file && is_single_html {
-                // write ONLY HTML result to output file
-                let (_, content) = html_items[0];
-                save_to_file(output_path, content)?;
-            } else {
-                // otherwise produce multiple output files
-                for (path, content) in html_items {
-                    let filename = path.with_extension("html");
-                    let output_file = if is_output_file {
-                        output_path.clone()
-                    } else {
-                        output_path.join(filename)
-                    };
-                    save_to_file(output_file, content)?;
-                }
-            }
-        } else {
-            // Raw source mode
-            for (filename, mech_src) in loaded_sources {
-                let content = mech_src.to_string();
-                let output_file = if is_output_file {
-                    output_path.clone()
-                } else {
-                    output_path.join(filename)
-                };
-                save_to_file(output_file, &content)?;
-            }
-        }
-
-        return Ok(());
-    }
-
-    // --------------------------------------------------------------------------
-    // Run
-    // --------------------------------------------------------------------------
-    let mut caught_inturrupts = Arc::new(Mutex::new(0));
-    #[cfg(feature = "run")]
     let uuid = generate_uuid();
-    #[cfg(feature = "run")]
-    let mut repl_runtime_config: Option<RuntimeConfig> = None;
-
-    #[cfg(feature = "run")]
-    {
-        let run_matches = cli_matches.subcommand_matches("run");
-        let explicit_run_command = run_matches.is_some();
-        let run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
-            run_matches
-                .get_many::<String>("mech_run_paths")
-                .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
-        } else if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
-            m.map(|s| s.to_string()).collect()
-        } else {
-            vec![]
-        };
-
-        let run_debug_flag =
-            debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
-        let run_trace_flag =
-            trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
-        let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);
-        let run_deny_cli_env = cli_matches.get_flag("deny_cli_env")
-            || run_matches
-                .map(|m| m.get_flag("deny_cli_env"))
-                .unwrap_or(false);
-        let run_deny_cli_stdout = cli_matches.get_flag("deny_cli_stdout")
-            || run_matches
-                .map(|m| m.get_flag("deny_cli_stdout"))
-                .unwrap_or(false);
-        let run_deny_cli_stderr = cli_matches.get_flag("deny_cli_stderr")
-            || run_matches
-                .map(|m| m.get_flag("deny_cli_stderr"))
-                .unwrap_or(false);
-        let run_rounds_per_step = run_matches
-            .and_then(|m| m.get_one::<String>("rounds-per-step"))
-            .and_then(|s| s.parse::<usize>().ok())
-            .or(root_rounds_per_step);
-
-        let any_look_like_paths = run_inputs.iter().any(|p| is_intended_path(p));
-        let config_matches = run_matches.unwrap_or(&cli_matches);
-        let config_inputs = if any_look_like_paths {
-            run_inputs.as_slice()
-        } else {
-            &[]
-        };
-        let loaded_config = config::load_run_cli_config(config_matches, config_inputs)?;
-
-        let runtime_config = effective_run_runtime_config(
-            loaded_config.as_ref(),
-            format!("program-{}", uuid),
-            run_debug_flag,
-            run_trace_flag,
-            run_time_flag,
-            run_rounds_per_step,
-        )?;
-        repl_runtime_config = Some(runtime_config.clone());
-
-        let cli_grants = config::effective_cli_host_grants(
-            loaded_config.as_ref(),
-            config::CliHostGrantAttenuation {
-                deny_env: run_deny_cli_env,
-                deny_stdout: run_deny_cli_stdout,
-                deny_stderr: run_deny_cli_stderr,
-            },
-        )?;
-
-        let mut runtime = new_cli_runtime(runtime_config, &cli_grants)?;
-
-        if !run_inputs.is_empty() && !any_look_like_paths {
-            let joined = run_inputs.join(" ");
-            match run_cli_source(&mut runtime, joined.trim()) {
-                Ok(r) => {
-                    println!("{}", r.kind());
-                    #[cfg(feature = "pretty_print")]
-                    println!("{}", r.pretty_print());
-                    #[cfg(not(feature = "pretty_print"))]
-                    println!("{:#?}", r);
-                    std::process::exit(0);
-                }
-                Err(err) => {
-                    println!("{} {:#?}", "[Error]".truecolor(246, 98, 78), err);
-                    std::process::exit(1);
-                }
-            }
-        }
-
-        let options = config::effective_run_options(
-            run_inputs,
-            loaded_config.as_ref(),
-            explicit_run_command,
-        )?;
-
-        let result: MResult<Value> = if let Some(options) = options {
-            let mut last = Value::Empty;
-            for p in &options.paths {
-                let src = std::fs::read_to_string(p)?;
-                last = run_cli_source(&mut runtime, &src)?;
-            }
-            Ok(last)
-        } else {
-            repl_flag = true;
-            Ok(Value::Empty)
-        };
-
-        if !repl_flag {
-            match &result {
-                Ok(r) => {
-                    println!("{}", r.kind());
-                    #[cfg(feature = "pretty_print")]
-                    println!("{}", r.pretty_print());
-                    #[cfg(not(feature = "pretty_print"))]
-                    println!("{:#?}", r);
-                    std::process::exit(0);
-                }
-                Err(err) => {
-                    print_mech_error(err);
-                    std::process::exit(1);
-                }
-            };
-        }
-
-        #[cfg(windows)]
-        control::set_virtual_terminal(true).unwrap();
-        clc();
-        let mut stdo = stdout();
-        stdo.execute(Print(text_logo));
-        stdo.execute(cursor::MoveToNextLine(1));
-        println!(
-            "\n                {}                ",
-            format!("v{}", VERSION).truecolor(246, 192, 78)
-        );
-        println!("           {}           \n", "www.mech-lang.org");
-        let intro_message = format!(
-            "{}Enter {} for a list of all commands.{}\n",
-            mika_open, help_cmd, mika_close
-        );
-        println!("{} {}", micromika, intro_message);
-
-        // Catch Ctrl-C a couple times before quitting
-        let mut ci = caught_inturrupts.clone();
-        ctrlc::set_handler(move || {
-            println!("{}", ctrlc_cmd);
-            let mut caught_inturrupts = ci.lock().unwrap();
-            *caught_inturrupts += 1;
-            if *caught_inturrupts >= 3 {
-                let final_state = ProgressBar::new_spinner();
-                let completed_style = ProgressStyle::with_template("\n{spinner:.yellow} {msg}")
-                    .unwrap()
-                    .tick_strings(MICROMIKA_WAVE);
-                final_state.set_style(completed_style);
-                final_state.set_message(format!("{}Okay cya!{}\n", mika_open, mika_close));
-                for _ in 0..MICROMIKA_WAVE.len() - 1 {
-                    thread::sleep(Duration::from_millis(100));
-                    final_state.tick();
-                }
-                std::process::exit(0);
-            }
-            println!(
-                "\n{} {}Enter {} to terminate this REPL session.{}\n",
-                micromika_point, mika_open, quit_cmd, mika_close
-            );
-            print_prompt();
-        })
-        .expect("Error setting Ctrl+C handler");
+    let mut program = MechProgram::new(MechProgramConfig { name: format!("program-{}", uuid), environment: MechProgramEnvironment::default() });
+    let _ = tree_flag;
+    let _ = trace_flag;
+    program.configure(debug_flag, trace_flag, time_flag, rounds_per_step);
+    for path in mech_paths {
+      let source = std::fs::read_to_string(&path)?;
+      let _ = program.run_string(&source)?;
     }
 
-    // --------------------------------------------------------------------------
-    // REPL
-    // --------------------------------------------------------------------------
-    #[cfg(all(feature = "repl", feature = "run"))]
-    // TODO: move the REPL onto MechRuntime as a separate PR so CLI host contexts work interactively too.
-    let mut repl = {
-        let config = repl_runtime_config.unwrap_or_else(RuntimeConfig::default);
-        let mut repl_program = MechProgram::new(MechProgramConfig {
-            name: config.name.clone(),
-            environment: MechProgramEnvironment::default(),
-        });
-        repl_program.configure(
-            config.diagnostics.debug_enabled,
-            config.diagnostics.trace_enabled,
-            config.diagnostics.profile_enabled,
-            config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+    let bytecode = program.interpreter_mut().compile()?;
+
+    let mut output_file = output_path.join("output.mecb");
+
+    let mut f = std::fs::File::create(&output_file)?;
+    f.write_all(&bytecode)?;
+    f.flush()?;
+
+    // print debug info for the context
+    if debug_flag {
+      println!("{} Bytecode Size: {:#?} bytes", "[Debug]".truecolor(246,192,78), &program.interpreter().context);
+    }
+
+    println!("{} Mech bytecode written to: {}", "[Output]".truecolor(153,221,85), output_file.display());
+
+    return Ok(());
+  }
+
+  // --------------------------------------------------------------------------
+  // Format
+  // --------------------------------------------------------------------------
+  #[cfg(feature = "formatter")]
+  if let Some(matches) = cli_matches.subcommand_matches("format") {
+    let badge = "[Mech Formatter]".truecolor(34, 204, 187);
+    let html_flag = matches.get_flag("html");
+    let stylesheet_paths: Vec<String> = matches
+        .get_many::<String>("stylesheet")
+        .map_or(vec![], |paths| paths.map(|path| path.to_string()).collect());
+
+    let shim_path = matches
+        .get_one::<String>("shim")
+        .cloned()
+        .unwrap_or("".to_string());
+
+    let output_path =
+        PathBuf::from(matches.get_one::<String>("output_path").cloned().unwrap_or(".".to_string()));
+    let is_output_file = output_path.extension().is_some();
+
+    let mech_paths: Vec<String> = matches
+        .get_many::<String>("mech_format_file_paths")
+        .map_or(vec![], |files| files.map(|file| file.to_string()).collect());
+
+    // If the user provided exactly one path
+    if mech_paths.len() == 1 {
+      let input_path = PathBuf::from(&mech_paths[0]);
+      if input_path.is_dir() && is_output_file {
+        eprintln!(
+          "{} Cannot write directory `{}` into single output file `{}`. Provide a directory for --out instead.",
+          "[Error]".truecolor(246,98,78),
+          input_path.display(),
+          output_path.display()
         );
-        MechRepl::from(repl_program)
+        return Ok(());
+      }
+    }
+    println!("{} Loading resources…", badge);
+
+    // Load stylesheet
+    print!("{} Loading stylesheet…", badge);
+    let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
+
+    // Load shim HTML
+    print!("{} Loading HTML shim…", badge);
+    let shim = read_or_download(&shim_path, &shim_backup_url, Some(SHIMHTML.as_bytes())).await?;
+    let shim_str = String::from_utf8(shim).map_err(|e| {
+      MechError::new(
+        Utf8ConversionError {
+          source_error: e.to_string(),
+        },
+        None,
+      )
+      .with_compiler_loc()
+    })?;
+
+    let mut loaded_sources: Vec<(PathBuf, MechSourceCode)> = Vec::new();
+    for path in mech_paths {
+      let pb = PathBuf::from(&path);
+      let source = std::fs::read_to_string(&pb)?;
+      let code = match pb.extension().and_then(|e| e.to_str()) {
+        Some("html") => MechSourceCode::Html(source),
+        _ => MechSourceCode::String(source),
+      };
+      loaded_sources.push((pb, code));
+    }
+
+    // Only create directory if output_path is not a file
+    if !is_output_file && output_path != PathBuf::from(".") {
+      match fs::create_dir_all(&output_path) {
+        Ok(_) => println!(
+          "{} Directory created: {}",
+          "[Created]".truecolor(153, 221, 85),
+          output_path.display()
+        ),
+        Err(err) => println!("Error creating directory: {:?}", err),
+      }
+    }
+
+    // HTML mode
+    if html_flag {
+      let html_items: Vec<_> = loaded_sources.iter().filter_map(|(p, src)| {
+        if let MechSourceCode::Html(content) = src {
+          Some((p, content))
+        } else {
+          None
+        }
+      }).collect();
+      let is_single_html = html_items.len() == 1;
+
+      if is_output_file && is_single_html {
+        // write ONLY HTML result to output file
+        let (_, content) = html_items[0];
+        save_to_file(output_path, content)?;
+      } else {
+        // otherwise produce multiple output files
+        for (path, content) in html_items {
+          let filename = path.with_extension("html");
+          let output_file = if is_output_file { output_path.clone() }
+                            else { output_path.join(filename) };
+          save_to_file(output_file, content)?;
+        }
+      }
+    } else {
+      // Raw source mode
+      for (filename, mech_src) in loaded_sources {
+        let content = mech_src.to_string();
+        let output_file = if is_output_file { output_path.clone() }
+                          else { output_path.join(filename) };
+        save_to_file(output_file, &content)?;
+      }
+    }
+
+    return Ok(());
+  }
+
+
+  // --------------------------------------------------------------------------
+  // Run
+  // --------------------------------------------------------------------------
+  let mut caught_inturrupts = Arc::new(Mutex::new(0));
+  #[cfg(feature = "run")]
+  let uuid = generate_uuid();
+  #[cfg(feature = "run")]
+  let mut repl_runtime_config: Option<RuntimeConfig> = None;
+
+  #[cfg(feature = "run")]
+  {
+    let run_matches = cli_matches.subcommand_matches("run");
+    let explicit_run_command = run_matches.is_some();
+    let run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
+      run_matches
+        .get_many::<String>("mech_run_paths")
+        .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
+    } else if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
+      m.map(|s| s.to_string()).collect()
+    } else {
+      vec![]
     };
-    #[cfg(all(feature = "repl", not(feature = "run")))]
-    let mut repl = MechRepl::from(MechProgram::new(MechProgramConfig {
-        name: format!("repl-{}", generate_uuid()),
-        environment: MechProgramEnvironment::default(),
-    }));
-    #[cfg(feature = "repl")]
-    'REPL: loop {
-        {
-            let mut ci = caught_inturrupts.lock().unwrap();
-            *ci = 0;
-        }
-        // Prompt the user for input
-        print_prompt();
-        let mut input = String::new();
-        io::stdin().read_line(&mut input).unwrap();
 
-        // Parse the input
-        if input.chars().nth(0) == Some(':') {
-            match parse_repl_command(&input.as_str()) {
-                Ok((_, repl_command)) => match repl.execute_repl_command(repl_command) {
-                    Ok(output) => {
-                        println!("{}", output);
-                    }
-                    Err(err) => {
-                        println!("!{:?}", err);
-                    }
-                },
-                Err(x) => {
-                    println!(
-                        "{} Unrecognized command: {}",
-                        "[Error]".truecolor(246, 98, 78),
-                        x
-                    );
-                }
-            }
-        } else if input.trim() == "" {
-            continue;
-        } else {
-            let cmd = ReplCommand::Code(vec![("repl".to_string(), MechSourceCode::String(input))]);
-            match repl.execute_repl_command(cmd) {
-                Ok(output) => {
-                    println!("{}", output);
-                }
-                Err(err) => {
-                    println!("(x)> {:#?}", err);
-                }
-            }
+    let run_debug_flag = debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
+    let run_trace_flag = trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
+    let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);
+    let run_deny_cli_env = cli_matches.get_flag("deny_cli_env")
+      || run_matches.map(|m| m.get_flag("deny_cli_env")).unwrap_or(false);
+    let run_deny_cli_stdout = cli_matches.get_flag("deny_cli_stdout")
+      || run_matches.map(|m| m.get_flag("deny_cli_stdout")).unwrap_or(false);
+    let run_deny_cli_stderr = cli_matches.get_flag("deny_cli_stderr")
+      || run_matches.map(|m| m.get_flag("deny_cli_stderr")).unwrap_or(false);
+    let run_rounds_per_step = run_matches
+      .and_then(|m| m.get_one::<String>("rounds-per-step"))
+      .and_then(|s| s.parse::<usize>().ok())
+      .or(root_rounds_per_step);
+
+    let any_look_like_paths = run_inputs.iter().any(|p| is_intended_path(p));
+    let config_matches = run_matches.unwrap_or(&cli_matches);
+    let config_inputs = if any_look_like_paths { run_inputs.as_slice() } else { &[] };
+    let loaded_config = config::load_run_cli_config(config_matches, config_inputs)?;
+
+    let runtime_config = effective_run_runtime_config(
+      loaded_config.as_ref(),
+      format!("program-{}", uuid),
+      run_debug_flag,
+      run_trace_flag,
+      run_time_flag,
+      run_rounds_per_step,
+    )?;
+    repl_runtime_config = Some(runtime_config.clone());
+
+    let cli_grants = config::effective_cli_host_grants(
+      loaded_config.as_ref(),
+      config::CliHostGrantAttenuation {
+        deny_env: run_deny_cli_env,
+        deny_stdout: run_deny_cli_stdout,
+        deny_stderr: run_deny_cli_stderr,
+      },
+    )?;
+
+    let mut runtime = new_cli_runtime(runtime_config, &cli_grants)?;
+
+    if !run_inputs.is_empty() && !any_look_like_paths {
+      let joined = run_inputs.join(" ");
+      match run_cli_source(&mut runtime, joined.trim()) {
+        Ok(r) => {
+          println!("{}", r.kind());
+          #[cfg(feature = "pretty_print")]
+          println!("{}", r.pretty_print());
+          #[cfg(not(feature = "pretty_print"))]
+          println!("{:#?}", r);
+          std::process::exit(0);
         }
+        Err(err) => {
+          println!("{} {:#?}",
+            "[Error]".truecolor(246,98,78),
+            err
+          );
+          std::process::exit(1);
+        }
+      }
     }
 
-    Ok(())
+    let options = config::effective_run_options(
+      run_inputs,
+      loaded_config.as_ref(),
+      explicit_run_command,
+    )?;
+
+    let result: MResult<Value> = if let Some(options) = options {
+      let mut last = Value::Empty;
+      for p in &options.paths {
+        let src = std::fs::read_to_string(p)?;
+        last = run_cli_source(&mut runtime, &src)?;
+      }
+      Ok(last)
+    } else {
+      repl_flag = true;
+      Ok(Value::Empty)
+    };
+
+    if !repl_flag {
+      match &result {
+        Ok(r) => {
+          println!("{}", r.kind());
+          #[cfg(feature = "pretty_print")]
+          println!("{}", r.pretty_print());
+          #[cfg(not(feature = "pretty_print"))]
+          println!("{:#?}", r);
+          std::process::exit(0);
+        }
+        Err(err) => {
+          print_mech_error(err);
+          std::process::exit(1);
+        }
+      };
+    }
+
+    #[cfg(windows)]
+    control::set_virtual_terminal(true).unwrap();
+    clc();
+    let mut stdo = stdout();
+    stdo.execute(Print(text_logo));
+    stdo.execute(cursor::MoveToNextLine(1));
+    println!("\n                {}                ",format!("v{}",VERSION).truecolor(246,192,78));
+    println!("           {}           \n", "www.mech-lang.org");
+    let intro_message = format!("{}Enter {} for a list of all commands.{}\n", mika_open, help_cmd, mika_close);
+    println!("{} {}", micromika, intro_message);
+
+    // Catch Ctrl-C a couple times before quitting
+    let mut ci = caught_inturrupts.clone();
+    ctrlc::set_handler(move || {
+      println!("{}", ctrlc_cmd);
+      let mut caught_inturrupts = ci.lock().unwrap();
+      *caught_inturrupts += 1;
+      if *caught_inturrupts >= 3 {
+        let final_state = ProgressBar::new_spinner();
+        let completed_style = ProgressStyle::with_template(
+          "\n{spinner:.yellow} {msg}"
+        ).unwrap().tick_strings(MICROMIKA_WAVE);
+        final_state.set_style(completed_style);
+        final_state.set_message(format!("{}Okay cya!{}\n", mika_open, mika_close));
+        for _ in 0..MICROMIKA_WAVE.len() - 1 {
+          thread::sleep(Duration::from_millis(100));
+          final_state.tick();
+        }
+        std::process::exit(0);
+      }
+      println!("\n{} {}Enter {} to terminate this REPL session.{}\n", micromika_point, mika_open, quit_cmd, mika_close);
+      print_prompt();
+    }).expect("Error setting Ctrl+C handler");
+  }
+
+  // --------------------------------------------------------------------------
+  // REPL
+  // --------------------------------------------------------------------------
+  #[cfg(all(feature = "repl", feature = "run"))]
+  // TODO: move the REPL onto MechRuntime as a separate PR so CLI host contexts work interactively too.
+  let mut repl = {
+    let config = repl_runtime_config.unwrap_or_else(RuntimeConfig::default);
+    let mut repl_program = MechProgram::new(MechProgramConfig {
+      name: config.name.clone(),
+      environment: MechProgramEnvironment::default(),
+    });
+    repl_program.configure(
+      config.diagnostics.debug_enabled,
+      config.diagnostics.trace_enabled,
+      config.diagnostics.profile_enabled,
+      config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+    );
+    MechRepl::from(repl_program)
+  };
+  #[cfg(all(feature = "repl", not(feature = "run")))]
+  let mut repl = MechRepl::from(MechProgram::new(MechProgramConfig {
+    name: format!("repl-{}", generate_uuid()),
+    environment: MechProgramEnvironment::default(),
+  }));
+  #[cfg(feature = "repl")]
+  'REPL: loop {
+    {
+      let mut ci = caught_inturrupts.lock().unwrap();
+      *ci = 0;
+    }
+    // Prompt the user for input
+    print_prompt();
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+
+    // Parse the input
+    if input.chars().nth(0) == Some(':') {
+      match parse_repl_command(&input.as_str()) {
+        Ok((_, repl_command)) => {
+          match repl.execute_repl_command(repl_command) {
+            Ok(output) => {
+              println!("{}", output);
+            }
+            Err(err) => {
+              println!("!{:?}", err);
+            }
+          }
+        }
+        Err(x) => {
+          println!("{} Unrecognized command: {}", "[Error]".truecolor(246,98,78), x);
+        }
+      }
+    } else if input.trim() == "" {
+      continue;
+    } else {
+      let cmd = ReplCommand::Code(vec![("repl".to_string(),MechSourceCode::String(input))]);
+      match repl.execute_repl_command(cmd) {
+        Ok(output) => {
+          println!("{}", output);
+        }
+        Err(err) => {
+          println!("(x)> {:#?}", err);
+        }
+      }
+    }
+  }
+
+  Ok(())
 }
 
 #[cfg(feature = "async")]
 pub async fn load_resource(resource_path: &str) -> String {
-    if resource_path.starts_with("http") {
-        match reqwest::get(resource_path).await {
-            Ok(response) => match response.text().await {
-                Ok(text) => text,
-                Err(err) => {
-                    eprintln!("Error fetching resource text: {:?}", err);
-                    String::new()
-                }
-            },
-            Err(err) => {
-                eprintln!("Error fetching resource: {:?}", err);
-                String::new()
-            }
+  if resource_path.starts_with("http") {
+    match reqwest::get(resource_path).await {
+      Ok(response) => match response.text().await {
+        Ok(text) => text,
+        Err(err) => {
+          eprintln!("Error fetching resource text: {:?}", err);
+          String::new()
         }
-    } else {
-        match tokio::fs::read_to_string(resource_path).await {
-            Ok(content) => content,
-            Err(err) => {
-                eprintln!("Error reading resource file: {:?}", err);
-                String::new()
-            }
-        }
+      },
+      Err(err) => {
+        eprintln!("Error fetching resource: {:?}", err);
+        String::new()
+      }
     }
+  } else {
+    match tokio::fs::read_to_string(resource_path).await {
+      Ok(content) => content,
+      Err(err) => {
+        eprintln!("Error reading resource file: {:?}", err);
+        String::new()
+      }
+    }
+  }
 }
 
 #[cfg(not(feature = "async"))]
 pub fn load_resource(resource_path: &str) -> String {
-    if resource_path.starts_with("http") {
-        match reqwest::blocking::get(resource_path) {
-            Ok(response) => match response.text() {
-                Ok(text) => text,
-                Err(err) => {
-                    eprintln!("Error fetching resource text: {:?}", err);
-                    String::new()
-                }
-            },
-            Err(err) => {
-                eprintln!("Error fetching resource: {:?}", err);
-                String::new()
-            }
+  if resource_path.starts_with("http") {
+    match reqwest::blocking::get(resource_path) {
+      Ok(response) => match response.text() {
+        Ok(text) => text,
+        Err(err) => {
+          eprintln!("Error fetching resource text: {:?}", err);
+          String::new()
         }
-    } else {
-        match std::fs::read_to_string(resource_path) {
-            Ok(content) => content,
-            Err(err) => {
-                eprintln!("Error reading resource file: {:?}", err);
-                String::new()
-            }
-        }
+      },
+      Err(err) => {
+        eprintln!("Error fetching resource: {:?}", err);
+        String::new()
+      }
     }
+  } else {
+    match std::fs::read_to_string(resource_path) {
+      Ok(content) => content,
+      Err(err) => {
+        eprintln!("Error reading resource file: {:?}", err);
+        String::new()
+      }
+    }
+  }
 }
+
 
 #[cfg(all(feature = "host_delegation_signing", feature = "serve"))]
 fn host_delegation_args() -> Vec<Arg> {
-    vec![
-        Arg::new("host_delegation_key")
-            .long("host-delegation-key")
-            .value_name("PATH")
-            .num_args(1),
-        Arg::new("host_delegation_public_key")
-            .long("host-delegation-public-key")
-            .value_name("PATH")
-            .num_args(1),
-        Arg::new("host_delegation_key_id")
-            .long("host-delegation-key-id")
-            .value_name("ID")
-            .num_args(1),
-        Arg::new("host_delegation_issuer")
-            .long("host-delegation-issuer")
-            .value_name("ISSUER")
-            .num_args(1),
-        Arg::new("host_delegation_subject")
-            .long("host-delegation-subject")
-            .value_name("SUBJECT")
-            .num_args(1),
-        Arg::new("host_delegation_audience")
-            .long("host-delegation-audience")
-            .value_name("AUDIENCE")
-            .num_args(1),
-        Arg::new("host_delegation_expires_ms")
-            .long("host-delegation-expires-ms")
-            .value_name("MS")
-            .num_args(1),
-    ]
+  vec![
+    Arg::new("host_delegation_key").long("host-delegation-key").value_name("PATH").num_args(1),
+    Arg::new("host_delegation_public_key").long("host-delegation-public-key").value_name("PATH").num_args(1),
+    Arg::new("host_delegation_key_id").long("host-delegation-key-id").value_name("ID").num_args(1),
+    Arg::new("host_delegation_issuer").long("host-delegation-issuer").value_name("ISSUER").num_args(1),
+    Arg::new("host_delegation_subject").long("host-delegation-subject").value_name("SUBJECT").num_args(1),
+    Arg::new("host_delegation_audience").long("host-delegation-audience").value_name("AUDIENCE").num_args(1),
+    Arg::new("host_delegation_expires_ms").long("host-delegation-expires-ms").value_name("MS").num_args(1),
+  ]
 }
 
 #[cfg(any(not(feature = "host_delegation_signing"), not(feature = "serve")))]
 fn host_delegation_args() -> Vec<Arg> {
-    Vec::new()
+  Vec::new()
 }
 
 #[cfg(all(feature = "host_delegation_signing", feature = "serve"))]
 fn serve_host_delegation_injection(
-    matches: &clap::ArgMatches,
-    loaded_config: Option<&mech::LoadedMechConfig>,
-    runtime_config: &mech_runtime::RuntimeConfig,
-    full_address: &str,
+  matches: &clap::ArgMatches,
+  loaded_config: Option<&mech::LoadedMechConfig>,
+  runtime_config: &mech_runtime::RuntimeConfig,
+  full_address: &str,
 ) -> MResult<Option<mech::HostAuthorityInjection>> {
-    let Some(private_key) = matches.get_one::<String>("host_delegation_key") else {
-        return Ok(None);
-    };
-    let public_key = matches
-        .get_one::<String>("host_delegation_public_key")
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "--host-delegation-public-key is required with --host-delegation-key",
-            )
-        })?;
-    let Some(loaded_config) = loaded_config else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "host delegation signing requires a loaded config",
-        )
-        .into());
-    };
-    let current_dir = std::env::current_dir()?;
-    let options = mech::HostDelegationSigningOptions {
-        private_key_path: current_dir.join(private_key),
-        public_key_path: current_dir.join(public_key),
-        key_id: matches
-            .get_one::<String>("host_delegation_key_id")
-            .cloned()
-            .unwrap_or_else(|| "dev".to_string()),
-        issuer: matches
-            .get_one::<String>("host_delegation_issuer")
-            .cloned()
-            .unwrap_or_else(|| "host://mech-cli".to_string()),
-        subject: matches
-            .get_one::<String>("host_delegation_subject")
-            .cloned()
-            .unwrap_or_else(|| "wasm://browser".to_string()),
-        audience: matches
-            .get_one::<String>("host_delegation_audience")
-            .cloned()
-            .unwrap_or_else(|| format!("browser://serve/{full_address}")),
-        expires_ms: matches
-            .get_one::<String>("host_delegation_expires_ms")
-            .map(|value| value.parse())
-            .transpose()
-            .map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "--host-delegation-expires-ms must be an integer",
-                )
-            })?,
-    };
-    let host_config = mech_host_browser::BrowserHostConfig::from_document_and_runtime(
-        &loaded_config.document,
-        runtime_config,
-    );
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))?
-        .as_millis() as u64;
-    mech::signed_browser_host_config_injection(host_config, &options, now_ms).map(Some)
+  let Some(private_key) = matches.get_one::<String>("host_delegation_key") else {
+    return Ok(None);
+  };
+  let public_key = matches
+    .get_one::<String>("host_delegation_public_key")
+    .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "--host-delegation-public-key is required with --host-delegation-key"))?;
+  let Some(loaded_config) = loaded_config else {
+    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "host delegation signing requires a loaded config").into());
+  };
+  let current_dir = std::env::current_dir()?;
+  let options = mech::HostDelegationSigningOptions {
+    private_key_path: current_dir.join(private_key),
+    public_key_path: current_dir.join(public_key),
+    key_id: matches.get_one::<String>("host_delegation_key_id").cloned().unwrap_or_else(|| "dev".to_string()),
+    issuer: matches.get_one::<String>("host_delegation_issuer").cloned().unwrap_or_else(|| "host://mech-cli".to_string()),
+    subject: matches.get_one::<String>("host_delegation_subject").cloned().unwrap_or_else(|| "wasm://browser".to_string()),
+    audience: matches.get_one::<String>("host_delegation_audience").cloned().unwrap_or_else(|| format!("browser://serve/{full_address}")),
+    expires_ms: matches.get_one::<String>("host_delegation_expires_ms").map(|value| value.parse()).transpose().map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "--host-delegation-expires-ms must be an integer"))?,
+  };
+  let host_config = mech_host_browser::BrowserHostConfig::from_document_and_runtime(
+    &loaded_config.document,
+    runtime_config,
+  );
+  let now_ms = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))?
+    .as_millis() as u64;
+  mech::signed_browser_host_config_injection(host_config, &options, now_ms).map(Some)
 }
 
 fn is_intended_path(s: &str) -> bool {
-    if s.trim().is_empty() {
-        return false;
-    }
+  if s.trim().is_empty() { return false; }
 
-    let path = Path::new(s);
-    if path.exists() {
-        return true;
+  let path = Path::new(s);
+  if path.exists() {
+    return true;
+  }
+  if s.starts_with("./") || s.starts_with(".\\") ||
+    s.starts_with("../") || s.starts_with("..\\") ||
+    s.starts_with('/') || s.starts_with('\\') {
+    return true;
+  }
+  if s.len() > 2 && s.as_bytes()[1] == b':' {
+    return true;
+  }
+  if s.contains('/') || s.contains('\\') {
+    return true;
+  }
+  if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+    match ext {
+      // Mech specific
+      "mec" | "🤖" | "mecb" | "mdoc" | "mpkg" => true,
+      // Data/Standard formats
+      "m" | "csv" | "tsv" | "txt" | "md" | "json" | "toml" | "yaml" => true,
+      // Web
+      "html" | "htm" | "css" | "js" | "wasm" => true,
+      // Images
+      "png" | "jpg" | "jpeg" | "gif" | "svg" | "bmp" | "ico" => true,
+      _ => false,
     }
-    if s.starts_with("./")
-        || s.starts_with(".\\")
-        || s.starts_with("../")
-        || s.starts_with("..\\")
-        || s.starts_with('/')
-        || s.starts_with('\\')
-    {
-        return true;
-    }
-    if s.len() > 2 && s.as_bytes()[1] == b':' {
-        return true;
-    }
-    if s.contains('/') || s.contains('\\') {
-        return true;
-    }
-    if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-        match ext {
-            // Mech specific
-            "mec" | "🤖" | "mecb" | "mdoc" | "mpkg" => true,
-            // Data/Standard formats
-            "m" | "csv" | "tsv" | "txt" | "md" | "json" | "toml" | "yaml" => true,
-            // Web
-            "html" | "htm" | "css" | "js" | "wasm" => true,
-            // Images
-            "png" | "jpg" | "jpeg" | "gif" | "svg" | "bmp" | "ico" => true,
-            _ => false,
-        }
-    } else {
-        false
-    }
+  } else {
+    false
+  }
 }
 
 fn source_range_to_offset_range(file_content: &str, range: &SourceRange) -> (usize, usize) {
-    let mut offset = 0;
-    let mut start_offset = 0;
-    let mut end_offset = 0;
+  let mut offset = 0;
+  let mut start_offset = 0;
+  let mut end_offset = 0;
 
-    for (line_index, line) in file_content.split_inclusive('\n').enumerate() {
-        let row = line_index + 1;
-        let line_len = line.len();
-        if row == range.start.row {
-            start_offset = offset + (range.start.col - 1);
-        }
-        if row == range.end.row {
-            end_offset = offset + (range.end.col - 1);
-            break;
-        }
-        offset += line_len;
+  for (line_index, line) in file_content.split_inclusive('\n').enumerate() {
+    let row = line_index + 1;
+    let line_len = line.len();
+    if row == range.start.row {
+      start_offset = offset + (range.start.col - 1);
     }
+    if row == range.end.row {
+      end_offset = offset + (range.end.col - 1);
+      break;
+    }
+    offset += line_len;
+  }
+  end_offset = end_offset.min(file_content.len());
+  while start_offset < end_offset
+    && file_content.as_bytes()[start_offset].is_ascii_whitespace()
+  {
+    start_offset += 1;
+  }
+  while end_offset > start_offset
+    && file_content.as_bytes()[end_offset - 1].is_ascii_whitespace()
+  {
+    end_offset -= 1;
+  }
+  if end_offset <= start_offset {
+    end_offset = start_offset + 1;
+    // Clamp in case we were at EOF
     end_offset = end_offset.min(file_content.len());
-    while start_offset < end_offset && file_content.as_bytes()[start_offset].is_ascii_whitespace() {
-        start_offset += 1;
-    }
-    while end_offset > start_offset && file_content.as_bytes()[end_offset - 1].is_ascii_whitespace()
-    {
-        end_offset -= 1;
-    }
-    if end_offset <= start_offset {
-        end_offset = start_offset + 1;
-        // Clamp in case we were at EOF
-        end_offset = end_offset.min(file_content.len());
-    }
-    (start_offset, end_offset)
+  }
+  (start_offset, end_offset)
 }
 
 pub fn print_mech_error(err: &MechError) {
-    if let Some(watch_error) = err.kind_as::<WatchPathFailed>() {
-        let src_file_path = watch_error.file_path.to_string();
-        match &err.source {
-            Some(src_err) => {
-                if let Some(report) = &src_err.kind_as::<ParserErrorReport>() {
-                    let first_error_range = report
-                        .1
-                        .first()
-                        .map(|e| e.cause_rng.clone())
-                        .unwrap_or(SourceRange::default());
-                    let (first_start, first_end) =
-                        source_range_to_offset_range(&report.0, &first_error_range);
-                    let mut error_report = Report::build(
-                        ReportKind::Error,
-                        (src_file_path.clone(), first_start..first_end),
-                    )
-                    .with_message(format!("Syntax Errors Found: {}", report.1.len()));
+  if let Some(watch_error) = err.kind_as::<WatchPathFailed>() {
+    let src_file_path = watch_error.file_path.to_string();
+    match &err.source {
+      Some(src_err) => {
+        if let Some(report) = &src_err.kind_as::<ParserErrorReport>() {
+          let first_error_range = report.1.first().map(|e| e.cause_rng.clone()).unwrap_or(SourceRange::default());
+          let (first_start, first_end) = source_range_to_offset_range(&report.0, &first_error_range);
+          let mut error_report = Report::build(ReportKind::Error, (src_file_path.clone(), first_start..first_end))
+              .with_message(format!("Syntax Errors Found: {}", report.1.len()));
 
-                    for (err_num, err_ctx) in report.1.iter().enumerate() {
-                        let (start, end) =
-                            source_range_to_offset_range(&report.0, &err_ctx.cause_rng);
+          for (err_num, err_ctx) in report.1.iter().enumerate() {
+            let (start, end) = source_range_to_offset_range(&report.0, &err_ctx.cause_rng);
 
-                        if let Some(annotation_rng) = err_ctx.annotation_rngs.first() {
-                            let (ann_start, ann_end) =
-                                source_range_to_offset_range(&report.0, annotation_rng);
+            if let Some(annotation_rng) = err_ctx.annotation_rngs.first() {
+              let (ann_start, ann_end) = source_range_to_offset_range(&report.0, annotation_rng);
 
-                            error_report = error_report.with_label(
-                                Label::new((src_file_path.clone(), ann_start..ann_end))
-                                    .with_message(format!(
-                                        "#{}: {} [{}:{}]",
-                                        err_num + 1,
-                                        err_ctx.err_message,
-                                        annotation_rng.start.row,
-                                        annotation_rng.start.col
-                                    ))
-                                    .with_color(Color::Yellow),
-                            );
-                        } else {
-                            error_report = error_report.with_label(
-                                Label::new((src_file_path.clone(), start..end))
-                                    .with_message(format!(
-                                        "#{}: {} [{}:{}]",
-                                        err_num + 1,
-                                        err_ctx.err_message,
-                                        err_ctx.cause_rng.start.row,
-                                        err_ctx.cause_rng.start.col
-                                    ))
-                                    .with_color(Color::Yellow),
-                            );
-                        }
-                    }
-                    let cache = sources([(src_file_path.clone(), report.0.clone())]);
-                    error_report.finish().print(cache).unwrap_or_else(|e| {
-                        println!("Error printing report: {:?}", e);
-                    });
-                } else {
-                    println!("Error:");
-                    println!("{:#?}", err);
-                }
+              error_report = error_report.with_label(
+                Label::new((src_file_path.clone(), ann_start..ann_end))
+                      .with_message(format!(
+                        "#{}: {} [{}:{}]",
+                        err_num + 1,
+                        err_ctx.err_message,
+                        annotation_rng.start.row,
+                        annotation_rng.start.col
+                      ))
+                    .with_color(Color::Yellow),
+              );
+            } else {
+              error_report = error_report.with_label(
+                Label::new((src_file_path.clone(), start..end))
+                      .with_message(format!(
+                        "#{}: {} [{}:{}]",
+                        err_num + 1,
+                        err_ctx.err_message,
+                        err_ctx.cause_rng.start.row,
+                        err_ctx.cause_rng.start.col
+                      ))
+                    .with_color(Color::Yellow),
+              );
             }
-            None => {
-                println!("Error:");
-                println!("{:#?}", err);
-            }
+          }
+          let cache = sources([(src_file_path.clone(), report.0.clone())]);
+          error_report.finish().print(cache).unwrap_or_else(|e| {
+            println!("Error printing report: {:?}", e);
+          });
+        } else {
+          println!("Error:");
+          println!("{:#?}", err);
         }
-    } else {
+      }
+      None => {
         println!("Error:");
         println!("{:#?}", err);
+      }
     }
+  } else {
+      println!("Error:");
+      println!("{:#?}", err);
+  }
 }
 
 #[cfg(all(test, feature = "serve"))]
 mod filesystem_capability_cli_tests {
     use super::*;
-    use mech_runtime::{
-        DefaultIdGenerator, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH,
-        SERVE_HOST_SUBJECT,
-    };
+    use mech_runtime::{DefaultIdGenerator, SERVE_HOST_SUBJECT, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH};
 
     fn capability_matches(arguments: &[&str]) -> clap::ArgMatches {
         capabilities::add_filesystem_capability_args(Command::new("mech").subcommand(
@@ -1459,8 +1307,7 @@ mod filesystem_capability_cli_tests {
     #[test]
     fn default_grants_current_directory_when_no_capability_options_are_present() {
         let matches = capability_matches(&["mech", "serve", "."]);
-        let authority =
-            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(
@@ -1484,8 +1331,7 @@ mod filesystem_capability_cli_tests {
         let outside_arg = outside.to_string_lossy();
         let matches =
             capability_matches(&["mech", "--cap-root", &allowed_arg, "serve", &outside_arg]);
-        let authority =
-            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         assert!(
             authority
@@ -1513,8 +1359,7 @@ mod filesystem_capability_cli_tests {
             "serve",
             root.to_str().unwrap(),
         ]);
-        let authority =
-            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         assert!(
             authority
@@ -1534,8 +1379,7 @@ mod filesystem_capability_cli_tests {
             "--allow-read",
             root.to_str().unwrap(),
         ]);
-        let authority =
-            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_READ])
@@ -1565,8 +1409,7 @@ mod filesystem_capability_cli_tests {
             "serve",
             &allowed_arg,
         ]);
-        let authority =
-            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         assert_eq!(authority.source_capabilities().len(), 1);
         let mut ids = DefaultIdGenerator::new();
         authority
@@ -1591,8 +1434,7 @@ mod filesystem_capability_cli_tests {
             "--allow-serve",
             root.to_str().unwrap(),
         ]);
-        let authority =
-            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_SERVE])

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -4,13 +4,7 @@ use mech::*;
 use mech_core::*;
 use mech_syntax::parser;
 #[cfg(feature = "run")]
-use mech_host_cli::{CliResourceProvider, StdCliBackend};
-
-#[cfg(feature = "run")]
-use mech_runtime::{
-  MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
-  RuntimeEvent, RuntimeEventKind,
-};
+use mech_runtime::RuntimeConfig;
 #[cfg(feature = "serve")]
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
@@ -84,7 +78,23 @@ use mech::cli::capabilities;
 
 #[cfg(any(feature = "serve", feature = "run"))]
 use mech::cli::config;
+#[cfg(feature = "run")]
+use mech::cli::run::{
+  cli_host_capability_args, cli_host_capability_path_values, cli_host_capability_selection,
+  effective_run_runtime_config, new_cli_runtime, run_cli_source,
+};
 
+
+
+#[cfg(feature = "run")]
+fn add_cli_host_capability_args(command: Command) -> Command {
+  command.args(cli_host_capability_args())
+}
+
+#[cfg(not(feature = "run"))]
+fn add_cli_host_capability_args(command: Command) -> Command {
+  command
+}
 
 async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
   if paths.is_empty() {
@@ -113,107 +123,6 @@ async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String
     combined.push_str(&stylesheet_str);
   }
   Ok(combined)
-}
-
-#[cfg(feature = "run")]
-fn new_cli_runtime(config: RuntimeConfig) -> MResult<MechRuntime> {
-  let mut runtime = RuntimeBuilder::new()
-    .config(config)
-    .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
-    .build()?;
-
-  grant_cli_runner_capabilities(&mut runtime)?;
-
-  Ok(runtime)
-}
-
-#[cfg(feature = "run")]
-fn effective_run_runtime_config(
-  loaded_config: Option<&mech::LoadedMechConfig>,
-  name: String,
-  debug_enabled: bool,
-  trace_enabled: bool,
-  profile_enabled: bool,
-  rounds_per_step: Option<usize>,
-) -> MResult<RuntimeConfig> {
-  let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
-
-  let mut config = mech::apply_runtime_config_patch(
-    RuntimeConfig::default(),
-    loaded_config
-      .as_ref()
-      .map(|loaded| &loaded.document.runtime)
-      .unwrap_or(&default_runtime_patch),
-  )?;
-
-  config.name = name;
-
-  if debug_enabled {
-    config.diagnostics.debug_enabled = true;
-  }
-
-  if trace_enabled {
-    config.diagnostics.trace_enabled = true;
-  }
-
-  if profile_enabled {
-    config.diagnostics.profile_enabled = true;
-  }
-
-  if let Some(rounds_per_step) = rounds_per_step {
-    config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
-  }
-
-  config.validate()?;
-  Ok(config)
-}
-
-#[cfg(feature = "run")]
-fn print_run_runtime_events(events: &[RuntimeEvent]) {
-  for event in events {
-    match &event.kind {
-      RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
-        println!("Cycle Time: {} ns", duration_ns);
-      }
-      _ => {}
-    }
-  }
-}
-
-#[cfg(feature = "run")]
-fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
-  let mut context = runtime.runtime_context()?;
-  let result = runtime.run_string_with_context(&mut context, source);
-  print_run_runtime_events(&context.events);
-  result
-}
-
-#[cfg(feature = "run")]
-fn grant_cli_runner_capabilities(runtime: &mut MechRuntime) -> MResult<()> {
-  let subject = runtime.runtime_context()?.subject;
-
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: subject.clone(),
-    resource: "cli://env".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
-    paths: vec!["*".to_string()],
-  })?;
-
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: subject.clone(),
-    resource: "cli://stdout".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec!["text".to_string(), "line".to_string()],
-  })?;
-
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject,
-    resource: "cli://stderr".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec!["text".to_string(), "line".to_string()],
-  })?;
-
-  Ok(())
 }
 
 #[tokio::main]
@@ -342,7 +251,7 @@ async fn main() -> Result<(), MechError> {
         .help("Print verbose pass/fail details.")
         .action(ArgAction::SetTrue)
         .required(false)))
-    .subcommand(Command::new("run")
+    .subcommand(add_cli_host_capability_args(Command::new("run")
       .about("Run Mech source files, project inputs, or inline Mech code.")
       .arg(Arg::new("mech_run_paths")
         .help("Source .mec files, project folders, or inline Mech code.")
@@ -366,7 +275,7 @@ async fn main() -> Result<(), MechError> {
       .arg(Arg::new("trace")
         .long("trace")
         .help("Print trace output for state-machine arms and function calls")
-        .action(ArgAction::SetTrue)))
+        .action(ArgAction::SetTrue))))
     .subcommand(Command::new("serve")
       .about("Serve Mech program over an HTTP server.")
       .arg(Arg::new("mech_serve_file_paths")
@@ -425,6 +334,8 @@ async fn main() -> Result<(), MechError> {
         .long("repl")
         .help("Start REPL")
         .action(ArgAction::SetTrue));
+
+  let cli_command = add_cli_host_capability_args(cli_command);
 
   #[cfg(feature = "bundle_web")]
   let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
@@ -787,7 +698,7 @@ async fn main() -> Result<(), MechError> {
   {
     let run_matches = cli_matches.subcommand_matches("run");
     let explicit_run_command = run_matches.is_some();
-    let run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
+    let mut run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
       run_matches
         .get_many::<String>("mech_run_paths")
         .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
@@ -796,6 +707,7 @@ async fn main() -> Result<(), MechError> {
     } else {
       vec![]
     };
+    run_inputs.extend(cli_host_capability_path_values(&cli_matches, run_matches));
 
     let run_debug_flag = debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
     let run_trace_flag = trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
@@ -820,7 +732,13 @@ async fn main() -> Result<(), MechError> {
     )?;
     repl_runtime_config = Some(runtime_config.clone());
 
-    let mut runtime = new_cli_runtime(runtime_config)?;
+    let cli_capability_selection = cli_host_capability_selection(&cli_matches, run_matches);
+    let cli_grants = config::effective_cli_host_grants(
+      loaded_config.as_ref(),
+      cli_capability_selection,
+    )?;
+
+    let mut runtime = new_cli_runtime(runtime_config, &cli_grants)?;
 
     if !run_inputs.is_empty() && !any_look_like_paths {
       let joined = run_inputs.join(" ");

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -2,45 +2,42 @@
 #![allow(warnings)]
 use mech::*;
 use mech_core::*;
-use mech_syntax::parser;
 #[cfg(feature = "run")]
 use mech_host_cli::{CliResourceProvider, StdCliBackend};
+use mech_syntax::parser;
 
 #[cfg(feature = "run")]
 use mech_runtime::{
-  MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
-  RuntimeEvent, RuntimeEventKind,
+    MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
+    RuntimeEvent, RuntimeEventKind,
 };
 #[cfg(feature = "serve")]
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
-use std::time::Instant;
-use std::fs;
 use std::env;
+use std::fs;
 use std::io;
+use std::time::Instant;
 
-use colored::*;
-use std::io::{Write, BufReader, BufWriter, stdout};
-use crossterm::{
-  ExecutableCommand, QueueableCommand,
-  terminal, cursor, style::Print,
-};
-use ariadne::{Report, ReportKind, Label, Color, sources};
+use ariadne::{Color, Label, Report, ReportKind, sources};
 use clap::{Arg, ArgAction, Command};
-use std::path::PathBuf;
-use tabled::{
-  builder::Builder,
-  settings::{object::Rows,Panel, Span, Alignment, Modify, Style},
-  Tabled,
-};
-use indicatif::{ProgressBar, ProgressStyle, MultiProgress};
+use colored::*;
+use crossterm::{ExecutableCommand, QueueableCommand, cursor, style::Print, terminal};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use serde_json;
-use std::panic;
-use std::sync::{Arc, Mutex};
-use std::path::Path;
 use std::ffi::OsStr;
-use std::time::Duration;
+use std::io::{BufReader, BufWriter, Write, stdout};
+use std::panic;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
+use tabled::{
+    Tabled,
+    builder::Builder,
+    settings::{Alignment, Modify, Panel, Span, Style, object::Rows},
+};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -66,15 +63,18 @@ static STYLESHEET: &str = "No Embedded Stylesheet";
 
 #[derive(Debug, Clone)]
 pub struct Utf8ConversionError {
-  pub source_error: String
+    pub source_error: String,
 }
 impl MechErrorKind for Utf8ConversionError {
-  fn name(&self) -> &str {
-    "Utf8ConversionError"
-  }
-  fn message(&self) -> String {
-    format!("Failed to convert bytes into UTF-8 string: {}", self.source_error)
-  }
+    fn name(&self) -> &str {
+        "Utf8ConversionError"
+    }
+    fn message(&self) -> String {
+        format!(
+            "Failed to convert bytes into UTF-8 string: {}",
+            self.source_error
+        )
+    }
 }
 
 #[cfg(feature = "bundle_web")]
@@ -85,153 +85,195 @@ use mech::cli::capabilities;
 #[cfg(any(feature = "serve", feature = "run"))]
 use mech::cli::config;
 
-
 async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
-  if paths.is_empty() {
-    let stylesheet = read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?;
-    return String::from_utf8(stylesheet)
-      .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc());
-  }
-
-  let mut combined = String::new();
-  for path in paths {
-    let stylesheet = match std::fs::read(path) {
-      Ok(content) => {
-        println!("Using stylesheet: {}", path);
-        content
-      }
-      Err(_) => {
-        println!("\nStylesheet not found:\n  {}", path);
-        read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?
-      }
-    };
-    let stylesheet_str = String::from_utf8(stylesheet)
-      .map_err(|e| MechError::new(Utf8ConversionError { source_error: e.to_string() }, None).with_compiler_loc())?;
-    if !combined.is_empty() {
-      combined.push('\n');
+    if paths.is_empty() {
+        let stylesheet = read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?;
+        return String::from_utf8(stylesheet).map_err(|e| {
+            MechError::new(
+                Utf8ConversionError {
+                    source_error: e.to_string(),
+                },
+                None,
+            )
+            .with_compiler_loc()
+        });
     }
-    combined.push_str(&stylesheet_str);
-  }
-  Ok(combined)
+
+    let mut combined = String::new();
+    for path in paths {
+        let stylesheet = match std::fs::read(path) {
+            Ok(content) => {
+                println!("Using stylesheet: {}", path);
+                content
+            }
+            Err(_) => {
+                println!("\nStylesheet not found:\n  {}", path);
+                read_or_download("", fallback_url, Some(STYLESHEET.as_bytes())).await?
+            }
+        };
+        let stylesheet_str = String::from_utf8(stylesheet).map_err(|e| {
+            MechError::new(
+                Utf8ConversionError {
+                    source_error: e.to_string(),
+                },
+                None,
+            )
+            .with_compiler_loc()
+        })?;
+        if !combined.is_empty() {
+            combined.push('\n');
+        }
+        combined.push_str(&stylesheet_str);
+    }
+    Ok(combined)
 }
 
 #[cfg(feature = "run")]
-fn new_cli_runtime(config: RuntimeConfig) -> MResult<MechRuntime> {
-  let mut runtime = RuntimeBuilder::new()
-    .config(config)
-    .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
-    .build()?;
+fn new_cli_runtime(
+    config: RuntimeConfig,
+    cli_grants: &config::EffectiveCliHostGrants,
+) -> MResult<MechRuntime> {
+    let mut runtime = RuntimeBuilder::new()
+        .config(config)
+        .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
+        .build()?;
 
-  grant_cli_runner_capabilities(&mut runtime)?;
+    grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
 
-  Ok(runtime)
+    Ok(runtime)
 }
 
 #[cfg(feature = "run")]
 fn effective_run_runtime_config(
-  loaded_config: Option<&mech::LoadedMechConfig>,
-  name: String,
-  debug_enabled: bool,
-  trace_enabled: bool,
-  profile_enabled: bool,
-  rounds_per_step: Option<usize>,
+    loaded_config: Option<&mech::LoadedMechConfig>,
+    name: String,
+    debug_enabled: bool,
+    trace_enabled: bool,
+    profile_enabled: bool,
+    rounds_per_step: Option<usize>,
 ) -> MResult<RuntimeConfig> {
-  let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+    let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
 
-  let mut config = mech::apply_runtime_config_patch(
-    RuntimeConfig::default(),
-    loaded_config
-      .as_ref()
-      .map(|loaded| &loaded.document.runtime)
-      .unwrap_or(&default_runtime_patch),
-  )?;
+    let mut config = mech::apply_runtime_config_patch(
+        RuntimeConfig::default(),
+        loaded_config
+            .as_ref()
+            .map(|loaded| &loaded.document.runtime)
+            .unwrap_or(&default_runtime_patch),
+    )?;
 
-  config.name = name;
+    config.name = name;
 
-  if debug_enabled {
-    config.diagnostics.debug_enabled = true;
-  }
+    if debug_enabled {
+        config.diagnostics.debug_enabled = true;
+    }
 
-  if trace_enabled {
-    config.diagnostics.trace_enabled = true;
-  }
+    if trace_enabled {
+        config.diagnostics.trace_enabled = true;
+    }
 
-  if profile_enabled {
-    config.diagnostics.profile_enabled = true;
-  }
+    if profile_enabled {
+        config.diagnostics.profile_enabled = true;
+    }
 
-  if let Some(rounds_per_step) = rounds_per_step {
-    config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
-  }
+    if let Some(rounds_per_step) = rounds_per_step {
+        config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
+    }
 
-  config.validate()?;
-  Ok(config)
+    config.validate()?;
+    Ok(config)
 }
 
 #[cfg(feature = "run")]
 fn print_run_runtime_events(events: &[RuntimeEvent]) {
-  for event in events {
-    match &event.kind {
-      RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
-        println!("Cycle Time: {} ns", duration_ns);
-      }
-      _ => {}
+    for event in events {
+        match &event.kind {
+            RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
+                println!("Cycle Time: {} ns", duration_ns);
+            }
+            _ => {}
+        }
     }
-  }
 }
 
 #[cfg(feature = "run")]
 fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
-  let mut context = runtime.runtime_context()?;
-  let result = runtime.run_string_with_context(&mut context, source);
-  print_run_runtime_events(&context.events);
-  result
+    let mut context = runtime.runtime_context()?;
+    let result = runtime.run_string_with_context(&mut context, source);
+    print_run_runtime_events(&context.events);
+    result
 }
 
 #[cfg(feature = "run")]
-fn grant_cli_runner_capabilities(runtime: &mut MechRuntime) -> MResult<()> {
-  let subject = runtime.runtime_context()?.subject;
+fn grant_cli_runner_capabilities(
+    runtime: &mut MechRuntime,
+    grants: &config::EffectiveCliHostGrants,
+) -> MResult<()> {
+    let subject = runtime.runtime_context()?.subject;
 
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: subject.clone(),
-    resource: "cli://env".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
-    paths: vec!["*".to_string()],
-  })?;
+    if !grants.env_read_paths.is_empty() {
+        runtime.grant_capability(RuntimeCapabilityGrant {
+            subject: subject.clone(),
+            resource: "cli://env".to_string(),
+            operations: vec![RuntimeCapabilityOperation::Read],
+            paths: grants.env_read_paths.clone(),
+        })?;
+    }
 
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: subject.clone(),
-    resource: "cli://stdout".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec!["text".to_string(), "line".to_string()],
-  })?;
+    if !grants.stdout_write_paths.is_empty() {
+        runtime.grant_capability(RuntimeCapabilityGrant {
+            subject: subject.clone(),
+            resource: "cli://stdout".to_string(),
+            operations: vec![RuntimeCapabilityOperation::Write],
+            paths: grants.stdout_write_paths.clone(),
+        })?;
+    }
 
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject,
-    resource: "cli://stderr".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec!["text".to_string(), "line".to_string()],
-  })?;
+    if !grants.stderr_write_paths.is_empty() {
+        runtime.grant_capability(RuntimeCapabilityGrant {
+            subject,
+            resource: "cli://stderr".to_string(),
+            operations: vec![RuntimeCapabilityOperation::Write],
+            paths: grants.stderr_write_paths.clone(),
+        })?;
+    }
 
-  Ok(())
+    Ok(())
+}
+
+fn cli_host_capability_args() -> Vec<Arg> {
+    vec![
+        Arg::new("deny_cli_env")
+            .long("deny-cli-env")
+            .help("Deny cli://env read grants for this run")
+            .action(ArgAction::SetTrue),
+        Arg::new("deny_cli_stdout")
+            .long("deny-cli-stdout")
+            .help("Deny cli://stdout write grants for this run")
+            .action(ArgAction::SetTrue),
+        Arg::new("deny_cli_stderr")
+            .long("deny-cli-stderr")
+            .help("Deny cli://stderr write grants for this run")
+            .action(ArgAction::SetTrue),
+    ]
 }
 
 #[tokio::main]
 async fn main() -> Result<(), MechError> {
-  /*panic::set_hook(Box::new(|panic_info| {
-    // do nothing.
-  }));*/
+    /*panic::set_hook(Box::new(|panic_info| {
+      // do nothing.
+    }));*/
 
-  let text_logo = r#"
+    let text_logo = r#"
   ┌─────────┐ ┌──────┐ ┌─┐ ┌──┐ ┌─┐  ┌─┐
   └───┐ ┌───┘ └──────┘ │ │ └┐ │ │ │  │ │
   ┌─┐ │ │ ┌─┐ ┌──────┐ │ │  └─┘ │ └─┐│ │
   │ │ │ │ │ │ │ ┌────┘ │ │  ┌─┐ │ ┌─┘│ │
   │ │ └─┘ │ │ │ └────┐ │ └──┘ │ │ │  │ │
-  └─┘     └─┘ └──────┘ └──────┘ └─┘  └─┘"#.truecolor(246,192,78);
+  └─┘     └─┘ └──────┘ └──────┘ └─┘  └─┘"#
+        .truecolor(246, 192, 78);
 
-
-  let super_3D_logo = r#"
+    let super_3D_logo = r#"
           _____                      _____                     _____                     _____
          ╱╲    ╲                    ╱╲    ╲                   ╱╲    ╲                   ╱╲    ╲
         ╱┊┊╲    ╲                  ╱┊┊╲    ╲                 ╱┊┊╲____╲                 ╱┊┊╲____╲
@@ -254,19 +296,18 @@ async fn main() -> Result<(), MechError> {
         ╲┊┊╱    ╱                  ╲╱____╱                   ╲╱____╱                   ╲╱____╱
          ╲╱____╱"#.truecolor(246,192,78);
 
+    let micromika = "╭◉╮".truecolor(246, 192, 78);
+    let micromika_point = "╭◉─".truecolor(246, 192, 78);
+    let micromika_hello = "╭◉╯".truecolor(246, 192, 78);
+    let help_cmd = ":help".bright_yellow();
+    let quit_cmd = ":quit".bright_yellow();
+    let ctrlc_cmd = ":ctrl+c".bright_yellow();
+    let mika_open = "⸢".bright_yellow();
+    let mika_close = "⸥".bright_yellow();
 
-  let micromika = "╭◉╮".truecolor(246,192,78);
-  let micromika_point = "╭◉─".truecolor(246,192,78);
-  let micromika_hello = "╭◉╯".truecolor(246,192,78);
-  let help_cmd = ":help".bright_yellow();
-  let quit_cmd = ":quit".bright_yellow();
-  let ctrlc_cmd = ":ctrl+c".bright_yellow();
-  let mika_open = "⸢".bright_yellow();
-  let mika_close = "⸥".bright_yellow();
+    let about = format!("{}", text_logo);
 
-  let about = format!("{}", text_logo);
-
-  let cli_command = Command::new("Mech")
+    let cli_command = Command::new("Mech")
     .subcommand_precedence_over_arg(true)
     .version(VERSION)
     .author("Corey Montella corey@mech-lang.org")
@@ -366,7 +407,8 @@ async fn main() -> Result<(), MechError> {
       .arg(Arg::new("trace")
         .long("trace")
         .help("Print trace output for state-machine arms and function calls")
-        .action(ArgAction::SetTrue)))
+        .action(ArgAction::SetTrue))
+      .args(cli_host_capability_args()))
     .subcommand(Command::new("serve")
       .about("Serve Mech program over an HTTP server.")
       .arg(Arg::new("mech_serve_file_paths")
@@ -424,812 +466,968 @@ async fn main() -> Result<(), MechError> {
         .short('r')
         .long("repl")
         .help("Start REPL")
-        .action(ArgAction::SetTrue));
+        .action(ArgAction::SetTrue))
+    .args(cli_host_capability_args());
 
-  #[cfg(feature = "bundle_web")]
-  let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
+    #[cfg(feature = "bundle_web")]
+    let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
 
-  #[cfg(feature = "serve")]
-  let cli_command = capabilities::add_filesystem_capability_args(cli_command);
+    #[cfg(feature = "serve")]
+    let cli_command = capabilities::add_filesystem_capability_args(cli_command);
 
-  #[cfg(any(feature = "serve", feature = "run"))]
-  let cli_command = config::add_config_args(cli_command);
+    #[cfg(any(feature = "serve", feature = "run"))]
+    let cli_command = config::add_config_args(cli_command);
 
-  #[cfg(all(feature = "bundle_web", not(feature = "serve")))]
-  let cli_command = bundle_web::add_config_args(cli_command);
+    #[cfg(all(feature = "bundle_web", not(feature = "serve")))]
+    let cli_command = bundle_web::add_config_args(cli_command);
 
-  let cli_matches = cli_command.get_matches();
+    let cli_matches = cli_command.get_matches();
 
-  let debug_flag = cli_matches.get_flag("debug");
-  let tree_flag = cli_matches.get_flag("tree");
-  let mut repl_flag = cli_matches.get_flag("repl");
-  let time_flag = cli_matches.get_flag("time");
-  let trace_flag = cli_matches.get_flag("trace");
-  let root_rounds_per_step = cli_matches.get_one::<String>("rounds-per-step").and_then(|s| s.parse::<usize>().ok());
+    let debug_flag = cli_matches.get_flag("debug");
+    let tree_flag = cli_matches.get_flag("tree");
+    let mut repl_flag = cli_matches.get_flag("repl");
+    let time_flag = cli_matches.get_flag("time");
+    let trace_flag = cli_matches.get_flag("trace");
+    let root_rounds_per_step = cli_matches
+        .get_one::<String>("rounds-per-step")
+        .and_then(|s| s.parse::<usize>().ok());
 
-  let shim_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/shim.html".to_string();
-  let stylesheet_backup_url = "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css".to_string();
-  let wasm_backup_url = format!("https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm_bg.wasm.br", VERSION);
-  let js_backup_url = format!("https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm.js", VERSION);
-
-  // --------------------------------------------------------------------------
-  // Bundle Web
-  // --------------------------------------------------------------------------
-  #[cfg(feature = "bundle_web")]
-  if let Some(bundle_matches) = cli_matches.subcommand_matches("bundle-web") {
-    let badge = "[Mech Bundle]".truecolor(34, 204, 187);
-
-    let loaded = bundle_web::load_bundle_web_config(bundle_matches)?;
-    println!("{badge} Loading config… {}", loaded.path.display());
-
-    let options = bundle_web::effective_bundle_web_options(bundle_matches, loaded)?;
-    let result = mech::bundle_web_project(options)?;
-
-    println!("{badge} Bundle written: {}", result.output_dir.display());
-    println!("{badge} Sources bundled: {}", result.source_count);
-    return Ok(());
-  }
-
-  // --------------------------------------------------------------------------
-  // Serve
-  // --------------------------------------------------------------------------
-  #[cfg(feature = "serve")]
-  if let Some(serve_matches) = cli_matches.subcommand_matches("serve") {
-    let badge = "[Mech Server]".truecolor(34, 204, 187);
-    let error_badge = "[Error]".truecolor(246, 98, 78);
-
-    let loaded_config = config::load_cli_config(serve_matches)?;
-    let effective = config::effective_serve_options(serve_matches, loaded_config.as_ref())?;
-    let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
-    let runtime_config = mech::apply_runtime_config_patch(
-      mech_runtime::RuntimeConfig::default(),
-      loaded_config
-        .as_ref()
-        .map(|loaded| &loaded.document.runtime)
-        .unwrap_or(&default_runtime_patch),
-    )?;
-    let host_config = loaded_config
-      .as_ref()
-      .map(|loaded| mech_host_browser::BrowserHostConfig::from_document_and_runtime(
-        &loaded.document,
-        &runtime_config,
-      ));
-    let config_shim_at_root = loaded_config
-      .as_ref()
-      .and_then(|loaded| loaded.document.serve.as_ref())
-      .and_then(|serve| serve.shim.as_ref())
-      .is_some()
-      && serve_matches.get_one::<String>("shim").is_none();
-    if let Some(loaded) = loaded_config.as_ref() {
-      println!("{badge} Loaded browser config grants: {}", loaded.document.browser.grants().len());
-    }
-
-    let full_address = format!("{}:{}", effective.address, effective.port);
-    #[cfg(feature = "host_delegation_signing")]
-    let host_config_injection = serve_host_delegation_injection(
-      serve_matches,
-      loaded_config.as_ref(),
-      &runtime_config,
-      &full_address,
-    )?;
-    #[cfg(not(feature = "host_delegation_signing"))]
-    let host_config_injection = None;
-    let mech_paths = effective.paths;
-    let stylesheet_paths = effective.stylesheet_paths;
-    let wasm_pkg = effective.wasm_pkg.as_str();
-    let shim_path = effective.shim_path.as_str();
-
-    let wasm_path = format!("{wasm_pkg}/mech_wasm_bg.wasm.br");
-    let js_path = format!("{wasm_pkg}/mech_wasm.js");
-
-    println!("{badge} Loading resources…");
-
-    print!("{badge} Loading stylesheet…");
-    let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
-
-    print!("{badge} Loading HTML shim…");
-    let shim = read_or_download(
-      shim_path,
-      &shim_backup_url,
-      Some(SHIMHTML.as_bytes()),
-    )
-    .await?;
-
-    let shim_str = String::from_utf8(shim)
-      .map_err(|e| {
-        MechError::new(
-          Utf8ConversionError {
-            source_error: e.to_string(),
-          },
-          None,
-        )
-        .with_compiler_loc()
-      })?;
-
-    print!("{badge} Loading WASM…");
-    let wasm = read_or_download(
-      &wasm_path,
-      &wasm_backup_url,
-      Some(MECHWASM),
-    )
-    .await?;
-
-    print!("{badge} Loading JS…");
-    let js = read_or_download(
-      &js_path,
-      &js_backup_url,
-      Some(MECHJS),
-    )
-    .await?;
-
-    let authority = capabilities::build_mech_filesystem_authority(
-      serve_matches,
-      loaded_config.as_ref(),
-      &badge,
-    )?;
-
-    let mut server = MechServer::new_with_runtime_config_and_host_config(
-      "Mech Server".to_string(),
-      full_address,
-      stylesheet_str,
-      shim_str,
-      wasm,
-      js,
-      authority,
-      runtime_config,
-      host_config,
-      host_config_injection,
-      config_shim_at_root,
+    let shim_backup_url =
+        "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/shim.html"
+            .to_string();
+    let stylesheet_backup_url =
+        "https://raw.githubusercontent.com/mech-lang/mech/refs/heads/main/include/style.css"
+            .to_string();
+    let wasm_backup_url = format!(
+        "https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm_bg.wasm.br",
+        VERSION
+    );
+    let js_backup_url = format!(
+        "https://github.com/mech-lang/mech/releases/download/v{}-beta/mech_wasm.js",
+        VERSION
     );
 
-    server.init().await?;
+    // --------------------------------------------------------------------------
+    // Bundle Web
+    // --------------------------------------------------------------------------
+    #[cfg(feature = "bundle_web")]
+    if let Some(bundle_matches) = cli_matches.subcommand_matches("bundle-web") {
+        let badge = "[Mech Bundle]".truecolor(34, 204, 187);
 
-    if let Err(err) = server.load_workspace(&mech_paths) {
-      println!("{error_badge} {err:#?}");
-      std::process::exit(1);
-    }
+        let loaded = bundle_web::load_bundle_web_config(bundle_matches)?;
+        println!("{badge} Loading config… {}", loaded.path.display());
 
-    println!("{badge} Sources loaded.");
+        let options = bundle_web::effective_bundle_web_options(bundle_matches, loaded)?;
+        let result = mech::bundle_web_project(options)?;
 
-    server.serve().await?;
-  }
-
-  // --------------------------------------------------------------------------
-  // Test
-  // --------------------------------------------------------------------------
-  #[cfg(all(feature = "run", feature = "variable_define", feature = "invariant_define", feature = "symbol_table", feature = "bool"))]
-  if let Some(matches) = cli_matches.subcommand_matches("test") {
-    let mech_paths: Vec<String> = matches
-      .get_many::<String>("mech_test_file_paths")
-      .map_or(vec![".".to_string()], |files| files.map(|file| file.to_string()).collect());
-    let output_path = matches.get_one::<String>("output_path").cloned();
-    let verbose = matches.get_flag("verbose");
-    let exit_code = run_mech_tests(mech_paths, tree_flag, debug_flag, time_flag, trace_flag, output_path, verbose)?;
-    std::process::exit(exit_code);
-  }
-
-  // --------------------------------------------------------------------------
-  // Build
-  // --------------------------------------------------------------------------
-  #[cfg(feature = "build")]
-  if let Some(matches) = cli_matches.subcommand_matches("build") {
-    let mech_paths: Vec<String> = matches.get_many::<String>("mech_build_file_paths").map_or(vec![], |files| files.map(|file| file.to_string()).collect());
-    let output_path = PathBuf::from(matches.get_one::<String>("output_path").cloned().unwrap_or(".".to_string()));
-    let debug_flag = matches.get_flag("debug");
-    let rounds_per_step = matches.get_one::<String>("rounds-per-step").and_then(|s| s.parse::<usize>().ok()).unwrap_or(10_000);
-    // Create the directory html_output_path
-    if output_path != PathBuf::from(".") {
-      match fs::create_dir_all(&output_path) {
-        Ok(_) => {
-          println!("{} Directory created: {}", "[Created]".truecolor(153,221,85), output_path.display());
-        }
-        Err(err) => {
-          println!("Error creating directory: {:?}", err);
-        }
-      }
-    }
-
-    let uuid = generate_uuid();
-    let mut program = MechProgram::new(MechProgramConfig { name: format!("program-{}", uuid), environment: MechProgramEnvironment::default() });
-    let _ = tree_flag;
-    let _ = trace_flag;
-    program.configure(debug_flag, trace_flag, time_flag, rounds_per_step);
-    for path in mech_paths {
-      let source = std::fs::read_to_string(&path)?;
-      let _ = program.run_string(&source)?;
-    }
-
-    let bytecode = program.interpreter_mut().compile()?;
-
-    let mut output_file = output_path.join("output.mecb");
-
-    let mut f = std::fs::File::create(&output_file)?;
-    f.write_all(&bytecode)?;
-    f.flush()?;
-
-    // print debug info for the context
-    if debug_flag {
-      println!("{} Bytecode Size: {:#?} bytes", "[Debug]".truecolor(246,192,78), &program.interpreter().context);
-    }
-
-    println!("{} Mech bytecode written to: {}", "[Output]".truecolor(153,221,85), output_file.display());
-
-    return Ok(());
-  }
-
-  // --------------------------------------------------------------------------
-  // Format
-  // --------------------------------------------------------------------------
-  #[cfg(feature = "formatter")]
-  if let Some(matches) = cli_matches.subcommand_matches("format") {
-    let badge = "[Mech Formatter]".truecolor(34, 204, 187);
-    let html_flag = matches.get_flag("html");
-    let stylesheet_paths: Vec<String> = matches
-        .get_many::<String>("stylesheet")
-        .map_or(vec![], |paths| paths.map(|path| path.to_string()).collect());
-
-    let shim_path = matches
-        .get_one::<String>("shim")
-        .cloned()
-        .unwrap_or("".to_string());
-
-    let output_path =
-        PathBuf::from(matches.get_one::<String>("output_path").cloned().unwrap_or(".".to_string()));
-    let is_output_file = output_path.extension().is_some();
-
-    let mech_paths: Vec<String> = matches
-        .get_many::<String>("mech_format_file_paths")
-        .map_or(vec![], |files| files.map(|file| file.to_string()).collect());
-
-    // If the user provided exactly one path
-    if mech_paths.len() == 1 {
-      let input_path = PathBuf::from(&mech_paths[0]);
-      if input_path.is_dir() && is_output_file {
-        eprintln!(
-          "{} Cannot write directory `{}` into single output file `{}`. Provide a directory for --out instead.",
-          "[Error]".truecolor(246,98,78),
-          input_path.display(),
-          output_path.display()
-        );
+        println!("{badge} Bundle written: {}", result.output_dir.display());
+        println!("{badge} Sources bundled: {}", result.source_count);
         return Ok(());
-      }
-    }
-    println!("{} Loading resources…", badge);
-
-    // Load stylesheet
-    print!("{} Loading stylesheet…", badge);
-    let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
-
-    // Load shim HTML
-    print!("{} Loading HTML shim…", badge);
-    let shim = read_or_download(&shim_path, &shim_backup_url, Some(SHIMHTML.as_bytes())).await?;
-    let shim_str = String::from_utf8(shim).map_err(|e| {
-      MechError::new(
-        Utf8ConversionError {
-          source_error: e.to_string(),
-        },
-        None,
-      )
-      .with_compiler_loc()
-    })?;
-
-    let mut loaded_sources: Vec<(PathBuf, MechSourceCode)> = Vec::new();
-    for path in mech_paths {
-      let pb = PathBuf::from(&path);
-      let source = std::fs::read_to_string(&pb)?;
-      let code = match pb.extension().and_then(|e| e.to_str()) {
-        Some("html") => MechSourceCode::Html(source),
-        _ => MechSourceCode::String(source),
-      };
-      loaded_sources.push((pb, code));
     }
 
-    // Only create directory if output_path is not a file
-    if !is_output_file && output_path != PathBuf::from(".") {
-      match fs::create_dir_all(&output_path) {
-        Ok(_) => println!(
-          "{} Directory created: {}",
-          "[Created]".truecolor(153, 221, 85),
-          output_path.display()
-        ),
-        Err(err) => println!("Error creating directory: {:?}", err),
-      }
+    // --------------------------------------------------------------------------
+    // Serve
+    // --------------------------------------------------------------------------
+    #[cfg(feature = "serve")]
+    if let Some(serve_matches) = cli_matches.subcommand_matches("serve") {
+        let badge = "[Mech Server]".truecolor(34, 204, 187);
+        let error_badge = "[Error]".truecolor(246, 98, 78);
+
+        let loaded_config = config::load_cli_config(serve_matches)?;
+        let effective = config::effective_serve_options(serve_matches, loaded_config.as_ref())?;
+        let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+        let runtime_config = mech::apply_runtime_config_patch(
+            mech_runtime::RuntimeConfig::default(),
+            loaded_config
+                .as_ref()
+                .map(|loaded| &loaded.document.runtime)
+                .unwrap_or(&default_runtime_patch),
+        )?;
+        let host_config = loaded_config.as_ref().map(|loaded| {
+            mech_host_browser::BrowserHostConfig::from_document_and_runtime(
+                &loaded.document,
+                &runtime_config,
+            )
+        });
+        let config_shim_at_root = loaded_config
+            .as_ref()
+            .and_then(|loaded| loaded.document.serve.as_ref())
+            .and_then(|serve| serve.shim.as_ref())
+            .is_some()
+            && serve_matches.get_one::<String>("shim").is_none();
+        if let Some(loaded) = loaded_config.as_ref() {
+            println!(
+                "{badge} Loaded browser config grants: {}",
+                loaded.document.browser.grants().len()
+            );
+        }
+
+        let full_address = format!("{}:{}", effective.address, effective.port);
+        #[cfg(feature = "host_delegation_signing")]
+        let host_config_injection = serve_host_delegation_injection(
+            serve_matches,
+            loaded_config.as_ref(),
+            &runtime_config,
+            &full_address,
+        )?;
+        #[cfg(not(feature = "host_delegation_signing"))]
+        let host_config_injection = None;
+        let mech_paths = effective.paths;
+        let stylesheet_paths = effective.stylesheet_paths;
+        let wasm_pkg = effective.wasm_pkg.as_str();
+        let shim_path = effective.shim_path.as_str();
+
+        let wasm_path = format!("{wasm_pkg}/mech_wasm_bg.wasm.br");
+        let js_path = format!("{wasm_pkg}/mech_wasm.js");
+
+        println!("{badge} Loading resources…");
+
+        print!("{badge} Loading stylesheet…");
+        let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
+
+        print!("{badge} Loading HTML shim…");
+        let shim = read_or_download(shim_path, &shim_backup_url, Some(SHIMHTML.as_bytes())).await?;
+
+        let shim_str = String::from_utf8(shim).map_err(|e| {
+            MechError::new(
+                Utf8ConversionError {
+                    source_error: e.to_string(),
+                },
+                None,
+            )
+            .with_compiler_loc()
+        })?;
+
+        print!("{badge} Loading WASM…");
+        let wasm = read_or_download(&wasm_path, &wasm_backup_url, Some(MECHWASM)).await?;
+
+        print!("{badge} Loading JS…");
+        let js = read_or_download(&js_path, &js_backup_url, Some(MECHJS)).await?;
+
+        let authority = capabilities::build_mech_filesystem_authority(
+            serve_matches,
+            loaded_config.as_ref(),
+            &badge,
+        )?;
+
+        let mut server = MechServer::new_with_runtime_config_and_host_config(
+            "Mech Server".to_string(),
+            full_address,
+            stylesheet_str,
+            shim_str,
+            wasm,
+            js,
+            authority,
+            runtime_config,
+            host_config,
+            host_config_injection,
+            config_shim_at_root,
+        );
+
+        server.init().await?;
+
+        if let Err(err) = server.load_workspace(&mech_paths) {
+            println!("{error_badge} {err:#?}");
+            std::process::exit(1);
+        }
+
+        println!("{badge} Sources loaded.");
+
+        server.serve().await?;
     }
 
-    // HTML mode
-    if html_flag {
-      let html_items: Vec<_> = loaded_sources.iter().filter_map(|(p, src)| {
-        if let MechSourceCode::Html(content) = src {
-          Some((p, content))
+    // --------------------------------------------------------------------------
+    // Test
+    // --------------------------------------------------------------------------
+    #[cfg(all(
+        feature = "run",
+        feature = "variable_define",
+        feature = "invariant_define",
+        feature = "symbol_table",
+        feature = "bool"
+    ))]
+    if let Some(matches) = cli_matches.subcommand_matches("test") {
+        let mech_paths: Vec<String> = matches
+            .get_many::<String>("mech_test_file_paths")
+            .map_or(vec![".".to_string()], |files| {
+                files.map(|file| file.to_string()).collect()
+            });
+        let output_path = matches.get_one::<String>("output_path").cloned();
+        let verbose = matches.get_flag("verbose");
+        let exit_code = run_mech_tests(
+            mech_paths,
+            tree_flag,
+            debug_flag,
+            time_flag,
+            trace_flag,
+            output_path,
+            verbose,
+        )?;
+        std::process::exit(exit_code);
+    }
+
+    // --------------------------------------------------------------------------
+    // Build
+    // --------------------------------------------------------------------------
+    #[cfg(feature = "build")]
+    if let Some(matches) = cli_matches.subcommand_matches("build") {
+        let mech_paths: Vec<String> = matches
+            .get_many::<String>("mech_build_file_paths")
+            .map_or(vec![], |files| files.map(|file| file.to_string()).collect());
+        let output_path = PathBuf::from(
+            matches
+                .get_one::<String>("output_path")
+                .cloned()
+                .unwrap_or(".".to_string()),
+        );
+        let debug_flag = matches.get_flag("debug");
+        let rounds_per_step = matches
+            .get_one::<String>("rounds-per-step")
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(10_000);
+        // Create the directory html_output_path
+        if output_path != PathBuf::from(".") {
+            match fs::create_dir_all(&output_path) {
+                Ok(_) => {
+                    println!(
+                        "{} Directory created: {}",
+                        "[Created]".truecolor(153, 221, 85),
+                        output_path.display()
+                    );
+                }
+                Err(err) => {
+                    println!("Error creating directory: {:?}", err);
+                }
+            }
+        }
+
+        let uuid = generate_uuid();
+        let mut program = MechProgram::new(MechProgramConfig {
+            name: format!("program-{}", uuid),
+            environment: MechProgramEnvironment::default(),
+        });
+        let _ = tree_flag;
+        let _ = trace_flag;
+        program.configure(debug_flag, trace_flag, time_flag, rounds_per_step);
+        for path in mech_paths {
+            let source = std::fs::read_to_string(&path)?;
+            let _ = program.run_string(&source)?;
+        }
+
+        let bytecode = program.interpreter_mut().compile()?;
+
+        let mut output_file = output_path.join("output.mecb");
+
+        let mut f = std::fs::File::create(&output_file)?;
+        f.write_all(&bytecode)?;
+        f.flush()?;
+
+        // print debug info for the context
+        if debug_flag {
+            println!(
+                "{} Bytecode Size: {:#?} bytes",
+                "[Debug]".truecolor(246, 192, 78),
+                &program.interpreter().context
+            );
+        }
+
+        println!(
+            "{} Mech bytecode written to: {}",
+            "[Output]".truecolor(153, 221, 85),
+            output_file.display()
+        );
+
+        return Ok(());
+    }
+
+    // --------------------------------------------------------------------------
+    // Format
+    // --------------------------------------------------------------------------
+    #[cfg(feature = "formatter")]
+    if let Some(matches) = cli_matches.subcommand_matches("format") {
+        let badge = "[Mech Formatter]".truecolor(34, 204, 187);
+        let html_flag = matches.get_flag("html");
+        let stylesheet_paths: Vec<String> = matches
+            .get_many::<String>("stylesheet")
+            .map_or(vec![], |paths| paths.map(|path| path.to_string()).collect());
+
+        let shim_path = matches
+            .get_one::<String>("shim")
+            .cloned()
+            .unwrap_or("".to_string());
+
+        let output_path = PathBuf::from(
+            matches
+                .get_one::<String>("output_path")
+                .cloned()
+                .unwrap_or(".".to_string()),
+        );
+        let is_output_file = output_path.extension().is_some();
+
+        let mech_paths: Vec<String> = matches
+            .get_many::<String>("mech_format_file_paths")
+            .map_or(vec![], |files| files.map(|file| file.to_string()).collect());
+
+        // If the user provided exactly one path
+        if mech_paths.len() == 1 {
+            let input_path = PathBuf::from(&mech_paths[0]);
+            if input_path.is_dir() && is_output_file {
+                eprintln!(
+                    "{} Cannot write directory `{}` into single output file `{}`. Provide a directory for --out instead.",
+                    "[Error]".truecolor(246, 98, 78),
+                    input_path.display(),
+                    output_path.display()
+                );
+                return Ok(());
+            }
+        }
+        println!("{} Loading resources…", badge);
+
+        // Load stylesheet
+        print!("{} Loading stylesheet…", badge);
+        let stylesheet_str = load_stylesheets(&stylesheet_paths, &stylesheet_backup_url).await?;
+
+        // Load shim HTML
+        print!("{} Loading HTML shim…", badge);
+        let shim =
+            read_or_download(&shim_path, &shim_backup_url, Some(SHIMHTML.as_bytes())).await?;
+        let shim_str = String::from_utf8(shim).map_err(|e| {
+            MechError::new(
+                Utf8ConversionError {
+                    source_error: e.to_string(),
+                },
+                None,
+            )
+            .with_compiler_loc()
+        })?;
+
+        let mut loaded_sources: Vec<(PathBuf, MechSourceCode)> = Vec::new();
+        for path in mech_paths {
+            let pb = PathBuf::from(&path);
+            let source = std::fs::read_to_string(&pb)?;
+            let code = match pb.extension().and_then(|e| e.to_str()) {
+                Some("html") => MechSourceCode::Html(source),
+                _ => MechSourceCode::String(source),
+            };
+            loaded_sources.push((pb, code));
+        }
+
+        // Only create directory if output_path is not a file
+        if !is_output_file && output_path != PathBuf::from(".") {
+            match fs::create_dir_all(&output_path) {
+                Ok(_) => println!(
+                    "{} Directory created: {}",
+                    "[Created]".truecolor(153, 221, 85),
+                    output_path.display()
+                ),
+                Err(err) => println!("Error creating directory: {:?}", err),
+            }
+        }
+
+        // HTML mode
+        if html_flag {
+            let html_items: Vec<_> = loaded_sources
+                .iter()
+                .filter_map(|(p, src)| {
+                    if let MechSourceCode::Html(content) = src {
+                        Some((p, content))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let is_single_html = html_items.len() == 1;
+
+            if is_output_file && is_single_html {
+                // write ONLY HTML result to output file
+                let (_, content) = html_items[0];
+                save_to_file(output_path, content)?;
+            } else {
+                // otherwise produce multiple output files
+                for (path, content) in html_items {
+                    let filename = path.with_extension("html");
+                    let output_file = if is_output_file {
+                        output_path.clone()
+                    } else {
+                        output_path.join(filename)
+                    };
+                    save_to_file(output_file, content)?;
+                }
+            }
         } else {
-          None
+            // Raw source mode
+            for (filename, mech_src) in loaded_sources {
+                let content = mech_src.to_string();
+                let output_file = if is_output_file {
+                    output_path.clone()
+                } else {
+                    output_path.join(filename)
+                };
+                save_to_file(output_file, &content)?;
+            }
         }
-      }).collect();
-      let is_single_html = html_items.len() == 1;
 
-      if is_output_file && is_single_html {
-        // write ONLY HTML result to output file
-        let (_, content) = html_items[0];
-        save_to_file(output_path, content)?;
-      } else {
-        // otherwise produce multiple output files
-        for (path, content) in html_items {
-          let filename = path.with_extension("html");
-          let output_file = if is_output_file { output_path.clone() }
-                            else { output_path.join(filename) };
-          save_to_file(output_file, content)?;
-        }
-      }
-    } else {
-      // Raw source mode
-      for (filename, mech_src) in loaded_sources {
-        let content = mech_src.to_string();
-        let output_file = if is_output_file { output_path.clone() }
-                          else { output_path.join(filename) };
-        save_to_file(output_file, &content)?;
-      }
+        return Ok(());
     }
 
-    return Ok(());
-  }
+    // --------------------------------------------------------------------------
+    // Run
+    // --------------------------------------------------------------------------
+    let mut caught_inturrupts = Arc::new(Mutex::new(0));
+    #[cfg(feature = "run")]
+    let uuid = generate_uuid();
+    #[cfg(feature = "run")]
+    let mut repl_runtime_config: Option<RuntimeConfig> = None;
 
-
-  // --------------------------------------------------------------------------
-  // Run
-  // --------------------------------------------------------------------------
-  let mut caught_inturrupts = Arc::new(Mutex::new(0));
-  #[cfg(feature = "run")]
-  let uuid = generate_uuid();
-  #[cfg(feature = "run")]
-  let mut repl_runtime_config: Option<RuntimeConfig> = None;
-
-  #[cfg(feature = "run")]
-  {
-    let run_matches = cli_matches.subcommand_matches("run");
-    let explicit_run_command = run_matches.is_some();
-    let run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
-      run_matches
-        .get_many::<String>("mech_run_paths")
-        .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
-    } else if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
-      m.map(|s| s.to_string()).collect()
-    } else {
-      vec![]
-    };
-
-    let run_debug_flag = debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
-    let run_trace_flag = trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
-    let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);
-    let run_rounds_per_step = run_matches
-      .and_then(|m| m.get_one::<String>("rounds-per-step"))
-      .and_then(|s| s.parse::<usize>().ok())
-      .or(root_rounds_per_step);
-
-    let any_look_like_paths = run_inputs.iter().any(|p| is_intended_path(p));
-    let config_matches = run_matches.unwrap_or(&cli_matches);
-    let config_inputs = if any_look_like_paths { run_inputs.as_slice() } else { &[] };
-    let loaded_config = config::load_run_cli_config(config_matches, config_inputs)?;
-
-    let runtime_config = effective_run_runtime_config(
-      loaded_config.as_ref(),
-      format!("program-{}", uuid),
-      run_debug_flag,
-      run_trace_flag,
-      run_time_flag,
-      run_rounds_per_step,
-    )?;
-    repl_runtime_config = Some(runtime_config.clone());
-
-    let mut runtime = new_cli_runtime(runtime_config)?;
-
-    if !run_inputs.is_empty() && !any_look_like_paths {
-      let joined = run_inputs.join(" ");
-      match run_cli_source(&mut runtime, joined.trim()) {
-        Ok(r) => {
-          println!("{}", r.kind());
-          #[cfg(feature = "pretty_print")]
-          println!("{}", r.pretty_print());
-          #[cfg(not(feature = "pretty_print"))]
-          println!("{:#?}", r);
-          std::process::exit(0);
-        }
-        Err(err) => {
-          println!("{} {:#?}",
-            "[Error]".truecolor(246,98,78),
-            err
-          );
-          std::process::exit(1);
-        }
-      }
-    }
-
-    let options = config::effective_run_options(
-      run_inputs,
-      loaded_config.as_ref(),
-      explicit_run_command,
-    )?;
-
-    let result: MResult<Value> = if let Some(options) = options {
-      let mut last = Value::Empty;
-      for p in &options.paths {
-        let src = std::fs::read_to_string(p)?;
-        last = run_cli_source(&mut runtime, &src)?;
-      }
-      Ok(last)
-    } else {
-      repl_flag = true;
-      Ok(Value::Empty)
-    };
-
-    if !repl_flag {
-      match &result {
-        Ok(r) => {
-          println!("{}", r.kind());
-          #[cfg(feature = "pretty_print")]
-          println!("{}", r.pretty_print());
-          #[cfg(not(feature = "pretty_print"))]
-          println!("{:#?}", r);
-          std::process::exit(0);
-        }
-        Err(err) => {
-          print_mech_error(err);
-          std::process::exit(1);
-        }
-      };
-    }
-
-    #[cfg(windows)]
-    control::set_virtual_terminal(true).unwrap();
-    clc();
-    let mut stdo = stdout();
-    stdo.execute(Print(text_logo));
-    stdo.execute(cursor::MoveToNextLine(1));
-    println!("\n                {}                ",format!("v{}",VERSION).truecolor(246,192,78));
-    println!("           {}           \n", "www.mech-lang.org");
-    let intro_message = format!("{}Enter {} for a list of all commands.{}\n", mika_open, help_cmd, mika_close);
-    println!("{} {}", micromika, intro_message);
-
-    // Catch Ctrl-C a couple times before quitting
-    let mut ci = caught_inturrupts.clone();
-    ctrlc::set_handler(move || {
-      println!("{}", ctrlc_cmd);
-      let mut caught_inturrupts = ci.lock().unwrap();
-      *caught_inturrupts += 1;
-      if *caught_inturrupts >= 3 {
-        let final_state = ProgressBar::new_spinner();
-        let completed_style = ProgressStyle::with_template(
-          "\n{spinner:.yellow} {msg}"
-        ).unwrap().tick_strings(MICROMIKA_WAVE);
-        final_state.set_style(completed_style);
-        final_state.set_message(format!("{}Okay cya!{}\n", mika_open, mika_close));
-        for _ in 0..MICROMIKA_WAVE.len() - 1 {
-          thread::sleep(Duration::from_millis(100));
-          final_state.tick();
-        }
-        std::process::exit(0);
-      }
-      println!("\n{} {}Enter {} to terminate this REPL session.{}\n", micromika_point, mika_open, quit_cmd, mika_close);
-      print_prompt();
-    }).expect("Error setting Ctrl+C handler");
-  }
-
-  // --------------------------------------------------------------------------
-  // REPL
-  // --------------------------------------------------------------------------
-  #[cfg(all(feature = "repl", feature = "run"))]
-  // TODO: move the REPL onto MechRuntime as a separate PR so CLI host contexts work interactively too.
-  let mut repl = {
-    let config = repl_runtime_config.unwrap_or_else(RuntimeConfig::default);
-    let mut repl_program = MechProgram::new(MechProgramConfig {
-      name: config.name.clone(),
-      environment: MechProgramEnvironment::default(),
-    });
-    repl_program.configure(
-      config.diagnostics.debug_enabled,
-      config.diagnostics.trace_enabled,
-      config.diagnostics.profile_enabled,
-      config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
-    );
-    MechRepl::from(repl_program)
-  };
-  #[cfg(all(feature = "repl", not(feature = "run")))]
-  let mut repl = MechRepl::from(MechProgram::new(MechProgramConfig {
-    name: format!("repl-{}", generate_uuid()),
-    environment: MechProgramEnvironment::default(),
-  }));
-  #[cfg(feature = "repl")]
-  'REPL: loop {
+    #[cfg(feature = "run")]
     {
-      let mut ci = caught_inturrupts.lock().unwrap();
-      *ci = 0;
-    }
-    // Prompt the user for input
-    print_prompt();
-    let mut input = String::new();
-    io::stdin().read_line(&mut input).unwrap();
+        let run_matches = cli_matches.subcommand_matches("run");
+        let explicit_run_command = run_matches.is_some();
+        let run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
+            run_matches
+                .get_many::<String>("mech_run_paths")
+                .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
+        } else if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
+            m.map(|s| s.to_string()).collect()
+        } else {
+            vec![]
+        };
 
-    // Parse the input
-    if input.chars().nth(0) == Some(':') {
-      match parse_repl_command(&input.as_str()) {
-        Ok((_, repl_command)) => {
-          match repl.execute_repl_command(repl_command) {
-            Ok(output) => {
-              println!("{}", output);
-            }
-            Err(err) => {
-              println!("!{:?}", err);
-            }
-          }
-        }
-        Err(x) => {
-          println!("{} Unrecognized command: {}", "[Error]".truecolor(246,98,78), x);
-        }
-      }
-    } else if input.trim() == "" {
-      continue;
-    } else {
-      let cmd = ReplCommand::Code(vec![("repl".to_string(),MechSourceCode::String(input))]);
-      match repl.execute_repl_command(cmd) {
-        Ok(output) => {
-          println!("{}", output);
-        }
-        Err(err) => {
-          println!("(x)> {:#?}", err);
-        }
-      }
-    }
-  }
+        let run_debug_flag =
+            debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
+        let run_trace_flag =
+            trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
+        let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);
+        let run_deny_cli_env = cli_matches.get_flag("deny_cli_env")
+            || run_matches
+                .map(|m| m.get_flag("deny_cli_env"))
+                .unwrap_or(false);
+        let run_deny_cli_stdout = cli_matches.get_flag("deny_cli_stdout")
+            || run_matches
+                .map(|m| m.get_flag("deny_cli_stdout"))
+                .unwrap_or(false);
+        let run_deny_cli_stderr = cli_matches.get_flag("deny_cli_stderr")
+            || run_matches
+                .map(|m| m.get_flag("deny_cli_stderr"))
+                .unwrap_or(false);
+        let run_rounds_per_step = run_matches
+            .and_then(|m| m.get_one::<String>("rounds-per-step"))
+            .and_then(|s| s.parse::<usize>().ok())
+            .or(root_rounds_per_step);
 
-  Ok(())
+        let any_look_like_paths = run_inputs.iter().any(|p| is_intended_path(p));
+        let config_matches = run_matches.unwrap_or(&cli_matches);
+        let config_inputs = if any_look_like_paths {
+            run_inputs.as_slice()
+        } else {
+            &[]
+        };
+        let loaded_config = config::load_run_cli_config(config_matches, config_inputs)?;
+
+        let runtime_config = effective_run_runtime_config(
+            loaded_config.as_ref(),
+            format!("program-{}", uuid),
+            run_debug_flag,
+            run_trace_flag,
+            run_time_flag,
+            run_rounds_per_step,
+        )?;
+        repl_runtime_config = Some(runtime_config.clone());
+
+        let cli_grants = config::effective_cli_host_grants(
+            loaded_config.as_ref(),
+            config::CliHostGrantAttenuation {
+                deny_env: run_deny_cli_env,
+                deny_stdout: run_deny_cli_stdout,
+                deny_stderr: run_deny_cli_stderr,
+            },
+        )?;
+
+        let mut runtime = new_cli_runtime(runtime_config, &cli_grants)?;
+
+        if !run_inputs.is_empty() && !any_look_like_paths {
+            let joined = run_inputs.join(" ");
+            match run_cli_source(&mut runtime, joined.trim()) {
+                Ok(r) => {
+                    println!("{}", r.kind());
+                    #[cfg(feature = "pretty_print")]
+                    println!("{}", r.pretty_print());
+                    #[cfg(not(feature = "pretty_print"))]
+                    println!("{:#?}", r);
+                    std::process::exit(0);
+                }
+                Err(err) => {
+                    println!("{} {:#?}", "[Error]".truecolor(246, 98, 78), err);
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        let options = config::effective_run_options(
+            run_inputs,
+            loaded_config.as_ref(),
+            explicit_run_command,
+        )?;
+
+        let result: MResult<Value> = if let Some(options) = options {
+            let mut last = Value::Empty;
+            for p in &options.paths {
+                let src = std::fs::read_to_string(p)?;
+                last = run_cli_source(&mut runtime, &src)?;
+            }
+            Ok(last)
+        } else {
+            repl_flag = true;
+            Ok(Value::Empty)
+        };
+
+        if !repl_flag {
+            match &result {
+                Ok(r) => {
+                    println!("{}", r.kind());
+                    #[cfg(feature = "pretty_print")]
+                    println!("{}", r.pretty_print());
+                    #[cfg(not(feature = "pretty_print"))]
+                    println!("{:#?}", r);
+                    std::process::exit(0);
+                }
+                Err(err) => {
+                    print_mech_error(err);
+                    std::process::exit(1);
+                }
+            };
+        }
+
+        #[cfg(windows)]
+        control::set_virtual_terminal(true).unwrap();
+        clc();
+        let mut stdo = stdout();
+        stdo.execute(Print(text_logo));
+        stdo.execute(cursor::MoveToNextLine(1));
+        println!(
+            "\n                {}                ",
+            format!("v{}", VERSION).truecolor(246, 192, 78)
+        );
+        println!("           {}           \n", "www.mech-lang.org");
+        let intro_message = format!(
+            "{}Enter {} for a list of all commands.{}\n",
+            mika_open, help_cmd, mika_close
+        );
+        println!("{} {}", micromika, intro_message);
+
+        // Catch Ctrl-C a couple times before quitting
+        let mut ci = caught_inturrupts.clone();
+        ctrlc::set_handler(move || {
+            println!("{}", ctrlc_cmd);
+            let mut caught_inturrupts = ci.lock().unwrap();
+            *caught_inturrupts += 1;
+            if *caught_inturrupts >= 3 {
+                let final_state = ProgressBar::new_spinner();
+                let completed_style = ProgressStyle::with_template("\n{spinner:.yellow} {msg}")
+                    .unwrap()
+                    .tick_strings(MICROMIKA_WAVE);
+                final_state.set_style(completed_style);
+                final_state.set_message(format!("{}Okay cya!{}\n", mika_open, mika_close));
+                for _ in 0..MICROMIKA_WAVE.len() - 1 {
+                    thread::sleep(Duration::from_millis(100));
+                    final_state.tick();
+                }
+                std::process::exit(0);
+            }
+            println!(
+                "\n{} {}Enter {} to terminate this REPL session.{}\n",
+                micromika_point, mika_open, quit_cmd, mika_close
+            );
+            print_prompt();
+        })
+        .expect("Error setting Ctrl+C handler");
+    }
+
+    // --------------------------------------------------------------------------
+    // REPL
+    // --------------------------------------------------------------------------
+    #[cfg(all(feature = "repl", feature = "run"))]
+    // TODO: move the REPL onto MechRuntime as a separate PR so CLI host contexts work interactively too.
+    let mut repl = {
+        let config = repl_runtime_config.unwrap_or_else(RuntimeConfig::default);
+        let mut repl_program = MechProgram::new(MechProgramConfig {
+            name: config.name.clone(),
+            environment: MechProgramEnvironment::default(),
+        });
+        repl_program.configure(
+            config.diagnostics.debug_enabled,
+            config.diagnostics.trace_enabled,
+            config.diagnostics.profile_enabled,
+            config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+        );
+        MechRepl::from(repl_program)
+    };
+    #[cfg(all(feature = "repl", not(feature = "run")))]
+    let mut repl = MechRepl::from(MechProgram::new(MechProgramConfig {
+        name: format!("repl-{}", generate_uuid()),
+        environment: MechProgramEnvironment::default(),
+    }));
+    #[cfg(feature = "repl")]
+    'REPL: loop {
+        {
+            let mut ci = caught_inturrupts.lock().unwrap();
+            *ci = 0;
+        }
+        // Prompt the user for input
+        print_prompt();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).unwrap();
+
+        // Parse the input
+        if input.chars().nth(0) == Some(':') {
+            match parse_repl_command(&input.as_str()) {
+                Ok((_, repl_command)) => match repl.execute_repl_command(repl_command) {
+                    Ok(output) => {
+                        println!("{}", output);
+                    }
+                    Err(err) => {
+                        println!("!{:?}", err);
+                    }
+                },
+                Err(x) => {
+                    println!(
+                        "{} Unrecognized command: {}",
+                        "[Error]".truecolor(246, 98, 78),
+                        x
+                    );
+                }
+            }
+        } else if input.trim() == "" {
+            continue;
+        } else {
+            let cmd = ReplCommand::Code(vec![("repl".to_string(), MechSourceCode::String(input))]);
+            match repl.execute_repl_command(cmd) {
+                Ok(output) => {
+                    println!("{}", output);
+                }
+                Err(err) => {
+                    println!("(x)> {:#?}", err);
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(feature = "async")]
 pub async fn load_resource(resource_path: &str) -> String {
-  if resource_path.starts_with("http") {
-    match reqwest::get(resource_path).await {
-      Ok(response) => match response.text().await {
-        Ok(text) => text,
-        Err(err) => {
-          eprintln!("Error fetching resource text: {:?}", err);
-          String::new()
+    if resource_path.starts_with("http") {
+        match reqwest::get(resource_path).await {
+            Ok(response) => match response.text().await {
+                Ok(text) => text,
+                Err(err) => {
+                    eprintln!("Error fetching resource text: {:?}", err);
+                    String::new()
+                }
+            },
+            Err(err) => {
+                eprintln!("Error fetching resource: {:?}", err);
+                String::new()
+            }
         }
-      },
-      Err(err) => {
-        eprintln!("Error fetching resource: {:?}", err);
-        String::new()
-      }
+    } else {
+        match tokio::fs::read_to_string(resource_path).await {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("Error reading resource file: {:?}", err);
+                String::new()
+            }
+        }
     }
-  } else {
-    match tokio::fs::read_to_string(resource_path).await {
-      Ok(content) => content,
-      Err(err) => {
-        eprintln!("Error reading resource file: {:?}", err);
-        String::new()
-      }
-    }
-  }
 }
 
 #[cfg(not(feature = "async"))]
 pub fn load_resource(resource_path: &str) -> String {
-  if resource_path.starts_with("http") {
-    match reqwest::blocking::get(resource_path) {
-      Ok(response) => match response.text() {
-        Ok(text) => text,
-        Err(err) => {
-          eprintln!("Error fetching resource text: {:?}", err);
-          String::new()
+    if resource_path.starts_with("http") {
+        match reqwest::blocking::get(resource_path) {
+            Ok(response) => match response.text() {
+                Ok(text) => text,
+                Err(err) => {
+                    eprintln!("Error fetching resource text: {:?}", err);
+                    String::new()
+                }
+            },
+            Err(err) => {
+                eprintln!("Error fetching resource: {:?}", err);
+                String::new()
+            }
         }
-      },
-      Err(err) => {
-        eprintln!("Error fetching resource: {:?}", err);
-        String::new()
-      }
+    } else {
+        match std::fs::read_to_string(resource_path) {
+            Ok(content) => content,
+            Err(err) => {
+                eprintln!("Error reading resource file: {:?}", err);
+                String::new()
+            }
+        }
     }
-  } else {
-    match std::fs::read_to_string(resource_path) {
-      Ok(content) => content,
-      Err(err) => {
-        eprintln!("Error reading resource file: {:?}", err);
-        String::new()
-      }
-    }
-  }
 }
-
 
 #[cfg(all(feature = "host_delegation_signing", feature = "serve"))]
 fn host_delegation_args() -> Vec<Arg> {
-  vec![
-    Arg::new("host_delegation_key").long("host-delegation-key").value_name("PATH").num_args(1),
-    Arg::new("host_delegation_public_key").long("host-delegation-public-key").value_name("PATH").num_args(1),
-    Arg::new("host_delegation_key_id").long("host-delegation-key-id").value_name("ID").num_args(1),
-    Arg::new("host_delegation_issuer").long("host-delegation-issuer").value_name("ISSUER").num_args(1),
-    Arg::new("host_delegation_subject").long("host-delegation-subject").value_name("SUBJECT").num_args(1),
-    Arg::new("host_delegation_audience").long("host-delegation-audience").value_name("AUDIENCE").num_args(1),
-    Arg::new("host_delegation_expires_ms").long("host-delegation-expires-ms").value_name("MS").num_args(1),
-  ]
+    vec![
+        Arg::new("host_delegation_key")
+            .long("host-delegation-key")
+            .value_name("PATH")
+            .num_args(1),
+        Arg::new("host_delegation_public_key")
+            .long("host-delegation-public-key")
+            .value_name("PATH")
+            .num_args(1),
+        Arg::new("host_delegation_key_id")
+            .long("host-delegation-key-id")
+            .value_name("ID")
+            .num_args(1),
+        Arg::new("host_delegation_issuer")
+            .long("host-delegation-issuer")
+            .value_name("ISSUER")
+            .num_args(1),
+        Arg::new("host_delegation_subject")
+            .long("host-delegation-subject")
+            .value_name("SUBJECT")
+            .num_args(1),
+        Arg::new("host_delegation_audience")
+            .long("host-delegation-audience")
+            .value_name("AUDIENCE")
+            .num_args(1),
+        Arg::new("host_delegation_expires_ms")
+            .long("host-delegation-expires-ms")
+            .value_name("MS")
+            .num_args(1),
+    ]
 }
 
 #[cfg(any(not(feature = "host_delegation_signing"), not(feature = "serve")))]
 fn host_delegation_args() -> Vec<Arg> {
-  Vec::new()
+    Vec::new()
 }
 
 #[cfg(all(feature = "host_delegation_signing", feature = "serve"))]
 fn serve_host_delegation_injection(
-  matches: &clap::ArgMatches,
-  loaded_config: Option<&mech::LoadedMechConfig>,
-  runtime_config: &mech_runtime::RuntimeConfig,
-  full_address: &str,
+    matches: &clap::ArgMatches,
+    loaded_config: Option<&mech::LoadedMechConfig>,
+    runtime_config: &mech_runtime::RuntimeConfig,
+    full_address: &str,
 ) -> MResult<Option<mech::HostAuthorityInjection>> {
-  let Some(private_key) = matches.get_one::<String>("host_delegation_key") else {
-    return Ok(None);
-  };
-  let public_key = matches
-    .get_one::<String>("host_delegation_public_key")
-    .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "--host-delegation-public-key is required with --host-delegation-key"))?;
-  let Some(loaded_config) = loaded_config else {
-    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "host delegation signing requires a loaded config").into());
-  };
-  let current_dir = std::env::current_dir()?;
-  let options = mech::HostDelegationSigningOptions {
-    private_key_path: current_dir.join(private_key),
-    public_key_path: current_dir.join(public_key),
-    key_id: matches.get_one::<String>("host_delegation_key_id").cloned().unwrap_or_else(|| "dev".to_string()),
-    issuer: matches.get_one::<String>("host_delegation_issuer").cloned().unwrap_or_else(|| "host://mech-cli".to_string()),
-    subject: matches.get_one::<String>("host_delegation_subject").cloned().unwrap_or_else(|| "wasm://browser".to_string()),
-    audience: matches.get_one::<String>("host_delegation_audience").cloned().unwrap_or_else(|| format!("browser://serve/{full_address}")),
-    expires_ms: matches.get_one::<String>("host_delegation_expires_ms").map(|value| value.parse()).transpose().map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "--host-delegation-expires-ms must be an integer"))?,
-  };
-  let host_config = mech_host_browser::BrowserHostConfig::from_document_and_runtime(
-    &loaded_config.document,
-    runtime_config,
-  );
-  let now_ms = std::time::SystemTime::now()
-    .duration_since(std::time::UNIX_EPOCH)
-    .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))?
-    .as_millis() as u64;
-  mech::signed_browser_host_config_injection(host_config, &options, now_ms).map(Some)
+    let Some(private_key) = matches.get_one::<String>("host_delegation_key") else {
+        return Ok(None);
+    };
+    let public_key = matches
+        .get_one::<String>("host_delegation_public_key")
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "--host-delegation-public-key is required with --host-delegation-key",
+            )
+        })?;
+    let Some(loaded_config) = loaded_config else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "host delegation signing requires a loaded config",
+        )
+        .into());
+    };
+    let current_dir = std::env::current_dir()?;
+    let options = mech::HostDelegationSigningOptions {
+        private_key_path: current_dir.join(private_key),
+        public_key_path: current_dir.join(public_key),
+        key_id: matches
+            .get_one::<String>("host_delegation_key_id")
+            .cloned()
+            .unwrap_or_else(|| "dev".to_string()),
+        issuer: matches
+            .get_one::<String>("host_delegation_issuer")
+            .cloned()
+            .unwrap_or_else(|| "host://mech-cli".to_string()),
+        subject: matches
+            .get_one::<String>("host_delegation_subject")
+            .cloned()
+            .unwrap_or_else(|| "wasm://browser".to_string()),
+        audience: matches
+            .get_one::<String>("host_delegation_audience")
+            .cloned()
+            .unwrap_or_else(|| format!("browser://serve/{full_address}")),
+        expires_ms: matches
+            .get_one::<String>("host_delegation_expires_ms")
+            .map(|value| value.parse())
+            .transpose()
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "--host-delegation-expires-ms must be an integer",
+                )
+            })?,
+    };
+    let host_config = mech_host_browser::BrowserHostConfig::from_document_and_runtime(
+        &loaded_config.document,
+        runtime_config,
+    );
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))?
+        .as_millis() as u64;
+    mech::signed_browser_host_config_injection(host_config, &options, now_ms).map(Some)
 }
 
 fn is_intended_path(s: &str) -> bool {
-  if s.trim().is_empty() { return false; }
-
-  let path = Path::new(s);
-  if path.exists() {
-    return true;
-  }
-  if s.starts_with("./") || s.starts_with(".\\") ||
-    s.starts_with("../") || s.starts_with("..\\") ||
-    s.starts_with('/') || s.starts_with('\\') {
-    return true;
-  }
-  if s.len() > 2 && s.as_bytes()[1] == b':' {
-    return true;
-  }
-  if s.contains('/') || s.contains('\\') {
-    return true;
-  }
-  if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-    match ext {
-      // Mech specific
-      "mec" | "🤖" | "mecb" | "mdoc" | "mpkg" => true,
-      // Data/Standard formats
-      "m" | "csv" | "tsv" | "txt" | "md" | "json" | "toml" | "yaml" => true,
-      // Web
-      "html" | "htm" | "css" | "js" | "wasm" => true,
-      // Images
-      "png" | "jpg" | "jpeg" | "gif" | "svg" | "bmp" | "ico" => true,
-      _ => false,
+    if s.trim().is_empty() {
+        return false;
     }
-  } else {
-    false
-  }
+
+    let path = Path::new(s);
+    if path.exists() {
+        return true;
+    }
+    if s.starts_with("./")
+        || s.starts_with(".\\")
+        || s.starts_with("../")
+        || s.starts_with("..\\")
+        || s.starts_with('/')
+        || s.starts_with('\\')
+    {
+        return true;
+    }
+    if s.len() > 2 && s.as_bytes()[1] == b':' {
+        return true;
+    }
+    if s.contains('/') || s.contains('\\') {
+        return true;
+    }
+    if let Some(ext) = path.extension().and_then(OsStr::to_str) {
+        match ext {
+            // Mech specific
+            "mec" | "🤖" | "mecb" | "mdoc" | "mpkg" => true,
+            // Data/Standard formats
+            "m" | "csv" | "tsv" | "txt" | "md" | "json" | "toml" | "yaml" => true,
+            // Web
+            "html" | "htm" | "css" | "js" | "wasm" => true,
+            // Images
+            "png" | "jpg" | "jpeg" | "gif" | "svg" | "bmp" | "ico" => true,
+            _ => false,
+        }
+    } else {
+        false
+    }
 }
 
 fn source_range_to_offset_range(file_content: &str, range: &SourceRange) -> (usize, usize) {
-  let mut offset = 0;
-  let mut start_offset = 0;
-  let mut end_offset = 0;
+    let mut offset = 0;
+    let mut start_offset = 0;
+    let mut end_offset = 0;
 
-  for (line_index, line) in file_content.split_inclusive('\n').enumerate() {
-    let row = line_index + 1;
-    let line_len = line.len();
-    if row == range.start.row {
-      start_offset = offset + (range.start.col - 1);
+    for (line_index, line) in file_content.split_inclusive('\n').enumerate() {
+        let row = line_index + 1;
+        let line_len = line.len();
+        if row == range.start.row {
+            start_offset = offset + (range.start.col - 1);
+        }
+        if row == range.end.row {
+            end_offset = offset + (range.end.col - 1);
+            break;
+        }
+        offset += line_len;
     }
-    if row == range.end.row {
-      end_offset = offset + (range.end.col - 1);
-      break;
-    }
-    offset += line_len;
-  }
-  end_offset = end_offset.min(file_content.len());
-  while start_offset < end_offset
-    && file_content.as_bytes()[start_offset].is_ascii_whitespace()
-  {
-    start_offset += 1;
-  }
-  while end_offset > start_offset
-    && file_content.as_bytes()[end_offset - 1].is_ascii_whitespace()
-  {
-    end_offset -= 1;
-  }
-  if end_offset <= start_offset {
-    end_offset = start_offset + 1;
-    // Clamp in case we were at EOF
     end_offset = end_offset.min(file_content.len());
-  }
-  (start_offset, end_offset)
+    while start_offset < end_offset && file_content.as_bytes()[start_offset].is_ascii_whitespace() {
+        start_offset += 1;
+    }
+    while end_offset > start_offset && file_content.as_bytes()[end_offset - 1].is_ascii_whitespace()
+    {
+        end_offset -= 1;
+    }
+    if end_offset <= start_offset {
+        end_offset = start_offset + 1;
+        // Clamp in case we were at EOF
+        end_offset = end_offset.min(file_content.len());
+    }
+    (start_offset, end_offset)
 }
 
 pub fn print_mech_error(err: &MechError) {
-  if let Some(watch_error) = err.kind_as::<WatchPathFailed>() {
-    let src_file_path = watch_error.file_path.to_string();
-    match &err.source {
-      Some(src_err) => {
-        if let Some(report) = &src_err.kind_as::<ParserErrorReport>() {
-          let first_error_range = report.1.first().map(|e| e.cause_rng.clone()).unwrap_or(SourceRange::default());
-          let (first_start, first_end) = source_range_to_offset_range(&report.0, &first_error_range);
-          let mut error_report = Report::build(ReportKind::Error, (src_file_path.clone(), first_start..first_end))
-              .with_message(format!("Syntax Errors Found: {}", report.1.len()));
+    if let Some(watch_error) = err.kind_as::<WatchPathFailed>() {
+        let src_file_path = watch_error.file_path.to_string();
+        match &err.source {
+            Some(src_err) => {
+                if let Some(report) = &src_err.kind_as::<ParserErrorReport>() {
+                    let first_error_range = report
+                        .1
+                        .first()
+                        .map(|e| e.cause_rng.clone())
+                        .unwrap_or(SourceRange::default());
+                    let (first_start, first_end) =
+                        source_range_to_offset_range(&report.0, &first_error_range);
+                    let mut error_report = Report::build(
+                        ReportKind::Error,
+                        (src_file_path.clone(), first_start..first_end),
+                    )
+                    .with_message(format!("Syntax Errors Found: {}", report.1.len()));
 
-          for (err_num, err_ctx) in report.1.iter().enumerate() {
-            let (start, end) = source_range_to_offset_range(&report.0, &err_ctx.cause_rng);
+                    for (err_num, err_ctx) in report.1.iter().enumerate() {
+                        let (start, end) =
+                            source_range_to_offset_range(&report.0, &err_ctx.cause_rng);
 
-            if let Some(annotation_rng) = err_ctx.annotation_rngs.first() {
-              let (ann_start, ann_end) = source_range_to_offset_range(&report.0, annotation_rng);
+                        if let Some(annotation_rng) = err_ctx.annotation_rngs.first() {
+                            let (ann_start, ann_end) =
+                                source_range_to_offset_range(&report.0, annotation_rng);
 
-              error_report = error_report.with_label(
-                Label::new((src_file_path.clone(), ann_start..ann_end))
-                      .with_message(format!(
-                        "#{}: {} [{}:{}]",
-                        err_num + 1,
-                        err_ctx.err_message,
-                        annotation_rng.start.row,
-                        annotation_rng.start.col
-                      ))
-                    .with_color(Color::Yellow),
-              );
-            } else {
-              error_report = error_report.with_label(
-                Label::new((src_file_path.clone(), start..end))
-                      .with_message(format!(
-                        "#{}: {} [{}:{}]",
-                        err_num + 1,
-                        err_ctx.err_message,
-                        err_ctx.cause_rng.start.row,
-                        err_ctx.cause_rng.start.col
-                      ))
-                    .with_color(Color::Yellow),
-              );
+                            error_report = error_report.with_label(
+                                Label::new((src_file_path.clone(), ann_start..ann_end))
+                                    .with_message(format!(
+                                        "#{}: {} [{}:{}]",
+                                        err_num + 1,
+                                        err_ctx.err_message,
+                                        annotation_rng.start.row,
+                                        annotation_rng.start.col
+                                    ))
+                                    .with_color(Color::Yellow),
+                            );
+                        } else {
+                            error_report = error_report.with_label(
+                                Label::new((src_file_path.clone(), start..end))
+                                    .with_message(format!(
+                                        "#{}: {} [{}:{}]",
+                                        err_num + 1,
+                                        err_ctx.err_message,
+                                        err_ctx.cause_rng.start.row,
+                                        err_ctx.cause_rng.start.col
+                                    ))
+                                    .with_color(Color::Yellow),
+                            );
+                        }
+                    }
+                    let cache = sources([(src_file_path.clone(), report.0.clone())]);
+                    error_report.finish().print(cache).unwrap_or_else(|e| {
+                        println!("Error printing report: {:?}", e);
+                    });
+                } else {
+                    println!("Error:");
+                    println!("{:#?}", err);
+                }
             }
-          }
-          let cache = sources([(src_file_path.clone(), report.0.clone())]);
-          error_report.finish().print(cache).unwrap_or_else(|e| {
-            println!("Error printing report: {:?}", e);
-          });
-        } else {
-          println!("Error:");
-          println!("{:#?}", err);
+            None => {
+                println!("Error:");
+                println!("{:#?}", err);
+            }
         }
-      }
-      None => {
+    } else {
         println!("Error:");
         println!("{:#?}", err);
-      }
     }
-  } else {
-      println!("Error:");
-      println!("{:#?}", err);
-  }
 }
 
 #[cfg(all(test, feature = "serve"))]
 mod filesystem_capability_cli_tests {
     use super::*;
-    use mech_runtime::{DefaultIdGenerator, SERVE_HOST_SUBJECT, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH};
+    use mech_runtime::{
+        DefaultIdGenerator, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH,
+        SERVE_HOST_SUBJECT,
+    };
 
     fn capability_matches(arguments: &[&str]) -> clap::ArgMatches {
         capabilities::add_filesystem_capability_args(Command::new("mech").subcommand(
@@ -1261,7 +1459,8 @@ mod filesystem_capability_cli_tests {
     #[test]
     fn default_grants_current_directory_when_no_capability_options_are_present() {
         let matches = capability_matches(&["mech", "serve", "."]);
-        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority =
+            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(
@@ -1285,7 +1484,8 @@ mod filesystem_capability_cli_tests {
         let outside_arg = outside.to_string_lossy();
         let matches =
             capability_matches(&["mech", "--cap-root", &allowed_arg, "serve", &outside_arg]);
-        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority =
+            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         assert!(
             authority
@@ -1313,7 +1513,8 @@ mod filesystem_capability_cli_tests {
             "serve",
             root.to_str().unwrap(),
         ]);
-        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority =
+            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         assert!(
             authority
@@ -1333,7 +1534,8 @@ mod filesystem_capability_cli_tests {
             "--allow-read",
             root.to_str().unwrap(),
         ]);
-        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority =
+            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_READ])
@@ -1363,7 +1565,8 @@ mod filesystem_capability_cli_tests {
             "serve",
             &allowed_arg,
         ]);
-        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority =
+            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         assert_eq!(authority.source_capabilities().len(), 1);
         let mut ids = DefaultIdGenerator::new();
         authority
@@ -1388,7 +1591,8 @@ mod filesystem_capability_cli_tests {
             "--allow-serve",
             root.to_str().unwrap(),
         ]);
-        let authority = capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
+        let authority =
+            capabilities::build_mech_filesystem_authority(&matches, None, &test_badge()).unwrap();
         let mut ids = DefaultIdGenerator::new();
         authority
             .delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &root, true, [FS_SERVE])

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -80,8 +80,8 @@ use mech::cli::capabilities;
 use mech::cli::config;
 #[cfg(feature = "run")]
 use mech::cli::run::{
-  cli_host_capability_args, cli_host_capability_selection,
-  effective_run_runtime_config, new_cli_runtime, run_cli_source,
+  cli_host_capability_args, cli_host_capability_passthrough_values,
+  cli_host_capability_selection, effective_run_runtime_config, new_cli_runtime, run_cli_source,
 };
 
 
@@ -707,6 +707,8 @@ async fn main() -> Result<(), MechError> {
     } else {
       vec![]
     };
+    run_inputs.extend(cli_host_capability_passthrough_values(&cli_matches, run_matches));
+
     let run_debug_flag = debug_flag || run_matches.map(|m| m.get_flag("debug")).unwrap_or(false);
     let run_trace_flag = trace_flag || run_matches.map(|m| m.get_flag("trace")).unwrap_or(false);
     let run_time_flag = time_flag || run_matches.map(|m| m.get_flag("time")).unwrap_or(false);

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -4,13 +4,7 @@ use mech::*;
 use mech_core::*;
 use mech_syntax::parser;
 #[cfg(feature = "run")]
-use mech_host_cli::{CliResourceProvider, StdCliBackend};
-
-#[cfg(feature = "run")]
-use mech_runtime::{
-  MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
-  RuntimeEvent, RuntimeEventKind,
-};
+use mech_runtime::RuntimeConfig;
 #[cfg(feature = "serve")]
 #[cfg(feature = "formatter")]
 use mech_syntax::formatter::*;
@@ -84,6 +78,10 @@ use mech::cli::capabilities;
 
 #[cfg(any(feature = "serve", feature = "run"))]
 use mech::cli::config;
+#[cfg(feature = "run")]
+use mech::cli::run::{
+  cli_host_capability_args, effective_run_runtime_config, new_cli_runtime, run_cli_source,
+};
 
 
 async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String, MechError> {
@@ -113,136 +111,6 @@ async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String
     combined.push_str(&stylesheet_str);
   }
   Ok(combined)
-}
-
-#[cfg(feature = "run")]
-fn new_cli_runtime(
-  config: RuntimeConfig,
-  cli_grants: &config::EffectiveCliHostGrants,
-) -> MResult<MechRuntime> {
-  let mut runtime = RuntimeBuilder::new()
-    .config(config)
-    .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
-    .build()?;
-
-  grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
-
-  Ok(runtime)
-}
-
-#[cfg(feature = "run")]
-fn effective_run_runtime_config(
-  loaded_config: Option<&mech::LoadedMechConfig>,
-  name: String,
-  debug_enabled: bool,
-  trace_enabled: bool,
-  profile_enabled: bool,
-  rounds_per_step: Option<usize>,
-) -> MResult<RuntimeConfig> {
-  let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
-
-  let mut config = mech::apply_runtime_config_patch(
-    RuntimeConfig::default(),
-    loaded_config
-      .as_ref()
-      .map(|loaded| &loaded.document.runtime)
-      .unwrap_or(&default_runtime_patch),
-  )?;
-
-  config.name = name;
-
-  if debug_enabled {
-    config.diagnostics.debug_enabled = true;
-  }
-
-  if trace_enabled {
-    config.diagnostics.trace_enabled = true;
-  }
-
-  if profile_enabled {
-    config.diagnostics.profile_enabled = true;
-  }
-
-  if let Some(rounds_per_step) = rounds_per_step {
-    config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
-  }
-
-  config.validate()?;
-  Ok(config)
-}
-
-#[cfg(feature = "run")]
-fn print_run_runtime_events(events: &[RuntimeEvent]) {
-  for event in events {
-    match &event.kind {
-      RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
-        println!("Cycle Time: {} ns", duration_ns);
-      }
-      _ => {}
-    }
-  }
-}
-
-#[cfg(feature = "run")]
-fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
-  let mut context = runtime.runtime_context()?;
-  let result = runtime.run_string_with_context(&mut context, source);
-  print_run_runtime_events(&context.events);
-  result
-}
-
-#[cfg(feature = "run")]
-fn grant_cli_runner_capabilities(
-  runtime: &mut MechRuntime,
-  grants: &config::EffectiveCliHostGrants,
-) -> MResult<()> {
-  let subject = runtime.runtime_context()?.subject;
-
-  if !grants.env_read_paths.is_empty() {
-    runtime.grant_capability(RuntimeCapabilityGrant {
-      subject: subject.clone(),
-      resource: "cli://env".to_string(),
-      operations: vec![RuntimeCapabilityOperation::Read],
-      paths: grants.env_read_paths.clone(),
-    })?;
-  }
-
-  if !grants.stdout_write_paths.is_empty() {
-    runtime.grant_capability(RuntimeCapabilityGrant {
-      subject: subject.clone(),
-      resource: "cli://stdout".to_string(),
-      operations: vec![RuntimeCapabilityOperation::Write],
-      paths: grants.stdout_write_paths.clone(),
-    })?;
-  }
-
-  if !grants.stderr_write_paths.is_empty() {
-    runtime.grant_capability(RuntimeCapabilityGrant {
-      subject,
-      resource: "cli://stderr".to_string(),
-      operations: vec![RuntimeCapabilityOperation::Write],
-      paths: grants.stderr_write_paths.clone(),
-    })?;
-  }
-
-  Ok(())
-}
-
-fn cli_host_capability_args() -> Vec<Arg> {
-  vec![
-    Arg::new("deny_cli_env")
-      .long("deny-cli-env")
-      .help("Deny cli://env read grants for this run")
-      .action(ArgAction::SetTrue),
-    Arg::new("deny_cli_stdout")
-      .long("deny-cli-stdout")
-      .help("Deny cli://stdout write grants for this run")
-      .action(ArgAction::SetTrue),
-    Arg::new("deny_cli_stderr")
-      .long("deny-cli-stderr")
-      .help("Deny cli://stderr write grants for this run")
-      .action(ArgAction::SetTrue),
-  ]
 }
 
 #[tokio::main]

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -701,12 +701,7 @@ async fn main() -> Result<(), MechError> {
     let mut run_inputs: Vec<String> = if let Some(run_matches) = run_matches {
       run_matches
         .get_many::<String>("mech_run_paths")
-        .map_or(vec![], |files| {
-          files
-            .filter(|file| !file.starts_with(':'))
-            .map(|file| file.to_string())
-            .collect()
-        })
+        .map_or(vec![], |files| files.map(|file| file.to_string()).collect())
     } else if let Some(m) = cli_matches.get_many::<String>("mech_paths") {
       m.map(|s| s.to_string()).collect()
     } else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,10 @@
 pub mod bundle_web;
 #[cfg(feature = "serve")]
 pub mod capabilities;
-#[cfg(feature = "serve")]
+#[cfg(any(feature = "serve", feature = "run"))]
 pub mod config;
+#[cfg(feature = "run")]
+pub mod run;
 
 #[cfg(all(test, any(feature = "serve", feature = "bundle_web")))]
 pub(crate) static CURRENT_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -61,6 +61,172 @@ pub fn load_run_cli_config(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectiveCliHostGrants {
+  pub env_read_paths: Vec<String>,
+  pub stdout_write_paths: Vec<String>,
+  pub stderr_write_paths: Vec<String>,
+}
+
+impl EffectiveCliHostGrants {
+  pub fn empty() -> Self {
+    Self {
+      env_read_paths: Vec::new(),
+      stdout_write_paths: Vec::new(),
+      stderr_write_paths: Vec::new(),
+    }
+  }
+}
+
+impl Default for EffectiveCliHostGrants {
+  fn default() -> Self {
+    Self::empty()
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CliHostCapabilitySelection {
+  pub include_defaults: bool,
+  pub profiles: Vec<String>,
+}
+
+impl Default for CliHostCapabilitySelection {
+  fn default() -> Self {
+    Self {
+      include_defaults: true,
+      profiles: Vec::new(),
+    }
+  }
+}
+
+const CLI_PROFILE_ENV: &str = ":cli/env";
+const CLI_PROFILE_STDOUT: &str = ":cli/stdout";
+const CLI_PROFILE_STDERR: &str = ":cli/stderr";
+
+const DEFAULT_CLI_CAPABILITY_PROFILES: &[&str] = &[
+  CLI_PROFILE_ENV,
+  CLI_PROFILE_STDOUT,
+  CLI_PROFILE_STDERR,
+];
+
+pub fn effective_cli_host_grants(
+  config: Option<&LoadedMechConfig>,
+  selection: CliHostCapabilitySelection,
+) -> MResult<EffectiveCliHostGrants> {
+  let mut grants = EffectiveCliHostGrants::empty();
+
+  if selection.include_defaults {
+    for profile in DEFAULT_CLI_CAPABILITY_PROFILES {
+      grant_cli_profile(&mut grants, profile)?;
+    }
+  }
+
+  for profile in &selection.profiles {
+    grant_cli_profile(&mut grants, profile)?;
+  }
+
+  if let Some(run) = config.and_then(|loaded| loaded.document.run.as_ref()) {
+    apply_run_cli_attenuation(&mut grants, run)?;
+  }
+
+  Ok(grants)
+}
+
+fn grant_cli_profile(
+  grants: &mut EffectiveCliHostGrants,
+  profile: &str,
+) -> MResult<()> {
+  match profile {
+    CLI_PROFILE_ENV => {
+      if !grants.env_read_paths.iter().any(|path| path == "*") {
+        grants.env_read_paths.clear();
+        grants.env_read_paths.push("*".to_string());
+      }
+      Ok(())
+    }
+    CLI_PROFILE_STDOUT => {
+      union_string(&mut grants.stdout_write_paths, "text");
+      union_string(&mut grants.stdout_write_paths, "line");
+      Ok(())
+    }
+    CLI_PROFILE_STDERR => {
+      union_string(&mut grants.stderr_write_paths, "text");
+      union_string(&mut grants.stderr_write_paths, "line");
+      Ok(())
+    }
+    other => Err(MechError::new(
+      GenericError {
+        msg: format!("unknown CLI capability profile `{other}`"),
+      },
+      None,
+    ).with_compiler_loc()),
+  }
+}
+
+fn union_string(paths: &mut Vec<String>, value: &str) {
+  if !paths.iter().any(|path| path == value) {
+    paths.push(value.to_string());
+  }
+}
+
+fn apply_run_cli_attenuation(
+  grants: &mut EffectiveCliHostGrants,
+  run: &mech_runtime::RunHostConfig,
+) -> MResult<()> {
+  if let Some(paths) = &run.cli.env.read {
+    grants.env_read_paths = intersect_env_paths(&grants.env_read_paths, paths);
+  }
+  if let Some(paths) = &run.cli.stdout.write {
+    let paths = validated_cli_stream_paths("run.cli.stdout.write", paths)?;
+    grants.stdout_write_paths = intersect_paths(&grants.stdout_write_paths, &paths);
+  }
+  if let Some(paths) = &run.cli.stderr.write {
+    let paths = validated_cli_stream_paths("run.cli.stderr.write", paths)?;
+    grants.stderr_write_paths = intersect_paths(&grants.stderr_write_paths, &paths);
+  }
+
+  Ok(())
+}
+
+fn intersect_env_paths(current: &[String], configured: &[String]) -> Vec<String> {
+  if current.is_empty() || configured.is_empty() {
+    return Vec::new();
+  }
+  if current.iter().any(|path| path == "*") {
+    return configured.to_vec();
+  }
+  if configured.iter().any(|path| path == "*") {
+    return current.to_vec();
+  }
+  intersect_paths(current, configured)
+}
+
+fn intersect_paths(current: &[String], configured: &[String]) -> Vec<String> {
+  current
+    .iter()
+    .filter(|path| configured.iter().any(|configured_path| configured_path == *path))
+    .cloned()
+    .collect()
+}
+
+fn validated_cli_stream_paths(where_: &str, paths: &[String]) -> MResult<Vec<String>> {
+  let mut out = Vec::new();
+  for path in paths {
+    match path.as_str() {
+      "text" | "line" => out.push(path.clone()),
+      other => {
+        return Err(MechError::new(
+          GenericError {
+            msg: format!("{where_} cannot grant unsupported CLI stream path `{other}`"),
+          },
+          None,
+        ).with_compiler_loc());
+      }
+    }
+  }
+  Ok(out)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EffectiveRunOptions {
   pub paths: Vec<String>,
 }
@@ -849,6 +1015,106 @@ mod config_tests {
       effective.wasm_pkg,
       root.join("web/pkg").to_string_lossy().to_string()
     );
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  fn stdout_selection() -> CliHostCapabilitySelection {
+    CliHostCapabilitySelection {
+      include_defaults: false,
+      profiles: vec![":cli/stdout".to_string()],
+    }
+  }
+
+  #[test]
+  fn default_cli_host_grants_include_default_envelope() {
+    let grants = effective_cli_host_grants(None, CliHostCapabilitySelection::default()).unwrap();
+    assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert_eq!(grants.stderr_write_paths, vec!["text".to_string(), "line".to_string()]);
+  }
+
+  #[test]
+  fn explicit_stdout_only_selection_grants_only_stdout() {
+    let grants = effective_cli_host_grants(None, stdout_selection()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert!(grants.stderr_write_paths.is_empty());
+  }
+
+  #[test]
+  fn explicit_stdout_and_env_selection_grants_stdout_and_env_only() {
+    let grants = effective_cli_host_grants(
+      None,
+      CliHostCapabilitySelection {
+        include_defaults: false,
+        profiles: vec![":cli/stdout".to_string(), ":cli/env".to_string()],
+      },
+    )
+    .unwrap();
+    assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert!(grants.stderr_write_paths.is_empty());
+  }
+
+  #[test]
+  fn unknown_cli_capability_profile_errors() {
+    let error = effective_cli_host_grants(
+      None,
+      CliHostCapabilitySelection {
+        include_defaults: false,
+        profiles: vec![":quxx".to_string()],
+      },
+    )
+    .unwrap_err();
+    assert!(format!("{error:?}").contains("unknown CLI capability profile `:quxx`"));
+  }
+
+  #[test]
+  fn config_can_narrow_selected_stdout_to_line() {
+    let root = temp_root("cli-stdout-line");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
+    assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_cannot_add_unselected_env() {
+    let root = temp_root("cli-env-unselected");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn default_profiles_plus_config_env_path_narrows_env() {
+    let root = temp_root("cli-env-path");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
+    assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_can_deny_selected_stdout_with_empty_list() {
+    let root = temp_root("cli-stdout-empty");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
+    assert!(grants.stdout_write_paths.is_empty());
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -67,52 +67,145 @@ pub struct EffectiveCliHostGrants {
   pub stderr_write_paths: Vec<String>,
 }
 
-impl Default for EffectiveCliHostGrants {
-  fn default() -> Self {
+impl EffectiveCliHostGrants {
+  pub fn empty() -> Self {
     Self {
-      env_read_paths: vec!["*".to_string()],
-      stdout_write_paths: vec!["text".to_string(), "line".to_string()],
-      stderr_write_paths: vec!["text".to_string(), "line".to_string()],
+      env_read_paths: Vec::new(),
+      stdout_write_paths: Vec::new(),
+      stderr_write_paths: Vec::new(),
     }
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CliHostGrantAttenuation {
-  pub deny_env: bool,
-  pub deny_stdout: bool,
-  pub deny_stderr: bool,
+impl Default for EffectiveCliHostGrants {
+  fn default() -> Self {
+    Self::empty()
+  }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CliHostCapabilitySelection {
+  pub include_defaults: bool,
+  pub profiles: Vec<String>,
+}
+
+impl Default for CliHostCapabilitySelection {
+  fn default() -> Self {
+    Self {
+      include_defaults: true,
+      profiles: Vec::new(),
+    }
+  }
+}
+
+const CLI_PROFILE_ENV: &str = ":cli/env";
+const CLI_PROFILE_STDOUT: &str = ":cli/stdout";
+const CLI_PROFILE_STDERR: &str = ":cli/stderr";
+
+const DEFAULT_CLI_CAPABILITY_PROFILES: &[&str] = &[
+  CLI_PROFILE_ENV,
+  CLI_PROFILE_STDOUT,
+  CLI_PROFILE_STDERR,
+];
 
 pub fn effective_cli_host_grants(
   config: Option<&LoadedMechConfig>,
-  attenuation: CliHostGrantAttenuation,
+  selection: CliHostCapabilitySelection,
 ) -> MResult<EffectiveCliHostGrants> {
-  let mut grants = EffectiveCliHostGrants::default();
+  let mut grants = EffectiveCliHostGrants::empty();
+
+  if selection.include_defaults {
+    for profile in DEFAULT_CLI_CAPABILITY_PROFILES {
+      grant_cli_profile(&mut grants, profile)?;
+    }
+  }
+
+  for profile in &selection.profiles {
+    grant_cli_profile(&mut grants, profile)?;
+  }
 
   if let Some(run) = config.and_then(|loaded| loaded.document.run.as_ref()) {
-    if let Some(paths) = &run.cli.env.read {
-      grants.env_read_paths = paths.clone();
-    }
-    if let Some(paths) = &run.cli.stdout.write {
-      grants.stdout_write_paths = validated_cli_stream_paths("run.cli.stdout.write", paths)?;
-    }
-    if let Some(paths) = &run.cli.stderr.write {
-      grants.stderr_write_paths = validated_cli_stream_paths("run.cli.stderr.write", paths)?;
-    }
-  }
-
-  if attenuation.deny_env {
-    grants.env_read_paths.clear();
-  }
-  if attenuation.deny_stdout {
-    grants.stdout_write_paths.clear();
-  }
-  if attenuation.deny_stderr {
-    grants.stderr_write_paths.clear();
+    apply_run_cli_attenuation(&mut grants, run)?;
   }
 
   Ok(grants)
+}
+
+fn grant_cli_profile(
+  grants: &mut EffectiveCliHostGrants,
+  profile: &str,
+) -> MResult<()> {
+  match profile {
+    CLI_PROFILE_ENV => {
+      if !grants.env_read_paths.iter().any(|path| path == "*") {
+        grants.env_read_paths.clear();
+        grants.env_read_paths.push("*".to_string());
+      }
+      Ok(())
+    }
+    CLI_PROFILE_STDOUT => {
+      union_string(&mut grants.stdout_write_paths, "text");
+      union_string(&mut grants.stdout_write_paths, "line");
+      Ok(())
+    }
+    CLI_PROFILE_STDERR => {
+      union_string(&mut grants.stderr_write_paths, "text");
+      union_string(&mut grants.stderr_write_paths, "line");
+      Ok(())
+    }
+    other => Err(MechError::new(
+      GenericError {
+        msg: format!("unknown CLI capability profile `{other}`"),
+      },
+      None,
+    ).with_compiler_loc()),
+  }
+}
+
+fn union_string(paths: &mut Vec<String>, value: &str) {
+  if !paths.iter().any(|path| path == value) {
+    paths.push(value.to_string());
+  }
+}
+
+fn apply_run_cli_attenuation(
+  grants: &mut EffectiveCliHostGrants,
+  run: &mech_runtime::RunHostConfig,
+) -> MResult<()> {
+  if let Some(paths) = &run.cli.env.read {
+    grants.env_read_paths = intersect_env_paths(&grants.env_read_paths, paths);
+  }
+  if let Some(paths) = &run.cli.stdout.write {
+    let paths = validated_cli_stream_paths("run.cli.stdout.write", paths)?;
+    grants.stdout_write_paths = intersect_paths(&grants.stdout_write_paths, &paths);
+  }
+  if let Some(paths) = &run.cli.stderr.write {
+    let paths = validated_cli_stream_paths("run.cli.stderr.write", paths)?;
+    grants.stderr_write_paths = intersect_paths(&grants.stderr_write_paths, &paths);
+  }
+
+  Ok(())
+}
+
+fn intersect_env_paths(current: &[String], configured: &[String]) -> Vec<String> {
+  if current.is_empty() || configured.is_empty() {
+    return Vec::new();
+  }
+  if current.iter().any(|path| path == "*") {
+    return configured.to_vec();
+  }
+  if configured.iter().any(|path| path == "*") {
+    return current.to_vec();
+  }
+  intersect_paths(current, configured)
+}
+
+fn intersect_paths(current: &[String], configured: &[String]) -> Vec<String> {
+  current
+    .iter()
+    .filter(|path| configured.iter().any(|configured_path| configured_path == *path))
+    .cloned()
+    .collect()
 }
 
 fn validated_cli_stream_paths(where_: &str, paths: &[String]) -> MResult<Vec<String>> {
@@ -925,87 +1018,103 @@ mod config_tests {
     std::fs::remove_dir_all(root).unwrap();
   }
 
+  fn stdout_selection() -> CliHostCapabilitySelection {
+    CliHostCapabilitySelection {
+      include_defaults: false,
+      profiles: vec![":cli/stdout".to_string()],
+    }
+  }
+
   #[test]
   fn default_cli_host_grants_include_default_envelope() {
-    let grants = effective_cli_host_grants(None, CliHostGrantAttenuation::default()).unwrap();
+    let grants = effective_cli_host_grants(None, CliHostCapabilitySelection::default()).unwrap();
     assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
     assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
     assert_eq!(grants.stderr_write_paths, vec!["text".to_string(), "line".to_string()]);
   }
 
   #[test]
-  fn config_can_narrow_stdout_to_line() {
+  fn explicit_stdout_only_selection_grants_only_stdout() {
+    let grants = effective_cli_host_grants(None, stdout_selection()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert!(grants.stderr_write_paths.is_empty());
+  }
+
+  #[test]
+  fn explicit_stdout_and_env_selection_grants_stdout_and_env_only() {
+    let grants = effective_cli_host_grants(
+      None,
+      CliHostCapabilitySelection {
+        include_defaults: false,
+        profiles: vec![":cli/stdout".to_string(), ":cli/env".to_string()],
+      },
+    )
+    .unwrap();
+    assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert!(grants.stderr_write_paths.is_empty());
+  }
+
+  #[test]
+  fn unknown_cli_capability_profile_errors() {
+    let error = effective_cli_host_grants(
+      None,
+      CliHostCapabilitySelection {
+        include_defaults: false,
+        profiles: vec![":quxx".to_string()],
+      },
+    )
+    .unwrap_err();
+    assert!(format!("{error:?}").contains("unknown CLI capability profile `:quxx`"));
+  }
+
+  #[test]
+  fn config_can_narrow_selected_stdout_to_line() {
     let root = temp_root("cli-stdout-line");
     let config = loaded_config_at(
       root.clone(),
       r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
     );
-    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
     assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
     std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]
-  fn config_can_deny_stdout_with_empty_list() {
-    let root = temp_root("cli-stdout-empty");
+  fn config_cannot_add_unselected_env() {
+    let root = temp_root("cli-env-unselected");
     let config = loaded_config_at(
       root.clone(),
-      r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
+      r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
     );
-    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
-    assert!(grants.stdout_write_paths.is_empty());
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
     std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]
-  fn config_can_narrow_env_to_path() {
+  fn default_profiles_plus_config_env_path_narrows_env() {
     let root = temp_root("cli-env-path");
     let config = loaded_config_at(
       root.clone(),
       r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
     );
-    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
     assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
     std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]
-  fn command_line_attenuation_clears_stdout_even_if_config_allows() {
-    let root = temp_root("cli-deny-stdout");
+  fn config_can_deny_selected_stdout_with_empty_list() {
+    let root = temp_root("cli-stdout-empty");
     let config = loaded_config_at(
       root.clone(),
-      r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+      r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
     );
-    let grants = effective_cli_host_grants(
-      Some(&config),
-      CliHostGrantAttenuation {
-        deny_stdout: true,
-        ..Default::default()
-      },
-    )
-    .unwrap();
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
     assert!(grants.stdout_write_paths.is_empty());
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn attenuation_never_adds_back_capability() {
-    let root = temp_root("cli-never-adds");
-    let config = loaded_config_at(
-      root.clone(),
-      r#"config := { run: { cli: { stdout: { write: [] }, env: { read: [] } } } }"#,
-    );
-    let grants = effective_cli_host_grants(
-      Some(&config),
-      CliHostGrantAttenuation {
-        deny_stderr: true,
-        ..Default::default()
-      },
-    )
-    .unwrap();
-    assert!(grants.stdout_write_paths.is_empty());
-    assert!(grants.env_read_paths.is_empty());
-    assert!(grants.stderr_write_paths.is_empty());
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,629 +1,699 @@
 use std::path::{Path, PathBuf};
 
-use clap::{Arg, ArgAction, Command};
 use crate::*;
+use clap::{Arg, ArgAction, Command};
 use mech_core::*;
 
 pub fn add_config_args(command: Command) -> Command {
-  command
-    .arg(
-      Arg::new("config")
-        .long("config")
-        .value_name("PATH")
-        .num_args(1)
-        .global(true)
-        .help("Load configuration from a Mech config file."),
-    )
-    .arg(
-      Arg::new("no_config")
-        .long("no-config")
-        .action(ArgAction::SetTrue)
-        .global(true)
-        .help("Disable automatic Mech config loading."),
-    )
+    command
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .value_name("PATH")
+                .num_args(1)
+                .global(true)
+                .help("Load configuration from a Mech config file."),
+        )
+        .arg(
+            Arg::new("no_config")
+                .long("no-config")
+                .action(ArgAction::SetTrue)
+                .global(true)
+                .help("Disable automatic Mech config loading."),
+        )
 }
 
 pub fn load_cli_config(matches: &clap::ArgMatches) -> MResult<Option<LoadedMechConfig>> {
-  let project_inputs: Vec<String> = matches
-    .get_many::<String>("mech_serve_file_paths")
-    .into_iter()
-    .flatten()
-    .cloned()
-    .collect();
-  load_cli_config_with_inputs(matches, &project_inputs, "Server")
+    let project_inputs: Vec<String> = matches
+        .get_many::<String>("mech_serve_file_paths")
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect();
+    load_cli_config_with_inputs(matches, &project_inputs, "Server")
 }
 
 pub fn load_cli_config_with_inputs(
-  matches: &clap::ArgMatches,
-  project_inputs: &[String],
-  label: &str,
+    matches: &clap::ArgMatches,
+    project_inputs: &[String],
+    label: &str,
 ) -> MResult<Option<LoadedMechConfig>> {
-  let no_config = matches.get_flag("no_config");
-  let explicit_config = matches.get_one::<String>("config").map(|path| path.as_str());
-  let current_dir = std::env::current_dir()?;
-  let loaded = crate::load_optional_mech_config(
-    &current_dir,
-    explicit_config,
-    no_config,
-    project_inputs,
-  )?;
-  if let Some(config) = loaded.as_ref() {
-    println!("[Mech {label}] Loading config… {}", config.path.display());
-  }
-  Ok(loaded)
+    let no_config = matches.get_flag("no_config");
+    let explicit_config = matches
+        .get_one::<String>("config")
+        .map(|path| path.as_str());
+    let current_dir = std::env::current_dir()?;
+    let loaded =
+        crate::load_optional_mech_config(&current_dir, explicit_config, no_config, project_inputs)?;
+    if let Some(config) = loaded.as_ref() {
+        println!("[Mech {label}] Loading config… {}", config.path.display());
+    }
+    Ok(loaded)
 }
 
 pub fn load_run_cli_config(
-  matches: &clap::ArgMatches,
-  run_inputs: &[String],
+    matches: &clap::ArgMatches,
+    run_inputs: &[String],
 ) -> MResult<Option<LoadedMechConfig>> {
-  load_cli_config_with_inputs(matches, run_inputs, "Run")
+    load_cli_config_with_inputs(matches, run_inputs, "Run")
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectiveCliHostGrants {
+    pub env_read_paths: Vec<String>,
+    pub stdout_write_paths: Vec<String>,
+    pub stderr_write_paths: Vec<String>,
+}
+
+impl Default for EffectiveCliHostGrants {
+    fn default() -> Self {
+        Self {
+            env_read_paths: vec!["*".to_string()],
+            stdout_write_paths: vec!["text".to_string(), "line".to_string()],
+            stderr_write_paths: vec!["text".to_string(), "line".to_string()],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CliHostGrantAttenuation {
+    pub deny_env: bool,
+    pub deny_stdout: bool,
+    pub deny_stderr: bool,
+}
+
+pub fn effective_cli_host_grants(
+    config: Option<&LoadedMechConfig>,
+    attenuation: CliHostGrantAttenuation,
+) -> MResult<EffectiveCliHostGrants> {
+    let mut grants = EffectiveCliHostGrants::default();
+
+    if let Some(run) = config.and_then(|loaded| loaded.document.run.as_ref()) {
+        if let Some(paths) = &run.cli.env.read {
+            grants.env_read_paths = paths.clone();
+        }
+        if let Some(paths) = &run.cli.stdout.write {
+            grants.stdout_write_paths = validated_cli_stream_paths("run.cli.stdout.write", paths)?;
+        }
+        if let Some(paths) = &run.cli.stderr.write {
+            grants.stderr_write_paths = validated_cli_stream_paths("run.cli.stderr.write", paths)?;
+        }
+    }
+
+    if attenuation.deny_env {
+        grants.env_read_paths.clear();
+    }
+    if attenuation.deny_stdout {
+        grants.stdout_write_paths.clear();
+    }
+    if attenuation.deny_stderr {
+        grants.stderr_write_paths.clear();
+    }
+
+    Ok(grants)
+}
+
+fn validated_cli_stream_paths(where_: &str, paths: &[String]) -> MResult<Vec<String>> {
+    let mut out = Vec::new();
+    for path in paths {
+        match path.as_str() {
+            "text" | "line" => out.push(path.clone()),
+            other => {
+                return Err(MechError::new(
+                    GenericError {
+                        msg: format!("{where_} cannot grant unsupported CLI stream path `{other}`"),
+                    },
+                    None,
+                )
+                .with_compiler_loc());
+            }
+        }
+    }
+    Ok(out)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EffectiveRunOptions {
-  pub paths: Vec<String>,
+    pub paths: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EffectiveServeOptions {
-  pub address: String,
-  pub port: String,
-  pub paths: Vec<String>,
-  pub stylesheet_paths: Vec<String>,
-  pub shim_path: String,
-  pub wasm_pkg: String,
+    pub address: String,
+    pub port: String,
+    pub paths: Vec<String>,
+    pub stylesheet_paths: Vec<String>,
+    pub shim_path: String,
+    pub wasm_pkg: String,
 }
 
 pub fn effective_run_options(
-  cli_paths: Vec<String>,
-  config: Option<&LoadedMechConfig>,
-  explicit_run_command: bool,
+    cli_paths: Vec<String>,
+    config: Option<&LoadedMechConfig>,
+    explicit_run_command: bool,
 ) -> MResult<Option<EffectiveRunOptions>> {
-  let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
-    resolve_config_path(&loaded.base_dir, path)
-      .to_string_lossy()
-      .to_string()
-  };
+    let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
+        resolve_config_path(&loaded.base_dir, path)
+            .to_string_lossy()
+            .to_string()
+    };
 
-  let config_paths = config
-    .and_then(|loaded| {
-      loaded.document.run.as_ref().map(|run| {
-        run.paths
-          .iter()
-          .map(|path| config_path_to_string(loaded, path))
-          .collect::<Vec<_>>()
-      })
-    })
-    .unwrap_or_default();
+    let config_paths = config
+        .and_then(|loaded| {
+            loaded.document.run.as_ref().map(|run| {
+                run.paths
+                    .iter()
+                    .map(|path| config_path_to_string(loaded, path))
+                    .collect::<Vec<_>>()
+            })
+        })
+        .unwrap_or_default();
 
-  let mut effective_cli_paths = cli_paths;
+    let mut effective_cli_paths = cli_paths;
 
-  if let Some(loaded) = config {
-    if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
-      if effective_cli_paths.len() == 1 {
-        let current_dir = std::env::current_dir()?;
-        let input = PathBuf::from(&effective_cli_paths[0]);
-        let input_path = if input.is_absolute() {
-          input
-        } else {
-          current_dir.join(input)
-        };
+    if let Some(loaded) = config {
+        if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
+            if effective_cli_paths.len() == 1 {
+                let current_dir = std::env::current_dir()?;
+                let input = PathBuf::from(&effective_cli_paths[0]);
+                let input_path = if input.is_absolute() {
+                    input
+                } else {
+                    current_dir.join(input)
+                };
 
-        if input_path.exists()
-          && input_path.is_dir()
-          && input_path.canonicalize()? == *project_dir
-        {
-          effective_cli_paths.clear();
+                if input_path.exists()
+                    && input_path.is_dir()
+                    && input_path.canonicalize()? == *project_dir
+                {
+                    effective_cli_paths.clear();
+                }
+            }
         }
-      }
-    }
-  }
-
-  let paths = if !effective_cli_paths.is_empty() {
-    effective_cli_paths
-  } else {
-    config_paths
-  };
-
-  if paths.is_empty() {
-    if explicit_run_command {
-      return Err(MechError::new(
-        GenericError {
-          msg: "no run inputs supplied; pass path(s) or configure run.paths".to_string(),
-        },
-        None,
-      ).with_compiler_loc());
     }
 
-    return Ok(None);
-  }
+    let paths = if !effective_cli_paths.is_empty() {
+        effective_cli_paths
+    } else {
+        config_paths
+    };
 
-  Ok(Some(EffectiveRunOptions { paths }))
+    if paths.is_empty() {
+        if explicit_run_command {
+            return Err(MechError::new(
+                GenericError {
+                    msg: "no run inputs supplied; pass path(s) or configure run.paths".to_string(),
+                },
+                None,
+            )
+            .with_compiler_loc());
+        }
+
+        return Ok(None);
+    }
+
+    Ok(Some(EffectiveRunOptions { paths }))
 }
 
 pub fn effective_serve_options(
-  serve_matches: &clap::ArgMatches,
-  config: Option<&LoadedMechConfig>,
+    serve_matches: &clap::ArgMatches,
+    config: Option<&LoadedMechConfig>,
 ) -> MResult<EffectiveServeOptions> {
-  let serve_config = config.and_then(|loaded| loaded.document.serve.as_ref());
-  let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
-    resolve_config_path(&loaded.base_dir, path)
-      .to_string_lossy()
-      .to_string()
-  };
+    let serve_config = config.and_then(|loaded| loaded.document.serve.as_ref());
+    let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
+        resolve_config_path(&loaded.base_dir, path)
+            .to_string_lossy()
+            .to_string()
+    };
 
-  let address = serve_matches
-    .get_one::<String>("address")
-    .cloned()
-    .or_else(|| serve_config.and_then(|serve| serve.address.clone()))
-    .unwrap_or_else(|| "127.0.0.1".to_string());
+    let address = serve_matches
+        .get_one::<String>("address")
+        .cloned()
+        .or_else(|| serve_config.and_then(|serve| serve.address.clone()))
+        .unwrap_or_else(|| "127.0.0.1".to_string());
 
-  let port = serve_matches
-    .get_one::<String>("port")
-    .cloned()
-    .or_else(|| serve_config.and_then(|serve| serve.port.map(|port| port.to_string())))
-    .unwrap_or_else(|| "8081".to_string());
+    let port = serve_matches
+        .get_one::<String>("port")
+        .cloned()
+        .or_else(|| serve_config.and_then(|serve| serve.port.map(|port| port.to_string())))
+        .unwrap_or_else(|| "8081".to_string());
 
-  let cli_shim = serve_matches.get_one::<String>("shim").cloned();
-  let config_shim = config.and_then(|loaded| {
-    loaded.document.serve.as_ref().and_then(|serve| {
-      serve
-        .shim
-        .as_ref()
-        .map(|path| config_path_to_string(loaded, path))
-    })
-  });
-  let shim_path = cli_shim
-    .clone()
-    .or_else(|| config_shim.clone())
-    .unwrap_or_default();
-  if cli_shim.is_none() {
-    if let Some(path) = config_shim.as_ref() {
-      require_config_file("serve.shim", Path::new(path))?;
-    }
-  }
-
-  let cli_wasm = serve_matches.get_one::<String>("wasm").cloned();
-  let config_wasm = config.and_then(|loaded| {
-    loaded.document.serve.as_ref().and_then(|serve| {
-      serve
-        .wasm
-        .as_ref()
-        .map(|path| config_path_to_string(loaded, path))
-    })
-  });
-  let wasm_pkg = cli_wasm
-    .clone()
-    .or_else(|| config_wasm.clone())
-    .unwrap_or_default();
-  if cli_wasm.is_none() {
-    if let Some(path) = config_wasm.as_ref() {
-      require_config_wasm_package("serve.wasm", Path::new(path))?;
-    }
-  }
-
-  let config_stylesheets: Vec<String> = config
-    .and_then(|loaded| {
-      loaded.document.serve.as_ref().map(|serve| {
-        serve
-          .stylesheets
-          .iter()
-          .map(|path| config_path_to_string(loaded, path))
-          .collect::<Vec<_>>()
-      })
-    })
-    .unwrap_or_default();
-  for path in &config_stylesheets {
-    require_config_file("serve.stylesheets", Path::new(path))?;
-  }
-  let cli_stylesheets = serve_matches
-    .get_many::<String>("stylesheet")
-    .into_iter()
-    .flatten()
-    .cloned();
-  let mut stylesheet_paths = config_stylesheets;
-  stylesheet_paths.extend(cli_stylesheets);
-
-  let mut cli_paths: Vec<String> = serve_matches
-    .get_many::<String>("mech_serve_file_paths")
-    .into_iter()
-    .flatten()
-    .cloned()
-    .collect();
-
-  if let Some(loaded) = config {
-    if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
-      if cli_paths.len() == 1 {
-        let current_dir = std::env::current_dir()?;
-        let input = PathBuf::from(&cli_paths[0]);
-        let input_path = if input.is_absolute() {
-          input
-        } else {
-          current_dir.join(input)
-        };
-
-        if input_path.exists()
-          && input_path.is_dir()
-          && input_path.canonicalize()? == *project_dir
-        {
-          cli_paths.clear();
-        }
-      }
-    }
-  }
-
-  let paths = if !cli_paths.is_empty() {
-    cli_paths
-  } else {
-    config
-      .and_then(|loaded| {
-        loaded.document.serve.as_ref().map(|serve| {
-          serve
-            .paths
-            .iter()
-            .map(|path| config_path_to_string(loaded, path))
-            .collect()
+    let cli_shim = serve_matches.get_one::<String>("shim").cloned();
+    let config_shim = config.and_then(|loaded| {
+        loaded.document.serve.as_ref().and_then(|serve| {
+            serve
+                .shim
+                .as_ref()
+                .map(|path| config_path_to_string(loaded, path))
         })
-      })
-      .filter(|paths: &Vec<String>| !paths.is_empty())
-      .unwrap_or_default()
-  };
+    });
+    let shim_path = cli_shim
+        .clone()
+        .or_else(|| config_shim.clone())
+        .unwrap_or_default();
+    if cli_shim.is_none() {
+        if let Some(path) = config_shim.as_ref() {
+            require_config_file("serve.shim", Path::new(path))?;
+        }
+    }
 
-  Ok(EffectiveServeOptions {
-    address,
-    port,
-    paths,
-    stylesheet_paths,
-    shim_path,
-    wasm_pkg,
-  })
+    let cli_wasm = serve_matches.get_one::<String>("wasm").cloned();
+    let config_wasm = config.and_then(|loaded| {
+        loaded.document.serve.as_ref().and_then(|serve| {
+            serve
+                .wasm
+                .as_ref()
+                .map(|path| config_path_to_string(loaded, path))
+        })
+    });
+    let wasm_pkg = cli_wasm
+        .clone()
+        .or_else(|| config_wasm.clone())
+        .unwrap_or_default();
+    if cli_wasm.is_none() {
+        if let Some(path) = config_wasm.as_ref() {
+            require_config_wasm_package("serve.wasm", Path::new(path))?;
+        }
+    }
+
+    let config_stylesheets: Vec<String> = config
+        .and_then(|loaded| {
+            loaded.document.serve.as_ref().map(|serve| {
+                serve
+                    .stylesheets
+                    .iter()
+                    .map(|path| config_path_to_string(loaded, path))
+                    .collect::<Vec<_>>()
+            })
+        })
+        .unwrap_or_default();
+    for path in &config_stylesheets {
+        require_config_file("serve.stylesheets", Path::new(path))?;
+    }
+    let cli_stylesheets = serve_matches
+        .get_many::<String>("stylesheet")
+        .into_iter()
+        .flatten()
+        .cloned();
+    let mut stylesheet_paths = config_stylesheets;
+    stylesheet_paths.extend(cli_stylesheets);
+
+    let mut cli_paths: Vec<String> = serve_matches
+        .get_many::<String>("mech_serve_file_paths")
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect();
+
+    if let Some(loaded) = config {
+        if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
+            if cli_paths.len() == 1 {
+                let current_dir = std::env::current_dir()?;
+                let input = PathBuf::from(&cli_paths[0]);
+                let input_path = if input.is_absolute() {
+                    input
+                } else {
+                    current_dir.join(input)
+                };
+
+                if input_path.exists()
+                    && input_path.is_dir()
+                    && input_path.canonicalize()? == *project_dir
+                {
+                    cli_paths.clear();
+                }
+            }
+        }
+    }
+
+    let paths = if !cli_paths.is_empty() {
+        cli_paths
+    } else {
+        config
+            .and_then(|loaded| {
+                loaded.document.serve.as_ref().map(|serve| {
+                    serve
+                        .paths
+                        .iter()
+                        .map(|path| config_path_to_string(loaded, path))
+                        .collect()
+                })
+            })
+            .filter(|paths: &Vec<String>| !paths.is_empty())
+            .unwrap_or_default()
+    };
+
+    Ok(EffectiveServeOptions {
+        address,
+        port,
+        paths,
+        stylesheet_paths,
+        shim_path,
+        wasm_pkg,
+    })
 }
 
 #[cfg(test)]
 mod config_tests {
-  use super::*;
-  use mech_runtime::{ConfigProfileOptions, MechConfigDocument, DEFAULT_CONFIG_FILENAME};
-  use std::time::{SystemTime, UNIX_EPOCH};
+    use super::*;
+    use mech_runtime::{ConfigProfileOptions, DEFAULT_CONFIG_FILENAME, MechConfigDocument};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-  struct CurrentDirGuard {
-    previous: PathBuf,
-    _lock: std::sync::MutexGuard<'static, ()>,
-  }
-
-  impl CurrentDirGuard {
-    fn enter(path: &std::path::Path) -> Self {
-      let lock = crate::cli::CURRENT_DIR_LOCK.lock().unwrap();
-      let previous = std::env::current_dir().unwrap();
-      std::env::set_current_dir(path).unwrap();
-      Self {
-        previous,
-        _lock: lock,
-      }
+    struct CurrentDirGuard {
+        previous: PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
     }
-  }
 
-  impl Drop for CurrentDirGuard {
-    fn drop(&mut self) {
-      std::env::set_current_dir(&self.previous).unwrap();
+    impl CurrentDirGuard {
+        fn enter(path: &std::path::Path) -> Self {
+            let lock = crate::cli::CURRENT_DIR_LOCK.lock().unwrap();
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
     }
-  }
 
-  fn temp_root(name: &str) -> PathBuf {
-    let root = std::env::temp_dir().join(format!(
-      "mech-cli-config-{name}-{}",
-      SystemTime::now()
-        .duration_since(UNIX_EPOCH)
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.previous).unwrap();
+        }
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mech-cli-config-{name}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root.canonicalize().unwrap()
+    }
+
+    fn command() -> Command {
+        add_config_args(
+            Command::new("mech").subcommand(
+                Command::new("serve")
+                    .arg(
+                        Arg::new("mech_serve_file_paths")
+                            .required(false)
+                            .action(ArgAction::Append),
+                    )
+                    .arg(Arg::new("port").long("port").num_args(1))
+                    .arg(Arg::new("address").long("address").num_args(1))
+                    .arg(
+                        Arg::new("stylesheet")
+                            .long("stylesheet")
+                            .num_args(1..)
+                            .action(ArgAction::Append),
+                    )
+                    .arg(Arg::new("shim").long("shim").num_args(1))
+                    .arg(Arg::new("wasm").long("wasm").num_args(1)),
+            ),
+        )
+    }
+
+    fn matches(args: &[&str]) -> clap::ArgMatches {
+        command().try_get_matches_from(args).unwrap()
+    }
+
+    fn parse_document(source: &str) -> MechConfigDocument {
+        mech_runtime::parse_config_document(
+            "test.mcfg".to_string(),
+            source,
+            ConfigProfileOptions::default(),
+        )
         .unwrap()
-        .as_nanos(),
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    root.canonicalize().unwrap()
-  }
-
-  fn command() -> Command {
-    add_config_args(
-      Command::new("mech").subcommand(
-        Command::new("serve")
-          .arg(
-            Arg::new("mech_serve_file_paths")
-              .required(false)
-              .action(ArgAction::Append),
-          )
-          .arg(Arg::new("port").long("port").num_args(1))
-          .arg(Arg::new("address").long("address").num_args(1))
-          .arg(
-            Arg::new("stylesheet")
-              .long("stylesheet")
-              .num_args(1..)
-              .action(ArgAction::Append),
-          )
-          .arg(Arg::new("shim").long("shim").num_args(1))
-          .arg(Arg::new("wasm").long("wasm").num_args(1)),
-      ),
-    )
-  }
-
-  fn matches(args: &[&str]) -> clap::ArgMatches {
-    command().try_get_matches_from(args).unwrap()
-  }
-
-  fn parse_document(source: &str) -> MechConfigDocument {
-    mech_runtime::parse_config_document(
-      "test.mcfg".to_string(),
-      source,
-      ConfigProfileOptions::default(),
-    )
-    .unwrap()
-  }
-
-  fn loaded_config(source: &str) -> LoadedMechConfig {
-    LoadedMechConfig {
-      path: PathBuf::from("test.mcfg"),
-      base_dir: PathBuf::new(),
-      document: parse_document(source),
-      discovered_project_dir: None,
     }
-  }
 
-  fn loaded_config_at(base_dir: PathBuf, source: &str) -> LoadedMechConfig {
-    LoadedMechConfig {
-      path: base_dir.join("mech.mcfg"),
-      base_dir,
-      document: parse_document(source),
-      discovered_project_dir: None,
+    fn loaded_config(source: &str) -> LoadedMechConfig {
+        LoadedMechConfig {
+            path: PathBuf::from("test.mcfg"),
+            base_dir: PathBuf::new(),
+            document: parse_document(source),
+            discovered_project_dir: None,
+        }
     }
-  }
 
-  fn loaded_run_project_config_at(base_dir: PathBuf, source: &str, project_dir: PathBuf) -> LoadedMechConfig {
-    LoadedMechConfig {
-      path: base_dir.join("mech.mcfg"),
-      base_dir,
-      document: parse_document(source),
-      discovered_project_dir: Some(project_dir),
+    fn loaded_config_at(base_dir: PathBuf, source: &str) -> LoadedMechConfig {
+        LoadedMechConfig {
+            path: base_dir.join("mech.mcfg"),
+            base_dir,
+            document: parse_document(source),
+            discovered_project_dir: None,
+        }
     }
-  }
 
-  fn create_wasm_pkg(path: &Path) {
-    std::fs::create_dir_all(path).unwrap();
-    std::fs::write(path.join("mech_wasm_bg.wasm.br"), b"wasm").unwrap();
-    std::fs::write(path.join("mech_wasm.js"), b"js").unwrap();
-  }
+    fn loaded_run_project_config_at(
+        base_dir: PathBuf,
+        source: &str,
+        project_dir: PathBuf,
+    ) -> LoadedMechConfig {
+        LoadedMechConfig {
+            path: base_dir.join("mech.mcfg"),
+            base_dir,
+            document: parse_document(source),
+            discovered_project_dir: Some(project_dir),
+        }
+    }
 
-  fn create_serve_project_with_config_name(root: &Path, config_name: &str) -> PathBuf {
-    let project = root.join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::write(project.join("index.html"), "<html></html>").unwrap();
-    std::fs::write(project.join("demo.mec"), "# demo\n").unwrap();
-    std::fs::write(
-      project.join(config_name),
-      r#"config := {
+    fn create_wasm_pkg(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        std::fs::write(path.join("mech_wasm_bg.wasm.br"), b"wasm").unwrap();
+        std::fs::write(path.join("mech_wasm.js"), b"js").unwrap();
+    }
+
+    fn create_serve_project_with_config_name(root: &Path, config_name: &str) -> PathBuf {
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("index.html"), "<html></html>").unwrap();
+        std::fs::write(project.join("demo.mec"), "# demo\n").unwrap();
+        std::fs::write(
+            project.join(config_name),
+            r#"config := {
   serve: {
   paths: ["demo.mec"]
   shim: "index.html"
   }
 }
 "#,
-    )
-    .unwrap();
-    project
-  }
-
-  fn create_serve_project(root: &Path) -> PathBuf {
-    create_serve_project_with_config_name(root, DEFAULT_CONFIG_FILENAME)
-  }
-
-  fn error_text(result: MResult<EffectiveServeOptions>) -> String {
-    format!("{:?}", result.unwrap_err())
-  }
-
-  fn run_error_text(result: MResult<Option<EffectiveRunOptions>>) -> String {
-    format!("{:?}", result.unwrap_err())
-  }
-
-  #[test]
-  fn config_run_paths_used_when_cli_paths_absent() {
-    let config = loaded_config(r#"config := {run: {paths: ["foo.mec", "bar.mec"]}}"#);
-    let effective = effective_run_options(vec![], Some(&config), true)
-      .unwrap()
-      .unwrap();
-    assert_eq!(effective.paths, vec!["foo.mec", "bar.mec"]);
-  }
-
-  #[test]
-  fn cli_run_paths_override_config_paths() {
-    let config = loaded_config(r#"config := {run: {paths: ["foo.mec"]}}"#);
-    let effective = effective_run_options(vec!["cli.mec".to_string()], Some(&config), true)
-      .unwrap()
-      .unwrap();
-    assert_eq!(effective.paths, vec!["cli.mec"]);
-  }
-
-  #[test]
-  fn run_project_directory_uses_config_paths_not_selector_path() {
-    let root = temp_root("run-project-uses-config-paths");
-    let project = root.join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    let config = loaded_run_project_config_at(
-      project.clone(),
-      r#"config := {run: {paths: ["demo.mec"]}}"#,
-      project.canonicalize().unwrap(),
-    );
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      let effective = effective_run_options(vec!["project".to_string()], Some(&config), false)
-        .unwrap()
+        )
         .unwrap();
-      assert_eq!(
-        effective.paths,
-        vec![project.join("demo.mec").to_string_lossy().to_string()]
-      );
+        project
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-  #[test]
-  fn implicit_run_without_inputs_returns_none() {
-    let options = effective_run_options(vec![], None, false).unwrap();
-    assert_eq!(options, None);
-  }
-
-  #[test]
-  fn explicit_run_without_inputs_and_without_config_paths_errors() {
-    let msg = run_error_text(effective_run_options(vec![], None, true));
-    assert!(msg.contains("no run inputs supplied"));
-  }
-
-
-
-
-
-  #[test]
-  fn serve_project_directory_uses_config_paths_not_selector_path() {
-    let root = temp_root("serve-project-uses-config-paths");
-    let project = create_serve_project(&root);
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      let matches = matches(&["mech", "serve", "project"]);
-      let serve_matches = matches.subcommand_matches("serve").unwrap();
-      let loaded = load_cli_config(serve_matches).unwrap().unwrap();
-      let options = effective_serve_options(serve_matches, Some(&loaded)).unwrap();
-      assert_eq!(
-        options.paths,
-        vec![project.join("demo.mec").to_string_lossy().to_string()]
-      );
-      assert_eq!(
-        options.shim_path,
-        project.join("index.html").to_string_lossy().to_string()
-      );
-      assert!(!options.paths.iter().any(|path| path == "project"));
+    fn create_serve_project(root: &Path) -> PathBuf {
+        create_serve_project_with_config_name(root, DEFAULT_CONFIG_FILENAME)
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-
-
-
-  #[test]
-  fn project_directory_without_mech_config_falls_back_to_current_dir_config() {
-    let root = temp_root("project-without-config-falls-back");
-    let project = root.join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::write(
-      root.join(DEFAULT_CONFIG_FILENAME),
-      "config := {serve: {port: 9090}}\n",
-    )
-    .unwrap();
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      let matches = matches(&["mech", "serve", "project"]);
-      let loaded = load_cli_config(matches.subcommand_matches("serve").unwrap())
-        .unwrap()
-        .unwrap();
-      assert_eq!(loaded.path, root.join(DEFAULT_CONFIG_FILENAME));
-      assert_eq!(loaded.discovered_project_dir, None);
+    fn error_text(result: MResult<EffectiveServeOptions>) -> String {
+        format!("{:?}", result.unwrap_err())
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-  #[test]
-  fn explicit_config_loads() {
-    let root = temp_root("explicit");
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
-      let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
-      let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
-        .unwrap()
-        .unwrap();
-      assert_eq!(config.document.serve.unwrap().port, Some(9090));
-      assert_eq!(config.path, root.join("custom.mcfg"));
-      assert_eq!(config.base_dir, root);
+    fn run_error_text(result: MResult<Option<EffectiveRunOptions>>) -> String {
+        format!("{:?}", result.unwrap_err())
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-  #[test]
-  fn default_config_auto_loads() {
-    let root = temp_root("auto");
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
-      let matches = matches(&["mech", "serve"]);
-      assert!(
-        load_cli_config(matches.subcommand_matches("serve").unwrap())
-          .unwrap()
-          .is_some()
-      );
+    #[test]
+    fn config_run_paths_used_when_cli_paths_absent() {
+        let config = loaded_config(r#"config := {run: {paths: ["foo.mec", "bar.mec"]}}"#);
+        let effective = effective_run_options(vec![], Some(&config), true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(effective.paths, vec!["foo.mec", "bar.mec"]);
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
+    #[test]
+    fn cli_run_paths_override_config_paths() {
+        let config = loaded_config(r#"config := {run: {paths: ["foo.mec"]}}"#);
+        let effective = effective_run_options(vec!["cli.mec".to_string()], Some(&config), true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(effective.paths, vec!["cli.mec"]);
+    }
 
-  #[test]
-  fn cli_scalar_options_override_config() {
-    let config = loaded_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
-    let matches = matches(&["mech", "serve", "--address", "0.0.0.0", "--port", "9090"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+    #[test]
+    fn run_project_directory_uses_config_paths_not_selector_path() {
+        let root = temp_root("run-project-uses-config-paths");
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let config = loaded_run_project_config_at(
+            project.clone(),
+            r#"config := {run: {paths: ["demo.mec"]}}"#,
+            project.canonicalize().unwrap(),
+        );
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let effective =
+                effective_run_options(vec!["project".to_string()], Some(&config), false)
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(
+                effective.paths,
+                vec![project.join("demo.mec").to_string_lossy().to_string()]
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn implicit_run_without_inputs_returns_none() {
+        let options = effective_run_options(vec![], None, false).unwrap();
+        assert_eq!(options, None);
+    }
+
+    #[test]
+    fn explicit_run_without_inputs_and_without_config_paths_errors() {
+        let msg = run_error_text(effective_run_options(vec![], None, true));
+        assert!(msg.contains("no run inputs supplied"));
+    }
+
+    #[test]
+    fn serve_project_directory_uses_config_paths_not_selector_path() {
+        let root = temp_root("serve-project-uses-config-paths");
+        let project = create_serve_project(&root);
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&["mech", "serve", "project"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let loaded = load_cli_config(serve_matches).unwrap().unwrap();
+            let options = effective_serve_options(serve_matches, Some(&loaded)).unwrap();
+            assert_eq!(
+                options.paths,
+                vec![project.join("demo.mec").to_string_lossy().to_string()]
+            );
+            assert_eq!(
+                options.shim_path,
+                project.join("index.html").to_string_lossy().to_string()
+            );
+            assert!(!options.paths.iter().any(|path| path == "project"));
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn project_directory_without_mech_config_falls_back_to_current_dir_config() {
+        let root = temp_root("project-without-config-falls-back");
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            root.join(DEFAULT_CONFIG_FILENAME),
+            "config := {serve: {port: 9090}}\n",
+        )
         .unwrap();
-    assert_eq!(effective.address, "0.0.0.0");
-    assert_eq!(effective.port, "9090");
-  }
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&["mech", "serve", "project"]);
+            let loaded = load_cli_config(matches.subcommand_matches("serve").unwrap())
+                .unwrap()
+                .unwrap();
+            assert_eq!(loaded.path, root.join(DEFAULT_CONFIG_FILENAME));
+            assert_eq!(loaded.discovered_project_dir, None);
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
-  #[test]
-  fn config_serve_paths_used_when_cli_paths_absent() {
-    let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
-    let matches = matches(&["mech", "serve"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-        .unwrap();
-    assert_eq!(effective.paths, vec!["docs/reference"]);
-  }
+    #[test]
+    fn explicit_config_loads() {
+        let root = temp_root("explicit");
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
+            let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
+            let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
+                .unwrap()
+                .unwrap();
+            assert_eq!(config.document.serve.unwrap().port, Some(9090));
+            assert_eq!(config.path, root.join("custom.mcfg"));
+            assert_eq!(config.base_dir, root);
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
-  #[test]
-  fn cli_serve_paths_override_config_paths() {
-    let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
-    let matches = matches(&["mech", "serve", "examples/working"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-        .unwrap();
-    assert_eq!(effective.paths, vec!["examples/working"]);
-  }
+    #[test]
+    fn default_config_auto_loads() {
+        let root = temp_root("auto");
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
+            let matches = matches(&["mech", "serve"]);
+            assert!(
+                load_cli_config(matches.subcommand_matches("serve").unwrap())
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
-  #[test]
-  fn stylesheets_combine() {
-    let root = temp_root("stylesheets-combine");
-    std::fs::write(root.join("a.css"), "body {}").unwrap();
-    let config = loaded_config_at(
-      root.clone(),
-      r#"config := {serve: {stylesheets: ["a.css"]}}"#,
-    );
-    let matches = matches(&["mech", "serve", "--stylesheet", "b.css"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-        .unwrap();
-    assert_eq!(
-      effective.stylesheet_paths,
-      vec![
-        root.join("a.css").to_string_lossy().to_string(),
-        "b.css".to_string()
-      ]
-    );
-    std::fs::remove_dir_all(root).unwrap();
-  }
+    #[test]
+    fn cli_scalar_options_override_config() {
+        let config = loaded_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
+        let matches = matches(&["mech", "serve", "--address", "0.0.0.0", "--port", "9090"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(effective.address, "0.0.0.0");
+        assert_eq!(effective.port, "9090");
+    }
 
-  #[test]
-  fn config_relative_serve_paths_resolve_from_config_file_directory() {
-    let root = temp_root("relative-serve-paths");
-    let subdir = root.join("subdir");
-    std::fs::create_dir_all(&subdir).unwrap();
-    std::fs::write(subdir.join("style.css"), "body {}").unwrap();
-    std::fs::write(subdir.join("shim.html"), "<html></html>").unwrap();
-    create_wasm_pkg(&subdir.join("pkg"));
-    std::fs::write(
-      subdir.join(DEFAULT_CONFIG_FILENAME),
-      r#"config := {
+    #[test]
+    fn config_serve_paths_used_when_cli_paths_absent() {
+        let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+        let matches = matches(&["mech", "serve"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(effective.paths, vec!["docs/reference"]);
+    }
+
+    #[test]
+    fn cli_serve_paths_override_config_paths() {
+        let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+        let matches = matches(&["mech", "serve", "examples/working"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(effective.paths, vec!["examples/working"]);
+    }
+
+    #[test]
+    fn stylesheets_combine() {
+        let root = temp_root("stylesheets-combine");
+        std::fs::write(root.join("a.css"), "body {}").unwrap();
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := {serve: {stylesheets: ["a.css"]}}"#,
+        );
+        let matches = matches(&["mech", "serve", "--stylesheet", "b.css"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(
+            effective.stylesheet_paths,
+            vec![
+                root.join("a.css").to_string_lossy().to_string(),
+                "b.css".to_string()
+            ]
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_relative_serve_paths_resolve_from_config_file_directory() {
+        let root = temp_root("relative-serve-paths");
+        let subdir = root.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(subdir.join("style.css"), "body {}").unwrap();
+        std::fs::write(subdir.join("shim.html"), "<html></html>").unwrap();
+        create_wasm_pkg(&subdir.join("pkg"));
+        std::fs::write(
+            subdir.join(DEFAULT_CONFIG_FILENAME),
+            r#"config := {
   serve: {
   paths: ["app.mec"]
   stylesheets: ["style.css"]
@@ -632,224 +702,316 @@ mod config_tests {
   }
 }
 "#,
-    )
-    .unwrap();
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve"]);
-      let serve_matches = matches.subcommand_matches("serve").unwrap();
-      let config = load_cli_config(serve_matches).unwrap().unwrap();
-      let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
-      assert_eq!(
-        effective.paths,
-        vec![subdir.join("app.mec").to_string_lossy().to_string()]
-      );
-      assert_eq!(
-        effective.stylesheet_paths,
-        vec![subdir.join("style.css").to_string_lossy().to_string()]
-      );
-      assert_eq!(
-        effective.shim_path,
-        subdir.join("shim.html").to_string_lossy().to_string()
-      );
-      assert_eq!(
-        effective.wasm_pkg,
-        subdir.join("pkg").to_string_lossy().to_string()
-      );
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let config = load_cli_config(serve_matches).unwrap().unwrap();
+            let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
+            assert_eq!(
+                effective.paths,
+                vec![subdir.join("app.mec").to_string_lossy().to_string()]
+            );
+            assert_eq!(
+                effective.stylesheet_paths,
+                vec![subdir.join("style.css").to_string_lossy().to_string()]
+            );
+            assert_eq!(
+                effective.shim_path,
+                subdir.join("shim.html").to_string_lossy().to_string()
+            );
+            assert_eq!(
+                effective.wasm_pkg,
+                subdir.join("pkg").to_string_lossy().to_string()
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-  #[test]
-  fn cli_paths_override_config_paths_and_remain_cwd_relative() {
-    let root = temp_root("cli-paths-cwd-relative");
-    let subdir = root.join("subdir");
-    std::fs::create_dir_all(&subdir).unwrap();
-    std::fs::write(
-      subdir.join(DEFAULT_CONFIG_FILENAME),
-      r#"config := {serve: {paths: ["app.mec"]}}"#,
-    )
-    .unwrap();
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve", "other.mec"]);
-      let serve_matches = matches.subcommand_matches("serve").unwrap();
-      let config = load_cli_config(serve_matches).unwrap().unwrap();
-      let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
-      assert_eq!(effective.paths, vec!["other.mec"]);
+    #[test]
+    fn cli_paths_override_config_paths_and_remain_cwd_relative() {
+        let root = temp_root("cli-paths-cwd-relative");
+        let subdir = root.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(
+            subdir.join(DEFAULT_CONFIG_FILENAME),
+            r#"config := {serve: {paths: ["app.mec"]}}"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve", "other.mec"]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let config = load_cli_config(serve_matches).unwrap().unwrap();
+            let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
+            assert_eq!(effective.paths, vec!["other.mec"]);
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-  #[test]
-  fn cli_shim_and_wasm_override_config_and_remain_cwd_relative() {
-    let root = temp_root("cli-shim-wasm-cwd-relative");
-    let subdir = root.join("subdir");
-    std::fs::create_dir_all(&subdir).unwrap();
-    std::fs::write(
-      subdir.join(DEFAULT_CONFIG_FILENAME),
-      r#"config := {serve: {shim: "shim.html", wasm: "pkg"}}"#,
-    )
-    .unwrap();
-    {
-      let _guard = CurrentDirGuard::enter(&root);
-      let matches = matches(&[
-        "mech",
-        "--config",
-        "subdir/mech.mcfg",
-        "serve",
-        "--shim",
-        "cli-shim.html",
-        "--wasm",
-        "cli-pkg",
-      ]);
-      let serve_matches = matches.subcommand_matches("serve").unwrap();
-      let config = load_cli_config(serve_matches).unwrap().unwrap();
-      let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
-      assert_eq!(effective.shim_path, "cli-shim.html");
-      assert_eq!(effective.wasm_pkg, "cli-pkg");
+    #[test]
+    fn cli_shim_and_wasm_override_config_and_remain_cwd_relative() {
+        let root = temp_root("cli-shim-wasm-cwd-relative");
+        let subdir = root.join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(
+            subdir.join(DEFAULT_CONFIG_FILENAME),
+            r#"config := {serve: {shim: "shim.html", wasm: "pkg"}}"#,
+        )
+        .unwrap();
+        {
+            let _guard = CurrentDirGuard::enter(&root);
+            let matches = matches(&[
+                "mech",
+                "--config",
+                "subdir/mech.mcfg",
+                "serve",
+                "--shim",
+                "cli-shim.html",
+                "--wasm",
+                "cli-pkg",
+            ]);
+            let serve_matches = matches.subcommand_matches("serve").unwrap();
+            let config = load_cli_config(serve_matches).unwrap().unwrap();
+            let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
+            assert_eq!(effective.shim_path, "cli-shim.html");
+            assert_eq!(effective.wasm_pkg, "cli-pkg");
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
-    std::fs::remove_dir_all(root).unwrap();
-  }
 
-  #[test]
-  fn missing_config_shim_is_ignored_when_cli_shim_overrides() {
-    let config = loaded_config(r#"config := {serve: {shim: "missing-shim.html"}}"#);
-    let matches = matches(&["mech", "serve", "--shim", "local.html"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+    #[test]
+    fn missing_config_shim_is_ignored_when_cli_shim_overrides() {
+        let config = loaded_config(r#"config := {serve: {shim: "missing-shim.html"}}"#);
+        let matches = matches(&["mech", "serve", "--shim", "local.html"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(effective.shim_path, "local.html");
+    }
+
+    #[test]
+    fn missing_config_wasm_is_ignored_when_cli_wasm_overrides() {
+        let config = loaded_config(r#"config := {serve: {wasm: "missing-pkg"}}"#);
+        let matches = matches(&["mech", "serve", "--wasm", "local-pkg"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(effective.wasm_pkg, "local-pkg");
+    }
+
+    #[test]
+    fn missing_config_stylesheet_fails_even_with_cli_stylesheet() {
+        let config = loaded_config(r#"config := {serve: {stylesheets: ["missing.css"]}}"#);
+        let matches = matches(&["mech", "serve", "--stylesheet", "local.css"]);
+        let error = error_text(effective_serve_options(
+            matches.subcommand_matches("serve").unwrap(),
+            Some(&config),
+        ));
+        assert!(error.contains("configuration error: serve.stylesheets must be an existing file"));
+    }
+
+    #[test]
+    fn config_stylesheet_directory_is_rejected() {
+        let root = temp_root("stylesheet-dir");
+        std::fs::create_dir_all(root.join("style.css")).unwrap();
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := {serve: {stylesheets: ["style.css"]}}"#,
+        );
+        let matches = matches(&["mech", "serve"]);
+        let error = error_text(effective_serve_options(
+            matches.subcommand_matches("serve").unwrap(),
+            Some(&config),
+        ));
+        assert!(error.contains("serve.stylesheets must be an existing file"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_shim_directory_is_rejected() {
+        let root = temp_root("shim-dir");
+        std::fs::create_dir_all(root.join("shim.html")).unwrap();
+        let config = loaded_config_at(root.clone(), r#"config := {serve: {shim: "shim.html"}}"#);
+        let matches = matches(&["mech", "serve"]);
+        let error = error_text(effective_serve_options(
+            matches.subcommand_matches("serve").unwrap(),
+            Some(&config),
+        ));
+        assert!(error.contains("serve.shim must be an existing file"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_wasm_file_is_rejected() {
+        let root = temp_root("wasm-file");
+        std::fs::write(root.join("pkg"), b"not a dir").unwrap();
+        let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
+        let matches = matches(&["mech", "serve"]);
+        let error = error_text(effective_serve_options(
+            matches.subcommand_matches("serve").unwrap(),
+            Some(&config),
+        ));
+        assert!(error.contains("serve.wasm must be an existing directory"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_wasm_directory_missing_required_files_is_rejected() {
+        let root = temp_root("wasm-missing-files");
+        std::fs::create_dir_all(root.join("pkg")).unwrap();
+        let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
+        let matches = matches(&["mech", "serve"]);
+        let error = error_text(effective_serve_options(
+            matches.subcommand_matches("serve").unwrap(),
+            Some(&config),
+        ));
+        assert!(error.contains("serve.wasm is missing required file"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_wasm_directory_with_required_files_is_accepted() {
+        let root = temp_root("wasm-complete");
+        create_wasm_pkg(&root.join("pkg"));
+        let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
+        let matches = matches(&["mech", "serve"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(
+            effective.wasm_pkg,
+            root.join("pkg").to_string_lossy().to_string()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_relative_paths_normalize_backslashes_with_validation() {
+        let root = temp_root("normalize-backslashes");
+        std::fs::create_dir_all(root.join("include")).unwrap();
+        std::fs::write(root.join("include/style.css"), "body {}").unwrap();
+        std::fs::write(root.join("include/shim.html"), "<html></html>").unwrap();
+        create_wasm_pkg(&root.join("web/pkg"));
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := {serve: {paths: ["docs\\reference"], stylesheets: ["include\\style.css"], shim: "include\\shim.html", wasm: "web\\pkg"}}"#,
+        );
+        let matches = matches(&["mech", "serve"]);
+        let effective =
+            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+                .unwrap();
+        assert_eq!(
+            effective.paths,
+            vec![root.join("docs/reference").to_string_lossy().to_string()]
+        );
+        assert_eq!(
+            effective.stylesheet_paths,
+            vec![root.join("include/style.css").to_string_lossy().to_string()]
+        );
+        assert_eq!(
+            effective.shim_path,
+            root.join("include/shim.html").to_string_lossy().to_string()
+        );
+        assert_eq!(
+            effective.wasm_pkg,
+            root.join("web/pkg").to_string_lossy().to_string()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn default_cli_host_grants_include_default_envelope() {
+        let grants = effective_cli_host_grants(None, CliHostGrantAttenuation::default()).unwrap();
+        assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+        assert_eq!(
+            grants.stdout_write_paths,
+            vec!["text".to_string(), "line".to_string()]
+        );
+        assert_eq!(
+            grants.stderr_write_paths,
+            vec!["text".to_string(), "line".to_string()]
+        );
+    }
+
+    #[test]
+    fn config_can_narrow_stdout_to_line() {
+        let root = temp_root("cli-stdout-line");
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+        );
+        let grants =
+            effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+        assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_can_deny_stdout_with_empty_list() {
+        let root = temp_root("cli-stdout-empty");
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
+        );
+        let grants =
+            effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+        assert!(grants.stdout_write_paths.is_empty());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_can_narrow_env_to_path() {
+        let root = temp_root("cli-env-path");
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+        );
+        let grants =
+            effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+        assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn command_line_attenuation_clears_stdout_even_if_config_allows() {
+        let root = temp_root("cli-deny-stdout");
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+        );
+        let grants = effective_cli_host_grants(
+            Some(&config),
+            CliHostGrantAttenuation {
+                deny_stdout: true,
+                ..Default::default()
+            },
+        )
         .unwrap();
-    assert_eq!(effective.shim_path, "local.html");
-  }
+        assert!(grants.stdout_write_paths.is_empty());
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
-  #[test]
-  fn missing_config_wasm_is_ignored_when_cli_wasm_overrides() {
-    let config = loaded_config(r#"config := {serve: {wasm: "missing-pkg"}}"#);
-    let matches = matches(&["mech", "serve", "--wasm", "local-pkg"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+    #[test]
+    fn attenuation_never_adds_back_capability() {
+        let root = temp_root("cli-never-adds");
+        let config = loaded_config_at(
+            root.clone(),
+            r#"config := { run: { cli: { stdout: { write: [] }, env: { read: [] } } } }"#,
+        );
+        let grants = effective_cli_host_grants(
+            Some(&config),
+            CliHostGrantAttenuation {
+                deny_stderr: true,
+                ..Default::default()
+            },
+        )
         .unwrap();
-    assert_eq!(effective.wasm_pkg, "local-pkg");
-  }
-
-  #[test]
-  fn missing_config_stylesheet_fails_even_with_cli_stylesheet() {
-    let config = loaded_config(r#"config := {serve: {stylesheets: ["missing.css"]}}"#);
-    let matches = matches(&["mech", "serve", "--stylesheet", "local.css"]);
-    let error = error_text(effective_serve_options(
-      matches.subcommand_matches("serve").unwrap(),
-      Some(&config),
-    ));
-    assert!(error.contains("configuration error: serve.stylesheets must be an existing file"));
-  }
-
-  #[test]
-  fn config_stylesheet_directory_is_rejected() {
-    let root = temp_root("stylesheet-dir");
-    std::fs::create_dir_all(root.join("style.css")).unwrap();
-    let config = loaded_config_at(
-      root.clone(),
-      r#"config := {serve: {stylesheets: ["style.css"]}}"#,
-    );
-    let matches = matches(&["mech", "serve"]);
-    let error = error_text(effective_serve_options(
-      matches.subcommand_matches("serve").unwrap(),
-      Some(&config),
-    ));
-    assert!(error.contains("serve.stylesheets must be an existing file"));
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn config_shim_directory_is_rejected() {
-    let root = temp_root("shim-dir");
-    std::fs::create_dir_all(root.join("shim.html")).unwrap();
-    let config = loaded_config_at(root.clone(), r#"config := {serve: {shim: "shim.html"}}"#);
-    let matches = matches(&["mech", "serve"]);
-    let error = error_text(effective_serve_options(
-      matches.subcommand_matches("serve").unwrap(),
-      Some(&config),
-    ));
-    assert!(error.contains("serve.shim must be an existing file"));
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn config_wasm_file_is_rejected() {
-    let root = temp_root("wasm-file");
-    std::fs::write(root.join("pkg"), b"not a dir").unwrap();
-    let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
-    let matches = matches(&["mech", "serve"]);
-    let error = error_text(effective_serve_options(
-      matches.subcommand_matches("serve").unwrap(),
-      Some(&config),
-    ));
-    assert!(error.contains("serve.wasm must be an existing directory"));
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn config_wasm_directory_missing_required_files_is_rejected() {
-    let root = temp_root("wasm-missing-files");
-    std::fs::create_dir_all(root.join("pkg")).unwrap();
-    let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
-    let matches = matches(&["mech", "serve"]);
-    let error = error_text(effective_serve_options(
-      matches.subcommand_matches("serve").unwrap(),
-      Some(&config),
-    ));
-    assert!(error.contains("serve.wasm is missing required file"));
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn config_wasm_directory_with_required_files_is_accepted() {
-    let root = temp_root("wasm-complete");
-    create_wasm_pkg(&root.join("pkg"));
-    let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
-    let matches = matches(&["mech", "serve"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-        .unwrap();
-    assert_eq!(
-      effective.wasm_pkg,
-      root.join("pkg").to_string_lossy().to_string()
-    );
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn config_relative_paths_normalize_backslashes_with_validation() {
-    let root = temp_root("normalize-backslashes");
-    std::fs::create_dir_all(root.join("include")).unwrap();
-    std::fs::write(root.join("include/style.css"), "body {}").unwrap();
-    std::fs::write(root.join("include/shim.html"), "<html></html>").unwrap();
-    create_wasm_pkg(&root.join("web/pkg"));
-    let config = loaded_config_at(
-      root.clone(),
-      r#"config := {serve: {paths: ["docs\\reference"], stylesheets: ["include\\style.css"], shim: "include\\shim.html", wasm: "web\\pkg"}}"#,
-    );
-    let matches = matches(&["mech", "serve"]);
-    let effective =
-      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-        .unwrap();
-    assert_eq!(
-      effective.paths,
-      vec![root.join("docs/reference").to_string_lossy().to_string()]
-    );
-    assert_eq!(
-      effective.stylesheet_paths,
-      vec![root.join("include/style.css").to_string_lossy().to_string()]
-    );
-    assert_eq!(
-      effective.shim_path,
-      root.join("include/shim.html").to_string_lossy().to_string()
-    );
-    assert_eq!(
-      effective.wasm_pkg,
-      root.join("web/pkg").to_string_lossy().to_string()
-    );
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
+        assert!(grants.stdout_write_paths.is_empty());
+        assert!(grants.env_read_paths.is_empty());
+        assert!(grants.stderr_write_paths.is_empty());
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,699 +1,702 @@
 use std::path::{Path, PathBuf};
 
-use crate::*;
 use clap::{Arg, ArgAction, Command};
+use crate::*;
 use mech_core::*;
 
 pub fn add_config_args(command: Command) -> Command {
-    command
-        .arg(
-            Arg::new("config")
-                .long("config")
-                .value_name("PATH")
-                .num_args(1)
-                .global(true)
-                .help("Load configuration from a Mech config file."),
-        )
-        .arg(
-            Arg::new("no_config")
-                .long("no-config")
-                .action(ArgAction::SetTrue)
-                .global(true)
-                .help("Disable automatic Mech config loading."),
-        )
+  command
+    .arg(
+      Arg::new("config")
+        .long("config")
+        .value_name("PATH")
+        .num_args(1)
+        .global(true)
+        .help("Load configuration from a Mech config file."),
+    )
+    .arg(
+      Arg::new("no_config")
+        .long("no-config")
+        .action(ArgAction::SetTrue)
+        .global(true)
+        .help("Disable automatic Mech config loading."),
+    )
 }
 
 pub fn load_cli_config(matches: &clap::ArgMatches) -> MResult<Option<LoadedMechConfig>> {
-    let project_inputs: Vec<String> = matches
-        .get_many::<String>("mech_serve_file_paths")
-        .into_iter()
-        .flatten()
-        .cloned()
-        .collect();
-    load_cli_config_with_inputs(matches, &project_inputs, "Server")
+  let project_inputs: Vec<String> = matches
+    .get_many::<String>("mech_serve_file_paths")
+    .into_iter()
+    .flatten()
+    .cloned()
+    .collect();
+  load_cli_config_with_inputs(matches, &project_inputs, "Server")
 }
 
 pub fn load_cli_config_with_inputs(
-    matches: &clap::ArgMatches,
-    project_inputs: &[String],
-    label: &str,
+  matches: &clap::ArgMatches,
+  project_inputs: &[String],
+  label: &str,
 ) -> MResult<Option<LoadedMechConfig>> {
-    let no_config = matches.get_flag("no_config");
-    let explicit_config = matches
-        .get_one::<String>("config")
-        .map(|path| path.as_str());
-    let current_dir = std::env::current_dir()?;
-    let loaded =
-        crate::load_optional_mech_config(&current_dir, explicit_config, no_config, project_inputs)?;
-    if let Some(config) = loaded.as_ref() {
-        println!("[Mech {label}] Loading config… {}", config.path.display());
-    }
-    Ok(loaded)
+  let no_config = matches.get_flag("no_config");
+  let explicit_config = matches.get_one::<String>("config").map(|path| path.as_str());
+  let current_dir = std::env::current_dir()?;
+  let loaded = crate::load_optional_mech_config(
+    &current_dir,
+    explicit_config,
+    no_config,
+    project_inputs,
+  )?;
+  if let Some(config) = loaded.as_ref() {
+    println!("[Mech {label}] Loading config… {}", config.path.display());
+  }
+  Ok(loaded)
 }
 
 pub fn load_run_cli_config(
-    matches: &clap::ArgMatches,
-    run_inputs: &[String],
+  matches: &clap::ArgMatches,
+  run_inputs: &[String],
 ) -> MResult<Option<LoadedMechConfig>> {
-    load_cli_config_with_inputs(matches, run_inputs, "Run")
+  load_cli_config_with_inputs(matches, run_inputs, "Run")
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EffectiveCliHostGrants {
-    pub env_read_paths: Vec<String>,
-    pub stdout_write_paths: Vec<String>,
-    pub stderr_write_paths: Vec<String>,
+  pub env_read_paths: Vec<String>,
+  pub stdout_write_paths: Vec<String>,
+  pub stderr_write_paths: Vec<String>,
 }
 
 impl Default for EffectiveCliHostGrants {
-    fn default() -> Self {
-        Self {
-            env_read_paths: vec!["*".to_string()],
-            stdout_write_paths: vec!["text".to_string(), "line".to_string()],
-            stderr_write_paths: vec!["text".to_string(), "line".to_string()],
-        }
+  fn default() -> Self {
+    Self {
+      env_read_paths: vec!["*".to_string()],
+      stdout_write_paths: vec!["text".to_string(), "line".to_string()],
+      stderr_write_paths: vec!["text".to_string(), "line".to_string()],
     }
+  }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CliHostGrantAttenuation {
-    pub deny_env: bool,
-    pub deny_stdout: bool,
-    pub deny_stderr: bool,
+  pub deny_env: bool,
+  pub deny_stdout: bool,
+  pub deny_stderr: bool,
 }
 
 pub fn effective_cli_host_grants(
-    config: Option<&LoadedMechConfig>,
-    attenuation: CliHostGrantAttenuation,
+  config: Option<&LoadedMechConfig>,
+  attenuation: CliHostGrantAttenuation,
 ) -> MResult<EffectiveCliHostGrants> {
-    let mut grants = EffectiveCliHostGrants::default();
+  let mut grants = EffectiveCliHostGrants::default();
 
-    if let Some(run) = config.and_then(|loaded| loaded.document.run.as_ref()) {
-        if let Some(paths) = &run.cli.env.read {
-            grants.env_read_paths = paths.clone();
-        }
-        if let Some(paths) = &run.cli.stdout.write {
-            grants.stdout_write_paths = validated_cli_stream_paths("run.cli.stdout.write", paths)?;
-        }
-        if let Some(paths) = &run.cli.stderr.write {
-            grants.stderr_write_paths = validated_cli_stream_paths("run.cli.stderr.write", paths)?;
-        }
+  if let Some(run) = config.and_then(|loaded| loaded.document.run.as_ref()) {
+    if let Some(paths) = &run.cli.env.read {
+      grants.env_read_paths = paths.clone();
     }
+    if let Some(paths) = &run.cli.stdout.write {
+      grants.stdout_write_paths = validated_cli_stream_paths("run.cli.stdout.write", paths)?;
+    }
+    if let Some(paths) = &run.cli.stderr.write {
+      grants.stderr_write_paths = validated_cli_stream_paths("run.cli.stderr.write", paths)?;
+    }
+  }
 
-    if attenuation.deny_env {
-        grants.env_read_paths.clear();
-    }
-    if attenuation.deny_stdout {
-        grants.stdout_write_paths.clear();
-    }
-    if attenuation.deny_stderr {
-        grants.stderr_write_paths.clear();
-    }
+  if attenuation.deny_env {
+    grants.env_read_paths.clear();
+  }
+  if attenuation.deny_stdout {
+    grants.stdout_write_paths.clear();
+  }
+  if attenuation.deny_stderr {
+    grants.stderr_write_paths.clear();
+  }
 
-    Ok(grants)
+  Ok(grants)
 }
 
 fn validated_cli_stream_paths(where_: &str, paths: &[String]) -> MResult<Vec<String>> {
-    let mut out = Vec::new();
-    for path in paths {
-        match path.as_str() {
-            "text" | "line" => out.push(path.clone()),
-            other => {
-                return Err(MechError::new(
-                    GenericError {
-                        msg: format!("{where_} cannot grant unsupported CLI stream path `{other}`"),
-                    },
-                    None,
-                )
-                .with_compiler_loc());
-            }
-        }
+  let mut out = Vec::new();
+  for path in paths {
+    match path.as_str() {
+      "text" | "line" => out.push(path.clone()),
+      other => {
+        return Err(MechError::new(
+          GenericError {
+            msg: format!("{where_} cannot grant unsupported CLI stream path `{other}`"),
+          },
+          None,
+        ).with_compiler_loc());
+      }
     }
-    Ok(out)
+  }
+  Ok(out)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EffectiveRunOptions {
-    pub paths: Vec<String>,
+  pub paths: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EffectiveServeOptions {
-    pub address: String,
-    pub port: String,
-    pub paths: Vec<String>,
-    pub stylesheet_paths: Vec<String>,
-    pub shim_path: String,
-    pub wasm_pkg: String,
+  pub address: String,
+  pub port: String,
+  pub paths: Vec<String>,
+  pub stylesheet_paths: Vec<String>,
+  pub shim_path: String,
+  pub wasm_pkg: String,
 }
 
 pub fn effective_run_options(
-    cli_paths: Vec<String>,
-    config: Option<&LoadedMechConfig>,
-    explicit_run_command: bool,
+  cli_paths: Vec<String>,
+  config: Option<&LoadedMechConfig>,
+  explicit_run_command: bool,
 ) -> MResult<Option<EffectiveRunOptions>> {
-    let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
-        resolve_config_path(&loaded.base_dir, path)
-            .to_string_lossy()
-            .to_string()
-    };
+  let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
+    resolve_config_path(&loaded.base_dir, path)
+      .to_string_lossy()
+      .to_string()
+  };
 
-    let config_paths = config
-        .and_then(|loaded| {
-            loaded.document.run.as_ref().map(|run| {
-                run.paths
-                    .iter()
-                    .map(|path| config_path_to_string(loaded, path))
-                    .collect::<Vec<_>>()
-            })
-        })
-        .unwrap_or_default();
+  let config_paths = config
+    .and_then(|loaded| {
+      loaded.document.run.as_ref().map(|run| {
+        run.paths
+          .iter()
+          .map(|path| config_path_to_string(loaded, path))
+          .collect::<Vec<_>>()
+      })
+    })
+    .unwrap_or_default();
 
-    let mut effective_cli_paths = cli_paths;
+  let mut effective_cli_paths = cli_paths;
 
-    if let Some(loaded) = config {
-        if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
-            if effective_cli_paths.len() == 1 {
-                let current_dir = std::env::current_dir()?;
-                let input = PathBuf::from(&effective_cli_paths[0]);
-                let input_path = if input.is_absolute() {
-                    input
-                } else {
-                    current_dir.join(input)
-                };
+  if let Some(loaded) = config {
+    if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
+      if effective_cli_paths.len() == 1 {
+        let current_dir = std::env::current_dir()?;
+        let input = PathBuf::from(&effective_cli_paths[0]);
+        let input_path = if input.is_absolute() {
+          input
+        } else {
+          current_dir.join(input)
+        };
 
-                if input_path.exists()
-                    && input_path.is_dir()
-                    && input_path.canonicalize()? == *project_dir
-                {
-                    effective_cli_paths.clear();
-                }
-            }
+        if input_path.exists()
+          && input_path.is_dir()
+          && input_path.canonicalize()? == *project_dir
+        {
+          effective_cli_paths.clear();
         }
+      }
+    }
+  }
+
+  let paths = if !effective_cli_paths.is_empty() {
+    effective_cli_paths
+  } else {
+    config_paths
+  };
+
+  if paths.is_empty() {
+    if explicit_run_command {
+      return Err(MechError::new(
+        GenericError {
+          msg: "no run inputs supplied; pass path(s) or configure run.paths".to_string(),
+        },
+        None,
+      ).with_compiler_loc());
     }
 
-    let paths = if !effective_cli_paths.is_empty() {
-        effective_cli_paths
-    } else {
-        config_paths
-    };
+    return Ok(None);
+  }
 
-    if paths.is_empty() {
-        if explicit_run_command {
-            return Err(MechError::new(
-                GenericError {
-                    msg: "no run inputs supplied; pass path(s) or configure run.paths".to_string(),
-                },
-                None,
-            )
-            .with_compiler_loc());
-        }
-
-        return Ok(None);
-    }
-
-    Ok(Some(EffectiveRunOptions { paths }))
+  Ok(Some(EffectiveRunOptions { paths }))
 }
 
 pub fn effective_serve_options(
-    serve_matches: &clap::ArgMatches,
-    config: Option<&LoadedMechConfig>,
+  serve_matches: &clap::ArgMatches,
+  config: Option<&LoadedMechConfig>,
 ) -> MResult<EffectiveServeOptions> {
-    let serve_config = config.and_then(|loaded| loaded.document.serve.as_ref());
-    let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
-        resolve_config_path(&loaded.base_dir, path)
-            .to_string_lossy()
-            .to_string()
-    };
+  let serve_config = config.and_then(|loaded| loaded.document.serve.as_ref());
+  let config_path_to_string = |loaded: &LoadedMechConfig, path: &Path| {
+    resolve_config_path(&loaded.base_dir, path)
+      .to_string_lossy()
+      .to_string()
+  };
 
-    let address = serve_matches
-        .get_one::<String>("address")
-        .cloned()
-        .or_else(|| serve_config.and_then(|serve| serve.address.clone()))
-        .unwrap_or_else(|| "127.0.0.1".to_string());
+  let address = serve_matches
+    .get_one::<String>("address")
+    .cloned()
+    .or_else(|| serve_config.and_then(|serve| serve.address.clone()))
+    .unwrap_or_else(|| "127.0.0.1".to_string());
 
-    let port = serve_matches
-        .get_one::<String>("port")
-        .cloned()
-        .or_else(|| serve_config.and_then(|serve| serve.port.map(|port| port.to_string())))
-        .unwrap_or_else(|| "8081".to_string());
+  let port = serve_matches
+    .get_one::<String>("port")
+    .cloned()
+    .or_else(|| serve_config.and_then(|serve| serve.port.map(|port| port.to_string())))
+    .unwrap_or_else(|| "8081".to_string());
 
-    let cli_shim = serve_matches.get_one::<String>("shim").cloned();
-    let config_shim = config.and_then(|loaded| {
-        loaded.document.serve.as_ref().and_then(|serve| {
-            serve
-                .shim
-                .as_ref()
-                .map(|path| config_path_to_string(loaded, path))
-        })
-    });
-    let shim_path = cli_shim
-        .clone()
-        .or_else(|| config_shim.clone())
-        .unwrap_or_default();
-    if cli_shim.is_none() {
-        if let Some(path) = config_shim.as_ref() {
-            require_config_file("serve.shim", Path::new(path))?;
-        }
-    }
-
-    let cli_wasm = serve_matches.get_one::<String>("wasm").cloned();
-    let config_wasm = config.and_then(|loaded| {
-        loaded.document.serve.as_ref().and_then(|serve| {
-            serve
-                .wasm
-                .as_ref()
-                .map(|path| config_path_to_string(loaded, path))
-        })
-    });
-    let wasm_pkg = cli_wasm
-        .clone()
-        .or_else(|| config_wasm.clone())
-        .unwrap_or_default();
-    if cli_wasm.is_none() {
-        if let Some(path) = config_wasm.as_ref() {
-            require_config_wasm_package("serve.wasm", Path::new(path))?;
-        }
-    }
-
-    let config_stylesheets: Vec<String> = config
-        .and_then(|loaded| {
-            loaded.document.serve.as_ref().map(|serve| {
-                serve
-                    .stylesheets
-                    .iter()
-                    .map(|path| config_path_to_string(loaded, path))
-                    .collect::<Vec<_>>()
-            })
-        })
-        .unwrap_or_default();
-    for path in &config_stylesheets {
-        require_config_file("serve.stylesheets", Path::new(path))?;
-    }
-    let cli_stylesheets = serve_matches
-        .get_many::<String>("stylesheet")
-        .into_iter()
-        .flatten()
-        .cloned();
-    let mut stylesheet_paths = config_stylesheets;
-    stylesheet_paths.extend(cli_stylesheets);
-
-    let mut cli_paths: Vec<String> = serve_matches
-        .get_many::<String>("mech_serve_file_paths")
-        .into_iter()
-        .flatten()
-        .cloned()
-        .collect();
-
-    if let Some(loaded) = config {
-        if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
-            if cli_paths.len() == 1 {
-                let current_dir = std::env::current_dir()?;
-                let input = PathBuf::from(&cli_paths[0]);
-                let input_path = if input.is_absolute() {
-                    input
-                } else {
-                    current_dir.join(input)
-                };
-
-                if input_path.exists()
-                    && input_path.is_dir()
-                    && input_path.canonicalize()? == *project_dir
-                {
-                    cli_paths.clear();
-                }
-            }
-        }
-    }
-
-    let paths = if !cli_paths.is_empty() {
-        cli_paths
-    } else {
-        config
-            .and_then(|loaded| {
-                loaded.document.serve.as_ref().map(|serve| {
-                    serve
-                        .paths
-                        .iter()
-                        .map(|path| config_path_to_string(loaded, path))
-                        .collect()
-                })
-            })
-            .filter(|paths: &Vec<String>| !paths.is_empty())
-            .unwrap_or_default()
-    };
-
-    Ok(EffectiveServeOptions {
-        address,
-        port,
-        paths,
-        stylesheet_paths,
-        shim_path,
-        wasm_pkg,
+  let cli_shim = serve_matches.get_one::<String>("shim").cloned();
+  let config_shim = config.and_then(|loaded| {
+    loaded.document.serve.as_ref().and_then(|serve| {
+      serve
+        .shim
+        .as_ref()
+        .map(|path| config_path_to_string(loaded, path))
     })
+  });
+  let shim_path = cli_shim
+    .clone()
+    .or_else(|| config_shim.clone())
+    .unwrap_or_default();
+  if cli_shim.is_none() {
+    if let Some(path) = config_shim.as_ref() {
+      require_config_file("serve.shim", Path::new(path))?;
+    }
+  }
+
+  let cli_wasm = serve_matches.get_one::<String>("wasm").cloned();
+  let config_wasm = config.and_then(|loaded| {
+    loaded.document.serve.as_ref().and_then(|serve| {
+      serve
+        .wasm
+        .as_ref()
+        .map(|path| config_path_to_string(loaded, path))
+    })
+  });
+  let wasm_pkg = cli_wasm
+    .clone()
+    .or_else(|| config_wasm.clone())
+    .unwrap_or_default();
+  if cli_wasm.is_none() {
+    if let Some(path) = config_wasm.as_ref() {
+      require_config_wasm_package("serve.wasm", Path::new(path))?;
+    }
+  }
+
+  let config_stylesheets: Vec<String> = config
+    .and_then(|loaded| {
+      loaded.document.serve.as_ref().map(|serve| {
+        serve
+          .stylesheets
+          .iter()
+          .map(|path| config_path_to_string(loaded, path))
+          .collect::<Vec<_>>()
+      })
+    })
+    .unwrap_or_default();
+  for path in &config_stylesheets {
+    require_config_file("serve.stylesheets", Path::new(path))?;
+  }
+  let cli_stylesheets = serve_matches
+    .get_many::<String>("stylesheet")
+    .into_iter()
+    .flatten()
+    .cloned();
+  let mut stylesheet_paths = config_stylesheets;
+  stylesheet_paths.extend(cli_stylesheets);
+
+  let mut cli_paths: Vec<String> = serve_matches
+    .get_many::<String>("mech_serve_file_paths")
+    .into_iter()
+    .flatten()
+    .cloned()
+    .collect();
+
+  if let Some(loaded) = config {
+    if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
+      if cli_paths.len() == 1 {
+        let current_dir = std::env::current_dir()?;
+        let input = PathBuf::from(&cli_paths[0]);
+        let input_path = if input.is_absolute() {
+          input
+        } else {
+          current_dir.join(input)
+        };
+
+        if input_path.exists()
+          && input_path.is_dir()
+          && input_path.canonicalize()? == *project_dir
+        {
+          cli_paths.clear();
+        }
+      }
+    }
+  }
+
+  let paths = if !cli_paths.is_empty() {
+    cli_paths
+  } else {
+    config
+      .and_then(|loaded| {
+        loaded.document.serve.as_ref().map(|serve| {
+          serve
+            .paths
+            .iter()
+            .map(|path| config_path_to_string(loaded, path))
+            .collect()
+        })
+      })
+      .filter(|paths: &Vec<String>| !paths.is_empty())
+      .unwrap_or_default()
+  };
+
+  Ok(EffectiveServeOptions {
+    address,
+    port,
+    paths,
+    stylesheet_paths,
+    shim_path,
+    wasm_pkg,
+  })
 }
 
 #[cfg(test)]
 mod config_tests {
-    use super::*;
-    use mech_runtime::{ConfigProfileOptions, DEFAULT_CONFIG_FILENAME, MechConfigDocument};
-    use std::time::{SystemTime, UNIX_EPOCH};
+  use super::*;
+  use mech_runtime::{ConfigProfileOptions, MechConfigDocument, DEFAULT_CONFIG_FILENAME};
+  use std::time::{SystemTime, UNIX_EPOCH};
 
-    struct CurrentDirGuard {
-        previous: PathBuf,
-        _lock: std::sync::MutexGuard<'static, ()>,
+  struct CurrentDirGuard {
+    previous: PathBuf,
+    _lock: std::sync::MutexGuard<'static, ()>,
+  }
+
+  impl CurrentDirGuard {
+    fn enter(path: &std::path::Path) -> Self {
+      let lock = crate::cli::CURRENT_DIR_LOCK.lock().unwrap();
+      let previous = std::env::current_dir().unwrap();
+      std::env::set_current_dir(path).unwrap();
+      Self {
+        previous,
+        _lock: lock,
+      }
     }
+  }
 
-    impl CurrentDirGuard {
-        fn enter(path: &std::path::Path) -> Self {
-            let lock = crate::cli::CURRENT_DIR_LOCK.lock().unwrap();
-            let previous = std::env::current_dir().unwrap();
-            std::env::set_current_dir(path).unwrap();
-            Self {
-                previous,
-                _lock: lock,
-            }
-        }
+  impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+      std::env::set_current_dir(&self.previous).unwrap();
     }
+  }
 
-    impl Drop for CurrentDirGuard {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.previous).unwrap();
-        }
-    }
-
-    fn temp_root(name: &str) -> PathBuf {
-        let root = std::env::temp_dir().join(format!(
-            "mech-cli-config-{name}-{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos(),
-        ));
-        std::fs::create_dir_all(&root).unwrap();
-        root.canonicalize().unwrap()
-    }
-
-    fn command() -> Command {
-        add_config_args(
-            Command::new("mech").subcommand(
-                Command::new("serve")
-                    .arg(
-                        Arg::new("mech_serve_file_paths")
-                            .required(false)
-                            .action(ArgAction::Append),
-                    )
-                    .arg(Arg::new("port").long("port").num_args(1))
-                    .arg(Arg::new("address").long("address").num_args(1))
-                    .arg(
-                        Arg::new("stylesheet")
-                            .long("stylesheet")
-                            .num_args(1..)
-                            .action(ArgAction::Append),
-                    )
-                    .arg(Arg::new("shim").long("shim").num_args(1))
-                    .arg(Arg::new("wasm").long("wasm").num_args(1)),
-            ),
-        )
-    }
-
-    fn matches(args: &[&str]) -> clap::ArgMatches {
-        command().try_get_matches_from(args).unwrap()
-    }
-
-    fn parse_document(source: &str) -> MechConfigDocument {
-        mech_runtime::parse_config_document(
-            "test.mcfg".to_string(),
-            source,
-            ConfigProfileOptions::default(),
-        )
+  fn temp_root(name: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+      "mech-cli-config-{name}-{}",
+      SystemTime::now()
+        .duration_since(UNIX_EPOCH)
         .unwrap()
-    }
+        .as_nanos(),
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    root.canonicalize().unwrap()
+  }
 
-    fn loaded_config(source: &str) -> LoadedMechConfig {
-        LoadedMechConfig {
-            path: PathBuf::from("test.mcfg"),
-            base_dir: PathBuf::new(),
-            document: parse_document(source),
-            discovered_project_dir: None,
-        }
-    }
+  fn command() -> Command {
+    add_config_args(
+      Command::new("mech").subcommand(
+        Command::new("serve")
+          .arg(
+            Arg::new("mech_serve_file_paths")
+              .required(false)
+              .action(ArgAction::Append),
+          )
+          .arg(Arg::new("port").long("port").num_args(1))
+          .arg(Arg::new("address").long("address").num_args(1))
+          .arg(
+            Arg::new("stylesheet")
+              .long("stylesheet")
+              .num_args(1..)
+              .action(ArgAction::Append),
+          )
+          .arg(Arg::new("shim").long("shim").num_args(1))
+          .arg(Arg::new("wasm").long("wasm").num_args(1)),
+      ),
+    )
+  }
 
-    fn loaded_config_at(base_dir: PathBuf, source: &str) -> LoadedMechConfig {
-        LoadedMechConfig {
-            path: base_dir.join("mech.mcfg"),
-            base_dir,
-            document: parse_document(source),
-            discovered_project_dir: None,
-        }
-    }
+  fn matches(args: &[&str]) -> clap::ArgMatches {
+    command().try_get_matches_from(args).unwrap()
+  }
 
-    fn loaded_run_project_config_at(
-        base_dir: PathBuf,
-        source: &str,
-        project_dir: PathBuf,
-    ) -> LoadedMechConfig {
-        LoadedMechConfig {
-            path: base_dir.join("mech.mcfg"),
-            base_dir,
-            document: parse_document(source),
-            discovered_project_dir: Some(project_dir),
-        }
-    }
+  fn parse_document(source: &str) -> MechConfigDocument {
+    mech_runtime::parse_config_document(
+      "test.mcfg".to_string(),
+      source,
+      ConfigProfileOptions::default(),
+    )
+    .unwrap()
+  }
 
-    fn create_wasm_pkg(path: &Path) {
-        std::fs::create_dir_all(path).unwrap();
-        std::fs::write(path.join("mech_wasm_bg.wasm.br"), b"wasm").unwrap();
-        std::fs::write(path.join("mech_wasm.js"), b"js").unwrap();
+  fn loaded_config(source: &str) -> LoadedMechConfig {
+    LoadedMechConfig {
+      path: PathBuf::from("test.mcfg"),
+      base_dir: PathBuf::new(),
+      document: parse_document(source),
+      discovered_project_dir: None,
     }
+  }
 
-    fn create_serve_project_with_config_name(root: &Path, config_name: &str) -> PathBuf {
-        let project = root.join("project");
-        std::fs::create_dir_all(&project).unwrap();
-        std::fs::write(project.join("index.html"), "<html></html>").unwrap();
-        std::fs::write(project.join("demo.mec"), "# demo\n").unwrap();
-        std::fs::write(
-            project.join(config_name),
-            r#"config := {
+  fn loaded_config_at(base_dir: PathBuf, source: &str) -> LoadedMechConfig {
+    LoadedMechConfig {
+      path: base_dir.join("mech.mcfg"),
+      base_dir,
+      document: parse_document(source),
+      discovered_project_dir: None,
+    }
+  }
+
+  fn loaded_run_project_config_at(base_dir: PathBuf, source: &str, project_dir: PathBuf) -> LoadedMechConfig {
+    LoadedMechConfig {
+      path: base_dir.join("mech.mcfg"),
+      base_dir,
+      document: parse_document(source),
+      discovered_project_dir: Some(project_dir),
+    }
+  }
+
+  fn create_wasm_pkg(path: &Path) {
+    std::fs::create_dir_all(path).unwrap();
+    std::fs::write(path.join("mech_wasm_bg.wasm.br"), b"wasm").unwrap();
+    std::fs::write(path.join("mech_wasm.js"), b"js").unwrap();
+  }
+
+  fn create_serve_project_with_config_name(root: &Path, config_name: &str) -> PathBuf {
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(project.join("index.html"), "<html></html>").unwrap();
+    std::fs::write(project.join("demo.mec"), "# demo\n").unwrap();
+    std::fs::write(
+      project.join(config_name),
+      r#"config := {
   serve: {
   paths: ["demo.mec"]
   shim: "index.html"
   }
 }
 "#,
-        )
+    )
+    .unwrap();
+    project
+  }
+
+  fn create_serve_project(root: &Path) -> PathBuf {
+    create_serve_project_with_config_name(root, DEFAULT_CONFIG_FILENAME)
+  }
+
+  fn error_text(result: MResult<EffectiveServeOptions>) -> String {
+    format!("{:?}", result.unwrap_err())
+  }
+
+  fn run_error_text(result: MResult<Option<EffectiveRunOptions>>) -> String {
+    format!("{:?}", result.unwrap_err())
+  }
+
+  #[test]
+  fn config_run_paths_used_when_cli_paths_absent() {
+    let config = loaded_config(r#"config := {run: {paths: ["foo.mec", "bar.mec"]}}"#);
+    let effective = effective_run_options(vec![], Some(&config), true)
+      .unwrap()
+      .unwrap();
+    assert_eq!(effective.paths, vec!["foo.mec", "bar.mec"]);
+  }
+
+  #[test]
+  fn cli_run_paths_override_config_paths() {
+    let config = loaded_config(r#"config := {run: {paths: ["foo.mec"]}}"#);
+    let effective = effective_run_options(vec!["cli.mec".to_string()], Some(&config), true)
+      .unwrap()
+      .unwrap();
+    assert_eq!(effective.paths, vec!["cli.mec"]);
+  }
+
+  #[test]
+  fn run_project_directory_uses_config_paths_not_selector_path() {
+    let root = temp_root("run-project-uses-config-paths");
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let config = loaded_run_project_config_at(
+      project.clone(),
+      r#"config := {run: {paths: ["demo.mec"]}}"#,
+      project.canonicalize().unwrap(),
+    );
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      let effective = effective_run_options(vec!["project".to_string()], Some(&config), false)
+        .unwrap()
         .unwrap();
-        project
+      assert_eq!(
+        effective.paths,
+        vec![project.join("demo.mec").to_string_lossy().to_string()]
+      );
     }
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    fn create_serve_project(root: &Path) -> PathBuf {
-        create_serve_project_with_config_name(root, DEFAULT_CONFIG_FILENAME)
+  #[test]
+  fn implicit_run_without_inputs_returns_none() {
+    let options = effective_run_options(vec![], None, false).unwrap();
+    assert_eq!(options, None);
+  }
+
+  #[test]
+  fn explicit_run_without_inputs_and_without_config_paths_errors() {
+    let msg = run_error_text(effective_run_options(vec![], None, true));
+    assert!(msg.contains("no run inputs supplied"));
+  }
+
+
+
+
+
+  #[test]
+  fn serve_project_directory_uses_config_paths_not_selector_path() {
+    let root = temp_root("serve-project-uses-config-paths");
+    let project = create_serve_project(&root);
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      let matches = matches(&["mech", "serve", "project"]);
+      let serve_matches = matches.subcommand_matches("serve").unwrap();
+      let loaded = load_cli_config(serve_matches).unwrap().unwrap();
+      let options = effective_serve_options(serve_matches, Some(&loaded)).unwrap();
+      assert_eq!(
+        options.paths,
+        vec![project.join("demo.mec").to_string_lossy().to_string()]
+      );
+      assert_eq!(
+        options.shim_path,
+        project.join("index.html").to_string_lossy().to_string()
+      );
+      assert!(!options.paths.iter().any(|path| path == "project"));
     }
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    fn error_text(result: MResult<EffectiveServeOptions>) -> String {
-        format!("{:?}", result.unwrap_err())
-    }
 
-    fn run_error_text(result: MResult<Option<EffectiveRunOptions>>) -> String {
-        format!("{:?}", result.unwrap_err())
-    }
 
-    #[test]
-    fn config_run_paths_used_when_cli_paths_absent() {
-        let config = loaded_config(r#"config := {run: {paths: ["foo.mec", "bar.mec"]}}"#);
-        let effective = effective_run_options(vec![], Some(&config), true)
-            .unwrap()
-            .unwrap();
-        assert_eq!(effective.paths, vec!["foo.mec", "bar.mec"]);
-    }
 
-    #[test]
-    fn cli_run_paths_override_config_paths() {
-        let config = loaded_config(r#"config := {run: {paths: ["foo.mec"]}}"#);
-        let effective = effective_run_options(vec!["cli.mec".to_string()], Some(&config), true)
-            .unwrap()
-            .unwrap();
-        assert_eq!(effective.paths, vec!["cli.mec"]);
-    }
-
-    #[test]
-    fn run_project_directory_uses_config_paths_not_selector_path() {
-        let root = temp_root("run-project-uses-config-paths");
-        let project = root.join("project");
-        std::fs::create_dir_all(&project).unwrap();
-        let config = loaded_run_project_config_at(
-            project.clone(),
-            r#"config := {run: {paths: ["demo.mec"]}}"#,
-            project.canonicalize().unwrap(),
-        );
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            let effective =
-                effective_run_options(vec!["project".to_string()], Some(&config), false)
-                    .unwrap()
-                    .unwrap();
-            assert_eq!(
-                effective.paths,
-                vec![project.join("demo.mec").to_string_lossy().to_string()]
-            );
-        }
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn implicit_run_without_inputs_returns_none() {
-        let options = effective_run_options(vec![], None, false).unwrap();
-        assert_eq!(options, None);
-    }
-
-    #[test]
-    fn explicit_run_without_inputs_and_without_config_paths_errors() {
-        let msg = run_error_text(effective_run_options(vec![], None, true));
-        assert!(msg.contains("no run inputs supplied"));
-    }
-
-    #[test]
-    fn serve_project_directory_uses_config_paths_not_selector_path() {
-        let root = temp_root("serve-project-uses-config-paths");
-        let project = create_serve_project(&root);
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            let matches = matches(&["mech", "serve", "project"]);
-            let serve_matches = matches.subcommand_matches("serve").unwrap();
-            let loaded = load_cli_config(serve_matches).unwrap().unwrap();
-            let options = effective_serve_options(serve_matches, Some(&loaded)).unwrap();
-            assert_eq!(
-                options.paths,
-                vec![project.join("demo.mec").to_string_lossy().to_string()]
-            );
-            assert_eq!(
-                options.shim_path,
-                project.join("index.html").to_string_lossy().to_string()
-            );
-            assert!(!options.paths.iter().any(|path| path == "project"));
-        }
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn project_directory_without_mech_config_falls_back_to_current_dir_config() {
-        let root = temp_root("project-without-config-falls-back");
-        let project = root.join("project");
-        std::fs::create_dir_all(&project).unwrap();
-        std::fs::write(
-            root.join(DEFAULT_CONFIG_FILENAME),
-            "config := {serve: {port: 9090}}\n",
-        )
+  #[test]
+  fn project_directory_without_mech_config_falls_back_to_current_dir_config() {
+    let root = temp_root("project-without-config-falls-back");
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(
+      root.join(DEFAULT_CONFIG_FILENAME),
+      "config := {serve: {port: 9090}}\n",
+    )
+    .unwrap();
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      let matches = matches(&["mech", "serve", "project"]);
+      let loaded = load_cli_config(matches.subcommand_matches("serve").unwrap())
+        .unwrap()
         .unwrap();
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            let matches = matches(&["mech", "serve", "project"]);
-            let loaded = load_cli_config(matches.subcommand_matches("serve").unwrap())
-                .unwrap()
-                .unwrap();
-            assert_eq!(loaded.path, root.join(DEFAULT_CONFIG_FILENAME));
-            assert_eq!(loaded.discovered_project_dir, None);
-        }
-        std::fs::remove_dir_all(root).unwrap();
+      assert_eq!(loaded.path, root.join(DEFAULT_CONFIG_FILENAME));
+      assert_eq!(loaded.discovered_project_dir, None);
     }
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    #[test]
-    fn explicit_config_loads() {
-        let root = temp_root("explicit");
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
-            let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
-            let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
-                .unwrap()
-                .unwrap();
-            assert_eq!(config.document.serve.unwrap().port, Some(9090));
-            assert_eq!(config.path, root.join("custom.mcfg"));
-            assert_eq!(config.base_dir, root);
-        }
-        std::fs::remove_dir_all(root).unwrap();
+  #[test]
+  fn explicit_config_loads() {
+    let root = temp_root("explicit");
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      std::fs::write("custom.mcfg", "config := {serve: {port: 9090}}\n").unwrap();
+      let matches = matches(&["mech", "--config", "custom.mcfg", "serve"]);
+      let config = load_cli_config(matches.subcommand_matches("serve").unwrap())
+        .unwrap()
+        .unwrap();
+      assert_eq!(config.document.serve.unwrap().port, Some(9090));
+      assert_eq!(config.path, root.join("custom.mcfg"));
+      assert_eq!(config.base_dir, root);
     }
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    #[test]
-    fn default_config_auto_loads() {
-        let root = temp_root("auto");
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
-            let matches = matches(&["mech", "serve"]);
-            assert!(
-                load_cli_config(matches.subcommand_matches("serve").unwrap())
-                    .unwrap()
-                    .is_some()
-            );
-        }
-        std::fs::remove_dir_all(root).unwrap();
+  #[test]
+  fn default_config_auto_loads() {
+    let root = temp_root("auto");
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      std::fs::write(DEFAULT_CONFIG_FILENAME, "config := {serve: {port: 9090}}\n").unwrap();
+      let matches = matches(&["mech", "serve"]);
+      assert!(
+        load_cli_config(matches.subcommand_matches("serve").unwrap())
+          .unwrap()
+          .is_some()
+      );
     }
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    #[test]
-    fn cli_scalar_options_override_config() {
-        let config = loaded_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
-        let matches = matches(&["mech", "serve", "--address", "0.0.0.0", "--port", "9090"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(effective.address, "0.0.0.0");
-        assert_eq!(effective.port, "9090");
-    }
 
-    #[test]
-    fn config_serve_paths_used_when_cli_paths_absent() {
-        let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
-        let matches = matches(&["mech", "serve"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(effective.paths, vec!["docs/reference"]);
-    }
+  #[test]
+  fn cli_scalar_options_override_config() {
+    let config = loaded_config(r#"config := {serve: {address: "127.0.0.1", port: 8081}}"#);
+    let matches = matches(&["mech", "serve", "--address", "0.0.0.0", "--port", "9090"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+        .unwrap();
+    assert_eq!(effective.address, "0.0.0.0");
+    assert_eq!(effective.port, "9090");
+  }
 
-    #[test]
-    fn cli_serve_paths_override_config_paths() {
-        let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
-        let matches = matches(&["mech", "serve", "examples/working"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(effective.paths, vec!["examples/working"]);
-    }
+  #[test]
+  fn config_serve_paths_used_when_cli_paths_absent() {
+    let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+    let matches = matches(&["mech", "serve"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+        .unwrap();
+    assert_eq!(effective.paths, vec!["docs/reference"]);
+  }
 
-    #[test]
-    fn stylesheets_combine() {
-        let root = temp_root("stylesheets-combine");
-        std::fs::write(root.join("a.css"), "body {}").unwrap();
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := {serve: {stylesheets: ["a.css"]}}"#,
-        );
-        let matches = matches(&["mech", "serve", "--stylesheet", "b.css"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(
-            effective.stylesheet_paths,
-            vec![
-                root.join("a.css").to_string_lossy().to_string(),
-                "b.css".to_string()
-            ]
-        );
-        std::fs::remove_dir_all(root).unwrap();
-    }
+  #[test]
+  fn cli_serve_paths_override_config_paths() {
+    let config = loaded_config(r#"config := {serve: {paths: ["docs/reference"]}}"#);
+    let matches = matches(&["mech", "serve", "examples/working"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+        .unwrap();
+    assert_eq!(effective.paths, vec!["examples/working"]);
+  }
 
-    #[test]
-    fn config_relative_serve_paths_resolve_from_config_file_directory() {
-        let root = temp_root("relative-serve-paths");
-        let subdir = root.join("subdir");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::write(subdir.join("style.css"), "body {}").unwrap();
-        std::fs::write(subdir.join("shim.html"), "<html></html>").unwrap();
-        create_wasm_pkg(&subdir.join("pkg"));
-        std::fs::write(
-            subdir.join(DEFAULT_CONFIG_FILENAME),
-            r#"config := {
+  #[test]
+  fn stylesheets_combine() {
+    let root = temp_root("stylesheets-combine");
+    std::fs::write(root.join("a.css"), "body {}").unwrap();
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := {serve: {stylesheets: ["a.css"]}}"#,
+    );
+    let matches = matches(&["mech", "serve", "--stylesheet", "b.css"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
+        .unwrap();
+    assert_eq!(
+      effective.stylesheet_paths,
+      vec![
+        root.join("a.css").to_string_lossy().to_string(),
+        "b.css".to_string()
+      ]
+    );
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_relative_serve_paths_resolve_from_config_file_directory() {
+    let root = temp_root("relative-serve-paths");
+    let subdir = root.join("subdir");
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(subdir.join("style.css"), "body {}").unwrap();
+    std::fs::write(subdir.join("shim.html"), "<html></html>").unwrap();
+    create_wasm_pkg(&subdir.join("pkg"));
+    std::fs::write(
+      subdir.join(DEFAULT_CONFIG_FILENAME),
+      r#"config := {
   serve: {
   paths: ["app.mec"]
   stylesheets: ["style.css"]
@@ -702,316 +705,308 @@ mod config_tests {
   }
 }
 "#,
-        )
+    )
+    .unwrap();
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve"]);
+      let serve_matches = matches.subcommand_matches("serve").unwrap();
+      let config = load_cli_config(serve_matches).unwrap().unwrap();
+      let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
+      assert_eq!(
+        effective.paths,
+        vec![subdir.join("app.mec").to_string_lossy().to_string()]
+      );
+      assert_eq!(
+        effective.stylesheet_paths,
+        vec![subdir.join("style.css").to_string_lossy().to_string()]
+      );
+      assert_eq!(
+        effective.shim_path,
+        subdir.join("shim.html").to_string_lossy().to_string()
+      );
+      assert_eq!(
+        effective.wasm_pkg,
+        subdir.join("pkg").to_string_lossy().to_string()
+      );
+    }
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn cli_paths_override_config_paths_and_remain_cwd_relative() {
+    let root = temp_root("cli-paths-cwd-relative");
+    let subdir = root.join("subdir");
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(
+      subdir.join(DEFAULT_CONFIG_FILENAME),
+      r#"config := {serve: {paths: ["app.mec"]}}"#,
+    )
+    .unwrap();
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve", "other.mec"]);
+      let serve_matches = matches.subcommand_matches("serve").unwrap();
+      let config = load_cli_config(serve_matches).unwrap().unwrap();
+      let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
+      assert_eq!(effective.paths, vec!["other.mec"]);
+    }
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn cli_shim_and_wasm_override_config_and_remain_cwd_relative() {
+    let root = temp_root("cli-shim-wasm-cwd-relative");
+    let subdir = root.join("subdir");
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(
+      subdir.join(DEFAULT_CONFIG_FILENAME),
+      r#"config := {serve: {shim: "shim.html", wasm: "pkg"}}"#,
+    )
+    .unwrap();
+    {
+      let _guard = CurrentDirGuard::enter(&root);
+      let matches = matches(&[
+        "mech",
+        "--config",
+        "subdir/mech.mcfg",
+        "serve",
+        "--shim",
+        "cli-shim.html",
+        "--wasm",
+        "cli-pkg",
+      ]);
+      let serve_matches = matches.subcommand_matches("serve").unwrap();
+      let config = load_cli_config(serve_matches).unwrap().unwrap();
+      let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
+      assert_eq!(effective.shim_path, "cli-shim.html");
+      assert_eq!(effective.wasm_pkg, "cli-pkg");
+    }
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn missing_config_shim_is_ignored_when_cli_shim_overrides() {
+    let config = loaded_config(r#"config := {serve: {shim: "missing-shim.html"}}"#);
+    let matches = matches(&["mech", "serve", "--shim", "local.html"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
         .unwrap();
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve"]);
-            let serve_matches = matches.subcommand_matches("serve").unwrap();
-            let config = load_cli_config(serve_matches).unwrap().unwrap();
-            let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
-            assert_eq!(
-                effective.paths,
-                vec![subdir.join("app.mec").to_string_lossy().to_string()]
-            );
-            assert_eq!(
-                effective.stylesheet_paths,
-                vec![subdir.join("style.css").to_string_lossy().to_string()]
-            );
-            assert_eq!(
-                effective.shim_path,
-                subdir.join("shim.html").to_string_lossy().to_string()
-            );
-            assert_eq!(
-                effective.wasm_pkg,
-                subdir.join("pkg").to_string_lossy().to_string()
-            );
-        }
-        std::fs::remove_dir_all(root).unwrap();
-    }
+    assert_eq!(effective.shim_path, "local.html");
+  }
 
-    #[test]
-    fn cli_paths_override_config_paths_and_remain_cwd_relative() {
-        let root = temp_root("cli-paths-cwd-relative");
-        let subdir = root.join("subdir");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::write(
-            subdir.join(DEFAULT_CONFIG_FILENAME),
-            r#"config := {serve: {paths: ["app.mec"]}}"#,
-        )
+  #[test]
+  fn missing_config_wasm_is_ignored_when_cli_wasm_overrides() {
+    let config = loaded_config(r#"config := {serve: {wasm: "missing-pkg"}}"#);
+    let matches = matches(&["mech", "serve", "--wasm", "local-pkg"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
         .unwrap();
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            let matches = matches(&["mech", "--config", "subdir/mech.mcfg", "serve", "other.mec"]);
-            let serve_matches = matches.subcommand_matches("serve").unwrap();
-            let config = load_cli_config(serve_matches).unwrap().unwrap();
-            let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
-            assert_eq!(effective.paths, vec!["other.mec"]);
-        }
-        std::fs::remove_dir_all(root).unwrap();
-    }
+    assert_eq!(effective.wasm_pkg, "local-pkg");
+  }
 
-    #[test]
-    fn cli_shim_and_wasm_override_config_and_remain_cwd_relative() {
-        let root = temp_root("cli-shim-wasm-cwd-relative");
-        let subdir = root.join("subdir");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::write(
-            subdir.join(DEFAULT_CONFIG_FILENAME),
-            r#"config := {serve: {shim: "shim.html", wasm: "pkg"}}"#,
-        )
+  #[test]
+  fn missing_config_stylesheet_fails_even_with_cli_stylesheet() {
+    let config = loaded_config(r#"config := {serve: {stylesheets: ["missing.css"]}}"#);
+    let matches = matches(&["mech", "serve", "--stylesheet", "local.css"]);
+    let error = error_text(effective_serve_options(
+      matches.subcommand_matches("serve").unwrap(),
+      Some(&config),
+    ));
+    assert!(error.contains("configuration error: serve.stylesheets must be an existing file"));
+  }
+
+  #[test]
+  fn config_stylesheet_directory_is_rejected() {
+    let root = temp_root("stylesheet-dir");
+    std::fs::create_dir_all(root.join("style.css")).unwrap();
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := {serve: {stylesheets: ["style.css"]}}"#,
+    );
+    let matches = matches(&["mech", "serve"]);
+    let error = error_text(effective_serve_options(
+      matches.subcommand_matches("serve").unwrap(),
+      Some(&config),
+    ));
+    assert!(error.contains("serve.stylesheets must be an existing file"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_shim_directory_is_rejected() {
+    let root = temp_root("shim-dir");
+    std::fs::create_dir_all(root.join("shim.html")).unwrap();
+    let config = loaded_config_at(root.clone(), r#"config := {serve: {shim: "shim.html"}}"#);
+    let matches = matches(&["mech", "serve"]);
+    let error = error_text(effective_serve_options(
+      matches.subcommand_matches("serve").unwrap(),
+      Some(&config),
+    ));
+    assert!(error.contains("serve.shim must be an existing file"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_wasm_file_is_rejected() {
+    let root = temp_root("wasm-file");
+    std::fs::write(root.join("pkg"), b"not a dir").unwrap();
+    let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
+    let matches = matches(&["mech", "serve"]);
+    let error = error_text(effective_serve_options(
+      matches.subcommand_matches("serve").unwrap(),
+      Some(&config),
+    ));
+    assert!(error.contains("serve.wasm must be an existing directory"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_wasm_directory_missing_required_files_is_rejected() {
+    let root = temp_root("wasm-missing-files");
+    std::fs::create_dir_all(root.join("pkg")).unwrap();
+    let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
+    let matches = matches(&["mech", "serve"]);
+    let error = error_text(effective_serve_options(
+      matches.subcommand_matches("serve").unwrap(),
+      Some(&config),
+    ));
+    assert!(error.contains("serve.wasm is missing required file"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_wasm_directory_with_required_files_is_accepted() {
+    let root = temp_root("wasm-complete");
+    create_wasm_pkg(&root.join("pkg"));
+    let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
+    let matches = matches(&["mech", "serve"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
         .unwrap();
-        {
-            let _guard = CurrentDirGuard::enter(&root);
-            let matches = matches(&[
-                "mech",
-                "--config",
-                "subdir/mech.mcfg",
-                "serve",
-                "--shim",
-                "cli-shim.html",
-                "--wasm",
-                "cli-pkg",
-            ]);
-            let serve_matches = matches.subcommand_matches("serve").unwrap();
-            let config = load_cli_config(serve_matches).unwrap().unwrap();
-            let effective = effective_serve_options(serve_matches, Some(&config)).unwrap();
-            assert_eq!(effective.shim_path, "cli-shim.html");
-            assert_eq!(effective.wasm_pkg, "cli-pkg");
-        }
-        std::fs::remove_dir_all(root).unwrap();
-    }
+    assert_eq!(
+      effective.wasm_pkg,
+      root.join("pkg").to_string_lossy().to_string()
+    );
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    #[test]
-    fn missing_config_shim_is_ignored_when_cli_shim_overrides() {
-        let config = loaded_config(r#"config := {serve: {shim: "missing-shim.html"}}"#);
-        let matches = matches(&["mech", "serve", "--shim", "local.html"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(effective.shim_path, "local.html");
-    }
-
-    #[test]
-    fn missing_config_wasm_is_ignored_when_cli_wasm_overrides() {
-        let config = loaded_config(r#"config := {serve: {wasm: "missing-pkg"}}"#);
-        let matches = matches(&["mech", "serve", "--wasm", "local-pkg"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(effective.wasm_pkg, "local-pkg");
-    }
-
-    #[test]
-    fn missing_config_stylesheet_fails_even_with_cli_stylesheet() {
-        let config = loaded_config(r#"config := {serve: {stylesheets: ["missing.css"]}}"#);
-        let matches = matches(&["mech", "serve", "--stylesheet", "local.css"]);
-        let error = error_text(effective_serve_options(
-            matches.subcommand_matches("serve").unwrap(),
-            Some(&config),
-        ));
-        assert!(error.contains("configuration error: serve.stylesheets must be an existing file"));
-    }
-
-    #[test]
-    fn config_stylesheet_directory_is_rejected() {
-        let root = temp_root("stylesheet-dir");
-        std::fs::create_dir_all(root.join("style.css")).unwrap();
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := {serve: {stylesheets: ["style.css"]}}"#,
-        );
-        let matches = matches(&["mech", "serve"]);
-        let error = error_text(effective_serve_options(
-            matches.subcommand_matches("serve").unwrap(),
-            Some(&config),
-        ));
-        assert!(error.contains("serve.stylesheets must be an existing file"));
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_shim_directory_is_rejected() {
-        let root = temp_root("shim-dir");
-        std::fs::create_dir_all(root.join("shim.html")).unwrap();
-        let config = loaded_config_at(root.clone(), r#"config := {serve: {shim: "shim.html"}}"#);
-        let matches = matches(&["mech", "serve"]);
-        let error = error_text(effective_serve_options(
-            matches.subcommand_matches("serve").unwrap(),
-            Some(&config),
-        ));
-        assert!(error.contains("serve.shim must be an existing file"));
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_wasm_file_is_rejected() {
-        let root = temp_root("wasm-file");
-        std::fs::write(root.join("pkg"), b"not a dir").unwrap();
-        let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
-        let matches = matches(&["mech", "serve"]);
-        let error = error_text(effective_serve_options(
-            matches.subcommand_matches("serve").unwrap(),
-            Some(&config),
-        ));
-        assert!(error.contains("serve.wasm must be an existing directory"));
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_wasm_directory_missing_required_files_is_rejected() {
-        let root = temp_root("wasm-missing-files");
-        std::fs::create_dir_all(root.join("pkg")).unwrap();
-        let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
-        let matches = matches(&["mech", "serve"]);
-        let error = error_text(effective_serve_options(
-            matches.subcommand_matches("serve").unwrap(),
-            Some(&config),
-        ));
-        assert!(error.contains("serve.wasm is missing required file"));
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_wasm_directory_with_required_files_is_accepted() {
-        let root = temp_root("wasm-complete");
-        create_wasm_pkg(&root.join("pkg"));
-        let config = loaded_config_at(root.clone(), r#"config := {serve: {wasm: "pkg"}}"#);
-        let matches = matches(&["mech", "serve"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(
-            effective.wasm_pkg,
-            root.join("pkg").to_string_lossy().to_string()
-        );
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_relative_paths_normalize_backslashes_with_validation() {
-        let root = temp_root("normalize-backslashes");
-        std::fs::create_dir_all(root.join("include")).unwrap();
-        std::fs::write(root.join("include/style.css"), "body {}").unwrap();
-        std::fs::write(root.join("include/shim.html"), "<html></html>").unwrap();
-        create_wasm_pkg(&root.join("web/pkg"));
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := {serve: {paths: ["docs\\reference"], stylesheets: ["include\\style.css"], shim: "include\\shim.html", wasm: "web\\pkg"}}"#,
-        );
-        let matches = matches(&["mech", "serve"]);
-        let effective =
-            effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
-                .unwrap();
-        assert_eq!(
-            effective.paths,
-            vec![root.join("docs/reference").to_string_lossy().to_string()]
-        );
-        assert_eq!(
-            effective.stylesheet_paths,
-            vec![root.join("include/style.css").to_string_lossy().to_string()]
-        );
-        assert_eq!(
-            effective.shim_path,
-            root.join("include/shim.html").to_string_lossy().to_string()
-        );
-        assert_eq!(
-            effective.wasm_pkg,
-            root.join("web/pkg").to_string_lossy().to_string()
-        );
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn default_cli_host_grants_include_default_envelope() {
-        let grants = effective_cli_host_grants(None, CliHostGrantAttenuation::default()).unwrap();
-        assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
-        assert_eq!(
-            grants.stdout_write_paths,
-            vec!["text".to_string(), "line".to_string()]
-        );
-        assert_eq!(
-            grants.stderr_write_paths,
-            vec!["text".to_string(), "line".to_string()]
-        );
-    }
-
-    #[test]
-    fn config_can_narrow_stdout_to_line() {
-        let root = temp_root("cli-stdout-line");
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
-        );
-        let grants =
-            effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
-        assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_can_deny_stdout_with_empty_list() {
-        let root = temp_root("cli-stdout-empty");
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
-        );
-        let grants =
-            effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
-        assert!(grants.stdout_write_paths.is_empty());
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn config_can_narrow_env_to_path() {
-        let root = temp_root("cli-env-path");
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
-        );
-        let grants =
-            effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
-        assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn command_line_attenuation_clears_stdout_even_if_config_allows() {
-        let root = temp_root("cli-deny-stdout");
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
-        );
-        let grants = effective_cli_host_grants(
-            Some(&config),
-            CliHostGrantAttenuation {
-                deny_stdout: true,
-                ..Default::default()
-            },
-        )
+  #[test]
+  fn config_relative_paths_normalize_backslashes_with_validation() {
+    let root = temp_root("normalize-backslashes");
+    std::fs::create_dir_all(root.join("include")).unwrap();
+    std::fs::write(root.join("include/style.css"), "body {}").unwrap();
+    std::fs::write(root.join("include/shim.html"), "<html></html>").unwrap();
+    create_wasm_pkg(&root.join("web/pkg"));
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := {serve: {paths: ["docs\\reference"], stylesheets: ["include\\style.css"], shim: "include\\shim.html", wasm: "web\\pkg"}}"#,
+    );
+    let matches = matches(&["mech", "serve"]);
+    let effective =
+      effective_serve_options(matches.subcommand_matches("serve").unwrap(), Some(&config))
         .unwrap();
-        assert!(grants.stdout_write_paths.is_empty());
-        std::fs::remove_dir_all(root).unwrap();
-    }
+    assert_eq!(
+      effective.paths,
+      vec![root.join("docs/reference").to_string_lossy().to_string()]
+    );
+    assert_eq!(
+      effective.stylesheet_paths,
+      vec![root.join("include/style.css").to_string_lossy().to_string()]
+    );
+    assert_eq!(
+      effective.shim_path,
+      root.join("include/shim.html").to_string_lossy().to_string()
+    );
+    assert_eq!(
+      effective.wasm_pkg,
+      root.join("web/pkg").to_string_lossy().to_string()
+    );
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
-    #[test]
-    fn attenuation_never_adds_back_capability() {
-        let root = temp_root("cli-never-adds");
-        let config = loaded_config_at(
-            root.clone(),
-            r#"config := { run: { cli: { stdout: { write: [] }, env: { read: [] } } } }"#,
-        );
-        let grants = effective_cli_host_grants(
-            Some(&config),
-            CliHostGrantAttenuation {
-                deny_stderr: true,
-                ..Default::default()
-            },
-        )
-        .unwrap();
-        assert!(grants.stdout_write_paths.is_empty());
-        assert!(grants.env_read_paths.is_empty());
-        assert!(grants.stderr_write_paths.is_empty());
-        std::fs::remove_dir_all(root).unwrap();
-    }
+  #[test]
+  fn default_cli_host_grants_include_default_envelope() {
+    let grants = effective_cli_host_grants(None, CliHostGrantAttenuation::default()).unwrap();
+    assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert_eq!(grants.stderr_write_paths, vec!["text".to_string(), "line".to_string()]);
+  }
+
+  #[test]
+  fn config_can_narrow_stdout_to_line() {
+    let root = temp_root("cli-stdout-line");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_can_deny_stdout_with_empty_list() {
+    let root = temp_root("cli-stdout-empty");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    assert!(grants.stdout_write_paths.is_empty());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn config_can_narrow_env_to_path() {
+    let root = temp_root("cli-env-path");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn command_line_attenuation_clears_stdout_even_if_config_allows() {
+    let root = temp_root("cli-deny-stdout");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(
+      Some(&config),
+      CliHostGrantAttenuation {
+        deny_stdout: true,
+        ..Default::default()
+      },
+    )
+    .unwrap();
+    assert!(grants.stdout_write_paths.is_empty());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn attenuation_never_adds_back_capability() {
+    let root = temp_root("cli-never-adds");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { cli: { stdout: { write: [] }, env: { read: [] } } } }"#,
+    );
+    let grants = effective_cli_host_grants(
+      Some(&config),
+      CliHostGrantAttenuation {
+        deny_stderr: true,
+        ..Default::default()
+      },
+    )
+    .unwrap();
+    assert!(grants.stdout_write_paths.is_empty());
+    assert!(grants.env_read_paths.is_empty());
+    assert!(grants.stderr_write_paths.is_empty());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -153,9 +153,6 @@ pub fn cli_host_capability_selection(
     if let Some(values) = run_matches.get_many::<String>("capabilities") {
       profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
     }
-    if let Some(values) = run_matches.get_many::<String>("mech_run_paths") {
-      profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
-    }
   }
 
   config::CliHostCapabilitySelection {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,0 +1,180 @@
+use clap::{Arg, ArgAction};
+use mech_core::*;
+use mech_host_cli::{CliResourceProvider, StdCliBackend};
+use mech_runtime::{
+  MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
+  RuntimeEvent, RuntimeEventKind,
+};
+
+use crate::cli::config;
+
+pub fn new_cli_runtime(
+  config: RuntimeConfig,
+  cli_grants: &config::EffectiveCliHostGrants,
+) -> MResult<MechRuntime> {
+  let mut runtime = RuntimeBuilder::new()
+    .config(config)
+    .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
+    .build()?;
+
+  grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
+
+  Ok(runtime)
+}
+
+pub fn effective_run_runtime_config(
+  loaded_config: Option<&crate::LoadedMechConfig>,
+  name: String,
+  debug_enabled: bool,
+  trace_enabled: bool,
+  profile_enabled: bool,
+  rounds_per_step: Option<usize>,
+) -> MResult<RuntimeConfig> {
+  let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+
+  let mut config = crate::apply_runtime_config_patch(
+    RuntimeConfig::default(),
+    loaded_config
+      .as_ref()
+      .map(|loaded| &loaded.document.runtime)
+      .unwrap_or(&default_runtime_patch),
+  )?;
+
+  config.name = name;
+
+  if debug_enabled {
+    config.diagnostics.debug_enabled = true;
+  }
+
+  if trace_enabled {
+    config.diagnostics.trace_enabled = true;
+  }
+
+  if profile_enabled {
+    config.diagnostics.profile_enabled = true;
+  }
+
+  if let Some(rounds_per_step) = rounds_per_step {
+    config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
+  }
+
+  config.validate()?;
+  Ok(config)
+}
+
+fn print_run_runtime_events(events: &[RuntimeEvent]) {
+  for event in events {
+    match &event.kind {
+      RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
+        println!("Cycle Time: {} ns", duration_ns);
+      }
+      _ => {}
+    }
+  }
+}
+
+pub fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
+  let mut context = runtime.runtime_context()?;
+  let result = runtime.run_string_with_context(&mut context, source);
+  print_run_runtime_events(&context.events);
+  result
+}
+
+fn grant_cli_runner_capabilities(
+  runtime: &mut MechRuntime,
+  grants: &config::EffectiveCliHostGrants,
+) -> MResult<()> {
+  let subject = runtime.runtime_context()?.subject;
+
+  if !grants.env_read_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://env".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: grants.env_read_paths.clone(),
+    })?;
+  }
+
+  if !grants.stdout_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://stdout".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stdout_write_paths.clone(),
+    })?;
+  }
+
+  if !grants.stderr_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://stderr".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stderr_write_paths.clone(),
+    })?;
+  }
+
+  Ok(())
+}
+
+pub fn cli_host_capability_args() -> Vec<Arg> {
+  vec![
+    Arg::new("deny_default_capabilities")
+      .long("deny-default-capabilities")
+      .help("Disable default CLI host capability profiles for this run")
+      .action(ArgAction::SetTrue),
+    Arg::new("capabilities")
+      .long("capabilities")
+      .value_name("CAPABILITY")
+      .help("Enable named CLI host capability profiles for this run, e.g. :cli/stdout")
+      .num_args(1..)
+      .action(ArgAction::Append),
+  ]
+}
+
+pub fn cli_host_capability_selection(
+  cli_matches: &clap::ArgMatches,
+  run_matches: Option<&clap::ArgMatches>,
+) -> config::CliHostCapabilitySelection {
+  let deny_defaults =
+    cli_matches.get_flag("deny_default_capabilities")
+      || run_matches
+        .map(|matches| matches.get_flag("deny_default_capabilities"))
+        .unwrap_or(false);
+
+  let mut profiles = Vec::new();
+
+  if let Some(values) = cli_matches.get_many::<String>("capabilities") {
+    profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
+  }
+
+  if let Some(run_matches) = run_matches {
+    if let Some(values) = run_matches.get_many::<String>("capabilities") {
+      profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
+    }
+  }
+
+  config::CliHostCapabilitySelection {
+    include_defaults: !deny_defaults,
+    profiles,
+  }
+}
+
+
+pub fn cli_host_capability_path_values(
+  cli_matches: &clap::ArgMatches,
+  run_matches: Option<&clap::ArgMatches>,
+) -> Vec<String> {
+  let mut paths = Vec::new();
+
+  if let Some(values) = cli_matches.get_many::<String>("capabilities") {
+    paths.extend(values.filter(|value| !value.starts_with(':')).cloned());
+  }
+
+  if let Some(run_matches) = run_matches {
+    if let Some(values) = run_matches.get_many::<String>("capabilities") {
+      paths.extend(values.filter(|value| !value.starts_with(':')).cloned());
+    }
+  }
+
+  paths
+}

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -133,36 +133,22 @@ pub fn cli_host_capability_args() -> Vec<Arg> {
   ]
 }
 
-fn cli_host_capability_values(
-  cli_matches: &clap::ArgMatches,
-  run_matches: Option<&clap::ArgMatches>,
-) -> Vec<String> {
-  let mut values = Vec::new();
-
-  if let Some(raw) = cli_matches.get_many::<String>("capabilities") {
-    values.extend(raw.cloned());
-  }
-
-  if let Some(run_matches) = run_matches {
-    if let Some(raw) = run_matches.get_many::<String>("capabilities") {
-      values.extend(raw.cloned());
-    }
-  }
-
-  values
+fn cli_host_capability_values(cli_matches: &clap::ArgMatches) -> Vec<String> {
+  cli_matches
+    .get_many::<String>("capabilities")
+    .into_iter()
+    .flatten()
+    .cloned()
+    .collect()
 }
 
 pub fn cli_host_capability_selection(
   cli_matches: &clap::ArgMatches,
-  run_matches: Option<&clap::ArgMatches>,
+  _run_matches: Option<&clap::ArgMatches>,
 ) -> config::CliHostCapabilitySelection {
-  let deny_defaults =
-    cli_matches.get_flag("deny_default_capabilities")
-      || run_matches
-        .map(|matches| matches.get_flag("deny_default_capabilities"))
-        .unwrap_or(false);
+  let deny_defaults = cli_matches.get_flag("deny_default_capabilities");
 
-  let profiles = cli_host_capability_values(cli_matches, run_matches)
+  let profiles = cli_host_capability_values(cli_matches)
     .into_iter()
     .filter(|value| value.starts_with(':'))
     .collect();
@@ -175,9 +161,9 @@ pub fn cli_host_capability_selection(
 
 pub fn cli_host_capability_passthrough_values(
   cli_matches: &clap::ArgMatches,
-  run_matches: Option<&clap::ArgMatches>,
+  _run_matches: Option<&clap::ArgMatches>,
 ) -> Vec<String> {
-  cli_host_capability_values(cli_matches, run_matches)
+  cli_host_capability_values(cli_matches)
     .into_iter()
     .filter(|value| !value.starts_with(':'))
     .collect()

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -121,12 +121,14 @@ pub fn cli_host_capability_args() -> Vec<Arg> {
     Arg::new("deny_default_capabilities")
       .long("deny-default-capabilities")
       .help("Disable default CLI host capability profiles for this run")
+      .global(true)
       .action(ArgAction::SetTrue),
     Arg::new("capabilities")
       .long("capabilities")
       .value_name("CAPABILITY")
       .help("Enable named CLI host capability profiles for this run, e.g. :cli/stdout")
-      .num_args(1..)
+      .global(true)
+      .num_args(1)
       .action(ArgAction::Append),
   ]
 }
@@ -149,6 +151,9 @@ pub fn cli_host_capability_selection(
 
   if let Some(run_matches) = run_matches {
     if let Some(values) = run_matches.get_many::<String>("capabilities") {
+      profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
+    }
+    if let Some(values) = run_matches.get_many::<String>("mech_run_paths") {
       profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
     }
   }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -126,9 +126,10 @@ pub fn cli_host_capability_args() -> Vec<Arg> {
     Arg::new("capabilities")
       .long("capabilities")
       .value_name("CAPABILITY")
-      .help("Enable named CLI host capability profiles for this run, e.g. :cli/stdout")
+      .help("Enable one named CLI host capability profile for this run, e.g. :cli/stdout")
       .global(true)
-      .num_args(1..)
+      .num_args(1)
+      .value_parser([":cli/env", ":cli/stdout", ":cli/stderr"])
       .action(ArgAction::Append),
   ]
 }
@@ -148,10 +149,7 @@ pub fn cli_host_capability_selection(
 ) -> config::CliHostCapabilitySelection {
   let deny_defaults = cli_matches.get_flag("deny_default_capabilities");
 
-  let profiles = cli_host_capability_values(cli_matches)
-    .into_iter()
-    .filter(|value| value.starts_with(':'))
-    .collect();
+  let profiles = cli_host_capability_values(cli_matches);
 
   config::CliHostCapabilitySelection {
     include_defaults: !deny_defaults,
@@ -163,8 +161,5 @@ pub fn cli_host_capability_passthrough_values(
   cli_matches: &clap::ArgMatches,
   _run_matches: Option<&clap::ArgMatches>,
 ) -> Vec<String> {
-  cli_host_capability_values(cli_matches)
-    .into_iter()
-    .filter(|value| !value.starts_with(':'))
-    .collect()
+  Vec::new()
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -128,9 +128,28 @@ pub fn cli_host_capability_args() -> Vec<Arg> {
       .value_name("CAPABILITY")
       .help("Enable named CLI host capability profiles for this run, e.g. :cli/stdout")
       .global(true)
-      .num_args(1)
+      .num_args(1..)
       .action(ArgAction::Append),
   ]
+}
+
+fn cli_host_capability_values(
+  cli_matches: &clap::ArgMatches,
+  run_matches: Option<&clap::ArgMatches>,
+) -> Vec<String> {
+  let mut values = Vec::new();
+
+  if let Some(raw) = cli_matches.get_many::<String>("capabilities") {
+    values.extend(raw.cloned());
+  }
+
+  if let Some(run_matches) = run_matches {
+    if let Some(raw) = run_matches.get_many::<String>("capabilities") {
+      values.extend(raw.cloned());
+    }
+  }
+
+  values
 }
 
 pub fn cli_host_capability_selection(
@@ -143,17 +162,10 @@ pub fn cli_host_capability_selection(
         .map(|matches| matches.get_flag("deny_default_capabilities"))
         .unwrap_or(false);
 
-  let mut profiles = Vec::new();
-
-  if let Some(values) = cli_matches.get_many::<String>("capabilities") {
-    profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
-  }
-
-  if let Some(run_matches) = run_matches {
-    if let Some(values) = run_matches.get_many::<String>("capabilities") {
-      profiles.extend(values.filter(|value| value.starts_with(':')).cloned());
-    }
-  }
+  let profiles = cli_host_capability_values(cli_matches, run_matches)
+    .into_iter()
+    .filter(|value| value.starts_with(':'))
+    .collect();
 
   config::CliHostCapabilitySelection {
     include_defaults: !deny_defaults,
@@ -161,22 +173,12 @@ pub fn cli_host_capability_selection(
   }
 }
 
-
-pub fn cli_host_capability_path_values(
+pub fn cli_host_capability_passthrough_values(
   cli_matches: &clap::ArgMatches,
   run_matches: Option<&clap::ArgMatches>,
 ) -> Vec<String> {
-  let mut paths = Vec::new();
-
-  if let Some(values) = cli_matches.get_many::<String>("capabilities") {
-    paths.extend(values.filter(|value| !value.starts_with(':')).cloned());
-  }
-
-  if let Some(run_matches) = run_matches {
-    if let Some(values) = run_matches.get_many::<String>("capabilities") {
-      paths.extend(values.filter(|value| !value.starts_with(':')).cloned());
-    }
-  }
-
-  paths
+  cli_host_capability_values(cli_matches, run_matches)
+    .into_iter()
+    .filter(|value| !value.starts_with(':'))
+    .collect()
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -118,17 +118,43 @@ fn grant_cli_runner_capabilities(
 
 pub fn cli_host_capability_args() -> Vec<Arg> {
   vec![
-    Arg::new("deny_cli_env")
-      .long("deny-cli-env")
-      .help("Deny cli://env read grants for this run")
+    Arg::new("deny_default_capabilities")
+      .long("deny-default-capabilities")
+      .help("Disable default CLI host capability profiles for this run")
       .action(ArgAction::SetTrue),
-    Arg::new("deny_cli_stdout")
-      .long("deny-cli-stdout")
-      .help("Deny cli://stdout write grants for this run")
-      .action(ArgAction::SetTrue),
-    Arg::new("deny_cli_stderr")
-      .long("deny-cli-stderr")
-      .help("Deny cli://stderr write grants for this run")
-      .action(ArgAction::SetTrue),
+    Arg::new("capabilities")
+      .long("capabilities")
+      .value_name("CAPABILITY")
+      .help("Enable named CLI host capability profiles for this run, e.g. :cli/stdout")
+      .num_args(1)
+      .action(ArgAction::Append),
   ]
+}
+
+pub fn cli_host_capability_selection(
+  cli_matches: &clap::ArgMatches,
+  run_matches: Option<&clap::ArgMatches>,
+) -> config::CliHostCapabilitySelection {
+  let deny_defaults =
+    cli_matches.get_flag("deny_default_capabilities")
+      || run_matches
+        .map(|matches| matches.get_flag("deny_default_capabilities"))
+        .unwrap_or(false);
+
+  let mut profiles = Vec::new();
+
+  if let Some(values) = cli_matches.get_many::<String>("capabilities") {
+    profiles.extend(values.cloned());
+  }
+
+  if let Some(run_matches) = run_matches {
+    if let Some(values) = run_matches.get_many::<String>("capabilities") {
+      profiles.extend(values.cloned());
+    }
+  }
+
+  config::CliHostCapabilitySelection {
+    include_defaults: !deny_defaults,
+    profiles,
+  }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,0 +1,134 @@
+use clap::{Arg, ArgAction};
+use mech_core::*;
+use mech_host_cli::{CliResourceProvider, StdCliBackend};
+use mech_runtime::{
+  MechRuntime, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfig,
+  RuntimeEvent, RuntimeEventKind,
+};
+
+use crate::cli::config;
+
+pub fn new_cli_runtime(
+  config: RuntimeConfig,
+  cli_grants: &config::EffectiveCliHostGrants,
+) -> MResult<MechRuntime> {
+  let mut runtime = RuntimeBuilder::new()
+    .config(config)
+    .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
+    .build()?;
+
+  grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
+
+  Ok(runtime)
+}
+
+pub fn effective_run_runtime_config(
+  loaded_config: Option<&crate::LoadedMechConfig>,
+  name: String,
+  debug_enabled: bool,
+  trace_enabled: bool,
+  profile_enabled: bool,
+  rounds_per_step: Option<usize>,
+) -> MResult<RuntimeConfig> {
+  let default_runtime_patch = mech_runtime::RuntimeConfigPatch::default();
+
+  let mut config = crate::apply_runtime_config_patch(
+    RuntimeConfig::default(),
+    loaded_config
+      .as_ref()
+      .map(|loaded| &loaded.document.runtime)
+      .unwrap_or(&default_runtime_patch),
+  )?;
+
+  config.name = name;
+
+  if debug_enabled {
+    config.diagnostics.debug_enabled = true;
+  }
+
+  if trace_enabled {
+    config.diagnostics.trace_enabled = true;
+  }
+
+  if profile_enabled {
+    config.diagnostics.profile_enabled = true;
+  }
+
+  if let Some(rounds_per_step) = rounds_per_step {
+    config.limits.max_steps_per_turn = Some(rounds_per_step as u64);
+  }
+
+  config.validate()?;
+  Ok(config)
+}
+
+fn print_run_runtime_events(events: &[RuntimeEvent]) {
+  for event in events {
+    match &event.kind {
+      RuntimeEventKind::ProgramProfiled { duration_ns, .. } => {
+        println!("Cycle Time: {} ns", duration_ns);
+      }
+      _ => {}
+    }
+  }
+}
+
+pub fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
+  let mut context = runtime.runtime_context()?;
+  let result = runtime.run_string_with_context(&mut context, source);
+  print_run_runtime_events(&context.events);
+  result
+}
+
+fn grant_cli_runner_capabilities(
+  runtime: &mut MechRuntime,
+  grants: &config::EffectiveCliHostGrants,
+) -> MResult<()> {
+  let subject = runtime.runtime_context()?.subject;
+
+  if !grants.env_read_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://env".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: grants.env_read_paths.clone(),
+    })?;
+  }
+
+  if !grants.stdout_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://stdout".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stdout_write_paths.clone(),
+    })?;
+  }
+
+  if !grants.stderr_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://stderr".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stderr_write_paths.clone(),
+    })?;
+  }
+
+  Ok(())
+}
+
+pub fn cli_host_capability_args() -> Vec<Arg> {
+  vec![
+    Arg::new("deny_cli_env")
+      .long("deny-cli-env")
+      .help("Deny cli://env read grants for this run")
+      .action(ArgAction::SetTrue),
+    Arg::new("deny_cli_stdout")
+      .long("deny-cli-stdout")
+      .help("Deny cli://stdout write grants for this run")
+      .action(ArgAction::SetTrue),
+    Arg::new("deny_cli_stderr")
+      .long("deny-cli-stderr")
+      .help("Deny cli://stderr write grants for this run")
+      .action(ArgAction::SetTrue),
+  ]
+}

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -61,6 +61,26 @@ pub struct ServeHostConfig {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RunHostConfig {
     pub paths: Vec<PathBuf>,
+    pub cli: RunCliHostConfig,
+}
+
+// Native CLI runner attenuation policy; resource providers are not required to
+// use this shape for host-specific configuration.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliHostConfig {
+    pub env: RunCliEnvConfig,
+    pub stdout: RunCliStreamConfig,
+    pub stderr: RunCliStreamConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliEnvConfig {
+    pub read: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliStreamConfig {
+    pub write: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -286,10 +306,69 @@ impl ConfigLowerer {
         for (key, value) in map {
             match key.as_str() {
                 "paths" => out.paths = expect_path_list("run.paths", value)?,
+                "cli" => out.cli = self.lower_run_cli(value)?,
                 other => return invalid(format!("unknown run field `{other}`")),
             }
         }
 
+        Ok(out)
+    }
+
+    fn lower_run_cli(&self, value: &ConfigValue) -> MResult<RunCliHostConfig> {
+        let map = expect_map("run.cli", value)?;
+        let mut out = RunCliHostConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "env" => out.env = self.lower_run_cli_env(value)?,
+                "stdout" => out.stdout = self.lower_run_cli_stream("run.cli.stdout", value)?,
+                "stderr" => out.stderr = self.lower_run_cli_stream("run.cli.stderr", value)?,
+                other => return invalid(format!("unknown run.cli field `{other}`")),
+            }
+        }
+        Ok(out)
+    }
+
+    fn lower_run_cli_env(&self, value: &ConfigValue) -> MResult<RunCliEnvConfig> {
+        let map = expect_map("run.cli.env", value)?;
+        let mut out = RunCliEnvConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "read" => {
+                    let paths = expect_string_list("run.cli.env.read", value)?;
+                    for path in &paths {
+                        if path != "*" && !is_cli_env_key(path) {
+                            return invalid(format!("run.cli.env.read contains invalid env key `{path}`"));
+                        }
+                    }
+                    out.read = Some(paths);
+                }
+                other => return invalid(format!("unknown run.cli.env field `{other}`")),
+            }
+        }
+        Ok(out)
+    }
+
+    fn lower_run_cli_stream(
+        &self,
+        where_: &str,
+        value: &ConfigValue,
+    ) -> MResult<RunCliStreamConfig> {
+        let map = expect_map(where_, value)?;
+        let mut out = RunCliStreamConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "write" => {
+                    let paths = expect_string_list(&format!("{where_}.write"), value)?;
+                    for path in &paths {
+                        if path != "text" && path != "line" {
+                            return invalid(format!("{where_}.write contains invalid path `{path}`"));
+                        }
+                    }
+                    out.write = Some(paths);
+                }
+                other => return invalid(format!("unknown {where_} field `{other}`")),
+            }
+        }
         Ok(out)
     }
 
@@ -689,6 +768,15 @@ fn browser_resource_allows_operation(
     }
 }
 
+fn is_cli_env_key(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
 fn invalid_error(reason: impl Into<String>) -> MechError {
     MechError::new(InvalidConfigField::new(reason), None).with_compiler_loc()
 }
@@ -750,5 +838,49 @@ mod tests {
         .expect_err("unknown run fields must fail");
         let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
         assert!(msg.contains("unknown run field `bad`"));
+    }
+
+    #[test]
+    fn run_cli_stdout_empty_write_parses() {
+        let doc = parse(r#"config := { run: { cli: { stdout: { write: [] } } } }"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.stdout.write, Some(vec![]));
+    }
+
+    #[test]
+    fn run_cli_stdout_line_write_parses() {
+        let doc = parse(r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.stdout.write, Some(vec!["line".to_string()]));
+    }
+
+    #[test]
+    fn run_cli_env_path_read_parses() {
+        let doc = parse(r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.env.read, Some(vec!["PATH".to_string()]));
+    }
+
+    #[test]
+    fn invalid_run_cli_stdout_path_fails() {
+        let err = parse(r#"config := { run: { cli: { stdout: { write: ["html"] } } } }"#)
+            .expect_err("invalid stdout path should fail");
+        let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
+        assert!(msg.contains("run.cli.stdout.write contains invalid path `html`"));
+    }
+
+    #[test]
+    fn invalid_run_cli_env_key_fails() {
+        for key in ["HOME/PATH", "1HOME", "HOME-PATH"] {
+            let source = format!(r#"config := {{ run: {{ cli: {{ env: {{ read: ["{key}"] }} }} }} }}"#);
+            let err = parse(&source).expect_err("invalid env key should fail");
+            let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
+            assert!(msg.contains("run.cli.env.read contains invalid env key"));
+        }
+    }
+
+    #[test]
+    fn unknown_run_cli_field_fails() {
+        let err = parse(r#"config := { run: { cli: { prompt: true } } }"#)
+            .expect_err("unknown run.cli field should fail");
+        let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
+        assert!(msg.contains("unknown run.cli field `prompt`"));
     }
 }

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -61,6 +61,24 @@ pub struct ServeHostConfig {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RunHostConfig {
     pub paths: Vec<PathBuf>,
+    pub cli: RunCliHostConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliHostConfig {
+    pub env: RunCliEnvConfig,
+    pub stdout: RunCliStreamConfig,
+    pub stderr: RunCliStreamConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliEnvConfig {
+    pub read: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliStreamConfig {
+    pub write: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -110,7 +128,6 @@ impl ConfigLowerer {
         Ok(doc)
     }
 
-
     fn lower_module(&self, value: &ConfigValue) -> MResult<ModuleManifestConfig> {
         let map = expect_map("module", value)?;
         let mut name = None;
@@ -120,18 +137,29 @@ impl ConfigLowerer {
                 "name" => name = Some(expect_string("module.name", value)?),
                 "exports" => {
                     let list = expect_list("module.exports", value)?;
-                    exports = Some(list.iter().enumerate().map(|(idx, v)| self.lower_module_export(idx, v)).collect::<MResult<Vec<_>>>()?);
+                    exports = Some(
+                        list.iter()
+                            .enumerate()
+                            .map(|(idx, v)| self.lower_module_export(idx, v))
+                            .collect::<MResult<Vec<_>>>()?,
+                    );
                 }
                 other => return invalid(format!("unknown module field `{other}`")),
             }
         }
         let name = name.ok_or_else(|| invalid_error("module.name is required"))?;
-        if name.trim().is_empty() { return invalid("module.name must be non-empty"); }
+        if name.trim().is_empty() {
+            return invalid("module.name must be non-empty");
+        }
         let exports = exports.ok_or_else(|| invalid_error("module.exports is required"))?;
         Ok(ModuleManifestConfig { name, exports })
     }
 
-    fn lower_module_export(&self, idx: usize, value: &ConfigValue) -> MResult<ModuleManifestExportConfig> {
+    fn lower_module_export(
+        &self,
+        idx: usize,
+        value: &ConfigValue,
+    ) -> MResult<ModuleManifestExportConfig> {
         let where_ = format!("module.exports[{idx}]");
         let map = expect_map(&where_, value)?;
         let mut name = None;
@@ -145,27 +173,48 @@ impl ConfigLowerer {
                     let raw = expect_string(&format!("{where_}.kind"), value)?;
                     kind = Some(match raw.as_str() {
                         "context" => ModuleManifestExportKind::Context,
-                        _ => return invalid(format!("{where_}.kind must be `context`; got `{raw}`")),
+                        _ => {
+                            return invalid(format!("{where_}.kind must be `context`; got `{raw}`"));
+                        }
                     });
                 }
                 "base-uri" => base_uri = Some(expect_string(&format!("{where_}.base-uri"), value)?),
-                "operations" => operations = Some(expect_string_list(&format!("{where_}.operations"), value)?),
+                "operations" => {
+                    operations = Some(expect_string_list(&format!("{where_}.operations"), value)?)
+                }
                 other => return invalid(format!("unknown {where_} field `{other}`")),
             }
         }
         let name = name.ok_or_else(|| invalid_error(format!("{where_}.name is required")))?;
-        if name.trim().is_empty() { return invalid(format!("{where_}.name must be non-empty")); }
+        if name.trim().is_empty() {
+            return invalid(format!("{where_}.name must be non-empty"));
+        }
         let kind = kind.ok_or_else(|| invalid_error(format!("{where_}.kind is required")))?;
-        let base_uri = base_uri.ok_or_else(|| invalid_error(format!("{where_}.base-uri is required")))?;
-        if !base_uri.contains("://") { return invalid(format!("{where_}.base-uri must contain `://`")); }
-        let operations = operations.ok_or_else(|| invalid_error(format!("{where_}.operations is required")))?;
-        if operations.is_empty() { return invalid(format!("{where_}.operations must contain at least one operation")); }
+        let base_uri =
+            base_uri.ok_or_else(|| invalid_error(format!("{where_}.base-uri is required")))?;
+        if !base_uri.contains("://") {
+            return invalid(format!("{where_}.base-uri must contain `://`"));
+        }
+        let operations =
+            operations.ok_or_else(|| invalid_error(format!("{where_}.operations is required")))?;
+        if operations.is_empty() {
+            return invalid(format!(
+                "{where_}.operations must contain at least one operation"
+            ));
+        }
         for op in &operations {
             if op != "read" && op != "write" {
-                return invalid(format!("module context exports only support operations `read` and `write`; got `{op}`"));
+                return invalid(format!(
+                    "module context exports only support operations `read` and `write`; got `{op}`"
+                ));
             }
         }
-        Ok(ModuleManifestExportConfig { name, kind, base_uri, operations })
+        Ok(ModuleManifestExportConfig {
+            name,
+            kind,
+            base_uri,
+            operations,
+        })
     }
 
     fn lower_runtime(&self, value: &ConfigValue) -> MResult<RuntimeConfigPatch> {
@@ -286,10 +335,73 @@ impl ConfigLowerer {
         for (key, value) in map {
             match key.as_str() {
                 "paths" => out.paths = expect_path_list("run.paths", value)?,
+                "cli" => out.cli = self.lower_run_cli(value)?,
                 other => return invalid(format!("unknown run field `{other}`")),
             }
         }
 
+        Ok(out)
+    }
+
+    fn lower_run_cli(&self, value: &ConfigValue) -> MResult<RunCliHostConfig> {
+        let map = expect_map("run.cli", value)?;
+        let mut out = RunCliHostConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "env" => out.env = self.lower_run_cli_env(value)?,
+                "stdout" => out.stdout = self.lower_run_cli_stream("run.cli.stdout", value)?,
+                "stderr" => out.stderr = self.lower_run_cli_stream("run.cli.stderr", value)?,
+                other => return invalid(format!("unknown run.cli field `{other}`")),
+            }
+        }
+        Ok(out)
+    }
+
+    fn lower_run_cli_env(&self, value: &ConfigValue) -> MResult<RunCliEnvConfig> {
+        let map = expect_map("run.cli.env", value)?;
+        let mut out = RunCliEnvConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "read" => {
+                    let paths = expect_string_list("run.cli.env.read", value)?;
+                    for path in &paths {
+                        if path != "*" && !is_cli_env_key(path) {
+                            return invalid(format!(
+                                "run.cli.env.read contains invalid env key `{path}`"
+                            ));
+                        }
+                    }
+                    out.read = Some(paths);
+                }
+                other => return invalid(format!("unknown run.cli.env field `{other}`")),
+            }
+        }
+        Ok(out)
+    }
+
+    fn lower_run_cli_stream(
+        &self,
+        where_: &str,
+        value: &ConfigValue,
+    ) -> MResult<RunCliStreamConfig> {
+        let map = expect_map(where_, value)?;
+        let mut out = RunCliStreamConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "write" => {
+                    let paths = expect_string_list(&format!("{where_}.write"), value)?;
+                    for path in &paths {
+                        if path != "text" && path != "line" {
+                            return invalid(format!(
+                                "{where_}.write contains invalid path `{path}`"
+                            ));
+                        }
+                    }
+                    out.write = Some(paths);
+                }
+                other => return invalid(format!("unknown {where_} field `{other}`")),
+            }
+        }
         Ok(out)
     }
 
@@ -368,7 +480,7 @@ impl ConfigLowerer {
                 Some(other) => {
                     return invalid(format!(
                         "{where_}.mode must be `node` or `subtree`; got `{other}`"
-                    ))
+                    ));
                 }
             };
             if path.is_wildcard() && !matches!(mode.as_deref(), None | Some("subtree")) {
@@ -383,19 +495,19 @@ impl ConfigLowerer {
             }
             let property = if matches!(mode.as_deref(), Some("subtree")) {
                 if property.is_some() {
-                    return invalid(format!("{where_}.property is not allowed when mode is `subtree`"));
+                    return invalid(format!(
+                        "{where_}.property is not allowed when mode is `subtree`"
+                    ));
                 }
                 if attribute.is_some() {
-                    return invalid(format!("{where_}.attribute is not allowed when mode is `subtree`"));
+                    return invalid(format!(
+                        "{where_}.attribute is not allowed when mode is `subtree`"
+                    ));
                 }
                 BrowserDomProperty::Text
             } else {
-                BrowserDomProperty::parse_manifest(
-                    property.as_deref(),
-                    attribute.as_deref(),
-                    &path,
-                )
-                .map_err(|error| invalid_error(format!("{where_}: {error}")))?
+                BrowserDomProperty::parse_manifest(property.as_deref(), attribute.as_deref(), &path)
+                    .map_err(|error| invalid_error(format!("{where_}: {error}")))?
             };
             authority.bind_dom_path(BrowserDomManifestEntry::new(path, scope, property));
         }
@@ -689,6 +801,15 @@ fn browser_resource_allows_operation(
     }
 }
 
+fn is_cli_env_key(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
 fn invalid_error(reason: impl Into<String>) -> MechError {
     MechError::new(InvalidConfigField::new(reason), None).with_compiler_loc()
 }
@@ -750,5 +871,56 @@ mod tests {
         .expect_err("unknown run fields must fail");
         let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
         assert!(msg.contains("unknown run field `bad`"));
+    }
+
+    #[test]
+    fn run_cli_stdout_empty_write_parses() {
+        let doc = parse(r#"config := { run: { cli: { stdout: { write: [] } } } }"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.stdout.write, Some(vec![]));
+    }
+
+    #[test]
+    fn run_cli_stdout_line_write_parses() {
+        let doc = parse(r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#).unwrap();
+        assert_eq!(
+            doc.run.unwrap().cli.stdout.write,
+            Some(vec!["line".to_string()])
+        );
+    }
+
+    #[test]
+    fn run_cli_env_path_read_parses() {
+        let doc = parse(r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#).unwrap();
+        assert_eq!(
+            doc.run.unwrap().cli.env.read,
+            Some(vec!["PATH".to_string()])
+        );
+    }
+
+    #[test]
+    fn invalid_run_cli_stdout_write_path_errors() {
+        let err = parse(r#"config := { run: { cli: { stdout: { write: ["html"] } } } }"#)
+            .expect_err("invalid stdout path must fail");
+        let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
+        assert!(msg.contains("invalid path `html`"), "got {msg}");
+    }
+
+    #[test]
+    fn invalid_run_cli_env_key_errors() {
+        for key in ["HOME/PATH", "1HOME", "HOME-PATH"] {
+            let source =
+                format!(r#"config := {{ run: {{ cli: {{ env: {{ read: ["{key}"] }} }} }} }}"#);
+            let err = parse(&source).expect_err("invalid env key must fail");
+            let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
+            assert!(msg.contains("invalid env key"), "got {msg}");
+        }
+    }
+
+    #[test]
+    fn unknown_run_cli_field_errors() {
+        let err = parse(r#"config := { run: { cli: { bad: true } } }"#)
+            .expect_err("unknown run.cli field must fail");
+        let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
+        assert!(msg.contains("unknown run.cli field `bad`"), "got {msg}");
     }
 }

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -64,6 +64,8 @@ pub struct RunHostConfig {
     pub cli: RunCliHostConfig,
 }
 
+// Native CLI runner attenuation policy; resource providers are not required to
+// use this shape for host-specific configuration.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RunCliHostConfig {
     pub env: RunCliEnvConfig,

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -128,6 +128,7 @@ impl ConfigLowerer {
         Ok(doc)
     }
 
+
     fn lower_module(&self, value: &ConfigValue) -> MResult<ModuleManifestConfig> {
         let map = expect_map("module", value)?;
         let mut name = None;
@@ -137,29 +138,18 @@ impl ConfigLowerer {
                 "name" => name = Some(expect_string("module.name", value)?),
                 "exports" => {
                     let list = expect_list("module.exports", value)?;
-                    exports = Some(
-                        list.iter()
-                            .enumerate()
-                            .map(|(idx, v)| self.lower_module_export(idx, v))
-                            .collect::<MResult<Vec<_>>>()?,
-                    );
+                    exports = Some(list.iter().enumerate().map(|(idx, v)| self.lower_module_export(idx, v)).collect::<MResult<Vec<_>>>()?);
                 }
                 other => return invalid(format!("unknown module field `{other}`")),
             }
         }
         let name = name.ok_or_else(|| invalid_error("module.name is required"))?;
-        if name.trim().is_empty() {
-            return invalid("module.name must be non-empty");
-        }
+        if name.trim().is_empty() { return invalid("module.name must be non-empty"); }
         let exports = exports.ok_or_else(|| invalid_error("module.exports is required"))?;
         Ok(ModuleManifestConfig { name, exports })
     }
 
-    fn lower_module_export(
-        &self,
-        idx: usize,
-        value: &ConfigValue,
-    ) -> MResult<ModuleManifestExportConfig> {
+    fn lower_module_export(&self, idx: usize, value: &ConfigValue) -> MResult<ModuleManifestExportConfig> {
         let where_ = format!("module.exports[{idx}]");
         let map = expect_map(&where_, value)?;
         let mut name = None;
@@ -173,48 +163,27 @@ impl ConfigLowerer {
                     let raw = expect_string(&format!("{where_}.kind"), value)?;
                     kind = Some(match raw.as_str() {
                         "context" => ModuleManifestExportKind::Context,
-                        _ => {
-                            return invalid(format!("{where_}.kind must be `context`; got `{raw}`"));
-                        }
+                        _ => return invalid(format!("{where_}.kind must be `context`; got `{raw}`")),
                     });
                 }
                 "base-uri" => base_uri = Some(expect_string(&format!("{where_}.base-uri"), value)?),
-                "operations" => {
-                    operations = Some(expect_string_list(&format!("{where_}.operations"), value)?)
-                }
+                "operations" => operations = Some(expect_string_list(&format!("{where_}.operations"), value)?),
                 other => return invalid(format!("unknown {where_} field `{other}`")),
             }
         }
         let name = name.ok_or_else(|| invalid_error(format!("{where_}.name is required")))?;
-        if name.trim().is_empty() {
-            return invalid(format!("{where_}.name must be non-empty"));
-        }
+        if name.trim().is_empty() { return invalid(format!("{where_}.name must be non-empty")); }
         let kind = kind.ok_or_else(|| invalid_error(format!("{where_}.kind is required")))?;
-        let base_uri =
-            base_uri.ok_or_else(|| invalid_error(format!("{where_}.base-uri is required")))?;
-        if !base_uri.contains("://") {
-            return invalid(format!("{where_}.base-uri must contain `://`"));
-        }
-        let operations =
-            operations.ok_or_else(|| invalid_error(format!("{where_}.operations is required")))?;
-        if operations.is_empty() {
-            return invalid(format!(
-                "{where_}.operations must contain at least one operation"
-            ));
-        }
+        let base_uri = base_uri.ok_or_else(|| invalid_error(format!("{where_}.base-uri is required")))?;
+        if !base_uri.contains("://") { return invalid(format!("{where_}.base-uri must contain `://`")); }
+        let operations = operations.ok_or_else(|| invalid_error(format!("{where_}.operations is required")))?;
+        if operations.is_empty() { return invalid(format!("{where_}.operations must contain at least one operation")); }
         for op in &operations {
             if op != "read" && op != "write" {
-                return invalid(format!(
-                    "module context exports only support operations `read` and `write`; got `{op}`"
-                ));
+                return invalid(format!("module context exports only support operations `read` and `write`; got `{op}`"));
             }
         }
-        Ok(ModuleManifestExportConfig {
-            name,
-            kind,
-            base_uri,
-            operations,
-        })
+        Ok(ModuleManifestExportConfig { name, kind, base_uri, operations })
     }
 
     fn lower_runtime(&self, value: &ConfigValue) -> MResult<RuntimeConfigPatch> {
@@ -366,9 +335,7 @@ impl ConfigLowerer {
                     let paths = expect_string_list("run.cli.env.read", value)?;
                     for path in &paths {
                         if path != "*" && !is_cli_env_key(path) {
-                            return invalid(format!(
-                                "run.cli.env.read contains invalid env key `{path}`"
-                            ));
+                            return invalid(format!("run.cli.env.read contains invalid env key `{path}`"));
                         }
                     }
                     out.read = Some(paths);
@@ -392,9 +359,7 @@ impl ConfigLowerer {
                     let paths = expect_string_list(&format!("{where_}.write"), value)?;
                     for path in &paths {
                         if path != "text" && path != "line" {
-                            return invalid(format!(
-                                "{where_}.write contains invalid path `{path}`"
-                            ));
+                            return invalid(format!("{where_}.write contains invalid path `{path}`"));
                         }
                     }
                     out.write = Some(paths);
@@ -480,7 +445,7 @@ impl ConfigLowerer {
                 Some(other) => {
                     return invalid(format!(
                         "{where_}.mode must be `node` or `subtree`; got `{other}`"
-                    ));
+                    ))
                 }
             };
             if path.is_wildcard() && !matches!(mode.as_deref(), None | Some("subtree")) {
@@ -495,19 +460,19 @@ impl ConfigLowerer {
             }
             let property = if matches!(mode.as_deref(), Some("subtree")) {
                 if property.is_some() {
-                    return invalid(format!(
-                        "{where_}.property is not allowed when mode is `subtree`"
-                    ));
+                    return invalid(format!("{where_}.property is not allowed when mode is `subtree`"));
                 }
                 if attribute.is_some() {
-                    return invalid(format!(
-                        "{where_}.attribute is not allowed when mode is `subtree`"
-                    ));
+                    return invalid(format!("{where_}.attribute is not allowed when mode is `subtree`"));
                 }
                 BrowserDomProperty::Text
             } else {
-                BrowserDomProperty::parse_manifest(property.as_deref(), attribute.as_deref(), &path)
-                    .map_err(|error| invalid_error(format!("{where_}: {error}")))?
+                BrowserDomProperty::parse_manifest(
+                    property.as_deref(),
+                    attribute.as_deref(),
+                    &path,
+                )
+                .map_err(|error| invalid_error(format!("{where_}: {error}")))?
             };
             authority.bind_dom_path(BrowserDomManifestEntry::new(path, scope, property));
         }
@@ -882,45 +847,38 @@ mod tests {
     #[test]
     fn run_cli_stdout_line_write_parses() {
         let doc = parse(r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#).unwrap();
-        assert_eq!(
-            doc.run.unwrap().cli.stdout.write,
-            Some(vec!["line".to_string()])
-        );
+        assert_eq!(doc.run.unwrap().cli.stdout.write, Some(vec!["line".to_string()]));
     }
 
     #[test]
     fn run_cli_env_path_read_parses() {
         let doc = parse(r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#).unwrap();
-        assert_eq!(
-            doc.run.unwrap().cli.env.read,
-            Some(vec!["PATH".to_string()])
-        );
+        assert_eq!(doc.run.unwrap().cli.env.read, Some(vec!["PATH".to_string()]));
     }
 
     #[test]
-    fn invalid_run_cli_stdout_write_path_errors() {
+    fn invalid_run_cli_stdout_path_fails() {
         let err = parse(r#"config := { run: { cli: { stdout: { write: ["html"] } } } }"#)
-            .expect_err("invalid stdout path must fail");
+            .expect_err("invalid stdout path should fail");
         let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
-        assert!(msg.contains("invalid path `html`"), "got {msg}");
+        assert!(msg.contains("run.cli.stdout.write contains invalid path `html`"));
     }
 
     #[test]
-    fn invalid_run_cli_env_key_errors() {
+    fn invalid_run_cli_env_key_fails() {
         for key in ["HOME/PATH", "1HOME", "HOME-PATH"] {
-            let source =
-                format!(r#"config := {{ run: {{ cli: {{ env: {{ read: ["{key}"] }} }} }} }}"#);
-            let err = parse(&source).expect_err("invalid env key must fail");
+            let source = format!(r#"config := {{ run: {{ cli: {{ env: {{ read: ["{key}"] }} }} }} }}"#);
+            let err = parse(&source).expect_err("invalid env key should fail");
             let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
-            assert!(msg.contains("invalid env key"), "got {msg}");
+            assert!(msg.contains("run.cli.env.read contains invalid env key"));
         }
     }
 
     #[test]
-    fn unknown_run_cli_field_errors() {
-        let err = parse(r#"config := { run: { cli: { bad: true } } }"#)
-            .expect_err("unknown run.cli field must fail");
+    fn unknown_run_cli_field_fails() {
+        let err = parse(r#"config := { run: { cli: { prompt: true } } }"#)
+            .expect_err("unknown run.cli field should fail");
         let msg = format!("{} {} {:?}", err.kind_name(), err.kind_message(), err);
-        assert!(msg.contains("unknown run.cli field `bad`"), "got {msg}");
+        assert!(msg.contains("unknown run.cli field `prompt`"));
     }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1849,6 +1849,33 @@ impl MechRuntime {
       )?;
     }
 
+    let scoped_refs = record
+      .scopes
+      .iter()
+      .find(|metadata| &metadata.scope == scope)
+      .map(|metadata| metadata.address_references.as_slice())
+      .unwrap_or(&[]);
+
+    for reference in scoped_refs {
+      match resolve_runtime_address_target(&record, scope, &context_registry, &reference.target) {
+        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+          if !matches!(scope, SourceScope::Program) {
+            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+          }
+          self.preflight_module_graph_for_scope(
+            context,
+            version,
+            &interpreter_scope,
+            seen,
+          )?;
+        }
+        RuntimeAddressTarget::Context(_) => {}
+        RuntimeAddressTarget::Unknown => {
+          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+        }
+      }
+    }
+
     Ok(())
   }
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -16,2650 +16,2065 @@ use crate::SourceIndex;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
-    Interpreter(SourceScope),
-    Context(RuntimeContextBinding),
-    Unknown,
+  Interpreter(SourceScope),
+  Context(RuntimeContextBinding),
+  Unknown,
 }
 
 struct ActiveRuntimeProgramHostGuard {
-    previous: Option<RuntimeProgramHostTarget>,
+  previous: Option<RuntimeProgramHostTarget>,
 }
 
 impl ActiveRuntimeProgramHostGuard {
-    fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
-        let previous = ACTIVE_RUNTIME_PROGRAM_HOST
-            .with(|slot| slot.replace(Some(RuntimeProgramHostTarget { runtime, context })));
-        Self { previous }
-    }
+  fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
+    let previous = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(Some(RuntimeProgramHostTarget { runtime, context }))
+    });
+    Self { previous }
+  }
 }
 
 impl Drop for ActiveRuntimeProgramHostGuard {
-    fn drop(&mut self) {
-        ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-            slot.replace(self.previous.take());
-        });
-    }
+  fn drop(&mut self) {
+    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(self.previous.take());
+    });
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAddressedAssignmentUnsupported {
-    pub target: String,
+  pub target: String,
 }
 
 impl MechErrorKind for RuntimeAddressedAssignmentUnsupported {
-    fn name(&self) -> &str {
-        "RuntimeAddressedAssignmentUnsupported"
-    }
+  fn name(&self) -> &str { "RuntimeAddressedAssignmentUnsupported" }
 
-    fn message(&self) -> String {
-        format!(
-            "addressed assignment is not supported for `{}`",
-            self.target
-        )
-    }
+  fn message(&self) -> String {
+    format!("addressed assignment is not supported for `{}`", self.target)
+  }
 }
+
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedContextResourceRequest {
-    provider_base_uri: String,
-    provider_path: String,
-    context_path: String,
+  provider_base_uri: String,
+  provider_path: String,
+  context_path: String,
 }
 
 fn join_resource_paths(prefix: &str, child: &str) -> String {
-    let prefix = prefix.trim_matches('/');
-    let child = child.trim_matches('/');
-    match (prefix.is_empty(), child.is_empty()) {
-        (true, true) => String::new(),
-        (true, false) => child.to_string(),
-        (false, true) => prefix.to_string(),
-        (false, false) => format!("{}/{}", prefix, child),
-    }
+  let prefix = prefix.trim_matches('/');
+  let child = child.trim_matches('/');
+  match (prefix.is_empty(), child.is_empty()) {
+    (true, true) => String::new(),
+    (true, false) => child.to_string(),
+    (false, true) => prefix.to_string(),
+    (false, false) => format!("{}/{}", prefix, child),
+  }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
-    mech_core::Identifier {
-        name: mech_core::Token::new(
-            mech_core::TokenKind::Identifier,
-            mech_core::SourceRange::default(),
-            name.chars().collect(),
-        ),
-    }
+  mech_core::Identifier {
+    name: mech_core::Token::new(
+      mech_core::TokenKind::Identifier,
+      mech_core::SourceRange::default(),
+      name.chars().collect(),
+    ),
+  }
 }
 
+
 fn execution_scope_for_extracted_module_source(scope: &SourceScope) -> SourceScope {
-    match scope {
-        SourceScope::Program => SourceScope::Program,
-        SourceScope::Interpreter(_) => SourceScope::Program,
-    }
+  match scope {
+    SourceScope::Program => SourceScope::Program,
+    SourceScope::Interpreter(_) => SourceScope::Program,
+  }
 }
 
 fn resolve_runtime_address_target(
-    record: &ModuleVersionRecord,
-    scope: &SourceScope,
-    context_registry: &RuntimeContextRegistry,
-    target: &str,
+  record: &ModuleVersionRecord,
+  scope: &SourceScope,
+  context_registry: &RuntimeContextRegistry,
+  target: &str,
 ) -> RuntimeAddressTarget {
-    if !matches!(scope, SourceScope::Program) {
-        if let Some(binding) = context_registry.get(target) {
-            return RuntimeAddressTarget::Context(binding.clone());
-        }
-    }
-
-    for metadata in &record.scopes {
-        if let SourceScope::Interpreter(interpreter) = &metadata.scope {
-            if interpreter.namespace_str == target {
-                return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
-            }
-        }
-    }
-
+  if !matches!(scope, SourceScope::Program) {
     if let Some(binding) = context_registry.get(target) {
-        return RuntimeAddressTarget::Context(binding.clone());
+      return RuntimeAddressTarget::Context(binding.clone());
     }
+  }
 
-    RuntimeAddressTarget::Unknown
+  for metadata in &record.scopes {
+    if let SourceScope::Interpreter(interpreter) = &metadata.scope {
+      if interpreter.namespace_str == target {
+        return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
+      }
+    }
+  }
+
+  if let Some(binding) = context_registry.get(target) {
+    return RuntimeAddressTarget::Context(binding.clone());
+  }
+
+  RuntimeAddressTarget::Unknown
 }
 
 fn context_registry_for_scope(
-    record: &ModuleVersionRecord,
-    scope: &SourceScope,
+  record: &ModuleVersionRecord,
+  scope: &SourceScope,
 ) -> MResult<RuntimeContextRegistry> {
-    let declarations = record
-        .scopes
-        .iter()
-        .find(|metadata| &metadata.scope == scope)
-        .map(|metadata| metadata.contexts.as_slice())
-        .unwrap_or(&[]);
-    RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
+  let declarations = record
+    .scopes
+    .iter()
+    .find(|metadata| &metadata.scope == scope)
+    .map(|metadata| metadata.contexts.as_slice())
+    .unwrap_or(&[]);
+  RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
 }
 
 fn runtime_context_base_uri(binding: &RuntimeContextBinding) -> String {
-    match &binding.base {
-        RuntimeContextBase::ResourceUri(uri) => uri.clone(),
-    }
+  match &binding.base {
+    RuntimeContextBase::ResourceUri(uri) => uri.clone(),
+  }
 }
 
-fn runtime_context_allows_read(binding: &RuntimeContextBinding, path: &str) -> bool {
-    binding.capabilities.iter().any(|capability| {
-        if capability.operation != "read" {
-            return false;
-        }
+fn runtime_context_allows_read(
+  binding: &RuntimeContextBinding,
+  path: &str,
+) -> bool {
+  binding.capabilities.iter().any(|capability| {
+    if capability.operation != "read" {
+      return false;
+    }
 
-        match &capability.scope {
-            RuntimeContextCapabilityScope::Wildcard => true,
-            RuntimeContextCapabilityScope::Path(exact) => {
-                if exact == path {
-                    return true;
-                }
-                if let Some(prefix) = exact.strip_suffix("/*") {
-                    let required_prefix = format!("{}/", prefix);
-                    return path.starts_with(&required_prefix);
-                }
-                false
-            }
+    match &capability.scope {
+      RuntimeContextCapabilityScope::Wildcard => true,
+      RuntimeContextCapabilityScope::Path(exact) => {
+        if exact == path {
+          return true;
         }
-    })
+        if let Some(prefix) = exact.strip_suffix("/*") {
+          let required_prefix = format!("{}/", prefix);
+          return path.starts_with(&required_prefix);
+        }
+        false
+      }
+    }
+  })
 }
 
 #[allow(dead_code)]
-fn runtime_context_allows_write(binding: &RuntimeContextBinding, path: &str) -> bool {
-    binding.capabilities.iter().any(|capability| {
-        if capability.operation != "write" {
-            return false;
-        }
+fn runtime_context_allows_write(
+  binding: &RuntimeContextBinding,
+  path: &str,
+) -> bool {
+  binding.capabilities.iter().any(|capability| {
+    if capability.operation != "write" {
+      return false;
+    }
 
-        match &capability.scope {
-            RuntimeContextCapabilityScope::Wildcard => true,
-            RuntimeContextCapabilityScope::Path(exact) => {
-                if exact == path {
-                    return true;
-                }
-                if let Some(prefix) = exact.strip_suffix("/*") {
-                    let required_prefix = format!("{}/", prefix);
-                    return path.starts_with(&required_prefix);
-                }
-                false
-            }
+    match &capability.scope {
+      RuntimeContextCapabilityScope::Wildcard => true,
+      RuntimeContextCapabilityScope::Path(exact) => {
+        if exact == path {
+          return true;
         }
-    })
+        if let Some(prefix) = exact.strip_suffix("/*") {
+          let required_prefix = format!("{}/", prefix);
+          return path.starts_with(&required_prefix);
+        }
+        false
+      }
+    }
+  })
 }
 
+
+
 fn single_code_program(
-    code: mech_core::MechCode,
-    comment: Option<mech_core::Comment>,
+  code: mech_core::MechCode,
+  comment: Option<mech_core::Comment>,
 ) -> mech_core::Program {
-    mech_core::Program {
-        title: None,
-        body: mech_core::Body {
-            sections: vec![mech_core::Section {
-                subtitle: None,
-                elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
-            }],
-        },
-    }
+  mech_core::Program {
+    title: None,
+    body: mech_core::Body {
+      sections: vec![mech_core::Section {
+        subtitle: None,
+        elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
+      }],
+    },
+  }
 }
 
 fn bind_runtime_value_on_program(
-    program: &mut MechProgram,
-    var: &mech_core::Var,
-    value: Value,
-    mutable: bool,
+  program: &mut MechProgram,
+  var: &mech_core::Var,
+  value: Value,
+  mutable: bool,
 ) -> MResult<()> {
-    if var.context.is_some() {
-        return Err(MechError::new(
-            RuntimeAddressedAssignmentUnsupported {
-                target: var.name.to_string(),
-            },
-            None,
-        )
-        .with_compiler_loc()
-        .with_tokens(var.tokens()));
-    }
-    let (id, name) = (var.name.hash(), var.name.to_string());
-    let symbols = program.interpreter_mut().symbols();
-    let mut symbols = symbols.borrow_mut();
-    symbols.insert(id, value, mutable);
-    symbols.dictionary.borrow_mut().insert(id, name);
-    Ok(())
+  if var.context.is_some() {
+    return Err(MechError::new(
+      RuntimeAddressedAssignmentUnsupported { target: var.name.to_string() },
+      None,
+    ).with_compiler_loc().with_tokens(var.tokens()));
+  }
+  let (id, name) = (var.name.hash(), var.name.to_string());
+  let symbols = program.interpreter_mut().symbols();
+  let mut symbols = symbols.borrow_mut();
+  symbols.insert(id, value, mutable);
+  symbols.dictionary.borrow_mut().insert(id, name);
+  Ok(())
 }
 
 fn resolve_runtime_value(value: Value) -> Value {
-    match value {
-        Value::MutableReference(value) => value.borrow().clone(),
-        other => other,
-    }
+  match value {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  }
 }
+
+
 
 impl MechRuntime {
-    fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
-        matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
+  fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
+    matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
+  }
+
+
+  fn context_declarations_from_index_scope(
+    &self,
+    index: &SourceIndex,
+    scope: &SourceScope,
+  ) -> MResult<Vec<crate::SourceContextDeclaration>> {
+    let mut declarations = index
+      .contexts
+      .iter()
+      .filter(|ctx| &ctx.occurrence.scope == scope)
+      .map(|ctx| ctx.declaration.clone())
+      .collect::<Vec<_>>();
+
+    for import in index.imports.iter().filter(|import| &import.occurrence.scope == scope) {
+      let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
+        continue;
+      };
+      let module = import.declaration.module.as_deref().ok_or_else(|| {
+        MechError::new(RuntimeInvalidOperationError {
+          operation: "materialize_direct_manifest_context_imports",
+          reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
+        }, None)
+      })?;
+      let item = import.declaration.item.as_deref().ok_or_else(|| {
+        MechError::new(RuntimeInvalidOperationError {
+          operation: "materialize_direct_manifest_context_imports",
+          reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
+        }, None)
+      })?;
+      let export = self.module_manifests.context_export(module, item)?;
+      declarations.push(crate::SourceContextDeclaration {
+        name: alias.clone(),
+        base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
+        capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
+          operation: operation.clone(),
+          scope: crate::SourceContextCapabilityScope::Wildcard,
+        }).collect(),
+      });
     }
 
-    fn context_declarations_from_index_scope(
-        &self,
-        index: &SourceIndex,
-        scope: &SourceScope,
-    ) -> MResult<Vec<crate::SourceContextDeclaration>> {
-        let mut declarations = index
-            .contexts
-            .iter()
-            .filter(|ctx| &ctx.occurrence.scope == scope)
-            .map(|ctx| ctx.declaration.clone())
-            .collect::<Vec<_>>();
+    Ok(declarations)
+  }
 
-        for import in index
-            .imports
-            .iter()
-            .filter(|import| &import.occurrence.scope == scope)
+  fn direct_context_registry_for_scope(
+    &self,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<RuntimeContextRegistry> {
+    let index = SourceIndex::from_program(tree);
+    let declarations = self.context_declarations_from_index_scope(&index, scope)?;
+    RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
+  }
+
+  fn resolve_context_resource_request(
+    &self,
+    binding: &RuntimeContextBinding,
+    requested_path: &str,
+  ) -> MResult<ResolvedContextResourceRequest> {
+    let context_base_uri = runtime_context_base_uri(binding).trim_end_matches('/').to_string();
+    let provider_base_uri = self
+      .resources
+      .provider_base_uri_for(&context_base_uri)?
+      .unwrap_or_else(|| context_base_uri.clone());
+    let context_root = context_base_uri
+      .strip_prefix(&provider_base_uri)
+      .unwrap_or_default()
+      .trim_matches('/');
+    Ok(ResolvedContextResourceRequest {
+      provider_base_uri,
+      provider_path: join_resource_paths(context_root, requested_path),
+      context_path: requested_path.trim_matches('/').to_string(),
+    })
+  }
+
+  fn read_context_resource(
+    &self,
+    context: &RuntimeContext,
+    binding: &RuntimeContextBinding,
+    path: &str,
+  ) -> MResult<Value> {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    if !runtime_context_allows_read(binding, &resolved.context_path) {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: "read".to_string(),
+        path: resolved.context_path,
+      }, None));
+    }
+    if !self.grants.allows(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &RuntimeCapabilityOperation::Read,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: context.subject.clone(),
+        resource: resolved.provider_base_uri,
+        operation: RuntimeCapabilityOperation::Read,
+        path: resolved.provider_path,
+      }, None));
+    }
+    self.resources.read(RuntimeResourceReadRequest {
+      base_uri: resolved.provider_base_uri,
+      path: resolved.provider_path,
+      context_name: binding.name.clone(),
+    })
+  }
+
+  fn write_context_resource(
+    &mut self,
+    context: &RuntimeContext,
+    binding: &RuntimeContextBinding,
+    path: &str,
+    value: Value,
+    intent: RuntimeResourceWriteIntent,
+  ) -> MResult<()> {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    if !runtime_context_allows_write(binding, &resolved.context_path) {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: "write".to_string(),
+        path: resolved.context_path,
+      }, None));
+    }
+    if !self.grants.allows(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &RuntimeCapabilityOperation::Write,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: context.subject.clone(),
+        resource: resolved.provider_base_uri,
+        operation: RuntimeCapabilityOperation::Write,
+        path: resolved.provider_path,
+      }, None));
+    }
+    self.resources.write(RuntimeResourceWriteRequest {
+      base_uri: resolved.provider_base_uri,
+      path: resolved.provider_path,
+      context_name: binding.name.clone(),
+      value,
+      intent,
+    })
+  }
+
+  fn bind_context_read_temp(
+    &self,
+    program: &mut MechProgram,
+    target: &str,
+    path: &str,
+    value: Value,
+  ) -> MResult<mech_core::Expression> {
+    let name = format!("mech-internal-context-{}-{}", hash_str(target), hash_str(path));
+    let var = mech_core::Var {
+      name: identifier_from_str(&name),
+      context: None,
+      kind: None,
+    };
+    bind_runtime_value_on_program(program, &var, resolve_runtime_value(value), false)?;
+    Ok(mech_core::Expression::Var(var))
+  }
+
+  fn resolve_context_reads_in_expression(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<mech_core::Expression> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        let Some(var_context) = &var.context else {
+          return Ok(expression.clone());
+        };
+        let target = var_context.to_string();
+        let Some(binding) = registry.get(&target) else {
+          return Ok(expression.clone());
+        };
+        let path = var.name.to_string();
+        let value = self.read_context_resource(context, binding, &path)?;
+        self.bind_context_read_temp(program, &target, &path, value)
+      }
+      mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
+        self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+      )),
+      mech_core::Expression::FunctionCall(call) => {
+        let args = call.args.iter().map(|(name, expression)| {
+          Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        let mut pipe = pipe.clone();
+        if let Some(args) = &pipe.start.args {
+          pipe.start.args = Some(args.iter().map(|(name, expression)| {
+            Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
+          }).collect::<MResult<Vec<_>>>()?);
+        }
+        Ok(mech_core::Expression::FsmPipe(pipe))
+      }
+      mech_core::Expression::Literal(_) => Ok(expression.clone()),
+      mech_core::Expression::Match(match_expression) => {
+        let mut match_expression = match_expression.as_ref().clone();
+        match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
+        match_expression.arms = match_expression.arms.iter().map(|arm| {
+          Ok(mech_core::MatchArm {
+            pattern: arm.pattern.clone(),
+            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
+            expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
+          })
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::Match(Box::new(match_expression)))
+      }
+      mech_core::Expression::Range(range) => {
+        let mut range = range.as_ref().clone();
+        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
+          None => None,
+        };
+        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
+        Ok(mech_core::Expression::Range(Box::new(range)))
+      }
+      mech_core::Expression::Slice(slice) => {
+        if slice
+          .context
+          .as_ref()
+          .is_some_and(|context| registry.contains(&context.to_string()))
         {
-            let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
-                continue;
-            };
-            let module = import.declaration.module.as_deref().ok_or_else(|| {
-                MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "materialize_direct_manifest_context_imports",
-                        reason: format!(
-                            "context import `{}` is missing module metadata",
-                            import.declaration.specifier
-                        ),
-                    },
-                    None,
-                )
-            })?;
-            let item = import.declaration.item.as_deref().ok_or_else(|| {
-                MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "materialize_direct_manifest_context_imports",
-                        reason: format!(
-                            "context import `{}` is missing item metadata",
-                            import.declaration.specifier
-                        ),
-                    },
-                    None,
-                )
-            })?;
-            let export = self.module_manifests.context_export(module, item)?;
-            declarations.push(crate::SourceContextDeclaration {
-                name: alias.clone(),
-                base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
-                capabilities: export
-                    .operations
-                    .iter()
-                    .map(|operation| crate::SourceContextCapability {
-                        operation: operation.clone(),
-                        scope: crate::SourceContextCapabilityScope::Wildcard,
-                    })
-                    .collect(),
-            });
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "context_read",
+            reason: "context-addressed slices are not supported".to_string(),
+          }, None));
         }
-
-        Ok(declarations)
+        Ok(mech_core::Expression::Slice(
+          self.resolve_context_reads_in_slice(context, program, registry, slice)?,
+        ))
+      }
+      mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
+        self.resolve_context_reads_in_structure(context, program, registry, structure)?,
+      )),
+      mech_core::Expression::SetComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
+      }
     }
+  }
 
-    fn direct_context_registry_for_scope(
-        &self,
-        tree: &mech_core::Program,
-        scope: &SourceScope,
-    ) -> MResult<RuntimeContextRegistry> {
-        let index = SourceIndex::from_program(tree);
-        let declarations = self.context_declarations_from_index_scope(&index, scope)?;
-        RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
+  fn resolve_context_reads_in_factor(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<mech_core::Factor> {
+    match factor {
+      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
+      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Term(term) => {
+        let rhs = term.rhs.iter().map(|(operator, factor)| {
+          Ok((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, factor)?))
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
+          lhs: self.resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
+          rhs,
+        })))
+      }
     }
+  }
 
-    fn resolve_context_resource_request(
-        &self,
-        binding: &RuntimeContextBinding,
-        requested_path: &str,
-    ) -> MResult<ResolvedContextResourceRequest> {
-        let context_base_uri = runtime_context_base_uri(binding)
-            .trim_end_matches('/')
-            .to_string();
-        let provider_base_uri = self
-            .resources
-            .provider_base_uri_for(&context_base_uri)?
-            .unwrap_or_else(|| context_base_uri.clone());
-        let context_root = context_base_uri
-            .strip_prefix(&provider_base_uri)
-            .unwrap_or_default()
-            .trim_matches('/');
-        Ok(ResolvedContextResourceRequest {
-            provider_base_uri,
-            provider_path: join_resource_paths(context_root, requested_path),
-            context_path: requested_path.trim_matches('/').to_string(),
-        })
-    }
+  fn resolve_context_reads_in_slice(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    slice: &mech_core::Slice,
+  ) -> MResult<mech_core::Slice> {
+    Ok(mech_core::Slice {
+      name: slice.name.clone(),
+      context: slice.context.clone(),
+      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
+    })
+  }
 
-    fn read_context_resource(
-        &self,
-        context: &RuntimeContext,
-        binding: &RuntimeContextBinding,
-        path: &str,
-    ) -> MResult<Value> {
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        if !runtime_context_allows_read(binding, &resolved.context_path) {
-            return Err(MechError::new(
-                RuntimeResourceCapabilityDenied {
-                    context_name: binding.name.clone(),
-                    operation: "read".to_string(),
-                    path: resolved.context_path,
-                },
-                None,
-            ));
-        }
-        if !self.grants.allows(
-            &context.subject,
-            &resolved.provider_base_uri,
-            &RuntimeCapabilityOperation::Read,
-            &resolved.provider_path,
-        ) {
-            return Err(MechError::new(
-                RuntimeCapabilityGrantDenied {
-                    subject: context.subject.clone(),
-                    resource: resolved.provider_base_uri,
-                    operation: RuntimeCapabilityOperation::Read,
-                    path: resolved.provider_path,
-                },
-                None,
-            ));
-        }
-        self.resources.read(RuntimeResourceReadRequest {
-            base_uri: resolved.provider_base_uri,
-            path: resolved.provider_path,
-            context_name: binding.name.clone(),
-        })
-    }
-
-    fn write_context_resource(
-        &mut self,
-        context: &RuntimeContext,
-        binding: &RuntimeContextBinding,
-        path: &str,
-        value: Value,
-        intent: RuntimeResourceWriteIntent,
-    ) -> MResult<()> {
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        if !runtime_context_allows_write(binding, &resolved.context_path) {
-            return Err(MechError::new(
-                RuntimeResourceCapabilityDenied {
-                    context_name: binding.name.clone(),
-                    operation: "write".to_string(),
-                    path: resolved.context_path,
-                },
-                None,
-            ));
-        }
-        if !self.grants.allows(
-            &context.subject,
-            &resolved.provider_base_uri,
-            &RuntimeCapabilityOperation::Write,
-            &resolved.provider_path,
-        ) {
-            return Err(MechError::new(
-                RuntimeCapabilityGrantDenied {
-                    subject: context.subject.clone(),
-                    resource: resolved.provider_base_uri,
-                    operation: RuntimeCapabilityOperation::Write,
-                    path: resolved.provider_path,
-                },
-                None,
-            ));
-        }
-        self.resources.write(RuntimeResourceWriteRequest {
-            base_uri: resolved.provider_base_uri,
-            path: resolved.provider_path,
-            context_name: binding.name.clone(),
-            value,
-            intent,
-        })
-    }
-
-    fn bind_context_read_temp(
-        &self,
-        program: &mut MechProgram,
-        target: &str,
-        path: &str,
-        value: Value,
-    ) -> MResult<mech_core::Expression> {
-        let name = format!(
-            "mech-internal-context-{}-{}",
-            hash_str(target),
-            hash_str(path)
-        );
-        let var = mech_core::Var {
-            name: identifier_from_str(&name),
-            context: None,
-            kind: None,
+  fn resolve_context_reads_in_subscript(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    subscript: &mech_core::Subscript,
+  ) -> MResult<mech_core::Subscript> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(context, program, registry, factor)?)),
+      mech_core::Subscript::Range(range) => {
+        let mut range = range.clone();
+        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
+          None => None,
         };
-        bind_runtime_value_on_program(program, &var, resolve_runtime_value(value), false)?;
-        Ok(mech_core::Expression::Var(var))
+        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
+        Ok(mech_core::Subscript::Range(range))
+      }
+      _ => Ok(subscript.clone()),
     }
+  }
 
-    fn resolve_context_reads_in_expression(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        expression: &mech_core::Expression,
-    ) -> MResult<mech_core::Expression> {
-        match expression {
-            mech_core::Expression::Var(var) => {
-                let Some(var_context) = &var.context else {
-                    return Ok(expression.clone());
-                };
-                let target = var_context.to_string();
-                let Some(binding) = registry.get(&target) else {
-                    return Ok(expression.clone());
-                };
-                let path = var.name.to_string();
-                let value = self.read_context_resource(context, binding, &path)?;
-                self.bind_context_read_temp(program, &target, &path, value)
-            }
-            mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            )),
-            mech_core::Expression::FunctionCall(call) => {
-                let args = call
-                    .args
-                    .iter()
-                    .map(|(name, expression)| {
-                        Ok((
-                            name.clone(),
-                            self.resolve_context_reads_in_expression(
-                                context, program, registry, expression,
-                            )?,
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::FunctionCall(
-                    mech_core::FunctionCall {
-                        name: call.name.clone(),
-                        args,
-                    },
-                ))
-            }
-            mech_core::Expression::FsmPipe(pipe) => {
-                let mut pipe = pipe.clone();
-                if let Some(args) = &pipe.start.args {
-                    pipe.start.args = Some(
-                        args.iter()
-                            .map(|(name, expression)| {
-                                Ok((
-                                    name.clone(),
-                                    self.resolve_context_reads_in_expression(
-                                        context, program, registry, expression,
-                                    )?,
-                                ))
-                            })
-                            .collect::<MResult<Vec<_>>>()?,
-                    );
-                }
-                Ok(mech_core::Expression::FsmPipe(pipe))
-            }
-            mech_core::Expression::Literal(_) => Ok(expression.clone()),
-            mech_core::Expression::Match(match_expression) => {
-                let mut match_expression = match_expression.as_ref().clone();
-                match_expression.source = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &match_expression.source,
-                )?;
-                match_expression.arms = match_expression
-                    .arms
-                    .iter()
-                    .map(|arm| {
-                        Ok(mech_core::MatchArm {
-                            pattern: arm.pattern.clone(),
-                            guard: arm
-                                .guard
-                                .as_ref()
-                                .map(|guard| {
-                                    self.resolve_context_reads_in_expression(
-                                        context, program, registry, guard,
-                                    )
-                                })
-                                .transpose()?,
-                            expression: self.resolve_context_reads_in_expression(
-                                context,
-                                program,
-                                registry,
-                                &arm.expression,
-                            )?,
-                        })
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::Match(Box::new(match_expression)))
-            }
-            mech_core::Expression::Range(range) => {
-                let mut range = range.as_ref().clone();
-                range.start =
-                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-                range.increment = match &range.increment {
-                    Some((operator, increment)) => Some((
-                        operator.clone(),
-                        self.resolve_context_reads_in_factor(
-                            context, program, registry, increment,
-                        )?,
-                    )),
-                    None => None,
-                };
-                range.terminal = self.resolve_context_reads_in_factor(
-                    context,
-                    program,
-                    registry,
-                    &range.terminal,
-                )?;
-                Ok(mech_core::Expression::Range(Box::new(range)))
-            }
-            mech_core::Expression::Slice(slice) => {
-                if slice
-                    .context
-                    .as_ref()
-                    .is_some_and(|context| registry.contains(&context.to_string()))
-                {
-                    return Err(MechError::new(
-                        RuntimeInvalidOperationError {
-                            operation: "context_read",
-                            reason: "context-addressed slices are not supported".to_string(),
-                        },
-                        None,
-                    ));
-                }
-                Ok(mech_core::Expression::Slice(
-                    self.resolve_context_reads_in_slice(context, program, registry, slice)?,
-                ))
-            }
-            mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
-                self.resolve_context_reads_in_structure(context, program, registry, structure)?,
-            )),
-            mech_core::Expression::SetComprehension(comprehension) => {
-                let mut comprehension = comprehension.as_ref().clone();
-                comprehension.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &comprehension.expression,
-                )?;
-                comprehension.qualifiers = comprehension
-                    .qualifiers
-                    .iter()
-                    .map(|qualifier| {
-                        self.resolve_context_reads_in_comprehension_qualifier(
-                            context, program, registry, qualifier,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::SetComprehension(Box::new(
-                    comprehension,
-                )))
-            }
-            mech_core::Expression::MatrixComprehension(comprehension) => {
-                let mut comprehension = comprehension.as_ref().clone();
-                comprehension.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &comprehension.expression,
-                )?;
-                comprehension.qualifiers = comprehension
-                    .qualifiers
-                    .iter()
-                    .map(|qualifier| {
-                        self.resolve_context_reads_in_comprehension_qualifier(
-                            context, program, registry, qualifier,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::MatrixComprehension(Box::new(
-                    comprehension,
-                )))
-            }
-        }
+  fn resolve_context_reads_in_structure(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    structure: &mech_core::Structure,
+  ) -> MResult<mech_core::Structure> {
+    match structure {
+      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
+      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
+        elements: map.elements.iter().map(|mapping| Ok(mech_core::Mapping {
+          key: self.resolve_context_reads_in_expression(context, program, registry, &mapping.key)?,
+          value: self.resolve_context_reads_in_expression(context, program, registry, &mapping.value)?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
+        rows: matrix.rows.iter().map(|row| Ok(mech_core::MatrixRow {
+          columns: row.columns.iter().map(|column| Ok(mech_core::MatrixColumn {
+            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
+          })).collect::<MResult<Vec<_>>>()?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
+        bindings: record.bindings.iter().map(|binding| Ok(mech_core::Binding {
+          name: binding.name.clone(),
+          kind: binding.kind.clone(),
+          value: self.resolve_context_reads_in_expression(context, program, registry, &binding.value)?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
+        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
+        header: table.header.clone(),
+        rows: table.rows.iter().map(|row| Ok(mech_core::TableRow {
+          columns: row.columns.iter().map(|column| Ok(mech_core::TableColumn {
+            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
+          })).collect::<MResult<Vec<_>>>()?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
+        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::TupleStruct(tuple_struct) => Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
+        name: tuple_struct.name.clone(),
+        value: Box::new(self.resolve_context_reads_in_expression(context, program, registry, &tuple_struct.value)?),
+      })),
     }
+  }
 
-    fn resolve_context_reads_in_factor(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        factor: &mech_core::Factor,
-    ) -> MResult<mech_core::Factor> {
-        match factor {
-            mech_core::Factor::Expression(expression) => {
-                Ok(mech_core::Factor::Expression(Box::new(
-                    self.resolve_context_reads_in_expression(
-                        context, program, registry, expression,
-                    )?,
-                )))
-            }
-            mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            ))),
-            mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            ))),
-            mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(
-                Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?),
-            )),
-            mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            ))),
-            mech_core::Factor::Term(term) => {
-                let rhs = term
-                    .rhs
-                    .iter()
-                    .map(|(operator, factor)| {
-                        Ok((
-                            operator.clone(),
-                            self.resolve_context_reads_in_factor(
-                                context, program, registry, factor,
-                            )?,
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
-                    lhs: self
-                        .resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
-                    rhs,
-                })))
-            }
-        }
+  fn resolve_context_reads_in_comprehension_qualifier(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> MResult<mech_core::ComprehensionQualifier> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => Ok(mech_core::ComprehensionQualifier::Generator((pattern.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
+      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(context, program, registry, expression)?)),
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+        Ok(mech_core::ComprehensionQualifier::Let(var_def))
+      }
     }
+  }
 
-    fn resolve_context_reads_in_slice(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        slice: &mech_core::Slice,
-    ) -> MResult<mech_core::Slice> {
-        Ok(mech_core::Slice {
-            name: slice.name.clone(),
-            context: slice.context.clone(),
-            subscript: slice
-                .subscript
-                .iter()
-                .map(|subscript| {
-                    self.resolve_context_reads_in_subscript(context, program, registry, subscript)
-                })
-                .collect::<MResult<Vec<_>>>()?,
-        })
+  fn flush_direct_execution(
+    &mut self,
+    program: &mut MechProgram,
+    pending: &mut Vec<mech_core::SectionElement>,
+    result: &mut Value,
+  ) -> MResult<()> {
+    if pending.is_empty() {
+      return Ok(());
     }
+    let tree = mech_core::Program {
+      title: None,
+      body: mech_core::Body {
+        sections: vec![mech_core::Section {
+          subtitle: None,
+          elements: std::mem::take(pending),
+        }],
+      },
+    };
+    *result = program.run_tree(&tree)?;
+    Ok(())
+  }
 
-    fn resolve_context_reads_in_subscript(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        subscript: &mech_core::Subscript,
-    ) -> MResult<mech_core::Subscript> {
-        match subscript {
-            mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(
-                subscripts
-                    .iter()
-                    .map(|subscript| {
-                        self.resolve_context_reads_in_subscript(
-                            context, program, registry, subscript,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            )),
-            mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(
-                subscripts
-                    .iter()
-                    .map(|subscript| {
-                        self.resolve_context_reads_in_subscript(
-                            context, program, registry, subscript,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            )),
-            mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            )),
-            mech_core::Subscript::Range(range) => {
-                let mut range = range.clone();
-                range.start =
-                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-                range.increment = match &range.increment {
-                    Some((operator, increment)) => Some((
-                        operator.clone(),
-                        self.resolve_context_reads_in_factor(
-                            context, program, registry, increment,
-                        )?,
-                    )),
-                    None => None,
-                };
-                range.terminal = self.resolve_context_reads_in_factor(
-                    context,
-                    program,
-                    registry,
-                    &range.terminal,
-                )?;
-                Ok(mech_core::Subscript::Range(range))
-            }
-            _ => Ok(subscript.clone()),
-        }
+  fn executable_fence_for_scope(
+    fenced: &mech_core::FencedMechCode,
+    scope: &SourceScope,
+  ) -> bool {
+    match scope {
+      SourceScope::Program => fenced.config.namespace_str.is_empty(),
+      SourceScope::Interpreter(interpreter) => fenced.config.namespace_str == interpreter.namespace_str,
     }
+  }
 
-    fn resolve_context_reads_in_structure(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        structure: &mech_core::Structure,
-    ) -> MResult<mech_core::Structure> {
-        match structure {
-            mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
-            mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
-                elements: map
-                    .elements
-                    .iter()
-                    .map(|mapping| {
-                        Ok(mech_core::Mapping {
-                            key: self.resolve_context_reads_in_expression(
-                                context,
-                                program,
-                                registry,
-                                &mapping.key,
-                            )?,
-                            value: self.resolve_context_reads_in_expression(
-                                context,
-                                program,
-                                registry,
-                                &mapping.value,
-                            )?,
-                        })
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            })),
-            mech_core::Structure::Matrix(matrix) => {
-                Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
-                    rows: matrix
-                        .rows
-                        .iter()
-                        .map(|row| {
-                            Ok(mech_core::MatrixRow {
-                                columns: row
-                                    .columns
-                                    .iter()
-                                    .map(|column| {
-                                        Ok(mech_core::MatrixColumn {
-                                            element: self.resolve_context_reads_in_expression(
-                                                context,
-                                                program,
-                                                registry,
-                                                &column.element,
-                                            )?,
-                                        })
-                                    })
-                                    .collect::<MResult<Vec<_>>>()?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::Record(record) => {
-                Ok(mech_core::Structure::Record(mech_core::Record {
-                    bindings: record
-                        .bindings
-                        .iter()
-                        .map(|binding| {
-                            Ok(mech_core::Binding {
-                                name: binding.name.clone(),
-                                kind: binding.kind.clone(),
-                                value: self.resolve_context_reads_in_expression(
-                                    context,
-                                    program,
-                                    registry,
-                                    &binding.value,
-                                )?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
-                elements: set
-                    .elements
-                    .iter()
-                    .map(|expression| {
-                        self.resolve_context_reads_in_expression(
-                            context, program, registry, expression,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            })),
-            mech_core::Structure::Table(table) => {
-                Ok(mech_core::Structure::Table(mech_core::Table {
-                    header: table.header.clone(),
-                    rows: table
-                        .rows
-                        .iter()
-                        .map(|row| {
-                            Ok(mech_core::TableRow {
-                                columns: row
-                                    .columns
-                                    .iter()
-                                    .map(|column| {
-                                        Ok(mech_core::TableColumn {
-                                            element: self.resolve_context_reads_in_expression(
-                                                context,
-                                                program,
-                                                registry,
-                                                &column.element,
-                                            )?,
-                                        })
-                                    })
-                                    .collect::<MResult<Vec<_>>>()?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::Tuple(tuple) => {
-                Ok(mech_core::Structure::Tuple(mech_core::Tuple {
-                    elements: tuple
-                        .elements
-                        .iter()
-                        .map(|expression| {
-                            self.resolve_context_reads_in_expression(
-                                context, program, registry, expression,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::TupleStruct(tuple_struct) => {
-                Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
-                    name: tuple_struct.name.clone(),
-                    value: Box::new(self.resolve_context_reads_in_expression(
-                        context,
-                        program,
-                        registry,
-                        &tuple_struct.value,
-                    )?),
-                }))
-            }
-        }
-    }
-
-    fn resolve_context_reads_in_comprehension_qualifier(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        qualifier: &mech_core::ComprehensionQualifier,
-    ) -> MResult<mech_core::ComprehensionQualifier> {
-        match qualifier {
-            mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
-                Ok(mech_core::ComprehensionQualifier::Generator((
-                    pattern.clone(),
-                    self.resolve_context_reads_in_expression(
-                        context, program, registry, expression,
-                    )?,
-                )))
-            }
-            mech_core::ComprehensionQualifier::Filter(expression) => {
-                Ok(mech_core::ComprehensionQualifier::Filter(
-                    self.resolve_context_reads_in_expression(
-                        context, program, registry, expression,
-                    )?,
-                ))
-            }
-            mech_core::ComprehensionQualifier::Let(var_def) => {
-                let mut var_def = var_def.clone();
-                var_def.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &var_def.expression,
-                )?;
-                Ok(mech_core::ComprehensionQualifier::Let(var_def))
-            }
-        }
-    }
-
-    fn flush_direct_execution(
-        &mut self,
-        program: &mut MechProgram,
-        pending: &mut Vec<mech_core::SectionElement>,
-        result: &mut Value,
-    ) -> MResult<()> {
-        if pending.is_empty() {
-            return Ok(());
-        }
-        let tree = mech_core::Program {
-            title: None,
-            body: mech_core::Body {
-                sections: vec![mech_core::Section {
-                    subtitle: None,
-                    elements: std::mem::take(pending),
-                }],
-            },
+  fn resolve_context_reads_in_pattern(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<mech_core::Pattern> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+      )),
+      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
+        name: tuple_struct.name.clone(),
+        patterns: tuple_struct.patterns.iter()
+          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+        tuple.0.iter()
+          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      ))),
+      mech_core::Pattern::Array(array) => {
+        let spread = if let Some(spread) = &array.spread {
+          Some(mech_core::PatternArraySpread {
+            kind: spread.kind.clone(),
+            binding: spread.binding.as_ref()
+              .map(|binding| self.resolve_context_reads_in_pattern(context, program, registry, binding).map(Box::new))
+              .transpose()?,
+          })
+        } else {
+          None
         };
-        *result = program.run_tree(&tree)?;
-        Ok(())
+        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+          prefix: array.prefix.iter()
+            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+          spread,
+          suffix: array.suffix.iter()
+            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        }))
+      }
+      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
     }
+  }
 
-    fn executable_fence_for_scope(fenced: &mech_core::FencedMechCode, scope: &SourceScope) -> bool {
-        match scope {
-            SourceScope::Program => fenced.config.namespace_str.is_empty(),
-            SourceScope::Interpreter(interpreter) => {
-                fenced.config.namespace_str == interpreter.namespace_str
-            }
+  fn resolve_context_reads_in_transition(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    transition: &mech_core::Transition,
+  ) -> MResult<mech_core::Transition> {
+    match transition {
+      mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
+        code_items.iter()
+          .map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone())))
+          .collect::<MResult<Vec<_>>>()?,
+      )),
+      mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
+        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+      )),
+    }
+  }
+
+  fn resolve_context_reads_in_fsm_implementation(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    fsm: &mech_core::FsmImplementation,
+  ) -> MResult<mech_core::FsmImplementation> {
+    let arms = fsm.arms.iter().map(|arm| {
+      match arm {
+        mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
+          self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+          guards.iter().map(|guard| Ok(mech_core::Guard {
+            condition: self.resolve_context_reads_in_pattern(context, program, registry, &guard.condition)?,
+            transitions: guard.transitions.iter()
+              .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+              .collect::<MResult<Vec<_>>>()?,
+          })).collect::<MResult<Vec<_>>>()?,
+        )),
+        mech_core::FsmArm::Transition(pattern, transitions) => Ok(mech_core::FsmArm::Transition(
+          self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+          transitions.iter()
+            .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+            .collect::<MResult<Vec<_>>>()?,
+        )),
+        mech_core::FsmArm::Comment(comment) => Ok(mech_core::FsmArm::Comment(comment.clone())),
+      }
+    }).collect::<MResult<Vec<_>>>()?;
+
+    Ok(mech_core::FsmImplementation {
+      name: fsm.name.clone(),
+      input: fsm.input.clone(),
+      start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
+      arms,
+    })
+  }
+
+  fn resolve_context_reads_in_function_define(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    function: &mech_core::FunctionDefine,
+  ) -> MResult<mech_core::FunctionDefine> {
+    Ok(mech_core::FunctionDefine {
+      name: function.name.clone(),
+      input: function.input.clone(),
+      output: function.output.clone(),
+      statements: function.statements.iter()
+        .map(|statement| self.resolve_context_reads_in_statement(context, program, registry, statement))
+        .collect::<MResult<Vec<_>>>()?,
+      match_arms: function.match_arms.iter().map(|arm| Ok(mech_core::FunctionMatchArm {
+        pattern: self.resolve_context_reads_in_pattern(context, program, registry, &arm.pattern)?,
+        expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
+      })).collect::<MResult<Vec<_>>>()?,
+    })
+  }
+
+  fn resolve_context_reads_in_mech_code(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    code: &mech_core::MechCode,
+  ) -> MResult<mech_core::MechCode> {
+    match code {
+      mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
+        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+      )),
+      mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
+        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+      )),
+      mech_core::MechCode::FsmImplementation(fsm) => Ok(mech_core::MechCode::FsmImplementation(
+        self.resolve_context_reads_in_fsm_implementation(context, program, registry, fsm)?,
+      )),
+      mech_core::MechCode::FsmSpecification(spec) => Ok(mech_core::MechCode::FsmSpecification(spec.clone())),
+      mech_core::MechCode::FunctionDefine(function) => Ok(mech_core::MechCode::FunctionDefine(
+        self.resolve_context_reads_in_function_define(context, program, registry, function)?,
+      )),
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Comment(_)
+      | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
+    }
+  }
+
+  fn resolve_context_reads_in_statement(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    statement: &mech_core::Statement,
+  ) -> MResult<mech_core::Statement> {
+    match statement {
+      mech_core::Statement::VariableDefine(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+        Ok(mech_core::Statement::VariableDefine(var_def))
+      }
+      mech_core::Statement::VariableAssign(assign) => {
+        let mut assign = assign.clone();
+        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+        Ok(mech_core::Statement::VariableAssign(assign))
+      }
+      mech_core::Statement::OpAssign(op_assign) => {
+        let mut op_assign = op_assign.clone();
+        op_assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &op_assign.expression)?;
+        Ok(mech_core::Statement::OpAssign(op_assign))
+      }
+      mech_core::Statement::TupleDestructure(tuple_destructure) => {
+        let mut tuple_destructure = tuple_destructure.clone();
+        tuple_destructure.expression = self.resolve_context_reads_in_expression(context, program, registry, &tuple_destructure.expression)?;
+        Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
+      }
+      #[cfg(feature = "invariant_define")]
+      mech_core::Statement::InvariantDefine(invariant) => {
+        let mut invariant = invariant.clone();
+        invariant.expression = self.resolve_context_reads_in_expression(context, program, registry, &invariant.expression)?;
+        Ok(mech_core::Statement::InvariantDefine(invariant))
+      }
+      _ => Ok(statement.clone()),
+    }
+  }
+
+  fn push_direct_code(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pending: &mut Vec<mech_core::SectionElement>,
+    pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
+    result: &mut Value,
+    skip_non_context_imports: bool,
+    code: &mech_core::MechCode,
+    comment: &Option<mech_core::Comment>,
+  ) -> MResult<()> {
+    match code {
+      mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => Ok(()),
+      mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
+      mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
+      | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
+      mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
+        if !pending_codes.is_empty() {
+          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
         }
-    }
-
-    fn resolve_context_reads_in_pattern(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        pattern: &mech_core::Pattern,
-    ) -> MResult<mech_core::Pattern> {
-        match pattern {
-            mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
-                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-            )),
-            mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(
-                mech_core::PatternTupleStruct {
-                    name: tuple_struct.name.clone(),
-                    patterns: tuple_struct
-                        .patterns
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                },
-            )),
-            mech_core::Pattern::Tuple(tuple) => {
-                Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-                    tuple
-                        .0
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                )))
-            }
-            mech_core::Pattern::Array(array) => {
-                let spread = if let Some(spread) = &array.spread {
-                    Some(mech_core::PatternArraySpread {
-                        kind: spread.kind.clone(),
-                        binding: spread
-                            .binding
-                            .as_ref()
-                            .map(|binding| {
-                                self.resolve_context_reads_in_pattern(
-                                    context, program, registry, binding,
-                                )
-                                .map(Box::new)
-                            })
-                            .transpose()?,
-                    })
-                } else {
-                    None
-                };
-                Ok(mech_core::Pattern::Array(mech_core::PatternArray {
-                    prefix: array
-                        .prefix
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                    spread,
-                    suffix: array
-                        .suffix
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
-        }
-    }
-
-    fn resolve_context_reads_in_transition(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        transition: &mech_core::Transition,
-    ) -> MResult<mech_core::Transition> {
-        match transition {
-            mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
-                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-            )),
-            mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
-                code_items
-                    .iter()
-                    .map(|(code, comment)| {
-                        Ok((
-                            self.resolve_context_reads_in_mech_code(
-                                context, program, registry, code,
-                            )?,
-                            comment.clone(),
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            )),
-            mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
-                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-            )),
-            mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
-                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-            )),
-            mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
-                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-            )),
-        }
-    }
-
-    fn resolve_context_reads_in_fsm_implementation(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        fsm: &mech_core::FsmImplementation,
-    ) -> MResult<mech_core::FsmImplementation> {
-        let arms = fsm
-            .arms
-            .iter()
-            .map(|arm| match arm {
-                mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
-                    self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-                    guards
-                        .iter()
-                        .map(|guard| {
-                            Ok(mech_core::Guard {
-                                condition: self.resolve_context_reads_in_pattern(
-                                    context,
-                                    program,
-                                    registry,
-                                    &guard.condition,
-                                )?,
-                                transitions: guard
-                                    .transitions
-                                    .iter()
-                                    .map(|transition| {
-                                        self.resolve_context_reads_in_transition(
-                                            context, program, registry, transition,
-                                        )
-                                    })
-                                    .collect::<MResult<Vec<_>>>()?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                )),
-                mech_core::FsmArm::Transition(pattern, transitions) => {
-                    Ok(mech_core::FsmArm::Transition(
-                        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-                        transitions
-                            .iter()
-                            .map(|transition| {
-                                self.resolve_context_reads_in_transition(
-                                    context, program, registry, transition,
-                                )
-                            })
-                            .collect::<MResult<Vec<_>>>()?,
-                    ))
-                }
-                mech_core::FsmArm::Comment(comment) => {
-                    Ok(mech_core::FsmArm::Comment(comment.clone()))
-                }
-            })
-            .collect::<MResult<Vec<_>>>()?;
-
-        Ok(mech_core::FsmImplementation {
-            name: fsm.name.clone(),
-            input: fsm.input.clone(),
-            start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
-            arms,
-        })
-    }
-
-    fn resolve_context_reads_in_function_define(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        function: &mech_core::FunctionDefine,
-    ) -> MResult<mech_core::FunctionDefine> {
-        Ok(mech_core::FunctionDefine {
-            name: function.name.clone(),
-            input: function.input.clone(),
-            output: function.output.clone(),
-            statements: function
-                .statements
-                .iter()
-                .map(|statement| {
-                    self.resolve_context_reads_in_statement(context, program, registry, statement)
-                })
-                .collect::<MResult<Vec<_>>>()?,
-            match_arms: function
-                .match_arms
-                .iter()
-                .map(|arm| {
-                    Ok(mech_core::FunctionMatchArm {
-                        pattern: self.resolve_context_reads_in_pattern(
-                            context,
-                            program,
-                            registry,
-                            &arm.pattern,
-                        )?,
-                        expression: self.resolve_context_reads_in_expression(
-                            context,
-                            program,
-                            registry,
-                            &arm.expression,
-                        )?,
-                    })
-                })
-                .collect::<MResult<Vec<_>>>()?,
-        })
-    }
-
-    fn resolve_context_reads_in_mech_code(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        code: &mech_core::MechCode,
-    ) -> MResult<mech_core::MechCode> {
-        match code {
-            mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
-                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-            )),
-            mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
-                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-            )),
-            mech_core::MechCode::FsmImplementation(fsm) => {
-                Ok(mech_core::MechCode::FsmImplementation(
-                    self.resolve_context_reads_in_fsm_implementation(
-                        context, program, registry, fsm,
-                    )?,
-                ))
-            }
-            mech_core::MechCode::FsmSpecification(spec) => {
-                Ok(mech_core::MechCode::FsmSpecification(spec.clone()))
-            }
-            mech_core::MechCode::FunctionDefine(function) => {
-                Ok(mech_core::MechCode::FunctionDefine(
-                    self.resolve_context_reads_in_function_define(
-                        context, program, registry, function,
-                    )?,
-                ))
-            }
-            mech_core::MechCode::Import(_)
-            | mech_core::MechCode::Comment(_)
-            | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
-        }
-    }
-
-    fn resolve_context_reads_in_statement(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        statement: &mech_core::Statement,
-    ) -> MResult<mech_core::Statement> {
-        match statement {
-            mech_core::Statement::VariableDefine(var_def) => {
-                let mut var_def = var_def.clone();
-                var_def.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &var_def.expression,
-                )?;
-                Ok(mech_core::Statement::VariableDefine(var_def))
-            }
-            mech_core::Statement::VariableAssign(assign) => {
-                let mut assign = assign.clone();
-                assign.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &assign.expression,
-                )?;
-                Ok(mech_core::Statement::VariableAssign(assign))
-            }
-            mech_core::Statement::OpAssign(op_assign) => {
-                let mut op_assign = op_assign.clone();
-                op_assign.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &op_assign.expression,
-                )?;
-                Ok(mech_core::Statement::OpAssign(op_assign))
-            }
-            mech_core::Statement::TupleDestructure(tuple_destructure) => {
-                let mut tuple_destructure = tuple_destructure.clone();
-                tuple_destructure.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &tuple_destructure.expression,
-                )?;
-                Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
-            }
-            #[cfg(feature = "invariant_define")]
-            mech_core::Statement::InvariantDefine(invariant) => {
-                let mut invariant = invariant.clone();
-                invariant.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &invariant.expression,
-                )?;
-                Ok(mech_core::Statement::InvariantDefine(invariant))
-            }
-            _ => Ok(statement.clone()),
-        }
-    }
-
-    fn push_direct_code(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        pending: &mut Vec<mech_core::SectionElement>,
-        pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
-        result: &mut Value,
-        skip_non_context_imports: bool,
-        code: &mech_core::MechCode,
-        comment: &Option<mech_core::Comment>,
-    ) -> MResult<()> {
-        match code {
-            mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => {
-                Ok(())
-            }
-            mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
-            mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
-            | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
-            mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
-                if !pending_codes.is_empty() {
-                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                        pending_codes,
-                    )));
-                }
-                self.flush_direct_execution(program, pending, result)?;
-                let id = hash_str(&export.name.to_string());
-                if let Some(value) = program.interpreter().symbols().borrow().get(id) {
-                    *result = resolve_runtime_value(value.borrow().clone());
-                } else {
-                    *result = Value::Empty;
-                }
-                Ok(())
-            }
-            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-                if let Some(context_name) = &var_def.var.context {
-                    let target = context_name.to_string();
-                    if let Some(binding) = registry.get(&target).cloned() {
-                        if !pending_codes.is_empty() {
-                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                                pending_codes,
-                            )));
-                        }
-                        self.flush_direct_execution(program, pending, result)?;
-                        return Err(MechError::new(
-                            RuntimeInvalidOperationError {
-                                operation: "direct_context_define",
-                                reason: format!(
-                                    "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
-                                    binding.name,
-                                    var_def.var.name.to_string()
-                                ),
-                            },
-                            None,
-                        ));
-                    }
-                }
-                let code = self.resolve_context_reads_in_mech_code(
-                    context,
-                    program,
-                    registry,
-                    &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(
-                        var_def.clone(),
-                    )),
-                )?;
-                pending_codes.push((code, comment.clone()));
-                Ok(())
-            }
-            mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
-                // Context sends are executed only at module top level for now. Parser paths
-                // intentionally reject nested sends until interpreter/effect execution can
-                // support them in functions and state machines.
-                let Some(context_name) = &send.target.context else {
-                    return Err(MechError::new(
-                        RuntimeAddressedAssignmentUnsupported {
-                            target: send.target.name.to_string(),
-                        },
-                        None,
-                    ));
-                };
-                let target = context_name.to_string();
-                let Some(binding) = registry.get(&target).cloned() else {
-                    return Err(MechError::new(
-                        RuntimeAddressedAssignmentUnsupported { target },
-                        None,
-                    ));
-                };
-                if !pending_codes.is_empty() {
-                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                        pending_codes,
-                    )));
-                }
-                self.flush_direct_execution(program, pending, result)?;
-                let expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &send.expression,
-                )?;
-                let value = resolve_runtime_value(
-                    self.evaluate_expression_on_program(program, &expression)?,
-                );
-                self.write_context_resource(
-                    context,
-                    &binding,
-                    &send.target.name.to_string(),
-                    value.clone(),
-                    RuntimeResourceWriteIntent::Send,
-                )?;
-                *result = value;
-                return Ok(());
-            }
-            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-                if let Some(context_name) = &assign.target.context {
-                    let target = context_name.to_string();
-                    if let Some(binding) = registry.get(&target).cloned() {
-                        if !pending_codes.is_empty() {
-                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                                pending_codes,
-                            )));
-                        }
-                        self.flush_direct_execution(program, pending, result)?;
-                        let expression = self.resolve_context_reads_in_expression(
-                            context,
-                            program,
-                            registry,
-                            &assign.expression,
-                        )?;
-                        let value = resolve_runtime_value(
-                            self.evaluate_expression_on_program(program, &expression)?,
-                        );
-                        self.write_context_resource(
-                            context,
-                            &binding,
-                            &assign.target.name.to_string(),
-                            value.clone(),
-                            RuntimeResourceWriteIntent::Assign,
-                        )?;
-                        *result = value;
-                        return Ok(());
-                    }
-                }
-                let code = self.resolve_context_reads_in_mech_code(
-                    context,
-                    program,
-                    registry,
-                    &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(
-                        assign.clone(),
-                    )),
-                )?;
-                pending_codes.push((code, comment.clone()));
-                Ok(())
-            }
-            _ => {
-                let code =
-                    self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
-                pending_codes.push((code, comment.clone()));
-                Ok(())
-            }
-        }
-    }
-
-    fn preflight_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        tree: &mech_core::Program,
-        scope: &SourceScope,
-    ) -> MResult<()> {
-        let registry = self.direct_context_registry_for_scope(tree, scope)?;
-        for section in &tree.body.sections {
-            for element in &section.elements {
-                match element {
-                    mech_core::SectionElement::MechCode(codes) => {
-                        for (code, _) in codes {
-                            self.preflight_code_context_capabilities(context, &registry, code)?;
-                        }
-                    }
-                    mech_core::SectionElement::FencedMechCode(fenced)
-                        if Self::executable_fence_for_scope(fenced, scope) =>
-                    {
-                        for (code, _) in &fenced.code {
-                            self.preflight_code_context_capabilities(context, &registry, code)?;
-                        }
-                    }
-                    _ => {}
-                }
-            }
+        self.flush_direct_execution(program, pending, result)?;
+        let id = hash_str(&export.name.to_string());
+        if let Some(value) = program.interpreter().symbols().borrow().get(id) {
+          *result = resolve_runtime_value(value.borrow().clone());
+        } else {
+          *result = Value::Empty;
         }
         Ok(())
-    }
-
-    fn preflight_code_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        code: &mech_core::MechCode,
-    ) -> MResult<()> {
-        match code {
-            mech_core::MechCode::Statement(statement) => {
-                self.preflight_statement_context_capabilities(context, registry, statement)
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+        if let Some(context_name) = &var_def.var.context {
+          let target = context_name.to_string();
+          if let Some(binding) = registry.get(&target).cloned() {
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
             }
-            mech_core::MechCode::Expression(expression) => {
-                self.preflight_expression_context_reads(context, registry, expression)
-            }
-            _ => Ok(()),
+            self.flush_direct_execution(program, pending, result)?;
+            return Err(MechError::new(RuntimeInvalidOperationError {
+              operation: "direct_context_define",
+              reason: format!(
+                "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
+                binding.name,
+                var_def.var.name.to_string()
+              ),
+            }, None));
+          }
         }
-    }
-
-    fn preflight_statement_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        statement: &mech_core::Statement,
-    ) -> MResult<()> {
-        match statement {
-            mech_core::Statement::VariableDefine(var_def) => {
-                self.preflight_expression_context_reads(context, registry, &var_def.expression)
-            }
-            mech_core::Statement::VariableAssign(assign) => {
-                self.preflight_expression_context_reads(context, registry, &assign.expression)?;
-                if let Some(context_name) = &assign.target.context {
-                    self.preflight_context_access(
-                        context,
-                        registry,
-                        &context_name.to_string(),
-                        &assign.target.name.to_string(),
-                        RuntimeCapabilityOperation::Write,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::Statement::ContextSend(send) => {
-                self.preflight_expression_context_reads(context, registry, &send.expression)?;
-                if let Some(context_name) = &send.target.context {
-                    self.preflight_context_access(
-                        context,
-                        registry,
-                        &context_name.to_string(),
-                        &send.target.name.to_string(),
-                        RuntimeCapabilityOperation::Write,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::Statement::OpAssign(op_assign) => {
-                self.preflight_expression_context_reads(context, registry, &op_assign.expression)
-            }
-            mech_core::Statement::TupleDestructure(tuple_destructure) => self
-                .preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &tuple_destructure.expression,
-                ),
-            #[cfg(feature = "invariant_define")]
-            mech_core::Statement::InvariantDefine(invariant) => {
-                self.preflight_expression_context_reads(context, registry, &invariant.expression)
-            }
-            _ => Ok(()),
-        }
-    }
-
-    fn preflight_expression_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        expression: &mech_core::Expression,
-    ) -> MResult<()> {
-        match expression {
-            mech_core::Expression::Var(var) => {
-                if let Some(context_name) = &var.context {
-                    self.preflight_context_access(
-                        context,
-                        registry,
-                        &context_name.to_string(),
-                        &var.name.to_string(),
-                        RuntimeCapabilityOperation::Read,
-                    )?;
-                }
-            }
-            mech_core::Expression::Slice(_) => {}
-            mech_core::Expression::Formula(factor) => {
-                self.preflight_factor_context_reads(context, registry, factor)?
-            }
-            mech_core::Expression::Structure(structure) => {
-                self.preflight_structure_context_reads(context, registry, structure)?
-            }
-            mech_core::Expression::Match(match_expression) => {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &match_expression.source,
-                )?;
-                for arm in &match_expression.arms {
-                    if let Some(guard) = &arm.guard {
-                        self.preflight_expression_context_reads(context, registry, guard)?;
-                    }
-                    self.preflight_expression_context_reads(context, registry, &arm.expression)?;
-                }
-            }
-            mech_core::Expression::Range(range) => {
-                self.preflight_factor_context_reads(context, registry, &range.start)?;
-                if let Some((_, increment)) = &range.increment {
-                    self.preflight_factor_context_reads(context, registry, increment)?;
-                }
-                self.preflight_factor_context_reads(context, registry, &range.terminal)?;
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn preflight_factor_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        factor: &mech_core::Factor,
-    ) -> MResult<()> {
-        match factor {
-            mech_core::Factor::Expression(expression) => {
-                self.preflight_expression_context_reads(context, registry, expression)
-            }
-            mech_core::Factor::Negate(factor)
-            | mech_core::Factor::Not(factor)
-            | mech_core::Factor::Parenthetical(factor)
-            | mech_core::Factor::Transpose(factor) => {
-                self.preflight_factor_context_reads(context, registry, factor)
-            }
-            mech_core::Factor::Term(term) => {
-                self.preflight_factor_context_reads(context, registry, &term.lhs)?;
-                for (_, factor) in &term.rhs {
-                    self.preflight_factor_context_reads(context, registry, factor)?;
-                }
-                Ok(())
-            }
-        }
-    }
-
-    fn preflight_structure_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        structure: &mech_core::Structure,
-    ) -> MResult<()> {
-        match structure {
-            mech_core::Structure::Map(map) => {
-                for mapping in &map.elements {
-                    self.preflight_expression_context_reads(context, registry, &mapping.key)?;
-                    self.preflight_expression_context_reads(context, registry, &mapping.value)?;
-                }
-            }
-            mech_core::Structure::Set(set) => {
-                for expression in &set.elements {
-                    self.preflight_expression_context_reads(context, registry, expression)?;
-                }
-            }
-            mech_core::Structure::Tuple(tuple) => {
-                for expression in &tuple.elements {
-                    self.preflight_expression_context_reads(context, registry, expression)?;
-                }
-            }
-            mech_core::Structure::TupleStruct(tuple_struct) => {
-                self.preflight_expression_context_reads(context, registry, &tuple_struct.value)?
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn preflight_context_access(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        context_name: &str,
-        path: &str,
-        operation: RuntimeCapabilityOperation,
-    ) -> MResult<()> {
-        let Some(binding) = registry.get(context_name) else {
-            return Ok(());
-        };
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        let context_allowed = match operation {
-            RuntimeCapabilityOperation::Read => {
-                runtime_context_allows_read(binding, &resolved.context_path)
-            }
-            RuntimeCapabilityOperation::Write => {
-                runtime_context_allows_write(binding, &resolved.context_path)
-            }
-            _ => true,
-        };
-        if !context_allowed {
-            return Ok(());
-        }
-        if !self.grants.allows(
-            &context.subject,
-            &resolved.provider_base_uri,
-            &operation,
-            &resolved.provider_path,
-        ) {
-            return Err(MechError::new(
-                RuntimeCapabilityGrantDenied {
-                    subject: context.subject.clone(),
-                    resource: resolved.provider_base_uri,
-                    operation,
-                    path: resolved.provider_path,
-                },
-                None,
-            ));
-        }
-        Ok(())
-    }
-
-    fn run_tree_on_program(
-        &mut self,
-        context: &mut RuntimeContext,
-        program: &mut MechProgram,
-        tree: &mech_core::Program,
-        scope_hint: Option<&SourceScope>,
-    ) -> MResult<Value> {
-        let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
-        let skip_non_context_imports = scope_hint.is_some();
-        let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
-        let mut result = Value::Empty;
-        let mut pending = Vec::new();
-
-        for section in &tree.body.sections {
-            for element in &section.elements {
-                match element {
-                    mech_core::SectionElement::MechCode(codes) => {
-                        let mut pending_codes = Vec::new();
-                        for (code, comment) in codes {
-                            self.push_direct_code(
-                                context,
-                                program,
-                                &registry,
-                                &mut pending,
-                                &mut pending_codes,
-                                &mut result,
-                                skip_non_context_imports,
-                                code,
-                                comment,
-                            )?;
-                        }
-                        if !pending_codes.is_empty() {
-                            pending.push(mech_core::SectionElement::MechCode(pending_codes));
-                        }
-                    }
-                    mech_core::SectionElement::FencedMechCode(fenced)
-                        if Self::executable_fence_for_scope(fenced, execution_scope) =>
-                    {
-                        let mut pending_codes = Vec::new();
-                        for (code, comment) in &fenced.code {
-                            self.push_direct_code(
-                                context,
-                                program,
-                                &registry,
-                                &mut pending,
-                                &mut pending_codes,
-                                &mut result,
-                                skip_non_context_imports,
-                                code,
-                                comment,
-                            )?;
-                        }
-                        if !pending_codes.is_empty() {
-                            let mut fenced = fenced.clone();
-                            fenced.code = pending_codes;
-                            pending.push(mech_core::SectionElement::FencedMechCode(fenced));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        self.flush_direct_execution(program, &mut pending, &mut result)?;
-        Ok(result)
-    }
-
-    fn evaluate_expression_on_program(
-        &mut self,
-        program: &mut MechProgram,
-        expression: &mech_core::Expression,
-    ) -> MResult<Value> {
-        let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
-        program.run_tree(&single).map(resolve_runtime_value)
-    }
-
-    pub fn run_string(&mut self, source: &str) -> MResult<Value> {
-        let mut context = self.runtime_context()?;
-        self.run_string_with_context(&mut context, source)
-    }
-    pub fn run_string_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        source: &str,
-    ) -> MResult<Value> {
-        context.validate()?;
-        context.charge_step()?;
-        let profile_started = self
-            .config
-            .diagnostics
-            .profile_enabled
-            .then(std::time::Instant::now);
-
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
+        let code = self.resolve_context_reads_in_mech_code(
+          context,
+          program,
+          registry,
+          &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def.clone())),
         )?;
-
-        let result = match mech_syntax::parser::parse(source.trim()) {
-            Ok(tree) => {
-                self.preflight_context_capabilities(context, &tree, &SourceScope::Program)?;
-                let program_config = self.program.config.clone();
-                let mut program =
-                    std::mem::replace(&mut self.program, MechProgram::new(program_config));
-
-                self.register_runtime_program_host_functions(context, &mut program)?;
-
-                let runtime_ptr: *mut MechRuntime = self;
-                let context_ptr: *mut RuntimeContext = context;
-                let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-                let result = self.run_tree_on_program(context, &mut program, &tree, None);
-
-                self.program = program;
-                result
-            }
-            Err(error) => Err(error),
+        pending_codes.push((code, comment.clone()));
+        Ok(())
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+        // Context sends are executed only at module top level for now. Parser paths
+        // intentionally reject nested sends until interpreter/effect execution can
+        // support them in functions and state machines.
+        let Some(context_name) = &send.target.context else {
+          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: send.target.name.to_string() }, None));
         };
-
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
+        let target = context_name.to_string();
+        let Some(binding) = registry.get(&target).cloned() else {
+          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target }, None));
+        };
+        if !pending_codes.is_empty() {
+          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
         }
-
-        result
-    }
-
-    pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
-        let mut context = self.runtime_context()?;
-        self.run_tree_with_context(&mut context, tree)
-    }
-
-    pub fn run_tree_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        tree: &mech_core::Program,
-    ) -> MResult<Value> {
-        context.validate()?;
-        context.charge_step()?;
-        let profile_started = self
-            .config
-            .diagnostics
-            .profile_enabled
-            .then(std::time::Instant::now);
-
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
+        self.flush_direct_execution(program, pending, result)?;
+        let expression = self.resolve_context_reads_in_expression(context, program, registry, &send.expression)?;
+        let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
+        self.write_context_resource(context, &binding, &send.target.name.to_string(), value.clone(), RuntimeResourceWriteIntent::Send)?;
+        *result = value;
+        return Ok(());
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+        if let Some(context_name) = &assign.target.context {
+          let target = context_name.to_string();
+          if let Some(binding) = registry.get(&target).cloned() {
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+            }
+            self.flush_direct_execution(program, pending, result)?;
+            let expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+            let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
+            self.write_context_resource(context, &binding, &assign.target.name.to_string(), value.clone(), RuntimeResourceWriteIntent::Assign)?;
+            *result = value;
+            return Ok(());
+          }
+        }
+        let code = self.resolve_context_reads_in_mech_code(
+          context,
+          program,
+          registry,
+          &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign.clone())),
         )?;
+        pending_codes.push((code, comment.clone()));
+        Ok(())
+      }
+      _ => {
+        let code = self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
+        pending_codes.push((code, comment.clone()));
+        Ok(())
+      }
+    }
+  }
 
-        self.preflight_context_capabilities(context, tree, &SourceScope::Program)?;
+  fn preflight_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<()> {
+    let registry = self.direct_context_registry_for_scope(tree, scope)?;
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            for (code, _) in codes {
+              self.preflight_code_context_capabilities(context, &registry, code)?;
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, scope) =>
+          {
+            for (code, _) in &fenced.code {
+              self.preflight_code_context_capabilities(context, &registry, code)?;
+            }
+          }
+          _ => {}
+        }
+      }
+    }
+    Ok(())
+  }
 
+  fn preflight_code_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    code: &mech_core::MechCode,
+  ) -> MResult<()> {
+    match code {
+      mech_core::MechCode::Statement(statement) => {
+        self.preflight_statement_context_capabilities(context, registry, statement)
+      }
+      mech_core::MechCode::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      _ => Ok(()),
+    }
+  }
+
+  fn preflight_statement_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    statement: &mech_core::Statement,
+  ) -> MResult<()> {
+    match statement {
+      mech_core::Statement::VariableDefine(var_def) => {
+        self.preflight_expression_context_reads(context, registry, &var_def.expression)
+      }
+      mech_core::Statement::VariableAssign(assign) => {
+        self.preflight_expression_context_reads(context, registry, &assign.expression)?;
+        if let Some(context_name) = &assign.target.context {
+          self.preflight_context_access(
+            context,
+            registry,
+            &context_name.to_string(),
+            &assign.target.name.to_string(),
+            RuntimeCapabilityOperation::Write,
+          )?;
+        }
+        Ok(())
+      }
+      mech_core::Statement::ContextSend(send) => {
+        self.preflight_expression_context_reads(context, registry, &send.expression)?;
+        if let Some(context_name) = &send.target.context {
+          self.preflight_context_access(
+            context,
+            registry,
+            &context_name.to_string(),
+            &send.target.name.to_string(),
+            RuntimeCapabilityOperation::Write,
+          )?;
+        }
+        Ok(())
+      }
+      mech_core::Statement::OpAssign(op_assign) => {
+        self.preflight_expression_context_reads(context, registry, &op_assign.expression)
+      }
+      mech_core::Statement::TupleDestructure(tuple_destructure) => self
+        .preflight_expression_context_reads(context, registry, &tuple_destructure.expression),
+      #[cfg(feature = "invariant_define")]
+      mech_core::Statement::InvariantDefine(invariant) => {
+        self.preflight_expression_context_reads(context, registry, &invariant.expression)
+      }
+      _ => Ok(()),
+    }
+  }
+
+  fn preflight_expression_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<()> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        if let Some(context_name) = &var.context {
+          self.preflight_context_access(
+            context,
+            registry,
+            &context_name.to_string(),
+            &var.name.to_string(),
+            RuntimeCapabilityOperation::Read,
+          )?;
+        }
+      }
+      mech_core::Expression::Formula(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor)?;
+      }
+      mech_core::Expression::Range(range) => {
+        self.preflight_factor_context_reads(context, registry, &range.start)?;
+        if let Some((_, increment)) = &range.increment {
+          self.preflight_factor_context_reads(context, registry, increment)?;
+        }
+        self.preflight_factor_context_reads(context, registry, &range.terminal)?;
+      }
+      mech_core::Expression::Structure(structure) => {
+        self.preflight_structure_context_reads(context, registry, structure)?;
+      }
+      mech_core::Expression::Match(match_expression) => {
+        self.preflight_expression_context_reads(context, registry, &match_expression.source)?;
+        for arm in &match_expression.arms {
+          if let Some(guard) = &arm.guard {
+            self.preflight_expression_context_reads(context, registry, guard)?;
+          }
+          self.preflight_expression_context_reads(context, registry, &arm.expression)?;
+        }
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_factor_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<()> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::Factor::Negate(factor)
+      | mech_core::Factor::Not(factor)
+      | mech_core::Factor::Parenthetical(factor)
+      | mech_core::Factor::Transpose(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor)
+      }
+      mech_core::Factor::Term(term) => {
+        self.preflight_factor_context_reads(context, registry, &term.lhs)?;
+        for (_, factor) in &term.rhs {
+          self.preflight_factor_context_reads(context, registry, factor)?;
+        }
+        Ok(())
+      }
+    }
+  }
+
+  fn preflight_structure_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    structure: &mech_core::Structure,
+  ) -> MResult<()> {
+    match structure {
+      mech_core::Structure::Map(map) => {
+        for mapping in &map.elements {
+          self.preflight_expression_context_reads(context, registry, &mapping.key)?;
+          self.preflight_expression_context_reads(context, registry, &mapping.value)?;
+        }
+      }
+      mech_core::Structure::Set(set) => {
+        for expression in &set.elements {
+          self.preflight_expression_context_reads(context, registry, expression)?;
+        }
+      }
+      mech_core::Structure::Tuple(tuple) => {
+        for expression in &tuple.elements {
+          self.preflight_expression_context_reads(context, registry, expression)?;
+        }
+      }
+      mech_core::Structure::TupleStruct(tuple_struct) => {
+        self.preflight_expression_context_reads(context, registry, &tuple_struct.value)?;
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_context_access(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    context_name: &str,
+    path: &str,
+    operation: RuntimeCapabilityOperation,
+  ) -> MResult<()> {
+    let Some(binding) = registry.get(context_name) else {
+      return Ok(());
+    };
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    let context_allowed = match operation {
+      RuntimeCapabilityOperation::Read => runtime_context_allows_read(binding, &resolved.context_path),
+      RuntimeCapabilityOperation::Write => runtime_context_allows_write(binding, &resolved.context_path),
+      _ => true,
+    };
+    if !context_allowed {
+      return Ok(());
+    }
+    if !self.grants.allows(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &operation,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(
+        RuntimeCapabilityGrantDenied {
+          subject: context.subject.clone(),
+          resource: resolved.provider_base_uri,
+          operation,
+          path: resolved.provider_path,
+        },
+        None,
+      ));
+    }
+    Ok(())
+  }
+
+  fn run_tree_on_program(
+    &mut self,
+    context: &mut RuntimeContext,
+    program: &mut MechProgram,
+    tree: &mech_core::Program,
+    scope_hint: Option<&SourceScope>,
+  ) -> MResult<Value> {
+    let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
+    let skip_non_context_imports = scope_hint.is_some();
+    let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
+    let mut result = Value::Empty;
+    let mut pending = Vec::new();
+
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            let mut pending_codes = Vec::new();
+            for (code, comment) in codes {
+              self.push_direct_code(
+                context,
+                program,
+                &registry,
+                &mut pending,
+                &mut pending_codes,
+                &mut result,
+                skip_non_context_imports,
+                code,
+                comment,
+              )?;
+            }
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(pending_codes));
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, execution_scope) =>
+          {
+            let mut pending_codes = Vec::new();
+            for (code, comment) in &fenced.code {
+              self.push_direct_code(
+                context,
+                program,
+                &registry,
+                &mut pending,
+                &mut pending_codes,
+                &mut result,
+                skip_non_context_imports,
+                code,
+                comment,
+              )?;
+            }
+            if !pending_codes.is_empty() {
+              let mut fenced = fenced.clone();
+              fenced.code = pending_codes;
+              pending.push(mech_core::SectionElement::FencedMechCode(fenced));
+            }
+          }
+          _ => {}
+        }
+      }
+    }
+
+    self.flush_direct_execution(program, &mut pending, &mut result)?;
+    Ok(result)
+  }
+
+  fn evaluate_expression_on_program(
+    &mut self,
+    program: &mut MechProgram,
+    expression: &mech_core::Expression,
+  ) -> MResult<Value> {
+    let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
+    program.run_tree(&single).map(resolve_runtime_value)
+  }
+
+  pub fn run_string(&mut self, source: &str) -> MResult<Value> {
+    let mut context = self.runtime_context()?;
+    self.run_string_with_context(&mut context, source)
+  }
+  pub fn run_string_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &str,
+  ) -> MResult<Value> {
+    context.validate()?;
+    context.charge_step()?;
+    let profile_started = self.config.diagnostics.profile_enabled.then(std::time::Instant::now);
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    let result = match mech_syntax::parser::parse(source.trim()) {
+      Ok(tree) => {
+        self.preflight_context_capabilities(context, &tree, &SourceScope::Program)?;
         let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(&mut self.program, MechProgram::new(program_config));
+        let mut program = std::mem::replace(
+          &mut self.program,
+          MechProgram::new(program_config),
+        );
 
-        self.register_runtime_program_host_functions(context, &mut program)?;
+        self.register_runtime_program_host_functions(
+          context,
+          &mut program,
+        )?;
 
         let runtime_ptr: *mut MechRuntime = self;
         let context_ptr: *mut RuntimeContext = context;
         let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-        let result = self.run_tree_on_program(context, &mut program, tree, None);
+        let result = self.run_tree_on_program(context, &mut program, &tree, None);
 
         self.program = program;
-
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-        }
-
         result
-    }
+      }
+      Err(error) => Err(error),
+    };
 
-    pub fn out_string(&self) -> String {
-        self.program.out_string()
-    }
-
-    pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-        self.program.has_interpreter(interpreter_id)
-    }
-
-    pub fn output_value_for_interpreter(
-        &self,
-        interpreter_id: u64,
-        output_id: u64,
-    ) -> Option<Value> {
-        self.program
-            .output_value_for_interpreter(interpreter_id, output_id)
-    }
-
-    pub fn symbol_name_for_interpreter_output(
-        &self,
-        interpreter_id: u64,
-        output_id: u64,
-    ) -> Option<String> {
-        self.program
-            .symbol_name_for_interpreter_output(interpreter_id, output_id)
-    }
-
-    pub fn symbol_values_for_interpreter(
-        &self,
-        interpreter_id: u64,
-        names: &[String],
-    ) -> Option<Vec<(String, Value)>> {
-        self.program
-            .symbol_values_for_interpreter(interpreter_id, names)
-    }
-
-    pub fn bind_ans_for_interpreter(&mut self, interpreter_id: u64, value: &Value) -> MResult<()> {
-        if self.program.bind_ans_for_interpreter(interpreter_id, value) {
-            return Ok(());
-        }
-
-        Err(MechError::new(
-            RuntimeInvalidOperationError {
-                operation: "bind_ans_for_interpreter",
-                reason: format!("interpreter id {} not found", interpreter_id),
-            },
-            None,
-        ))
-    }
-
-    #[cfg(feature = "functions")]
-    pub fn step(&mut self, count: u64) -> MResult<()> {
-        self.program.step(count)
-    }
-
-    pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
-        let mut context = self.runtime_context()?.with_module_version(version);
-
-        self.run_module_with_context(&mut context, version)
-    }
-
-    pub fn run_module_scope(
-        &mut self,
-        version: ModuleVersionId,
-        scope: SourceScope,
-    ) -> MResult<Value> {
-        let mut context = self.runtime_context()?.with_module_version(version);
-
-        self.run_module_scope_with_context(&mut context, version, scope)
-    }
-
-    pub fn run_module_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-    ) -> MResult<Value> {
-        self.run_module_scope_with_context(context, version, SourceScope::Program)
-    }
-
-    pub fn run_module_scope_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-        scope: SourceScope,
-    ) -> MResult<Value> {
-        let mut seen = HashSet::new();
-        let mut module_instances = HashMap::new();
-
-        let instance = self.execute_module_isolated_for_scope(
-            context,
-            version,
-            &scope,
-            &mut seen,
-            &mut module_instances,
-        )?;
-
-        Ok(instance.result)
-    }
-
-    fn execute_module_isolated_for_scope(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-        scope: &SourceScope,
-        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-    ) -> MResult<ModuleInstance> {
-        context.validate()?;
-        context.charge_step()?;
-
-        let instance_key = (version, scope.clone());
-
-        if let Some(instance) = module_instances.get(&instance_key).cloned() {
-            return Ok(instance);
-        }
-
-        if seen.contains(&instance_key) {
-            return Ok(ModuleInstance {
-                version,
-                exports: HashMap::new(),
-                result: Value::Empty,
-            });
-        }
-        seen.insert(instance_key.clone());
-
-        let Some(record) = self.store.get_module_version(version)? else {
-            return Err(MechError::new(
-                RuntimeRecordNotFoundError {
-                    record_type: "module_version",
-                    id: version.to_string(),
-                },
-                None,
-            ));
-        };
-        validate_module_import_edges(&record)?;
-        let Some(source) = record.source.clone() else {
-            return Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_module",
-                    reason: "module version has no source".to_string(),
-                },
-                None,
-            ));
-        };
-
-        let context_registry = context_registry_for_scope(&record, scope)?;
-
-        for edge in &record.import_edges {
-            if &edge.scope != scope {
-                continue;
-            }
-
-            self.execute_module_isolated_for_scope(
-                context,
-                edge.dependency,
-                &SourceScope::Program,
-                seen,
-                module_instances,
-            )?;
-        }
-
-        let mut import_environment =
-            self.build_import_environment_for_scope(context, &record, scope, module_instances)?;
-
-        let address_environment = self.build_address_environment_for_scope(
-            context,
-            version,
-            &record,
-            scope,
-            &context_registry,
-            seen,
-            module_instances,
-        )?;
-        import_environment.extend(address_environment);
-        let mut module_program = MechProgram::new(MechProgramConfig {
-            name: self.config.name.clone(),
-            environment: MechProgramEnvironment {
-                trace_enabled: self.config.diagnostics.trace_enabled,
-                debug_enabled: self.config.diagnostics.debug_enabled,
-                profile_enabled: self.config.diagnostics.profile_enabled,
-                rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
-            },
-        });
-
-        {
-            let symbols = module_program.interpreter_mut().symbols();
-            let mut symbols_brrw = symbols.borrow_mut();
-            for (name, value_ref) in import_environment {
-                let id = hash_str(&name);
-                symbols_brrw.symbols.insert(id, value_ref);
-                symbols_brrw.dictionary.borrow_mut().insert(id, name);
-            }
-        }
-
+    match &result {
+      Ok(_) => {
         self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ModuleExecutionStarted {
-                module_version: version,
-            },
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
         )?;
-        let scoped_source = module_source_for_scope(&source, scope)?;
-        let result =
-            self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
-        let result = match result {
-            Ok(value) => value,
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ModuleExecutionFailed {
-                        module_version: version,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                return Err(error);
-            }
-        };
-        let mut exports = HashMap::new();
-        {
-            let symbols = module_program.interpreter_mut().symbols();
-            let symbols_brrw = symbols.borrow();
-            for export in exports_for_scope(&record, scope) {
-                let id = hash_str(&export.name);
-                let Some(value_ref) = symbols_brrw.get(id) else {
-                    let error = MechError::new(
-                        RuntimeModuleExportNotFound {
-                            dependency: record.id.to_string(),
-                            export: export.name.clone(),
-                        },
-                        None,
-                    );
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ModuleExecutionFailed {
-                            module_version: version,
-                            message: format!("{:?}", error),
-                        },
-                    )?;
-                    return Err(error);
-                };
-                exports.insert(export.name.clone(), value_ref.clone());
-            }
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
         }
-
-        let instance = ModuleInstance {
-            version,
-            exports,
-            result,
-        };
-        module_instances.insert(instance_key, instance.clone());
+      }
+      Err(error) => {
         self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ModuleExecutionCompleted {
-                module_version: version,
-            },
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
         )?;
-        Ok(instance)
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
     }
 
-    fn run_module_source_on_program(
-        &mut self,
-        context: &mut RuntimeContext,
-        program: &mut MechProgram,
-        source: &MechSourceCode,
-        scope: &SourceScope,
-    ) -> MResult<Value> {
-        self.register_runtime_program_host_functions(context, program)?;
+    result
+  }
 
-        let runtime_ptr: *mut MechRuntime = self;
-        let context_ptr: *mut RuntimeContext = context;
-        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
+  pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
+    let mut context = self.runtime_context()?;
+    self.run_tree_with_context(&mut context, tree)
+  }
+
+  pub fn run_tree_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    tree: &mech_core::Program,
+  ) -> MResult<Value> {
+    context.validate()?;
+    context.charge_step()?;
+    let profile_started = self.config.diagnostics.profile_enabled.then(std::time::Instant::now);
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    self.preflight_context_capabilities(context, tree, &SourceScope::Program)?;
+
+    let program_config = self.program.config.clone();
+    let mut program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config),
+    );
+
+    self.register_runtime_program_host_functions(
+      context,
+      &mut program,
+    )?;
+
+    let runtime_ptr: *mut MechRuntime = self;
+    let context_ptr: *mut RuntimeContext = context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+    let result = self.run_tree_on_program(context, &mut program, tree, None);
+
+    self.program = program;
+
+    match &result {
+      Ok(_) => {
         self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
         )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
+    }
 
-        // Named interpreter scopes are extracted to bare source by module_source_for_scope.
-        // Once extracted, their declarations are indexed as SourceScope::Program in the
-        // reparsed tree, so direct context handling must use Program scope for that tree.
-        // The surrounding module execution still uses the original scope for imports,
-        // exports, address environment, and ModuleInstance identity.
-        let execution_scope = execution_scope_for_extracted_module_source(scope);
+    result
+  }
 
-        let result = match source {
-            MechSourceCode::String(source) => {
-                mech_syntax::parser::parse(source.trim()).and_then(|tree| {
-                    self.run_tree_on_program(context, program, &tree, Some(&execution_scope))
-                })
-            }
-            other => program.run_source(other),
+  pub fn out_string(&self) -> String {
+    self.program.out_string()
+  }
+
+  pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
+    self.program.has_interpreter(interpreter_id)
+  }
+
+  pub fn output_value_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<Value> {
+    self.program.output_value_for_interpreter(interpreter_id, output_id)
+  }
+
+  pub fn symbol_name_for_interpreter_output(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<String> {
+    self.program.symbol_name_for_interpreter_output(interpreter_id, output_id)
+  }
+
+  pub fn symbol_values_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    names: &[String],
+  ) -> Option<Vec<(String, Value)>> {
+    self.program.symbol_values_for_interpreter(interpreter_id, names)
+  }
+
+  pub fn bind_ans_for_interpreter(
+    &mut self,
+    interpreter_id: u64,
+    value: &Value,
+  ) -> MResult<()> {
+    if self.program.bind_ans_for_interpreter(interpreter_id, value) {
+      return Ok(());
+    }
+
+    Err(MechError::new(
+      RuntimeInvalidOperationError {
+        operation: "bind_ans_for_interpreter",
+        reason: format!("interpreter id {} not found", interpreter_id),
+      },
+      None,
+    ))
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn step(&mut self, count: u64) -> MResult<()> {
+    self.program.step(count)
+  }
+
+  pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
+    let mut context = self.runtime_context()?
+      .with_module_version(version);
+
+    self.run_module_with_context(&mut context, version)
+  }
+
+  pub fn run_module_scope(
+    &mut self,
+    version: ModuleVersionId,
+    scope: SourceScope,
+  ) -> MResult<Value> {
+    let mut context = self.runtime_context()?
+      .with_module_version(version);
+
+    self.run_module_scope_with_context(&mut context, version, scope)
+  }
+
+  pub fn run_module_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+  ) -> MResult<Value> {
+    self.run_module_scope_with_context(context, version, SourceScope::Program)
+  }
+
+  pub fn run_module_scope_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    scope: SourceScope,
+  ) -> MResult<Value> {
+    let mut seen = HashSet::new();
+    let mut module_instances = HashMap::new();
+
+    let instance = self.execute_module_isolated_for_scope(
+      context,
+      version,
+      &scope,
+      &mut seen,
+      &mut module_instances,
+    )?;
+
+    Ok(instance.result)
+  }
+
+  fn execute_module_isolated_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    scope: &SourceScope,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<ModuleInstance> {
+    context.validate()?;
+    context.charge_step()?;
+
+    let instance_key = (version, scope.clone());
+
+    if let Some(instance) = module_instances.get(&instance_key).cloned() {
+      return Ok(instance);
+    }
+
+    if seen.contains(&instance_key) {
+      return Ok(ModuleInstance { version, exports: HashMap::new(), result: Value::Empty });
+    }
+    seen.insert(instance_key.clone());
+
+    let Some(record) = self.store.get_module_version(version)? else {
+      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
+    };
+    validate_module_import_edges(&record)?;
+    let Some(source) = record.source.clone() else {
+      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
+    };
+
+    let context_registry = context_registry_for_scope(&record, scope)?;
+
+    for edge in &record.import_edges {
+      if &edge.scope != scope {
+        continue;
+      }
+
+      self.execute_module_isolated_for_scope(
+        context,
+        edge.dependency,
+        &SourceScope::Program,
+        seen,
+        module_instances,
+      )?;
+    }
+
+    let mut import_environment = self.build_import_environment_for_scope(
+      context,
+      &record,
+      scope,
+      module_instances,
+    )?;
+
+    let address_environment = self.build_address_environment_for_scope(
+      context,
+      version,
+      &record,
+      scope,
+      &context_registry,
+      seen,
+      module_instances,
+    )?;
+    import_environment.extend(address_environment);
+    let mut module_program = MechProgram::new(MechProgramConfig {
+      name: self.config.name.clone(),
+      environment: MechProgramEnvironment {
+        trace_enabled: self.config.diagnostics.trace_enabled,
+        debug_enabled: self.config.diagnostics.debug_enabled,
+        profile_enabled: self.config.diagnostics.profile_enabled,
+        rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+      },
+    });
+
+    {
+      let symbols = module_program.interpreter_mut().symbols();
+      let mut symbols_brrw = symbols.borrow_mut();
+      for (name, value_ref) in import_environment {
+        let id = hash_str(&name);
+        symbols_brrw.symbols.insert(id, value_ref);
+        symbols_brrw.dictionary.borrow_mut().insert(id, name);
+      }
+    }
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ModuleExecutionStarted { module_version: version },
+    )?;
+    let scoped_source = module_source_for_scope(&source, scope)?;
+    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
+    let result = match result {
+      Ok(value) => value,
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ModuleExecutionFailed {
+            module_version: version,
+            message: format!("{:?}", error),
+          },
+        )?;
+        return Err(error);
+      }
+    };
+    let mut exports = HashMap::new();
+    {
+      let symbols = module_program.interpreter_mut().symbols();
+      let symbols_brrw = symbols.borrow();
+      for export in exports_for_scope(&record, scope) {
+        let id = hash_str(&export.name);
+        let Some(value_ref) = symbols_brrw.get(id) else {
+          let error = MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: export.name.clone() }, None);
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ModuleExecutionFailed {
+              module_version: version,
+              message: format!("{:?}", error),
+            },
+          )?;
+          return Err(error);
         };
-
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-            }
-        }
-
-        result
+        exports.insert(export.name.clone(), value_ref.clone());
+      }
     }
 
-    fn build_address_environment_for_scope(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-        record: &ModuleVersionRecord,
-        scope: &SourceScope,
-        context_registry: &RuntimeContextRegistry,
-        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-    ) -> MResult<HashMap<String, mech_core::ValRef>> {
-        fn address_binding_key(target: &str, name: &str) -> String {
-            format!("@{target}/{name}")
-        }
+    let instance = ModuleInstance { version, exports, result };
+    module_instances.insert(instance_key, instance.clone());
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ModuleExecutionCompleted { module_version: version },
+    )?;
+    Ok(instance)
+  }
 
-        let scoped_refs = record
-            .scopes
-            .iter()
-            .find(|metadata| &metadata.scope == scope)
-            .map(|metadata| metadata.address_references.as_slice())
-            .unwrap_or(&[]);
-
-        let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> =
-            HashMap::new();
-        let mut bindings = HashMap::new();
-        for reference in scoped_refs {
-            match resolve_runtime_address_target(record, scope, context_registry, &reference.target)
-            {
-                RuntimeAddressTarget::Interpreter(interpreter_scope) => {
-                    if !matches!(scope, SourceScope::Program) {
-                        return Err(MechError::new(
-                            UnknownAddressTarget {
-                                target: reference.target.clone(),
-                            },
-                            None,
-                        ));
-                    }
-                    requested_by_scope
-                        .entry(interpreter_scope)
-                        .or_default()
-                        .push(reference.clone());
-                }
-                RuntimeAddressTarget::Context(_) => {
-                    // Context-addressed resource reads are resolved while executing source
-                    // statements so reads observe earlier writes in the same module scope.
-                }
-                RuntimeAddressTarget::Unknown => {
-                    return Err(MechError::new(
-                        UnknownAddressTarget {
-                            target: reference.target.clone(),
-                        },
-                        None,
-                    ));
-                }
-            }
-        }
-
-        for (interpreter_scope, requested_refs) in requested_by_scope {
-            let instance = self.execute_module_isolated_for_scope(
-                context,
-                version,
-                &interpreter_scope,
-                seen,
-                module_instances,
-            )?;
-
-            for reference in requested_refs {
-                let Some(export_value) = instance.exports.get(&reference.name) else {
-                    return Err(MechError::new(
-                        RuntimeModuleExportNotFound {
-                            dependency: record.id.to_string(),
-                            export: reference.name.clone(),
-                        },
-                        None,
-                    ));
-                };
-                bindings.insert(
-                    address_binding_key(&reference.target, &reference.name),
-                    export_value.clone(),
-                );
-            }
-        }
-
-        Ok(bindings)
-    }
-
-    fn build_import_environment_for_scope(
-        &mut self,
-        context: &mut RuntimeContext,
-        importer: &ModuleVersionRecord,
-        scope: &SourceScope,
-        module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-    ) -> MResult<HashMap<String, mech_core::ValRef>> {
-        let mut bindings = HashMap::new();
-        let mut ownership: HashMap<String, String> = HashMap::new();
-
-        for edge in &importer.import_edges {
-            if &edge.scope != scope {
-                continue;
-            }
-
-            let import = &edge.import;
-            let dependency = edge.dependency;
-
-            let dependency_key = (dependency, SourceScope::Program);
-            let Some(dependency_instance) = module_instances.get(&dependency_key) else {
-                return Err(MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "build_import_environment",
-                        reason: format!("dependency instance missing for {}", dependency),
-                    },
-                    None,
-                ));
-            };
-
-            match &import.kind {
-                SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
-                    let Some(namespace) = module_namespace_for_import(import) else {
-                        continue;
-                    };
-                    for (export_name, export_value) in &dependency_instance.exports {
-                        let binding = format!("{}/{}", namespace, export_name);
-                        if let Some(first) =
-                            ownership.insert(binding.clone(), import.specifier.clone())
-                        {
-                            return Err(MechError::new(
-                                RuntimeModuleImportConflict {
-                                    binding,
-                                    first_import: first,
-                                    second_import: import.specifier.clone(),
-                                },
-                                None,
-                            ));
-                        }
-                        bindings.insert(
-                            format!("{}/{}", namespace, export_name),
-                            export_value.clone(),
-                        );
-                    }
-                }
-                SourceImportKind::Single { name } => {
-                    if matches!(
-                        import.alias,
-                        Some(crate::resolver::SourceImportAlias::Context(_))
-                    ) {
-                        continue;
-                    }
-                    let Some(export_value) = dependency_instance.exports.get(name) else {
-                        return Err(MechError::new(
-                            RuntimeModuleExportNotFound {
-                                dependency: import.specifier.clone(),
-                                export: name.clone(),
-                            },
-                            None,
-                        ));
-                    };
-
-                    let binding = match &import.alias {
-                        Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
-                        Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
-                        None => name.clone(),
-                    };
-
-                    if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone())
-                    {
-                        return Err(MechError::new(
-                            RuntimeModuleImportConflict {
-                                binding: binding.clone(),
-                                first_import: first,
-                                second_import: import.specifier.clone(),
-                            },
-                            None,
-                        ));
-                    }
-                    bindings.insert(binding, export_value.clone());
-                }
-                SourceImportKind::Wildcard => {
-                    for (export_name, export_value) in &dependency_instance.exports {
-                        if let Some(first) =
-                            ownership.insert(export_name.clone(), import.specifier.clone())
-                        {
-                            return Err(MechError::new(
-                                RuntimeModuleImportConflict {
-                                    binding: export_name.clone(),
-                                    first_import: first,
-                                    second_import: import.specifier.clone(),
-                                },
-                                None,
-                            ));
-                        }
-                        bindings.insert(export_name.clone(), export_value.clone());
-                    }
-                }
-            }
-
-            self.emit_event_to_context(
-                context,
-                RuntimeEventKind::ModuleImportLinked {
-                    importer: importer.id,
-                    dependency,
-                    specifier: import.specifier.clone(),
-                },
-            )?;
-        }
-
-        Ok(bindings)
-    }
-}
-
-fn module_source_for_scope(
+  fn run_module_source_on_program(
+    &mut self,
+    context: &mut RuntimeContext,
+    program: &mut MechProgram,
     source: &MechSourceCode,
     scope: &SourceScope,
-) -> MResult<MechSourceCode> {
-    match scope {
-        SourceScope::Program => Ok(source.clone()),
-        SourceScope::Interpreter(interpreter) => {
-            let MechSourceCode::String(source_text) = source else {
-                return Err(MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "run_module_scope",
-                        reason: "interpreter scope execution requires string source".to_string(),
-                    },
-                    None,
-                ));
-            };
+  ) -> MResult<Value> {
+    self.register_runtime_program_host_functions(context, program)?;
 
-            let tree = mech_syntax::parser::parse(source_text.trim())?;
+    let runtime_ptr: *mut MechRuntime = self;
+    let context_ptr: *mut RuntimeContext = context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-            if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
-                return Ok(MechSourceCode::String(source));
-            }
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
 
-            Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_module_scope",
-                    reason: format!(
-                        "interpreter scope `{}` not found",
-                        interpreter.namespace_str
-                    ),
-                },
-                None,
-            ))
-        }
+    // Named interpreter scopes are extracted to bare source by module_source_for_scope.
+    // Once extracted, their declarations are indexed as SourceScope::Program in the
+    // reparsed tree, so direct context handling must use Program scope for that tree.
+    // The surrounding module execution still uses the original scope for imports,
+    // exports, address environment, and ModuleInstance identity.
+    let execution_scope = execution_scope_for_extracted_module_source(scope);
+
+    let result = match source {
+      MechSourceCode::String(source) => {
+        mech_syntax::parser::parse(source.trim())
+          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(&execution_scope)))
+      }
+      other => program.run_source(other),
+    };
+
+    match &result {
+      Ok(_) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
+        )?;
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+      }
     }
+
+    result
+  }
+
+  fn build_address_environment_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    record: &ModuleVersionRecord,
+    scope: &SourceScope,
+    context_registry: &RuntimeContextRegistry,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<HashMap<String, mech_core::ValRef>> {
+    fn address_binding_key(target: &str, name: &str) -> String {
+      format!("@{target}/{name}")
+    }
+
+    let scoped_refs = record
+      .scopes
+      .iter()
+      .find(|metadata| &metadata.scope == scope)
+      .map(|metadata| metadata.address_references.as_slice())
+      .unwrap_or(&[]);
+
+    let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> = HashMap::new();
+    let mut bindings = HashMap::new();
+    for reference in scoped_refs {
+      match resolve_runtime_address_target(record, scope, context_registry, &reference.target) {
+        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+          if !matches!(scope, SourceScope::Program) {
+            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+          }
+          requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
+        }
+        RuntimeAddressTarget::Context(_) => {
+          // Context-addressed resource reads are resolved while executing source
+          // statements so reads observe earlier writes in the same module scope.
+        }
+        RuntimeAddressTarget::Unknown => {
+          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+        }
+      }
+    }
+
+    for (interpreter_scope, requested_refs) in requested_by_scope {
+      let instance = self.execute_module_isolated_for_scope(
+        context,
+        version,
+        &interpreter_scope,
+        seen,
+        module_instances,
+      )?;
+
+      for reference in requested_refs {
+        let Some(export_value) = instance.exports.get(&reference.name) else {
+          return Err(MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: reference.name.clone() }, None));
+        };
+        bindings.insert(address_binding_key(&reference.target, &reference.name), export_value.clone());
+      }
+    }
+
+    Ok(bindings)
+  }
+
+  fn build_import_environment_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    importer: &ModuleVersionRecord,
+    scope: &SourceScope,
+    module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<HashMap<String, mech_core::ValRef>> {
+    let mut bindings = HashMap::new();
+    let mut ownership: HashMap<String, String> = HashMap::new();
+
+    for edge in &importer.import_edges {
+      if &edge.scope != scope {
+        continue;
+      }
+
+      let import = &edge.import;
+      let dependency = edge.dependency;
+
+      let dependency_key = (dependency, SourceScope::Program);
+      let Some(dependency_instance) = module_instances.get(&dependency_key) else {
+        return Err(MechError::new(RuntimeInvalidOperationError { operation: "build_import_environment", reason: format!("dependency instance missing for {}", dependency) }, None));
+      };
+
+      match &import.kind {
+        SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
+          let Some(namespace) = module_namespace_for_import(import) else { continue; };
+          for (export_name, export_value) in &dependency_instance.exports {
+            let binding = format!("{}/{}", namespace, export_name);
+            if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
+              return Err(MechError::new(RuntimeModuleImportConflict { binding, first_import: first, second_import: import.specifier.clone() }, None));
+            }
+            bindings.insert(format!("{}/{}", namespace, export_name), export_value.clone());
+          }
+        }
+        SourceImportKind::Single { name } => {
+          if matches!(import.alias, Some(crate::resolver::SourceImportAlias::Context(_))) {
+            continue;
+          }
+          let Some(export_value) = dependency_instance.exports.get(name) else {
+            return Err(MechError::new(RuntimeModuleExportNotFound { dependency: import.specifier.clone(), export: name.clone() }, None));
+          };
+
+          let binding = match &import.alias {
+            Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
+            Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
+            None => name.clone(),
+          };
+
+          if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
+            return Err(MechError::new(RuntimeModuleImportConflict { binding: binding.clone(), first_import: first, second_import: import.specifier.clone() }, None));
+          }
+          bindings.insert(binding, export_value.clone());
+        }
+        SourceImportKind::Wildcard => {
+          for (export_name, export_value) in &dependency_instance.exports {
+            if let Some(first) = ownership.insert(export_name.clone(), import.specifier.clone()) {
+              return Err(MechError::new(RuntimeModuleImportConflict { binding: export_name.clone(), first_import: first, second_import: import.specifier.clone() }, None));
+            }
+            bindings.insert(export_name.clone(), export_value.clone());
+          }
+        }
+      }
+
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ModuleImportLinked {
+          importer: importer.id,
+          dependency,
+          specifier: import.specifier.clone(),
+        },
+      )?;
+    }
+
+    Ok(bindings)
+  }
+}
+
+
+
+fn module_source_for_scope(
+  source: &MechSourceCode,
+  scope: &SourceScope,
+) -> MResult<MechSourceCode> {
+  match scope {
+    SourceScope::Program => Ok(source.clone()),
+    SourceScope::Interpreter(interpreter) => {
+      let MechSourceCode::String(source_text) = source else {
+        return Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "run_module_scope",
+            reason: "interpreter scope execution requires string source".to_string(),
+          },
+          None,
+        ));
+      };
+
+      let tree = mech_syntax::parser::parse(source_text.trim())?;
+
+      if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
+        return Ok(MechSourceCode::String(source));
+      }
+
+      Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "run_module_scope",
+          reason: format!("interpreter scope `{}` not found", interpreter.namespace_str),
+        },
+        None,
+      ))
+    }
+  }
 }
 
 fn source_from_parsed_fenced_blocks(
-    tree: &mech_core::Program,
-    namespace: u64,
+  tree: &mech_core::Program,
+  namespace: u64,
 ) -> MResult<Option<String>> {
-    let mut blocks = Vec::new();
+  let mut blocks = Vec::new();
 
-    for section in &tree.body.sections {
-        for element in &section.elements {
-            if let mech_core::SectionElement::FencedMechCode(fenced) = element {
-                if fenced.config.namespace == namespace {
-                    let block = source_from_parsed_fenced_code(fenced)?;
-                    blocks.push(block.trim_end().to_string());
-                }
-            }
+  for section in &tree.body.sections {
+    for element in &section.elements {
+      if let mech_core::SectionElement::FencedMechCode(fenced) = element {
+        if fenced.config.namespace == namespace {
+          let block = source_from_parsed_fenced_code(fenced)?;
+          blocks.push(block.trim_end().to_string());
         }
+      }
     }
+  }
 
-    if blocks.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(blocks.join("\n")))
-    }
+  if blocks.is_empty() {
+    Ok(None)
+  } else {
+    Ok(Some(blocks.join("\n")))
+  }
 }
 
-fn source_from_parsed_fenced_code(fenced: &mech_core::FencedMechCode) -> MResult<String> {
-    source_from_tokens(std::slice::from_ref(&fenced.source))
+fn source_from_parsed_fenced_code(
+  fenced: &mech_core::FencedMechCode,
+) -> MResult<String> {
+  source_from_tokens(std::slice::from_ref(&fenced.source))
 }
 
 fn source_from_tokens(tokens: &[mech_core::Token]) -> MResult<String> {
-    if tokens.is_empty() {
-        return Ok(String::new());
+  if tokens.is_empty() {
+    return Ok(String::new());
+  }
+
+  if tokens.iter().any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0) {
+    return Ok(tokens.iter().map(|token| token.to_string()).collect::<Vec<_>>().join(" "));
+  }
+
+  let mut source = String::new();
+  let mut row = tokens[0].src_range.start.row;
+  let mut col = tokens[0].src_range.start.col;
+
+  for token in tokens {
+    let start = &token.src_range.start;
+    while row < start.row {
+      source.push('\n');
+      row += 1;
+      col = 1;
+    }
+    while col < start.col {
+      source.push(' ');
+      col += 1;
     }
 
-    if tokens
-        .iter()
-        .any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0)
-    {
-        return Ok(tokens
-            .iter()
-            .map(|token| token.to_string())
-            .collect::<Vec<_>>()
-            .join(" "));
+    let token_text = token.to_string();
+    for ch in token_text.chars() {
+      source.push(ch);
+      if ch == '\n' {
+        row += 1;
+        col = 1;
+      } else {
+        col += 1;
+      }
     }
+  }
 
-    let mut source = String::new();
-    let mut row = tokens[0].src_range.start.row;
-    let mut col = tokens[0].src_range.start.col;
-
-    for token in tokens {
-        let start = &token.src_range.start;
-        while row < start.row {
-            source.push('\n');
-            row += 1;
-            col = 1;
-        }
-        while col < start.col {
-            source.push(' ');
-            col += 1;
-        }
-
-        let token_text = token.to_string();
-        for ch in token_text.chars() {
-            source.push(ch);
-            if ch == '\n' {
-                row += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-    }
-
-    Ok(source)
+  Ok(source)
 }
 
 fn exports_for_scope<'a>(
-    record: &'a ModuleVersionRecord,
-    scope: &SourceScope,
+  record: &'a ModuleVersionRecord,
+  scope: &SourceScope,
 ) -> &'a [SourceExportDeclaration] {
-    record
-        .scopes
-        .iter()
-        .find(|metadata| &metadata.scope == scope)
-        .map(|metadata| metadata.exports.as_slice())
-        .unwrap_or(&[])
+  record
+    .scopes
+    .iter()
+    .find(|metadata| &metadata.scope == scope)
+    .map(|metadata| metadata.exports.as_slice())
+    .unwrap_or(&[])
 }
+
+
+
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use mech_core::Ref;
+  use super::*;
+  use mech_core::Ref;
 
-    #[test]
-    fn runtime_has_interpreter_finds_root_interpreter() {
-        let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        assert!(runtime.has_interpreter(0));
-    }
+  #[test]
+  fn runtime_has_interpreter_finds_root_interpreter() {
+    let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    assert!(runtime.has_interpreter(0));
+  }
 
-    #[test]
-    fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
-        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        let source = "```mech
+  #[test]
+  fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let source = "```mech
 1
 ```";
-        let _ = runtime.run_string(source).unwrap();
-        let root_id = runtime.program().interpreter().id;
-        let output_id = {
-            let out_values = runtime.program().interpreter().out_values.borrow();
-            *out_values
-                .keys()
-                .next()
-                .expect("expected output value after run_string")
-        };
-        let output = runtime.output_value_for_interpreter(root_id, output_id);
-        assert!(output.is_some());
-    }
+    let _ = runtime.run_string(source).unwrap();
+    let root_id = runtime.program().interpreter().id;
+    let output_id = {
+      let out_values = runtime.program().interpreter().out_values.borrow();
+      *out_values.keys().next().expect("expected output value after run_string")
+    };
+    let output = runtime.output_value_for_interpreter(root_id, output_id);
+    assert!(output.is_some());
+  }
 
-    #[test]
-    fn run_string_with_context_emits_profile_event_when_enabled() {
-        let mut config = RuntimeConfig::default();
-        config.diagnostics.profile_enabled = true;
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
+  #[test]
+  fn run_string_with_context_emits_profile_event_when_enabled() {
+    let mut config = RuntimeConfig::default();
+    config.diagnostics.profile_enabled = true;
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
 
-        runtime
-            .run_string_with_context(&mut context, "1 + 1")
-            .unwrap();
+    runtime.run_string_with_context(&mut context, "1 + 1").unwrap();
 
-        assert!(context.events.iter().any(|event| {
-            matches!(
-              event.kind,
-              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-            )
-        }));
-    }
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+      )
+    }));
+  }
 
-    #[test]
-    fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
-        let mut config = RuntimeConfig::default();
-        config.diagnostics.profile_enabled = true;
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
+  #[test]
+  fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
+    let mut config = RuntimeConfig::default();
+    config.diagnostics.profile_enabled = true;
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
 
-        assert!(
-            runtime
-                .run_string_with_context(&mut context, "1 +")
-                .is_err()
-        );
+    assert!(runtime.run_string_with_context(&mut context, "1 +").is_err());
 
-        assert!(context.events.iter().any(|event| {
-            matches!(
-              event.kind,
-              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-            )
-        }));
-    }
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+      )
+    }));
+  }
 
-    #[test]
-    fn runtime_bind_ans_for_interpreter_binds_ans() {
-        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        let value = Value::U64(Ref::new(42));
-        runtime.bind_ans_for_interpreter(0, &value).unwrap();
-        let ans_id = hash_str("ans");
-        let bound = runtime
-            .program()
-            .interpreter()
-            .symbols()
-            .borrow()
-            .get(ans_id)
-            .map(|value| value.borrow().clone());
-        assert_eq!(bound, Some(value));
-    }
+  #[test]
+  fn runtime_bind_ans_for_interpreter_binds_ans() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let value = Value::U64(Ref::new(42));
+    runtime.bind_ans_for_interpreter(0, &value).unwrap();
+    let ans_id = hash_str("ans");
+    let bound = runtime
+      .program()
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(ans_id)
+      .map(|value| value.borrow().clone());
+    assert_eq!(bound, Some(value));
+  }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1084,6 +1084,19 @@ impl MechRuntime {
       mech_core::Expression::Formula(factor) => {
         self.preflight_factor_context_reads(context, registry, factor)?;
       }
+      mech_core::Expression::FunctionCall(call) => {
+        for (_, expression) in &call.args {
+          self.preflight_expression_context_reads(context, registry, expression)?;
+        }
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        if let Some(args) = &pipe.start.args {
+          for (_, expression) in args {
+            self.preflight_expression_context_reads(context, registry, expression)?;
+          }
+        }
+      }
+      mech_core::Expression::Literal(_) => {}
       mech_core::Expression::Range(range) => {
         self.preflight_factor_context_reads(context, registry, &range.start)?;
         if let Some((_, increment)) = &range.increment {
@@ -1103,7 +1116,31 @@ impl MechRuntime {
           self.preflight_expression_context_reads(context, registry, &arm.expression)?;
         }
       }
-      _ => {}
+      mech_core::Expression::Slice(slice) => {
+        if slice
+          .context
+          .as_ref()
+          .is_some_and(|context| registry.contains(&context.to_string()))
+        {
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "context_read",
+            reason: "context-addressed slices are not supported".to_string(),
+          }, None));
+        }
+        self.preflight_slice_context_reads(context, registry, slice)?;
+      }
+      mech_core::Expression::SetComprehension(comprehension) => {
+        self.preflight_expression_context_reads(context, registry, &comprehension.expression)?;
+        for qualifier in &comprehension.qualifiers {
+          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier)?;
+        }
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        self.preflight_expression_context_reads(context, registry, &comprehension.expression)?;
+        for qualifier in &comprehension.qualifiers {
+          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier)?;
+        }
+      }
     }
     Ok(())
   }
@@ -1152,6 +1189,25 @@ impl MechRuntime {
           self.preflight_expression_context_reads(context, registry, expression)?;
         }
       }
+      mech_core::Structure::Matrix(matrix) => {
+        for row in &matrix.rows {
+          for column in &row.columns {
+            self.preflight_expression_context_reads(context, registry, &column.element)?;
+          }
+        }
+      }
+      mech_core::Structure::Record(record) => {
+        for binding in &record.bindings {
+          self.preflight_expression_context_reads(context, registry, &binding.value)?;
+        }
+      }
+      mech_core::Structure::Table(table) => {
+        for row in &table.rows {
+          for column in &row.columns {
+            self.preflight_expression_context_reads(context, registry, &column.element)?;
+          }
+        }
+      }
       mech_core::Structure::Tuple(tuple) => {
         for expression in &tuple.elements {
           self.preflight_expression_context_reads(context, registry, expression)?;
@@ -1163,6 +1219,62 @@ impl MechRuntime {
       _ => {}
     }
     Ok(())
+  }
+
+  fn preflight_slice_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    slice: &mech_core::Slice,
+  ) -> MResult<()> {
+    for subscript in &slice.subscript {
+      self.preflight_subscript_context_reads(context, registry, subscript)?;
+    }
+    Ok(())
+  }
+
+  fn preflight_subscript_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    subscript: &mech_core::Subscript,
+  ) -> MResult<()> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
+        for subscript in subscripts {
+          self.preflight_subscript_context_reads(context, registry, subscript)?;
+        }
+      }
+      mech_core::Subscript::Formula(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor)?;
+      }
+      mech_core::Subscript::Range(range) => {
+        self.preflight_factor_context_reads(context, registry, &range.start)?;
+        if let Some((_, increment)) = &range.increment {
+          self.preflight_factor_context_reads(context, registry, increment)?;
+        }
+        self.preflight_factor_context_reads(context, registry, &range.terminal)?;
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_comprehension_qualifier_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> MResult<()> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((_, expression))
+      | mech_core::ComprehensionQualifier::Filter(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        self.preflight_expression_context_reads(context, registry, &var_def.expression)
+      }
+    }
   }
 
   fn preflight_context_access(
@@ -1389,26 +1501,30 @@ impl MechRuntime {
       },
     )?;
 
-    self.preflight_context_capabilities(context, tree, &SourceScope::Program)?;
+    let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program) {
+      Ok(()) => {
+        let program_config = self.program.config.clone();
+        let mut program = std::mem::replace(
+          &mut self.program,
+          MechProgram::new(program_config),
+        );
 
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
+        self.register_runtime_program_host_functions(
+          context,
+          &mut program,
+        )?;
 
-    self.register_runtime_program_host_functions(
-      context,
-      &mut program,
-    )?;
+        let runtime_ptr: *mut MechRuntime = self;
+        let context_ptr: *mut RuntimeContext = context;
+        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+        let result = self.run_tree_on_program(context, &mut program, tree, None);
 
-    let result = self.run_tree_on_program(context, &mut program, tree, None);
-
-    self.program = program;
+        self.program = program;
+        result
+      }
+      Err(error) => Err(error),
+    };
 
     match &result {
       Ok(_) => {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -968,6 +968,473 @@ impl MechRuntime {
     }
   }
 
+  fn preflight_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<()> {
+    let registry = self.direct_context_registry_for_scope(tree, scope)?;
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            for (code, _) in codes {
+              self.preflight_code_context_capabilities(context, &registry, code)?;
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, scope) =>
+          {
+            for (code, _) in &fenced.code {
+              self.preflight_code_context_capabilities(context, &registry, code)?;
+            }
+          }
+          _ => {}
+        }
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_code_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    code: &mech_core::MechCode,
+  ) -> MResult<()> {
+    match code {
+      mech_core::MechCode::Statement(statement) => {
+        self.preflight_statement_context_capabilities(context, registry, statement)
+      }
+      mech_core::MechCode::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::MechCode::FsmImplementation(fsm) => {
+        self.preflight_fsm_implementation_context_capabilities(context, registry, fsm)
+      }
+      mech_core::MechCode::FunctionDefine(function) => {
+        self.preflight_function_define_context_capabilities(context, registry, function)
+      }
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Comment(_)
+      | mech_core::MechCode::FsmSpecification(_)
+      | mech_core::MechCode::Error(_, _) => Ok(()),
+    }
+  }
+
+  fn preflight_function_define_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    function: &mech_core::FunctionDefine,
+  ) -> MResult<()> {
+    for statement in &function.statements {
+      self.preflight_statement_context_capabilities(context, registry, statement)?;
+    }
+    for arm in &function.match_arms {
+      self.preflight_pattern_context_reads(context, registry, &arm.pattern)?;
+      self.preflight_expression_context_reads(context, registry, &arm.expression)?;
+    }
+    Ok(())
+  }
+
+  fn preflight_fsm_implementation_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    fsm: &mech_core::FsmImplementation,
+  ) -> MResult<()> {
+    self.preflight_pattern_context_reads(context, registry, &fsm.start)?;
+    for arm in &fsm.arms {
+      match arm {
+        mech_core::FsmArm::Guard(pattern, guards) => {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+          for guard in guards {
+            self.preflight_pattern_context_reads(context, registry, &guard.condition)?;
+            for transition in &guard.transitions {
+              self.preflight_transition_context_capabilities(context, registry, transition)?;
+            }
+          }
+        }
+        mech_core::FsmArm::Transition(pattern, transitions) => {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+          for transition in transitions {
+            self.preflight_transition_context_capabilities(context, registry, transition)?;
+          }
+        }
+        mech_core::FsmArm::Comment(_) => {}
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_transition_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    transition: &mech_core::Transition,
+  ) -> MResult<()> {
+    match transition {
+      mech_core::Transition::Async(pattern)
+      | mech_core::Transition::Next(pattern)
+      | mech_core::Transition::Output(pattern) => {
+        self.preflight_pattern_context_reads(context, registry, pattern)
+      }
+      mech_core::Transition::CodeBlock(code_items) => {
+        for (code, _) in code_items {
+          self.preflight_code_context_capabilities(context, registry, code)?;
+        }
+        Ok(())
+      }
+      mech_core::Transition::Statement(statement) => {
+        self.preflight_statement_context_capabilities(context, registry, statement)
+      }
+    }
+  }
+
+  fn preflight_pattern_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<()> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::Pattern::TupleStruct(tuple_struct) => {
+        for pattern in &tuple_struct.patterns {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Tuple(tuple) => {
+        for pattern in &tuple.0 {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Array(array) => {
+        for pattern in &array.prefix {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        if let Some(spread) = &array.spread {
+          if let Some(binding) = &spread.binding {
+            self.preflight_pattern_context_reads(context, registry, binding)?;
+          }
+        }
+        for pattern in &array.suffix {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Wildcard => Ok(()),
+    }
+  }
+
+  fn preflight_statement_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    statement: &mech_core::Statement,
+  ) -> MResult<()> {
+    match statement {
+      mech_core::Statement::VariableDefine(var_def) => {
+        self.preflight_expression_context_reads(context, registry, &var_def.expression)
+      }
+      mech_core::Statement::VariableAssign(assign) => {
+        self.preflight_expression_context_reads(context, registry, &assign.expression)?;
+        if let Some(context_name) = &assign.target.context {
+          self.preflight_context_access(
+            context,
+            registry,
+            &context_name.to_string(),
+            &assign.target.name.to_string(),
+            RuntimeCapabilityOperation::Write,
+          )?;
+        }
+        Ok(())
+      }
+      mech_core::Statement::ContextSend(send) => {
+        self.preflight_expression_context_reads(context, registry, &send.expression)?;
+        if let Some(context_name) = &send.target.context {
+          self.preflight_context_access(
+            context,
+            registry,
+            &context_name.to_string(),
+            &send.target.name.to_string(),
+            RuntimeCapabilityOperation::Write,
+          )?;
+        }
+        Ok(())
+      }
+      mech_core::Statement::OpAssign(op_assign) => {
+        self.preflight_expression_context_reads(context, registry, &op_assign.expression)
+      }
+      mech_core::Statement::TupleDestructure(tuple_destructure) => self
+        .preflight_expression_context_reads(context, registry, &tuple_destructure.expression),
+      #[cfg(feature = "invariant_define")]
+      mech_core::Statement::InvariantDefine(invariant) => {
+        self.preflight_expression_context_reads(context, registry, &invariant.expression)
+      }
+      _ => Ok(()),
+    }
+  }
+
+  fn preflight_expression_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<()> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        if let Some(context_name) = &var.context {
+          self.preflight_context_access(
+            context,
+            registry,
+            &context_name.to_string(),
+            &var.name.to_string(),
+            RuntimeCapabilityOperation::Read,
+          )?;
+        }
+      }
+      mech_core::Expression::Formula(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor)?;
+      }
+      mech_core::Expression::FunctionCall(call) => {
+        for (_, expression) in &call.args {
+          self.preflight_expression_context_reads(context, registry, expression)?;
+        }
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        if let Some(args) = &pipe.start.args {
+          for (_, expression) in args {
+            self.preflight_expression_context_reads(context, registry, expression)?;
+          }
+        }
+      }
+      mech_core::Expression::Literal(_) => {}
+      mech_core::Expression::Range(range) => {
+        self.preflight_factor_context_reads(context, registry, &range.start)?;
+        if let Some((_, increment)) = &range.increment {
+          self.preflight_factor_context_reads(context, registry, increment)?;
+        }
+        self.preflight_factor_context_reads(context, registry, &range.terminal)?;
+      }
+      mech_core::Expression::Structure(structure) => {
+        self.preflight_structure_context_reads(context, registry, structure)?;
+      }
+      mech_core::Expression::Match(match_expression) => {
+        self.preflight_expression_context_reads(context, registry, &match_expression.source)?;
+        for arm in &match_expression.arms {
+          if let Some(guard) = &arm.guard {
+            self.preflight_expression_context_reads(context, registry, guard)?;
+          }
+          self.preflight_expression_context_reads(context, registry, &arm.expression)?;
+        }
+      }
+      mech_core::Expression::Slice(slice) => {
+        if slice
+          .context
+          .as_ref()
+          .is_some_and(|context| registry.contains(&context.to_string()))
+        {
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "context_read",
+            reason: "context-addressed slices are not supported".to_string(),
+          }, None));
+        }
+        self.preflight_slice_context_reads(context, registry, slice)?;
+      }
+      mech_core::Expression::SetComprehension(comprehension) => {
+        self.preflight_expression_context_reads(context, registry, &comprehension.expression)?;
+        for qualifier in &comprehension.qualifiers {
+          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier)?;
+        }
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        self.preflight_expression_context_reads(context, registry, &comprehension.expression)?;
+        for qualifier in &comprehension.qualifiers {
+          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier)?;
+        }
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_factor_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<()> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::Factor::Negate(factor)
+      | mech_core::Factor::Not(factor)
+      | mech_core::Factor::Parenthetical(factor)
+      | mech_core::Factor::Transpose(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor)
+      }
+      mech_core::Factor::Term(term) => {
+        self.preflight_factor_context_reads(context, registry, &term.lhs)?;
+        for (_, factor) in &term.rhs {
+          self.preflight_factor_context_reads(context, registry, factor)?;
+        }
+        Ok(())
+      }
+    }
+  }
+
+  fn preflight_structure_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    structure: &mech_core::Structure,
+  ) -> MResult<()> {
+    match structure {
+      mech_core::Structure::Map(map) => {
+        for mapping in &map.elements {
+          self.preflight_expression_context_reads(context, registry, &mapping.key)?;
+          self.preflight_expression_context_reads(context, registry, &mapping.value)?;
+        }
+      }
+      mech_core::Structure::Set(set) => {
+        for expression in &set.elements {
+          self.preflight_expression_context_reads(context, registry, expression)?;
+        }
+      }
+      mech_core::Structure::Matrix(matrix) => {
+        for row in &matrix.rows {
+          for column in &row.columns {
+            self.preflight_expression_context_reads(context, registry, &column.element)?;
+          }
+        }
+      }
+      mech_core::Structure::Record(record) => {
+        for binding in &record.bindings {
+          self.preflight_expression_context_reads(context, registry, &binding.value)?;
+        }
+      }
+      mech_core::Structure::Table(table) => {
+        for row in &table.rows {
+          for column in &row.columns {
+            self.preflight_expression_context_reads(context, registry, &column.element)?;
+          }
+        }
+      }
+      mech_core::Structure::Tuple(tuple) => {
+        for expression in &tuple.elements {
+          self.preflight_expression_context_reads(context, registry, expression)?;
+        }
+      }
+      mech_core::Structure::TupleStruct(tuple_struct) => {
+        self.preflight_expression_context_reads(context, registry, &tuple_struct.value)?;
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_slice_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    slice: &mech_core::Slice,
+  ) -> MResult<()> {
+    for subscript in &slice.subscript {
+      self.preflight_subscript_context_reads(context, registry, subscript)?;
+    }
+    Ok(())
+  }
+
+  fn preflight_subscript_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    subscript: &mech_core::Subscript,
+  ) -> MResult<()> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
+        for subscript in subscripts {
+          self.preflight_subscript_context_reads(context, registry, subscript)?;
+        }
+      }
+      mech_core::Subscript::Formula(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor)?;
+      }
+      mech_core::Subscript::Range(range) => {
+        self.preflight_factor_context_reads(context, registry, &range.start)?;
+        if let Some((_, increment)) = &range.increment {
+          self.preflight_factor_context_reads(context, registry, increment)?;
+        }
+        self.preflight_factor_context_reads(context, registry, &range.terminal)?;
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_comprehension_qualifier_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> MResult<()> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((_, expression))
+      | mech_core::ComprehensionQualifier::Filter(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        self.preflight_expression_context_reads(context, registry, &var_def.expression)
+      }
+    }
+  }
+
+  fn preflight_context_access(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    context_name: &str,
+    path: &str,
+    operation: RuntimeCapabilityOperation,
+  ) -> MResult<()> {
+    let Some(binding) = registry.get(context_name) else {
+      return Ok(());
+    };
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    let context_allowed = match operation {
+      RuntimeCapabilityOperation::Read => runtime_context_allows_read(binding, &resolved.context_path),
+      RuntimeCapabilityOperation::Write => runtime_context_allows_write(binding, &resolved.context_path),
+      _ => true,
+    };
+    if !context_allowed {
+      return Ok(());
+    }
+    if !self.grants.allows(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &operation,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(
+        RuntimeCapabilityGrantDenied {
+          subject: context.subject.clone(),
+          resource: resolved.provider_base_uri,
+          operation,
+          path: resolved.provider_path,
+        },
+        None,
+      ));
+    }
+    Ok(())
+  }
+
   fn run_tree_on_program(
     &mut self,
     context: &mut RuntimeContext,
@@ -1066,6 +1533,7 @@ impl MechRuntime {
 
     let result = match mech_syntax::parser::parse(source.trim()) {
       Ok(tree) => {
+        self.preflight_context_capabilities(context, &tree, &SourceScope::Program)?;
         let program_config = self.program.config.clone();
         let mut program = std::mem::replace(
           &mut self.program,
@@ -1152,24 +1620,30 @@ impl MechRuntime {
       },
     )?;
 
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
+    let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program) {
+      Ok(()) => {
+        let program_config = self.program.config.clone();
+        let mut program = std::mem::replace(
+          &mut self.program,
+          MechProgram::new(program_config),
+        );
 
-    self.register_runtime_program_host_functions(
-      context,
-      &mut program,
-    )?;
+        self.register_runtime_program_host_functions(
+          context,
+          &mut program,
+        )?;
 
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+        let runtime_ptr: *mut MechRuntime = self;
+        let context_ptr: *mut RuntimeContext = context;
+        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-    let result = self.run_tree_on_program(context, &mut program, tree, None);
+        let result = self.run_tree_on_program(context, &mut program, tree, None);
 
-    self.program = program;
+        self.program = program;
+        result
+      }
+      Err(error) => Err(error),
+    };
 
     match &result {
       Ok(_) => {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -16,1826 +16,2650 @@ use crate::SourceIndex;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
-  Interpreter(SourceScope),
-  Context(RuntimeContextBinding),
-  Unknown,
+    Interpreter(SourceScope),
+    Context(RuntimeContextBinding),
+    Unknown,
 }
 
 struct ActiveRuntimeProgramHostGuard {
-  previous: Option<RuntimeProgramHostTarget>,
+    previous: Option<RuntimeProgramHostTarget>,
 }
 
 impl ActiveRuntimeProgramHostGuard {
-  fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
-    let previous = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(Some(RuntimeProgramHostTarget { runtime, context }))
-    });
-    Self { previous }
-  }
+    fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
+        let previous = ACTIVE_RUNTIME_PROGRAM_HOST
+            .with(|slot| slot.replace(Some(RuntimeProgramHostTarget { runtime, context })));
+        Self { previous }
+    }
 }
 
 impl Drop for ActiveRuntimeProgramHostGuard {
-  fn drop(&mut self) {
-    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(self.previous.take());
-    });
-  }
+    fn drop(&mut self) {
+        ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+            slot.replace(self.previous.take());
+        });
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAddressedAssignmentUnsupported {
-  pub target: String,
+    pub target: String,
 }
 
 impl MechErrorKind for RuntimeAddressedAssignmentUnsupported {
-  fn name(&self) -> &str { "RuntimeAddressedAssignmentUnsupported" }
+    fn name(&self) -> &str {
+        "RuntimeAddressedAssignmentUnsupported"
+    }
 
-  fn message(&self) -> String {
-    format!("addressed assignment is not supported for `{}`", self.target)
-  }
+    fn message(&self) -> String {
+        format!(
+            "addressed assignment is not supported for `{}`",
+            self.target
+        )
+    }
 }
-
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedContextResourceRequest {
-  provider_base_uri: String,
-  provider_path: String,
-  context_path: String,
+    provider_base_uri: String,
+    provider_path: String,
+    context_path: String,
 }
 
 fn join_resource_paths(prefix: &str, child: &str) -> String {
-  let prefix = prefix.trim_matches('/');
-  let child = child.trim_matches('/');
-  match (prefix.is_empty(), child.is_empty()) {
-    (true, true) => String::new(),
-    (true, false) => child.to_string(),
-    (false, true) => prefix.to_string(),
-    (false, false) => format!("{}/{}", prefix, child),
-  }
+    let prefix = prefix.trim_matches('/');
+    let child = child.trim_matches('/');
+    match (prefix.is_empty(), child.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => child.to_string(),
+        (false, true) => prefix.to_string(),
+        (false, false) => format!("{}/{}", prefix, child),
+    }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
-  mech_core::Identifier {
-    name: mech_core::Token::new(
-      mech_core::TokenKind::Identifier,
-      mech_core::SourceRange::default(),
-      name.chars().collect(),
-    ),
-  }
+    mech_core::Identifier {
+        name: mech_core::Token::new(
+            mech_core::TokenKind::Identifier,
+            mech_core::SourceRange::default(),
+            name.chars().collect(),
+        ),
+    }
 }
 
-
 fn execution_scope_for_extracted_module_source(scope: &SourceScope) -> SourceScope {
-  match scope {
-    SourceScope::Program => SourceScope::Program,
-    SourceScope::Interpreter(_) => SourceScope::Program,
-  }
+    match scope {
+        SourceScope::Program => SourceScope::Program,
+        SourceScope::Interpreter(_) => SourceScope::Program,
+    }
 }
 
 fn resolve_runtime_address_target(
-  record: &ModuleVersionRecord,
-  scope: &SourceScope,
-  context_registry: &RuntimeContextRegistry,
-  target: &str,
+    record: &ModuleVersionRecord,
+    scope: &SourceScope,
+    context_registry: &RuntimeContextRegistry,
+    target: &str,
 ) -> RuntimeAddressTarget {
-  if !matches!(scope, SourceScope::Program) {
+    if !matches!(scope, SourceScope::Program) {
+        if let Some(binding) = context_registry.get(target) {
+            return RuntimeAddressTarget::Context(binding.clone());
+        }
+    }
+
+    for metadata in &record.scopes {
+        if let SourceScope::Interpreter(interpreter) = &metadata.scope {
+            if interpreter.namespace_str == target {
+                return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
+            }
+        }
+    }
+
     if let Some(binding) = context_registry.get(target) {
-      return RuntimeAddressTarget::Context(binding.clone());
+        return RuntimeAddressTarget::Context(binding.clone());
     }
-  }
 
-  for metadata in &record.scopes {
-    if let SourceScope::Interpreter(interpreter) = &metadata.scope {
-      if interpreter.namespace_str == target {
-        return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
-      }
-    }
-  }
-
-  if let Some(binding) = context_registry.get(target) {
-    return RuntimeAddressTarget::Context(binding.clone());
-  }
-
-  RuntimeAddressTarget::Unknown
+    RuntimeAddressTarget::Unknown
 }
 
 fn context_registry_for_scope(
-  record: &ModuleVersionRecord,
-  scope: &SourceScope,
+    record: &ModuleVersionRecord,
+    scope: &SourceScope,
 ) -> MResult<RuntimeContextRegistry> {
-  let declarations = record
-    .scopes
-    .iter()
-    .find(|metadata| &metadata.scope == scope)
-    .map(|metadata| metadata.contexts.as_slice())
-    .unwrap_or(&[]);
-  RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
+    let declarations = record
+        .scopes
+        .iter()
+        .find(|metadata| &metadata.scope == scope)
+        .map(|metadata| metadata.contexts.as_slice())
+        .unwrap_or(&[]);
+    RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
 }
 
 fn runtime_context_base_uri(binding: &RuntimeContextBinding) -> String {
-  match &binding.base {
-    RuntimeContextBase::ResourceUri(uri) => uri.clone(),
-  }
+    match &binding.base {
+        RuntimeContextBase::ResourceUri(uri) => uri.clone(),
+    }
 }
 
-fn runtime_context_allows_read(
-  binding: &RuntimeContextBinding,
-  path: &str,
-) -> bool {
-  binding.capabilities.iter().any(|capability| {
-    if capability.operation != "read" {
-      return false;
-    }
+fn runtime_context_allows_read(binding: &RuntimeContextBinding, path: &str) -> bool {
+    binding.capabilities.iter().any(|capability| {
+        if capability.operation != "read" {
+            return false;
+        }
 
-    match &capability.scope {
-      RuntimeContextCapabilityScope::Wildcard => true,
-      RuntimeContextCapabilityScope::Path(exact) => {
-        if exact == path {
-          return true;
+        match &capability.scope {
+            RuntimeContextCapabilityScope::Wildcard => true,
+            RuntimeContextCapabilityScope::Path(exact) => {
+                if exact == path {
+                    return true;
+                }
+                if let Some(prefix) = exact.strip_suffix("/*") {
+                    let required_prefix = format!("{}/", prefix);
+                    return path.starts_with(&required_prefix);
+                }
+                false
+            }
         }
-        if let Some(prefix) = exact.strip_suffix("/*") {
-          let required_prefix = format!("{}/", prefix);
-          return path.starts_with(&required_prefix);
-        }
-        false
-      }
-    }
-  })
+    })
 }
 
 #[allow(dead_code)]
-fn runtime_context_allows_write(
-  binding: &RuntimeContextBinding,
-  path: &str,
-) -> bool {
-  binding.capabilities.iter().any(|capability| {
-    if capability.operation != "write" {
-      return false;
-    }
+fn runtime_context_allows_write(binding: &RuntimeContextBinding, path: &str) -> bool {
+    binding.capabilities.iter().any(|capability| {
+        if capability.operation != "write" {
+            return false;
+        }
 
-    match &capability.scope {
-      RuntimeContextCapabilityScope::Wildcard => true,
-      RuntimeContextCapabilityScope::Path(exact) => {
-        if exact == path {
-          return true;
+        match &capability.scope {
+            RuntimeContextCapabilityScope::Wildcard => true,
+            RuntimeContextCapabilityScope::Path(exact) => {
+                if exact == path {
+                    return true;
+                }
+                if let Some(prefix) = exact.strip_suffix("/*") {
+                    let required_prefix = format!("{}/", prefix);
+                    return path.starts_with(&required_prefix);
+                }
+                false
+            }
         }
-        if let Some(prefix) = exact.strip_suffix("/*") {
-          let required_prefix = format!("{}/", prefix);
-          return path.starts_with(&required_prefix);
-        }
-        false
-      }
-    }
-  })
+    })
 }
 
-
-
 fn single_code_program(
-  code: mech_core::MechCode,
-  comment: Option<mech_core::Comment>,
+    code: mech_core::MechCode,
+    comment: Option<mech_core::Comment>,
 ) -> mech_core::Program {
-  mech_core::Program {
-    title: None,
-    body: mech_core::Body {
-      sections: vec![mech_core::Section {
-        subtitle: None,
-        elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
-      }],
-    },
-  }
+    mech_core::Program {
+        title: None,
+        body: mech_core::Body {
+            sections: vec![mech_core::Section {
+                subtitle: None,
+                elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
+            }],
+        },
+    }
 }
 
 fn bind_runtime_value_on_program(
-  program: &mut MechProgram,
-  var: &mech_core::Var,
-  value: Value,
-  mutable: bool,
+    program: &mut MechProgram,
+    var: &mech_core::Var,
+    value: Value,
+    mutable: bool,
 ) -> MResult<()> {
-  if var.context.is_some() {
-    return Err(MechError::new(
-      RuntimeAddressedAssignmentUnsupported { target: var.name.to_string() },
-      None,
-    ).with_compiler_loc().with_tokens(var.tokens()));
-  }
-  let (id, name) = (var.name.hash(), var.name.to_string());
-  let symbols = program.interpreter_mut().symbols();
-  let mut symbols = symbols.borrow_mut();
-  symbols.insert(id, value, mutable);
-  symbols.dictionary.borrow_mut().insert(id, name);
-  Ok(())
+    if var.context.is_some() {
+        return Err(MechError::new(
+            RuntimeAddressedAssignmentUnsupported {
+                target: var.name.to_string(),
+            },
+            None,
+        )
+        .with_compiler_loc()
+        .with_tokens(var.tokens()));
+    }
+    let (id, name) = (var.name.hash(), var.name.to_string());
+    let symbols = program.interpreter_mut().symbols();
+    let mut symbols = symbols.borrow_mut();
+    symbols.insert(id, value, mutable);
+    symbols.dictionary.borrow_mut().insert(id, name);
+    Ok(())
 }
 
 fn resolve_runtime_value(value: Value) -> Value {
-  match value {
-    Value::MutableReference(value) => value.borrow().clone(),
-    other => other,
-  }
+    match value {
+        Value::MutableReference(value) => value.borrow().clone(),
+        other => other,
+    }
 }
 
-
-
 impl MechRuntime {
-  fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
-    matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
-  }
-
-
-  fn context_declarations_from_index_scope(
-    &self,
-    index: &SourceIndex,
-    scope: &SourceScope,
-  ) -> MResult<Vec<crate::SourceContextDeclaration>> {
-    let mut declarations = index
-      .contexts
-      .iter()
-      .filter(|ctx| &ctx.occurrence.scope == scope)
-      .map(|ctx| ctx.declaration.clone())
-      .collect::<Vec<_>>();
-
-    for import in index.imports.iter().filter(|import| &import.occurrence.scope == scope) {
-      let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
-        continue;
-      };
-      let module = import.declaration.module.as_deref().ok_or_else(|| {
-        MechError::new(RuntimeInvalidOperationError {
-          operation: "materialize_direct_manifest_context_imports",
-          reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
-        }, None)
-      })?;
-      let item = import.declaration.item.as_deref().ok_or_else(|| {
-        MechError::new(RuntimeInvalidOperationError {
-          operation: "materialize_direct_manifest_context_imports",
-          reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
-        }, None)
-      })?;
-      let export = self.module_manifests.context_export(module, item)?;
-      declarations.push(crate::SourceContextDeclaration {
-        name: alias.clone(),
-        base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
-        capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
-          operation: operation.clone(),
-          scope: crate::SourceContextCapabilityScope::Wildcard,
-        }).collect(),
-      });
+    fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
+        matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
     }
 
-    Ok(declarations)
-  }
+    fn context_declarations_from_index_scope(
+        &self,
+        index: &SourceIndex,
+        scope: &SourceScope,
+    ) -> MResult<Vec<crate::SourceContextDeclaration>> {
+        let mut declarations = index
+            .contexts
+            .iter()
+            .filter(|ctx| &ctx.occurrence.scope == scope)
+            .map(|ctx| ctx.declaration.clone())
+            .collect::<Vec<_>>();
 
-  fn direct_context_registry_for_scope(
-    &self,
-    tree: &mech_core::Program,
-    scope: &SourceScope,
-  ) -> MResult<RuntimeContextRegistry> {
-    let index = SourceIndex::from_program(tree);
-    let declarations = self.context_declarations_from_index_scope(&index, scope)?;
-    RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
-  }
-
-  fn resolve_context_resource_request(
-    &self,
-    binding: &RuntimeContextBinding,
-    requested_path: &str,
-  ) -> MResult<ResolvedContextResourceRequest> {
-    let context_base_uri = runtime_context_base_uri(binding).trim_end_matches('/').to_string();
-    let provider_base_uri = self
-      .resources
-      .provider_base_uri_for(&context_base_uri)?
-      .unwrap_or_else(|| context_base_uri.clone());
-    let context_root = context_base_uri
-      .strip_prefix(&provider_base_uri)
-      .unwrap_or_default()
-      .trim_matches('/');
-    Ok(ResolvedContextResourceRequest {
-      provider_base_uri,
-      provider_path: join_resource_paths(context_root, requested_path),
-      context_path: requested_path.trim_matches('/').to_string(),
-    })
-  }
-
-  fn read_context_resource(
-    &self,
-    context: &RuntimeContext,
-    binding: &RuntimeContextBinding,
-    path: &str,
-  ) -> MResult<Value> {
-    let resolved = self.resolve_context_resource_request(binding, path)?;
-    if !runtime_context_allows_read(binding, &resolved.context_path) {
-      return Err(MechError::new(RuntimeResourceCapabilityDenied {
-        context_name: binding.name.clone(),
-        operation: "read".to_string(),
-        path: resolved.context_path,
-      }, None));
-    }
-    if !self.grants.allows(
-      &context.subject,
-      &resolved.provider_base_uri,
-      &RuntimeCapabilityOperation::Read,
-      &resolved.provider_path,
-    ) {
-      return Err(MechError::new(RuntimeCapabilityGrantDenied {
-        subject: context.subject.clone(),
-        resource: resolved.provider_base_uri,
-        operation: RuntimeCapabilityOperation::Read,
-        path: resolved.provider_path,
-      }, None));
-    }
-    self.resources.read(RuntimeResourceReadRequest {
-      base_uri: resolved.provider_base_uri,
-      path: resolved.provider_path,
-      context_name: binding.name.clone(),
-    })
-  }
-
-  fn write_context_resource(
-    &mut self,
-    context: &RuntimeContext,
-    binding: &RuntimeContextBinding,
-    path: &str,
-    value: Value,
-    intent: RuntimeResourceWriteIntent,
-  ) -> MResult<()> {
-    let resolved = self.resolve_context_resource_request(binding, path)?;
-    if !runtime_context_allows_write(binding, &resolved.context_path) {
-      return Err(MechError::new(RuntimeResourceCapabilityDenied {
-        context_name: binding.name.clone(),
-        operation: "write".to_string(),
-        path: resolved.context_path,
-      }, None));
-    }
-    if !self.grants.allows(
-      &context.subject,
-      &resolved.provider_base_uri,
-      &RuntimeCapabilityOperation::Write,
-      &resolved.provider_path,
-    ) {
-      return Err(MechError::new(RuntimeCapabilityGrantDenied {
-        subject: context.subject.clone(),
-        resource: resolved.provider_base_uri,
-        operation: RuntimeCapabilityOperation::Write,
-        path: resolved.provider_path,
-      }, None));
-    }
-    self.resources.write(RuntimeResourceWriteRequest {
-      base_uri: resolved.provider_base_uri,
-      path: resolved.provider_path,
-      context_name: binding.name.clone(),
-      value,
-      intent,
-    })
-  }
-
-  fn bind_context_read_temp(
-    &self,
-    program: &mut MechProgram,
-    target: &str,
-    path: &str,
-    value: Value,
-  ) -> MResult<mech_core::Expression> {
-    let name = format!("mech-internal-context-{}-{}", hash_str(target), hash_str(path));
-    let var = mech_core::Var {
-      name: identifier_from_str(&name),
-      context: None,
-      kind: None,
-    };
-    bind_runtime_value_on_program(program, &var, resolve_runtime_value(value), false)?;
-    Ok(mech_core::Expression::Var(var))
-  }
-
-  fn resolve_context_reads_in_expression(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    expression: &mech_core::Expression,
-  ) -> MResult<mech_core::Expression> {
-    match expression {
-      mech_core::Expression::Var(var) => {
-        let Some(var_context) = &var.context else {
-          return Ok(expression.clone());
-        };
-        let target = var_context.to_string();
-        let Some(binding) = registry.get(&target) else {
-          return Ok(expression.clone());
-        };
-        let path = var.name.to_string();
-        let value = self.read_context_resource(context, binding, &path)?;
-        self.bind_context_read_temp(program, &target, &path, value)
-      }
-      mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
-        self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-      )),
-      mech_core::Expression::FunctionCall(call) => {
-        let args = call.args.iter().map(|(name, expression)| {
-          Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
-        }).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
-      }
-      mech_core::Expression::FsmPipe(pipe) => {
-        let mut pipe = pipe.clone();
-        if let Some(args) = &pipe.start.args {
-          pipe.start.args = Some(args.iter().map(|(name, expression)| {
-            Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
-          }).collect::<MResult<Vec<_>>>()?);
-        }
-        Ok(mech_core::Expression::FsmPipe(pipe))
-      }
-      mech_core::Expression::Literal(_) => Ok(expression.clone()),
-      mech_core::Expression::Match(match_expression) => {
-        let mut match_expression = match_expression.as_ref().clone();
-        match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
-        match_expression.arms = match_expression.arms.iter().map(|arm| {
-          Ok(mech_core::MatchArm {
-            pattern: arm.pattern.clone(),
-            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
-            expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
-          })
-        }).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::Match(Box::new(match_expression)))
-      }
-      mech_core::Expression::Range(range) => {
-        let mut range = range.as_ref().clone();
-        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-        range.increment = match &range.increment {
-          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
-          None => None,
-        };
-        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
-        Ok(mech_core::Expression::Range(Box::new(range)))
-      }
-      mech_core::Expression::Slice(slice) => {
-        if slice
-          .context
-          .as_ref()
-          .is_some_and(|context| registry.contains(&context.to_string()))
+        for import in index
+            .imports
+            .iter()
+            .filter(|import| &import.occurrence.scope == scope)
         {
-          return Err(MechError::new(RuntimeInvalidOperationError {
-            operation: "context_read",
-            reason: "context-addressed slices are not supported".to_string(),
-          }, None));
+            let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
+                continue;
+            };
+            let module = import.declaration.module.as_deref().ok_or_else(|| {
+                MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "materialize_direct_manifest_context_imports",
+                        reason: format!(
+                            "context import `{}` is missing module metadata",
+                            import.declaration.specifier
+                        ),
+                    },
+                    None,
+                )
+            })?;
+            let item = import.declaration.item.as_deref().ok_or_else(|| {
+                MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "materialize_direct_manifest_context_imports",
+                        reason: format!(
+                            "context import `{}` is missing item metadata",
+                            import.declaration.specifier
+                        ),
+                    },
+                    None,
+                )
+            })?;
+            let export = self.module_manifests.context_export(module, item)?;
+            declarations.push(crate::SourceContextDeclaration {
+                name: alias.clone(),
+                base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
+                capabilities: export
+                    .operations
+                    .iter()
+                    .map(|operation| crate::SourceContextCapability {
+                        operation: operation.clone(),
+                        scope: crate::SourceContextCapabilityScope::Wildcard,
+                    })
+                    .collect(),
+            });
         }
-        Ok(mech_core::Expression::Slice(
-          self.resolve_context_reads_in_slice(context, program, registry, slice)?,
-        ))
-      }
-      mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
-        self.resolve_context_reads_in_structure(context, program, registry, structure)?,
-      )),
-      mech_core::Expression::SetComprehension(comprehension) => {
-        let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
-        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
-      }
-      mech_core::Expression::MatrixComprehension(comprehension) => {
-        let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
-        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
-      }
+
+        Ok(declarations)
     }
-  }
 
-  fn resolve_context_reads_in_factor(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-  ) -> MResult<mech_core::Factor> {
-    match factor {
-      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
-      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Term(term) => {
-        let rhs = term.rhs.iter().map(|(operator, factor)| {
-          Ok((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, factor)?))
-        }).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
-          lhs: self.resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
-          rhs,
-        })))
-      }
+    fn direct_context_registry_for_scope(
+        &self,
+        tree: &mech_core::Program,
+        scope: &SourceScope,
+    ) -> MResult<RuntimeContextRegistry> {
+        let index = SourceIndex::from_program(tree);
+        let declarations = self.context_declarations_from_index_scope(&index, scope)?;
+        RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
     }
-  }
 
-  fn resolve_context_reads_in_slice(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    slice: &mech_core::Slice,
-  ) -> MResult<mech_core::Slice> {
-    Ok(mech_core::Slice {
-      name: slice.name.clone(),
-      context: slice.context.clone(),
-      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
-    })
-  }
-
-  fn resolve_context_reads_in_subscript(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    subscript: &mech_core::Subscript,
-  ) -> MResult<mech_core::Subscript> {
-    match subscript {
-      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
-      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
-      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(context, program, registry, factor)?)),
-      mech_core::Subscript::Range(range) => {
-        let mut range = range.clone();
-        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-        range.increment = match &range.increment {
-          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
-          None => None,
-        };
-        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
-        Ok(mech_core::Subscript::Range(range))
-      }
-      _ => Ok(subscript.clone()),
+    fn resolve_context_resource_request(
+        &self,
+        binding: &RuntimeContextBinding,
+        requested_path: &str,
+    ) -> MResult<ResolvedContextResourceRequest> {
+        let context_base_uri = runtime_context_base_uri(binding)
+            .trim_end_matches('/')
+            .to_string();
+        let provider_base_uri = self
+            .resources
+            .provider_base_uri_for(&context_base_uri)?
+            .unwrap_or_else(|| context_base_uri.clone());
+        let context_root = context_base_uri
+            .strip_prefix(&provider_base_uri)
+            .unwrap_or_default()
+            .trim_matches('/');
+        Ok(ResolvedContextResourceRequest {
+            provider_base_uri,
+            provider_path: join_resource_paths(context_root, requested_path),
+            context_path: requested_path.trim_matches('/').to_string(),
+        })
     }
-  }
 
-  fn resolve_context_reads_in_structure(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    structure: &mech_core::Structure,
-  ) -> MResult<mech_core::Structure> {
-    match structure {
-      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
-      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
-        elements: map.elements.iter().map(|mapping| Ok(mech_core::Mapping {
-          key: self.resolve_context_reads_in_expression(context, program, registry, &mapping.key)?,
-          value: self.resolve_context_reads_in_expression(context, program, registry, &mapping.value)?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
-        rows: matrix.rows.iter().map(|row| Ok(mech_core::MatrixRow {
-          columns: row.columns.iter().map(|column| Ok(mech_core::MatrixColumn {
-            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
-          })).collect::<MResult<Vec<_>>>()?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
-        bindings: record.bindings.iter().map(|binding| Ok(mech_core::Binding {
-          name: binding.name.clone(),
-          kind: binding.kind.clone(),
-          value: self.resolve_context_reads_in_expression(context, program, registry, &binding.value)?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
-        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
-        header: table.header.clone(),
-        rows: table.rows.iter().map(|row| Ok(mech_core::TableRow {
-          columns: row.columns.iter().map(|column| Ok(mech_core::TableColumn {
-            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
-          })).collect::<MResult<Vec<_>>>()?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
-        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::TupleStruct(tuple_struct) => Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
-        name: tuple_struct.name.clone(),
-        value: Box::new(self.resolve_context_reads_in_expression(context, program, registry, &tuple_struct.value)?),
-      })),
-    }
-  }
-
-  fn resolve_context_reads_in_comprehension_qualifier(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    qualifier: &mech_core::ComprehensionQualifier,
-  ) -> MResult<mech_core::ComprehensionQualifier> {
-    match qualifier {
-      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => Ok(mech_core::ComprehensionQualifier::Generator((pattern.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
-      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(context, program, registry, expression)?)),
-      mech_core::ComprehensionQualifier::Let(var_def) => {
-        let mut var_def = var_def.clone();
-        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
-        Ok(mech_core::ComprehensionQualifier::Let(var_def))
-      }
-    }
-  }
-
-  fn flush_direct_execution(
-    &mut self,
-    program: &mut MechProgram,
-    pending: &mut Vec<mech_core::SectionElement>,
-    result: &mut Value,
-  ) -> MResult<()> {
-    if pending.is_empty() {
-      return Ok(());
-    }
-    let tree = mech_core::Program {
-      title: None,
-      body: mech_core::Body {
-        sections: vec![mech_core::Section {
-          subtitle: None,
-          elements: std::mem::take(pending),
-        }],
-      },
-    };
-    *result = program.run_tree(&tree)?;
-    Ok(())
-  }
-
-  fn executable_fence_for_scope(
-    fenced: &mech_core::FencedMechCode,
-    scope: &SourceScope,
-  ) -> bool {
-    match scope {
-      SourceScope::Program => fenced.config.namespace_str.is_empty(),
-      SourceScope::Interpreter(interpreter) => fenced.config.namespace_str == interpreter.namespace_str,
-    }
-  }
-
-  fn resolve_context_reads_in_pattern(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    pattern: &mech_core::Pattern,
-  ) -> MResult<mech_core::Pattern> {
-    match pattern {
-      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
-        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-      )),
-      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
-        name: tuple_struct.name.clone(),
-        patterns: tuple_struct.patterns.iter()
-          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-        tuple.0.iter()
-          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-          .collect::<MResult<Vec<_>>>()?,
-      ))),
-      mech_core::Pattern::Array(array) => {
-        let spread = if let Some(spread) = &array.spread {
-          Some(mech_core::PatternArraySpread {
-            kind: spread.kind.clone(),
-            binding: spread.binding.as_ref()
-              .map(|binding| self.resolve_context_reads_in_pattern(context, program, registry, binding).map(Box::new))
-              .transpose()?,
-          })
-        } else {
-          None
-        };
-        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
-          prefix: array.prefix.iter()
-            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-          spread,
-          suffix: array.suffix.iter()
-            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-        }))
-      }
-      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
-    }
-  }
-
-  fn resolve_context_reads_in_transition(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    transition: &mech_core::Transition,
-  ) -> MResult<mech_core::Transition> {
-    match transition {
-      mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
-        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-      )),
-      mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
-        code_items.iter()
-          .map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone())))
-          .collect::<MResult<Vec<_>>>()?,
-      )),
-      mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
-        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-      )),
-      mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
-        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-      )),
-      mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
-        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-      )),
-    }
-  }
-
-  fn resolve_context_reads_in_fsm_implementation(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    fsm: &mech_core::FsmImplementation,
-  ) -> MResult<mech_core::FsmImplementation> {
-    let arms = fsm.arms.iter().map(|arm| {
-      match arm {
-        mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
-          self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-          guards.iter().map(|guard| Ok(mech_core::Guard {
-            condition: self.resolve_context_reads_in_pattern(context, program, registry, &guard.condition)?,
-            transitions: guard.transitions.iter()
-              .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
-              .collect::<MResult<Vec<_>>>()?,
-          })).collect::<MResult<Vec<_>>>()?,
-        )),
-        mech_core::FsmArm::Transition(pattern, transitions) => Ok(mech_core::FsmArm::Transition(
-          self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-          transitions.iter()
-            .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
-            .collect::<MResult<Vec<_>>>()?,
-        )),
-        mech_core::FsmArm::Comment(comment) => Ok(mech_core::FsmArm::Comment(comment.clone())),
-      }
-    }).collect::<MResult<Vec<_>>>()?;
-
-    Ok(mech_core::FsmImplementation {
-      name: fsm.name.clone(),
-      input: fsm.input.clone(),
-      start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
-      arms,
-    })
-  }
-
-  fn resolve_context_reads_in_function_define(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    function: &mech_core::FunctionDefine,
-  ) -> MResult<mech_core::FunctionDefine> {
-    Ok(mech_core::FunctionDefine {
-      name: function.name.clone(),
-      input: function.input.clone(),
-      output: function.output.clone(),
-      statements: function.statements.iter()
-        .map(|statement| self.resolve_context_reads_in_statement(context, program, registry, statement))
-        .collect::<MResult<Vec<_>>>()?,
-      match_arms: function.match_arms.iter().map(|arm| Ok(mech_core::FunctionMatchArm {
-        pattern: self.resolve_context_reads_in_pattern(context, program, registry, &arm.pattern)?,
-        expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
-      })).collect::<MResult<Vec<_>>>()?,
-    })
-  }
-
-  fn resolve_context_reads_in_mech_code(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    code: &mech_core::MechCode,
-  ) -> MResult<mech_core::MechCode> {
-    match code {
-      mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
-        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-      )),
-      mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
-        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-      )),
-      mech_core::MechCode::FsmImplementation(fsm) => Ok(mech_core::MechCode::FsmImplementation(
-        self.resolve_context_reads_in_fsm_implementation(context, program, registry, fsm)?,
-      )),
-      mech_core::MechCode::FsmSpecification(spec) => Ok(mech_core::MechCode::FsmSpecification(spec.clone())),
-      mech_core::MechCode::FunctionDefine(function) => Ok(mech_core::MechCode::FunctionDefine(
-        self.resolve_context_reads_in_function_define(context, program, registry, function)?,
-      )),
-      mech_core::MechCode::Import(_)
-      | mech_core::MechCode::Comment(_)
-      | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
-    }
-  }
-
-  fn resolve_context_reads_in_statement(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    statement: &mech_core::Statement,
-  ) -> MResult<mech_core::Statement> {
-    match statement {
-      mech_core::Statement::VariableDefine(var_def) => {
-        let mut var_def = var_def.clone();
-        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
-        Ok(mech_core::Statement::VariableDefine(var_def))
-      }
-      mech_core::Statement::VariableAssign(assign) => {
-        let mut assign = assign.clone();
-        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
-        Ok(mech_core::Statement::VariableAssign(assign))
-      }
-      mech_core::Statement::OpAssign(op_assign) => {
-        let mut op_assign = op_assign.clone();
-        op_assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &op_assign.expression)?;
-        Ok(mech_core::Statement::OpAssign(op_assign))
-      }
-      mech_core::Statement::TupleDestructure(tuple_destructure) => {
-        let mut tuple_destructure = tuple_destructure.clone();
-        tuple_destructure.expression = self.resolve_context_reads_in_expression(context, program, registry, &tuple_destructure.expression)?;
-        Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
-      }
-      #[cfg(feature = "invariant_define")]
-      mech_core::Statement::InvariantDefine(invariant) => {
-        let mut invariant = invariant.clone();
-        invariant.expression = self.resolve_context_reads_in_expression(context, program, registry, &invariant.expression)?;
-        Ok(mech_core::Statement::InvariantDefine(invariant))
-      }
-      _ => Ok(statement.clone()),
-    }
-  }
-
-  fn push_direct_code(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    pending: &mut Vec<mech_core::SectionElement>,
-    pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
-    result: &mut Value,
-    skip_non_context_imports: bool,
-    code: &mech_core::MechCode,
-    comment: &Option<mech_core::Comment>,
-  ) -> MResult<()> {
-    match code {
-      mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => Ok(()),
-      mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
-      mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
-      | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
-      mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
-        if !pending_codes.is_empty() {
-          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+    fn read_context_resource(
+        &self,
+        context: &RuntimeContext,
+        binding: &RuntimeContextBinding,
+        path: &str,
+    ) -> MResult<Value> {
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        if !runtime_context_allows_read(binding, &resolved.context_path) {
+            return Err(MechError::new(
+                RuntimeResourceCapabilityDenied {
+                    context_name: binding.name.clone(),
+                    operation: "read".to_string(),
+                    path: resolved.context_path,
+                },
+                None,
+            ));
         }
-        self.flush_direct_execution(program, pending, result)?;
-        let id = hash_str(&export.name.to_string());
-        if let Some(value) = program.interpreter().symbols().borrow().get(id) {
-          *result = resolve_runtime_value(value.borrow().clone());
-        } else {
-          *result = Value::Empty;
+        if !self.grants.allows(
+            &context.subject,
+            &resolved.provider_base_uri,
+            &RuntimeCapabilityOperation::Read,
+            &resolved.provider_path,
+        ) {
+            return Err(MechError::new(
+                RuntimeCapabilityGrantDenied {
+                    subject: context.subject.clone(),
+                    resource: resolved.provider_base_uri,
+                    operation: RuntimeCapabilityOperation::Read,
+                    path: resolved.provider_path,
+                },
+                None,
+            ));
         }
-        Ok(())
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-        if let Some(context_name) = &var_def.var.context {
-          let target = context_name.to_string();
-          if let Some(binding) = registry.get(&target).cloned() {
-            if !pending_codes.is_empty() {
-              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
-            }
-            self.flush_direct_execution(program, pending, result)?;
-            return Err(MechError::new(RuntimeInvalidOperationError {
-              operation: "direct_context_define",
-              reason: format!(
-                "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
-                binding.name,
-                var_def.var.name.to_string()
-              ),
-            }, None));
-          }
-        }
-        let code = self.resolve_context_reads_in_mech_code(
-          context,
-          program,
-          registry,
-          &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def.clone())),
-        )?;
-        pending_codes.push((code, comment.clone()));
-        Ok(())
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
-        // Context sends are executed only at module top level for now. Parser paths
-        // intentionally reject nested sends until interpreter/effect execution can
-        // support them in functions and state machines.
-        let Some(context_name) = &send.target.context else {
-          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: send.target.name.to_string() }, None));
-        };
-        let target = context_name.to_string();
-        let Some(binding) = registry.get(&target).cloned() else {
-          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target }, None));
-        };
-        if !pending_codes.is_empty() {
-          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
-        }
-        self.flush_direct_execution(program, pending, result)?;
-        let expression = self.resolve_context_reads_in_expression(context, program, registry, &send.expression)?;
-        let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
-        self.write_context_resource(context, &binding, &send.target.name.to_string(), value.clone(), RuntimeResourceWriteIntent::Send)?;
-        *result = value;
-        return Ok(());
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-        if let Some(context_name) = &assign.target.context {
-          let target = context_name.to_string();
-          if let Some(binding) = registry.get(&target).cloned() {
-            if !pending_codes.is_empty() {
-              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
-            }
-            self.flush_direct_execution(program, pending, result)?;
-            let expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
-            let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
-            self.write_context_resource(context, &binding, &assign.target.name.to_string(), value.clone(), RuntimeResourceWriteIntent::Assign)?;
-            *result = value;
-            return Ok(());
-          }
-        }
-        let code = self.resolve_context_reads_in_mech_code(
-          context,
-          program,
-          registry,
-          &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign.clone())),
-        )?;
-        pending_codes.push((code, comment.clone()));
-        Ok(())
-      }
-      _ => {
-        let code = self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
-        pending_codes.push((code, comment.clone()));
-        Ok(())
-      }
-    }
-  }
-
-  fn run_tree_on_program(
-    &mut self,
-    context: &mut RuntimeContext,
-    program: &mut MechProgram,
-    tree: &mech_core::Program,
-    scope_hint: Option<&SourceScope>,
-  ) -> MResult<Value> {
-    let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
-    let skip_non_context_imports = scope_hint.is_some();
-    let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
-    let mut result = Value::Empty;
-    let mut pending = Vec::new();
-
-    for section in &tree.body.sections {
-      for element in &section.elements {
-        match element {
-          mech_core::SectionElement::MechCode(codes) => {
-            let mut pending_codes = Vec::new();
-            for (code, comment) in codes {
-              self.push_direct_code(
-                context,
-                program,
-                &registry,
-                &mut pending,
-                &mut pending_codes,
-                &mut result,
-                skip_non_context_imports,
-                code,
-                comment,
-              )?;
-            }
-            if !pending_codes.is_empty() {
-              pending.push(mech_core::SectionElement::MechCode(pending_codes));
-            }
-          }
-          mech_core::SectionElement::FencedMechCode(fenced)
-            if Self::executable_fence_for_scope(fenced, execution_scope) =>
-          {
-            let mut pending_codes = Vec::new();
-            for (code, comment) in &fenced.code {
-              self.push_direct_code(
-                context,
-                program,
-                &registry,
-                &mut pending,
-                &mut pending_codes,
-                &mut result,
-                skip_non_context_imports,
-                code,
-                comment,
-              )?;
-            }
-            if !pending_codes.is_empty() {
-              let mut fenced = fenced.clone();
-              fenced.code = pending_codes;
-              pending.push(mech_core::SectionElement::FencedMechCode(fenced));
-            }
-          }
-          _ => {}
-        }
-      }
+        self.resources.read(RuntimeResourceReadRequest {
+            base_uri: resolved.provider_base_uri,
+            path: resolved.provider_path,
+            context_name: binding.name.clone(),
+        })
     }
 
-    self.flush_direct_execution(program, &mut pending, &mut result)?;
-    Ok(result)
-  }
+    fn write_context_resource(
+        &mut self,
+        context: &RuntimeContext,
+        binding: &RuntimeContextBinding,
+        path: &str,
+        value: Value,
+        intent: RuntimeResourceWriteIntent,
+    ) -> MResult<()> {
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        if !runtime_context_allows_write(binding, &resolved.context_path) {
+            return Err(MechError::new(
+                RuntimeResourceCapabilityDenied {
+                    context_name: binding.name.clone(),
+                    operation: "write".to_string(),
+                    path: resolved.context_path,
+                },
+                None,
+            ));
+        }
+        if !self.grants.allows(
+            &context.subject,
+            &resolved.provider_base_uri,
+            &RuntimeCapabilityOperation::Write,
+            &resolved.provider_path,
+        ) {
+            return Err(MechError::new(
+                RuntimeCapabilityGrantDenied {
+                    subject: context.subject.clone(),
+                    resource: resolved.provider_base_uri,
+                    operation: RuntimeCapabilityOperation::Write,
+                    path: resolved.provider_path,
+                },
+                None,
+            ));
+        }
+        self.resources.write(RuntimeResourceWriteRequest {
+            base_uri: resolved.provider_base_uri,
+            path: resolved.provider_path,
+            context_name: binding.name.clone(),
+            value,
+            intent,
+        })
+    }
 
-  fn evaluate_expression_on_program(
-    &mut self,
-    program: &mut MechProgram,
-    expression: &mech_core::Expression,
-  ) -> MResult<Value> {
-    let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
-    program.run_tree(&single).map(resolve_runtime_value)
-  }
-
-  pub fn run_string(&mut self, source: &str) -> MResult<Value> {
-    let mut context = self.runtime_context()?;
-    self.run_string_with_context(&mut context, source)
-  }
-  pub fn run_string_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    source: &str,
-  ) -> MResult<Value> {
-    context.validate()?;
-    context.charge_step()?;
-    let profile_started = self.config.diagnostics.profile_enabled.then(std::time::Instant::now);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    let result = match mech_syntax::parser::parse(source.trim()) {
-      Ok(tree) => {
-        let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(
-          &mut self.program,
-          MechProgram::new(program_config),
+    fn bind_context_read_temp(
+        &self,
+        program: &mut MechProgram,
+        target: &str,
+        path: &str,
+        value: Value,
+    ) -> MResult<mech_core::Expression> {
+        let name = format!(
+            "mech-internal-context-{}-{}",
+            hash_str(target),
+            hash_str(path)
         );
+        let var = mech_core::Var {
+            name: identifier_from_str(&name),
+            context: None,
+            kind: None,
+        };
+        bind_runtime_value_on_program(program, &var, resolve_runtime_value(value), false)?;
+        Ok(mech_core::Expression::Var(var))
+    }
 
-        self.register_runtime_program_host_functions(
-          context,
-          &mut program,
+    fn resolve_context_reads_in_expression(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        expression: &mech_core::Expression,
+    ) -> MResult<mech_core::Expression> {
+        match expression {
+            mech_core::Expression::Var(var) => {
+                let Some(var_context) = &var.context else {
+                    return Ok(expression.clone());
+                };
+                let target = var_context.to_string();
+                let Some(binding) = registry.get(&target) else {
+                    return Ok(expression.clone());
+                };
+                let path = var.name.to_string();
+                let value = self.read_context_resource(context, binding, &path)?;
+                self.bind_context_read_temp(program, &target, &path, value)
+            }
+            mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            )),
+            mech_core::Expression::FunctionCall(call) => {
+                let args = call
+                    .args
+                    .iter()
+                    .map(|(name, expression)| {
+                        Ok((
+                            name.clone(),
+                            self.resolve_context_reads_in_expression(
+                                context, program, registry, expression,
+                            )?,
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::FunctionCall(
+                    mech_core::FunctionCall {
+                        name: call.name.clone(),
+                        args,
+                    },
+                ))
+            }
+            mech_core::Expression::FsmPipe(pipe) => {
+                let mut pipe = pipe.clone();
+                if let Some(args) = &pipe.start.args {
+                    pipe.start.args = Some(
+                        args.iter()
+                            .map(|(name, expression)| {
+                                Ok((
+                                    name.clone(),
+                                    self.resolve_context_reads_in_expression(
+                                        context, program, registry, expression,
+                                    )?,
+                                ))
+                            })
+                            .collect::<MResult<Vec<_>>>()?,
+                    );
+                }
+                Ok(mech_core::Expression::FsmPipe(pipe))
+            }
+            mech_core::Expression::Literal(_) => Ok(expression.clone()),
+            mech_core::Expression::Match(match_expression) => {
+                let mut match_expression = match_expression.as_ref().clone();
+                match_expression.source = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &match_expression.source,
+                )?;
+                match_expression.arms = match_expression
+                    .arms
+                    .iter()
+                    .map(|arm| {
+                        Ok(mech_core::MatchArm {
+                            pattern: arm.pattern.clone(),
+                            guard: arm
+                                .guard
+                                .as_ref()
+                                .map(|guard| {
+                                    self.resolve_context_reads_in_expression(
+                                        context, program, registry, guard,
+                                    )
+                                })
+                                .transpose()?,
+                            expression: self.resolve_context_reads_in_expression(
+                                context,
+                                program,
+                                registry,
+                                &arm.expression,
+                            )?,
+                        })
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::Match(Box::new(match_expression)))
+            }
+            mech_core::Expression::Range(range) => {
+                let mut range = range.as_ref().clone();
+                range.start =
+                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+                range.increment = match &range.increment {
+                    Some((operator, increment)) => Some((
+                        operator.clone(),
+                        self.resolve_context_reads_in_factor(
+                            context, program, registry, increment,
+                        )?,
+                    )),
+                    None => None,
+                };
+                range.terminal = self.resolve_context_reads_in_factor(
+                    context,
+                    program,
+                    registry,
+                    &range.terminal,
+                )?;
+                Ok(mech_core::Expression::Range(Box::new(range)))
+            }
+            mech_core::Expression::Slice(slice) => {
+                if slice
+                    .context
+                    .as_ref()
+                    .is_some_and(|context| registry.contains(&context.to_string()))
+                {
+                    return Err(MechError::new(
+                        RuntimeInvalidOperationError {
+                            operation: "context_read",
+                            reason: "context-addressed slices are not supported".to_string(),
+                        },
+                        None,
+                    ));
+                }
+                Ok(mech_core::Expression::Slice(
+                    self.resolve_context_reads_in_slice(context, program, registry, slice)?,
+                ))
+            }
+            mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
+                self.resolve_context_reads_in_structure(context, program, registry, structure)?,
+            )),
+            mech_core::Expression::SetComprehension(comprehension) => {
+                let mut comprehension = comprehension.as_ref().clone();
+                comprehension.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &comprehension.expression,
+                )?;
+                comprehension.qualifiers = comprehension
+                    .qualifiers
+                    .iter()
+                    .map(|qualifier| {
+                        self.resolve_context_reads_in_comprehension_qualifier(
+                            context, program, registry, qualifier,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::SetComprehension(Box::new(
+                    comprehension,
+                )))
+            }
+            mech_core::Expression::MatrixComprehension(comprehension) => {
+                let mut comprehension = comprehension.as_ref().clone();
+                comprehension.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &comprehension.expression,
+                )?;
+                comprehension.qualifiers = comprehension
+                    .qualifiers
+                    .iter()
+                    .map(|qualifier| {
+                        self.resolve_context_reads_in_comprehension_qualifier(
+                            context, program, registry, qualifier,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::MatrixComprehension(Box::new(
+                    comprehension,
+                )))
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_factor(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        factor: &mech_core::Factor,
+    ) -> MResult<mech_core::Factor> {
+        match factor {
+            mech_core::Factor::Expression(expression) => {
+                Ok(mech_core::Factor::Expression(Box::new(
+                    self.resolve_context_reads_in_expression(
+                        context, program, registry, expression,
+                    )?,
+                )))
+            }
+            mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            ))),
+            mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            ))),
+            mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(
+                Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?),
+            )),
+            mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            ))),
+            mech_core::Factor::Term(term) => {
+                let rhs = term
+                    .rhs
+                    .iter()
+                    .map(|(operator, factor)| {
+                        Ok((
+                            operator.clone(),
+                            self.resolve_context_reads_in_factor(
+                                context, program, registry, factor,
+                            )?,
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
+                    lhs: self
+                        .resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
+                    rhs,
+                })))
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_slice(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        slice: &mech_core::Slice,
+    ) -> MResult<mech_core::Slice> {
+        Ok(mech_core::Slice {
+            name: slice.name.clone(),
+            context: slice.context.clone(),
+            subscript: slice
+                .subscript
+                .iter()
+                .map(|subscript| {
+                    self.resolve_context_reads_in_subscript(context, program, registry, subscript)
+                })
+                .collect::<MResult<Vec<_>>>()?,
+        })
+    }
+
+    fn resolve_context_reads_in_subscript(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        subscript: &mech_core::Subscript,
+    ) -> MResult<mech_core::Subscript> {
+        match subscript {
+            mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(
+                subscripts
+                    .iter()
+                    .map(|subscript| {
+                        self.resolve_context_reads_in_subscript(
+                            context, program, registry, subscript,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            )),
+            mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(
+                subscripts
+                    .iter()
+                    .map(|subscript| {
+                        self.resolve_context_reads_in_subscript(
+                            context, program, registry, subscript,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            )),
+            mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            )),
+            mech_core::Subscript::Range(range) => {
+                let mut range = range.clone();
+                range.start =
+                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+                range.increment = match &range.increment {
+                    Some((operator, increment)) => Some((
+                        operator.clone(),
+                        self.resolve_context_reads_in_factor(
+                            context, program, registry, increment,
+                        )?,
+                    )),
+                    None => None,
+                };
+                range.terminal = self.resolve_context_reads_in_factor(
+                    context,
+                    program,
+                    registry,
+                    &range.terminal,
+                )?;
+                Ok(mech_core::Subscript::Range(range))
+            }
+            _ => Ok(subscript.clone()),
+        }
+    }
+
+    fn resolve_context_reads_in_structure(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        structure: &mech_core::Structure,
+    ) -> MResult<mech_core::Structure> {
+        match structure {
+            mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
+            mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
+                elements: map
+                    .elements
+                    .iter()
+                    .map(|mapping| {
+                        Ok(mech_core::Mapping {
+                            key: self.resolve_context_reads_in_expression(
+                                context,
+                                program,
+                                registry,
+                                &mapping.key,
+                            )?,
+                            value: self.resolve_context_reads_in_expression(
+                                context,
+                                program,
+                                registry,
+                                &mapping.value,
+                            )?,
+                        })
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            })),
+            mech_core::Structure::Matrix(matrix) => {
+                Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
+                    rows: matrix
+                        .rows
+                        .iter()
+                        .map(|row| {
+                            Ok(mech_core::MatrixRow {
+                                columns: row
+                                    .columns
+                                    .iter()
+                                    .map(|column| {
+                                        Ok(mech_core::MatrixColumn {
+                                            element: self.resolve_context_reads_in_expression(
+                                                context,
+                                                program,
+                                                registry,
+                                                &column.element,
+                                            )?,
+                                        })
+                                    })
+                                    .collect::<MResult<Vec<_>>>()?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::Record(record) => {
+                Ok(mech_core::Structure::Record(mech_core::Record {
+                    bindings: record
+                        .bindings
+                        .iter()
+                        .map(|binding| {
+                            Ok(mech_core::Binding {
+                                name: binding.name.clone(),
+                                kind: binding.kind.clone(),
+                                value: self.resolve_context_reads_in_expression(
+                                    context,
+                                    program,
+                                    registry,
+                                    &binding.value,
+                                )?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
+                elements: set
+                    .elements
+                    .iter()
+                    .map(|expression| {
+                        self.resolve_context_reads_in_expression(
+                            context, program, registry, expression,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            })),
+            mech_core::Structure::Table(table) => {
+                Ok(mech_core::Structure::Table(mech_core::Table {
+                    header: table.header.clone(),
+                    rows: table
+                        .rows
+                        .iter()
+                        .map(|row| {
+                            Ok(mech_core::TableRow {
+                                columns: row
+                                    .columns
+                                    .iter()
+                                    .map(|column| {
+                                        Ok(mech_core::TableColumn {
+                                            element: self.resolve_context_reads_in_expression(
+                                                context,
+                                                program,
+                                                registry,
+                                                &column.element,
+                                            )?,
+                                        })
+                                    })
+                                    .collect::<MResult<Vec<_>>>()?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::Tuple(tuple) => {
+                Ok(mech_core::Structure::Tuple(mech_core::Tuple {
+                    elements: tuple
+                        .elements
+                        .iter()
+                        .map(|expression| {
+                            self.resolve_context_reads_in_expression(
+                                context, program, registry, expression,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::TupleStruct(tuple_struct) => {
+                Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
+                    name: tuple_struct.name.clone(),
+                    value: Box::new(self.resolve_context_reads_in_expression(
+                        context,
+                        program,
+                        registry,
+                        &tuple_struct.value,
+                    )?),
+                }))
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_comprehension_qualifier(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        qualifier: &mech_core::ComprehensionQualifier,
+    ) -> MResult<mech_core::ComprehensionQualifier> {
+        match qualifier {
+            mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+                Ok(mech_core::ComprehensionQualifier::Generator((
+                    pattern.clone(),
+                    self.resolve_context_reads_in_expression(
+                        context, program, registry, expression,
+                    )?,
+                )))
+            }
+            mech_core::ComprehensionQualifier::Filter(expression) => {
+                Ok(mech_core::ComprehensionQualifier::Filter(
+                    self.resolve_context_reads_in_expression(
+                        context, program, registry, expression,
+                    )?,
+                ))
+            }
+            mech_core::ComprehensionQualifier::Let(var_def) => {
+                let mut var_def = var_def.clone();
+                var_def.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &var_def.expression,
+                )?;
+                Ok(mech_core::ComprehensionQualifier::Let(var_def))
+            }
+        }
+    }
+
+    fn flush_direct_execution(
+        &mut self,
+        program: &mut MechProgram,
+        pending: &mut Vec<mech_core::SectionElement>,
+        result: &mut Value,
+    ) -> MResult<()> {
+        if pending.is_empty() {
+            return Ok(());
+        }
+        let tree = mech_core::Program {
+            title: None,
+            body: mech_core::Body {
+                sections: vec![mech_core::Section {
+                    subtitle: None,
+                    elements: std::mem::take(pending),
+                }],
+            },
+        };
+        *result = program.run_tree(&tree)?;
+        Ok(())
+    }
+
+    fn executable_fence_for_scope(fenced: &mech_core::FencedMechCode, scope: &SourceScope) -> bool {
+        match scope {
+            SourceScope::Program => fenced.config.namespace_str.is_empty(),
+            SourceScope::Interpreter(interpreter) => {
+                fenced.config.namespace_str == interpreter.namespace_str
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_pattern(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        pattern: &mech_core::Pattern,
+    ) -> MResult<mech_core::Pattern> {
+        match pattern {
+            mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+            )),
+            mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(
+                mech_core::PatternTupleStruct {
+                    name: tuple_struct.name.clone(),
+                    patterns: tuple_struct
+                        .patterns
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                },
+            )),
+            mech_core::Pattern::Tuple(tuple) => {
+                Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+                    tuple
+                        .0
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                )))
+            }
+            mech_core::Pattern::Array(array) => {
+                let spread = if let Some(spread) = &array.spread {
+                    Some(mech_core::PatternArraySpread {
+                        kind: spread.kind.clone(),
+                        binding: spread
+                            .binding
+                            .as_ref()
+                            .map(|binding| {
+                                self.resolve_context_reads_in_pattern(
+                                    context, program, registry, binding,
+                                )
+                                .map(Box::new)
+                            })
+                            .transpose()?,
+                    })
+                } else {
+                    None
+                };
+                Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+                    prefix: array
+                        .prefix
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                    spread,
+                    suffix: array
+                        .suffix
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+        }
+    }
+
+    fn resolve_context_reads_in_transition(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        transition: &mech_core::Transition,
+    ) -> MResult<mech_core::Transition> {
+        match transition {
+            mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
+                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+            )),
+            mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
+                code_items
+                    .iter()
+                    .map(|(code, comment)| {
+                        Ok((
+                            self.resolve_context_reads_in_mech_code(
+                                context, program, registry, code,
+                            )?,
+                            comment.clone(),
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            )),
+            mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
+                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+            )),
+            mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
+                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+            )),
+            mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
+                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+            )),
+        }
+    }
+
+    fn resolve_context_reads_in_fsm_implementation(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        fsm: &mech_core::FsmImplementation,
+    ) -> MResult<mech_core::FsmImplementation> {
+        let arms = fsm
+            .arms
+            .iter()
+            .map(|arm| match arm {
+                mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
+                    self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+                    guards
+                        .iter()
+                        .map(|guard| {
+                            Ok(mech_core::Guard {
+                                condition: self.resolve_context_reads_in_pattern(
+                                    context,
+                                    program,
+                                    registry,
+                                    &guard.condition,
+                                )?,
+                                transitions: guard
+                                    .transitions
+                                    .iter()
+                                    .map(|transition| {
+                                        self.resolve_context_reads_in_transition(
+                                            context, program, registry, transition,
+                                        )
+                                    })
+                                    .collect::<MResult<Vec<_>>>()?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                )),
+                mech_core::FsmArm::Transition(pattern, transitions) => {
+                    Ok(mech_core::FsmArm::Transition(
+                        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+                        transitions
+                            .iter()
+                            .map(|transition| {
+                                self.resolve_context_reads_in_transition(
+                                    context, program, registry, transition,
+                                )
+                            })
+                            .collect::<MResult<Vec<_>>>()?,
+                    ))
+                }
+                mech_core::FsmArm::Comment(comment) => {
+                    Ok(mech_core::FsmArm::Comment(comment.clone()))
+                }
+            })
+            .collect::<MResult<Vec<_>>>()?;
+
+        Ok(mech_core::FsmImplementation {
+            name: fsm.name.clone(),
+            input: fsm.input.clone(),
+            start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
+            arms,
+        })
+    }
+
+    fn resolve_context_reads_in_function_define(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        function: &mech_core::FunctionDefine,
+    ) -> MResult<mech_core::FunctionDefine> {
+        Ok(mech_core::FunctionDefine {
+            name: function.name.clone(),
+            input: function.input.clone(),
+            output: function.output.clone(),
+            statements: function
+                .statements
+                .iter()
+                .map(|statement| {
+                    self.resolve_context_reads_in_statement(context, program, registry, statement)
+                })
+                .collect::<MResult<Vec<_>>>()?,
+            match_arms: function
+                .match_arms
+                .iter()
+                .map(|arm| {
+                    Ok(mech_core::FunctionMatchArm {
+                        pattern: self.resolve_context_reads_in_pattern(
+                            context,
+                            program,
+                            registry,
+                            &arm.pattern,
+                        )?,
+                        expression: self.resolve_context_reads_in_expression(
+                            context,
+                            program,
+                            registry,
+                            &arm.expression,
+                        )?,
+                    })
+                })
+                .collect::<MResult<Vec<_>>>()?,
+        })
+    }
+
+    fn resolve_context_reads_in_mech_code(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        code: &mech_core::MechCode,
+    ) -> MResult<mech_core::MechCode> {
+        match code {
+            mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
+                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+            )),
+            mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
+                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+            )),
+            mech_core::MechCode::FsmImplementation(fsm) => {
+                Ok(mech_core::MechCode::FsmImplementation(
+                    self.resolve_context_reads_in_fsm_implementation(
+                        context, program, registry, fsm,
+                    )?,
+                ))
+            }
+            mech_core::MechCode::FsmSpecification(spec) => {
+                Ok(mech_core::MechCode::FsmSpecification(spec.clone()))
+            }
+            mech_core::MechCode::FunctionDefine(function) => {
+                Ok(mech_core::MechCode::FunctionDefine(
+                    self.resolve_context_reads_in_function_define(
+                        context, program, registry, function,
+                    )?,
+                ))
+            }
+            mech_core::MechCode::Import(_)
+            | mech_core::MechCode::Comment(_)
+            | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
+        }
+    }
+
+    fn resolve_context_reads_in_statement(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        statement: &mech_core::Statement,
+    ) -> MResult<mech_core::Statement> {
+        match statement {
+            mech_core::Statement::VariableDefine(var_def) => {
+                let mut var_def = var_def.clone();
+                var_def.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &var_def.expression,
+                )?;
+                Ok(mech_core::Statement::VariableDefine(var_def))
+            }
+            mech_core::Statement::VariableAssign(assign) => {
+                let mut assign = assign.clone();
+                assign.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &assign.expression,
+                )?;
+                Ok(mech_core::Statement::VariableAssign(assign))
+            }
+            mech_core::Statement::OpAssign(op_assign) => {
+                let mut op_assign = op_assign.clone();
+                op_assign.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &op_assign.expression,
+                )?;
+                Ok(mech_core::Statement::OpAssign(op_assign))
+            }
+            mech_core::Statement::TupleDestructure(tuple_destructure) => {
+                let mut tuple_destructure = tuple_destructure.clone();
+                tuple_destructure.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &tuple_destructure.expression,
+                )?;
+                Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
+            }
+            #[cfg(feature = "invariant_define")]
+            mech_core::Statement::InvariantDefine(invariant) => {
+                let mut invariant = invariant.clone();
+                invariant.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &invariant.expression,
+                )?;
+                Ok(mech_core::Statement::InvariantDefine(invariant))
+            }
+            _ => Ok(statement.clone()),
+        }
+    }
+
+    fn push_direct_code(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        pending: &mut Vec<mech_core::SectionElement>,
+        pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
+        result: &mut Value,
+        skip_non_context_imports: bool,
+        code: &mech_core::MechCode,
+        comment: &Option<mech_core::Comment>,
+    ) -> MResult<()> {
+        match code {
+            mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => {
+                Ok(())
+            }
+            mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
+            mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
+            | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
+            mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
+                if !pending_codes.is_empty() {
+                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                        pending_codes,
+                    )));
+                }
+                self.flush_direct_execution(program, pending, result)?;
+                let id = hash_str(&export.name.to_string());
+                if let Some(value) = program.interpreter().symbols().borrow().get(id) {
+                    *result = resolve_runtime_value(value.borrow().clone());
+                } else {
+                    *result = Value::Empty;
+                }
+                Ok(())
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+                if let Some(context_name) = &var_def.var.context {
+                    let target = context_name.to_string();
+                    if let Some(binding) = registry.get(&target).cloned() {
+                        if !pending_codes.is_empty() {
+                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                                pending_codes,
+                            )));
+                        }
+                        self.flush_direct_execution(program, pending, result)?;
+                        return Err(MechError::new(
+                            RuntimeInvalidOperationError {
+                                operation: "direct_context_define",
+                                reason: format!(
+                                    "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
+                                    binding.name,
+                                    var_def.var.name.to_string()
+                                ),
+                            },
+                            None,
+                        ));
+                    }
+                }
+                let code = self.resolve_context_reads_in_mech_code(
+                    context,
+                    program,
+                    registry,
+                    &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(
+                        var_def.clone(),
+                    )),
+                )?;
+                pending_codes.push((code, comment.clone()));
+                Ok(())
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+                // Context sends are executed only at module top level for now. Parser paths
+                // intentionally reject nested sends until interpreter/effect execution can
+                // support them in functions and state machines.
+                let Some(context_name) = &send.target.context else {
+                    return Err(MechError::new(
+                        RuntimeAddressedAssignmentUnsupported {
+                            target: send.target.name.to_string(),
+                        },
+                        None,
+                    ));
+                };
+                let target = context_name.to_string();
+                let Some(binding) = registry.get(&target).cloned() else {
+                    return Err(MechError::new(
+                        RuntimeAddressedAssignmentUnsupported { target },
+                        None,
+                    ));
+                };
+                if !pending_codes.is_empty() {
+                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                        pending_codes,
+                    )));
+                }
+                self.flush_direct_execution(program, pending, result)?;
+                let expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &send.expression,
+                )?;
+                let value = resolve_runtime_value(
+                    self.evaluate_expression_on_program(program, &expression)?,
+                );
+                self.write_context_resource(
+                    context,
+                    &binding,
+                    &send.target.name.to_string(),
+                    value.clone(),
+                    RuntimeResourceWriteIntent::Send,
+                )?;
+                *result = value;
+                return Ok(());
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+                if let Some(context_name) = &assign.target.context {
+                    let target = context_name.to_string();
+                    if let Some(binding) = registry.get(&target).cloned() {
+                        if !pending_codes.is_empty() {
+                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                                pending_codes,
+                            )));
+                        }
+                        self.flush_direct_execution(program, pending, result)?;
+                        let expression = self.resolve_context_reads_in_expression(
+                            context,
+                            program,
+                            registry,
+                            &assign.expression,
+                        )?;
+                        let value = resolve_runtime_value(
+                            self.evaluate_expression_on_program(program, &expression)?,
+                        );
+                        self.write_context_resource(
+                            context,
+                            &binding,
+                            &assign.target.name.to_string(),
+                            value.clone(),
+                            RuntimeResourceWriteIntent::Assign,
+                        )?;
+                        *result = value;
+                        return Ok(());
+                    }
+                }
+                let code = self.resolve_context_reads_in_mech_code(
+                    context,
+                    program,
+                    registry,
+                    &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(
+                        assign.clone(),
+                    )),
+                )?;
+                pending_codes.push((code, comment.clone()));
+                Ok(())
+            }
+            _ => {
+                let code =
+                    self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
+                pending_codes.push((code, comment.clone()));
+                Ok(())
+            }
+        }
+    }
+
+    fn preflight_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        tree: &mech_core::Program,
+        scope: &SourceScope,
+    ) -> MResult<()> {
+        let registry = self.direct_context_registry_for_scope(tree, scope)?;
+        for section in &tree.body.sections {
+            for element in &section.elements {
+                match element {
+                    mech_core::SectionElement::MechCode(codes) => {
+                        for (code, _) in codes {
+                            self.preflight_code_context_capabilities(context, &registry, code)?;
+                        }
+                    }
+                    mech_core::SectionElement::FencedMechCode(fenced)
+                        if Self::executable_fence_for_scope(fenced, scope) =>
+                    {
+                        for (code, _) in &fenced.code {
+                            self.preflight_code_context_capabilities(context, &registry, code)?;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn preflight_code_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        code: &mech_core::MechCode,
+    ) -> MResult<()> {
+        match code {
+            mech_core::MechCode::Statement(statement) => {
+                self.preflight_statement_context_capabilities(context, registry, statement)
+            }
+            mech_core::MechCode::Expression(expression) => {
+                self.preflight_expression_context_reads(context, registry, expression)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn preflight_statement_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        statement: &mech_core::Statement,
+    ) -> MResult<()> {
+        match statement {
+            mech_core::Statement::VariableDefine(var_def) => {
+                self.preflight_expression_context_reads(context, registry, &var_def.expression)
+            }
+            mech_core::Statement::VariableAssign(assign) => {
+                self.preflight_expression_context_reads(context, registry, &assign.expression)?;
+                if let Some(context_name) = &assign.target.context {
+                    self.preflight_context_access(
+                        context,
+                        registry,
+                        &context_name.to_string(),
+                        &assign.target.name.to_string(),
+                        RuntimeCapabilityOperation::Write,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::Statement::ContextSend(send) => {
+                self.preflight_expression_context_reads(context, registry, &send.expression)?;
+                if let Some(context_name) = &send.target.context {
+                    self.preflight_context_access(
+                        context,
+                        registry,
+                        &context_name.to_string(),
+                        &send.target.name.to_string(),
+                        RuntimeCapabilityOperation::Write,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::Statement::OpAssign(op_assign) => {
+                self.preflight_expression_context_reads(context, registry, &op_assign.expression)
+            }
+            mech_core::Statement::TupleDestructure(tuple_destructure) => self
+                .preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &tuple_destructure.expression,
+                ),
+            #[cfg(feature = "invariant_define")]
+            mech_core::Statement::InvariantDefine(invariant) => {
+                self.preflight_expression_context_reads(context, registry, &invariant.expression)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn preflight_expression_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        expression: &mech_core::Expression,
+    ) -> MResult<()> {
+        match expression {
+            mech_core::Expression::Var(var) => {
+                if let Some(context_name) = &var.context {
+                    self.preflight_context_access(
+                        context,
+                        registry,
+                        &context_name.to_string(),
+                        &var.name.to_string(),
+                        RuntimeCapabilityOperation::Read,
+                    )?;
+                }
+            }
+            mech_core::Expression::Slice(_) => {}
+            mech_core::Expression::Formula(factor) => {
+                self.preflight_factor_context_reads(context, registry, factor)?
+            }
+            mech_core::Expression::Structure(structure) => {
+                self.preflight_structure_context_reads(context, registry, structure)?
+            }
+            mech_core::Expression::Match(match_expression) => {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &match_expression.source,
+                )?;
+                for arm in &match_expression.arms {
+                    if let Some(guard) = &arm.guard {
+                        self.preflight_expression_context_reads(context, registry, guard)?;
+                    }
+                    self.preflight_expression_context_reads(context, registry, &arm.expression)?;
+                }
+            }
+            mech_core::Expression::Range(range) => {
+                self.preflight_factor_context_reads(context, registry, &range.start)?;
+                if let Some((_, increment)) = &range.increment {
+                    self.preflight_factor_context_reads(context, registry, increment)?;
+                }
+                self.preflight_factor_context_reads(context, registry, &range.terminal)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn preflight_factor_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        factor: &mech_core::Factor,
+    ) -> MResult<()> {
+        match factor {
+            mech_core::Factor::Expression(expression) => {
+                self.preflight_expression_context_reads(context, registry, expression)
+            }
+            mech_core::Factor::Negate(factor)
+            | mech_core::Factor::Not(factor)
+            | mech_core::Factor::Parenthetical(factor)
+            | mech_core::Factor::Transpose(factor) => {
+                self.preflight_factor_context_reads(context, registry, factor)
+            }
+            mech_core::Factor::Term(term) => {
+                self.preflight_factor_context_reads(context, registry, &term.lhs)?;
+                for (_, factor) in &term.rhs {
+                    self.preflight_factor_context_reads(context, registry, factor)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn preflight_structure_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        structure: &mech_core::Structure,
+    ) -> MResult<()> {
+        match structure {
+            mech_core::Structure::Map(map) => {
+                for mapping in &map.elements {
+                    self.preflight_expression_context_reads(context, registry, &mapping.key)?;
+                    self.preflight_expression_context_reads(context, registry, &mapping.value)?;
+                }
+            }
+            mech_core::Structure::Set(set) => {
+                for expression in &set.elements {
+                    self.preflight_expression_context_reads(context, registry, expression)?;
+                }
+            }
+            mech_core::Structure::Tuple(tuple) => {
+                for expression in &tuple.elements {
+                    self.preflight_expression_context_reads(context, registry, expression)?;
+                }
+            }
+            mech_core::Structure::TupleStruct(tuple_struct) => {
+                self.preflight_expression_context_reads(context, registry, &tuple_struct.value)?
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn preflight_context_access(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        context_name: &str,
+        path: &str,
+        operation: RuntimeCapabilityOperation,
+    ) -> MResult<()> {
+        let Some(binding) = registry.get(context_name) else {
+            return Ok(());
+        };
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        let context_allowed = match operation {
+            RuntimeCapabilityOperation::Read => {
+                runtime_context_allows_read(binding, &resolved.context_path)
+            }
+            RuntimeCapabilityOperation::Write => {
+                runtime_context_allows_write(binding, &resolved.context_path)
+            }
+            _ => true,
+        };
+        if !context_allowed {
+            return Ok(());
+        }
+        if !self.grants.allows(
+            &context.subject,
+            &resolved.provider_base_uri,
+            &operation,
+            &resolved.provider_path,
+        ) {
+            return Err(MechError::new(
+                RuntimeCapabilityGrantDenied {
+                    subject: context.subject.clone(),
+                    resource: resolved.provider_base_uri,
+                    operation,
+                    path: resolved.provider_path,
+                },
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn run_tree_on_program(
+        &mut self,
+        context: &mut RuntimeContext,
+        program: &mut MechProgram,
+        tree: &mech_core::Program,
+        scope_hint: Option<&SourceScope>,
+    ) -> MResult<Value> {
+        let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
+        let skip_non_context_imports = scope_hint.is_some();
+        let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
+        let mut result = Value::Empty;
+        let mut pending = Vec::new();
+
+        for section in &tree.body.sections {
+            for element in &section.elements {
+                match element {
+                    mech_core::SectionElement::MechCode(codes) => {
+                        let mut pending_codes = Vec::new();
+                        for (code, comment) in codes {
+                            self.push_direct_code(
+                                context,
+                                program,
+                                &registry,
+                                &mut pending,
+                                &mut pending_codes,
+                                &mut result,
+                                skip_non_context_imports,
+                                code,
+                                comment,
+                            )?;
+                        }
+                        if !pending_codes.is_empty() {
+                            pending.push(mech_core::SectionElement::MechCode(pending_codes));
+                        }
+                    }
+                    mech_core::SectionElement::FencedMechCode(fenced)
+                        if Self::executable_fence_for_scope(fenced, execution_scope) =>
+                    {
+                        let mut pending_codes = Vec::new();
+                        for (code, comment) in &fenced.code {
+                            self.push_direct_code(
+                                context,
+                                program,
+                                &registry,
+                                &mut pending,
+                                &mut pending_codes,
+                                &mut result,
+                                skip_non_context_imports,
+                                code,
+                                comment,
+                            )?;
+                        }
+                        if !pending_codes.is_empty() {
+                            let mut fenced = fenced.clone();
+                            fenced.code = pending_codes;
+                            pending.push(mech_core::SectionElement::FencedMechCode(fenced));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        self.flush_direct_execution(program, &mut pending, &mut result)?;
+        Ok(result)
+    }
+
+    fn evaluate_expression_on_program(
+        &mut self,
+        program: &mut MechProgram,
+        expression: &mech_core::Expression,
+    ) -> MResult<Value> {
+        let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
+        program.run_tree(&single).map(resolve_runtime_value)
+    }
+
+    pub fn run_string(&mut self, source: &str) -> MResult<Value> {
+        let mut context = self.runtime_context()?;
+        self.run_string_with_context(&mut context, source)
+    }
+    pub fn run_string_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+    ) -> MResult<Value> {
+        context.validate()?;
+        context.charge_step()?;
+        let profile_started = self
+            .config
+            .diagnostics
+            .profile_enabled
+            .then(std::time::Instant::now);
+
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
+            },
         )?;
+
+        let result = match mech_syntax::parser::parse(source.trim()) {
+            Ok(tree) => {
+                self.preflight_context_capabilities(context, &tree, &SourceScope::Program)?;
+                let program_config = self.program.config.clone();
+                let mut program =
+                    std::mem::replace(&mut self.program, MechProgram::new(program_config));
+
+                self.register_runtime_program_host_functions(context, &mut program)?;
+
+                let runtime_ptr: *mut MechRuntime = self;
+                let context_ptr: *mut RuntimeContext = context;
+                let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+                let result = self.run_tree_on_program(context, &mut program, &tree, None);
+
+                self.program = program;
+                result
+            }
+            Err(error) => Err(error),
+        };
+
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+        }
+
+        result
+    }
+
+    pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
+        let mut context = self.runtime_context()?;
+        self.run_tree_with_context(&mut context, tree)
+    }
+
+    pub fn run_tree_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        tree: &mech_core::Program,
+    ) -> MResult<Value> {
+        context.validate()?;
+        context.charge_step()?;
+        let profile_started = self
+            .config
+            .diagnostics
+            .profile_enabled
+            .then(std::time::Instant::now);
+
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
+            },
+        )?;
+
+        self.preflight_context_capabilities(context, tree, &SourceScope::Program)?;
+
+        let program_config = self.program.config.clone();
+        let mut program = std::mem::replace(&mut self.program, MechProgram::new(program_config));
+
+        self.register_runtime_program_host_functions(context, &mut program)?;
 
         let runtime_ptr: *mut MechRuntime = self;
         let context_ptr: *mut RuntimeContext = context;
         let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-        let result = self.run_tree_on_program(context, &mut program, &tree, None);
+        let result = self.run_tree_on_program(context, &mut program, tree, None);
 
         self.program = program;
+
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+        }
+
         result
-      }
-      Err(error) => Err(error),
-    };
+    }
 
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
+    pub fn out_string(&self) -> String {
+        self.program.out_string()
+    }
+
+    pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
+        self.program.has_interpreter(interpreter_id)
+    }
+
+    pub fn output_value_for_interpreter(
+        &self,
+        interpreter_id: u64,
+        output_id: u64,
+    ) -> Option<Value> {
+        self.program
+            .output_value_for_interpreter(interpreter_id, output_id)
+    }
+
+    pub fn symbol_name_for_interpreter_output(
+        &self,
+        interpreter_id: u64,
+        output_id: u64,
+    ) -> Option<String> {
+        self.program
+            .symbol_name_for_interpreter_output(interpreter_id, output_id)
+    }
+
+    pub fn symbol_values_for_interpreter(
+        &self,
+        interpreter_id: u64,
+        names: &[String],
+    ) -> Option<Vec<(String, Value)>> {
+        self.program
+            .symbol_values_for_interpreter(interpreter_id, names)
+    }
+
+    pub fn bind_ans_for_interpreter(&mut self, interpreter_id: u64, value: &Value) -> MResult<()> {
+        if self.program.bind_ans_for_interpreter(interpreter_id, value) {
+            return Ok(());
         }
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
+
+        Err(MechError::new(
+            RuntimeInvalidOperationError {
+                operation: "bind_ans_for_interpreter",
+                reason: format!("interpreter id {} not found", interpreter_id),
             },
-          )?;
+            None,
+        ))
+    }
+
+    #[cfg(feature = "functions")]
+    pub fn step(&mut self, count: u64) -> MResult<()> {
+        self.program.step(count)
+    }
+
+    pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
+        let mut context = self.runtime_context()?.with_module_version(version);
+
+        self.run_module_with_context(&mut context, version)
+    }
+
+    pub fn run_module_scope(
+        &mut self,
+        version: ModuleVersionId,
+        scope: SourceScope,
+    ) -> MResult<Value> {
+        let mut context = self.runtime_context()?.with_module_version(version);
+
+        self.run_module_scope_with_context(&mut context, version, scope)
+    }
+
+    pub fn run_module_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+    ) -> MResult<Value> {
+        self.run_module_scope_with_context(context, version, SourceScope::Program)
+    }
+
+    pub fn run_module_scope_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+        scope: SourceScope,
+    ) -> MResult<Value> {
+        let mut seen = HashSet::new();
+        let mut module_instances = HashMap::new();
+
+        let instance = self.execute_module_isolated_for_scope(
+            context,
+            version,
+            &scope,
+            &mut seen,
+            &mut module_instances,
+        )?;
+
+        Ok(instance.result)
+    }
+
+    fn execute_module_isolated_for_scope(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+        scope: &SourceScope,
+        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    ) -> MResult<ModuleInstance> {
+        context.validate()?;
+        context.charge_step()?;
+
+        let instance_key = (version, scope.clone());
+
+        if let Some(instance) = module_instances.get(&instance_key).cloned() {
+            return Ok(instance);
         }
-      }
-    }
 
-    result
-  }
-
-
-  pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
-    let mut context = self.runtime_context()?;
-    self.run_tree_with_context(&mut context, tree)
-  }
-
-  pub fn run_tree_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    tree: &mech_core::Program,
-  ) -> MResult<Value> {
-    context.validate()?;
-    context.charge_step()?;
-    let profile_started = self.config.diagnostics.profile_enabled.then(std::time::Instant::now);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
-
-    self.register_runtime_program_host_functions(
-      context,
-      &mut program,
-    )?;
-
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-    let result = self.run_tree_on_program(context, &mut program, tree, None);
-
-    self.program = program;
-
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
+        if seen.contains(&instance_key) {
+            return Ok(ModuleInstance {
+                version,
+                exports: HashMap::new(),
+                result: Value::Empty,
+            });
         }
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-    }
+        seen.insert(instance_key.clone());
 
-    result
-  }
-
-  pub fn out_string(&self) -> String {
-    self.program.out_string()
-  }
-
-  pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-    self.program.has_interpreter(interpreter_id)
-  }
-
-  pub fn output_value_for_interpreter(
-    &self,
-    interpreter_id: u64,
-    output_id: u64,
-  ) -> Option<Value> {
-    self.program.output_value_for_interpreter(interpreter_id, output_id)
-  }
-
-  pub fn symbol_name_for_interpreter_output(
-    &self,
-    interpreter_id: u64,
-    output_id: u64,
-  ) -> Option<String> {
-    self.program.symbol_name_for_interpreter_output(interpreter_id, output_id)
-  }
-
-  pub fn symbol_values_for_interpreter(
-    &self,
-    interpreter_id: u64,
-    names: &[String],
-  ) -> Option<Vec<(String, Value)>> {
-    self.program.symbol_values_for_interpreter(interpreter_id, names)
-  }
-
-  pub fn bind_ans_for_interpreter(
-    &mut self,
-    interpreter_id: u64,
-    value: &Value,
-  ) -> MResult<()> {
-    if self.program.bind_ans_for_interpreter(interpreter_id, value) {
-      return Ok(());
-    }
-
-    Err(MechError::new(
-      RuntimeInvalidOperationError {
-        operation: "bind_ans_for_interpreter",
-        reason: format!("interpreter id {} not found", interpreter_id),
-      },
-      None,
-    ))
-  }
-
-  #[cfg(feature = "functions")]
-  pub fn step(&mut self, count: u64) -> MResult<()> {
-    self.program.step(count)
-  }
-
-  pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
-    let mut context = self.runtime_context()?
-      .with_module_version(version);
-
-    self.run_module_with_context(&mut context, version)
-  }
-
-  pub fn run_module_scope(
-    &mut self,
-    version: ModuleVersionId,
-    scope: SourceScope,
-  ) -> MResult<Value> {
-    let mut context = self.runtime_context()?
-      .with_module_version(version);
-
-    self.run_module_scope_with_context(&mut context, version, scope)
-  }
-
-  pub fn run_module_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-  ) -> MResult<Value> {
-    self.run_module_scope_with_context(context, version, SourceScope::Program)
-  }
-
-  pub fn run_module_scope_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-    scope: SourceScope,
-  ) -> MResult<Value> {
-    let mut seen = HashSet::new();
-    let mut module_instances = HashMap::new();
-
-    let instance = self.execute_module_isolated_for_scope(
-      context,
-      version,
-      &scope,
-      &mut seen,
-      &mut module_instances,
-    )?;
-
-    Ok(instance.result)
-  }
-
-  fn execute_module_isolated_for_scope(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-    scope: &SourceScope,
-    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<ModuleInstance> {
-    context.validate()?;
-    context.charge_step()?;
-
-    let instance_key = (version, scope.clone());
-
-    if let Some(instance) = module_instances.get(&instance_key).cloned() {
-      return Ok(instance);
-    }
-
-    if seen.contains(&instance_key) {
-      return Ok(ModuleInstance { version, exports: HashMap::new(), result: Value::Empty });
-    }
-    seen.insert(instance_key.clone());
-
-    let Some(record) = self.store.get_module_version(version)? else {
-      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
-    };
-    validate_module_import_edges(&record)?;
-    let Some(source) = record.source.clone() else {
-      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
-    };
-
-    let context_registry = context_registry_for_scope(&record, scope)?;
-
-    for edge in &record.import_edges {
-      if &edge.scope != scope {
-        continue;
-      }
-
-      self.execute_module_isolated_for_scope(
-        context,
-        edge.dependency,
-        &SourceScope::Program,
-        seen,
-        module_instances,
-      )?;
-    }
-
-    let mut import_environment = self.build_import_environment_for_scope(
-      context,
-      &record,
-      scope,
-      module_instances,
-    )?;
-
-    let address_environment = self.build_address_environment_for_scope(
-      context,
-      version,
-      &record,
-      scope,
-      &context_registry,
-      seen,
-      module_instances,
-    )?;
-    import_environment.extend(address_environment);
-    let mut module_program = MechProgram::new(MechProgramConfig {
-      name: self.config.name.clone(),
-      environment: MechProgramEnvironment {
-        trace_enabled: self.config.diagnostics.trace_enabled,
-        debug_enabled: self.config.diagnostics.debug_enabled,
-        profile_enabled: self.config.diagnostics.profile_enabled,
-        rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
-      },
-    });
-
-    {
-      let symbols = module_program.interpreter_mut().symbols();
-      let mut symbols_brrw = symbols.borrow_mut();
-      for (name, value_ref) in import_environment {
-        let id = hash_str(&name);
-        symbols_brrw.symbols.insert(id, value_ref);
-        symbols_brrw.dictionary.borrow_mut().insert(id, name);
-      }
-    }
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ModuleExecutionStarted { module_version: version },
-    )?;
-    let scoped_source = module_source_for_scope(&source, scope)?;
-    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
-    let result = match result {
-      Ok(value) => value,
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ModuleExecutionFailed {
-            module_version: version,
-            message: format!("{:?}", error),
-          },
-        )?;
-        return Err(error);
-      }
-    };
-    let mut exports = HashMap::new();
-    {
-      let symbols = module_program.interpreter_mut().symbols();
-      let symbols_brrw = symbols.borrow();
-      for export in exports_for_scope(&record, scope) {
-        let id = hash_str(&export.name);
-        let Some(value_ref) = symbols_brrw.get(id) else {
-          let error = MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: export.name.clone() }, None);
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ModuleExecutionFailed {
-              module_version: version,
-              message: format!("{:?}", error),
-            },
-          )?;
-          return Err(error);
+        let Some(record) = self.store.get_module_version(version)? else {
+            return Err(MechError::new(
+                RuntimeRecordNotFoundError {
+                    record_type: "module_version",
+                    id: version.to_string(),
+                },
+                None,
+            ));
         };
-        exports.insert(export.name.clone(), value_ref.clone());
-      }
-    }
-
-    let instance = ModuleInstance { version, exports, result };
-    module_instances.insert(instance_key, instance.clone());
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ModuleExecutionCompleted { module_version: version },
-    )?;
-    Ok(instance)
-  }
-
-  fn run_module_source_on_program(
-    &mut self,
-    context: &mut RuntimeContext,
-    program: &mut MechProgram,
-    source: &MechSourceCode,
-    scope: &SourceScope,
-  ) -> MResult<Value> {
-    self.register_runtime_program_host_functions(context, program)?;
-
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    // Named interpreter scopes are extracted to bare source by module_source_for_scope.
-    // Once extracted, their declarations are indexed as SourceScope::Program in the
-    // reparsed tree, so direct context handling must use Program scope for that tree.
-    // The surrounding module execution still uses the original scope for imports,
-    // exports, address environment, and ModuleInstance identity.
-    let execution_scope = execution_scope_for_extracted_module_source(scope);
-
-    let result = match source {
-      MechSourceCode::String(source) => {
-        mech_syntax::parser::parse(source.trim())
-          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(&execution_scope)))
-      }
-      other => program.run_source(other),
-    };
-
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-      }
-    }
-
-    result
-  }
-
-  fn build_address_environment_for_scope(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-    record: &ModuleVersionRecord,
-    scope: &SourceScope,
-    context_registry: &RuntimeContextRegistry,
-    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<HashMap<String, mech_core::ValRef>> {
-    fn address_binding_key(target: &str, name: &str) -> String {
-      format!("@{target}/{name}")
-    }
-
-    let scoped_refs = record
-      .scopes
-      .iter()
-      .find(|metadata| &metadata.scope == scope)
-      .map(|metadata| metadata.address_references.as_slice())
-      .unwrap_or(&[]);
-
-    let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> = HashMap::new();
-    let mut bindings = HashMap::new();
-    for reference in scoped_refs {
-      match resolve_runtime_address_target(record, scope, context_registry, &reference.target) {
-        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
-          if !matches!(scope, SourceScope::Program) {
-            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
-          }
-          requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
-        }
-        RuntimeAddressTarget::Context(_) => {
-          // Context-addressed resource reads are resolved while executing source
-          // statements so reads observe earlier writes in the same module scope.
-        }
-        RuntimeAddressTarget::Unknown => {
-          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
-        }
-      }
-    }
-
-    for (interpreter_scope, requested_refs) in requested_by_scope {
-      let instance = self.execute_module_isolated_for_scope(
-        context,
-        version,
-        &interpreter_scope,
-        seen,
-        module_instances,
-      )?;
-
-      for reference in requested_refs {
-        let Some(export_value) = instance.exports.get(&reference.name) else {
-          return Err(MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: reference.name.clone() }, None));
+        validate_module_import_edges(&record)?;
+        let Some(source) = record.source.clone() else {
+            return Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_module",
+                    reason: "module version has no source".to_string(),
+                },
+                None,
+            ));
         };
-        bindings.insert(address_binding_key(&reference.target, &reference.name), export_value.clone());
-      }
+
+        let context_registry = context_registry_for_scope(&record, scope)?;
+
+        for edge in &record.import_edges {
+            if &edge.scope != scope {
+                continue;
+            }
+
+            self.execute_module_isolated_for_scope(
+                context,
+                edge.dependency,
+                &SourceScope::Program,
+                seen,
+                module_instances,
+            )?;
+        }
+
+        let mut import_environment =
+            self.build_import_environment_for_scope(context, &record, scope, module_instances)?;
+
+        let address_environment = self.build_address_environment_for_scope(
+            context,
+            version,
+            &record,
+            scope,
+            &context_registry,
+            seen,
+            module_instances,
+        )?;
+        import_environment.extend(address_environment);
+        let mut module_program = MechProgram::new(MechProgramConfig {
+            name: self.config.name.clone(),
+            environment: MechProgramEnvironment {
+                trace_enabled: self.config.diagnostics.trace_enabled,
+                debug_enabled: self.config.diagnostics.debug_enabled,
+                profile_enabled: self.config.diagnostics.profile_enabled,
+                rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+            },
+        });
+
+        {
+            let symbols = module_program.interpreter_mut().symbols();
+            let mut symbols_brrw = symbols.borrow_mut();
+            for (name, value_ref) in import_environment {
+                let id = hash_str(&name);
+                symbols_brrw.symbols.insert(id, value_ref);
+                symbols_brrw.dictionary.borrow_mut().insert(id, name);
+            }
+        }
+
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ModuleExecutionStarted {
+                module_version: version,
+            },
+        )?;
+        let scoped_source = module_source_for_scope(&source, scope)?;
+        let result =
+            self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
+        let result = match result {
+            Ok(value) => value,
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ModuleExecutionFailed {
+                        module_version: version,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                return Err(error);
+            }
+        };
+        let mut exports = HashMap::new();
+        {
+            let symbols = module_program.interpreter_mut().symbols();
+            let symbols_brrw = symbols.borrow();
+            for export in exports_for_scope(&record, scope) {
+                let id = hash_str(&export.name);
+                let Some(value_ref) = symbols_brrw.get(id) else {
+                    let error = MechError::new(
+                        RuntimeModuleExportNotFound {
+                            dependency: record.id.to_string(),
+                            export: export.name.clone(),
+                        },
+                        None,
+                    );
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ModuleExecutionFailed {
+                            module_version: version,
+                            message: format!("{:?}", error),
+                        },
+                    )?;
+                    return Err(error);
+                };
+                exports.insert(export.name.clone(), value_ref.clone());
+            }
+        }
+
+        let instance = ModuleInstance {
+            version,
+            exports,
+            result,
+        };
+        module_instances.insert(instance_key, instance.clone());
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ModuleExecutionCompleted {
+                module_version: version,
+            },
+        )?;
+        Ok(instance)
     }
 
-    Ok(bindings)
-  }
+    fn run_module_source_on_program(
+        &mut self,
+        context: &mut RuntimeContext,
+        program: &mut MechProgram,
+        source: &MechSourceCode,
+        scope: &SourceScope,
+    ) -> MResult<Value> {
+        self.register_runtime_program_host_functions(context, program)?;
 
-  fn build_import_environment_for_scope(
-    &mut self,
-    context: &mut RuntimeContext,
-    importer: &ModuleVersionRecord,
-    scope: &SourceScope,
-    module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<HashMap<String, mech_core::ValRef>> {
-    let mut bindings = HashMap::new();
-    let mut ownership: HashMap<String, String> = HashMap::new();
+        let runtime_ptr: *mut MechRuntime = self;
+        let context_ptr: *mut RuntimeContext = context;
+        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-    for edge in &importer.import_edges {
-      if &edge.scope != scope {
-        continue;
-      }
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
+            },
+        )?;
 
-      let import = &edge.import;
-      let dependency = edge.dependency;
+        // Named interpreter scopes are extracted to bare source by module_source_for_scope.
+        // Once extracted, their declarations are indexed as SourceScope::Program in the
+        // reparsed tree, so direct context handling must use Program scope for that tree.
+        // The surrounding module execution still uses the original scope for imports,
+        // exports, address environment, and ModuleInstance identity.
+        let execution_scope = execution_scope_for_extracted_module_source(scope);
 
-      let dependency_key = (dependency, SourceScope::Program);
-      let Some(dependency_instance) = module_instances.get(&dependency_key) else {
-        return Err(MechError::new(RuntimeInvalidOperationError { operation: "build_import_environment", reason: format!("dependency instance missing for {}", dependency) }, None));
-      };
-
-      match &import.kind {
-        SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
-          let Some(namespace) = module_namespace_for_import(import) else { continue; };
-          for (export_name, export_value) in &dependency_instance.exports {
-            let binding = format!("{}/{}", namespace, export_name);
-            if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
-              return Err(MechError::new(RuntimeModuleImportConflict { binding, first_import: first, second_import: import.specifier.clone() }, None));
+        let result = match source {
+            MechSourceCode::String(source) => {
+                mech_syntax::parser::parse(source.trim()).and_then(|tree| {
+                    self.run_tree_on_program(context, program, &tree, Some(&execution_scope))
+                })
             }
-            bindings.insert(format!("{}/{}", namespace, export_name), export_value.clone());
-          }
-        }
-        SourceImportKind::Single { name } => {
-          if matches!(import.alias, Some(crate::resolver::SourceImportAlias::Context(_))) {
-            continue;
-          }
-          let Some(export_value) = dependency_instance.exports.get(name) else {
-            return Err(MechError::new(RuntimeModuleExportNotFound { dependency: import.specifier.clone(), export: name.clone() }, None));
-          };
+            other => program.run_source(other),
+        };
 
-          let binding = match &import.alias {
-            Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
-            Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
-            None => name.clone(),
-          };
-
-          if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
-            return Err(MechError::new(RuntimeModuleImportConflict { binding: binding.clone(), first_import: first, second_import: import.specifier.clone() }, None));
-          }
-          bindings.insert(binding, export_value.clone());
-        }
-        SourceImportKind::Wildcard => {
-          for (export_name, export_value) in &dependency_instance.exports {
-            if let Some(first) = ownership.insert(export_name.clone(), import.specifier.clone()) {
-              return Err(MechError::new(RuntimeModuleImportConflict { binding: export_name.clone(), first_import: first, second_import: import.specifier.clone() }, None));
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
             }
-            bindings.insert(export_name.clone(), export_value.clone());
-          }
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+            }
         }
-      }
 
-      self.emit_event_to_context(
-        context,
-        RuntimeEventKind::ModuleImportLinked {
-          importer: importer.id,
-          dependency,
-          specifier: import.specifier.clone(),
-        },
-      )?;
+        result
     }
 
-    Ok(bindings)
-  }
+    fn build_address_environment_for_scope(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+        record: &ModuleVersionRecord,
+        scope: &SourceScope,
+        context_registry: &RuntimeContextRegistry,
+        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    ) -> MResult<HashMap<String, mech_core::ValRef>> {
+        fn address_binding_key(target: &str, name: &str) -> String {
+            format!("@{target}/{name}")
+        }
+
+        let scoped_refs = record
+            .scopes
+            .iter()
+            .find(|metadata| &metadata.scope == scope)
+            .map(|metadata| metadata.address_references.as_slice())
+            .unwrap_or(&[]);
+
+        let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> =
+            HashMap::new();
+        let mut bindings = HashMap::new();
+        for reference in scoped_refs {
+            match resolve_runtime_address_target(record, scope, context_registry, &reference.target)
+            {
+                RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+                    if !matches!(scope, SourceScope::Program) {
+                        return Err(MechError::new(
+                            UnknownAddressTarget {
+                                target: reference.target.clone(),
+                            },
+                            None,
+                        ));
+                    }
+                    requested_by_scope
+                        .entry(interpreter_scope)
+                        .or_default()
+                        .push(reference.clone());
+                }
+                RuntimeAddressTarget::Context(_) => {
+                    // Context-addressed resource reads are resolved while executing source
+                    // statements so reads observe earlier writes in the same module scope.
+                }
+                RuntimeAddressTarget::Unknown => {
+                    return Err(MechError::new(
+                        UnknownAddressTarget {
+                            target: reference.target.clone(),
+                        },
+                        None,
+                    ));
+                }
+            }
+        }
+
+        for (interpreter_scope, requested_refs) in requested_by_scope {
+            let instance = self.execute_module_isolated_for_scope(
+                context,
+                version,
+                &interpreter_scope,
+                seen,
+                module_instances,
+            )?;
+
+            for reference in requested_refs {
+                let Some(export_value) = instance.exports.get(&reference.name) else {
+                    return Err(MechError::new(
+                        RuntimeModuleExportNotFound {
+                            dependency: record.id.to_string(),
+                            export: reference.name.clone(),
+                        },
+                        None,
+                    ));
+                };
+                bindings.insert(
+                    address_binding_key(&reference.target, &reference.name),
+                    export_value.clone(),
+                );
+            }
+        }
+
+        Ok(bindings)
+    }
+
+    fn build_import_environment_for_scope(
+        &mut self,
+        context: &mut RuntimeContext,
+        importer: &ModuleVersionRecord,
+        scope: &SourceScope,
+        module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    ) -> MResult<HashMap<String, mech_core::ValRef>> {
+        let mut bindings = HashMap::new();
+        let mut ownership: HashMap<String, String> = HashMap::new();
+
+        for edge in &importer.import_edges {
+            if &edge.scope != scope {
+                continue;
+            }
+
+            let import = &edge.import;
+            let dependency = edge.dependency;
+
+            let dependency_key = (dependency, SourceScope::Program);
+            let Some(dependency_instance) = module_instances.get(&dependency_key) else {
+                return Err(MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "build_import_environment",
+                        reason: format!("dependency instance missing for {}", dependency),
+                    },
+                    None,
+                ));
+            };
+
+            match &import.kind {
+                SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
+                    let Some(namespace) = module_namespace_for_import(import) else {
+                        continue;
+                    };
+                    for (export_name, export_value) in &dependency_instance.exports {
+                        let binding = format!("{}/{}", namespace, export_name);
+                        if let Some(first) =
+                            ownership.insert(binding.clone(), import.specifier.clone())
+                        {
+                            return Err(MechError::new(
+                                RuntimeModuleImportConflict {
+                                    binding,
+                                    first_import: first,
+                                    second_import: import.specifier.clone(),
+                                },
+                                None,
+                            ));
+                        }
+                        bindings.insert(
+                            format!("{}/{}", namespace, export_name),
+                            export_value.clone(),
+                        );
+                    }
+                }
+                SourceImportKind::Single { name } => {
+                    if matches!(
+                        import.alias,
+                        Some(crate::resolver::SourceImportAlias::Context(_))
+                    ) {
+                        continue;
+                    }
+                    let Some(export_value) = dependency_instance.exports.get(name) else {
+                        return Err(MechError::new(
+                            RuntimeModuleExportNotFound {
+                                dependency: import.specifier.clone(),
+                                export: name.clone(),
+                            },
+                            None,
+                        ));
+                    };
+
+                    let binding = match &import.alias {
+                        Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
+                        Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
+                        None => name.clone(),
+                    };
+
+                    if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone())
+                    {
+                        return Err(MechError::new(
+                            RuntimeModuleImportConflict {
+                                binding: binding.clone(),
+                                first_import: first,
+                                second_import: import.specifier.clone(),
+                            },
+                            None,
+                        ));
+                    }
+                    bindings.insert(binding, export_value.clone());
+                }
+                SourceImportKind::Wildcard => {
+                    for (export_name, export_value) in &dependency_instance.exports {
+                        if let Some(first) =
+                            ownership.insert(export_name.clone(), import.specifier.clone())
+                        {
+                            return Err(MechError::new(
+                                RuntimeModuleImportConflict {
+                                    binding: export_name.clone(),
+                                    first_import: first,
+                                    second_import: import.specifier.clone(),
+                                },
+                                None,
+                            ));
+                        }
+                        bindings.insert(export_name.clone(), export_value.clone());
+                    }
+                }
+            }
+
+            self.emit_event_to_context(
+                context,
+                RuntimeEventKind::ModuleImportLinked {
+                    importer: importer.id,
+                    dependency,
+                    specifier: import.specifier.clone(),
+                },
+            )?;
+        }
+
+        Ok(bindings)
+    }
 }
 
-
-
 fn module_source_for_scope(
-  source: &MechSourceCode,
-  scope: &SourceScope,
+    source: &MechSourceCode,
+    scope: &SourceScope,
 ) -> MResult<MechSourceCode> {
-  match scope {
-    SourceScope::Program => Ok(source.clone()),
-    SourceScope::Interpreter(interpreter) => {
-      let MechSourceCode::String(source_text) = source else {
-        return Err(MechError::new(
-          RuntimeInvalidOperationError {
-            operation: "run_module_scope",
-            reason: "interpreter scope execution requires string source".to_string(),
-          },
-          None,
-        ));
-      };
+    match scope {
+        SourceScope::Program => Ok(source.clone()),
+        SourceScope::Interpreter(interpreter) => {
+            let MechSourceCode::String(source_text) = source else {
+                return Err(MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "run_module_scope",
+                        reason: "interpreter scope execution requires string source".to_string(),
+                    },
+                    None,
+                ));
+            };
 
-      let tree = mech_syntax::parser::parse(source_text.trim())?;
+            let tree = mech_syntax::parser::parse(source_text.trim())?;
 
-      if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
-        return Ok(MechSourceCode::String(source));
-      }
+            if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
+                return Ok(MechSourceCode::String(source));
+            }
 
-      Err(MechError::new(
-        RuntimeInvalidOperationError {
-          operation: "run_module_scope",
-          reason: format!("interpreter scope `{}` not found", interpreter.namespace_str),
-        },
-        None,
-      ))
+            Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_module_scope",
+                    reason: format!(
+                        "interpreter scope `{}` not found",
+                        interpreter.namespace_str
+                    ),
+                },
+                None,
+            ))
+        }
     }
-  }
 }
 
 fn source_from_parsed_fenced_blocks(
-  tree: &mech_core::Program,
-  namespace: u64,
+    tree: &mech_core::Program,
+    namespace: u64,
 ) -> MResult<Option<String>> {
-  let mut blocks = Vec::new();
+    let mut blocks = Vec::new();
 
-  for section in &tree.body.sections {
-    for element in &section.elements {
-      if let mech_core::SectionElement::FencedMechCode(fenced) = element {
-        if fenced.config.namespace == namespace {
-          let block = source_from_parsed_fenced_code(fenced)?;
-          blocks.push(block.trim_end().to_string());
+    for section in &tree.body.sections {
+        for element in &section.elements {
+            if let mech_core::SectionElement::FencedMechCode(fenced) = element {
+                if fenced.config.namespace == namespace {
+                    let block = source_from_parsed_fenced_code(fenced)?;
+                    blocks.push(block.trim_end().to_string());
+                }
+            }
         }
-      }
     }
-  }
 
-  if blocks.is_empty() {
-    Ok(None)
-  } else {
-    Ok(Some(blocks.join("\n")))
-  }
+    if blocks.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(blocks.join("\n")))
+    }
 }
 
-fn source_from_parsed_fenced_code(
-  fenced: &mech_core::FencedMechCode,
-) -> MResult<String> {
-  source_from_tokens(std::slice::from_ref(&fenced.source))
+fn source_from_parsed_fenced_code(fenced: &mech_core::FencedMechCode) -> MResult<String> {
+    source_from_tokens(std::slice::from_ref(&fenced.source))
 }
 
 fn source_from_tokens(tokens: &[mech_core::Token]) -> MResult<String> {
-  if tokens.is_empty() {
-    return Ok(String::new());
-  }
-
-  if tokens.iter().any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0) {
-    return Ok(tokens.iter().map(|token| token.to_string()).collect::<Vec<_>>().join(" "));
-  }
-
-  let mut source = String::new();
-  let mut row = tokens[0].src_range.start.row;
-  let mut col = tokens[0].src_range.start.col;
-
-  for token in tokens {
-    let start = &token.src_range.start;
-    while row < start.row {
-      source.push('\n');
-      row += 1;
-      col = 1;
-    }
-    while col < start.col {
-      source.push(' ');
-      col += 1;
+    if tokens.is_empty() {
+        return Ok(String::new());
     }
 
-    let token_text = token.to_string();
-    for ch in token_text.chars() {
-      source.push(ch);
-      if ch == '\n' {
-        row += 1;
-        col = 1;
-      } else {
-        col += 1;
-      }
+    if tokens
+        .iter()
+        .any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0)
+    {
+        return Ok(tokens
+            .iter()
+            .map(|token| token.to_string())
+            .collect::<Vec<_>>()
+            .join(" "));
     }
-  }
 
-  Ok(source)
+    let mut source = String::new();
+    let mut row = tokens[0].src_range.start.row;
+    let mut col = tokens[0].src_range.start.col;
+
+    for token in tokens {
+        let start = &token.src_range.start;
+        while row < start.row {
+            source.push('\n');
+            row += 1;
+            col = 1;
+        }
+        while col < start.col {
+            source.push(' ');
+            col += 1;
+        }
+
+        let token_text = token.to_string();
+        for ch in token_text.chars() {
+            source.push(ch);
+            if ch == '\n' {
+                row += 1;
+                col = 1;
+            } else {
+                col += 1;
+            }
+        }
+    }
+
+    Ok(source)
 }
 
 fn exports_for_scope<'a>(
-  record: &'a ModuleVersionRecord,
-  scope: &SourceScope,
+    record: &'a ModuleVersionRecord,
+    scope: &SourceScope,
 ) -> &'a [SourceExportDeclaration] {
-  record
-    .scopes
-    .iter()
-    .find(|metadata| &metadata.scope == scope)
-    .map(|metadata| metadata.exports.as_slice())
-    .unwrap_or(&[])
+    record
+        .scopes
+        .iter()
+        .find(|metadata| &metadata.scope == scope)
+        .map(|metadata| metadata.exports.as_slice())
+        .unwrap_or(&[])
 }
-
-
-
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use mech_core::Ref;
+    use super::*;
+    use mech_core::Ref;
 
-  #[test]
-  fn runtime_has_interpreter_finds_root_interpreter() {
-    let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    assert!(runtime.has_interpreter(0));
-  }
+    #[test]
+    fn runtime_has_interpreter_finds_root_interpreter() {
+        let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        assert!(runtime.has_interpreter(0));
+    }
 
-  #[test]
-  fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let source = "```mech
+    #[test]
+    fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
+        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        let source = "```mech
 1
 ```";
-    let _ = runtime.run_string(source).unwrap();
-    let root_id = runtime.program().interpreter().id;
-    let output_id = {
-      let out_values = runtime.program().interpreter().out_values.borrow();
-      *out_values.keys().next().expect("expected output value after run_string")
-    };
-    let output = runtime.output_value_for_interpreter(root_id, output_id);
-    assert!(output.is_some());
-  }
+        let _ = runtime.run_string(source).unwrap();
+        let root_id = runtime.program().interpreter().id;
+        let output_id = {
+            let out_values = runtime.program().interpreter().out_values.borrow();
+            *out_values
+                .keys()
+                .next()
+                .expect("expected output value after run_string")
+        };
+        let output = runtime.output_value_for_interpreter(root_id, output_id);
+        assert!(output.is_some());
+    }
 
-  #[test]
-  fn run_string_with_context_emits_profile_event_when_enabled() {
-    let mut config = RuntimeConfig::default();
-    config.diagnostics.profile_enabled = true;
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
+    #[test]
+    fn run_string_with_context_emits_profile_event_when_enabled() {
+        let mut config = RuntimeConfig::default();
+        config.diagnostics.profile_enabled = true;
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
 
-    runtime.run_string_with_context(&mut context, "1 + 1").unwrap();
+        runtime
+            .run_string_with_context(&mut context, "1 + 1")
+            .unwrap();
 
-    assert!(context.events.iter().any(|event| {
-      matches!(
-        event.kind,
-        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-      )
-    }));
-  }
+        assert!(context.events.iter().any(|event| {
+            matches!(
+              event.kind,
+              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+            )
+        }));
+    }
 
-  #[test]
-  fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
-    let mut config = RuntimeConfig::default();
-    config.diagnostics.profile_enabled = true;
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
+    #[test]
+    fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
+        let mut config = RuntimeConfig::default();
+        config.diagnostics.profile_enabled = true;
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
 
-    assert!(runtime.run_string_with_context(&mut context, "1 +").is_err());
+        assert!(
+            runtime
+                .run_string_with_context(&mut context, "1 +")
+                .is_err()
+        );
 
-    assert!(context.events.iter().any(|event| {
-      matches!(
-        event.kind,
-        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-      )
-    }));
-  }
+        assert!(context.events.iter().any(|event| {
+            matches!(
+              event.kind,
+              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+            )
+        }));
+    }
 
-  #[test]
-  fn runtime_bind_ans_for_interpreter_binds_ans() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let value = Value::U64(Ref::new(42));
-    runtime.bind_ans_for_interpreter(0, &value).unwrap();
-    let ans_id = hash_str("ans");
-    let bound = runtime
-      .program()
-      .interpreter()
-      .symbols()
-      .borrow()
-      .get(ans_id)
-      .map(|value| value.borrow().clone());
-    assert_eq!(bound, Some(value));
-  }
+    #[test]
+    fn runtime_bind_ans_for_interpreter_binds_ans() {
+        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        let value = Value::U64(Ref::new(42));
+        runtime.bind_ans_for_interpreter(0, &value).unwrap();
+        let ans_id = hash_str("ans");
+        let bound = runtime
+            .program()
+            .interpreter()
+            .symbols()
+            .borrow()
+            .get(ans_id)
+            .map(|value| value.borrow().clone());
+        assert_eq!(bound, Some(value));
+    }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1010,7 +1010,126 @@ impl MechRuntime {
       mech_core::MechCode::Expression(expression) => {
         self.preflight_expression_context_reads(context, registry, expression)
       }
-      _ => Ok(()),
+      mech_core::MechCode::FsmImplementation(fsm) => {
+        self.preflight_fsm_implementation_context_capabilities(context, registry, fsm)
+      }
+      mech_core::MechCode::FunctionDefine(function) => {
+        self.preflight_function_define_context_capabilities(context, registry, function)
+      }
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Comment(_)
+      | mech_core::MechCode::FsmSpecification(_)
+      | mech_core::MechCode::Error(_, _) => Ok(()),
+    }
+  }
+
+  fn preflight_function_define_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    function: &mech_core::FunctionDefine,
+  ) -> MResult<()> {
+    for statement in &function.statements {
+      self.preflight_statement_context_capabilities(context, registry, statement)?;
+    }
+    for arm in &function.match_arms {
+      self.preflight_pattern_context_reads(context, registry, &arm.pattern)?;
+      self.preflight_expression_context_reads(context, registry, &arm.expression)?;
+    }
+    Ok(())
+  }
+
+  fn preflight_fsm_implementation_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    fsm: &mech_core::FsmImplementation,
+  ) -> MResult<()> {
+    self.preflight_pattern_context_reads(context, registry, &fsm.start)?;
+    for arm in &fsm.arms {
+      match arm {
+        mech_core::FsmArm::Guard(pattern, guards) => {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+          for guard in guards {
+            self.preflight_pattern_context_reads(context, registry, &guard.condition)?;
+            for transition in &guard.transitions {
+              self.preflight_transition_context_capabilities(context, registry, transition)?;
+            }
+          }
+        }
+        mech_core::FsmArm::Transition(pattern, transitions) => {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+          for transition in transitions {
+            self.preflight_transition_context_capabilities(context, registry, transition)?;
+          }
+        }
+        mech_core::FsmArm::Comment(_) => {}
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_transition_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    transition: &mech_core::Transition,
+  ) -> MResult<()> {
+    match transition {
+      mech_core::Transition::Async(pattern)
+      | mech_core::Transition::Next(pattern)
+      | mech_core::Transition::Output(pattern) => {
+        self.preflight_pattern_context_reads(context, registry, pattern)
+      }
+      mech_core::Transition::CodeBlock(code_items) => {
+        for (code, _) in code_items {
+          self.preflight_code_context_capabilities(context, registry, code)?;
+        }
+        Ok(())
+      }
+      mech_core::Transition::Statement(statement) => {
+        self.preflight_statement_context_capabilities(context, registry, statement)
+      }
+    }
+  }
+
+  fn preflight_pattern_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<()> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::Pattern::TupleStruct(tuple_struct) => {
+        for pattern in &tuple_struct.patterns {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Tuple(tuple) => {
+        for pattern in &tuple.0 {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Array(array) => {
+        for pattern in &array.prefix {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        if let Some(spread) = &array.spread {
+          if let Some(binding) = &spread.binding {
+            self.preflight_pattern_context_reads(context, registry, binding)?;
+          }
+        }
+        for pattern in &array.suffix {
+          self.preflight_pattern_context_reads(context, registry, pattern)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Wildcard => Ok(()),
     }
   }
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -975,19 +975,29 @@ impl MechRuntime {
     scope: &SourceScope,
   ) -> MResult<()> {
     let registry = self.direct_context_registry_for_scope(tree, scope)?;
+    self.preflight_context_capabilities_with_registry(context, &registry, tree, scope)
+  }
+
+  fn preflight_context_capabilities_with_registry(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<()> {
     for section in &tree.body.sections {
       for element in &section.elements {
         match element {
           mech_core::SectionElement::MechCode(codes) => {
             for (code, _) in codes {
-              self.preflight_code_context_capabilities(context, &registry, code)?;
+              self.preflight_code_context_capabilities(context, registry, code)?;
             }
           }
           mech_core::SectionElement::FencedMechCode(fenced)
             if Self::executable_fence_for_scope(fenced, scope) =>
           {
             for (code, _) in &fenced.code {
-              self.preflight_code_context_capabilities(context, &registry, code)?;
+              self.preflight_code_context_capabilities(context, registry, code)?;
             }
           }
           _ => {}
@@ -1414,7 +1424,15 @@ impl MechRuntime {
       _ => true,
     };
     if !context_allowed {
-      return Ok(());
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: match operation {
+          RuntimeCapabilityOperation::Read => "read".to_string(),
+          RuntimeCapabilityOperation::Write => "write".to_string(),
+          other => format!("{other:?}"),
+        },
+        path: resolved.context_path,
+      }, None));
     }
     if !self.grants.allows(
       &context.subject,
@@ -1775,6 +1793,9 @@ impl MechRuntime {
     version: ModuleVersionId,
     scope: SourceScope,
   ) -> MResult<Value> {
+    let mut preflight_seen = HashSet::new();
+    self.preflight_module_graph_for_scope(context, version, &scope, &mut preflight_seen)?;
+
     let mut seen = HashSet::new();
     let mut module_instances = HashMap::new();
 
@@ -1787,6 +1808,77 @@ impl MechRuntime {
     )?;
 
     Ok(instance.result)
+  }
+
+  fn preflight_module_graph_for_scope(
+    &self,
+    context: &RuntimeContext,
+    version: ModuleVersionId,
+    scope: &SourceScope,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+  ) -> MResult<()> {
+    context.validate()?;
+    let instance_key = (version, scope.clone());
+    if !seen.insert(instance_key) {
+      return Ok(());
+    }
+
+    let Some(record) = self.store.get_module_version(version)? else {
+      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
+    };
+    validate_module_import_edges(&record)?;
+    let Some(source) = record.source.clone() else {
+      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
+    };
+
+    let context_registry = context_registry_for_scope(&record, scope)?;
+    let scoped_source = module_source_for_scope(&source, scope)?;
+    let execution_scope = execution_scope_for_extracted_module_source(scope);
+    self.preflight_module_source(context, &context_registry, &scoped_source, &execution_scope)?;
+
+    for edge in &record.import_edges {
+      if &edge.scope != scope {
+        continue;
+      }
+
+      self.preflight_module_graph_for_scope(
+        context,
+        edge.dependency,
+        &SourceScope::Program,
+        seen,
+      )?;
+    }
+
+    Ok(())
+  }
+
+  fn preflight_module_source(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    source: &MechSourceCode,
+    scope: &SourceScope,
+  ) -> MResult<()> {
+    match source {
+      MechSourceCode::String(source) => {
+        let tree = mech_syntax::parser::parse(source.trim())?;
+        self.preflight_context_capabilities_with_registry(context, registry, &tree, scope)
+      }
+      MechSourceCode::Tree(tree) => {
+        self.preflight_context_capabilities_with_registry(context, registry, tree, scope)
+      }
+      MechSourceCode::Program(sources) => {
+        for source in sources {
+          self.preflight_module_source(context, registry, source, scope)?;
+        }
+        Ok(())
+      }
+      MechSourceCode::Html(_) => Ok(()),
+      other => Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "run_module_preflight",
+        reason: format!("unsupported executable source kind for provider preflight: {other:?}"),
+      }, None)),
+    }
   }
 
   fn execute_module_isolated_for_scope(
@@ -1956,7 +2048,25 @@ impl MechRuntime {
         },
         Err(error) => Err(error),
       },
-      other => program.run_source(other),
+      MechSourceCode::Tree(tree) => match self.preflight_context_capabilities(context, tree, &execution_scope) {
+        Ok(()) => self.run_tree_on_program(context, program, tree, Some(&execution_scope)),
+        Err(error) => Err(error),
+      },
+      MechSourceCode::Program(sources) => {
+        let mut result = Ok(Value::Empty);
+        for source in sources {
+          result = self.run_module_source_on_program(context, program, source, scope);
+          if result.is_err() {
+            break;
+          }
+        }
+        result
+      }
+      MechSourceCode::Html(_) => program.run_source(source),
+      other => Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "run_module_preflight",
+        reason: format!("unsupported executable source kind for provider preflight: {other:?}"),
+      }, None)),
     };
 
     match &result {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1949,11 +1949,13 @@ impl MechRuntime {
     let execution_scope = execution_scope_for_extracted_module_source(scope);
 
     let result = match source {
-      MechSourceCode::String(source) => {
-        let tree = mech_syntax::parser::parse(source.trim())?;
-        self.preflight_context_capabilities(context, &tree, &execution_scope)?;
-        self.run_tree_on_program(context, program, &tree, Some(&execution_scope))
-      }
+      MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
+        Ok(tree) => match self.preflight_context_capabilities(context, &tree, &execution_scope) {
+          Ok(()) => self.run_tree_on_program(context, program, &tree, Some(&execution_scope)),
+          Err(error) => Err(error),
+        },
+        Err(error) => Err(error),
+      },
       other => program.run_source(other),
     };
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1532,28 +1532,30 @@ impl MechRuntime {
     )?;
 
     let result = match mech_syntax::parser::parse(source.trim()) {
-      Ok(tree) => {
-        self.preflight_context_capabilities(context, &tree, &SourceScope::Program)?;
-        let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(
-          &mut self.program,
-          MechProgram::new(program_config),
-        );
+      Ok(tree) => match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
+        Ok(()) => {
+          let program_config = self.program.config.clone();
+          let mut program = std::mem::replace(
+            &mut self.program,
+            MechProgram::new(program_config),
+          );
 
-        self.register_runtime_program_host_functions(
-          context,
-          &mut program,
-        )?;
+          self.register_runtime_program_host_functions(
+            context,
+            &mut program,
+          )?;
 
-        let runtime_ptr: *mut MechRuntime = self;
-        let context_ptr: *mut RuntimeContext = context;
-        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+          let runtime_ptr: *mut MechRuntime = self;
+          let context_ptr: *mut RuntimeContext = context;
+          let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-        let result = self.run_tree_on_program(context, &mut program, &tree, None);
+          let result = self.run_tree_on_program(context, &mut program, &tree, None);
 
-        self.program = program;
-        result
-      }
+          self.program = program;
+          result
+        }
+        Err(error) => Err(error),
+      },
       Err(error) => Err(error),
     };
 
@@ -1948,8 +1950,9 @@ impl MechRuntime {
 
     let result = match source {
       MechSourceCode::String(source) => {
-        mech_syntax::parser::parse(source.trim())
-          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(&execution_scope)))
+        let tree = mech_syntax::parser::parse(source.trim())?;
+        self.preflight_context_capabilities(context, &tree, &execution_scope)?;
+        self.run_tree_on_program(context, program, &tree, Some(&execution_scope))
       }
       other => program.run_source(other),
     };

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,2105 +1,3270 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use mech_core::{hash_str, MechSourceCode, ModuleManifestConfig, ModuleManifestExportConfig, ModuleManifestExportKind, Ref, Value};
+use mech_core::{
+    MechSourceCode, ModuleManifestConfig, ModuleManifestExportConfig, ModuleManifestExportKind,
+    Ref, Value, hash_str,
+};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::*;
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\nsecret := 42\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), main_source).unwrap();
-  root
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-smoke-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        root.join("math.mec"),
+        "tau := 6.28318\nsecret := 42\n<+ tau\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("main.mec"), main_source).unwrap();
+    root
 }
-
-
 
 fn runtime_with_root(root: &std::path::Path) -> mech_runtime::MechRuntime {
-  RuntimeBuilder::new().source_resolver(FileSourceResolver::new(root)).build().unwrap()
+    RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(root))
+        .build()
+        .unwrap()
 }
 
-fn docs_provider_with(
-  base_uri: &str,
-  path: &str,
-  value: Value,
-) -> InMemoryDocsProvider {
-  InMemoryDocsProvider::new()
-    .with_value(base_uri, path, value)
-    .unwrap()
+fn docs_provider_with(base_uri: &str, path: &str, value: Value) -> InMemoryDocsProvider {
+    InMemoryDocsProvider::new()
+        .with_value(base_uri, path, value)
+        .unwrap()
 }
 
 fn read_grant(resource: &str, path: &str) -> RuntimeCapabilityGrantSpec {
-  RuntimeCapabilityGrantSpec::new("task://main", resource)
-    .with_operation(RuntimeCapabilityOperation::Read)
-    .with_path(path)
+    RuntimeCapabilityGrantSpec::new("task://main", resource)
+        .with_operation(RuntimeCapabilityOperation::Read)
+        .with_path(path)
 }
 
 fn runtime_write_grant_for(subject: &str, resource: &str, path: &str) -> RuntimeCapabilityGrant {
-  RuntimeCapabilityGrant {
-    subject: subject.to_string(),
-    resource: resource.to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec![path.to_string()],
-  }
+    RuntimeCapabilityGrant {
+        subject: subject.to_string(),
+        resource: resource.to_string(),
+        operations: vec![RuntimeCapabilityOperation::Write],
+        paths: vec![path.to_string()],
+    }
 }
 
 fn runtime_read_grant_for(subject: &str, resource: &str, path: &str) -> RuntimeCapabilityGrant {
-  RuntimeCapabilityGrant {
-    subject: subject.to_string(),
-    resource: resource.to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
-    paths: vec![path.to_string()],
-  }
+    RuntimeCapabilityGrant {
+        subject: subject.to_string(),
+        resource: resource.to_string(),
+        operations: vec![RuntimeCapabilityOperation::Read],
+        paths: vec![path.to_string()],
+    }
 }
 
-fn runtime_context_read_grant(runtime: &MechRuntime, resource: &str, path: &str) -> RuntimeCapabilityGrant {
-  let subject = runtime.runtime_context().unwrap().subject;
-  runtime_read_grant_for(&subject, resource, path)
+fn runtime_context_read_grant(
+    runtime: &MechRuntime,
+    resource: &str,
+    path: &str,
+) -> RuntimeCapabilityGrant {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime_read_grant_for(&subject, resource, path)
 }
 
-fn runtime_context_write_grant(runtime: &MechRuntime, resource: &str, path: &str) -> RuntimeCapabilityGrant {
-  let subject = runtime.runtime_context().unwrap().subject;
-  runtime_write_grant_for(&subject, resource, path)
+fn runtime_context_write_grant(
+    runtime: &MechRuntime,
+    resource: &str,
+    path: &str,
+) -> RuntimeCapabilityGrant {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime_write_grant_for(&subject, resource, path)
 }
 
-fn run_module_as_main(runtime: &mut MechRuntime, version: ModuleVersionId) -> mech_core::MResult<Value> {
-  let mut context = runtime.runtime_context()?.with_subject("task://main");
-  runtime.run_module_with_context(&mut context, version)
+fn run_module_as_main(
+    runtime: &mut MechRuntime,
+    version: ModuleVersionId,
+) -> mech_core::MResult<Value> {
+    let mut context = runtime.runtime_context()?.with_subject("task://main");
+    runtime.run_module_with_context(&mut context, version)
 }
 
 fn bool_value(value: bool) -> Value {
-  Value::Bool(Ref::new(value))
+    Value::Bool(Ref::new(value))
 }
 
 fn docs_entry(path: &str, value: Value) -> RuntimeDocsEntrySpec {
-  RuntimeDocsEntrySpec {
-    path: path.to_string(),
-    value,
-  }
+    RuntimeDocsEntrySpec {
+        path: path.to_string(),
+        value,
+    }
 }
 
 fn module_options() -> ModuleBuildOptions<'static> {
-  ModuleBuildOptions::new("test", "v0.3", "native", &[], &[])
+    ModuleBuildOptions::new("test", "v0.3", "native", &[], &[])
 }
 
 fn assert_bool_true(result: Value, label: &str) {
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from {label}, got {:?}", other),
-  }
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from {label}, got {:?}", other),
+    }
 }
 
 fn assert_bool_false(result: Value, label: &str) {
-  match result {
-    Value::Bool(value) => assert!(!*value.borrow()),
-    other => panic!("expected bool result from {label}, got {:?}", other),
-  }
+    match result {
+        Value::Bool(value) => assert!(!*value.borrow()),
+        other => panic!("expected bool result from {label}, got {:?}", other),
+    }
 }
-
-
 
 #[test]
 fn direct_run_string_preserves_normal_imports() {
-  let root = setup_modules("+> ./math.mec
+    let root = setup_modules(
+        "+> ./math.mec
 ok := math/tau > 6.0
-");
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .build()
-    .unwrap();
-  let version = runtime
-    .resolve_and_store_module_source("main.mec", module_options())
-    .unwrap()
-    .unwrap();
+",
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  let result = runtime.run_module(version).unwrap();
+    let result = runtime.run_module(version).unwrap();
 
-  assert_bool_true(result, "direct run_string normal import");
+    assert_bool_true(result, "direct run_string normal import");
 }
 
 #[test]
 fn in_memory_docs_provider_write_then_read_returns_value() {
-  let mut provider = InMemoryDocsProvider::new();
-  provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
-  let value = provider.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
-  assert_bool_true(value, "provider write then read");
+    let mut provider = InMemoryDocsProvider::new();
+    provider
+        .write(RuntimeResourceWriteRequest {
+            base_uri: "docs://manual".to_string(),
+            path: "intro/title".to_string(),
+            context_name: "manual".to_string(),
+            value: bool_value(true),
+            intent: RuntimeResourceWriteIntent::Assign,
+        })
+        .unwrap();
+    let value = provider
+        .read(RuntimeResourceReadRequest {
+            base_uri: "docs://manual".to_string(),
+            path: "intro/title".to_string(),
+            context_name: "manual".to_string(),
+        })
+        .unwrap();
+    assert_bool_true(value, "provider write then read");
 }
 
 #[test]
 fn resource_registry_write_then_read_returns_value() {
-  let mut registry = RuntimeResourceRegistry::new();
-  registry.register_provider(Box::new(InMemoryDocsProvider::new())).unwrap();
-  registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
-  let value = registry.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
-  assert_bool_true(value, "registry write then read");
+    let mut registry = RuntimeResourceRegistry::new();
+    registry
+        .register_provider(Box::new(InMemoryDocsProvider::new()))
+        .unwrap();
+    registry
+        .write(RuntimeResourceWriteRequest {
+            base_uri: "docs://manual".to_string(),
+            path: "intro/title".to_string(),
+            context_name: "manual".to_string(),
+            value: bool_value(true),
+            intent: RuntimeResourceWriteIntent::Assign,
+        })
+        .unwrap();
+    let value = registry
+        .read(RuntimeResourceReadRequest {
+            base_uri: "docs://manual".to_string(),
+            path: "intro/title".to_string(),
+            context_name: "manual".to_string(),
+        })
+        .unwrap();
+    assert_bool_true(value, "registry write then read");
 }
 
 #[test]
 fn resource_registry_write_missing_provider_fails() {
-  let mut registry = RuntimeResourceRegistry::new();
-  let result = registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected missing provider error, got {error}");
-  assert!(error.contains("docs"), "expected scheme in error, got {error}");
-  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
+    let mut registry = RuntimeResourceRegistry::new();
+    let result = registry.write(RuntimeResourceWriteRequest {
+        base_uri: "docs://manual".to_string(),
+        path: "intro/title".to_string(),
+        context_name: "manual".to_string(),
+        value: bool_value(true),
+        intent: RuntimeResourceWriteIntent::Assign,
+    });
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderNotFound"),
+        "expected missing provider error, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected scheme in error, got {error}"
+    );
+    assert!(
+        error.contains("docs://manual"),
+        "expected base URI in error, got {error}"
+    );
 }
 
 #[test]
 fn in_memory_docs_write_invalid_scheme_fails() {
-  let mut provider = InMemoryDocsProvider::new();
-  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "db://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
-  assert!(error.contains("docs"), "expected docs scheme requirement, got {error}");
+    let mut provider = InMemoryDocsProvider::new();
+    let result = provider.write(RuntimeResourceWriteRequest {
+        base_uri: "db://manual".to_string(),
+        path: "intro/title".to_string(),
+        context_name: "manual".to_string(),
+        value: bool_value(true),
+        intent: RuntimeResourceWriteIntent::Assign,
+    });
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceInvalidUri"),
+        "expected invalid URI error, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected docs scheme requirement, got {error}"
+    );
 }
 
 #[test]
 fn in_memory_docs_write_empty_path_fails() {
-  let mut provider = InMemoryDocsProvider::new();
-  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: String::new(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
-  assert!(error.contains("resource path cannot be empty"), "expected empty path error, got {error}");
+    let mut provider = InMemoryDocsProvider::new();
+    let result = provider.write(RuntimeResourceWriteRequest {
+        base_uri: "docs://manual".to_string(),
+        path: String::new(),
+        context_name: "manual".to_string(),
+        value: bool_value(true),
+        intent: RuntimeResourceWriteIntent::Assign,
+    });
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceInvalidUri"),
+        "expected invalid URI error, got {error}"
+    );
+    assert!(
+        error.contains("resource path cannot be empty"),
+        "expected empty path error, got {error}"
+    );
 }
 
 #[derive(Debug)]
 struct ReadOnlyDocsProvider;
 
 impl RuntimeResourceProvider for ReadOnlyDocsProvider {
-  fn scheme(&self) -> &str { "docs" }
-  fn read(&self, _request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> { unreachable!("read is not needed for the default write behavior test") }
+    fn scheme(&self) -> &str {
+        "docs"
+    }
+    fn read(&self, _request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
+        unreachable!("read is not needed for the default write behavior test")
+    }
 }
 
 #[test]
 fn provider_default_write_is_unsupported() {
-  let mut provider = ReadOnlyDocsProvider;
-  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceWriteUnsupported"), "expected unsupported write error, got {error}");
-  assert!(error.contains("docs"), "expected provider scheme in error, got {error}");
-  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
-  assert!(error.contains("intro/title"), "expected path in error, got {error}");
+    let mut provider = ReadOnlyDocsProvider;
+    let result = provider.write(RuntimeResourceWriteRequest {
+        base_uri: "docs://manual".to_string(),
+        path: "intro/title".to_string(),
+        context_name: "manual".to_string(),
+        value: bool_value(true),
+        intent: RuntimeResourceWriteIntent::Assign,
+    });
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceWriteUnsupported"),
+        "expected unsupported write error, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected provider scheme in error, got {error}"
+    );
+    assert!(
+        error.contains("docs://manual"),
+        "expected base URI in error, got {error}"
+    );
+    assert!(
+        error.contains("intro/title"),
+        "expected path in error, got {error}"
+    );
 }
 
 #[test]
 fn interpreter_context_name_conflict_fails_resolution() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@foo := docs://foo{:read(ok)}\n");
-  let mut runtime = runtime_with_root(&root);
-  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
-  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+    let root =
+        setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@foo := docs://foo{:read(ok)}\n");
+    let mut runtime = runtime_with_root(&root);
+    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("AddressTargetNameConflict"),
+        "expected address target conflict, got {error}"
+    );
+    assert!(
+        error.contains("foo"),
+        "expected conflicting target in error, got {error}"
+    );
 }
 
 #[test]
 fn duplicate_context_address_target_fails_resolution() {
-  let root = setup_modules("@foo := docs://a{:read(*)}\n@foo := docs://b{:read(*)}\n");
-  let mut runtime = runtime_with_root(&root);
-  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
-  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+    let root = setup_modules("@foo := docs://a{:read(*)}\n@foo := docs://b{:read(*)}\n");
+    let mut runtime = runtime_with_root(&root);
+    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("AddressTargetNameConflict"),
+        "expected address target conflict, got {error}"
+    );
+    assert!(
+        error.contains("foo"),
+        "expected conflicting target in error, got {error}"
+    );
 }
 
 #[test]
 fn repeated_interpreter_fences_merge_before_resolution_and_execution() {
-  let root = setup_modules("~~~mech:foo\nx := 1\n~~~\n\nprose stays out\n\n~~~mech:foo\ny := x + 1\n<+ y\n~~~\n\nresult := @foo/y\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
-    other => panic!("expected merged interpreter result, got {:?}", other),
-  }
+    let root = setup_modules(
+        "~~~mech:foo\nx := 1\n~~~\n\nprose stays out\n\n~~~mech:foo\ny := x + 1\n<+ y\n~~~\n\nresult := @foo/y\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
+        other => panic!("expected merged interpreter result, got {:?}", other),
+    }
 }
 
 #[test]
 fn faux_tilde_interpreter_fence_inside_markdown_backtick_block_is_ignored() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n```text\n~~~mech:foo\nbroken := missing\n~~~\n```\n\nresult := @foo/ok\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "interpreter ignores faux tilde fence");
+    let root = setup_modules(
+        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n```text\n~~~mech:foo\nbroken := missing\n~~~\n```\n\nresult := @foo/ok\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        runtime.run_module(version).unwrap(),
+        "interpreter ignores faux tilde fence",
+    );
 }
 
 #[test]
 fn faux_backtick_interpreter_fence_inside_markdown_tilde_block_is_ignored() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~text\n```mech:foo\nbroken := missing\n```\n~~~\n\nresult := @foo/ok\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "interpreter ignores faux backtick fence");
+    let root = setup_modules(
+        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~text\n```mech:foo\nbroken := missing\n```\n~~~\n\nresult := @foo/ok\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        runtime.run_module(version).unwrap(),
+        "interpreter ignores faux backtick fence",
+    );
 }
 
 #[test]
 fn duplicate_resolved_interpreter_address_target_still_fails_validation() {
-  let foo = SourceInterpreterId {
-    namespace: hash_str("foo"),
-    namespace_str: "foo".to_string(),
-  };
-  let scope = ModuleScopeMetadata {
-    scope: SourceScope::Interpreter(foo),
-    imports: Vec::new(),
-    exports: Vec::new(),
-    contexts: Vec::new(),
-    address_references: Vec::new(),
-  };
-  let resolved = ResolvedSource::new(
-    "main.mec",
-    "memory:main.mec",
-    MechSourceCode::String("ok := true\n".to_string()),
-  )
-  .with_kind(SourceKind::Mech)
-  .with_scopes(vec![scope.clone(), scope]);
+    let foo = SourceInterpreterId {
+        namespace: hash_str("foo"),
+        namespace_str: "foo".to_string(),
+    };
+    let scope = ModuleScopeMetadata {
+        scope: SourceScope::Interpreter(foo),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        contexts: Vec::new(),
+        address_references: Vec::new(),
+    };
+    let resolved = ResolvedSource::new(
+        "main.mec",
+        "memory:main.mec",
+        MechSourceCode::String("ok := true\n".to_string()),
+    )
+    .with_kind(SourceKind::Mech)
+    .with_scopes(vec![scope.clone(), scope]);
 
-  let result = resolved.validate();
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
-  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+    let result = resolved.validate();
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("AddressTargetNameConflict"),
+        "expected address target conflict, got {error}"
+    );
+    assert!(
+        error.contains("foo"),
+        "expected conflicting target in error, got {error}"
+    );
 }
 
 #[test]
 fn resolved_source_scope_address_target_conflict_fails_validation() {
-  let foo = SourceInterpreterId {
-    namespace: hash_str("foo"),
-    namespace_str: "foo".to_string(),
-  };
-  let resolved = ResolvedSource::new(
-    "main.mec",
-    "memory:main.mec",
-    MechSourceCode::String("ok := true\n".to_string()),
-  )
-  .with_kind(SourceKind::Mech)
-  .with_scopes(vec![
-    ModuleScopeMetadata {
-      scope: SourceScope::Interpreter(foo),
-      imports: Vec::new(),
-      exports: Vec::new(),
-      contexts: Vec::new(),
-      address_references: Vec::new(),
-    },
-    ModuleScopeMetadata {
-      scope: SourceScope::Program,
-      imports: Vec::new(),
-      exports: Vec::new(),
-      contexts: vec![SourceContextDeclaration {
-        name: "foo".to_string(),
-        base: SourceContextBase::ResourceUri("docs://foo".to_string()),
-        capabilities: Vec::new(),
-      }],
-      address_references: Vec::new(),
-    },
-  ]);
+    let foo = SourceInterpreterId {
+        namespace: hash_str("foo"),
+        namespace_str: "foo".to_string(),
+    };
+    let resolved = ResolvedSource::new(
+        "main.mec",
+        "memory:main.mec",
+        MechSourceCode::String("ok := true\n".to_string()),
+    )
+    .with_kind(SourceKind::Mech)
+    .with_scopes(vec![
+        ModuleScopeMetadata {
+            scope: SourceScope::Interpreter(foo),
+            imports: Vec::new(),
+            exports: Vec::new(),
+            contexts: Vec::new(),
+            address_references: Vec::new(),
+        },
+        ModuleScopeMetadata {
+            scope: SourceScope::Program,
+            imports: Vec::new(),
+            exports: Vec::new(),
+            contexts: vec![SourceContextDeclaration {
+                name: "foo".to_string(),
+                base: SourceContextBase::ResourceUri("docs://foo".to_string()),
+                capabilities: Vec::new(),
+            }],
+            address_references: Vec::new(),
+        },
+    ]);
 
-  let result = resolved.validate();
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
-  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
+    let result = resolved.validate();
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("AddressTargetNameConflict"),
+        "expected address target conflict, got {error}"
+    );
+    assert!(
+        error.contains("foo"),
+        "expected conflicting target in error, got {error}"
+    );
 }
 
 #[test]
 fn distinct_interpreter_and_context_names_pass() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@manual := docs://foo{:read(ok)}\n\nresult := @foo/ok\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  assert_bool_true(result, "distinct interpreter/context names");
+    let root = setup_modules(
+        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@manual := docs://foo{:read(ok)}\n\nresult := @foo/ok\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    assert_bool_true(result, "distinct interpreter/context names");
 }
 
 #[test]
 fn context_docs_read_returns_value() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  assert_bool_true(result, "context docs read");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    assert_bool_true(result, "context docs read");
 }
 
 #[test]
 fn config_spec_registers_in_memory_docs_resource() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("intro/title", bool_value(true)),
-    ),
-  ).with_capability_grant(read_grant("docs://manual", "intro/title"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .config_spec(spec)
-    .build()
-    .unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "config spec docs read");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let spec = RuntimeConfigSpec::new()
+        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+                .with_entry("intro/title", bool_value(true)),
+        ))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .config_spec(spec)
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        run_module_as_main(&mut runtime, version).unwrap(),
+        "config spec docs read",
+    );
 }
 
 #[test]
 fn config_spec_merges_multiple_docs_bases_into_one_provider() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@guide := docs://guide{:read(start/title)}\n\nmanual-ok := @manual/intro/title\nguide-ok := @guide/start/title\n\nresult := manual-ok && guide-ok\n");
-  let spec = RuntimeConfigSpec::new()
-    .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("intro/title", bool_value(true)),
-    ))
-    .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://guide")
-        .with_entry("start/title", bool_value(true)),
-    ))
-    .with_capability_grant(read_grant("docs://manual", "intro/title"))
-    .with_capability_grant(read_grant("docs://guide", "start/title"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .config_spec(spec)
-    .build()
-    .unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "merged config spec docs bases");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n@guide := docs://guide{:read(start/title)}\n\nmanual-ok := @manual/intro/title\nguide-ok := @guide/start/title\n\nresult := manual-ok && guide-ok\n",
+    );
+    let spec = RuntimeConfigSpec::new()
+        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+                .with_entry("intro/title", bool_value(true)),
+        ))
+        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+            RuntimeInMemoryDocsResourceSpec::new("docs://guide")
+                .with_entry("start/title", bool_value(true)),
+        ))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"))
+        .with_capability_grant(read_grant("docs://guide", "start/title"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .config_spec(spec)
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        run_module_as_main(&mut runtime, version).unwrap(),
+        "merged config spec docs bases",
+    );
 }
 
 #[test]
 fn config_spec_multiple_entries_same_base() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/*)}\n\na := @manual/intro/title\nb := @manual/intro/subtitle\n\nresult := a && b\n");
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(RuntimeInMemoryDocsResourceSpec {
-      base_uri: "docs://manual".to_string(),
-      entries: vec![
-        docs_entry("intro/title", bool_value(true)),
-        docs_entry("intro/subtitle", bool_value(true)),
-      ],
-    }),
-  ).with_capability_grant(read_grant("docs://manual", "intro/*"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .config_spec(spec)
-    .build()
-    .unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "config spec docs entries under one base");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/*)}\n\na := @manual/intro/title\nb := @manual/intro/subtitle\n\nresult := a && b\n",
+    );
+    let spec = RuntimeConfigSpec::new()
+        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+            RuntimeInMemoryDocsResourceSpec {
+                base_uri: "docs://manual".to_string(),
+                entries: vec![
+                    docs_entry("intro/title", bool_value(true)),
+                    docs_entry("intro/subtitle", bool_value(true)),
+                ],
+            },
+        ))
+        .with_capability_grant(read_grant("docs://manual", "intro/*"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .config_spec(spec)
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        run_module_as_main(&mut runtime, version).unwrap(),
+        "config spec docs entries under one base",
+    );
 }
 
 #[test]
 fn config_spec_later_duplicate_path_overwrites_earlier() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("intro/title", bool_value(false))
-        .with_entry("intro/title", bool_value(true)),
-    ),
-  ).with_capability_grant(read_grant("docs://manual", "intro/title"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .config_spec(spec)
-    .build()
-    .unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "later duplicate config spec docs path");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let spec = RuntimeConfigSpec::new()
+        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+                .with_entry("intro/title", bool_value(false))
+                .with_entry("intro/title", bool_value(true)),
+        ))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .config_spec(spec)
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        run_module_as_main(&mut runtime, version).unwrap(),
+        "later duplicate config spec docs path",
+    );
 }
 
 #[test]
 fn config_spec_invalid_docs_uri_fails_build() {
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("db://manual")
-        .with_entry("intro/title", bool_value(true)),
-    ),
-  );
-  let result = RuntimeBuilder::new().config_spec(spec).build();
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
-  assert!(error.contains("docs"), "expected docs scheme requirement, got {error}");
+    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+        RuntimeInMemoryDocsResourceSpec::new("db://manual")
+            .with_entry("intro/title", bool_value(true)),
+    ));
+    let result = RuntimeBuilder::new().config_spec(spec).build();
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceInvalidUri"),
+        "expected invalid URI error, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected docs scheme requirement, got {error}"
+    );
 }
 
 #[test]
 fn config_spec_invalid_empty_path_fails_build() {
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("", bool_value(true)),
-    ),
-  );
-  let result = RuntimeBuilder::new().config_spec(spec).build();
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
-  assert!(error.contains("resource path cannot be empty"), "expected empty path error, got {error}");
+    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+        RuntimeInMemoryDocsResourceSpec::new("docs://manual").with_entry("", bool_value(true)),
+    ));
+    let result = RuntimeBuilder::new().config_spec(spec).build();
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceInvalidUri"),
+        "expected invalid URI error, got {error}"
+    );
+    assert!(
+        error.contains("resource path cannot be empty"),
+        "expected empty path error, got {error}"
+    );
 }
 
 #[test]
 fn config_spec_and_direct_docs_provider_conflict() {
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("intro/title", bool_value(true)),
-    ),
-  );
-  let result = RuntimeBuilder::new()
-    .config_spec(spec)
-    .in_memory_docs(InMemoryDocsProvider::new())
-    .build();
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceProviderConflict"), "expected provider conflict, got {error}");
-  assert!(error.contains("docs"), "expected docs scheme in conflict, got {error}");
+    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+        RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+            .with_entry("intro/title", bool_value(true)),
+    ));
+    let result = RuntimeBuilder::new()
+        .config_spec(spec)
+        .in_memory_docs(InMemoryDocsProvider::new())
+        .build();
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderConflict"),
+        "expected provider conflict, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected docs scheme in conflict, got {error}"
+    );
 }
 
 #[test]
 fn direct_provider_registration_still_works() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "direct docs provider registration");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        runtime.run_module(version).unwrap(),
+        "direct docs provider registration",
+    );
 }
 
 #[test]
 fn apply_config_spec_after_build_registers_docs() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("intro/title", bool_value(true)),
-    ),
-  ).with_capability_grant(read_grant("docs://manual", "intro/title"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .build()
-    .unwrap();
-  runtime.apply_config_spec(spec).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "applied config spec docs read");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let spec = RuntimeConfigSpec::new()
+        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+                .with_entry("intro/title", bool_value(true)),
+        ))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    runtime.apply_config_spec(spec).unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        run_module_as_main(&mut runtime, version).unwrap(),
+        "applied config spec docs read",
+    );
 }
 
 #[test]
 fn apply_config_spec_conflicts_with_existing_docs_provider() {
-  let spec = RuntimeConfigSpec::new().with_resource(
-    RuntimeResourceConfigSpec::InMemoryDocs(
-      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-        .with_entry("intro/title", bool_value(true)),
-    ),
-  );
-  let mut runtime = RuntimeBuilder::new()
-    .in_memory_docs(InMemoryDocsProvider::new())
-    .build()
-    .unwrap();
-  let result = runtime.apply_config_spec(spec);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceProviderConflict"), "expected provider conflict, got {error}");
-  assert!(error.contains("docs"), "expected docs scheme in conflict, got {error}");
+    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+        RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+            .with_entry("intro/title", bool_value(true)),
+    ));
+    let mut runtime = RuntimeBuilder::new()
+        .in_memory_docs(InMemoryDocsProvider::new())
+        .build()
+        .unwrap();
+    let result = runtime.apply_config_spec(spec);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderConflict"),
+        "expected provider conflict, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected docs scheme in conflict, got {error}"
+    );
 }
 
 #[test]
 fn unknown_address_target_is_explicit() {
-  let root = setup_modules("result := @missing/ok\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target error, got {error}");
-  assert!(error.contains("missing"), "expected missing target in error, got {error}");
+    let root = setup_modules("result := @missing/ok\n");
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("UnknownAddressTarget"),
+        "expected unknown address target error, got {error}"
+    );
+    assert!(
+        error.contains("missing"),
+        "expected missing target in error, got {error}"
+    );
 }
 
 #[test]
 fn interpreter_address_still_works() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  assert_bool_true(result, "interpreter address");
+    let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    assert_bool_true(result, "interpreter address");
 }
 
 #[test]
 fn string_and_comment_address_text_are_not_targets() {
-  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n-- @bar\n\nok := true\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
-  assert!(program.address_references.is_empty(), "expected no program address references, got {:?}", program.address_references);
-  let result = runtime.run_module(version);
-  assert!(result.is_ok(), "expected string/comment @bar not to execute interpreter, got {result:?}");
+    let root = setup_modules(
+        "~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n-- @bar\n\nok := true\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    let program = main
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program)
+        .unwrap();
+    assert!(
+        program.address_references.is_empty(),
+        "expected no program address references, got {:?}",
+        program.address_references
+    );
+    let result = runtime.run_module(version);
+    assert!(
+        result.is_ok(),
+        "expected string/comment @bar not to execute interpreter, got {result:?}"
+    );
 }
 
-fn foo_scope(runtime: &mech_runtime::MechRuntime, version: mech_runtime::ModuleVersionId) -> SourceScope {
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  main.scopes.iter().find_map(|metadata| match &metadata.scope {
-    SourceScope::Interpreter(interpreter) if interpreter.namespace_str == "foo" => Some(metadata.scope.clone()),
-    SourceScope::Interpreter(_) | SourceScope::Program => None,
-  }).unwrap()
+fn foo_scope(
+    runtime: &mech_runtime::MechRuntime,
+    version: mech_runtime::ModuleVersionId,
+) -> SourceScope {
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    main.scopes
+        .iter()
+        .find_map(|metadata| match &metadata.scope {
+            SourceScope::Interpreter(interpreter) if interpreter.namespace_str == "foo" => {
+                Some(metadata.scope.clone())
+            }
+            SourceScope::Interpreter(_) | SourceScope::Program => None,
+        })
+        .unwrap()
 }
 
-fn interpreter_scope_named(runtime: &mech_runtime::MechRuntime, version: mech_runtime::ModuleVersionId, name: &str) -> SourceScope {
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  main.scopes.iter().find_map(|metadata| match &metadata.scope {
-    SourceScope::Interpreter(interpreter) if interpreter.namespace_str == name => Some(metadata.scope.clone()),
-    SourceScope::Interpreter(_) | SourceScope::Program => None,
-  }).unwrap()
+fn interpreter_scope_named(
+    runtime: &mech_runtime::MechRuntime,
+    version: mech_runtime::ModuleVersionId,
+    name: &str,
+) -> SourceScope {
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    main.scopes
+        .iter()
+        .find_map(|metadata| match &metadata.scope {
+            SourceScope::Interpreter(interpreter) if interpreter.namespace_str == name => {
+                Some(metadata.scope.clone())
+            }
+            SourceScope::Interpreter(_) | SourceScope::Program => None,
+        })
+        .unwrap()
 }
-
 
 #[test]
 fn context_docs_read_without_provider_fails() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let mut runtime = runtime_with_root(&root);
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected missing provider error, got {error}");
-  assert!(error.contains("docs"), "expected scheme in error, got {error}");
-  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderNotFound"),
+        "expected missing provider error, got {error}"
+    );
+    assert!(
+        error.contains("docs"),
+        "expected scheme in error, got {error}"
+    );
+    assert!(
+        error.contains("docs://manual"),
+        "expected base URI in error, got {error}"
+    );
 }
 
 #[test]
 fn context_docs_read_missing_path_fails() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(InMemoryDocsProvider::new())
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourcePathNotFound"), "expected missing path error, got {error}");
-  assert!(error.contains("intro/title"), "expected path in error, got {error}");
-  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(InMemoryDocsProvider::new())
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourcePathNotFound"),
+        "expected missing path error, got {error}"
+    );
+    assert!(
+        error.contains("intro/title"),
+        "expected path in error, got {error}"
+    );
+    assert!(
+        error.contains("docs://manual"),
+        "expected base URI in error, got {error}"
+    );
 }
 
 #[test]
 fn context_docs_read_denied_by_capability_fails() {
-  let root = setup_modules("@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceCapabilityDenied"), "expected capability error, got {error}");
-  assert!(error.contains("manual"), "expected context name in error, got {error}");
-  assert!(error.contains("read"), "expected operation in error, got {error}");
-  assert!(error.contains("intro/title"), "expected path in error, got {error}");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceCapabilityDenied"),
+        "expected capability error, got {error}"
+    );
+    assert!(
+        error.contains("manual"),
+        "expected context name in error, got {error}"
+    );
+    assert!(
+        error.contains("read"),
+        "expected operation in error, got {error}"
+    );
+    assert!(
+        error.contains("intro/title"),
+        "expected path in error, got {error}"
+    );
 }
 
 #[test]
 fn context_docs_read_prefix_wildcard_allows_nested_path() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/*)}\n\nresult := @manual/intro/title\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/*")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  assert_bool_true(result, "context docs prefix wildcard");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/*)}\n\nresult := @manual/intro/title\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/*",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    assert_bool_true(result, "context docs prefix wildcard");
 }
 
 #[test]
 fn context_docs_read_prefix_wildcard_does_not_match_sibling() {
-  let root = setup_modules("@manual := docs://manual{:read(introduction/*)}\n\nresult := @manual/intro/title\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceCapabilityDenied"), "expected capability error, got {error}");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(introduction/*)}\n\nresult := @manual/intro/title\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceCapabilityDenied"),
+        "expected capability error, got {error}"
+    );
 }
 
 #[test]
 fn program_scope_does_not_see_interpreter_context() {
-  let root = setup_modules("~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nunused := true\n~~~\n\nresult := @manual/intro/title\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target, got {error}");
-  assert!(error.contains("manual"), "expected target in error, got {error}");
-  assert!(!error.contains("ContextAddressReadUnsupported"), "program scope should not resolve interpreter context, got {error}");
+    let root = setup_modules(
+        "~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nunused := true\n~~~\n\nresult := @manual/intro/title\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("UnknownAddressTarget"),
+        "expected unknown address target, got {error}"
+    );
+    assert!(
+        error.contains("manual"),
+        "expected target in error, got {error}"
+    );
+    assert!(
+        !error.contains("ContextAddressReadUnsupported"),
+        "program scope should not resolve interpreter context, got {error}"
+    );
 }
 
 #[test]
 fn interpreter_scope_context_docs_read_returns_value() {
-  let root = setup_modules("~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n~~~\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let foo = foo_scope(&runtime, version);
-  let result = runtime.run_module_scope(version, foo).unwrap();
-  assert_bool_true(result, "interpreter scope context docs read");
+    let root = setup_modules(
+        "~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n~~~\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let foo = foo_scope(&runtime, version);
+    let result = runtime.run_module_scope(version, foo).unwrap();
+    assert_bool_true(result, "interpreter scope context docs read");
 }
 
 #[test]
 fn interpreter_scope_does_not_resolve_interpreter_target() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\nresult := @foo/ok\n~~~\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let bar = interpreter_scope_named(&runtime, version, "bar");
-  let result = runtime.run_module_scope(version, bar);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target, got {error}");
-  assert!(error.contains("foo"), "expected interpreter target in error, got {error}");
+    let root = setup_modules(
+        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\nresult := @foo/ok\n~~~\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let bar = interpreter_scope_named(&runtime, version, "bar");
+    let result = runtime.run_module_scope(version, bar);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("UnknownAddressTarget"),
+        "expected unknown address target, got {error}"
+    );
+    assert!(
+        error.contains("foo"),
+        "expected interpreter target in error, got {error}"
+    );
 }
 
 #[test]
 fn interpreter_address_still_works_from_program() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  assert_bool_true(result, "interpreter address from program");
+    let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    assert_bool_true(result, "interpreter address from program");
 }
 
 #[test]
 fn duplicate_context_registry_binding_rejected() {
-  let first = SourceContextDeclaration {
-    name: "manual".to_string(),
-    base: SourceContextBase::ResourceUri("docs://manual".to_string()),
-    capabilities: vec![SourceContextCapability {
-      operation: "read".to_string(),
-      scope: SourceContextCapabilityScope::Path("intro/title".to_string()),
-    }],
-  };
-  let second = SourceContextDeclaration {
-    name: "manual".to_string(),
-    base: SourceContextBase::ResourceUri("docs://other".to_string()),
-    capabilities: vec![SourceContextCapability {
-      operation: "read".to_string(),
-      scope: SourceContextCapabilityScope::Wildcard,
-    }],
-  };
+    let first = SourceContextDeclaration {
+        name: "manual".to_string(),
+        base: SourceContextBase::ResourceUri("docs://manual".to_string()),
+        capabilities: vec![SourceContextCapability {
+            operation: "read".to_string(),
+            scope: SourceContextCapabilityScope::Path("intro/title".to_string()),
+        }],
+    };
+    let second = SourceContextDeclaration {
+        name: "manual".to_string(),
+        base: SourceContextBase::ResourceUri("docs://other".to_string()),
+        capabilities: vec![SourceContextCapability {
+            operation: "read".to_string(),
+            scope: SourceContextCapabilityScope::Wildcard,
+        }],
+    };
 
-  let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[first, second]);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeContextDuplicateBinding"), "expected duplicate binding error, got {error}");
-  assert!(error.contains("manual"), "expected duplicate context name in error, got {error}");
+    let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[first, second]);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeContextDuplicateBinding"),
+        "expected duplicate binding error, got {error}"
+    );
+    assert!(
+        error.contains("manual"),
+        "expected duplicate context name in error, got {error}"
+    );
 }
 
 #[test]
 fn derived_context_base_is_unsupported() {
-  let declaration = SourceContextDeclaration {
-    name: "manual".to_string(),
-    base: SourceContextBase::Context("base".to_string()),
-    capabilities: vec![SourceContextCapability {
-      operation: "read".to_string(),
-      scope: SourceContextCapabilityScope::Wildcard,
-    }],
-  };
+    let declaration = SourceContextDeclaration {
+        name: "manual".to_string(),
+        base: SourceContextBase::Context("base".to_string()),
+        capabilities: vec![SourceContextCapability {
+            operation: "read".to_string(),
+            scope: SourceContextCapabilityScope::Wildcard,
+        }],
+    };
 
-  let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[declaration]);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeContextDerivedBaseUnsupported"), "expected derived base error, got {error}");
-  assert!(error.contains("base"), "expected base context name in error, got {error}");
+    let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[declaration]);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeContextDerivedBaseUnsupported"),
+        "expected derived base error, got {error}"
+    );
+    assert!(
+        error.contains("base"),
+        "expected base context name in error, got {error}"
+    );
 }
 
 #[test]
 fn interpreter_scope_imports_work() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-imports-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-interpreter-imports-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let scope = foo_scope(&runtime, version);
-  let result = runtime.run_module_scope(version, scope).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module scope run, got {:?}", other),
-  }
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let scope = foo_scope(&runtime, version);
+    let result = runtime.run_module_scope(version, scope).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from module scope run, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn program_cannot_see_fenced_import_but_interpreter_can() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-import-privacy-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\ntop := math/tau > 6.0\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-interpreter-import-privacy-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\ntop := math/tau > 6.0\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let scope = foo_scope(&runtime, version);
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let scope = foo_scope(&runtime, version);
 
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("math/tau"));
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("math/tau"));
 
-  let result = runtime.run_module_scope(version, scope).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module scope run, got {:?}", other),
-  }
+    let result = runtime.run_module_scope(version, scope).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from module scope run, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn interpreter_scope_exports_only_interpreter_exports() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-exports-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("main.mec"), "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n\nprogram-value := false\n<+ program-value\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-interpreter-exports-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("main.mec"), "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n\nprogram-value := false\n<+ program-value\n").unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let scope = foo_scope(&runtime, version);
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  let foo = main.scopes.iter().find(|metadata| metadata.scope == scope).unwrap();
-  assert!(foo.exports.iter().any(|export| export.name == "foo-value"));
-  assert!(!foo.exports.iter().any(|export| export.name == "program-value"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let scope = foo_scope(&runtime, version);
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    let foo = main
+        .scopes
+        .iter()
+        .find(|metadata| metadata.scope == scope)
+        .unwrap();
+    assert!(foo.exports.iter().any(|export| export.name == "foo-value"));
+    assert!(
+        !foo.exports
+            .iter()
+            .any(|export| export.name == "program-value")
+    );
 
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(!*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(!*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 
-  let result = runtime.run_module_scope(version, scope).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module scope run, got {:?}", other),
-  }
+    let result = runtime.run_module_scope(version, scope).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from module scope run, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn interpreter_scope_executes_only_matching_import_edges() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-edge-filter-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("good.mec"), "value := true\n<+ value\n").unwrap();
-  std::fs::write(root.join("bad.mec"), "missing := bad/value\n").unwrap();
-  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./good.mec\nok := good/value\n<+ ok\n~~~\n\n~~~mech:bar\n+> ./bad.mec\n~~~\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-interpreter-edge-filter-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("good.mec"), "value := true\n<+ value\n").unwrap();
+    std::fs::write(root.join("bad.mec"), "missing := bad/value\n").unwrap();
+    std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./good.mec\nok := good/value\n<+ ok\n~~~\n\n~~~mech:bar\n+> ./bad.mec\n~~~\n").unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let scope = foo_scope(&runtime, version);
-  let result = runtime.run_module_scope(version, scope).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module scope run, got {:?}", other),
-  }
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let scope = foo_scope(&runtime, version);
+    let result = runtime.run_module_scope(version, scope).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from module scope run, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn missing_interpreter_scope_returns_error() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-missing-interpreter-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("main.mec"), "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-missing-interpreter-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let missing = SourceScope::Interpreter(SourceInterpreterId {
-    namespace: hash_str("missing"),
-    namespace_str: "missing".to_string(),
-  });
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let missing = SourceScope::Interpreter(SourceInterpreterId {
+        namespace: hash_str("missing"),
+        namespace_str: "missing".to_string(),
+    });
 
-  let result = runtime.run_module_scope(version, missing);
-  assert!(result.is_err());
+    let result = runtime.run_module_scope(version, missing);
+    assert!(result.is_err());
 }
-
 
 #[test]
 fn program_reads_interpreter_export_by_indexed_address() {
-  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+    let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from addressed interpreter export, got {:?}", other),
-  }
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from addressed interpreter export, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn program_reads_interpreter_export_by_address_with_interpreter_import() {
-  let root = setup_modules("~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+    let root = setup_modules(
+        "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\nresult := @foo/ok\n",
+    );
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from addressed interpreter export with import, got {:?}", other),
-  }
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from addressed interpreter export with import, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn program_address_does_not_execute_unreferenced_interpreter_from_string() {
-  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n");
+    let root =
+        setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n");
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_ok(), "expected string @bar not to execute interpreter, got {result:?}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(
+        result.is_ok(),
+        "expected string @bar not to execute interpreter, got {result:?}"
+    );
 }
-
 
 #[test]
 fn program_address_does_not_execute_unreferenced_interpreter_from_comment() {
-  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\n-- @bar\n\nok := true\n");
+    let root =
+        setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\n-- @bar\n\nok := true\n");
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_ok(), "expected comment @bar not to execute interpreter, got {result:?}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(
+        result.is_ok(),
+        "expected comment @bar not to execute interpreter, got {result:?}"
+    );
 }
 
 #[test]
 fn program_reads_only_requested_interpreter_export() {
-  let root = setup_modules("~~~mech:foo\nok := true\nother := false\n<+ ok\n<+ other\n~~~\n\nresult := @foo/ok\n");
+    let root = setup_modules(
+        "~~~mech:foo\nok := true\nother := false\n<+ ok\n<+ other\n~~~\n\nresult := @foo/ok\n",
+    );
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from requested addressed export, got {:?}", other),
-  }
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!(
+            "expected bool result from requested addressed export, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn program_rejects_non_exported_interpreter_address() {
-  let root = setup_modules("~~~mech:foo\nhidden := true\n~~~\n\nresult := @foo/hidden\n");
+    let root = setup_modules("~~~mech:foo\nhidden := true\n~~~\n\nresult := @foo/hidden\n");
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeModuleExportNotFound") || error.contains("does not export"), "expected missing export error, got {error}");
-  assert!(error.contains("hidden"), "expected addressed symbol in error, got {error}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeModuleExportNotFound") || error.contains("does not export"),
+        "expected missing export error, got {error}"
+    );
+    assert!(
+        error.contains("hidden"),
+        "expected addressed symbol in error, got {error}"
+    );
 }
 
 #[test]
 fn program_unknown_interpreter_address_returns_error() {
-  let root = setup_modules("result := @missing/ok\n");
+    let root = setup_modules("result := @missing/ok\n");
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target error, got {error}");
-  assert!(error.contains("missing"), "expected missing target in error, got {error}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("UnknownAddressTarget"),
+        "expected unknown address target error, got {error}"
+    );
+    assert!(
+        error.contains("missing"),
+        "expected missing target in error, got {error}"
+    );
 }
 
 #[test]
 fn addressed_assignment_is_unsupported() {
-  let root = setup_modules("@foo/x := 1\nresult := @foo/x\n");
+    let root = setup_modules("@foo/x := 1\nresult := @foo/x\n");
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let result = runtime.resolve_and_store_module_source("main.mec", options);
-  assert!(result.is_err(), "prefix addressed define should be rejected while parsing/building");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("ParserErrorContext"), "expected parser error for addressed define, got {error}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let result = runtime.resolve_and_store_module_source("main.mec", options);
+    assert!(
+        result.is_err(),
+        "prefix addressed define should be rejected while parsing/building"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("ParserErrorContext"),
+        "expected parser error for addressed define, got {error}"
+    );
 }
 
 #[test]
 fn addressed_assignment_to_context_is_still_unsupported() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n",
+    );
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-  assert!(result.is_err(), "prefix addressed define should be rejected while parsing/building");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("ParserErrorContext"), "expected parser error for addressed define, got {error}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+    assert!(
+        result.is_err(),
+        "prefix addressed define should be rejected while parsing/building"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("ParserErrorContext"),
+        "expected parser error for addressed define, got {error}"
+    );
 }
 
 #[test]
 fn addressed_assignment_with_docs_provider_is_still_unsupported() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n",
+    );
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(InMemoryDocsProvider::new()).build().unwrap();
-  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-  assert!(result.is_err(), "prefix addressed define should be rejected while parsing/building");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("ParserErrorContext"), "expected parser error for addressed define, got {error}");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(InMemoryDocsProvider::new())
+        .build()
+        .unwrap();
+    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+    assert!(
+        result.is_err(),
+        "prefix addressed define should be rejected while parsing/building"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("ParserErrorContext"),
+        "expected parser error for addressed define, got {error}"
+    );
 }
 
 #[test]
 fn resolver_metadata() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let resolver = FileSourceResolver::new(&root);
-  let main = resolver.resolve(&SourceRequest::new("main.mec")).unwrap().unwrap();
-  assert_eq!(main.imports.len(), 1);
-  assert_eq!(main.contexts.len(), 0);
-  assert_eq!(main.dependencies.len(), 1);
-  assert!(main.dependencies[0].specifier == "./math.mec" || main.dependencies[0].specifier == "./math.mec".trim());
-  assert!(main.dependencies[0].referrer.is_some());
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let resolver = FileSourceResolver::new(&root);
+    let main = resolver
+        .resolve(&SourceRequest::new("main.mec"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.imports.len(), 1);
+    assert_eq!(main.contexts.len(), 0);
+    assert_eq!(main.dependencies.len(), 1);
+    assert!(
+        main.dependencies[0].specifier == "./math.mec"
+            || main.dependencies[0].specifier == "./math.mec".trim()
+    );
+    assert!(main.dependencies[0].referrer.is_some());
 
-  let dep = resolver.resolve(&main.dependencies[0]).unwrap().unwrap();
-  assert!(dep.exports.iter().any(|e| e.name == "tau"));
+    let dep = resolver.resolve(&main.dependencies[0]).unwrap().unwrap();
+    assert!(dep.exports.iter().any(|e| e.name == "tau"));
 }
 
 #[test]
 fn module_records_store_scoped_source_declarations_without_execution_changes() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-scopes-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("foo.mec"), "foo-result := 1\n<+ foo-result\n").unwrap();
-  std::fs::write(root.join("bar.mec"), "bar-result := 2\n<+ bar-result\n").unwrap();
-  std::fs::write(
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-scopes-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(root.join("foo.mec"), "foo-result := 1\n<+ foo-result\n").unwrap();
+    std::fs::write(root.join("bar.mec"), "bar-result := 2\n<+ bar-result\n").unwrap();
+    std::fs::write(
     root.join("main.mec"),
     "@program-db := db://program{:read(*)}\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n\n~~~mech:bar\n@bar-db := db://bar{:read(*)}\n+> ./bar.mec\n<+ bar-result\n~~~\n",
   ).unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
 
-  assert_eq!(main.imports.len(), 3);
-  assert_eq!(main.exports.len(), 3);
-  assert_eq!(main.contexts.len(), 3);
-  assert_eq!(main.import_edges.len(), 3);
-  assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
-  assert!(main.import_edges.iter().any(|edge| match &edge.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
-    SourceScope::Program => false,
-  }));
-  assert!(main.import_edges.iter().any(|edge| match &edge.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar" && edge.import.specifier == "./bar.mec",
-    SourceScope::Program => false,
-  }));
+    assert_eq!(main.imports.len(), 3);
+    assert_eq!(main.exports.len(), 3);
+    assert_eq!(main.contexts.len(), 3);
+    assert_eq!(main.import_edges.len(), 3);
+    assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
+    assert!(main.import_edges.iter().any(|edge| match &edge.scope {
+        SourceScope::Interpreter(interpreter) =>
+            interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
+        SourceScope::Program => false,
+    }));
+    assert!(main.import_edges.iter().any(|edge| match &edge.scope {
+        SourceScope::Interpreter(interpreter) =>
+            interpreter.namespace_str == "bar" && edge.import.specifier == "./bar.mec",
+        SourceScope::Program => false,
+    }));
 
-  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
-  assert_eq!(program.imports.len(), 1);
-  assert_eq!(program.imports[0].specifier, "./math.mec");
-  assert_eq!(program.exports.len(), 1);
-  assert_eq!(program.exports[0].name, "ok");
-  assert_eq!(program.contexts.len(), 1);
-  assert_eq!(program.contexts[0].name, "program-db");
+    let program = main
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program)
+        .unwrap();
+    assert_eq!(program.imports.len(), 1);
+    assert_eq!(program.imports[0].specifier, "./math.mec");
+    assert_eq!(program.exports.len(), 1);
+    assert_eq!(program.exports[0].name, "ok");
+    assert_eq!(program.contexts.len(), 1);
+    assert_eq!(program.contexts[0].name, "program-db");
 
-  let foo = main.scopes.iter().find(|scope| match &scope.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-    SourceScope::Program => false,
-  }).unwrap();
-  assert_eq!(foo.imports.len(), 1);
-  assert_eq!(foo.imports[0].specifier, "./foo.mec");
-  assert_eq!(foo.exports.len(), 1);
-  assert_eq!(foo.exports[0].name, "foo-result");
-  assert_eq!(foo.contexts.len(), 1);
-  assert_eq!(foo.contexts[0].name, "foo-db");
+    let foo = main
+        .scopes
+        .iter()
+        .find(|scope| match &scope.scope {
+            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+            SourceScope::Program => false,
+        })
+        .unwrap();
+    assert_eq!(foo.imports.len(), 1);
+    assert_eq!(foo.imports[0].specifier, "./foo.mec");
+    assert_eq!(foo.exports.len(), 1);
+    assert_eq!(foo.exports[0].name, "foo-result");
+    assert_eq!(foo.contexts.len(), 1);
+    assert_eq!(foo.contexts[0].name, "foo-db");
 
-  let bar = main.scopes.iter().find(|scope| match &scope.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar",
-    SourceScope::Program => false,
-  }).unwrap();
-  assert_eq!(bar.imports.len(), 1);
-  assert_eq!(bar.imports[0].specifier, "./bar.mec");
-  assert_eq!(bar.exports.len(), 1);
-  assert_eq!(bar.exports[0].name, "bar-result");
-  assert_eq!(bar.contexts.len(), 1);
-  assert_eq!(bar.contexts[0].name, "bar-db");
+    let bar = main
+        .scopes
+        .iter()
+        .find(|scope| match &scope.scope {
+            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar",
+            SourceScope::Program => false,
+        })
+        .unwrap();
+    assert_eq!(bar.imports.len(), 1);
+    assert_eq!(bar.imports[0].specifier, "./bar.mec");
+    assert_eq!(bar.exports.len(), 1);
+    assert_eq!(bar.exports[0].name, "bar-result");
+    assert_eq!(bar.contexts.len(), 1);
+    assert_eq!(bar.contexts[0].name, "bar-db");
 
-  assert!(!foo.imports.iter().any(|import| import.specifier == "./bar.mec"));
-  assert!(!foo.exports.iter().any(|export| export.name == "bar-result"));
-  assert!(!foo.contexts.iter().any(|context| context.name == "bar-db"));
+    assert!(
+        !foo.imports
+            .iter()
+            .any(|import| import.specifier == "./bar.mec")
+    );
+    assert!(!foo.exports.iter().any(|export| export.name == "bar-result"));
+    assert!(!foo.contexts.iter().any(|context| context.name == "bar-db"));
 }
 
 #[test]
 fn program_scope_imports_still_work() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
-  assert_eq!(program.imports.len(), 1);
-  assert_eq!(program.imports[0].specifier, "./math.mec");
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    let program = main
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program)
+        .unwrap();
+    assert_eq!(program.imports.len(), 1);
+    assert_eq!(program.imports[0].specifier, "./math.mec");
 
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn fenced_import_does_not_leak_to_program_scope() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-scoped-fenced-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\n~~~\nok := math/tau > 6.0\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-scoped-fenced-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "~~~mech:foo\n+> ./math.mec\n~~~\nok := math/tau > 6.0\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main.imports.len(), 1);
-  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program);
-  assert!(program.map(|scope| scope.imports.is_empty()).unwrap_or(true));
-  assert!(main.scopes.iter().any(|scope| match &scope.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && scope.imports.len() == 1 && scope.imports[0].specifier == "./math.mec",
-    SourceScope::Program => false,
-  }));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.imports.len(), 1);
+    let program = main
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program);
+    assert!(
+        program
+            .map(|scope| scope.imports.is_empty())
+            .unwrap_or(true)
+    );
+    assert!(main.scopes.iter().any(|scope| match &scope.scope {
+        SourceScope::Interpreter(interpreter) =>
+            interpreter.namespace_str == "foo"
+                && scope.imports.len() == 1
+                && scope.imports[0].specifier == "./math.mec",
+        SourceScope::Program => false,
+    }));
 
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("math/tau"));
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("math/tau"));
 }
 
 #[test]
 fn program_and_fenced_imports_do_not_mix() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-scope-mix-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-scope-mix-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
-  assert_eq!(program.imports.len(), 1);
-  assert_eq!(program.imports[0].specifier, "./math.mec");
-  let foo = main.scopes.iter().find(|scope| match &scope.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-    SourceScope::Program => false,
-  }).unwrap();
-  assert_eq!(foo.imports.len(), 1);
-  assert_eq!(foo.imports[0].specifier, "./foo.mec");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    let program = main
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program)
+        .unwrap();
+    assert_eq!(program.imports.len(), 1);
+    assert_eq!(program.imports[0].specifier, "./math.mec");
+    let foo = main
+        .scopes
+        .iter()
+        .find(|scope| match &scope.scope {
+            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+            SourceScope::Program => false,
+        })
+        .unwrap();
+    assert_eq!(foo.imports.len(), 1);
+    assert_eq!(foo.imports[0].specifier, "./foo.mec");
 
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn program_and_fenced_can_import_same_module_without_duplicate_program_binding() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-same-import-scope-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./math.mec\n~~~\n\nok := math/tau > 6.0\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-same-import-scope-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> ./math.mec\n\n~~~mech:foo\n+> ./math.mec\n~~~\n\nok := math/tau > 6.0\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main.imports.len(), 2);
-  assert_eq!(main.import_edges.len(), 2);
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.imports.len(), 2);
+    assert_eq!(main.import_edges.len(), 2);
 
-  let program_edges = main.import_edges.iter().filter(|edge| edge.scope == SourceScope::Program).collect::<Vec<_>>();
-  assert_eq!(program_edges.len(), 1);
-  assert_eq!(program_edges[0].import.specifier, "./math.mec");
+    let program_edges = main
+        .import_edges
+        .iter()
+        .filter(|edge| edge.scope == SourceScope::Program)
+        .collect::<Vec<_>>();
+    assert_eq!(program_edges.len(), 1);
+    assert_eq!(program_edges[0].import.specifier, "./math.mec");
 
-  let foo_edges = main.import_edges.iter().filter(|edge| match &edge.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-    SourceScope::Program => false,
-  }).collect::<Vec<_>>();
-  assert_eq!(foo_edges.len(), 1);
-  assert_eq!(foo_edges[0].import.specifier, "./math.mec");
+    let foo_edges = main
+        .import_edges
+        .iter()
+        .filter(|edge| match &edge.scope {
+            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+            SourceScope::Program => false,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(foo_edges.len(), 1);
+    assert_eq!(foo_edges[0].import.specifier, "./math.mec");
 
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn fenced_import_binding_is_not_visible_to_program_scope() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-scope-negative-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := foo/foo-value > 0\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-scope-negative-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := foo/foo-value > 0\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("foo/foo-value"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("foo/foo-value"));
 }
 
 #[test]
 fn module_records_keep_flat_metadata_for_compatibility() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-flat-compat-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-flat-compat-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n",
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main.imports.len(), 2);
-  assert_eq!(main.import_edges.len(), 2);
-  assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
-  assert!(main.import_edges.iter().any(|edge| match &edge.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
-    SourceScope::Program => false,
-  }));
-  assert!(main.imports.iter().any(|import| import.specifier == "./math.mec"));
-  assert!(main.imports.iter().any(|import| import.specifier == "./foo.mec"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.imports.len(), 2);
+    assert_eq!(main.import_edges.len(), 2);
+    assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
+    assert!(main.import_edges.iter().any(|edge| match &edge.scope {
+        SourceScope::Interpreter(interpreter) =>
+            interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
+        SourceScope::Program => false,
+    }));
+    assert!(
+        main.imports
+            .iter()
+            .any(|import| import.specifier == "./math.mec")
+    );
+    assert!(
+        main.imports
+            .iter()
+            .any(|import| import.specifier == "./foo.mec")
+    );
 
-  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
-  assert_eq!(program.imports.len(), 1);
-  assert_eq!(program.imports[0].specifier, "./math.mec");
-  let foo = main.scopes.iter().find(|scope| match &scope.scope {
-    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-    SourceScope::Program => false,
-  }).unwrap();
-  assert_eq!(foo.imports.len(), 1);
-  assert_eq!(foo.imports[0].specifier, "./foo.mec");
+    let program = main
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program)
+        .unwrap();
+    assert_eq!(program.imports.len(), 1);
+    assert_eq!(program.imports[0].specifier, "./math.mec");
+    let foo = main
+        .scopes
+        .iter()
+        .find(|scope| match &scope.scope {
+            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+            SourceScope::Program => false,
+        })
+        .unwrap();
+    assert_eq!(foo.imports.len(), 1);
+    assert_eq!(foo.imports[0].specifier, "./foo.mec");
 
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn build_dependency_graph() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main_version = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main_version.dependencies.len(), 1);
-  assert_eq!(main_version.imports.len(), 1);
-  assert_eq!(main_version.import_edges.len(), 1);
-  let dep_version = runtime.store().get_module_version(main_version.dependencies[0]).unwrap().unwrap();
-  assert!(dep_version.exports.iter().any(|e| e.name == "tau"));
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main_version = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main_version.dependencies.len(), 1);
+    assert_eq!(main_version.imports.len(), 1);
+    assert_eq!(main_version.import_edges.len(), 1);
+    let dep_version = runtime
+        .store()
+        .get_module_version(main_version.dependencies[0])
+        .unwrap()
+        .unwrap();
+    assert!(dep_version.exports.iter().any(|e| e.name == "tau"));
 }
 
 #[test]
 fn run_module() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_ok());
-  match result.unwrap() {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_ok());
+    match result.unwrap() {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn file_import_exposes_exports_under_file_stem_namespace() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn file_import_does_not_imply_wildcard_import() {
-  let root = setup_modules("+> ./math.mec\nok := tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("tau"));
+    let root = setup_modules("+> ./math.mec\nok := tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("tau"));
 }
 
 #[test]
 fn file_import_does_not_expose_non_exported_binding() {
-  let root = setup_modules("+> ./math.mec\nok := math/secret > 0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("math/secret"));
+    let root = setup_modules("+> ./math.mec\nok := math/secret > 0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("math/secret"));
 }
 
 #[test]
 fn namespace_import_exposes_exports_under_module_namespace() {
-  let root = setup_modules("+> math\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let root = setup_modules("+> math\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn single_import_exposes_export_unqualified() {
-  let root = setup_modules("+> math/tau\nok := tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let root = setup_modules("+> math/tau\nok := tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn wildcard_import_exposes_all_exports_unqualified() {
-  let root = setup_modules("+> math/*\nok := tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(*value.borrow()),
-    other => panic!("expected bool result from module run, got {:?}", other),
-  }
+    let root = setup_modules("+> math/*\nok := tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(*value.borrow()),
+        other => panic!("expected bool result from module run, got {:?}", other),
+    }
 }
 
 #[test]
 fn wildcard_import_does_not_expose_non_exported_binding() {
-  let root = setup_modules("+> math/*\nok := secret > 0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("secret"));
+    let root = setup_modules("+> math/*\nok := secret > 0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("secret"));
 }
 
 #[test]
 fn import_conflict_fails() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-conflict-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("science.mec"), "tau := 6.2\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> math/tau\n+> science/tau\nok := tau > 0\n").unwrap();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeModuleImportConflict"));
-  assert!(error.contains("tau"));
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-conflict-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(root.join("science.mec"), "tau := 6.2\n<+ tau\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> math/tau\n+> science/tau\nok := tau > 0\n",
+    )
+    .unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeModuleImportConflict"));
+    assert!(error.contains("tau"));
 }
 
 #[test]
 fn re_export_works() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-reexport-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-  std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> bridge/tau\nok := tau > 6.0\n").unwrap();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  match result { Value::Bool(v) => assert!(*v.borrow()), other => panic!("expected bool got {:?}", other) }
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-reexport-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+    std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
+    std::fs::write(root.join("main.mec"), "+> bridge/tau\nok := tau > 6.0\n").unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    match result {
+        Value::Bool(v) => assert!(*v.borrow()),
+        other => panic!("expected bool got {:?}", other),
+    }
 }
 
 #[test]
 fn module_version_records_import_edges() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main.imports.len(), 1);
-  assert_eq!(main.contexts.len(), 0);
-  assert_eq!(main.dependencies.len(), 1);
-  assert_eq!(main.import_edges.len(), 1);
-  assert_eq!(main.import_edges[0].scope, SourceScope::Program);
-  assert_eq!(main.import_edges[0].import.specifier, "./math.mec");
-  assert_eq!(main.import_edges[0].dependency, main.dependencies[0]);
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.imports.len(), 1);
+    assert_eq!(main.contexts.len(), 0);
+    assert_eq!(main.dependencies.len(), 1);
+    assert_eq!(main.import_edges.len(), 1);
+    assert_eq!(main.import_edges[0].scope, SourceScope::Program);
+    assert_eq!(main.import_edges[0].import.specifier, "./math.mec");
+    assert_eq!(main.import_edges[0].dependency, main.dependencies[0]);
 }
 
 #[test]
 fn module_version_records_multiple_import_edges_in_order() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-edges-order-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
-  std::fs::write(root.join("b.mec"), "y := 2\n<+ y\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./a.mec\n+> ./b.mec\nok := a/x < b/y\n").unwrap();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main.import_edges.len(), 2);
-  assert_eq!(main.import_edges[0].scope, SourceScope::Program);
-  assert_eq!(main.import_edges[1].scope, SourceScope::Program);
-  assert_eq!(main.import_edges[0].import.specifier, "./a.mec");
-  assert_eq!(main.import_edges[1].import.specifier, "./b.mec");
-  assert!(main.dependencies.contains(&main.import_edges[0].dependency));
-  assert!(main.dependencies.contains(&main.import_edges[1].dependency));
-  match runtime.run_module(version).unwrap() { Value::Bool(v) => assert!(*v.borrow()), other => panic!("expected bool got {:?}", other) }
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-edges-order-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
+    std::fs::write(root.join("b.mec"), "y := 2\n<+ y\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> ./a.mec\n+> ./b.mec\nok := a/x < b/y\n",
+    )
+    .unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.import_edges.len(), 2);
+    assert_eq!(main.import_edges[0].scope, SourceScope::Program);
+    assert_eq!(main.import_edges[1].scope, SourceScope::Program);
+    assert_eq!(main.import_edges[0].import.specifier, "./a.mec");
+    assert_eq!(main.import_edges[1].import.specifier, "./b.mec");
+    assert!(main.dependencies.contains(&main.import_edges[0].dependency));
+    assert!(main.dependencies.contains(&main.import_edges[1].dependency));
+    match runtime.run_module(version).unwrap() {
+        Value::Bool(v) => assert!(*v.borrow()),
+        other => panic!("expected bool got {:?}", other),
+    }
 }
 
 #[test]
 fn module_version_records_contexts() {
-  let root = setup_modules("@main := db://main{:read(users/*), :write(users/name)}\n+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let main = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(main.contexts.len(), 1);
-  assert_eq!(main.contexts[0].name, "main");
-  assert_eq!(main.contexts[0].capabilities.len(), 2);
+    let root = setup_modules(
+        "@main := db://main{:read(users/*), :write(users/name)}\n+> ./math.mec\nok := math/tau > 6.0\n",
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let main = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(main.contexts.len(), 1);
+    assert_eq!(main.contexts[0].name, "main");
+    assert_eq!(main.contexts[0].capabilities.len(), 2);
 }
 
 #[test]
 fn multi_level_re_export_works() {
-  re_export_works();
+    re_export_works();
 }
 
 #[test]
 fn multi_level_private_symbol_does_not_leak() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-privacy-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 6.28318\nsecret := 42\n<+ tau\n").unwrap();
-  std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> bridge/*\nok := secret > 0\n").unwrap();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UndefinedVariable"));
-  assert!(error.contains("secret"));
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-privacy-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(
+        root.join("math.mec"),
+        "tau := 6.28318\nsecret := 42\n<+ tau\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
+    std::fs::write(root.join("main.mec"), "+> bridge/*\nok := secret > 0\n").unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("UndefinedVariable"));
+    assert!(error.contains("secret"));
 }
 
 #[test]
 fn duplicate_unqualified_import_conflict_fails() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-dupe-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
-  std::fs::write(root.join("b.mec"), "x := 2\n<+ x\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> a/*\n+> b/*\nok := x > 0\n").unwrap();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeModuleImportConflict"));
-  assert!(error.contains("x"));
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-dupe-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
+    std::fs::write(root.join("b.mec"), "x := 2\n<+ x\n").unwrap();
+    std::fs::write(root.join("main.mec"), "+> a/*\n+> b/*\nok := x > 0\n").unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeModuleImportConflict"));
+    assert!(error.contains("x"));
 }
 
 #[test]
 fn duplicate_same_export_import_policy_is_explicit() {
-  let root = setup_modules("+> math/tau\n+> math/*\nok := tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeModuleImportConflict"));
-  assert!(error.contains("tau"));
+    let root = setup_modules("+> math/tau\n+> math/*\nok := tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeModuleImportConflict"));
+    assert!(error.contains("tau"));
 }
 
 #[test]
 fn module_host_call_works_inside_isolated_execution() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-host-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := demo/value()\n<+ tau\n").unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./math.mec\nok := math/tau > 40\n").unwrap();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/value", |_s, _c, _a| Ok(Value::F64(Ref::new(42.0))))).unwrap();
-  runtime.grant_capability(std::sync::Arc::new(BasicCapability::new(
-    CapabilityId(1),
-    &BasicSubject::new("program:module-host-test"),
-    &BasicResource::new("host:demo/value"),
-    [BasicOperation::new("call")],
-  ))).unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let mut context = runtime.runtime_context().unwrap().with_subject("program:module-host-test");
-  let result = runtime.run_module_with_context(&mut context, version).unwrap();
-  match result { Value::Bool(v) => assert!(*v.borrow()), other => panic!("expected bool got {:?}", other) }
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-host-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := demo/value()\n<+ tau\n").unwrap();
+    std::fs::write(
+        root.join("main.mec"),
+        "+> ./math.mec\nok := math/tau > 40\n",
+    )
+    .unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new("demo/value", |_s, _c, _a| {
+            Ok(Value::F64(Ref::new(42.0)))
+        }))
+        .unwrap();
+    runtime
+        .grant_capability(std::sync::Arc::new(BasicCapability::new(
+            CapabilityId(1),
+            &BasicSubject::new("program:module-host-test"),
+            &BasicResource::new("host:demo/value"),
+            [BasicOperation::new("call")],
+        )))
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let mut context = runtime
+        .runtime_context()
+        .unwrap()
+        .with_subject("program:module-host-test");
+    let result = runtime
+        .run_module_with_context(&mut context, version)
+        .unwrap();
+    match result {
+        Value::Bool(v) => assert!(*v.borrow()),
+        other => panic!("expected bool got {:?}", other),
+    }
 }
 
 #[test]
 fn repeated_run_module_is_not_stale() {
-  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
-  let first = runtime.run_module(version).unwrap();
-  std::fs::write(root.join("math.mec"), "tau := 5.0\n<+ tau\n").unwrap();
-  let second = runtime.run_module(version).unwrap();
-  match (first, second) {
-    (Value::Bool(a), Value::Bool(b)) => {
-      assert!(*a.borrow());
-      assert!(*b.borrow());
+    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", options)
+        .unwrap()
+        .unwrap();
+    let first = runtime.run_module(version).unwrap();
+    std::fs::write(root.join("math.mec"), "tau := 5.0\n<+ tau\n").unwrap();
+    let second = runtime.run_module(version).unwrap();
+    match (first, second) {
+        (Value::Bool(a), Value::Bool(b)) => {
+            assert!(*a.borrow());
+            assert!(*b.borrow());
+        }
+        other => panic!("expected bool tuple got {:?}", other),
     }
-    other => panic!("expected bool tuple got {:?}", other),
-  }
 }
 
 #[test]
 fn missing_dependency_fails_module_build() {
-  let root = std::env::temp_dir().join(format!("mech-runtime-module-missing-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::write(root.join("main.mec"), "+> ./missing.mec\nok := 1\n").unwrap();
+    let root = std::env::temp_dir().join(format!(
+        "mech-runtime-module-missing-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("main.mec"), "+> ./missing.mec\nok := 1\n").unwrap();
 
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-  let result = runtime.resolve_and_store_module_source("main.mec", options);
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeModuleDependencyMissing"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+    let result = runtime.resolve_and_store_module_source("main.mec", options);
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeModuleDependencyMissing"));
 }
 
-
 fn docs_config(path: &str, value: Value) -> RuntimeConfigSpec {
-  RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-    RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-      .with_entry(path, value),
-  ))
+    RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+        RuntimeInMemoryDocsResourceSpec::new("docs://manual").with_entry(path, value),
+    ))
 }
 
 fn run_docs_config_read(spec: RuntimeConfigSpec) -> Result<Value, mech_core::MechError> {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .config_spec(spec)
-    .build()
-    .unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  run_module_as_main(&mut runtime, version)
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .config_spec(spec)
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    run_module_as_main(&mut runtime, version)
 }
 
 #[test]
 fn config_spec_docs_read_requires_host_grant() {
-  let result = run_docs_config_read(docs_config("intro/title", bool_value(true)));
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantDenied"));
-  assert!(error.contains("task://main"));
-  assert!(error.contains("docs://manual"));
-  assert!(error.contains("intro/title"));
+    let result = run_docs_config_read(docs_config("intro/title", bool_value(true)));
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeCapabilityGrantDenied"));
+    assert!(error.contains("task://main"));
+    assert!(error.contains("docs://manual"));
+    assert!(error.contains("intro/title"));
 }
 
 #[test]
 fn config_spec_docs_read_with_matching_grant_returns_value() {
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://manual", "intro/title"));
-  assert_bool_true(run_docs_config_read(spec).unwrap(), "matching grant");
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"));
+    assert_bool_true(run_docs_config_read(spec).unwrap(), "matching grant");
 }
 
 #[test]
 fn host_grant_path_prefix_allows_nested_read() {
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://manual", "intro/*"));
-  assert_bool_true(run_docs_config_read(spec).unwrap(), "prefix grant");
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://manual", "intro/*"));
+    assert_bool_true(run_docs_config_read(spec).unwrap(), "prefix grant");
 }
 
 #[test]
 fn host_grant_path_prefix_does_not_match_sibling() {
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://manual", "introduction/*"));
-  let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantDenied"));
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://manual", "introduction/*"));
+    let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
+    assert!(error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn host_grant_wrong_operation_denies_read() {
-  let grant = RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
-    .with_operation(RuntimeCapabilityOperation::Write)
-    .with_path("intro/title");
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(grant);
-  let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantDenied"));
+    let grant = RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
+        .with_operation(RuntimeCapabilityOperation::Write)
+        .with_path("intro/title");
+    let spec = docs_config("intro/title", bool_value(true)).with_capability_grant(grant);
+    let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
+    assert!(error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn host_grant_wrong_resource_denies_read() {
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://other", "intro/title"));
-  let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantDenied"));
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://other", "intro/title"));
+    let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
+    assert!(error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn context_denial_still_uses_context_capability_error() {
-  let root = setup_modules("@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n");
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://manual", "intro/title"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .config_spec(spec)
-    .build()
-    .unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let error = format!("{:?}", runtime.run_module(version).err().unwrap());
-  assert!(error.contains("RuntimeResourceCapabilityDenied"));
-  assert!(!error.contains("RuntimeCapabilityGrantDenied"));
+    let root = setup_modules(
+        "@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n",
+    );
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .config_spec(spec)
+        .build()
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let error = format!("{:?}", runtime.run_module(version).err().unwrap());
+    assert!(error.contains("RuntimeResourceCapabilityDenied"));
+    assert!(!error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn host_grant_wildcard_path_allows_read() {
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://manual", "*"));
-  assert_bool_true(run_docs_config_read(spec).unwrap(), "wildcard grant");
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://manual", "*"));
+    assert_bool_true(run_docs_config_read(spec).unwrap(), "wildcard grant");
 }
 
 #[test]
 fn direct_provider_read_with_runtime_grant_still_works() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .in_memory_docs(provider)
-    .build()
-    .unwrap();
-  let subject = runtime.runtime_context().unwrap().subject;
-  runtime.grant_capability(runtime_read_grant_for(&subject, "docs://manual", "intro/title")).unwrap();
-  assert!(runtime.has_capability_grant(&subject, "docs://manual", &RuntimeCapabilityOperation::Read, "intro/title"));
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(runtime.run_module(version).unwrap(), "runtime grant");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .in_memory_docs(provider)
+        .build()
+        .unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+        .grant_capability(runtime_read_grant_for(
+            &subject,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    assert!(runtime.has_capability_grant(
+        &subject,
+        "docs://manual",
+        &RuntimeCapabilityOperation::Read,
+        "intro/title"
+    ));
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(runtime.run_module(version).unwrap(), "runtime grant");
 }
 
 #[test]
 fn apply_config_spec_after_build_registers_resources_and_grants() {
-  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
-  let spec = docs_config("intro/title", bool_value(true))
-    .with_capability_grant(read_grant("docs://manual", "intro/title"));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .build()
-    .unwrap();
-  runtime.apply_config_spec(spec).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "apply spec");
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
+    );
+    let spec = docs_config("intro/title", bool_value(true))
+        .with_capability_grant(read_grant("docs://manual", "intro/title"));
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .build()
+        .unwrap();
+    runtime.apply_config_spec(spec).unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    assert_bool_true(
+        run_module_as_main(&mut runtime, version).unwrap(),
+        "apply spec",
+    );
 }
 
 #[test]
 fn invalid_grant_empty_subject_fails_build() {
-  let spec = RuntimeConfigSpec::new().with_capability_grant(
-    RuntimeCapabilityGrantSpec::new("", "docs://manual")
-      .with_operation(RuntimeCapabilityOperation::Read)
-      .with_path("intro/title"),
-  );
-  let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantInvalid"));
-  assert!(error.contains("subject"));
+    let spec = RuntimeConfigSpec::new().with_capability_grant(
+        RuntimeCapabilityGrantSpec::new("", "docs://manual")
+            .with_operation(RuntimeCapabilityOperation::Read)
+            .with_path("intro/title"),
+    );
+    let error = format!(
+        "{:?}",
+        RuntimeBuilder::new()
+            .config_spec(spec)
+            .build()
+            .err()
+            .unwrap()
+    );
+    assert!(error.contains("RuntimeCapabilityGrantInvalid"));
+    assert!(error.contains("subject"));
 }
 
 #[test]
 fn invalid_grant_empty_operation_fails_build() {
-  let spec = RuntimeConfigSpec::new().with_capability_grant(
-    RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
-      .with_operation(RuntimeCapabilityOperation::Custom(String::new()))
-      .with_path("intro/title"),
-  );
-  let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantInvalid"));
-  assert!(error.contains("operation"));
+    let spec = RuntimeConfigSpec::new().with_capability_grant(
+        RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
+            .with_operation(RuntimeCapabilityOperation::Custom(String::new()))
+            .with_path("intro/title"),
+    );
+    let error = format!(
+        "{:?}",
+        RuntimeBuilder::new()
+            .config_spec(spec)
+            .build()
+            .err()
+            .unwrap()
+    );
+    assert!(error.contains("RuntimeCapabilityGrantInvalid"));
+    assert!(error.contains("operation"));
 }
 
 #[test]
 fn invalid_grant_empty_path_fails_build() {
-  let spec = RuntimeConfigSpec::new().with_capability_grant(
-    RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
-      .with_operation(RuntimeCapabilityOperation::Read)
-      .with_path(""),
-  );
-  let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantInvalid"));
-  assert!(error.contains("path"));
+    let spec = RuntimeConfigSpec::new().with_capability_grant(
+        RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
+            .with_operation(RuntimeCapabilityOperation::Read)
+            .with_path(""),
+    );
+    let error = format!(
+        "{:?}",
+        RuntimeBuilder::new()
+            .config_spec(spec)
+            .build()
+            .err()
+            .unwrap()
+    );
+    assert!(error.contains("RuntimeCapabilityGrantInvalid"));
+    assert!(error.contains("path"));
 }
-
 
 #[test]
 fn workspace_open_rejects_duplicate_targets() {
-  let root = setup_modules("result := true\n");
-  let config = RuntimeWorkspaceConfig::new(&root)
-    .target("main", "main.mec")
-    .target("main", "other.mec");
+    let root = setup_modules("result := true\n");
+    let config = RuntimeWorkspaceConfig::new(&root)
+        .target("main", "main.mec")
+        .target("main", "other.mec");
 
-  let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
-  assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
-  assert!(error.contains("duplicate target"));
+    let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
+    assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
+    assert!(error.contains("duplicate target"));
 }
 
 #[test]
 fn workspace_open_rejects_empty_target_name() {
-  let root = setup_modules("result := true\n");
-  let config = RuntimeWorkspaceConfig::new(&root)
-    .target("", "main.mec");
+    let root = setup_modules("result := true\n");
+    let config = RuntimeWorkspaceConfig::new(&root).target("", "main.mec");
 
-  let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
-  assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
-  assert!(error.contains("target name"));
+    let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
+    assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
+    assert!(error.contains("target name"));
 }
 
 #[test]
 fn workspace_load_target_without_imports() {
-  let root = setup_modules("result := true\n");
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let root = setup_modules("result := true\n");
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert!(snapshot.diagnostics.is_empty());
-  let target = snapshot.targets.get("main").unwrap();
-  assert!(snapshot.sources.contains_key(&target.canonical_uri));
-  assert!(workspace.target("main").is_some());
-  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace target");
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert!(snapshot.diagnostics.is_empty());
+    let target = snapshot.targets.get("main").unwrap();
+    assert!(snapshot.sources.contains_key(&target.canonical_uri));
+    assert!(workspace.target("main").is_some());
+    assert_bool_true(
+        runtime.run_module(target.module_version).unwrap(),
+        "workspace target",
+    );
 }
 
 #[test]
 fn workspace_load_target_with_local_import() {
-  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
-  std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+    let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+    std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
 
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert!(snapshot.diagnostics.is_empty());
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert!(snapshot.diagnostics.is_empty());
 
-  let target = snapshot.targets.get("main").unwrap();
-  let main_path = root.join("main.mec").canonicalize().unwrap();
-  let math_path = root.join("math.mec").canonicalize().unwrap();
+    let target = snapshot.targets.get("main").unwrap();
+    let main_path = root.join("main.mec").canonicalize().unwrap();
+    let math_path = root.join("math.mec").canonicalize().unwrap();
 
-  assert!(
-    snapshot.sources.values().any(|source| {
-      source.path.as_ref() == Some(&main_path)
-    }),
-    "workspace snapshot should contain main.mec source; sources: {:?}",
-    snapshot.sources,
-  );
+    assert!(
+        snapshot
+            .sources
+            .values()
+            .any(|source| { source.path.as_ref() == Some(&main_path) }),
+        "workspace snapshot should contain main.mec source; sources: {:?}",
+        snapshot.sources,
+    );
 
-  assert!(
-    snapshot.sources.values().any(|source| {
-      source.path.as_ref() == Some(&math_path)
-    }),
-    "workspace snapshot should contain math.mec source; sources: {:?}",
-    snapshot.sources,
-  );
+    assert!(
+        snapshot
+            .sources
+            .values()
+            .any(|source| { source.path.as_ref() == Some(&math_path) }),
+        "workspace snapshot should contain math.mec source; sources: {:?}",
+        snapshot.sources,
+    );
 
-  assert!(snapshot.import_edges.iter().any(|edge| {
-    edge.specifier == "./math.mec"
-  }));
+    assert!(
+        snapshot
+            .import_edges
+            .iter()
+            .any(|edge| { edge.specifier == "./math.mec" })
+    );
 
-  assert_bool_true(
-    runtime.run_module(target.module_version).unwrap(),
-    "workspace imported target",
-  );
+    assert_bool_true(
+        runtime.run_module(target.module_version).unwrap(),
+        "workspace imported target",
+    );
 }
 
 #[test]
 fn workspace_load_relative_target_uses_workspace_root() {
-  let root_a = std::env::temp_dir().join(format!(
-    "mech-runtime-workspace-root-a-{}",
-    std::time::SystemTime::now()
-      .duration_since(std::time::UNIX_EPOCH)
-      .unwrap()
-      .as_nanos()
-  ));
-  let root_b = std::env::temp_dir().join(format!(
-    "mech-runtime-workspace-root-b-{}",
-    std::time::SystemTime::now()
-      .duration_since(std::time::UNIX_EPOCH)
-      .unwrap()
-      .as_nanos()
-  ));
-  std::fs::create_dir_all(&root_a).unwrap();
-  std::fs::create_dir_all(&root_b).unwrap();
+    let root_a = std::env::temp_dir().join(format!(
+        "mech-runtime-workspace-root-a-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let root_b = std::env::temp_dir().join(format!(
+        "mech-runtime-workspace-root-b-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root_a).unwrap();
+    std::fs::create_dir_all(&root_b).unwrap();
 
-  std::fs::write(root_a.join("main.mec"), "result := false\n").unwrap();
-  std::fs::write(root_b.join("main.mec"), "result := true\n").unwrap();
+    std::fs::write(root_a.join("main.mec"), "result := false\n").unwrap();
+    std::fs::write(root_b.join("main.mec"), "result := true\n").unwrap();
 
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root_b))
-    .build()
-    .unwrap();
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root_a)
-      .target("main", "main.mec"),
-  ).unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root_b))
+        .build()
+        .unwrap();
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root_a).target("main", "main.mec"))
+            .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert!(snapshot.diagnostics.is_empty());
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert!(snapshot.diagnostics.is_empty());
 
-  let target = snapshot.targets.get("main").unwrap();
-  assert_eq!(target.specifier, "main.mec");
-  let result = runtime.run_module(target.module_version).unwrap();
-  match result {
-    Value::Bool(value) => assert!(!*value.borrow()),
-    other => panic!("expected false bool result from workspace root target, got {:?}", other),
-  }
+    let target = snapshot.targets.get("main").unwrap();
+    assert_eq!(target.specifier, "main.mec");
+    let result = runtime.run_module(target.module_version).unwrap();
+    match result {
+        Value::Bool(value) => assert!(!*value.borrow()),
+        other => panic!(
+            "expected false bool result from workspace root target, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn workspace_load_target_outside_root_records_diagnostic() {
-  let parent = std::env::temp_dir().join(format!(
-    "mech-runtime-workspace-outside-root-{}",
-    std::time::SystemTime::now()
-      .duration_since(std::time::UNIX_EPOCH)
-      .unwrap()
-      .as_nanos()
-  ));
-  let root = parent.join("workspace");
-  let outside = parent.join("outside");
-  std::fs::create_dir_all(&root).unwrap();
-  std::fs::create_dir_all(&outside).unwrap();
-  std::fs::write(outside.join("main.mec"), "result := true\n").unwrap();
+    let parent = std::env::temp_dir().join(format!(
+        "mech-runtime-workspace-outside-root-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let root = parent.join("workspace");
+    let outside = parent.join("outside");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("main.mec"), "result := true\n").unwrap();
 
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root)
-      .target("outside", "../outside/main.mec"),
-  ).unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace = RuntimeWorkspace::open(
+        RuntimeWorkspaceConfig::new(&root).target("outside", "../outside/main.mec"),
+    )
+    .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert_eq!(snapshot.diagnostics.len(), 1);
-  assert_eq!(snapshot.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
-  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("outside"));
-  assert!(snapshot.diagnostics[0].message.contains("outside workspace root"));
-  assert!(!snapshot.targets.contains_key("outside"));
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert_eq!(snapshot.diagnostics.len(), 1);
+    assert_eq!(
+        snapshot.diagnostics[0].severity,
+        RuntimeWorkspaceDiagnosticSeverity::Error
+    );
+    assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("outside"));
+    assert!(
+        snapshot.diagnostics[0]
+            .message
+            .contains("outside workspace root")
+    );
+    assert!(!snapshot.targets.contains_key("outside"));
 }
 
 #[test]
 fn workspace_load_missing_target_records_diagnostic() {
-  let root = setup_modules("result := true\n");
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("missing", "missing.mec"),
-  ).unwrap();
+    let root = setup_modules("result := true\n");
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("missing", "missing.mec"))
+            .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert_eq!(snapshot.diagnostics.len(), 1);
-  assert_eq!(snapshot.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
-  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
-  assert!(snapshot.diagnostics[0].message.contains("missing.mec"));
-  assert!(!snapshot.targets.contains_key("missing"));
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert_eq!(snapshot.diagnostics.len(), 1);
+    assert_eq!(
+        snapshot.diagnostics[0].severity,
+        RuntimeWorkspaceDiagnosticSeverity::Error
+    );
+    assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
+    assert!(snapshot.diagnostics[0].message.contains("missing.mec"));
+    assert!(!snapshot.targets.contains_key("missing"));
 }
 
 #[test]
 fn workspace_load_multiple_targets_continues_after_failure() {
-  let root = setup_modules("result := true\n");
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root)
-      .target("missing", "missing.mec")
-      .target("main", "main.mec"),
-  ).unwrap();
+    let root = setup_modules("result := true\n");
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace = RuntimeWorkspace::open(
+        RuntimeWorkspaceConfig::new(&root)
+            .target("missing", "missing.mec")
+            .target("main", "main.mec"),
+    )
+    .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert_eq!(snapshot.diagnostics.len(), 1);
-  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
-  let target = snapshot.targets.get("main").unwrap();
-  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace surviving target");
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert_eq!(snapshot.diagnostics.len(), 1);
+    assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
+    let target = snapshot.targets.get("main").unwrap();
+    assert_bool_true(
+        runtime.run_module(target.module_version).unwrap(),
+        "workspace surviving target",
+    );
 }
-
 
 #[test]
 fn workspace_refresh_before_load_fails() {
-  let root = setup_modules("result := true\n");
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let root = setup_modules("result := true\n");
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  let error = format!("{:?}", workspace.refresh(&mut runtime, module_options()).err().unwrap());
-  assert!(error.contains("RuntimeWorkspaceNotLoaded"));
+    let error = format!(
+        "{:?}",
+        workspace
+            .refresh(&mut runtime, module_options())
+            .err()
+            .unwrap()
+    );
+    assert!(error.contains("RuntimeWorkspaceNotLoaded"));
 }
 
 #[test]
 fn workspace_refresh_without_changes_is_empty() {
-  let root = setup_modules("result := true\n");
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let root = setup_modules("result := true\n");
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  workspace.load(&mut runtime, module_options()).unwrap();
-  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-  assert!(refresh.changes.is_empty());
-  assert!(refresh.affected_targets.is_empty());
-  assert!(refresh.refresh_diagnostics.is_empty());
-  assert!(refresh.snapshot.targets.contains_key("main"));
+    workspace.load(&mut runtime, module_options()).unwrap();
+    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+    assert!(refresh.changes.is_empty());
+    assert!(refresh.affected_targets.is_empty());
+    assert!(refresh.refresh_diagnostics.is_empty());
+    assert!(refresh.snapshot.targets.contains_key("main"));
 }
 
 #[test]
 fn workspace_refresh_modified_dependency_reloads_target() {
-  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
-  std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+    std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert_bool_false(runtime.run_module(snapshot.targets["main"].module_version).unwrap(), "initial workspace dependency");
-  std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert_bool_false(
+        runtime
+            .run_module(snapshot.targets["main"].module_version)
+            .unwrap(),
+        "initial workspace dependency",
+    );
+    std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
 
-  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-  assert_eq!(refresh.changes.len(), 1);
-  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
-  assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
-  assert_eq!(refresh.affected_targets, vec!["main"]);
-  assert!(refresh.refresh_diagnostics.is_empty());
-  assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace dependency");
+    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+    assert_eq!(refresh.changes.len(), 1);
+    assert_eq!(
+        refresh.changes[0].kind,
+        RuntimeWorkspaceChangeKind::Modified
+    );
+    assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
+    assert_eq!(refresh.affected_targets, vec!["main"]);
+    assert!(refresh.refresh_diagnostics.is_empty());
+    assert_bool_true(
+        runtime
+            .run_module(refresh.snapshot.targets["main"].module_version)
+            .unwrap(),
+        "refreshed workspace dependency",
+    );
 }
 
 #[test]
 fn workspace_refresh_removed_dependency_records_diagnostic() {
-  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
-  std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+    let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+    std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
 
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  workspace.load(&mut runtime, module_options()).unwrap();
-  std::fs::remove_file(root.join("math.mec")).unwrap();
+    workspace.load(&mut runtime, module_options()).unwrap();
+    std::fs::remove_file(root.join("math.mec")).unwrap();
 
-  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
 
-  assert_eq!(refresh.changes.len(), 1);
-  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
-  assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
-  assert_eq!(refresh.affected_targets, vec!["main"]);
+    assert_eq!(refresh.changes.len(), 1);
+    assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
+    assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
+    assert_eq!(refresh.affected_targets, vec!["main"]);
 
-  assert_eq!(refresh.refresh_diagnostics.len(), 1);
-  assert_eq!(
-    refresh.refresh_diagnostics[0].severity,
-    RuntimeWorkspaceDiagnosticSeverity::Error,
-  );
-  assert_eq!(
-    refresh.refresh_diagnostics[0].target.as_deref(),
-    Some("main"),
-  );
+    assert_eq!(refresh.refresh_diagnostics.len(), 1);
+    assert_eq!(
+        refresh.refresh_diagnostics[0].severity,
+        RuntimeWorkspaceDiagnosticSeverity::Error,
+    );
+    assert_eq!(
+        refresh.refresh_diagnostics[0].target.as_deref(),
+        Some("main"),
+    );
 
-  assert_eq!(refresh.snapshot.diagnostics.len(), 1);
-  assert_eq!(
-    refresh.snapshot.diagnostics[0].target.as_deref(),
-    Some("main"),
-  );
-  assert!(!refresh.snapshot.targets.contains_key("main"));
+    assert_eq!(refresh.snapshot.diagnostics.len(), 1);
+    assert_eq!(
+        refresh.snapshot.diagnostics[0].target.as_deref(),
+        Some("main"),
+    );
+    assert!(!refresh.snapshot.targets.contains_key("main"));
 }
 
 #[test]
 fn workspace_refresh_modified_target_reloads_target() {
-  let root = setup_modules("result := false\n");
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
-  ).unwrap();
+    let root = setup_modules("result := false\n");
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace =
+        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
+            .unwrap();
 
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-  assert_bool_false(runtime.run_module(snapshot.targets["main"].module_version).unwrap(), "initial workspace target");
-  std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+    assert_bool_false(
+        runtime
+            .run_module(snapshot.targets["main"].module_version)
+            .unwrap(),
+        "initial workspace target",
+    );
+    std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
 
-  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-  assert_eq!(refresh.changes.len(), 1);
-  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
-  assert!(refresh.changes[0].canonical_uri.ends_with("/main.mec"));
-  assert_eq!(refresh.affected_targets, vec!["main"]);
-  assert!(refresh.refresh_diagnostics.is_empty());
-  assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace target");
+    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+    assert_eq!(refresh.changes.len(), 1);
+    assert_eq!(
+        refresh.changes[0].kind,
+        RuntimeWorkspaceChangeKind::Modified
+    );
+    assert!(refresh.changes[0].canonical_uri.ends_with("/main.mec"));
+    assert_eq!(refresh.affected_targets, vec!["main"]);
+    assert!(refresh.refresh_diagnostics.is_empty());
+    assert_bool_true(
+        runtime
+            .run_module(refresh.snapshot.targets["main"].module_version)
+            .unwrap(),
+        "refreshed workspace target",
+    );
 }
 
 #[test]
 fn workspace_refresh_preserves_unaffected_diagnostics() {
-  let root = setup_modules("result := false\n");
+    let root = setup_modules("result := false\n");
 
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root)
-      .target("missing", "missing.mec")
-      .target("main", "main.mec"),
-  ).unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace = RuntimeWorkspace::open(
+        RuntimeWorkspaceConfig::new(&root)
+            .target("missing", "missing.mec")
+            .target("main", "main.mec"),
+    )
+    .unwrap();
 
-  let initial = workspace.load(&mut runtime, module_options()).unwrap();
+    let initial = workspace.load(&mut runtime, module_options()).unwrap();
 
-  assert_eq!(initial.diagnostics.len(), 1);
-  assert_eq!(initial.diagnostics[0].target.as_deref(), Some("missing"));
-  assert!(initial.targets.contains_key("main"));
+    assert_eq!(initial.diagnostics.len(), 1);
+    assert_eq!(initial.diagnostics[0].target.as_deref(), Some("missing"));
+    assert!(initial.targets.contains_key("main"));
 
-  std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
+    std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
 
-  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
 
-  assert_eq!(refresh.affected_targets, vec!["main"]);
-  assert!(refresh.refresh_diagnostics.is_empty());
+    assert_eq!(refresh.affected_targets, vec!["main"]);
+    assert!(refresh.refresh_diagnostics.is_empty());
 
-  assert_eq!(refresh.snapshot.diagnostics.len(), 1);
-  assert_eq!(
-    refresh.snapshot.diagnostics[0].target.as_deref(),
-    Some("missing"),
-  );
+    assert_eq!(refresh.snapshot.diagnostics.len(), 1);
+    assert_eq!(
+        refresh.snapshot.diagnostics[0].target.as_deref(),
+        Some("missing"),
+    );
 
-  let target = refresh.snapshot.targets.get("main").unwrap();
-  assert_bool_true(
-    runtime.run_module(target.module_version).unwrap(),
-    "refreshed workspace target with retained diagnostic",
-  );
+    let target = refresh.snapshot.targets.get("main").unwrap();
+    assert_bool_true(
+        runtime.run_module(target.module_version).unwrap(),
+        "refreshed workspace target with retained diagnostic",
+    );
 }
 
 #[test]
 fn workspace_load_folder_discovers_non_target_sources() {
-  let root = setup_modules("result := true\n");
-  std::fs::create_dir_all(root.join("src/nested")).unwrap();
-  std::fs::write(root.join("src/nested/lib.mec"), "value := true\n").unwrap();
+    let root = setup_modules("result := true\n");
+    std::fs::create_dir_all(root.join("src/nested")).unwrap();
+    std::fs::write(root.join("src/nested/lib.mec"), "value := true\n").unwrap();
 
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root)
-      .target("main", "main.mec")
-      .folder("src"),
-  ).unwrap();
-
-  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-
-  assert!(snapshot.diagnostics.is_empty());
-  assert!(snapshot.targets.contains_key("main"));
-  assert_eq!(snapshot.targets.len(), 1);
-
-  let discovered_path = root
-    .join("src/nested/lib.mec")
-    .canonicalize()
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace = RuntimeWorkspace::open(
+        RuntimeWorkspaceConfig::new(&root)
+            .target("main", "main.mec")
+            .folder("src"),
+    )
     .unwrap();
 
-  assert!(
-    snapshot.sources.values().any(|source| {
-      source.path.as_ref() == Some(&discovered_path)
-    }),
-    "workspace snapshot should contain discovered source; sources: {:?}",
-    snapshot.sources,
-  );
+    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+
+    assert!(snapshot.diagnostics.is_empty());
+    assert!(snapshot.targets.contains_key("main"));
+    assert_eq!(snapshot.targets.len(), 1);
+
+    let discovered_path = root.join("src/nested/lib.mec").canonicalize().unwrap();
+
+    assert!(
+        snapshot
+            .sources
+            .values()
+            .any(|source| { source.path.as_ref() == Some(&discovered_path) }),
+        "workspace snapshot should contain discovered source; sources: {:?}",
+        snapshot.sources,
+    );
 }
 
 #[test]
 fn workspace_refresh_preserves_folder_discovered_sources() {
-  let root = setup_modules("result := true\n");
-  std::fs::create_dir_all(root.join("src")).unwrap();
-  std::fs::write(root.join("src/lib.mec"), "value := false\n").unwrap();
+    let root = setup_modules("result := true\n");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.mec"), "value := false\n").unwrap();
 
-  let mut runtime = runtime_with_root(&root);
-  let mut workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root)
-      .target("main", "main.mec")
-      .folder("src"),
-  ).unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let mut workspace = RuntimeWorkspace::open(
+        RuntimeWorkspaceConfig::new(&root)
+            .target("main", "main.mec")
+            .folder("src"),
+    )
+    .unwrap();
 
-  let initial = workspace.load(&mut runtime, module_options()).unwrap();
-  assert!(initial.diagnostics.is_empty());
+    let initial = workspace.load(&mut runtime, module_options()).unwrap();
+    assert!(initial.diagnostics.is_empty());
 
-  let discovered_path = root.join("src/lib.mec").canonicalize().unwrap();
-  assert!(initial.sources.values().any(|source| {
-    source.path.as_ref() == Some(&discovered_path)
-  }));
+    let discovered_path = root.join("src/lib.mec").canonicalize().unwrap();
+    assert!(
+        initial
+            .sources
+            .values()
+            .any(|source| { source.path.as_ref() == Some(&discovered_path) })
+    );
 
-  std::fs::write(root.join("main.mec"), "result := false\n").unwrap();
+    std::fs::write(root.join("main.mec"), "result := false\n").unwrap();
 
-  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-  assert!(refresh.refresh_diagnostics.is_empty());
+    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+    assert!(refresh.refresh_diagnostics.is_empty());
 
-  assert!(refresh.snapshot.sources.values().any(|source| {
-    source.path.as_ref() == Some(&discovered_path)
-  }));
+    assert!(
+        refresh
+            .snapshot
+            .sources
+            .values()
+            .any(|source| { source.path.as_ref() == Some(&discovered_path) })
+    );
 }
 
 #[test]
 fn workspace_watcher_watches_configured_folder() {
-  let root = setup_modules("result := true\n");
-  std::fs::create_dir_all(root.join("src")).unwrap();
+    let root = setup_modules("result := true\n");
+    std::fs::create_dir_all(root.join("src")).unwrap();
 
-  let workspace = RuntimeWorkspace::open(
-    RuntimeWorkspaceConfig::new(&root)
-      .target("main", "main.mec")
-      .folder("src"),
-  ).unwrap();
+    let workspace = RuntimeWorkspace::open(
+        RuntimeWorkspaceConfig::new(&root)
+            .target("main", "main.mec")
+            .folder("src"),
+    )
+    .unwrap();
 
-  let mut runtime = RuntimeBuilder::new().build().unwrap();
-  let watcher = RuntimeWorkspaceWatcher::open(&workspace, &mut runtime).unwrap();
-  let watched_paths = watcher.watched_paths();
+    let mut runtime = RuntimeBuilder::new().build().unwrap();
+    let watcher = RuntimeWorkspaceWatcher::open(&workspace, &mut runtime).unwrap();
+    let watched_paths = watcher.watched_paths();
 
-  assert!(watched_paths.contains(&root.join("src").canonicalize().unwrap()));
+    assert!(watched_paths.contains(&root.join("src").canonicalize().unwrap()));
 }
 
 #[test]
 fn interpreter_scope_ignores_faux_tilde_fence_inside_backtick_code_block() {
-  let root = setup_modules(
-    "~~~mech:foo\n\
+    let root = setup_modules(
+        "~~~mech:foo\n\
 ok := true\n\
 <+ ok\n\
 ~~~\n\
@@ -2111,26 +3276,26 @@ broken := missing\n\
 ```\n\
 \n\
 result := @foo/ok\n",
-  );
+    );
 
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime
-    .resolve_and_store_module_source("main.mec", module_options())
-    .unwrap()
-    .unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  let result = runtime.run_module(version).unwrap();
+    let result = runtime.run_module(version).unwrap();
 
-  match result {
-    Value::Bool(value) => assert_eq!(*value.borrow(), true),
-    other => panic!("expected faux tilde fence to be ignored, got {:?}", other),
-  }
+    match result {
+        Value::Bool(value) => assert_eq!(*value.borrow(), true),
+        other => panic!("expected faux tilde fence to be ignored, got {:?}", other),
+    }
 }
 
 #[test]
 fn interpreter_scope_ignores_faux_backtick_fence_inside_tilde_code_block() {
-  let root = setup_modules(
-    "~~~mech:foo\n\
+    let root = setup_modules(
+        "~~~mech:foo\n\
 ok := true\n\
 <+ ok\n\
 ~~~\n\
@@ -2142,929 +3307,1652 @@ broken := missing\n\
 ~~~\n\
 \n\
 result := @foo/ok\n",
-  );
+    );
 
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime
-    .resolve_and_store_module_source("main.mec", module_options())
-    .unwrap()
-    .unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  let result = runtime.run_module(version).unwrap();
+    let result = runtime.run_module(version).unwrap();
 
-  match result {
-    Value::Bool(value) => assert_eq!(*value.borrow(), true),
-    other => panic!("expected faux backtick fence to be ignored, got {:?}", other),
-  }
+    match result {
+        Value::Bool(value) => assert_eq!(*value.borrow(), true),
+        other => panic!(
+            "expected faux backtick fence to be ignored, got {:?}",
+            other
+        ),
+    }
 }
 
 #[test]
 fn manifest_context_import_materializes_without_source_dependency() {
-  let root = setup_modules("+> @ui := browser/dom\nx := 1\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let record = runtime.store().get_module_version(version).unwrap().unwrap();
+    let root = setup_modules("+> @ui := browser/dom\nx := 1\n");
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let record = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
 
-  assert_eq!(record.imports.len(), 1);
-  assert_eq!(record.import_edges.len(), 0);
-  assert_eq!(record.dependencies.len(), 0);
-  let program_scope = record.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
-  assert!(program_scope.contexts.iter().any(|context| context.name == "ui"));
-  assert!(record.contexts.iter().any(|context| context.name == "ui"));
+    assert_eq!(record.imports.len(), 1);
+    assert_eq!(record.import_edges.len(), 0);
+    assert_eq!(record.dependencies.len(), 0);
+    let program_scope = record
+        .scopes
+        .iter()
+        .find(|scope| scope.scope == SourceScope::Program)
+        .unwrap();
+    assert!(
+        program_scope
+            .contexts
+            .iter()
+            .any(|context| context.name == "ui")
+    );
+    assert!(record.contexts.iter().any(|context| context.name == "ui"));
 }
 
 #[test]
 fn manifest_context_import_is_visible_to_scoped_address_resolution() {
-  let root = setup_modules("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err(), "expected resource/provider failure without browser provider");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(!error.contains("UnknownAddressTarget"), "context import should be visible to address resolution, got {error}");
+    let root = setup_modules("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(
+        result.is_err(),
+        "expected resource/provider failure without browser provider"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        !error.contains("UnknownAddressTarget"),
+        "context import should be visible to address resolution, got {error}"
+    );
 }
 
 #[test]
 fn manifest_context_import_conflicts_with_interpreter_address_target() {
-  let root = setup_modules("+> @foo := browser/dom\n\n~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/counter/_text\n");
-  let mut runtime = runtime_with_root(&root);
-  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-  assert!(result.is_err(), "manifest context alias should conflict with interpreter target");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
-  assert!(error.contains("foo"), "expected conflicting target name in error, got {error}");
+    let root = setup_modules(
+        "+> @foo := browser/dom\n\n~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/counter/_text\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+    assert!(
+        result.is_err(),
+        "manifest context alias should conflict with interpreter target"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("AddressTargetNameConflict"),
+        "expected address target conflict, got {error}"
+    );
+    assert!(
+        error.contains("foo"),
+        "expected conflicting target name in error, got {error}"
+    );
 }
 
 #[test]
 fn context_import_alias_is_not_bound_as_value_import() {
-  let root = setup_modules("+> @ui := browser/dom\n+> ./math.mec\nresult := ui\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let record = runtime.store().get_module_version(version).unwrap().unwrap();
-  assert_eq!(record.imports.len(), 2);
-  assert_eq!(record.import_edges.len(), 1);
-  assert!(record.import_edges.iter().all(|edge| !matches!(edge.import.alias, Some(SourceImportAlias::Context(_)))));
+    let root = setup_modules("+> @ui := browser/dom\n+> ./math.mec\nresult := ui\n");
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let record = runtime
+        .store()
+        .get_module_version(version)
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.imports.len(), 2);
+    assert_eq!(record.import_edges.len(), 1);
+    assert!(
+        record
+            .import_edges
+            .iter()
+            .all(|edge| !matches!(edge.import.alias, Some(SourceImportAlias::Context(_))))
+    );
 
-  let result = runtime.run_module(version);
-  assert!(result.is_err(), "context alias should not be available as a value binding");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("Undefined") || error.contains("Variable"), "expected missing value binding error, got {error}");
+    let result = runtime.run_module(version);
+    assert!(
+        result.is_err(),
+        "context alias should not be available as a value binding"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("Undefined") || error.contains("Variable"),
+        "expected missing value binding error, got {error}"
+    );
 }
 
 #[cfg(feature = "linked_stdlib")]
 #[test]
 fn direct_runtime_normal_import_is_not_dropped() {
-  let mut runtime = RuntimeBuilder::new().build().unwrap();
-  let result = runtime.run_string("+> math/sin\nresult := sin(0)\n").unwrap();
+    let mut runtime = RuntimeBuilder::new().build().unwrap();
+    let result = runtime
+        .run_string("+> math/sin\nresult := sin(0)\n")
+        .unwrap();
 
-  match result {
-    Value::F64(value) => assert_eq!(*value.borrow(), 0.0),
-    other => panic!("expected sin(0) to return 0.0, got {other:?}"),
-  }
+    match result {
+        Value::F64(value) => assert_eq!(*value.borrow(), 0.0),
+        other => panic!("expected sin(0) to return 0.0, got {other:?}"),
+    }
 }
 
 #[test]
 fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lowering() {
-  let mut runtime = RuntimeBuilder::new().build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/_text")).unwrap();
-  let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
-  assert!(result.is_err(), "expected browser provider failure without a browser provider");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected browser provider lookup after recognizing @ui, got {error}");
-  assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
+    let mut runtime = RuntimeBuilder::new().build().unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "browser://dom",
+            "counter/_text",
+        ))
+        .unwrap();
+    let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+    assert!(
+        result.is_err(),
+        "expected browser provider failure without a browser provider"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderNotFound"),
+        "expected browser provider lookup after recognizing @ui, got {error}"
+    );
+    assert!(
+        !error.contains("UnknownAddressTarget"),
+        "@ui should not be treated as an unknown address target: {error}"
+    );
 }
 
 #[test]
 fn direct_runtime_manifest_context_import_write_uses_provider_lookup() {
-  let mut runtime = RuntimeBuilder::new().build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "browser://dom", "counter/_text")).unwrap();
-  let result = runtime.run_string("+> @ui := browser/dom
+    let mut runtime = RuntimeBuilder::new().build().unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "browser://dom",
+            "counter/_text",
+        ))
+        .unwrap();
+    let result = runtime.run_string(
+        "+> @ui := browser/dom
 @ui/counter/_text = \"hello\"
-");
-  assert!(result.is_err(), "browser write should reach provider lookup without a browser provider");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected provider lookup, got {error}");
-  assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
+",
+    );
+    assert!(
+        result.is_err(),
+        "browser write should reach provider lookup without a browser provider"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderNotFound"),
+        "expected provider lookup, got {error}"
+    );
+    assert!(
+        !error.contains("UnknownAddressTarget"),
+        "@ui should not be treated as an unknown address target: {error}"
+    );
 }
 
 #[test]
 fn repeated_manifest_context_alias_in_separate_fenced_scopes_is_legal() {
-  let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\n~~~mech:bar\n+> @ui := browser/dom\nb := @ui/counter/_text\n~~~\n");
-  let mut runtime = runtime_with_root(&root);
-  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-  assert!(result.is_ok(), "same context alias in separate fenced scopes should be legal: {result:?}");
+    let root = setup_modules(
+        "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\n~~~mech:bar\n+> @ui := browser/dom\nb := @ui/counter/_text\n~~~\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+    assert!(
+        result.is_ok(),
+        "same context alias in separate fenced scopes should be legal: {result:?}"
+    );
 }
 
 #[test]
 fn manifest_context_import_in_fenced_scope_does_not_leak_to_program_scope() {
-  let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\nresult := @ui/counter/_text\n");
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version);
-  assert!(result.is_err(), "program scope should not see fenced @ui context import");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("UnknownAddressTarget"), "expected scoped address-target failure, got {error}");
+    let root = setup_modules(
+        "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\nresult := @ui/counter/_text\n",
+    );
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version);
+    assert!(
+        result.is_err(),
+        "program scope should not see fenced @ui context import"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("UnknownAddressTarget"),
+        "expected scoped address-target failure, got {error}"
+    );
 }
 
 #[test]
 fn resolving_module_with_fenced_context_import_does_not_pollute_direct_runtime_bindings() {
-  let root = setup_modules(
-    "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n"
-  );
+    let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n");
 
-  let mut runtime = runtime_with_root(&root);
-  runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+    let mut runtime = runtime_with_root(&root);
+    runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  let result = runtime.run_string("x := @ui/counter/_text\n");
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
+    let result = runtime.run_string("x := @ui/counter/_text\n");
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
 
-  assert!(
-    error.contains("UnknownAddressTarget") || error.contains("Undefined"),
-    "expected @ui not to exist in direct runtime scope, got {error}"
-  );
-  assert!(
-    !error.contains("RuntimeResourceProviderNotFound"),
-    "module resolution leaked @ui into global browser bindings: {error}"
-  );
+    assert!(
+        error.contains("UnknownAddressTarget") || error.contains("Undefined"),
+        "expected @ui not to exist in direct runtime scope, got {error}"
+    );
+    assert!(
+        !error.contains("RuntimeResourceProviderNotFound"),
+        "module resolution leaked @ui into global browser bindings: {error}"
+    );
 }
 
 #[test]
 fn fenced_context_alias_can_match_unrelated_interpreter_name_without_resolving_as_interpreter() {
-  let root = setup_modules(
-    "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\n+> @foo := browser/dom\nx := @foo/counter/_text\n~~~\n"
-  );
+    let root = setup_modules(
+        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\n+> @foo := browser/dom\nx := @foo/counter/_text\n~~~\n",
+    );
 
-  let mut runtime = runtime_with_root(&root);
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+    let mut runtime = runtime_with_root(&root);
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  let result = runtime.run_module_scope(
-    version,
-    SourceScope::Interpreter(SourceInterpreterId {
-      namespace: hash_str("bar"),
-      namespace_str: "bar".to_string(),
-    }),
-  );
+    let result = runtime.run_module_scope(
+        version,
+        SourceScope::Interpreter(SourceInterpreterId {
+            namespace: hash_str("bar"),
+            namespace_str: "bar".to_string(),
+        }),
+    );
 
-  assert!(result.is_err(), "expected browser provider failure without browser provider");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(
-    error.contains("RuntimeResourceProviderNotFound")
-      || error.contains("RuntimeCapabilityGrantDenied")
-      || error.contains("RuntimeResourceCapabilityDenied"),
-    "expected @foo in bar to resolve as context, not interpreter, got {error}"
-  );
-  assert!(
-    !error.contains("RuntimeModuleExportNotFound"),
-    "@foo in bar resolved as interpreter foo instead of local context: {error}"
-  );
+    assert!(
+        result.is_err(),
+        "expected browser provider failure without browser provider"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourceProviderNotFound")
+            || error.contains("RuntimeCapabilityGrantDenied")
+            || error.contains("RuntimeResourceCapabilityDenied"),
+        "expected @foo in bar to resolve as context, not interpreter, got {error}"
+    );
+    assert!(
+        !error.contains("RuntimeModuleExportNotFound"),
+        "@foo in bar resolved as interpreter foo instead of local context: {error}"
+    );
 }
 #[test]
 fn direct_runtime_context_addressed_slice_is_rejected_explicitly() {
-  let mut runtime = RuntimeBuilder::new().build().unwrap();
-  let result = runtime.run_string("+> @ui := browser/dom\nx := @ui/counter[0]\n");
-  assert!(result.is_err(), "context-addressed browser slices should be explicit until semantics are defined");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("context-addressed slices are not supported"), "expected explicit slice error, got {error}");
+    let mut runtime = RuntimeBuilder::new().build().unwrap();
+    let result = runtime.run_string("+> @ui := browser/dom\nx := @ui/counter[0]\n");
+    assert!(
+        result.is_err(),
+        "context-addressed browser slices should be explicit until semantics are defined"
+    );
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("context-addressed slices are not supported"),
+        "expected explicit slice error, got {error}"
+    );
 }
 
 #[test]
 fn module_manifest_catalog_validates_builder_manifests() {
-  let invalids = [
-    ModuleManifestConfig { name: "".to_string(), exports: vec![] },
-    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["read".to_string()] }] },
-    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["read".to_string()] }, ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["write".to_string()] }] },
-    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser-dom".to_string(), operations: vec!["read".to_string()] }] },
-    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec![] }] },
-    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["list".to_string()] }] },
-  ];
+    let invalids = [
+        ModuleManifestConfig {
+            name: "".to_string(),
+            exports: vec![],
+        },
+        ModuleManifestConfig {
+            name: "bad".to_string(),
+            exports: vec![ModuleManifestExportConfig {
+                name: "".to_string(),
+                kind: ModuleManifestExportKind::Context,
+                base_uri: "browser://dom".to_string(),
+                operations: vec!["read".to_string()],
+            }],
+        },
+        ModuleManifestConfig {
+            name: "bad".to_string(),
+            exports: vec![
+                ModuleManifestExportConfig {
+                    name: "dom".to_string(),
+                    kind: ModuleManifestExportKind::Context,
+                    base_uri: "browser://dom".to_string(),
+                    operations: vec!["read".to_string()],
+                },
+                ModuleManifestExportConfig {
+                    name: "dom".to_string(),
+                    kind: ModuleManifestExportKind::Context,
+                    base_uri: "browser://dom".to_string(),
+                    operations: vec!["write".to_string()],
+                },
+            ],
+        },
+        ModuleManifestConfig {
+            name: "bad".to_string(),
+            exports: vec![ModuleManifestExportConfig {
+                name: "dom".to_string(),
+                kind: ModuleManifestExportKind::Context,
+                base_uri: "browser-dom".to_string(),
+                operations: vec!["read".to_string()],
+            }],
+        },
+        ModuleManifestConfig {
+            name: "bad".to_string(),
+            exports: vec![ModuleManifestExportConfig {
+                name: "dom".to_string(),
+                kind: ModuleManifestExportKind::Context,
+                base_uri: "browser://dom".to_string(),
+                operations: vec![],
+            }],
+        },
+        ModuleManifestConfig {
+            name: "bad".to_string(),
+            exports: vec![ModuleManifestExportConfig {
+                name: "dom".to_string(),
+                kind: ModuleManifestExportKind::Context,
+                base_uri: "browser://dom".to_string(),
+                operations: vec!["list".to_string()],
+            }],
+        },
+    ];
 
-  for manifest in invalids {
-    let result = RuntimeBuilder::new().module_manifest(manifest);
-    assert!(result.is_err(), "invalid manifest should be rejected by builder/catalog");
-  }
+    for manifest in invalids {
+        let result = RuntimeBuilder::new().module_manifest(manifest);
+        assert!(
+            result.is_err(),
+            "invalid manifest should be rejected by builder/catalog"
+        );
+    }
 }
-
 
 #[derive(Debug, Default)]
 struct RuntimeFakeCliState {
-  env: HashMap<String, String>,
-  stdout: Vec<String>,
-  stderr: Vec<String>,
-  env_reads: usize,
-  stdout_writes: usize,
-  stderr_writes: usize,
+    env: HashMap<String, String>,
+    stdout: Vec<String>,
+    stderr: Vec<String>,
+    env_reads: usize,
+    stdout_writes: usize,
+    stderr_writes: usize,
 }
 
 #[derive(Debug, Clone)]
 struct RuntimeFakeCliBackend {
-  state: Arc<Mutex<RuntimeFakeCliState>>,
+    state: Arc<Mutex<RuntimeFakeCliState>>,
 }
 
 impl RuntimeFakeCliBackend {
-  fn new(state: Arc<Mutex<RuntimeFakeCliState>>) -> Self {
-    Self { state }
-  }
+    fn new(state: Arc<Mutex<RuntimeFakeCliState>>) -> Self {
+        Self { state }
+    }
 }
 
 impl CliBackend for RuntimeFakeCliBackend {
-  fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
-    let mut state = self.state.lock().unwrap();
-    state.env_reads += 1;
-    Ok(state.env.get(name).cloned())
-  }
+    fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
+        let mut state = self.state.lock().unwrap();
+        state.env_reads += 1;
+        Ok(state.env.get(name).cloned())
+    }
 
-  fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
-    let mut state = self.state.lock().unwrap();
-    state.stdout_writes += 1;
-    state.stdout.push(text.to_string());
-    Ok(())
-  }
+    fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
+        let mut state = self.state.lock().unwrap();
+        state.stdout_writes += 1;
+        state.stdout.push(text.to_string());
+        Ok(())
+    }
 
-  fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
-    let mut state = self.state.lock().unwrap();
-    state.stderr_writes += 1;
-    state.stderr.push(text.to_string());
-    Ok(())
-  }
+    fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
+        let mut state = self.state.lock().unwrap();
+        state.stderr_writes += 1;
+        state.stderr.push(text.to_string());
+        Ok(())
+    }
 }
 
 fn runtime_with_fake_cli(state: Arc<Mutex<RuntimeFakeCliState>>) -> MechRuntime {
-  RuntimeBuilder::new()
-    .resource_provider(Box::new(CliResourceProvider::new(RuntimeFakeCliBackend::new(state))))
-    .build()
-    .unwrap()
+    RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(
+            RuntimeFakeCliBackend::new(state),
+        )))
+        .build()
+        .unwrap()
 }
 
 #[derive(Debug, Clone, Default)]
 struct FakeCliBackend {
-  env: std::collections::HashMap<String, String>,
-  stdout: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-  stderr: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-  calls: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    env: std::collections::HashMap<String, String>,
+    stdout: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    stderr: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    calls: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl FakeCliBackend {
-  fn with_env(mut self, name: &str, value: &str) -> Self {
-    self.env.insert(name.to_string(), value.to_string());
-    self
-  }
+    fn with_env(mut self, name: &str, value: &str) -> Self {
+        self.env.insert(name.to_string(), value.to_string());
+        self
+    }
 }
 
 impl CliBackend for FakeCliBackend {
-  fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
-    self.calls.lock().unwrap().push(format!("env:{name}"));
-    Ok(self.env.get(name).cloned())
-  }
+    fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
+        self.calls.lock().unwrap().push(format!("env:{name}"));
+        Ok(self.env.get(name).cloned())
+    }
 
-  fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
-    self.calls.lock().unwrap().push(format!("stdout:{text}"));
-    self.stdout.lock().unwrap().push(text.to_string());
-    Ok(())
-  }
+    fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
+        self.calls.lock().unwrap().push(format!("stdout:{text}"));
+        self.stdout.lock().unwrap().push(text.to_string());
+        Ok(())
+    }
 
-  fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
-    self.calls.lock().unwrap().push(format!("stderr:{text}"));
-    self.stderr.lock().unwrap().push(text.to_string());
-    Ok(())
-  }
+    fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
+        self.calls.lock().unwrap().push(format!("stderr:{text}"));
+        self.stderr.lock().unwrap().push(text.to_string());
+        Ok(())
+    }
 }
-
 
 #[test]
 fn cli_manifest_env_import_reads_through_runtime() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  state.lock().unwrap().env.insert("HOME".to_string(), "/tmp/home".to_string());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    state
+        .lock()
+        .unwrap()
+        .env
+        .insert("HOME".to_string(), "/tmp/home".to_string());
 
-  let mut runtime = runtime_with_fake_cli(state.clone());
-  runtime
-    .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-    .unwrap();
+    let mut runtime = runtime_with_fake_cli(state.clone());
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
 
-  let result = runtime
-    .run_string("+> @env := cli/env
+    let result = runtime
+        .run_string(
+            "+> @env := cli/env
 @env/HOME
-")
-    .unwrap();
+",
+        )
+        .unwrap();
 
-  let result = match result {
-    Value::MutableReference(value) => value.borrow().clone(),
-    other => other,
-  };
-  match result {
-    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/home"),
-    other => panic!("expected HOME string from cli env, got {:?}", other),
-  }
+    let result = match result {
+        Value::MutableReference(value) => value.borrow().clone(),
+        other => other,
+    };
+    match result {
+        Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/home"),
+        other => panic!("expected HOME string from cli env, got {:?}", other),
+    }
 
-  assert_eq!(state.lock().unwrap().env_reads, 1);
+    assert_eq!(state.lock().unwrap().env_reads, 1);
 }
 
 #[test]
 fn cli_manifest_stdout_send_line_writes_through_runtime() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  let mut runtime = runtime_with_fake_cli(state.clone());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    let mut runtime = runtime_with_fake_cli(state.clone());
 
-  runtime
-    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
-    .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
 
-  runtime
-    .run_string("+> @out := cli/stdout
+    runtime
+        .run_string(
+            "+> @out := cli/stdout
 @out/line <- \"hello\"
-")
-    .unwrap();
+",
+        )
+        .unwrap();
 
-  let state = state.lock().unwrap();
-  assert_eq!(state.stdout, vec!["hello\n".to_string()]);
-  assert_eq!(state.stdout_writes, 1);
+    let state = state.lock().unwrap();
+    assert_eq!(state.stdout, vec!["hello\n".to_string()]);
+    assert_eq!(state.stdout_writes, 1);
 }
 
 #[test]
 fn cli_manifest_stderr_send_text_writes_through_runtime() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  let mut runtime = runtime_with_fake_cli(state.clone());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    let mut runtime = runtime_with_fake_cli(state.clone());
 
-  runtime
-    .grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text"))
-    .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stderr",
+            "text",
+        ))
+        .unwrap();
 
-  runtime
-    .run_string("+> @err := cli/stderr
+    runtime
+        .run_string(
+            "+> @err := cli/stderr
 @err/text <- \"warning\"
-")
-    .unwrap();
+",
+        )
+        .unwrap();
 
-  let state = state.lock().unwrap();
-  assert_eq!(state.stderr, vec!["warning".to_string()]);
-  assert_eq!(state.stderr_writes, 1);
+    let state = state.lock().unwrap();
+    assert_eq!(state.stderr, vec!["warning".to_string()]);
+    assert_eq!(state.stderr_writes, 1);
 }
 
 #[test]
 fn cli_stdout_assignment_errors_and_writes_nothing() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  let mut runtime = runtime_with_fake_cli(state.clone());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    let mut runtime = runtime_with_fake_cli(state.clone());
 
-  runtime
-    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
-    .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
 
-  let result = runtime.run_string("+> @out := cli/stdout
+    let result = runtime.run_string(
+        "+> @out := cli/stdout
 @out/line = \"hello\"
-");
+",
+    );
 
-  assert!(result.is_err());
-  let state = state.lock().unwrap();
-  assert!(state.stdout.is_empty());
-  assert_eq!(state.stdout_writes, 0);
+    assert!(result.is_err());
+    let state = state.lock().unwrap();
+    assert!(state.stdout.is_empty());
+    assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]
 fn cli_stdout_define_errors_and_writes_nothing() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  let mut runtime = runtime_with_fake_cli(state.clone());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    let mut runtime = runtime_with_fake_cli(state.clone());
 
-  runtime
-    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
-    .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
 
-  let result = runtime.run_string("+> @out := cli/stdout
+    let result = runtime.run_string(
+        "+> @out := cli/stdout
 @out/line := \"hello\"
-");
+",
+    );
 
-  assert!(result.is_err());
-  let state = state.lock().unwrap();
-  assert!(state.stdout.is_empty());
-  assert_eq!(state.stdout_writes, 0);
+    assert!(result.is_err());
+    let state = state.lock().unwrap();
+    assert!(state.stdout.is_empty());
+    assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]
 fn cli_env_send_errors() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  let mut runtime = runtime_with_fake_cli(state.clone());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    let mut runtime = runtime_with_fake_cli(state.clone());
 
-  runtime
-    .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
-    .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
 
-  let result = runtime.run_string("+> @env := cli/env
+    let result = runtime.run_string(
+        "+> @env := cli/env
 @env/HOME <- \"x\"
-");
+",
+    );
 
-  assert!(result.is_err());
-  let state = state.lock().unwrap();
-  assert_eq!(state.env_reads, 0);
-  assert_eq!(state.stdout_writes, 0);
-  assert_eq!(state.stderr_writes, 0);
+    assert!(result.is_err());
+    let state = state.lock().unwrap();
+    assert_eq!(state.env_reads, 0);
+    assert_eq!(state.stdout_writes, 0);
+    assert_eq!(state.stderr_writes, 0);
 }
 
 #[test]
 fn cli_stdout_missing_write_grant_fails_before_backend() {
-  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-  let mut runtime = runtime_with_fake_cli(state.clone());
+    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+    let mut runtime = runtime_with_fake_cli(state.clone());
 
-  let result = runtime.run_string("+> @out := cli/stdout
+    let result = runtime.run_string(
+        "+> @out := cli/stdout
 @out/line <- \"hello\"
-");
+",
+    );
 
-  assert!(result.is_err());
-  let state = state.lock().unwrap();
-  assert!(state.stdout.is_empty());
-  assert_eq!(state.stdout_writes, 0);
+    assert!(result.is_err());
+    let state = state.lock().unwrap();
+    assert!(state.stdout.is_empty());
+    assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]
 fn cli_host_env_manifest_import_reads_with_runtime_grant() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/mech-home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
-  runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
-  let id = hash_str("home");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  match value {
-    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/mech-home"),
-    other => panic!("expected string home, got {other:?}"),
-  }
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/mech-home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    runtime
+        .run_string("+> @env := cli/env\nhome := @env/HOME\n")
+        .unwrap();
+    let id = hash_str("home");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    match value {
+        Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/mech-home"),
+        other => panic!("expected string home, got {other:?}"),
+    }
 }
 
 #[test]
 fn cli_host_stdout_send_writes_line_with_runtime_grant() {
-  let backend = FakeCliBackend::default();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n").unwrap();
-  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+    let backend = FakeCliBackend::default();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
+    runtime
+        .run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n")
+        .unwrap();
+    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
 #[test]
 fn cli_host_stderr_send_writes_text_with_runtime_grant() {
-  let backend = FakeCliBackend::default();
-  let stderr = backend.stderr.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text")).unwrap();
-  runtime.run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n").unwrap();
-  assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
+    let backend = FakeCliBackend::default();
+    let stderr = backend.stderr.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stderr",
+            "text",
+        ))
+        .unwrap();
+    runtime
+        .run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n")
+        .unwrap();
+    assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
 }
 
 #[test]
 fn cli_host_stdout_assignment_errors_and_writes_nothing() {
-  let backend = FakeCliBackend::default();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  let result = runtime.run_string("+> @out := cli/stdout\n@out/line = \"hello\"\n");
-  assert!(result.is_err(), "stdout assignment should error");
-  assert!(stdout.lock().unwrap().is_empty(), "stdout assignment should not write");
+    let backend = FakeCliBackend::default();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
+    let result = runtime.run_string("+> @out := cli/stdout\n@out/line = \"hello\"\n");
+    assert!(result.is_err(), "stdout assignment should error");
+    assert!(
+        stdout.lock().unwrap().is_empty(),
+        "stdout assignment should not write"
+    );
 }
 
 #[test]
 fn cli_host_stdout_definition_errors_and_writes_nothing() {
-  let backend = FakeCliBackend::default();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  let result = runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n");
-  assert!(result.is_err(), "stdout definition should error");
-  assert!(stdout.lock().unwrap().is_empty(), "stdout definition should not write");
+    let backend = FakeCliBackend::default();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
+    let result = runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n");
+    assert!(result.is_err(), "stdout definition should error");
+    assert!(
+        stdout.lock().unwrap().is_empty(),
+        "stdout definition should not write"
+    );
 }
 
 #[test]
 fn cli_host_env_send_errors() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME")).unwrap();
-  let result = runtime.run_string("+> @env := cli/env\n@env/HOME <- \"x\"\n");
-  assert!(result.is_err(), "env send should error");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    let result = runtime.run_string("+> @env := cli/env\n@env/HOME <- \"x\"\n");
+    assert!(result.is_err(), "env send should error");
 }
 
 #[test]
 fn cli_host_missing_env_read_grant_fails_before_backend_call() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-  let calls = backend.calls.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  let result = runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n");
-  assert!(result.is_err(), "env read without runtime grant should fail");
-  assert!(calls.lock().unwrap().is_empty(), "backend should not be called without read grant");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+    let calls = backend.calls.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    let result = runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n");
+    assert!(
+        result.is_err(),
+        "env read without runtime grant should fail"
+    );
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "backend should not be called without read grant"
+    );
 }
 
 #[test]
 fn cli_host_missing_stdout_write_grant_fails_before_backend_call() {
-  let backend = FakeCliBackend::default();
-  let calls = backend.calls.clone();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  let result = runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
-  assert!(result.is_err(), "stdout send without runtime grant should fail");
-  assert!(calls.lock().unwrap().is_empty(), "backend should not be called without write grant");
-  assert!(stdout.lock().unwrap().is_empty(), "stdout should not be written without grant");
+    let backend = FakeCliBackend::default();
+    let calls = backend.calls.clone();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    let result = runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
+    assert!(
+        result.is_err(),
+        "stdout send without runtime grant should fail"
+    );
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "backend should not be called without write grant"
+    );
+    assert!(
+        stdout.lock().unwrap().is_empty(),
+        "stdout should not be written without grant"
+    );
 }
 
 #[test]
 fn cli_host_missing_stderr_write_grant_fails_before_backend_call() {
-  let backend = FakeCliBackend::default();
-  let calls = backend.calls.clone();
-  let stderr = backend.stderr.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  let result = runtime.run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n");
-  assert!(result.is_err(), "stderr send without runtime grant should fail");
-  assert!(calls.lock().unwrap().is_empty(), "backend should not be called without write grant");
-  assert!(stderr.lock().unwrap().is_empty(), "stderr should not be written without grant");
+    let backend = FakeCliBackend::default();
+    let calls = backend.calls.clone();
+    let stderr = backend.stderr.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    let result = runtime.run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n");
+    assert!(
+        result.is_err(),
+        "stderr send without runtime grant should fail"
+    );
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "backend should not be called without write grant"
+    );
+    assert!(
+        stderr.lock().unwrap().is_empty(),
+        "stderr should not be written without grant"
+    );
 }
-
 
 #[test]
 fn cli_host_direct_env_declaration_reads_with_runtime_grant() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/direct-home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
-  runtime.run_string("@env := cli://env{:read(HOME)}\nhome := @env/HOME\n").unwrap();
-  let id = hash_str("home");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  assert_string_value(value, "/tmp/direct-home");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/direct-home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    runtime
+        .run_string("@env := cli://env{:read(HOME)}\nhome := @env/HOME\n")
+        .unwrap();
+    let id = hash_str("home");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    assert_string_value(value, "/tmp/direct-home");
 }
 
 #[test]
 fn cli_host_direct_stdout_declaration_sends_with_runtime_grant() {
-  let backend = FakeCliBackend::default();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  runtime.run_string("@out := cli://stdout{:write(line)}\n@out/line <- \"hello\"\n").unwrap();
-  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+    let backend = FakeCliBackend::default();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
+    runtime
+        .run_string("@out := cli://stdout{:write(line)}\n@out/line <- \"hello\"\n")
+        .unwrap();
+    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
 #[test]
 fn cli_host_direct_stderr_declaration_sends_with_runtime_grant() {
-  let backend = FakeCliBackend::default();
-  let stderr = backend.stderr.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text")).unwrap();
-  runtime.run_string("@err := cli://stderr{:write(text)}\n@err/text <- \"warning\"\n").unwrap();
-  assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
+    let backend = FakeCliBackend::default();
+    let stderr = backend.stderr.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stderr",
+            "text",
+        ))
+        .unwrap();
+    runtime
+        .run_string("@err := cli://stderr{:write(text)}\n@err/text <- \"warning\"\n")
+        .unwrap();
+    assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
 }
 
 #[test]
 fn cli_host_env_assignment_errors() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME")).unwrap();
-  let result = runtime.run_string("+> @env := cli/env\n@env/HOME = \"x\"\n");
-  assert!(result.is_err(), "env assignment should error");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    let result = runtime.run_string("+> @env := cli/env\n@env/HOME = \"x\"\n");
+    assert!(result.is_err(), "env assignment should error");
 }
 
 #[test]
 fn cli_host_stdout_read_errors() {
-  let backend = FakeCliBackend::default();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://stdout", "line")).unwrap();
-  let result = runtime.run_string("+> @out := cli/stdout\nx := @out/line\n");
-  assert!(result.is_err(), "stdout read should error");
+    let backend = FakeCliBackend::default();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://stdout", "line"))
+        .unwrap();
+    let result = runtime.run_string("+> @out := cli/stdout\nx := @out/line\n");
+    assert!(result.is_err(), "stdout read should error");
 }
 
 #[test]
 fn cli_context_module_read_exports_value() {
-  let root = setup_modules("+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n");
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/module-home");
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
-  let result = match result {
-    Value::MutableReference(value) => value.borrow().clone(),
-    other => other,
-  };
-  match result {
-    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/module-home"),
-    other => panic!("expected string home, got {other:?}"),
-  }
+    let root = setup_modules("+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/module-home");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
+    let result = match result {
+        Value::MutableReference(value) => value.borrow().clone(),
+        other => other,
+    };
+    match result {
+        Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/module-home"),
+        other => panic!("expected string home, got {other:?}"),
+    }
 }
 
 #[test]
 fn cli_context_module_send_is_not_stripped() {
-  let root = setup_modules("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
-  let backend = FakeCliBackend::default();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  runtime.run_module(version).unwrap();
-  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+    let root = setup_modules("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
+    let backend = FakeCliBackend::default();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    runtime.run_module(version).unwrap();
+    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
 #[derive(Debug, Clone)]
 struct RecordingResourceProvider {
-  scheme: &'static str,
-  bases: Vec<String>,
-  values: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Value>>>,
-  writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
+    scheme: &'static str,
+    bases: Vec<String>,
+    values: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Value>>>,
+    writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
 }
 
 impl RecordingResourceProvider {
-  fn new(scheme: &'static str, bases: &[&str]) -> Self {
-    Self {
-      scheme,
-      bases: bases.iter().map(|base| base.to_string()).collect(),
-      values: Default::default(),
-      writes: Default::default(),
+    fn new(scheme: &'static str, bases: &[&str]) -> Self {
+        Self {
+            scheme,
+            bases: bases.iter().map(|base| base.to_string()).collect(),
+            values: Default::default(),
+            writes: Default::default(),
+        }
     }
-  }
 
-  fn with_value(self, base: &str, path: &str, value: Value) -> Self {
-    self.values.lock().unwrap().insert(format!("{base}|{path}"), value);
-    self
-  }
+    fn with_value(self, base: &str, path: &str, value: Value) -> Self {
+        self.values
+            .lock()
+            .unwrap()
+            .insert(format!("{base}|{path}"), value);
+        self
+    }
 }
 
 impl RuntimeResourceProvider for RecordingResourceProvider {
-  fn scheme(&self) -> &str { self.scheme }
+    fn scheme(&self) -> &str {
+        self.scheme
+    }
 
-  fn base_uris(&self) -> Vec<String> { self.bases.clone() }
+    fn base_uris(&self) -> Vec<String> {
+        self.bases.clone()
+    }
 
-  fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
-    self.values
-      .lock()
-      .unwrap()
-      .get(&format!("{}|{}", request.base_uri, request.path))
-      .cloned()
-      .ok_or_else(|| mech_core::MechError::new(RuntimeResourcePathNotFound { base_uri: request.base_uri, path: request.path }, None))
-  }
+    fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
+        self.values
+            .lock()
+            .unwrap()
+            .get(&format!("{}|{}", request.base_uri, request.path))
+            .cloned()
+            .ok_or_else(|| {
+                mech_core::MechError::new(
+                    RuntimeResourcePathNotFound {
+                        base_uri: request.base_uri,
+                        path: request.path,
+                    },
+                    None,
+                )
+            })
+    }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
-    self.writes.lock().unwrap().push((request.base_uri.clone(), request.path.clone(), request.value.clone()));
-    self.values.lock().unwrap().insert(format!("{}|{}", request.base_uri, request.path), request.value);
-    Ok(())
-  }
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
+        self.writes.lock().unwrap().push((
+            request.base_uri.clone(),
+            request.path.clone(),
+            request.value.clone(),
+        ));
+        self.values.lock().unwrap().insert(
+            format!("{}|{}", request.base_uri, request.path),
+            request.value,
+        );
+        Ok(())
+    }
 }
 
 fn assert_string_value(value: Value, expected: &str) {
-  let value = match value {
-    Value::MutableReference(value) => value.borrow().clone(),
-    other => other,
-  };
-  match value {
-    Value::String(value) => assert_eq!(&*value.borrow(), expected),
-    other => panic!("expected string value `{expected}`, got {other:?}"),
-  }
+    let value = match value {
+        Value::MutableReference(value) => value.borrow().clone(),
+        other => other,
+    };
+    match value {
+        Value::String(value) => assert_eq!(&*value.borrow(), expected),
+        other => panic!("expected string value `{expected}`, got {other:?}"),
+    }
 }
 
 #[test]
 fn cli_context_direct_read_resolves_inside_formula_expression() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
-  runtime.run_string("+> @env := cli/env\nmsg := \"HOME=\" + @env/HOME\n").unwrap();
-  let id = hash_str("msg");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  assert_string_value(value, "HOME=/tmp/home");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    runtime
+        .run_string("+> @env := cli/env\nmsg := \"HOME=\" + @env/HOME\n")
+        .unwrap();
+    let id = hash_str("msg");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    assert_string_value(value, "HOME=/tmp/home");
 }
 
 #[test]
 fn cli_context_standalone_expression_returns_env_value() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
-  let value = runtime.run_string("+> @env := cli/env\n@env/HOME\n").unwrap();
-  assert_string_value(value, "/tmp/home");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    let value = runtime
+        .run_string("+> @env := cli/env\n@env/HOME\n")
+        .unwrap();
+    assert_string_value(value, "/tmp/home");
 }
-
 
 #[test]
 fn docs_context_send_errors_and_does_not_write() {
-  let mut runtime = RuntimeBuilder::new().in_memory_docs(InMemoryDocsProvider::new()).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .in_memory_docs(InMemoryDocsProvider::new())
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
 
-  let result = runtime.run_string("@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title <- \"hello\"\n");
-  assert!(result.is_err(), "docs context send should error");
+    let result = runtime.run_string("@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title <- \"hello\"\n");
+    assert!(result.is_err(), "docs context send should error");
 
-  let read_result = runtime.run_string("@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n");
-  assert!(read_result.is_err(), "docs send should not write a readable value");
-  let error = format!("{:?}", read_result.err().unwrap());
-  assert!(error.contains("RuntimeResourcePathNotFound"), "expected missing docs path after failed send, got {error}");
+    let read_result = runtime.run_string(
+        "@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n",
+    );
+    assert!(
+        read_result.is_err(),
+        "docs send should not write a readable value"
+    );
+    let error = format!("{:?}", read_result.err().unwrap());
+    assert!(
+        error.contains("RuntimeResourcePathNotFound"),
+        "expected missing docs path after failed send, got {error}"
+    );
 }
 
 #[test]
 fn docs_context_write_requires_runtime_grant_before_provider_write() {
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-  let writes = provider.writes.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  let result = runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n");
-  assert!(result.is_err(), "write without host grant should fail");
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected host grant denial, got {error}");
-  assert!(writes.lock().unwrap().is_empty(), "provider write should not be called without grant");
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+    let writes = provider.writes.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
+    let result = runtime.run_string(
+        "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
+    );
+    assert!(result.is_err(), "write without host grant should fail");
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(
+        error.contains("RuntimeCapabilityGrantDenied"),
+        "expected host grant denial, got {error}"
+    );
+    assert!(
+        writes.lock().unwrap().is_empty(),
+        "provider write should not be called without grant"
+    );
 }
 
 #[test]
 fn docs_context_write_with_runtime_grant_reaches_provider() {
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-  let writes = provider.writes.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n").unwrap();
-  let writes = writes.lock().unwrap();
-  assert_eq!(writes.len(), 1);
-  assert_eq!(writes[0].0, "docs://manual");
-  assert_eq!(writes[0].1, "intro/title");
-  assert_string_value(writes[0].2.clone(), "hello");
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+    let writes = provider.writes.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    runtime
+        .run_string(
+            "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
+        )
+        .unwrap();
+    let writes = writes.lock().unwrap();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].0, "docs://manual");
+    assert_eq!(writes[0].1, "intro/title");
+    assert_string_value(writes[0].2.clone(), "hello");
 }
 
 #[test]
 fn browser_context_subroot_normalizes_to_provider_base_path() {
-  let provider = RecordingResourceProvider::new("browser", &["browser://dom"])
-    .with_value("browser://dom", "counter/text", Value::String(Ref::new("count".to_string())));
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/text")).unwrap();
-  runtime.run_string("@ui := browser://dom/counter{:read(text)}\ntitle := @ui/text\n").unwrap();
-  let id = hash_str("title");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  assert_string_value(value, "count");
+    let provider = RecordingResourceProvider::new("browser", &["browser://dom"]).with_value(
+        "browser://dom",
+        "counter/text",
+        Value::String(Ref::new("count".to_string())),
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "browser://dom",
+            "counter/text",
+        ))
+        .unwrap();
+    runtime
+        .run_string("@ui := browser://dom/counter{:read(text)}\ntitle := @ui/text\n")
+        .unwrap();
+    let id = hash_str("title");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    assert_string_value(value, "count");
 }
 
 #[test]
 fn docs_context_subroot_normalizes_to_provider_base_path() {
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
-    .with_value("docs://manual", "intro/title", Value::String(Ref::new("Manual".to_string())));
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  runtime.run_string("@manual := docs://manual/intro{:read(title)}\ntitle := @manual/title\n").unwrap();
-  let id = hash_str("title");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  assert_string_value(value, "Manual");
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]).with_value(
+        "docs://manual",
+        "intro/title",
+        Value::String(Ref::new("Manual".to_string())),
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    runtime
+        .run_string("@manual := docs://manual/intro{:read(title)}\ntitle := @manual/title\n")
+        .unwrap();
+    let id = hash_str("title");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    assert_string_value(value, "Manual");
 }
-
 
 #[test]
 fn context_write_uses_active_runtime_context_subject() {
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-  let writes = provider.writes.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  let mut context = runtime.runtime_context().unwrap().with_subject("task://custom");
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+    let writes = provider.writes.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
+    let mut context = runtime
+        .runtime_context()
+        .unwrap()
+        .with_subject("task://custom");
 
-  runtime.grant_capability(runtime_write_grant_for("task://custom", "docs://manual", "intro/title")).unwrap();
+    runtime
+        .grant_capability(runtime_write_grant_for(
+            "task://custom",
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
 
-  runtime.run_string_with_context(
-    &mut context,
-    "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
-  ).unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
+        )
+        .unwrap();
 
-  assert_eq!(writes.lock().unwrap().len(), 1);
+    assert_eq!(writes.lock().unwrap().len(), 1);
 }
 
 #[test]
 fn context_write_does_not_accept_grant_for_default_subject_when_context_subject_differs() {
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-  let writes = provider.writes.clone();
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
-  runtime.grant_capability(runtime_write_grant_for("task://main", "docs://manual", "intro/title")).unwrap();
-  let mut context = runtime.runtime_context().unwrap().with_subject("task://custom");
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+    let writes = provider.writes.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
+    runtime
+        .grant_capability(runtime_write_grant_for(
+            "task://main",
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    let mut context = runtime
+        .runtime_context()
+        .unwrap()
+        .with_subject("task://custom");
 
-  let result = runtime.run_string_with_context(
-    &mut context,
-    "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
-  );
+    let result = runtime.run_string_with_context(
+        &mut context,
+        "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
+    );
 
-  assert!(result.is_err());
-  let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeCapabilityGrantDenied"));
-  assert!(writes.lock().unwrap().is_empty());
+    assert!(result.is_err());
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeCapabilityGrantDenied"));
+    assert!(writes.lock().unwrap().is_empty());
 }
 
 #[test]
 fn unqualified_fenced_context_import_is_available_to_program_execution() {
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/fenced-home");
-  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
-  let mut context = runtime.runtime_context().unwrap().with_subject("task://fenced");
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: "task://fenced".to_string(),
-    resource: "cli://env".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
-    paths: vec!["HOME".to_string()],
-  }).unwrap();
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/fenced-home");
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
+    let mut context = runtime
+        .runtime_context()
+        .unwrap()
+        .with_subject("task://fenced");
+    runtime
+        .grant_capability(RuntimeCapabilityGrant {
+            subject: "task://fenced".to_string(),
+            resource: "cli://env".to_string(),
+            operations: vec![RuntimeCapabilityOperation::Read],
+            paths: vec!["HOME".to_string()],
+        })
+        .unwrap();
 
-  runtime.run_string_with_context(
-    &mut context,
-    "```mech
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "```mech
 +> @env := cli/env
 home := @env/HOME
 ```
 ",
-  ).unwrap();
+        )
+        .unwrap();
 
-  let id = hash_str("home");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  assert_string_value(value, "/tmp/fenced-home");
+    let id = hash_str("home");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    assert_string_value(value, "/tmp/fenced-home");
 }
 
 #[test]
 fn named_fenced_context_import_write_uses_context_registry() {
-  let root = setup_modules("~~~mech:bar\n+> @out := cli/stdout\n@out/line <- \"hello\"\n~~~\n");
-  let backend = FakeCliBackend::default();
-  let stdout = backend.stdout.clone();
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .resource_provider(Box::new(CliResourceProvider::new(backend)))
-    .build()
-    .unwrap();
+    let root = setup_modules("~~~mech:bar\n+> @out := cli/stdout\n@out/line <- \"hello\"\n~~~\n");
+    let backend = FakeCliBackend::default();
+    let stdout = backend.stdout.clone();
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
 
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "cli://stdout",
+            "line",
+        ))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  runtime.run_module_scope(
-    version,
-    SourceScope::Interpreter(SourceInterpreterId {
-      namespace: hash_str("bar"),
-      namespace_str: "bar".to_string(),
-    }),
-  ).unwrap();
+    runtime
+        .run_module_scope(
+            version,
+            SourceScope::Interpreter(SourceInterpreterId {
+                namespace: hash_str("bar"),
+                namespace_str: "bar".to_string(),
+            }),
+        )
+        .unwrap();
 
-  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
 #[test]
 fn named_fenced_context_import_read_exports_value() {
-  let root = setup_modules("~~~mech:bar\n+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n~~~\n");
-  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/named-fence-home");
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .resource_provider(Box::new(CliResourceProvider::new(backend)))
-    .build()
-    .unwrap();
+    let root =
+        setup_modules("~~~mech:bar\n+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n~~~\n");
+    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/named-fence-home");
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap();
 
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+        .unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
 
-  let result = runtime.run_module_scope(
-    version,
-    SourceScope::Interpreter(SourceInterpreterId {
-      namespace: hash_str("bar"),
-      namespace_str: "bar".to_string(),
-    }),
-  ).unwrap();
+    let result = runtime
+        .run_module_scope(
+            version,
+            SourceScope::Interpreter(SourceInterpreterId {
+                namespace: hash_str("bar"),
+                namespace_str: "bar".to_string(),
+            }),
+        )
+        .unwrap();
 
-  assert_string_value(result, "/tmp/named-fence-home");
+    assert_string_value(result, "/tmp/named-fence-home");
 }
 
 #[test]
 fn module_context_read_after_context_write_uses_execution_order() {
-  let root = setup_modules(
-    "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"hello\"\nresult := @manual/intro/title\n<+ result\nresult\n",
-  );
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .resource_provider(Box::new(provider))
-    .build()
-    .unwrap();
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"hello\"\nresult := @manual/intro/title\n<+ result\nresult\n",
+    );
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
 
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
 
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
 
-  assert_string_value(result, "hello");
+    assert_string_value(result, "hello");
 }
 
 #[test]
 fn module_context_read_after_context_write_ignores_stale_provider_value() {
-  let root = setup_modules(
-    "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"new\"\nresult := @manual/intro/title\n<+ result\nresult\n",
-  );
-  let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
-    .with_value("docs://manual", "intro/title", Value::String(Ref::new("old".to_string())));
-  let mut runtime = RuntimeBuilder::new()
-    .source_resolver(FileSourceResolver::new(&root))
-    .resource_provider(Box::new(provider))
-    .build()
-    .unwrap();
+    let root = setup_modules(
+        "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"new\"\nresult := @manual/intro/title\n<+ result\nresult\n",
+    );
+    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]).with_value(
+        "docs://manual",
+        "intro/title",
+        Value::String(Ref::new("old".to_string())),
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .source_resolver(FileSourceResolver::new(&root))
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
 
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+    runtime
+        .grant_capability(runtime_context_write_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://manual",
+            "intro/title",
+        ))
+        .unwrap();
 
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
-  let result = runtime.run_module(version).unwrap();
+    let version = runtime
+        .resolve_and_store_module_source("main.mec", module_options())
+        .unwrap()
+        .unwrap();
+    let result = runtime.run_module(version).unwrap();
 
-  assert_string_value(result, "new");
+    assert_string_value(result, "new");
 }
 
 #[test]
 fn direct_context_read_resolves_inside_op_assign() {
-  let provider = RecordingResourceProvider::new("docs", &["docs://numbers"])
-    .with_value("docs://numbers", "increment", Value::F64(Ref::new(2.0)));
-  let mut runtime = RuntimeBuilder::new()
-    .resource_provider(Box::new(provider))
-    .build()
-    .unwrap();
+    let provider = RecordingResourceProvider::new("docs", &["docs://numbers"]).with_value(
+        "docs://numbers",
+        "increment",
+        Value::F64(Ref::new(2.0)),
+    );
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap();
 
-  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://numbers", "increment")).unwrap();
+    runtime
+        .grant_capability(runtime_context_read_grant(
+            &runtime,
+            "docs://numbers",
+            "increment",
+        ))
+        .unwrap();
 
-  runtime.run_string("@numbers := docs://numbers{:read(increment)}\n~total := 1.0\ntotal += @numbers/increment\n").unwrap();
+    runtime.run_string("@numbers := docs://numbers{:read(increment)}\n~total := 1.0\ntotal += @numbers/increment\n").unwrap();
 
-  let id = hash_str("total");
-  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
-  match value {
-    Value::F64(value) => assert_eq!(*value.borrow(), 3.0),
-    other => panic!("expected f64 total, got {other:?}"),
-  }
+    let id = hash_str("total");
+    let value = runtime
+        .program()
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(id)
+        .unwrap()
+        .borrow()
+        .clone();
+    match value {
+        Value::F64(value) => assert_eq!(*value.borrow(), 3.0),
+        other => panic!("expected f64 total, got {other:?}"),
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct CountingCliBackend {
+    env_reads: Arc<Mutex<usize>>,
+    stdout_writes: Arc<Mutex<usize>>,
+    stderr_writes: Arc<Mutex<usize>>,
+}
+
+impl CliBackend for CountingCliBackend {
+    fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
+        *self.env_reads.lock().unwrap() += 1;
+        Ok(Some(format!("value-{name}")))
+    }
+
+    fn write_stdout(&mut self, _text: &str) -> mech_core::MResult<()> {
+        *self.stdout_writes.lock().unwrap() += 1;
+        Ok(())
+    }
+
+    fn write_stderr(&mut self, _text: &str) -> mech_core::MResult<()> {
+        *self.stderr_writes.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+fn cli_runtime_with_backend(backend: CountingCliBackend) -> MechRuntime {
+    RuntimeBuilder::new()
+        .resource_provider(Box::new(CliResourceProvider::new(backend)))
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn default_cli_stdout_grant_allows_send() {
+    let backend = CountingCliBackend::default();
+    let writes = backend.stdout_writes.clone();
+    let mut runtime = cli_runtime_with_backend(backend);
+    let grant = runtime_context_write_grant(&runtime, "cli://stdout", "line");
+    runtime.grant_capability(grant).unwrap();
+
+    runtime
+        .run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n")
+        .unwrap();
+
+    assert_eq!(*writes.lock().unwrap(), 1);
+}
+
+#[test]
+fn missing_stdout_grant_fails_before_provider_write() {
+    let backend = CountingCliBackend::default();
+    let writes = backend.stdout_writes.clone();
+    let mut runtime = cli_runtime_with_backend(backend);
+
+    let result = runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
+
+    assert!(result.is_err());
+    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+    assert_eq!(*writes.lock().unwrap(), 0);
+}
+
+#[test]
+fn missing_env_grant_fails_before_provider_read() {
+    let backend = CountingCliBackend::default();
+    let reads = backend.env_reads.clone();
+    let mut runtime = cli_runtime_with_backend(backend);
+
+    let result = runtime.run_string("+> @env := cli/env\nx := @env/PATH\n");
+
+    assert!(result.is_err());
+    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+    assert_eq!(*reads.lock().unwrap(), 0);
+}
+
+#[test]
+fn narrow_env_grant_permits_path_but_denies_home() {
+    let backend = CountingCliBackend::default();
+    let mut runtime = cli_runtime_with_backend(backend);
+    let grant = runtime_context_read_grant(&runtime, "cli://env", "PATH");
+    runtime.grant_capability(grant).unwrap();
+
+    runtime
+        .run_string("+> @env := cli/env\nx := @env/PATH\n")
+        .unwrap();
+    let result = runtime.run_string("+> @env := cli/env\nx := @env/HOME\n");
+    assert!(result.is_err());
+    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+}
+
+#[test]
+fn narrow_stdout_grant_permits_line_but_denies_text() {
+    let backend = CountingCliBackend::default();
+    let mut runtime = cli_runtime_with_backend(backend);
+    let grant = runtime_context_write_grant(&runtime, "cli://stdout", "line");
+    runtime.grant_capability(grant).unwrap();
+
+    runtime
+        .run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n")
+        .unwrap();
+    let result = runtime.run_string("+> @out := cli/stdout\n@out/text <- \"bad\"\n");
+    assert!(result.is_err());
+    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1,3270 +1,2105 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use mech_core::{
-    MechSourceCode, ModuleManifestConfig, ModuleManifestExportConfig, ModuleManifestExportKind,
-    Ref, Value, hash_str,
-};
+use mech_core::{hash_str, MechSourceCode, ModuleManifestConfig, ModuleManifestExportConfig, ModuleManifestExportKind, Ref, Value};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::*;
 
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-smoke-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(
-        root.join("math.mec"),
-        "tau := 6.28318\nsecret := 42\n<+ tau\n",
-    )
-    .unwrap();
-    std::fs::write(root.join("main.mec"), main_source).unwrap();
-    root
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\nsecret := 42\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), main_source).unwrap();
+  root
 }
+
+
 
 fn runtime_with_root(root: &std::path::Path) -> mech_runtime::MechRuntime {
-    RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(root))
-        .build()
-        .unwrap()
+  RuntimeBuilder::new().source_resolver(FileSourceResolver::new(root)).build().unwrap()
 }
 
-fn docs_provider_with(base_uri: &str, path: &str, value: Value) -> InMemoryDocsProvider {
-    InMemoryDocsProvider::new()
-        .with_value(base_uri, path, value)
-        .unwrap()
+fn docs_provider_with(
+  base_uri: &str,
+  path: &str,
+  value: Value,
+) -> InMemoryDocsProvider {
+  InMemoryDocsProvider::new()
+    .with_value(base_uri, path, value)
+    .unwrap()
 }
 
 fn read_grant(resource: &str, path: &str) -> RuntimeCapabilityGrantSpec {
-    RuntimeCapabilityGrantSpec::new("task://main", resource)
-        .with_operation(RuntimeCapabilityOperation::Read)
-        .with_path(path)
+  RuntimeCapabilityGrantSpec::new("task://main", resource)
+    .with_operation(RuntimeCapabilityOperation::Read)
+    .with_path(path)
 }
 
 fn runtime_write_grant_for(subject: &str, resource: &str, path: &str) -> RuntimeCapabilityGrant {
-    RuntimeCapabilityGrant {
-        subject: subject.to_string(),
-        resource: resource.to_string(),
-        operations: vec![RuntimeCapabilityOperation::Write],
-        paths: vec![path.to_string()],
-    }
+  RuntimeCapabilityGrant {
+    subject: subject.to_string(),
+    resource: resource.to_string(),
+    operations: vec![RuntimeCapabilityOperation::Write],
+    paths: vec![path.to_string()],
+  }
 }
 
 fn runtime_read_grant_for(subject: &str, resource: &str, path: &str) -> RuntimeCapabilityGrant {
-    RuntimeCapabilityGrant {
-        subject: subject.to_string(),
-        resource: resource.to_string(),
-        operations: vec![RuntimeCapabilityOperation::Read],
-        paths: vec![path.to_string()],
-    }
+  RuntimeCapabilityGrant {
+    subject: subject.to_string(),
+    resource: resource.to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec![path.to_string()],
+  }
 }
 
-fn runtime_context_read_grant(
-    runtime: &MechRuntime,
-    resource: &str,
-    path: &str,
-) -> RuntimeCapabilityGrant {
-    let subject = runtime.runtime_context().unwrap().subject;
-    runtime_read_grant_for(&subject, resource, path)
+fn runtime_context_read_grant(runtime: &MechRuntime, resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime_read_grant_for(&subject, resource, path)
 }
 
-fn runtime_context_write_grant(
-    runtime: &MechRuntime,
-    resource: &str,
-    path: &str,
-) -> RuntimeCapabilityGrant {
-    let subject = runtime.runtime_context().unwrap().subject;
-    runtime_write_grant_for(&subject, resource, path)
+fn runtime_context_write_grant(runtime: &MechRuntime, resource: &str, path: &str) -> RuntimeCapabilityGrant {
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime_write_grant_for(&subject, resource, path)
 }
 
-fn run_module_as_main(
-    runtime: &mut MechRuntime,
-    version: ModuleVersionId,
-) -> mech_core::MResult<Value> {
-    let mut context = runtime.runtime_context()?.with_subject("task://main");
-    runtime.run_module_with_context(&mut context, version)
+fn run_module_as_main(runtime: &mut MechRuntime, version: ModuleVersionId) -> mech_core::MResult<Value> {
+  let mut context = runtime.runtime_context()?.with_subject("task://main");
+  runtime.run_module_with_context(&mut context, version)
 }
 
 fn bool_value(value: bool) -> Value {
-    Value::Bool(Ref::new(value))
+  Value::Bool(Ref::new(value))
 }
 
 fn docs_entry(path: &str, value: Value) -> RuntimeDocsEntrySpec {
-    RuntimeDocsEntrySpec {
-        path: path.to_string(),
-        value,
-    }
+  RuntimeDocsEntrySpec {
+    path: path.to_string(),
+    value,
+  }
 }
 
 fn module_options() -> ModuleBuildOptions<'static> {
-    ModuleBuildOptions::new("test", "v0.3", "native", &[], &[])
+  ModuleBuildOptions::new("test", "v0.3", "native", &[], &[])
 }
 
 fn assert_bool_true(result: Value, label: &str) {
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from {label}, got {:?}", other),
-    }
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from {label}, got {:?}", other),
+  }
 }
 
 fn assert_bool_false(result: Value, label: &str) {
-    match result {
-        Value::Bool(value) => assert!(!*value.borrow()),
-        other => panic!("expected bool result from {label}, got {:?}", other),
-    }
+  match result {
+    Value::Bool(value) => assert!(!*value.borrow()),
+    other => panic!("expected bool result from {label}, got {:?}", other),
+  }
 }
+
+
 
 #[test]
 fn direct_run_string_preserves_normal_imports() {
-    let root = setup_modules(
-        "+> ./math.mec
+  let root = setup_modules("+> ./math.mec
 ok := math/tau > 6.0
-",
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
+");
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .build()
+    .unwrap();
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
 
-    let result = runtime.run_module(version).unwrap();
+  let result = runtime.run_module(version).unwrap();
 
-    assert_bool_true(result, "direct run_string normal import");
+  assert_bool_true(result, "direct run_string normal import");
 }
 
 #[test]
 fn in_memory_docs_provider_write_then_read_returns_value() {
-    let mut provider = InMemoryDocsProvider::new();
-    provider
-        .write(RuntimeResourceWriteRequest {
-            base_uri: "docs://manual".to_string(),
-            path: "intro/title".to_string(),
-            context_name: "manual".to_string(),
-            value: bool_value(true),
-            intent: RuntimeResourceWriteIntent::Assign,
-        })
-        .unwrap();
-    let value = provider
-        .read(RuntimeResourceReadRequest {
-            base_uri: "docs://manual".to_string(),
-            path: "intro/title".to_string(),
-            context_name: "manual".to_string(),
-        })
-        .unwrap();
-    assert_bool_true(value, "provider write then read");
+  let mut provider = InMemoryDocsProvider::new();
+  provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  let value = provider.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
+  assert_bool_true(value, "provider write then read");
 }
 
 #[test]
 fn resource_registry_write_then_read_returns_value() {
-    let mut registry = RuntimeResourceRegistry::new();
-    registry
-        .register_provider(Box::new(InMemoryDocsProvider::new()))
-        .unwrap();
-    registry
-        .write(RuntimeResourceWriteRequest {
-            base_uri: "docs://manual".to_string(),
-            path: "intro/title".to_string(),
-            context_name: "manual".to_string(),
-            value: bool_value(true),
-            intent: RuntimeResourceWriteIntent::Assign,
-        })
-        .unwrap();
-    let value = registry
-        .read(RuntimeResourceReadRequest {
-            base_uri: "docs://manual".to_string(),
-            path: "intro/title".to_string(),
-            context_name: "manual".to_string(),
-        })
-        .unwrap();
-    assert_bool_true(value, "registry write then read");
+  let mut registry = RuntimeResourceRegistry::new();
+  registry.register_provider(Box::new(InMemoryDocsProvider::new())).unwrap();
+  registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  let value = registry.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
+  assert_bool_true(value, "registry write then read");
 }
 
 #[test]
 fn resource_registry_write_missing_provider_fails() {
-    let mut registry = RuntimeResourceRegistry::new();
-    let result = registry.write(RuntimeResourceWriteRequest {
-        base_uri: "docs://manual".to_string(),
-        path: "intro/title".to_string(),
-        context_name: "manual".to_string(),
-        value: bool_value(true),
-        intent: RuntimeResourceWriteIntent::Assign,
-    });
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderNotFound"),
-        "expected missing provider error, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected scheme in error, got {error}"
-    );
-    assert!(
-        error.contains("docs://manual"),
-        "expected base URI in error, got {error}"
-    );
+  let mut registry = RuntimeResourceRegistry::new();
+  let result = registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected missing provider error, got {error}");
+  assert!(error.contains("docs"), "expected scheme in error, got {error}");
+  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
 }
 
 #[test]
 fn in_memory_docs_write_invalid_scheme_fails() {
-    let mut provider = InMemoryDocsProvider::new();
-    let result = provider.write(RuntimeResourceWriteRequest {
-        base_uri: "db://manual".to_string(),
-        path: "intro/title".to_string(),
-        context_name: "manual".to_string(),
-        value: bool_value(true),
-        intent: RuntimeResourceWriteIntent::Assign,
-    });
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceInvalidUri"),
-        "expected invalid URI error, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected docs scheme requirement, got {error}"
-    );
+  let mut provider = InMemoryDocsProvider::new();
+  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "db://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
+  assert!(error.contains("docs"), "expected docs scheme requirement, got {error}");
 }
 
 #[test]
 fn in_memory_docs_write_empty_path_fails() {
-    let mut provider = InMemoryDocsProvider::new();
-    let result = provider.write(RuntimeResourceWriteRequest {
-        base_uri: "docs://manual".to_string(),
-        path: String::new(),
-        context_name: "manual".to_string(),
-        value: bool_value(true),
-        intent: RuntimeResourceWriteIntent::Assign,
-    });
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceInvalidUri"),
-        "expected invalid URI error, got {error}"
-    );
-    assert!(
-        error.contains("resource path cannot be empty"),
-        "expected empty path error, got {error}"
-    );
+  let mut provider = InMemoryDocsProvider::new();
+  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: String::new(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
+  assert!(error.contains("resource path cannot be empty"), "expected empty path error, got {error}");
 }
 
 #[derive(Debug)]
 struct ReadOnlyDocsProvider;
 
 impl RuntimeResourceProvider for ReadOnlyDocsProvider {
-    fn scheme(&self) -> &str {
-        "docs"
-    }
-    fn read(&self, _request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
-        unreachable!("read is not needed for the default write behavior test")
-    }
+  fn scheme(&self) -> &str { "docs" }
+  fn read(&self, _request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> { unreachable!("read is not needed for the default write behavior test") }
 }
 
 #[test]
 fn provider_default_write_is_unsupported() {
-    let mut provider = ReadOnlyDocsProvider;
-    let result = provider.write(RuntimeResourceWriteRequest {
-        base_uri: "docs://manual".to_string(),
-        path: "intro/title".to_string(),
-        context_name: "manual".to_string(),
-        value: bool_value(true),
-        intent: RuntimeResourceWriteIntent::Assign,
-    });
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceWriteUnsupported"),
-        "expected unsupported write error, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected provider scheme in error, got {error}"
-    );
-    assert!(
-        error.contains("docs://manual"),
-        "expected base URI in error, got {error}"
-    );
-    assert!(
-        error.contains("intro/title"),
-        "expected path in error, got {error}"
-    );
+  let mut provider = ReadOnlyDocsProvider;
+  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceWriteUnsupported"), "expected unsupported write error, got {error}");
+  assert!(error.contains("docs"), "expected provider scheme in error, got {error}");
+  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
+  assert!(error.contains("intro/title"), "expected path in error, got {error}");
 }
 
 #[test]
 fn interpreter_context_name_conflict_fails_resolution() {
-    let root =
-        setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@foo := docs://foo{:read(ok)}\n");
-    let mut runtime = runtime_with_root(&root);
-    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("AddressTargetNameConflict"),
-        "expected address target conflict, got {error}"
-    );
-    assert!(
-        error.contains("foo"),
-        "expected conflicting target in error, got {error}"
-    );
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@foo := docs://foo{:read(ok)}\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
 }
 
 #[test]
 fn duplicate_context_address_target_fails_resolution() {
-    let root = setup_modules("@foo := docs://a{:read(*)}\n@foo := docs://b{:read(*)}\n");
-    let mut runtime = runtime_with_root(&root);
-    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("AddressTargetNameConflict"),
-        "expected address target conflict, got {error}"
-    );
-    assert!(
-        error.contains("foo"),
-        "expected conflicting target in error, got {error}"
-    );
+  let root = setup_modules("@foo := docs://a{:read(*)}\n@foo := docs://b{:read(*)}\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
 }
 
 #[test]
 fn repeated_interpreter_fences_merge_before_resolution_and_execution() {
-    let root = setup_modules(
-        "~~~mech:foo\nx := 1\n~~~\n\nprose stays out\n\n~~~mech:foo\ny := x + 1\n<+ y\n~~~\n\nresult := @foo/y\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
-        other => panic!("expected merged interpreter result, got {:?}", other),
-    }
+  let root = setup_modules("~~~mech:foo\nx := 1\n~~~\n\nprose stays out\n\n~~~mech:foo\ny := x + 1\n<+ y\n~~~\n\nresult := @foo/y\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
+    other => panic!("expected merged interpreter result, got {:?}", other),
+  }
 }
 
 #[test]
 fn faux_tilde_interpreter_fence_inside_markdown_backtick_block_is_ignored() {
-    let root = setup_modules(
-        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n```text\n~~~mech:foo\nbroken := missing\n~~~\n```\n\nresult := @foo/ok\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        runtime.run_module(version).unwrap(),
-        "interpreter ignores faux tilde fence",
-    );
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n```text\n~~~mech:foo\nbroken := missing\n~~~\n```\n\nresult := @foo/ok\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(runtime.run_module(version).unwrap(), "interpreter ignores faux tilde fence");
 }
 
 #[test]
 fn faux_backtick_interpreter_fence_inside_markdown_tilde_block_is_ignored() {
-    let root = setup_modules(
-        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~text\n```mech:foo\nbroken := missing\n```\n~~~\n\nresult := @foo/ok\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        runtime.run_module(version).unwrap(),
-        "interpreter ignores faux backtick fence",
-    );
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~text\n```mech:foo\nbroken := missing\n```\n~~~\n\nresult := @foo/ok\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(runtime.run_module(version).unwrap(), "interpreter ignores faux backtick fence");
 }
 
 #[test]
 fn duplicate_resolved_interpreter_address_target_still_fails_validation() {
-    let foo = SourceInterpreterId {
-        namespace: hash_str("foo"),
-        namespace_str: "foo".to_string(),
-    };
-    let scope = ModuleScopeMetadata {
-        scope: SourceScope::Interpreter(foo),
-        imports: Vec::new(),
-        exports: Vec::new(),
-        contexts: Vec::new(),
-        address_references: Vec::new(),
-    };
-    let resolved = ResolvedSource::new(
-        "main.mec",
-        "memory:main.mec",
-        MechSourceCode::String("ok := true\n".to_string()),
-    )
-    .with_kind(SourceKind::Mech)
-    .with_scopes(vec![scope.clone(), scope]);
+  let foo = SourceInterpreterId {
+    namespace: hash_str("foo"),
+    namespace_str: "foo".to_string(),
+  };
+  let scope = ModuleScopeMetadata {
+    scope: SourceScope::Interpreter(foo),
+    imports: Vec::new(),
+    exports: Vec::new(),
+    contexts: Vec::new(),
+    address_references: Vec::new(),
+  };
+  let resolved = ResolvedSource::new(
+    "main.mec",
+    "memory:main.mec",
+    MechSourceCode::String("ok := true\n".to_string()),
+  )
+  .with_kind(SourceKind::Mech)
+  .with_scopes(vec![scope.clone(), scope]);
 
-    let result = resolved.validate();
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("AddressTargetNameConflict"),
-        "expected address target conflict, got {error}"
-    );
-    assert!(
-        error.contains("foo"),
-        "expected conflicting target in error, got {error}"
-    );
+  let result = resolved.validate();
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
 }
 
 #[test]
 fn resolved_source_scope_address_target_conflict_fails_validation() {
-    let foo = SourceInterpreterId {
-        namespace: hash_str("foo"),
-        namespace_str: "foo".to_string(),
-    };
-    let resolved = ResolvedSource::new(
-        "main.mec",
-        "memory:main.mec",
-        MechSourceCode::String("ok := true\n".to_string()),
-    )
-    .with_kind(SourceKind::Mech)
-    .with_scopes(vec![
-        ModuleScopeMetadata {
-            scope: SourceScope::Interpreter(foo),
-            imports: Vec::new(),
-            exports: Vec::new(),
-            contexts: Vec::new(),
-            address_references: Vec::new(),
-        },
-        ModuleScopeMetadata {
-            scope: SourceScope::Program,
-            imports: Vec::new(),
-            exports: Vec::new(),
-            contexts: vec![SourceContextDeclaration {
-                name: "foo".to_string(),
-                base: SourceContextBase::ResourceUri("docs://foo".to_string()),
-                capabilities: Vec::new(),
-            }],
-            address_references: Vec::new(),
-        },
-    ]);
+  let foo = SourceInterpreterId {
+    namespace: hash_str("foo"),
+    namespace_str: "foo".to_string(),
+  };
+  let resolved = ResolvedSource::new(
+    "main.mec",
+    "memory:main.mec",
+    MechSourceCode::String("ok := true\n".to_string()),
+  )
+  .with_kind(SourceKind::Mech)
+  .with_scopes(vec![
+    ModuleScopeMetadata {
+      scope: SourceScope::Interpreter(foo),
+      imports: Vec::new(),
+      exports: Vec::new(),
+      contexts: Vec::new(),
+      address_references: Vec::new(),
+    },
+    ModuleScopeMetadata {
+      scope: SourceScope::Program,
+      imports: Vec::new(),
+      exports: Vec::new(),
+      contexts: vec![SourceContextDeclaration {
+        name: "foo".to_string(),
+        base: SourceContextBase::ResourceUri("docs://foo".to_string()),
+        capabilities: Vec::new(),
+      }],
+      address_references: Vec::new(),
+    },
+  ]);
 
-    let result = resolved.validate();
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("AddressTargetNameConflict"),
-        "expected address target conflict, got {error}"
-    );
-    assert!(
-        error.contains("foo"),
-        "expected conflicting target in error, got {error}"
-    );
+  let result = resolved.validate();
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target in error, got {error}");
 }
 
 #[test]
 fn distinct_interpreter_and_context_names_pass() {
-    let root = setup_modules(
-        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@manual := docs://foo{:read(ok)}\n\nresult := @foo/ok\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    assert_bool_true(result, "distinct interpreter/context names");
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n@manual := docs://foo{:read(ok)}\n\nresult := @foo/ok\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "distinct interpreter/context names");
 }
 
 #[test]
 fn context_docs_read_returns_value() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    assert_bool_true(result, "context docs read");
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "context docs read");
 }
 
 #[test]
 fn config_spec_registers_in_memory_docs_resource() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let spec = RuntimeConfigSpec::new()
-        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-                .with_entry("intro/title", bool_value(true)),
-        ))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .config_spec(spec)
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        run_module_as_main(&mut runtime, version).unwrap(),
-        "config spec docs read",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("intro/title", bool_value(true)),
+    ),
+  ).with_capability_grant(read_grant("docs://manual", "intro/title"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .config_spec(spec)
+    .build()
+    .unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "config spec docs read");
 }
 
 #[test]
 fn config_spec_merges_multiple_docs_bases_into_one_provider() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n@guide := docs://guide{:read(start/title)}\n\nmanual-ok := @manual/intro/title\nguide-ok := @guide/start/title\n\nresult := manual-ok && guide-ok\n",
-    );
-    let spec = RuntimeConfigSpec::new()
-        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-                .with_entry("intro/title", bool_value(true)),
-        ))
-        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-            RuntimeInMemoryDocsResourceSpec::new("docs://guide")
-                .with_entry("start/title", bool_value(true)),
-        ))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"))
-        .with_capability_grant(read_grant("docs://guide", "start/title"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .config_spec(spec)
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        run_module_as_main(&mut runtime, version).unwrap(),
-        "merged config spec docs bases",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@guide := docs://guide{:read(start/title)}\n\nmanual-ok := @manual/intro/title\nguide-ok := @guide/start/title\n\nresult := manual-ok && guide-ok\n");
+  let spec = RuntimeConfigSpec::new()
+    .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("intro/title", bool_value(true)),
+    ))
+    .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://guide")
+        .with_entry("start/title", bool_value(true)),
+    ))
+    .with_capability_grant(read_grant("docs://manual", "intro/title"))
+    .with_capability_grant(read_grant("docs://guide", "start/title"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .config_spec(spec)
+    .build()
+    .unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "merged config spec docs bases");
 }
 
 #[test]
 fn config_spec_multiple_entries_same_base() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/*)}\n\na := @manual/intro/title\nb := @manual/intro/subtitle\n\nresult := a && b\n",
-    );
-    let spec = RuntimeConfigSpec::new()
-        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-            RuntimeInMemoryDocsResourceSpec {
-                base_uri: "docs://manual".to_string(),
-                entries: vec![
-                    docs_entry("intro/title", bool_value(true)),
-                    docs_entry("intro/subtitle", bool_value(true)),
-                ],
-            },
-        ))
-        .with_capability_grant(read_grant("docs://manual", "intro/*"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .config_spec(spec)
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        run_module_as_main(&mut runtime, version).unwrap(),
-        "config spec docs entries under one base",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/*)}\n\na := @manual/intro/title\nb := @manual/intro/subtitle\n\nresult := a && b\n");
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(RuntimeInMemoryDocsResourceSpec {
+      base_uri: "docs://manual".to_string(),
+      entries: vec![
+        docs_entry("intro/title", bool_value(true)),
+        docs_entry("intro/subtitle", bool_value(true)),
+      ],
+    }),
+  ).with_capability_grant(read_grant("docs://manual", "intro/*"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .config_spec(spec)
+    .build()
+    .unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "config spec docs entries under one base");
 }
 
 #[test]
 fn config_spec_later_duplicate_path_overwrites_earlier() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let spec = RuntimeConfigSpec::new()
-        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-                .with_entry("intro/title", bool_value(false))
-                .with_entry("intro/title", bool_value(true)),
-        ))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .config_spec(spec)
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        run_module_as_main(&mut runtime, version).unwrap(),
-        "later duplicate config spec docs path",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("intro/title", bool_value(false))
+        .with_entry("intro/title", bool_value(true)),
+    ),
+  ).with_capability_grant(read_grant("docs://manual", "intro/title"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .config_spec(spec)
+    .build()
+    .unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "later duplicate config spec docs path");
 }
 
 #[test]
 fn config_spec_invalid_docs_uri_fails_build() {
-    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-        RuntimeInMemoryDocsResourceSpec::new("db://manual")
-            .with_entry("intro/title", bool_value(true)),
-    ));
-    let result = RuntimeBuilder::new().config_spec(spec).build();
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceInvalidUri"),
-        "expected invalid URI error, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected docs scheme requirement, got {error}"
-    );
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("db://manual")
+        .with_entry("intro/title", bool_value(true)),
+    ),
+  );
+  let result = RuntimeBuilder::new().config_spec(spec).build();
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
+  assert!(error.contains("docs"), "expected docs scheme requirement, got {error}");
 }
 
 #[test]
 fn config_spec_invalid_empty_path_fails_build() {
-    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-        RuntimeInMemoryDocsResourceSpec::new("docs://manual").with_entry("", bool_value(true)),
-    ));
-    let result = RuntimeBuilder::new().config_spec(spec).build();
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceInvalidUri"),
-        "expected invalid URI error, got {error}"
-    );
-    assert!(
-        error.contains("resource path cannot be empty"),
-        "expected empty path error, got {error}"
-    );
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("", bool_value(true)),
+    ),
+  );
+  let result = RuntimeBuilder::new().config_spec(spec).build();
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
+  assert!(error.contains("resource path cannot be empty"), "expected empty path error, got {error}");
 }
 
 #[test]
 fn config_spec_and_direct_docs_provider_conflict() {
-    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-        RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-            .with_entry("intro/title", bool_value(true)),
-    ));
-    let result = RuntimeBuilder::new()
-        .config_spec(spec)
-        .in_memory_docs(InMemoryDocsProvider::new())
-        .build();
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderConflict"),
-        "expected provider conflict, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected docs scheme in conflict, got {error}"
-    );
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("intro/title", bool_value(true)),
+    ),
+  );
+  let result = RuntimeBuilder::new()
+    .config_spec(spec)
+    .in_memory_docs(InMemoryDocsProvider::new())
+    .build();
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderConflict"), "expected provider conflict, got {error}");
+  assert!(error.contains("docs"), "expected docs scheme in conflict, got {error}");
 }
 
 #[test]
 fn direct_provider_registration_still_works() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        runtime.run_module(version).unwrap(),
-        "direct docs provider registration",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(runtime.run_module(version).unwrap(), "direct docs provider registration");
 }
 
 #[test]
 fn apply_config_spec_after_build_registers_docs() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let spec = RuntimeConfigSpec::new()
-        .with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-            RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-                .with_entry("intro/title", bool_value(true)),
-        ))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    runtime.apply_config_spec(spec).unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        run_module_as_main(&mut runtime, version).unwrap(),
-        "applied config spec docs read",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("intro/title", bool_value(true)),
+    ),
+  ).with_capability_grant(read_grant("docs://manual", "intro/title"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .build()
+    .unwrap();
+  runtime.apply_config_spec(spec).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "applied config spec docs read");
 }
 
 #[test]
 fn apply_config_spec_conflicts_with_existing_docs_provider() {
-    let spec = RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-        RuntimeInMemoryDocsResourceSpec::new("docs://manual")
-            .with_entry("intro/title", bool_value(true)),
-    ));
-    let mut runtime = RuntimeBuilder::new()
-        .in_memory_docs(InMemoryDocsProvider::new())
-        .build()
-        .unwrap();
-    let result = runtime.apply_config_spec(spec);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderConflict"),
-        "expected provider conflict, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected docs scheme in conflict, got {error}"
-    );
+  let spec = RuntimeConfigSpec::new().with_resource(
+    RuntimeResourceConfigSpec::InMemoryDocs(
+      RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+        .with_entry("intro/title", bool_value(true)),
+    ),
+  );
+  let mut runtime = RuntimeBuilder::new()
+    .in_memory_docs(InMemoryDocsProvider::new())
+    .build()
+    .unwrap();
+  let result = runtime.apply_config_spec(spec);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderConflict"), "expected provider conflict, got {error}");
+  assert!(error.contains("docs"), "expected docs scheme in conflict, got {error}");
 }
 
 #[test]
 fn unknown_address_target_is_explicit() {
-    let root = setup_modules("result := @missing/ok\n");
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("UnknownAddressTarget"),
-        "expected unknown address target error, got {error}"
-    );
-    assert!(
-        error.contains("missing"),
-        "expected missing target in error, got {error}"
-    );
+  let root = setup_modules("result := @missing/ok\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target error, got {error}");
+  assert!(error.contains("missing"), "expected missing target in error, got {error}");
 }
 
 #[test]
 fn interpreter_address_still_works() {
-    let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    assert_bool_true(result, "interpreter address");
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "interpreter address");
 }
 
 #[test]
 fn string_and_comment_address_text_are_not_targets() {
-    let root = setup_modules(
-        "~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n-- @bar\n\nok := true\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    let program = main
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program)
-        .unwrap();
-    assert!(
-        program.address_references.is_empty(),
-        "expected no program address references, got {:?}",
-        program.address_references
-    );
-    let result = runtime.run_module(version);
-    assert!(
-        result.is_ok(),
-        "expected string/comment @bar not to execute interpreter, got {result:?}"
-    );
+  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n-- @bar\n\nok := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert!(program.address_references.is_empty(), "expected no program address references, got {:?}", program.address_references);
+  let result = runtime.run_module(version);
+  assert!(result.is_ok(), "expected string/comment @bar not to execute interpreter, got {result:?}");
 }
 
-fn foo_scope(
-    runtime: &mech_runtime::MechRuntime,
-    version: mech_runtime::ModuleVersionId,
-) -> SourceScope {
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    main.scopes
-        .iter()
-        .find_map(|metadata| match &metadata.scope {
-            SourceScope::Interpreter(interpreter) if interpreter.namespace_str == "foo" => {
-                Some(metadata.scope.clone())
-            }
-            SourceScope::Interpreter(_) | SourceScope::Program => None,
-        })
-        .unwrap()
+fn foo_scope(runtime: &mech_runtime::MechRuntime, version: mech_runtime::ModuleVersionId) -> SourceScope {
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  main.scopes.iter().find_map(|metadata| match &metadata.scope {
+    SourceScope::Interpreter(interpreter) if interpreter.namespace_str == "foo" => Some(metadata.scope.clone()),
+    SourceScope::Interpreter(_) | SourceScope::Program => None,
+  }).unwrap()
 }
 
-fn interpreter_scope_named(
-    runtime: &mech_runtime::MechRuntime,
-    version: mech_runtime::ModuleVersionId,
-    name: &str,
-) -> SourceScope {
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    main.scopes
-        .iter()
-        .find_map(|metadata| match &metadata.scope {
-            SourceScope::Interpreter(interpreter) if interpreter.namespace_str == name => {
-                Some(metadata.scope.clone())
-            }
-            SourceScope::Interpreter(_) | SourceScope::Program => None,
-        })
-        .unwrap()
+fn interpreter_scope_named(runtime: &mech_runtime::MechRuntime, version: mech_runtime::ModuleVersionId, name: &str) -> SourceScope {
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  main.scopes.iter().find_map(|metadata| match &metadata.scope {
+    SourceScope::Interpreter(interpreter) if interpreter.namespace_str == name => Some(metadata.scope.clone()),
+    SourceScope::Interpreter(_) | SourceScope::Program => None,
+  }).unwrap()
 }
+
 
 #[test]
 fn context_docs_read_without_provider_fails() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderNotFound"),
-        "expected missing provider error, got {error}"
-    );
-    assert!(
-        error.contains("docs"),
-        "expected scheme in error, got {error}"
-    );
-    assert!(
-        error.contains("docs://manual"),
-        "expected base URI in error, got {error}"
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let mut runtime = runtime_with_root(&root);
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected missing provider error, got {error}");
+  assert!(error.contains("docs"), "expected scheme in error, got {error}");
+  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
 }
 
 #[test]
 fn context_docs_read_missing_path_fails() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(InMemoryDocsProvider::new())
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourcePathNotFound"),
-        "expected missing path error, got {error}"
-    );
-    assert!(
-        error.contains("intro/title"),
-        "expected path in error, got {error}"
-    );
-    assert!(
-        error.contains("docs://manual"),
-        "expected base URI in error, got {error}"
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(InMemoryDocsProvider::new())
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourcePathNotFound"), "expected missing path error, got {error}");
+  assert!(error.contains("intro/title"), "expected path in error, got {error}");
+  assert!(error.contains("docs://manual"), "expected base URI in error, got {error}");
 }
 
 #[test]
 fn context_docs_read_denied_by_capability_fails() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceCapabilityDenied"),
-        "expected capability error, got {error}"
-    );
-    assert!(
-        error.contains("manual"),
-        "expected context name in error, got {error}"
-    );
-    assert!(
-        error.contains("read"),
-        "expected operation in error, got {error}"
-    );
-    assert!(
-        error.contains("intro/title"),
-        "expected path in error, got {error}"
-    );
+  let root = setup_modules("@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceCapabilityDenied"), "expected capability error, got {error}");
+  assert!(error.contains("manual"), "expected context name in error, got {error}");
+  assert!(error.contains("read"), "expected operation in error, got {error}");
+  assert!(error.contains("intro/title"), "expected path in error, got {error}");
 }
 
 #[test]
 fn context_docs_read_prefix_wildcard_allows_nested_path() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/*)}\n\nresult := @manual/intro/title\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/*",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    assert_bool_true(result, "context docs prefix wildcard");
+  let root = setup_modules("@manual := docs://manual{:read(intro/*)}\n\nresult := @manual/intro/title\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/*")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "context docs prefix wildcard");
 }
 
 #[test]
 fn context_docs_read_prefix_wildcard_does_not_match_sibling() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(introduction/*)}\n\nresult := @manual/intro/title\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceCapabilityDenied"),
-        "expected capability error, got {error}"
-    );
+  let root = setup_modules("@manual := docs://manual{:read(introduction/*)}\n\nresult := @manual/intro/title\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceCapabilityDenied"), "expected capability error, got {error}");
 }
 
 #[test]
 fn program_scope_does_not_see_interpreter_context() {
-    let root = setup_modules(
-        "~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nunused := true\n~~~\n\nresult := @manual/intro/title\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("UnknownAddressTarget"),
-        "expected unknown address target, got {error}"
-    );
-    assert!(
-        error.contains("manual"),
-        "expected target in error, got {error}"
-    );
-    assert!(
-        !error.contains("ContextAddressReadUnsupported"),
-        "program scope should not resolve interpreter context, got {error}"
-    );
+  let root = setup_modules("~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nunused := true\n~~~\n\nresult := @manual/intro/title\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target, got {error}");
+  assert!(error.contains("manual"), "expected target in error, got {error}");
+  assert!(!error.contains("ContextAddressReadUnsupported"), "program scope should not resolve interpreter context, got {error}");
 }
 
 #[test]
 fn interpreter_scope_context_docs_read_returns_value() {
-    let root = setup_modules(
-        "~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n~~~\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let foo = foo_scope(&runtime, version);
-    let result = runtime.run_module_scope(version, foo).unwrap();
-    assert_bool_true(result, "interpreter scope context docs read");
+  let root = setup_modules("~~~mech:foo\n@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n~~~\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let foo = foo_scope(&runtime, version);
+  let result = runtime.run_module_scope(version, foo).unwrap();
+  assert_bool_true(result, "interpreter scope context docs read");
 }
 
 #[test]
 fn interpreter_scope_does_not_resolve_interpreter_target() {
-    let root = setup_modules(
-        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\nresult := @foo/ok\n~~~\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let bar = interpreter_scope_named(&runtime, version, "bar");
-    let result = runtime.run_module_scope(version, bar);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("UnknownAddressTarget"),
-        "expected unknown address target, got {error}"
-    );
-    assert!(
-        error.contains("foo"),
-        "expected interpreter target in error, got {error}"
-    );
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\nresult := @foo/ok\n~~~\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let bar = interpreter_scope_named(&runtime, version, "bar");
+  let result = runtime.run_module_scope(version, bar);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target, got {error}");
+  assert!(error.contains("foo"), "expected interpreter target in error, got {error}");
 }
 
 #[test]
 fn interpreter_address_still_works_from_program() {
-    let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    assert_bool_true(result, "interpreter address from program");
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  assert_bool_true(result, "interpreter address from program");
 }
 
 #[test]
 fn duplicate_context_registry_binding_rejected() {
-    let first = SourceContextDeclaration {
-        name: "manual".to_string(),
-        base: SourceContextBase::ResourceUri("docs://manual".to_string()),
-        capabilities: vec![SourceContextCapability {
-            operation: "read".to_string(),
-            scope: SourceContextCapabilityScope::Path("intro/title".to_string()),
-        }],
-    };
-    let second = SourceContextDeclaration {
-        name: "manual".to_string(),
-        base: SourceContextBase::ResourceUri("docs://other".to_string()),
-        capabilities: vec![SourceContextCapability {
-            operation: "read".to_string(),
-            scope: SourceContextCapabilityScope::Wildcard,
-        }],
-    };
+  let first = SourceContextDeclaration {
+    name: "manual".to_string(),
+    base: SourceContextBase::ResourceUri("docs://manual".to_string()),
+    capabilities: vec![SourceContextCapability {
+      operation: "read".to_string(),
+      scope: SourceContextCapabilityScope::Path("intro/title".to_string()),
+    }],
+  };
+  let second = SourceContextDeclaration {
+    name: "manual".to_string(),
+    base: SourceContextBase::ResourceUri("docs://other".to_string()),
+    capabilities: vec![SourceContextCapability {
+      operation: "read".to_string(),
+      scope: SourceContextCapabilityScope::Wildcard,
+    }],
+  };
 
-    let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[first, second]);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeContextDuplicateBinding"),
-        "expected duplicate binding error, got {error}"
-    );
-    assert!(
-        error.contains("manual"),
-        "expected duplicate context name in error, got {error}"
-    );
+  let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[first, second]);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeContextDuplicateBinding"), "expected duplicate binding error, got {error}");
+  assert!(error.contains("manual"), "expected duplicate context name in error, got {error}");
 }
 
 #[test]
 fn derived_context_base_is_unsupported() {
-    let declaration = SourceContextDeclaration {
-        name: "manual".to_string(),
-        base: SourceContextBase::Context("base".to_string()),
-        capabilities: vec![SourceContextCapability {
-            operation: "read".to_string(),
-            scope: SourceContextCapabilityScope::Wildcard,
-        }],
-    };
+  let declaration = SourceContextDeclaration {
+    name: "manual".to_string(),
+    base: SourceContextBase::Context("base".to_string()),
+    capabilities: vec![SourceContextCapability {
+      operation: "read".to_string(),
+      scope: SourceContextCapabilityScope::Wildcard,
+    }],
+  };
 
-    let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[declaration]);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeContextDerivedBaseUnsupported"),
-        "expected derived base error, got {error}"
-    );
-    assert!(
-        error.contains("base"),
-        "expected base context name in error, got {error}"
-    );
+  let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[declaration]);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeContextDerivedBaseUnsupported"), "expected derived base error, got {error}");
+  assert!(error.contains("base"), "expected base context name in error, got {error}");
 }
 
 #[test]
 fn interpreter_scope_imports_work() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-interpreter-imports-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-imports-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let scope = foo_scope(&runtime, version);
-    let result = runtime.run_module_scope(version, scope).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from module scope run, got {:?}",
-            other
-        ),
-    }
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let scope = foo_scope(&runtime, version);
+  let result = runtime.run_module_scope(version, scope).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module scope run, got {:?}", other),
+  }
 }
 
 #[test]
 fn program_cannot_see_fenced_import_but_interpreter_can() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-interpreter-import-privacy-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\ntop := math/tau > 6.0\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-import-privacy-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\ntop := math/tau > 6.0\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let scope = foo_scope(&runtime, version);
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let scope = foo_scope(&runtime, version);
 
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("math/tau"));
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("math/tau"));
 
-    let result = runtime.run_module_scope(version, scope).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from module scope run, got {:?}",
-            other
-        ),
-    }
+  let result = runtime.run_module_scope(version, scope).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module scope run, got {:?}", other),
+  }
 }
 
 #[test]
 fn interpreter_scope_exports_only_interpreter_exports() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-interpreter-exports-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("main.mec"), "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n\nprogram-value := false\n<+ program-value\n").unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-exports-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n\nprogram-value := false\n<+ program-value\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let scope = foo_scope(&runtime, version);
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    let foo = main
-        .scopes
-        .iter()
-        .find(|metadata| metadata.scope == scope)
-        .unwrap();
-    assert!(foo.exports.iter().any(|export| export.name == "foo-value"));
-    assert!(
-        !foo.exports
-            .iter()
-            .any(|export| export.name == "program-value")
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let scope = foo_scope(&runtime, version);
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  let foo = main.scopes.iter().find(|metadata| metadata.scope == scope).unwrap();
+  assert!(foo.exports.iter().any(|export| export.name == "foo-value"));
+  assert!(!foo.exports.iter().any(|export| export.name == "program-value"));
 
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(!*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(!*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 
-    let result = runtime.run_module_scope(version, scope).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from module scope run, got {:?}",
-            other
-        ),
-    }
+  let result = runtime.run_module_scope(version, scope).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module scope run, got {:?}", other),
+  }
 }
 
 #[test]
 fn interpreter_scope_executes_only_matching_import_edges() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-interpreter-edge-filter-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("good.mec"), "value := true\n<+ value\n").unwrap();
-    std::fs::write(root.join("bad.mec"), "missing := bad/value\n").unwrap();
-    std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./good.mec\nok := good/value\n<+ ok\n~~~\n\n~~~mech:bar\n+> ./bad.mec\n~~~\n").unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-interpreter-edge-filter-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("good.mec"), "value := true\n<+ value\n").unwrap();
+  std::fs::write(root.join("bad.mec"), "missing := bad/value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./good.mec\nok := good/value\n<+ ok\n~~~\n\n~~~mech:bar\n+> ./bad.mec\n~~~\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let scope = foo_scope(&runtime, version);
-    let result = runtime.run_module_scope(version, scope).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from module scope run, got {:?}",
-            other
-        ),
-    }
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let scope = foo_scope(&runtime, version);
+  let result = runtime.run_module_scope(version, scope).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module scope run, got {:?}", other),
+  }
 }
 
 #[test]
 fn missing_interpreter_scope_returns_error() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-missing-interpreter-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-missing-interpreter-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\nfoo-value := true\n<+ foo-value\n~~~\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let missing = SourceScope::Interpreter(SourceInterpreterId {
-        namespace: hash_str("missing"),
-        namespace_str: "missing".to_string(),
-    });
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let missing = SourceScope::Interpreter(SourceInterpreterId {
+    namespace: hash_str("missing"),
+    namespace_str: "missing".to_string(),
+  });
 
-    let result = runtime.run_module_scope(version, missing);
-    assert!(result.is_err());
+  let result = runtime.run_module_scope(version, missing);
+  assert!(result.is_err());
 }
+
 
 #[test]
 fn program_reads_interpreter_export_by_indexed_address() {
-    let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
+  let root = setup_modules("~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/ok\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from addressed interpreter export, got {:?}",
-            other
-        ),
-    }
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from addressed interpreter export, got {:?}", other),
+  }
 }
 
 #[test]
 fn program_reads_interpreter_export_by_address_with_interpreter_import() {
-    let root = setup_modules(
-        "~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\nresult := @foo/ok\n",
-    );
+  let root = setup_modules("~~~mech:foo\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n~~~\n\nresult := @foo/ok\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from addressed interpreter export with import, got {:?}",
-            other
-        ),
-    }
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from addressed interpreter export with import, got {:?}", other),
+  }
 }
 
 #[test]
 fn program_address_does_not_execute_unreferenced_interpreter_from_string() {
-    let root =
-        setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n");
+  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\ntext := \"@bar\"\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(
-        result.is_ok(),
-        "expected string @bar not to execute interpreter, got {result:?}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_ok(), "expected string @bar not to execute interpreter, got {result:?}");
 }
+
 
 #[test]
 fn program_address_does_not_execute_unreferenced_interpreter_from_comment() {
-    let root =
-        setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\n-- @bar\n\nok := true\n");
+  let root = setup_modules("~~~mech:bar\nbroken := missing\n<+ broken\n~~~\n\n-- @bar\n\nok := true\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(
-        result.is_ok(),
-        "expected comment @bar not to execute interpreter, got {result:?}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_ok(), "expected comment @bar not to execute interpreter, got {result:?}");
 }
 
 #[test]
 fn program_reads_only_requested_interpreter_export() {
-    let root = setup_modules(
-        "~~~mech:foo\nok := true\nother := false\n<+ ok\n<+ other\n~~~\n\nresult := @foo/ok\n",
-    );
+  let root = setup_modules("~~~mech:foo\nok := true\nother := false\n<+ ok\n<+ other\n~~~\n\nresult := @foo/ok\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!(
-            "expected bool result from requested addressed export, got {:?}",
-            other
-        ),
-    }
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from requested addressed export, got {:?}", other),
+  }
 }
 
 #[test]
 fn program_rejects_non_exported_interpreter_address() {
-    let root = setup_modules("~~~mech:foo\nhidden := true\n~~~\n\nresult := @foo/hidden\n");
+  let root = setup_modules("~~~mech:foo\nhidden := true\n~~~\n\nresult := @foo/hidden\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeModuleExportNotFound") || error.contains("does not export"),
-        "expected missing export error, got {error}"
-    );
-    assert!(
-        error.contains("hidden"),
-        "expected addressed symbol in error, got {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeModuleExportNotFound") || error.contains("does not export"), "expected missing export error, got {error}");
+  assert!(error.contains("hidden"), "expected addressed symbol in error, got {error}");
 }
 
 #[test]
 fn program_unknown_interpreter_address_returns_error() {
-    let root = setup_modules("result := @missing/ok\n");
+  let root = setup_modules("result := @missing/ok\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("UnknownAddressTarget"),
-        "expected unknown address target error, got {error}"
-    );
-    assert!(
-        error.contains("missing"),
-        "expected missing target in error, got {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected unknown address target error, got {error}");
+  assert!(error.contains("missing"), "expected missing target in error, got {error}");
 }
 
 #[test]
 fn addressed_assignment_is_unsupported() {
-    let root = setup_modules("@foo/x := 1\nresult := @foo/x\n");
+  let root = setup_modules("@foo/x := 1\nresult := @foo/x\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let result = runtime.resolve_and_store_module_source("main.mec", options);
-    assert!(
-        result.is_err(),
-        "prefix addressed define should be rejected while parsing/building"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("ParserErrorContext"),
-        "expected parser error for addressed define, got {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let result = runtime.resolve_and_store_module_source("main.mec", options);
+  assert!(result.is_err(), "prefix addressed define should be rejected while parsing/building");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("ParserErrorContext"), "expected parser error for addressed define, got {error}");
 }
 
 #[test]
 fn addressed_assignment_to_context_is_still_unsupported() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-    assert!(
-        result.is_err(),
-        "prefix addressed define should be rejected while parsing/building"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("ParserErrorContext"),
-        "expected parser error for addressed define, got {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err(), "prefix addressed define should be rejected while parsing/building");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("ParserErrorContext"), "expected parser error for addressed define, got {error}");
 }
 
 #[test]
 fn addressed_assignment_with_docs_provider_is_still_unsupported() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n@manual/intro/title := true\nresult := @manual/intro/title\n");
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(InMemoryDocsProvider::new())
-        .build()
-        .unwrap();
-    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-    assert!(
-        result.is_err(),
-        "prefix addressed define should be rejected while parsing/building"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("ParserErrorContext"),
-        "expected parser error for addressed define, got {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(InMemoryDocsProvider::new()).build().unwrap();
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err(), "prefix addressed define should be rejected while parsing/building");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("ParserErrorContext"), "expected parser error for addressed define, got {error}");
 }
 
 #[test]
 fn resolver_metadata() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let resolver = FileSourceResolver::new(&root);
-    let main = resolver
-        .resolve(&SourceRequest::new("main.mec"))
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.imports.len(), 1);
-    assert_eq!(main.contexts.len(), 0);
-    assert_eq!(main.dependencies.len(), 1);
-    assert!(
-        main.dependencies[0].specifier == "./math.mec"
-            || main.dependencies[0].specifier == "./math.mec".trim()
-    );
-    assert!(main.dependencies[0].referrer.is_some());
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let resolver = FileSourceResolver::new(&root);
+  let main = resolver.resolve(&SourceRequest::new("main.mec")).unwrap().unwrap();
+  assert_eq!(main.imports.len(), 1);
+  assert_eq!(main.contexts.len(), 0);
+  assert_eq!(main.dependencies.len(), 1);
+  assert!(main.dependencies[0].specifier == "./math.mec" || main.dependencies[0].specifier == "./math.mec".trim());
+  assert!(main.dependencies[0].referrer.is_some());
 
-    let dep = resolver.resolve(&main.dependencies[0]).unwrap().unwrap();
-    assert!(dep.exports.iter().any(|e| e.name == "tau"));
+  let dep = resolver.resolve(&main.dependencies[0]).unwrap().unwrap();
+  assert!(dep.exports.iter().any(|e| e.name == "tau"));
 }
 
 #[test]
 fn module_records_store_scoped_source_declarations_without_execution_changes() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-scopes-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(root.join("foo.mec"), "foo-result := 1\n<+ foo-result\n").unwrap();
-    std::fs::write(root.join("bar.mec"), "bar-result := 2\n<+ bar-result\n").unwrap();
-    std::fs::write(
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-scopes-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("foo.mec"), "foo-result := 1\n<+ foo-result\n").unwrap();
+  std::fs::write(root.join("bar.mec"), "bar-result := 2\n<+ bar-result\n").unwrap();
+  std::fs::write(
     root.join("main.mec"),
     "@program-db := db://program{:read(*)}\n+> ./math.mec\nok := math/tau > 6.0\n<+ ok\n\n~~~mech:foo\n@foo-db := db://foo{:read(*)}\n+> ./foo.mec\n<+ foo-result\n~~~\n\n~~~mech:bar\n@bar-db := db://bar{:read(*)}\n+> ./bar.mec\n<+ bar-result\n~~~\n",
   ).unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
 
-    assert_eq!(main.imports.len(), 3);
-    assert_eq!(main.exports.len(), 3);
-    assert_eq!(main.contexts.len(), 3);
-    assert_eq!(main.import_edges.len(), 3);
-    assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
-    assert!(main.import_edges.iter().any(|edge| match &edge.scope {
-        SourceScope::Interpreter(interpreter) =>
-            interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
-        SourceScope::Program => false,
-    }));
-    assert!(main.import_edges.iter().any(|edge| match &edge.scope {
-        SourceScope::Interpreter(interpreter) =>
-            interpreter.namespace_str == "bar" && edge.import.specifier == "./bar.mec",
-        SourceScope::Program => false,
-    }));
+  assert_eq!(main.imports.len(), 3);
+  assert_eq!(main.exports.len(), 3);
+  assert_eq!(main.contexts.len(), 3);
+  assert_eq!(main.import_edges.len(), 3);
+  assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
+  assert!(main.import_edges.iter().any(|edge| match &edge.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
+    SourceScope::Program => false,
+  }));
+  assert!(main.import_edges.iter().any(|edge| match &edge.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar" && edge.import.specifier == "./bar.mec",
+    SourceScope::Program => false,
+  }));
 
-    let program = main
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program)
-        .unwrap();
-    assert_eq!(program.imports.len(), 1);
-    assert_eq!(program.imports[0].specifier, "./math.mec");
-    assert_eq!(program.exports.len(), 1);
-    assert_eq!(program.exports[0].name, "ok");
-    assert_eq!(program.contexts.len(), 1);
-    assert_eq!(program.contexts[0].name, "program-db");
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert_eq!(program.imports.len(), 1);
+  assert_eq!(program.imports[0].specifier, "./math.mec");
+  assert_eq!(program.exports.len(), 1);
+  assert_eq!(program.exports[0].name, "ok");
+  assert_eq!(program.contexts.len(), 1);
+  assert_eq!(program.contexts[0].name, "program-db");
 
-    let foo = main
-        .scopes
-        .iter()
-        .find(|scope| match &scope.scope {
-            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-            SourceScope::Program => false,
-        })
-        .unwrap();
-    assert_eq!(foo.imports.len(), 1);
-    assert_eq!(foo.imports[0].specifier, "./foo.mec");
-    assert_eq!(foo.exports.len(), 1);
-    assert_eq!(foo.exports[0].name, "foo-result");
-    assert_eq!(foo.contexts.len(), 1);
-    assert_eq!(foo.contexts[0].name, "foo-db");
+  let foo = main.scopes.iter().find(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+    SourceScope::Program => false,
+  }).unwrap();
+  assert_eq!(foo.imports.len(), 1);
+  assert_eq!(foo.imports[0].specifier, "./foo.mec");
+  assert_eq!(foo.exports.len(), 1);
+  assert_eq!(foo.exports[0].name, "foo-result");
+  assert_eq!(foo.contexts.len(), 1);
+  assert_eq!(foo.contexts[0].name, "foo-db");
 
-    let bar = main
-        .scopes
-        .iter()
-        .find(|scope| match &scope.scope {
-            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar",
-            SourceScope::Program => false,
-        })
-        .unwrap();
-    assert_eq!(bar.imports.len(), 1);
-    assert_eq!(bar.imports[0].specifier, "./bar.mec");
-    assert_eq!(bar.exports.len(), 1);
-    assert_eq!(bar.exports[0].name, "bar-result");
-    assert_eq!(bar.contexts.len(), 1);
-    assert_eq!(bar.contexts[0].name, "bar-db");
+  let bar = main.scopes.iter().find(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "bar",
+    SourceScope::Program => false,
+  }).unwrap();
+  assert_eq!(bar.imports.len(), 1);
+  assert_eq!(bar.imports[0].specifier, "./bar.mec");
+  assert_eq!(bar.exports.len(), 1);
+  assert_eq!(bar.exports[0].name, "bar-result");
+  assert_eq!(bar.contexts.len(), 1);
+  assert_eq!(bar.contexts[0].name, "bar-db");
 
-    assert!(
-        !foo.imports
-            .iter()
-            .any(|import| import.specifier == "./bar.mec")
-    );
-    assert!(!foo.exports.iter().any(|export| export.name == "bar-result"));
-    assert!(!foo.contexts.iter().any(|context| context.name == "bar-db"));
+  assert!(!foo.imports.iter().any(|import| import.specifier == "./bar.mec"));
+  assert!(!foo.exports.iter().any(|export| export.name == "bar-result"));
+  assert!(!foo.contexts.iter().any(|context| context.name == "bar-db"));
 }
 
 #[test]
 fn program_scope_imports_still_work() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    let program = main
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program)
-        .unwrap();
-    assert_eq!(program.imports.len(), 1);
-    assert_eq!(program.imports[0].specifier, "./math.mec");
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert_eq!(program.imports.len(), 1);
+  assert_eq!(program.imports[0].specifier, "./math.mec");
 
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn fenced_import_does_not_leak_to_program_scope() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-scoped-fenced-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "~~~mech:foo\n+> ./math.mec\n~~~\nok := math/tau > 6.0\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-scoped-fenced-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "~~~mech:foo\n+> ./math.mec\n~~~\nok := math/tau > 6.0\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.imports.len(), 1);
-    let program = main
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program);
-    assert!(
-        program
-            .map(|scope| scope.imports.is_empty())
-            .unwrap_or(true)
-    );
-    assert!(main.scopes.iter().any(|scope| match &scope.scope {
-        SourceScope::Interpreter(interpreter) =>
-            interpreter.namespace_str == "foo"
-                && scope.imports.len() == 1
-                && scope.imports[0].specifier == "./math.mec",
-        SourceScope::Program => false,
-    }));
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.imports.len(), 1);
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program);
+  assert!(program.map(|scope| scope.imports.is_empty()).unwrap_or(true));
+  assert!(main.scopes.iter().any(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && scope.imports.len() == 1 && scope.imports[0].specifier == "./math.mec",
+    SourceScope::Program => false,
+  }));
 
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("math/tau"));
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("math/tau"));
 }
 
 #[test]
 fn program_and_fenced_imports_do_not_mix() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-scope-mix-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-scope-mix-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    let program = main
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program)
-        .unwrap();
-    assert_eq!(program.imports.len(), 1);
-    assert_eq!(program.imports[0].specifier, "./math.mec");
-    let foo = main
-        .scopes
-        .iter()
-        .find(|scope| match &scope.scope {
-            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-            SourceScope::Program => false,
-        })
-        .unwrap();
-    assert_eq!(foo.imports.len(), 1);
-    assert_eq!(foo.imports[0].specifier, "./foo.mec");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert_eq!(program.imports.len(), 1);
+  assert_eq!(program.imports[0].specifier, "./math.mec");
+  let foo = main.scopes.iter().find(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+    SourceScope::Program => false,
+  }).unwrap();
+  assert_eq!(foo.imports.len(), 1);
+  assert_eq!(foo.imports[0].specifier, "./foo.mec");
 
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn program_and_fenced_can_import_same_module_without_duplicate_program_binding() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-same-import-scope-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> ./math.mec\n\n~~~mech:foo\n+> ./math.mec\n~~~\n\nok := math/tau > 6.0\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-same-import-scope-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./math.mec\n~~~\n\nok := math/tau > 6.0\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.imports.len(), 2);
-    assert_eq!(main.import_edges.len(), 2);
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.imports.len(), 2);
+  assert_eq!(main.import_edges.len(), 2);
 
-    let program_edges = main
-        .import_edges
-        .iter()
-        .filter(|edge| edge.scope == SourceScope::Program)
-        .collect::<Vec<_>>();
-    assert_eq!(program_edges.len(), 1);
-    assert_eq!(program_edges[0].import.specifier, "./math.mec");
+  let program_edges = main.import_edges.iter().filter(|edge| edge.scope == SourceScope::Program).collect::<Vec<_>>();
+  assert_eq!(program_edges.len(), 1);
+  assert_eq!(program_edges[0].import.specifier, "./math.mec");
 
-    let foo_edges = main
-        .import_edges
-        .iter()
-        .filter(|edge| match &edge.scope {
-            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-            SourceScope::Program => false,
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(foo_edges.len(), 1);
-    assert_eq!(foo_edges[0].import.specifier, "./math.mec");
+  let foo_edges = main.import_edges.iter().filter(|edge| match &edge.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+    SourceScope::Program => false,
+  }).collect::<Vec<_>>();
+  assert_eq!(foo_edges.len(), 1);
+  assert_eq!(foo_edges[0].import.specifier, "./math.mec");
 
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn fenced_import_binding_is_not_visible_to_program_scope() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-scope-negative-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := foo/foo-value > 0\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-scope-negative-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := foo/foo-value > 0\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("foo/foo-value"));
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("foo/foo-value"));
 }
 
 #[test]
 fn module_records_keep_flat_metadata_for_compatibility() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-flat-compat-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n",
-    )
-    .unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-flat-compat-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("foo.mec"), "foo-value := 42\n<+ foo-value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./math.mec\n\n~~~mech:foo\n+> ./foo.mec\n~~~\n\nok := math/tau > 6.0\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.imports.len(), 2);
-    assert_eq!(main.import_edges.len(), 2);
-    assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
-    assert!(main.import_edges.iter().any(|edge| match &edge.scope {
-        SourceScope::Interpreter(interpreter) =>
-            interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
-        SourceScope::Program => false,
-    }));
-    assert!(
-        main.imports
-            .iter()
-            .any(|import| import.specifier == "./math.mec")
-    );
-    assert!(
-        main.imports
-            .iter()
-            .any(|import| import.specifier == "./foo.mec")
-    );
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.imports.len(), 2);
+  assert_eq!(main.import_edges.len(), 2);
+  assert!(main.import_edges.iter().any(|edge| edge.scope == SourceScope::Program && edge.import.specifier == "./math.mec"));
+  assert!(main.import_edges.iter().any(|edge| match &edge.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo" && edge.import.specifier == "./foo.mec",
+    SourceScope::Program => false,
+  }));
+  assert!(main.imports.iter().any(|import| import.specifier == "./math.mec"));
+  assert!(main.imports.iter().any(|import| import.specifier == "./foo.mec"));
 
-    let program = main
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program)
-        .unwrap();
-    assert_eq!(program.imports.len(), 1);
-    assert_eq!(program.imports[0].specifier, "./math.mec");
-    let foo = main
-        .scopes
-        .iter()
-        .find(|scope| match &scope.scope {
-            SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
-            SourceScope::Program => false,
-        })
-        .unwrap();
-    assert_eq!(foo.imports.len(), 1);
-    assert_eq!(foo.imports[0].specifier, "./foo.mec");
+  let program = main.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert_eq!(program.imports.len(), 1);
+  assert_eq!(program.imports[0].specifier, "./math.mec");
+  let foo = main.scopes.iter().find(|scope| match &scope.scope {
+    SourceScope::Interpreter(interpreter) => interpreter.namespace_str == "foo",
+    SourceScope::Program => false,
+  }).unwrap();
+  assert_eq!(foo.imports.len(), 1);
+  assert_eq!(foo.imports[0].specifier, "./foo.mec");
 
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn build_dependency_graph() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main_version = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main_version.dependencies.len(), 1);
-    assert_eq!(main_version.imports.len(), 1);
-    assert_eq!(main_version.import_edges.len(), 1);
-    let dep_version = runtime
-        .store()
-        .get_module_version(main_version.dependencies[0])
-        .unwrap()
-        .unwrap();
-    assert!(dep_version.exports.iter().any(|e| e.name == "tau"));
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main_version = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main_version.dependencies.len(), 1);
+  assert_eq!(main_version.imports.len(), 1);
+  assert_eq!(main_version.import_edges.len(), 1);
+  let dep_version = runtime.store().get_module_version(main_version.dependencies[0]).unwrap().unwrap();
+  assert!(dep_version.exports.iter().any(|e| e.name == "tau"));
 }
 
 #[test]
 fn run_module() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_ok());
-    match result.unwrap() {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_ok());
+  match result.unwrap() {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn file_import_exposes_exports_under_file_stem_namespace() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn file_import_does_not_imply_wildcard_import() {
-    let root = setup_modules("+> ./math.mec\nok := tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("tau"));
+  let root = setup_modules("+> ./math.mec\nok := tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("tau"));
 }
 
 #[test]
 fn file_import_does_not_expose_non_exported_binding() {
-    let root = setup_modules("+> ./math.mec\nok := math/secret > 0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("math/secret"));
+  let root = setup_modules("+> ./math.mec\nok := math/secret > 0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("math/secret"));
 }
 
 #[test]
 fn namespace_import_exposes_exports_under_module_namespace() {
-    let root = setup_modules("+> math\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let root = setup_modules("+> math\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn single_import_exposes_export_unqualified() {
-    let root = setup_modules("+> math/tau\nok := tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let root = setup_modules("+> math/tau\nok := tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn wildcard_import_exposes_all_exports_unqualified() {
-    let root = setup_modules("+> math/*\nok := tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(*value.borrow()),
-        other => panic!("expected bool result from module run, got {:?}", other),
-    }
+  let root = setup_modules("+> math/*\nok := tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected bool result from module run, got {:?}", other),
+  }
 }
 
 #[test]
 fn wildcard_import_does_not_expose_non_exported_binding() {
-    let root = setup_modules("+> math/*\nok := secret > 0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("secret"));
+  let root = setup_modules("+> math/*\nok := secret > 0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("secret"));
 }
 
 #[test]
 fn import_conflict_fails() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-conflict-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(root.join("science.mec"), "tau := 6.2\n<+ tau\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> math/tau\n+> science/tau\nok := tau > 0\n",
-    )
-    .unwrap();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("RuntimeModuleImportConflict"));
-    assert!(error.contains("tau"));
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-conflict-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("science.mec"), "tau := 6.2\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> math/tau\n+> science/tau\nok := tau > 0\n").unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeModuleImportConflict"));
+  assert!(error.contains("tau"));
 }
 
 #[test]
 fn re_export_works() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-reexport-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
-    std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
-    std::fs::write(root.join("main.mec"), "+> bridge/tau\nok := tau > 6.0\n").unwrap();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    match result {
-        Value::Bool(v) => assert!(*v.borrow()),
-        other => panic!("expected bool got {:?}", other),
-    }
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-reexport-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\n<+ tau\n").unwrap();
+  std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> bridge/tau\nok := tau > 6.0\n").unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  match result { Value::Bool(v) => assert!(*v.borrow()), other => panic!("expected bool got {:?}", other) }
 }
 
 #[test]
 fn module_version_records_import_edges() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.imports.len(), 1);
-    assert_eq!(main.contexts.len(), 0);
-    assert_eq!(main.dependencies.len(), 1);
-    assert_eq!(main.import_edges.len(), 1);
-    assert_eq!(main.import_edges[0].scope, SourceScope::Program);
-    assert_eq!(main.import_edges[0].import.specifier, "./math.mec");
-    assert_eq!(main.import_edges[0].dependency, main.dependencies[0]);
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.imports.len(), 1);
+  assert_eq!(main.contexts.len(), 0);
+  assert_eq!(main.dependencies.len(), 1);
+  assert_eq!(main.import_edges.len(), 1);
+  assert_eq!(main.import_edges[0].scope, SourceScope::Program);
+  assert_eq!(main.import_edges[0].import.specifier, "./math.mec");
+  assert_eq!(main.import_edges[0].dependency, main.dependencies[0]);
 }
 
 #[test]
 fn module_version_records_multiple_import_edges_in_order() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-edges-order-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
-    std::fs::write(root.join("b.mec"), "y := 2\n<+ y\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> ./a.mec\n+> ./b.mec\nok := a/x < b/y\n",
-    )
-    .unwrap();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.import_edges.len(), 2);
-    assert_eq!(main.import_edges[0].scope, SourceScope::Program);
-    assert_eq!(main.import_edges[1].scope, SourceScope::Program);
-    assert_eq!(main.import_edges[0].import.specifier, "./a.mec");
-    assert_eq!(main.import_edges[1].import.specifier, "./b.mec");
-    assert!(main.dependencies.contains(&main.import_edges[0].dependency));
-    assert!(main.dependencies.contains(&main.import_edges[1].dependency));
-    match runtime.run_module(version).unwrap() {
-        Value::Bool(v) => assert!(*v.borrow()),
-        other => panic!("expected bool got {:?}", other),
-    }
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-edges-order-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
+  std::fs::write(root.join("b.mec"), "y := 2\n<+ y\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./a.mec\n+> ./b.mec\nok := a/x < b/y\n").unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.import_edges.len(), 2);
+  assert_eq!(main.import_edges[0].scope, SourceScope::Program);
+  assert_eq!(main.import_edges[1].scope, SourceScope::Program);
+  assert_eq!(main.import_edges[0].import.specifier, "./a.mec");
+  assert_eq!(main.import_edges[1].import.specifier, "./b.mec");
+  assert!(main.dependencies.contains(&main.import_edges[0].dependency));
+  assert!(main.dependencies.contains(&main.import_edges[1].dependency));
+  match runtime.run_module(version).unwrap() { Value::Bool(v) => assert!(*v.borrow()), other => panic!("expected bool got {:?}", other) }
 }
 
 #[test]
 fn module_version_records_contexts() {
-    let root = setup_modules(
-        "@main := db://main{:read(users/*), :write(users/name)}\n+> ./math.mec\nok := math/tau > 6.0\n",
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let main = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(main.contexts.len(), 1);
-    assert_eq!(main.contexts[0].name, "main");
-    assert_eq!(main.contexts[0].capabilities.len(), 2);
+  let root = setup_modules("@main := db://main{:read(users/*), :write(users/name)}\n+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let main = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(main.contexts.len(), 1);
+  assert_eq!(main.contexts[0].name, "main");
+  assert_eq!(main.contexts[0].capabilities.len(), 2);
 }
 
 #[test]
 fn multi_level_re_export_works() {
-    re_export_works();
+  re_export_works();
 }
 
 #[test]
 fn multi_level_private_symbol_does_not_leak() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-privacy-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(
-        root.join("math.mec"),
-        "tau := 6.28318\nsecret := 42\n<+ tau\n",
-    )
-    .unwrap();
-    std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
-    std::fs::write(root.join("main.mec"), "+> bridge/*\nok := secret > 0\n").unwrap();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("UndefinedVariable"));
-    assert!(error.contains("secret"));
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-privacy-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 6.28318\nsecret := 42\n<+ tau\n").unwrap();
+  std::fs::write(root.join("bridge.mec"), "+> math/tau\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> bridge/*\nok := secret > 0\n").unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UndefinedVariable"));
+  assert!(error.contains("secret"));
 }
 
 #[test]
 fn duplicate_unqualified_import_conflict_fails() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-dupe-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
-    std::fs::write(root.join("b.mec"), "x := 2\n<+ x\n").unwrap();
-    std::fs::write(root.join("main.mec"), "+> a/*\n+> b/*\nok := x > 0\n").unwrap();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("RuntimeModuleImportConflict"));
-    assert!(error.contains("x"));
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-dupe-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("a.mec"), "x := 1\n<+ x\n").unwrap();
+  std::fs::write(root.join("b.mec"), "x := 2\n<+ x\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> a/*\n+> b/*\nok := x > 0\n").unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeModuleImportConflict"));
+  assert!(error.contains("x"));
 }
 
 #[test]
 fn duplicate_same_export_import_policy_is_explicit() {
-    let root = setup_modules("+> math/tau\n+> math/*\nok := tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("RuntimeModuleImportConflict"));
-    assert!(error.contains("tau"));
+  let root = setup_modules("+> math/tau\n+> math/*\nok := tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeModuleImportConflict"));
+  assert!(error.contains("tau"));
 }
 
 #[test]
 fn module_host_call_works_inside_isolated_execution() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-host-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := demo/value()\n<+ tau\n").unwrap();
-    std::fs::write(
-        root.join("main.mec"),
-        "+> ./math.mec\nok := math/tau > 40\n",
-    )
-    .unwrap();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new("demo/value", |_s, _c, _a| {
-            Ok(Value::F64(Ref::new(42.0)))
-        }))
-        .unwrap();
-    runtime
-        .grant_capability(std::sync::Arc::new(BasicCapability::new(
-            CapabilityId(1),
-            &BasicSubject::new("program:module-host-test"),
-            &BasicResource::new("host:demo/value"),
-            [BasicOperation::new("call")],
-        )))
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let mut context = runtime
-        .runtime_context()
-        .unwrap()
-        .with_subject("program:module-host-test");
-    let result = runtime
-        .run_module_with_context(&mut context, version)
-        .unwrap();
-    match result {
-        Value::Bool(v) => assert!(*v.borrow()),
-        other => panic!("expected bool got {:?}", other),
-    }
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-host-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := demo/value()\n<+ tau\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./math.mec\nok := math/tau > 40\n").unwrap();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  runtime.register_mech_host_function(ClosureHostFunction::new("demo/value", |_s, _c, _a| Ok(Value::F64(Ref::new(42.0))))).unwrap();
+  runtime.grant_capability(std::sync::Arc::new(BasicCapability::new(
+    CapabilityId(1),
+    &BasicSubject::new("program:module-host-test"),
+    &BasicResource::new("host:demo/value"),
+    [BasicOperation::new("call")],
+  ))).unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("program:module-host-test");
+  let result = runtime.run_module_with_context(&mut context, version).unwrap();
+  match result { Value::Bool(v) => assert!(*v.borrow()), other => panic!("expected bool got {:?}", other) }
 }
 
 #[test]
 fn repeated_run_module_is_not_stale() {
-    let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", options)
-        .unwrap()
-        .unwrap();
-    let first = runtime.run_module(version).unwrap();
-    std::fs::write(root.join("math.mec"), "tau := 5.0\n<+ tau\n").unwrap();
-    let second = runtime.run_module(version).unwrap();
-    match (first, second) {
-        (Value::Bool(a), Value::Bool(b)) => {
-            assert!(*a.borrow());
-            assert!(*b.borrow());
-        }
-        other => panic!("expected bool tuple got {:?}", other),
+  let root = setup_modules("+> ./math.mec\nok := math/tau > 6.0\n");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let version = runtime.resolve_and_store_module_source("main.mec", options).unwrap().unwrap();
+  let first = runtime.run_module(version).unwrap();
+  std::fs::write(root.join("math.mec"), "tau := 5.0\n<+ tau\n").unwrap();
+  let second = runtime.run_module(version).unwrap();
+  match (first, second) {
+    (Value::Bool(a), Value::Bool(b)) => {
+      assert!(*a.borrow());
+      assert!(*b.borrow());
     }
+    other => panic!("expected bool tuple got {:?}", other),
+  }
 }
 
 #[test]
 fn missing_dependency_fails_module_build() {
-    let root = std::env::temp_dir().join(format!(
-        "mech-runtime-module-missing-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::write(root.join("main.mec"), "+> ./missing.mec\nok := 1\n").unwrap();
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-missing-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./missing.mec\nok := 1\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
-    let result = runtime.resolve_and_store_module_source("main.mec", options);
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("RuntimeModuleDependencyMissing"));
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
+  let options = ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]);
+  let result = runtime.resolve_and_store_module_source("main.mec", options);
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeModuleDependencyMissing"));
 }
 
+
 fn docs_config(path: &str, value: Value) -> RuntimeConfigSpec {
-    RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
-        RuntimeInMemoryDocsResourceSpec::new("docs://manual").with_entry(path, value),
-    ))
+  RuntimeConfigSpec::new().with_resource(RuntimeResourceConfigSpec::InMemoryDocs(
+    RuntimeInMemoryDocsResourceSpec::new("docs://manual")
+      .with_entry(path, value),
+  ))
 }
 
 fn run_docs_config_read(spec: RuntimeConfigSpec) -> Result<Value, mech_core::MechError> {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .config_spec(spec)
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    run_module_as_main(&mut runtime, version)
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .config_spec(spec)
+    .build()
+    .unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  run_module_as_main(&mut runtime, version)
 }
 
 #[test]
 fn config_spec_docs_read_requires_host_grant() {
-    let result = run_docs_config_read(docs_config("intro/title", bool_value(true)));
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("RuntimeCapabilityGrantDenied"));
-    assert!(error.contains("task://main"));
-    assert!(error.contains("docs://manual"));
-    assert!(error.contains("intro/title"));
+  let result = run_docs_config_read(docs_config("intro/title", bool_value(true)));
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"));
+  assert!(error.contains("task://main"));
+  assert!(error.contains("docs://manual"));
+  assert!(error.contains("intro/title"));
 }
 
 #[test]
 fn config_spec_docs_read_with_matching_grant_returns_value() {
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"));
-    assert_bool_true(run_docs_config_read(spec).unwrap(), "matching grant");
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://manual", "intro/title"));
+  assert_bool_true(run_docs_config_read(spec).unwrap(), "matching grant");
 }
 
 #[test]
 fn host_grant_path_prefix_allows_nested_read() {
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://manual", "intro/*"));
-    assert_bool_true(run_docs_config_read(spec).unwrap(), "prefix grant");
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://manual", "intro/*"));
+  assert_bool_true(run_docs_config_read(spec).unwrap(), "prefix grant");
 }
 
 #[test]
 fn host_grant_path_prefix_does_not_match_sibling() {
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://manual", "introduction/*"));
-    let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
-    assert!(error.contains("RuntimeCapabilityGrantDenied"));
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://manual", "introduction/*"));
+  let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn host_grant_wrong_operation_denies_read() {
-    let grant = RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
-        .with_operation(RuntimeCapabilityOperation::Write)
-        .with_path("intro/title");
-    let spec = docs_config("intro/title", bool_value(true)).with_capability_grant(grant);
-    let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
-    assert!(error.contains("RuntimeCapabilityGrantDenied"));
+  let grant = RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
+    .with_operation(RuntimeCapabilityOperation::Write)
+    .with_path("intro/title");
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(grant);
+  let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn host_grant_wrong_resource_denies_read() {
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://other", "intro/title"));
-    let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
-    assert!(error.contains("RuntimeCapabilityGrantDenied"));
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://other", "intro/title"));
+  let error = format!("{:?}", run_docs_config_read(spec).err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn context_denial_still_uses_context_capability_error() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n",
-    );
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .config_spec(spec)
-        .build()
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let error = format!("{:?}", runtime.run_module(version).err().unwrap());
-    assert!(error.contains("RuntimeResourceCapabilityDenied"));
-    assert!(!error.contains("RuntimeCapabilityGrantDenied"));
+  let root = setup_modules("@manual := docs://manual{:read(other/path)}\n\nresult := @manual/intro/title\n");
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://manual", "intro/title"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .config_spec(spec)
+    .build()
+    .unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let error = format!("{:?}", runtime.run_module(version).err().unwrap());
+  assert!(error.contains("RuntimeResourceCapabilityDenied"));
+  assert!(!error.contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn host_grant_wildcard_path_allows_read() {
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://manual", "*"));
-    assert_bool_true(run_docs_config_read(spec).unwrap(), "wildcard grant");
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://manual", "*"));
+  assert_bool_true(run_docs_config_read(spec).unwrap(), "wildcard grant");
 }
 
 #[test]
 fn direct_provider_read_with_runtime_grant_still_works() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .in_memory_docs(provider)
-        .build()
-        .unwrap();
-    let subject = runtime.runtime_context().unwrap().subject;
-    runtime
-        .grant_capability(runtime_read_grant_for(
-            &subject,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    assert!(runtime.has_capability_grant(
-        &subject,
-        "docs://manual",
-        &RuntimeCapabilityOperation::Read,
-        "intro/title"
-    ));
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(runtime.run_module(version).unwrap(), "runtime grant");
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let provider = docs_provider_with("docs://manual", "intro/title", bool_value(true));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .in_memory_docs(provider)
+    .build()
+    .unwrap();
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(runtime_read_grant_for(&subject, "docs://manual", "intro/title")).unwrap();
+  assert!(runtime.has_capability_grant(&subject, "docs://manual", &RuntimeCapabilityOperation::Read, "intro/title"));
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(runtime.run_module(version).unwrap(), "runtime grant");
 }
 
 #[test]
 fn apply_config_spec_after_build_registers_resources_and_grants() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n",
-    );
-    let spec = docs_config("intro/title", bool_value(true))
-        .with_capability_grant(read_grant("docs://manual", "intro/title"));
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .build()
-        .unwrap();
-    runtime.apply_config_spec(spec).unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    assert_bool_true(
-        run_module_as_main(&mut runtime, version).unwrap(),
-        "apply spec",
-    );
+  let root = setup_modules("@manual := docs://manual{:read(intro/title)}\n\nresult := @manual/intro/title\n");
+  let spec = docs_config("intro/title", bool_value(true))
+    .with_capability_grant(read_grant("docs://manual", "intro/title"));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .build()
+    .unwrap();
+  runtime.apply_config_spec(spec).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  assert_bool_true(run_module_as_main(&mut runtime, version).unwrap(), "apply spec");
 }
 
 #[test]
 fn invalid_grant_empty_subject_fails_build() {
-    let spec = RuntimeConfigSpec::new().with_capability_grant(
-        RuntimeCapabilityGrantSpec::new("", "docs://manual")
-            .with_operation(RuntimeCapabilityOperation::Read)
-            .with_path("intro/title"),
-    );
-    let error = format!(
-        "{:?}",
-        RuntimeBuilder::new()
-            .config_spec(spec)
-            .build()
-            .err()
-            .unwrap()
-    );
-    assert!(error.contains("RuntimeCapabilityGrantInvalid"));
-    assert!(error.contains("subject"));
+  let spec = RuntimeConfigSpec::new().with_capability_grant(
+    RuntimeCapabilityGrantSpec::new("", "docs://manual")
+      .with_operation(RuntimeCapabilityOperation::Read)
+      .with_path("intro/title"),
+  );
+  let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantInvalid"));
+  assert!(error.contains("subject"));
 }
 
 #[test]
 fn invalid_grant_empty_operation_fails_build() {
-    let spec = RuntimeConfigSpec::new().with_capability_grant(
-        RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
-            .with_operation(RuntimeCapabilityOperation::Custom(String::new()))
-            .with_path("intro/title"),
-    );
-    let error = format!(
-        "{:?}",
-        RuntimeBuilder::new()
-            .config_spec(spec)
-            .build()
-            .err()
-            .unwrap()
-    );
-    assert!(error.contains("RuntimeCapabilityGrantInvalid"));
-    assert!(error.contains("operation"));
+  let spec = RuntimeConfigSpec::new().with_capability_grant(
+    RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
+      .with_operation(RuntimeCapabilityOperation::Custom(String::new()))
+      .with_path("intro/title"),
+  );
+  let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantInvalid"));
+  assert!(error.contains("operation"));
 }
 
 #[test]
 fn invalid_grant_empty_path_fails_build() {
-    let spec = RuntimeConfigSpec::new().with_capability_grant(
-        RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
-            .with_operation(RuntimeCapabilityOperation::Read)
-            .with_path(""),
-    );
-    let error = format!(
-        "{:?}",
-        RuntimeBuilder::new()
-            .config_spec(spec)
-            .build()
-            .err()
-            .unwrap()
-    );
-    assert!(error.contains("RuntimeCapabilityGrantInvalid"));
-    assert!(error.contains("path"));
+  let spec = RuntimeConfigSpec::new().with_capability_grant(
+    RuntimeCapabilityGrantSpec::new("task://main", "docs://manual")
+      .with_operation(RuntimeCapabilityOperation::Read)
+      .with_path(""),
+  );
+  let error = format!("{:?}", RuntimeBuilder::new().config_spec(spec).build().err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantInvalid"));
+  assert!(error.contains("path"));
 }
+
 
 #[test]
 fn workspace_open_rejects_duplicate_targets() {
-    let root = setup_modules("result := true\n");
-    let config = RuntimeWorkspaceConfig::new(&root)
-        .target("main", "main.mec")
-        .target("main", "other.mec");
+  let root = setup_modules("result := true\n");
+  let config = RuntimeWorkspaceConfig::new(&root)
+    .target("main", "main.mec")
+    .target("main", "other.mec");
 
-    let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
-    assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
-    assert!(error.contains("duplicate target"));
+  let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
+  assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
+  assert!(error.contains("duplicate target"));
 }
 
 #[test]
 fn workspace_open_rejects_empty_target_name() {
-    let root = setup_modules("result := true\n");
-    let config = RuntimeWorkspaceConfig::new(&root).target("", "main.mec");
+  let root = setup_modules("result := true\n");
+  let config = RuntimeWorkspaceConfig::new(&root)
+    .target("", "main.mec");
 
-    let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
-    assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
-    assert!(error.contains("target name"));
+  let error = format!("{:?}", RuntimeWorkspace::open(config).err().unwrap());
+  assert!(error.contains("RuntimeWorkspaceInvalidConfig"));
+  assert!(error.contains("target name"));
 }
 
 #[test]
 fn workspace_load_target_without_imports() {
-    let root = setup_modules("result := true\n");
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert!(snapshot.diagnostics.is_empty());
-    let target = snapshot.targets.get("main").unwrap();
-    assert!(snapshot.sources.contains_key(&target.canonical_uri));
-    assert!(workspace.target("main").is_some());
-    assert_bool_true(
-        runtime.run_module(target.module_version).unwrap(),
-        "workspace target",
-    );
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(snapshot.diagnostics.is_empty());
+  let target = snapshot.targets.get("main").unwrap();
+  assert!(snapshot.sources.contains_key(&target.canonical_uri));
+  assert!(workspace.target("main").is_some());
+  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace target");
 }
 
 #[test]
 fn workspace_load_target_with_local_import() {
-    let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
-    std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+  std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
 
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert!(snapshot.diagnostics.is_empty());
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(snapshot.diagnostics.is_empty());
 
-    let target = snapshot.targets.get("main").unwrap();
-    let main_path = root.join("main.mec").canonicalize().unwrap();
-    let math_path = root.join("math.mec").canonicalize().unwrap();
+  let target = snapshot.targets.get("main").unwrap();
+  let main_path = root.join("main.mec").canonicalize().unwrap();
+  let math_path = root.join("math.mec").canonicalize().unwrap();
 
-    assert!(
-        snapshot
-            .sources
-            .values()
-            .any(|source| { source.path.as_ref() == Some(&main_path) }),
-        "workspace snapshot should contain main.mec source; sources: {:?}",
-        snapshot.sources,
-    );
+  assert!(
+    snapshot.sources.values().any(|source| {
+      source.path.as_ref() == Some(&main_path)
+    }),
+    "workspace snapshot should contain main.mec source; sources: {:?}",
+    snapshot.sources,
+  );
 
-    assert!(
-        snapshot
-            .sources
-            .values()
-            .any(|source| { source.path.as_ref() == Some(&math_path) }),
-        "workspace snapshot should contain math.mec source; sources: {:?}",
-        snapshot.sources,
-    );
+  assert!(
+    snapshot.sources.values().any(|source| {
+      source.path.as_ref() == Some(&math_path)
+    }),
+    "workspace snapshot should contain math.mec source; sources: {:?}",
+    snapshot.sources,
+  );
 
-    assert!(
-        snapshot
-            .import_edges
-            .iter()
-            .any(|edge| { edge.specifier == "./math.mec" })
-    );
+  assert!(snapshot.import_edges.iter().any(|edge| {
+    edge.specifier == "./math.mec"
+  }));
 
-    assert_bool_true(
-        runtime.run_module(target.module_version).unwrap(),
-        "workspace imported target",
-    );
+  assert_bool_true(
+    runtime.run_module(target.module_version).unwrap(),
+    "workspace imported target",
+  );
 }
 
 #[test]
 fn workspace_load_relative_target_uses_workspace_root() {
-    let root_a = std::env::temp_dir().join(format!(
-        "mech-runtime-workspace-root-a-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    let root_b = std::env::temp_dir().join(format!(
-        "mech-runtime-workspace-root-b-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root_a).unwrap();
-    std::fs::create_dir_all(&root_b).unwrap();
+  let root_a = std::env::temp_dir().join(format!(
+    "mech-runtime-workspace-root-a-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  let root_b = std::env::temp_dir().join(format!(
+    "mech-runtime-workspace-root-b-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  std::fs::create_dir_all(&root_a).unwrap();
+  std::fs::create_dir_all(&root_b).unwrap();
 
-    std::fs::write(root_a.join("main.mec"), "result := false\n").unwrap();
-    std::fs::write(root_b.join("main.mec"), "result := true\n").unwrap();
+  std::fs::write(root_a.join("main.mec"), "result := false\n").unwrap();
+  std::fs::write(root_b.join("main.mec"), "result := true\n").unwrap();
 
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root_b))
-        .build()
-        .unwrap();
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root_a).target("main", "main.mec"))
-            .unwrap();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root_b))
+    .build()
+    .unwrap();
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root_a)
+      .target("main", "main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert!(snapshot.diagnostics.is_empty());
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(snapshot.diagnostics.is_empty());
 
-    let target = snapshot.targets.get("main").unwrap();
-    assert_eq!(target.specifier, "main.mec");
-    let result = runtime.run_module(target.module_version).unwrap();
-    match result {
-        Value::Bool(value) => assert!(!*value.borrow()),
-        other => panic!(
-            "expected false bool result from workspace root target, got {:?}",
-            other
-        ),
-    }
+  let target = snapshot.targets.get("main").unwrap();
+  assert_eq!(target.specifier, "main.mec");
+  let result = runtime.run_module(target.module_version).unwrap();
+  match result {
+    Value::Bool(value) => assert!(!*value.borrow()),
+    other => panic!("expected false bool result from workspace root target, got {:?}", other),
+  }
 }
 
 #[test]
 fn workspace_load_target_outside_root_records_diagnostic() {
-    let parent = std::env::temp_dir().join(format!(
-        "mech-runtime-workspace-outside-root-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    let root = parent.join("workspace");
-    let outside = parent.join("outside");
-    std::fs::create_dir_all(&root).unwrap();
-    std::fs::create_dir_all(&outside).unwrap();
-    std::fs::write(outside.join("main.mec"), "result := true\n").unwrap();
+  let parent = std::env::temp_dir().join(format!(
+    "mech-runtime-workspace-outside-root-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  let root = parent.join("workspace");
+  let outside = parent.join("outside");
+  std::fs::create_dir_all(&root).unwrap();
+  std::fs::create_dir_all(&outside).unwrap();
+  std::fs::write(outside.join("main.mec"), "result := true\n").unwrap();
 
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace = RuntimeWorkspace::open(
-        RuntimeWorkspaceConfig::new(&root).target("outside", "../outside/main.mec"),
-    )
-    .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("outside", "../outside/main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert_eq!(snapshot.diagnostics.len(), 1);
-    assert_eq!(
-        snapshot.diagnostics[0].severity,
-        RuntimeWorkspaceDiagnosticSeverity::Error
-    );
-    assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("outside"));
-    assert!(
-        snapshot.diagnostics[0]
-            .message
-            .contains("outside workspace root")
-    );
-    assert!(!snapshot.targets.contains_key("outside"));
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(snapshot.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
+  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("outside"));
+  assert!(snapshot.diagnostics[0].message.contains("outside workspace root"));
+  assert!(!snapshot.targets.contains_key("outside"));
 }
 
 #[test]
 fn workspace_load_missing_target_records_diagnostic() {
-    let root = setup_modules("result := true\n");
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("missing", "missing.mec"))
-            .unwrap();
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("missing", "missing.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert_eq!(snapshot.diagnostics.len(), 1);
-    assert_eq!(
-        snapshot.diagnostics[0].severity,
-        RuntimeWorkspaceDiagnosticSeverity::Error
-    );
-    assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
-    assert!(snapshot.diagnostics[0].message.contains("missing.mec"));
-    assert!(!snapshot.targets.contains_key("missing"));
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(snapshot.diagnostics[0].severity, RuntimeWorkspaceDiagnosticSeverity::Error);
+  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
+  assert!(snapshot.diagnostics[0].message.contains("missing.mec"));
+  assert!(!snapshot.targets.contains_key("missing"));
 }
 
 #[test]
 fn workspace_load_multiple_targets_continues_after_failure() {
-    let root = setup_modules("result := true\n");
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace = RuntimeWorkspace::open(
-        RuntimeWorkspaceConfig::new(&root)
-            .target("missing", "missing.mec")
-            .target("main", "main.mec"),
-    )
-    .unwrap();
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("missing", "missing.mec")
+      .target("main", "main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert_eq!(snapshot.diagnostics.len(), 1);
-    assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
-    let target = snapshot.targets.get("main").unwrap();
-    assert_bool_true(
-        runtime.run_module(target.module_version).unwrap(),
-        "workspace surviving target",
-    );
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(snapshot.diagnostics[0].target.as_deref(), Some("missing"));
+  let target = snapshot.targets.get("main").unwrap();
+  assert_bool_true(runtime.run_module(target.module_version).unwrap(), "workspace surviving target");
 }
+
 
 #[test]
 fn workspace_refresh_before_load_fails() {
-    let root = setup_modules("result := true\n");
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    let error = format!(
-        "{:?}",
-        workspace
-            .refresh(&mut runtime, module_options())
-            .err()
-            .unwrap()
-    );
-    assert!(error.contains("RuntimeWorkspaceNotLoaded"));
+  let error = format!("{:?}", workspace.refresh(&mut runtime, module_options()).err().unwrap());
+  assert!(error.contains("RuntimeWorkspaceNotLoaded"));
 }
 
 #[test]
 fn workspace_refresh_without_changes_is_empty() {
-    let root = setup_modules("result := true\n");
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let root = setup_modules("result := true\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    workspace.load(&mut runtime, module_options()).unwrap();
-    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-    assert!(refresh.changes.is_empty());
-    assert!(refresh.affected_targets.is_empty());
-    assert!(refresh.refresh_diagnostics.is_empty());
-    assert!(refresh.snapshot.targets.contains_key("main"));
+  workspace.load(&mut runtime, module_options()).unwrap();
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert!(refresh.changes.is_empty());
+  assert!(refresh.affected_targets.is_empty());
+  assert!(refresh.refresh_diagnostics.is_empty());
+  assert!(refresh.snapshot.targets.contains_key("main"));
 }
 
 #[test]
 fn workspace_refresh_modified_dependency_reloads_target() {
-    let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
-    std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+  std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert_bool_false(
-        runtime
-            .run_module(snapshot.targets["main"].module_version)
-            .unwrap(),
-        "initial workspace dependency",
-    );
-    std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_bool_false(runtime.run_module(snapshot.targets["main"].module_version).unwrap(), "initial workspace dependency");
+  std::fs::write(root.join("math.mec"), "value := true\n<+ value\n").unwrap();
 
-    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-    assert_eq!(refresh.changes.len(), 1);
-    assert_eq!(
-        refresh.changes[0].kind,
-        RuntimeWorkspaceChangeKind::Modified
-    );
-    assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
-    assert_eq!(refresh.affected_targets, vec!["main"]);
-    assert!(refresh.refresh_diagnostics.is_empty());
-    assert_bool_true(
-        runtime
-            .run_module(refresh.snapshot.targets["main"].module_version)
-            .unwrap(),
-        "refreshed workspace dependency",
-    );
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert_eq!(refresh.changes.len(), 1);
+  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
+  assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert!(refresh.refresh_diagnostics.is_empty());
+  assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace dependency");
 }
 
 #[test]
 fn workspace_refresh_removed_dependency_records_diagnostic() {
-    let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
-    std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
+  let root = setup_modules("+> ./math.mec\n\nresult := math/value\n");
+  std::fs::write(root.join("math.mec"), "value := false\n<+ value\n").unwrap();
 
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    workspace.load(&mut runtime, module_options()).unwrap();
-    std::fs::remove_file(root.join("math.mec")).unwrap();
+  workspace.load(&mut runtime, module_options()).unwrap();
+  std::fs::remove_file(root.join("math.mec")).unwrap();
 
-    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
 
-    assert_eq!(refresh.changes.len(), 1);
-    assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
-    assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
-    assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert_eq!(refresh.changes.len(), 1);
+  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Removed);
+  assert!(refresh.changes[0].canonical_uri.ends_with("/math.mec"));
+  assert_eq!(refresh.affected_targets, vec!["main"]);
 
-    assert_eq!(refresh.refresh_diagnostics.len(), 1);
-    assert_eq!(
-        refresh.refresh_diagnostics[0].severity,
-        RuntimeWorkspaceDiagnosticSeverity::Error,
-    );
-    assert_eq!(
-        refresh.refresh_diagnostics[0].target.as_deref(),
-        Some("main"),
-    );
+  assert_eq!(refresh.refresh_diagnostics.len(), 1);
+  assert_eq!(
+    refresh.refresh_diagnostics[0].severity,
+    RuntimeWorkspaceDiagnosticSeverity::Error,
+  );
+  assert_eq!(
+    refresh.refresh_diagnostics[0].target.as_deref(),
+    Some("main"),
+  );
 
-    assert_eq!(refresh.snapshot.diagnostics.len(), 1);
-    assert_eq!(
-        refresh.snapshot.diagnostics[0].target.as_deref(),
-        Some("main"),
-    );
-    assert!(!refresh.snapshot.targets.contains_key("main"));
+  assert_eq!(refresh.snapshot.diagnostics.len(), 1);
+  assert_eq!(
+    refresh.snapshot.diagnostics[0].target.as_deref(),
+    Some("main"),
+  );
+  assert!(!refresh.snapshot.targets.contains_key("main"));
 }
 
 #[test]
 fn workspace_refresh_modified_target_reloads_target() {
-    let root = setup_modules("result := false\n");
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace =
-        RuntimeWorkspace::open(RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"))
-            .unwrap();
+  let root = setup_modules("result := false\n");
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root).target("main", "main.mec"),
+  ).unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-    assert_bool_false(
-        runtime
-            .run_module(snapshot.targets["main"].module_version)
-            .unwrap(),
-        "initial workspace target",
-    );
-    std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+  assert_bool_false(runtime.run_module(snapshot.targets["main"].module_version).unwrap(), "initial workspace target");
+  std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
 
-    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-    assert_eq!(refresh.changes.len(), 1);
-    assert_eq!(
-        refresh.changes[0].kind,
-        RuntimeWorkspaceChangeKind::Modified
-    );
-    assert!(refresh.changes[0].canonical_uri.ends_with("/main.mec"));
-    assert_eq!(refresh.affected_targets, vec!["main"]);
-    assert!(refresh.refresh_diagnostics.is_empty());
-    assert_bool_true(
-        runtime
-            .run_module(refresh.snapshot.targets["main"].module_version)
-            .unwrap(),
-        "refreshed workspace target",
-    );
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert_eq!(refresh.changes.len(), 1);
+  assert_eq!(refresh.changes[0].kind, RuntimeWorkspaceChangeKind::Modified);
+  assert!(refresh.changes[0].canonical_uri.ends_with("/main.mec"));
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert!(refresh.refresh_diagnostics.is_empty());
+  assert_bool_true(runtime.run_module(refresh.snapshot.targets["main"].module_version).unwrap(), "refreshed workspace target");
 }
 
 #[test]
 fn workspace_refresh_preserves_unaffected_diagnostics() {
-    let root = setup_modules("result := false\n");
+  let root = setup_modules("result := false\n");
 
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace = RuntimeWorkspace::open(
-        RuntimeWorkspaceConfig::new(&root)
-            .target("missing", "missing.mec")
-            .target("main", "main.mec"),
-    )
-    .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("missing", "missing.mec")
+      .target("main", "main.mec"),
+  ).unwrap();
 
-    let initial = workspace.load(&mut runtime, module_options()).unwrap();
+  let initial = workspace.load(&mut runtime, module_options()).unwrap();
 
-    assert_eq!(initial.diagnostics.len(), 1);
-    assert_eq!(initial.diagnostics[0].target.as_deref(), Some("missing"));
-    assert!(initial.targets.contains_key("main"));
+  assert_eq!(initial.diagnostics.len(), 1);
+  assert_eq!(initial.diagnostics[0].target.as_deref(), Some("missing"));
+  assert!(initial.targets.contains_key("main"));
 
-    std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
+  std::fs::write(root.join("main.mec"), "result := true\n").unwrap();
 
-    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
 
-    assert_eq!(refresh.affected_targets, vec!["main"]);
-    assert!(refresh.refresh_diagnostics.is_empty());
+  assert_eq!(refresh.affected_targets, vec!["main"]);
+  assert!(refresh.refresh_diagnostics.is_empty());
 
-    assert_eq!(refresh.snapshot.diagnostics.len(), 1);
-    assert_eq!(
-        refresh.snapshot.diagnostics[0].target.as_deref(),
-        Some("missing"),
-    );
+  assert_eq!(refresh.snapshot.diagnostics.len(), 1);
+  assert_eq!(
+    refresh.snapshot.diagnostics[0].target.as_deref(),
+    Some("missing"),
+  );
 
-    let target = refresh.snapshot.targets.get("main").unwrap();
-    assert_bool_true(
-        runtime.run_module(target.module_version).unwrap(),
-        "refreshed workspace target with retained diagnostic",
-    );
+  let target = refresh.snapshot.targets.get("main").unwrap();
+  assert_bool_true(
+    runtime.run_module(target.module_version).unwrap(),
+    "refreshed workspace target with retained diagnostic",
+  );
 }
 
 #[test]
 fn workspace_load_folder_discovers_non_target_sources() {
-    let root = setup_modules("result := true\n");
-    std::fs::create_dir_all(root.join("src/nested")).unwrap();
-    std::fs::write(root.join("src/nested/lib.mec"), "value := true\n").unwrap();
+  let root = setup_modules("result := true\n");
+  std::fs::create_dir_all(root.join("src/nested")).unwrap();
+  std::fs::write(root.join("src/nested/lib.mec"), "value := true\n").unwrap();
 
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace = RuntimeWorkspace::open(
-        RuntimeWorkspaceConfig::new(&root)
-            .target("main", "main.mec")
-            .folder("src"),
-    )
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("main", "main.mec")
+      .folder("src"),
+  ).unwrap();
+
+  let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
+
+  assert!(snapshot.diagnostics.is_empty());
+  assert!(snapshot.targets.contains_key("main"));
+  assert_eq!(snapshot.targets.len(), 1);
+
+  let discovered_path = root
+    .join("src/nested/lib.mec")
+    .canonicalize()
     .unwrap();
 
-    let snapshot = workspace.load(&mut runtime, module_options()).unwrap();
-
-    assert!(snapshot.diagnostics.is_empty());
-    assert!(snapshot.targets.contains_key("main"));
-    assert_eq!(snapshot.targets.len(), 1);
-
-    let discovered_path = root.join("src/nested/lib.mec").canonicalize().unwrap();
-
-    assert!(
-        snapshot
-            .sources
-            .values()
-            .any(|source| { source.path.as_ref() == Some(&discovered_path) }),
-        "workspace snapshot should contain discovered source; sources: {:?}",
-        snapshot.sources,
-    );
+  assert!(
+    snapshot.sources.values().any(|source| {
+      source.path.as_ref() == Some(&discovered_path)
+    }),
+    "workspace snapshot should contain discovered source; sources: {:?}",
+    snapshot.sources,
+  );
 }
 
 #[test]
 fn workspace_refresh_preserves_folder_discovered_sources() {
-    let root = setup_modules("result := true\n");
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(root.join("src/lib.mec"), "value := false\n").unwrap();
+  let root = setup_modules("result := true\n");
+  std::fs::create_dir_all(root.join("src")).unwrap();
+  std::fs::write(root.join("src/lib.mec"), "value := false\n").unwrap();
 
-    let mut runtime = runtime_with_root(&root);
-    let mut workspace = RuntimeWorkspace::open(
-        RuntimeWorkspaceConfig::new(&root)
-            .target("main", "main.mec")
-            .folder("src"),
-    )
-    .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let mut workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("main", "main.mec")
+      .folder("src"),
+  ).unwrap();
 
-    let initial = workspace.load(&mut runtime, module_options()).unwrap();
-    assert!(initial.diagnostics.is_empty());
+  let initial = workspace.load(&mut runtime, module_options()).unwrap();
+  assert!(initial.diagnostics.is_empty());
 
-    let discovered_path = root.join("src/lib.mec").canonicalize().unwrap();
-    assert!(
-        initial
-            .sources
-            .values()
-            .any(|source| { source.path.as_ref() == Some(&discovered_path) })
-    );
+  let discovered_path = root.join("src/lib.mec").canonicalize().unwrap();
+  assert!(initial.sources.values().any(|source| {
+    source.path.as_ref() == Some(&discovered_path)
+  }));
 
-    std::fs::write(root.join("main.mec"), "result := false\n").unwrap();
+  std::fs::write(root.join("main.mec"), "result := false\n").unwrap();
 
-    let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
-    assert!(refresh.refresh_diagnostics.is_empty());
+  let refresh = workspace.refresh(&mut runtime, module_options()).unwrap();
+  assert!(refresh.refresh_diagnostics.is_empty());
 
-    assert!(
-        refresh
-            .snapshot
-            .sources
-            .values()
-            .any(|source| { source.path.as_ref() == Some(&discovered_path) })
-    );
+  assert!(refresh.snapshot.sources.values().any(|source| {
+    source.path.as_ref() == Some(&discovered_path)
+  }));
 }
 
 #[test]
 fn workspace_watcher_watches_configured_folder() {
-    let root = setup_modules("result := true\n");
-    std::fs::create_dir_all(root.join("src")).unwrap();
+  let root = setup_modules("result := true\n");
+  std::fs::create_dir_all(root.join("src")).unwrap();
 
-    let workspace = RuntimeWorkspace::open(
-        RuntimeWorkspaceConfig::new(&root)
-            .target("main", "main.mec")
-            .folder("src"),
-    )
-    .unwrap();
+  let workspace = RuntimeWorkspace::open(
+    RuntimeWorkspaceConfig::new(&root)
+      .target("main", "main.mec")
+      .folder("src"),
+  ).unwrap();
 
-    let mut runtime = RuntimeBuilder::new().build().unwrap();
-    let watcher = RuntimeWorkspaceWatcher::open(&workspace, &mut runtime).unwrap();
-    let watched_paths = watcher.watched_paths();
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let watcher = RuntimeWorkspaceWatcher::open(&workspace, &mut runtime).unwrap();
+  let watched_paths = watcher.watched_paths();
 
-    assert!(watched_paths.contains(&root.join("src").canonicalize().unwrap()));
+  assert!(watched_paths.contains(&root.join("src").canonicalize().unwrap()));
 }
 
 #[test]
 fn interpreter_scope_ignores_faux_tilde_fence_inside_backtick_code_block() {
-    let root = setup_modules(
-        "~~~mech:foo\n\
+  let root = setup_modules(
+    "~~~mech:foo\n\
 ok := true\n\
 <+ ok\n\
 ~~~\n\
@@ -3276,26 +2111,26 @@ broken := missing\n\
 ```\n\
 \n\
 result := @foo/ok\n",
-    );
+  );
 
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
 
-    let result = runtime.run_module(version).unwrap();
+  let result = runtime.run_module(version).unwrap();
 
-    match result {
-        Value::Bool(value) => assert_eq!(*value.borrow(), true),
-        other => panic!("expected faux tilde fence to be ignored, got {:?}", other),
-    }
+  match result {
+    Value::Bool(value) => assert_eq!(*value.borrow(), true),
+    other => panic!("expected faux tilde fence to be ignored, got {:?}", other),
+  }
 }
 
 #[test]
 fn interpreter_scope_ignores_faux_backtick_fence_inside_tilde_code_block() {
-    let root = setup_modules(
-        "~~~mech:foo\n\
+  let root = setup_modules(
+    "~~~mech:foo\n\
 ok := true\n\
 <+ ok\n\
 ~~~\n\
@@ -3307,1652 +2142,964 @@ broken := missing\n\
 ~~~\n\
 \n\
 result := @foo/ok\n",
-    );
+  );
 
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
 
-    let result = runtime.run_module(version).unwrap();
+  let result = runtime.run_module(version).unwrap();
 
-    match result {
-        Value::Bool(value) => assert_eq!(*value.borrow(), true),
-        other => panic!(
-            "expected faux backtick fence to be ignored, got {:?}",
-            other
-        ),
-    }
+  match result {
+    Value::Bool(value) => assert_eq!(*value.borrow(), true),
+    other => panic!("expected faux backtick fence to be ignored, got {:?}", other),
+  }
 }
 
 #[test]
 fn manifest_context_import_materializes_without_source_dependency() {
-    let root = setup_modules("+> @ui := browser/dom\nx := 1\n");
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let record = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
+  let root = setup_modules("+> @ui := browser/dom\nx := 1\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let record = runtime.store().get_module_version(version).unwrap().unwrap();
 
-    assert_eq!(record.imports.len(), 1);
-    assert_eq!(record.import_edges.len(), 0);
-    assert_eq!(record.dependencies.len(), 0);
-    let program_scope = record
-        .scopes
-        .iter()
-        .find(|scope| scope.scope == SourceScope::Program)
-        .unwrap();
-    assert!(
-        program_scope
-            .contexts
-            .iter()
-            .any(|context| context.name == "ui")
-    );
-    assert!(record.contexts.iter().any(|context| context.name == "ui"));
+  assert_eq!(record.imports.len(), 1);
+  assert_eq!(record.import_edges.len(), 0);
+  assert_eq!(record.dependencies.len(), 0);
+  let program_scope = record.scopes.iter().find(|scope| scope.scope == SourceScope::Program).unwrap();
+  assert!(program_scope.contexts.iter().any(|context| context.name == "ui"));
+  assert!(record.contexts.iter().any(|context| context.name == "ui"));
 }
 
 #[test]
 fn manifest_context_import_is_visible_to_scoped_address_resolution() {
-    let root = setup_modules("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(
-        result.is_err(),
-        "expected resource/provider failure without browser provider"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        !error.contains("UnknownAddressTarget"),
-        "context import should be visible to address resolution, got {error}"
-    );
+  let root = setup_modules("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err(), "expected resource/provider failure without browser provider");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(!error.contains("UnknownAddressTarget"), "context import should be visible to address resolution, got {error}");
 }
 
 #[test]
 fn manifest_context_import_conflicts_with_interpreter_address_target() {
-    let root = setup_modules(
-        "+> @foo := browser/dom\n\n~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/counter/_text\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-    assert!(
-        result.is_err(),
-        "manifest context alias should conflict with interpreter target"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("AddressTargetNameConflict"),
-        "expected address target conflict, got {error}"
-    );
-    assert!(
-        error.contains("foo"),
-        "expected conflicting target name in error, got {error}"
-    );
+  let root = setup_modules("+> @foo := browser/dom\n\n~~~mech:foo\nok := true\n<+ ok\n~~~\n\nresult := @foo/counter/_text\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_err(), "manifest context alias should conflict with interpreter target");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("AddressTargetNameConflict"), "expected address target conflict, got {error}");
+  assert!(error.contains("foo"), "expected conflicting target name in error, got {error}");
 }
 
 #[test]
 fn context_import_alias_is_not_bound_as_value_import() {
-    let root = setup_modules("+> @ui := browser/dom\n+> ./math.mec\nresult := ui\n");
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let record = runtime
-        .store()
-        .get_module_version(version)
-        .unwrap()
-        .unwrap();
-    assert_eq!(record.imports.len(), 2);
-    assert_eq!(record.import_edges.len(), 1);
-    assert!(
-        record
-            .import_edges
-            .iter()
-            .all(|edge| !matches!(edge.import.alias, Some(SourceImportAlias::Context(_))))
-    );
+  let root = setup_modules("+> @ui := browser/dom\n+> ./math.mec\nresult := ui\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let record = runtime.store().get_module_version(version).unwrap().unwrap();
+  assert_eq!(record.imports.len(), 2);
+  assert_eq!(record.import_edges.len(), 1);
+  assert!(record.import_edges.iter().all(|edge| !matches!(edge.import.alias, Some(SourceImportAlias::Context(_)))));
 
-    let result = runtime.run_module(version);
-    assert!(
-        result.is_err(),
-        "context alias should not be available as a value binding"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("Undefined") || error.contains("Variable"),
-        "expected missing value binding error, got {error}"
-    );
+  let result = runtime.run_module(version);
+  assert!(result.is_err(), "context alias should not be available as a value binding");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("Undefined") || error.contains("Variable"), "expected missing value binding error, got {error}");
 }
 
 #[cfg(feature = "linked_stdlib")]
 #[test]
 fn direct_runtime_normal_import_is_not_dropped() {
-    let mut runtime = RuntimeBuilder::new().build().unwrap();
-    let result = runtime
-        .run_string("+> math/sin\nresult := sin(0)\n")
-        .unwrap();
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("+> math/sin\nresult := sin(0)\n").unwrap();
 
-    match result {
-        Value::F64(value) => assert_eq!(*value.borrow(), 0.0),
-        other => panic!("expected sin(0) to return 0.0, got {other:?}"),
-    }
+  match result {
+    Value::F64(value) => assert_eq!(*value.borrow(), 0.0),
+    other => panic!("expected sin(0) to return 0.0, got {other:?}"),
+  }
 }
 
 #[test]
 fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lowering() {
-    let mut runtime = RuntimeBuilder::new().build().unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "browser://dom",
-            "counter/_text",
-        ))
-        .unwrap();
-    let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
-    assert!(
-        result.is_err(),
-        "expected browser provider failure without a browser provider"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderNotFound"),
-        "expected browser provider lookup after recognizing @ui, got {error}"
-    );
-    assert!(
-        !error.contains("UnknownAddressTarget"),
-        "@ui should not be treated as an unknown address target: {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/_text")).unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+  assert!(result.is_err(), "expected browser provider failure without a browser provider");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected browser provider lookup after recognizing @ui, got {error}");
+  assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
 }
 
 #[test]
 fn direct_runtime_manifest_context_import_write_uses_provider_lookup() {
-    let mut runtime = RuntimeBuilder::new().build().unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "browser://dom",
-            "counter/_text",
-        ))
-        .unwrap();
-    let result = runtime.run_string(
-        "+> @ui := browser/dom
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "browser://dom", "counter/_text")).unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom
 @ui/counter/_text = \"hello\"
-",
-    );
-    assert!(
-        result.is_err(),
-        "browser write should reach provider lookup without a browser provider"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderNotFound"),
-        "expected provider lookup, got {error}"
-    );
-    assert!(
-        !error.contains("UnknownAddressTarget"),
-        "@ui should not be treated as an unknown address target: {error}"
-    );
+");
+  assert!(result.is_err(), "browser write should reach provider lookup without a browser provider");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeResourceProviderNotFound"), "expected provider lookup, got {error}");
+  assert!(!error.contains("UnknownAddressTarget"), "@ui should not be treated as an unknown address target: {error}");
 }
 
 #[test]
 fn repeated_manifest_context_alias_in_separate_fenced_scopes_is_legal() {
-    let root = setup_modules(
-        "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\n~~~mech:bar\n+> @ui := browser/dom\nb := @ui/counter/_text\n~~~\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let result = runtime.resolve_and_store_module_source("main.mec", module_options());
-    assert!(
-        result.is_ok(),
-        "same context alias in separate fenced scopes should be legal: {result:?}"
-    );
+  let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\n~~~mech:bar\n+> @ui := browser/dom\nb := @ui/counter/_text\n~~~\n");
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_store_module_source("main.mec", module_options());
+  assert!(result.is_ok(), "same context alias in separate fenced scopes should be legal: {result:?}");
 }
 
 #[test]
 fn manifest_context_import_in_fenced_scope_does_not_leak_to_program_scope() {
-    let root = setup_modules(
-        "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\nresult := @ui/counter/_text\n",
-    );
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version);
-    assert!(
-        result.is_err(),
-        "program scope should not see fenced @ui context import"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("UnknownAddressTarget"),
-        "expected scoped address-target failure, got {error}"
-    );
+  let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n\nresult := @ui/counter/_text\n");
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+  assert!(result.is_err(), "program scope should not see fenced @ui context import");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("UnknownAddressTarget"), "expected scoped address-target failure, got {error}");
 }
 
 #[test]
 fn resolving_module_with_fenced_context_import_does_not_pollute_direct_runtime_bindings() {
-    let root = setup_modules("~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n");
+  let root = setup_modules(
+    "~~~mech:foo\n+> @ui := browser/dom\na := @ui/counter/_text\n~~~\n"
+  );
 
-    let mut runtime = runtime_with_root(&root);
-    runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
 
-    let result = runtime.run_string("x := @ui/counter/_text\n");
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
+  let result = runtime.run_string("x := @ui/counter/_text\n");
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
 
-    assert!(
-        error.contains("UnknownAddressTarget") || error.contains("Undefined"),
-        "expected @ui not to exist in direct runtime scope, got {error}"
-    );
-    assert!(
-        !error.contains("RuntimeResourceProviderNotFound"),
-        "module resolution leaked @ui into global browser bindings: {error}"
-    );
+  assert!(
+    error.contains("UnknownAddressTarget") || error.contains("Undefined"),
+    "expected @ui not to exist in direct runtime scope, got {error}"
+  );
+  assert!(
+    !error.contains("RuntimeResourceProviderNotFound"),
+    "module resolution leaked @ui into global browser bindings: {error}"
+  );
 }
 
 #[test]
 fn fenced_context_alias_can_match_unrelated_interpreter_name_without_resolving_as_interpreter() {
-    let root = setup_modules(
-        "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\n+> @foo := browser/dom\nx := @foo/counter/_text\n~~~\n",
-    );
+  let root = setup_modules(
+    "~~~mech:foo\nok := true\n<+ ok\n~~~\n\n~~~mech:bar\n+> @foo := browser/dom\nx := @foo/counter/_text\n~~~\n"
+  );
 
-    let mut runtime = runtime_with_root(&root);
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
 
-    let result = runtime.run_module_scope(
-        version,
-        SourceScope::Interpreter(SourceInterpreterId {
-            namespace: hash_str("bar"),
-            namespace_str: "bar".to_string(),
-        }),
-    );
+  let result = runtime.run_module_scope(
+    version,
+    SourceScope::Interpreter(SourceInterpreterId {
+      namespace: hash_str("bar"),
+      namespace_str: "bar".to_string(),
+    }),
+  );
 
-    assert!(
-        result.is_err(),
-        "expected browser provider failure without browser provider"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourceProviderNotFound")
-            || error.contains("RuntimeCapabilityGrantDenied")
-            || error.contains("RuntimeResourceCapabilityDenied"),
-        "expected @foo in bar to resolve as context, not interpreter, got {error}"
-    );
-    assert!(
-        !error.contains("RuntimeModuleExportNotFound"),
-        "@foo in bar resolved as interpreter foo instead of local context: {error}"
-    );
+  assert!(result.is_err(), "expected browser provider failure without browser provider");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeResourceProviderNotFound")
+      || error.contains("RuntimeCapabilityGrantDenied")
+      || error.contains("RuntimeResourceCapabilityDenied"),
+    "expected @foo in bar to resolve as context, not interpreter, got {error}"
+  );
+  assert!(
+    !error.contains("RuntimeModuleExportNotFound"),
+    "@foo in bar resolved as interpreter foo instead of local context: {error}"
+  );
 }
 #[test]
 fn direct_runtime_context_addressed_slice_is_rejected_explicitly() {
-    let mut runtime = RuntimeBuilder::new().build().unwrap();
-    let result = runtime.run_string("+> @ui := browser/dom\nx := @ui/counter[0]\n");
-    assert!(
-        result.is_err(),
-        "context-addressed browser slices should be explicit until semantics are defined"
-    );
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("context-addressed slices are not supported"),
-        "expected explicit slice error, got {error}"
-    );
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom\nx := @ui/counter[0]\n");
+  assert!(result.is_err(), "context-addressed browser slices should be explicit until semantics are defined");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("context-addressed slices are not supported"), "expected explicit slice error, got {error}");
 }
 
 #[test]
 fn module_manifest_catalog_validates_builder_manifests() {
-    let invalids = [
-        ModuleManifestConfig {
-            name: "".to_string(),
-            exports: vec![],
-        },
-        ModuleManifestConfig {
-            name: "bad".to_string(),
-            exports: vec![ModuleManifestExportConfig {
-                name: "".to_string(),
-                kind: ModuleManifestExportKind::Context,
-                base_uri: "browser://dom".to_string(),
-                operations: vec!["read".to_string()],
-            }],
-        },
-        ModuleManifestConfig {
-            name: "bad".to_string(),
-            exports: vec![
-                ModuleManifestExportConfig {
-                    name: "dom".to_string(),
-                    kind: ModuleManifestExportKind::Context,
-                    base_uri: "browser://dom".to_string(),
-                    operations: vec!["read".to_string()],
-                },
-                ModuleManifestExportConfig {
-                    name: "dom".to_string(),
-                    kind: ModuleManifestExportKind::Context,
-                    base_uri: "browser://dom".to_string(),
-                    operations: vec!["write".to_string()],
-                },
-            ],
-        },
-        ModuleManifestConfig {
-            name: "bad".to_string(),
-            exports: vec![ModuleManifestExportConfig {
-                name: "dom".to_string(),
-                kind: ModuleManifestExportKind::Context,
-                base_uri: "browser-dom".to_string(),
-                operations: vec!["read".to_string()],
-            }],
-        },
-        ModuleManifestConfig {
-            name: "bad".to_string(),
-            exports: vec![ModuleManifestExportConfig {
-                name: "dom".to_string(),
-                kind: ModuleManifestExportKind::Context,
-                base_uri: "browser://dom".to_string(),
-                operations: vec![],
-            }],
-        },
-        ModuleManifestConfig {
-            name: "bad".to_string(),
-            exports: vec![ModuleManifestExportConfig {
-                name: "dom".to_string(),
-                kind: ModuleManifestExportKind::Context,
-                base_uri: "browser://dom".to_string(),
-                operations: vec!["list".to_string()],
-            }],
-        },
-    ];
+  let invalids = [
+    ModuleManifestConfig { name: "".to_string(), exports: vec![] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["read".to_string()] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["read".to_string()] }, ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["write".to_string()] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser-dom".to_string(), operations: vec!["read".to_string()] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec![] }] },
+    ModuleManifestConfig { name: "bad".to_string(), exports: vec![ModuleManifestExportConfig { name: "dom".to_string(), kind: ModuleManifestExportKind::Context, base_uri: "browser://dom".to_string(), operations: vec!["list".to_string()] }] },
+  ];
 
-    for manifest in invalids {
-        let result = RuntimeBuilder::new().module_manifest(manifest);
-        assert!(
-            result.is_err(),
-            "invalid manifest should be rejected by builder/catalog"
-        );
-    }
+  for manifest in invalids {
+    let result = RuntimeBuilder::new().module_manifest(manifest);
+    assert!(result.is_err(), "invalid manifest should be rejected by builder/catalog");
+  }
 }
+
 
 #[derive(Debug, Default)]
 struct RuntimeFakeCliState {
-    env: HashMap<String, String>,
-    stdout: Vec<String>,
-    stderr: Vec<String>,
-    env_reads: usize,
-    stdout_writes: usize,
-    stderr_writes: usize,
+  env: HashMap<String, String>,
+  stdout: Vec<String>,
+  stderr: Vec<String>,
+  env_reads: usize,
+  stdout_writes: usize,
+  stderr_writes: usize,
 }
 
 #[derive(Debug, Clone)]
 struct RuntimeFakeCliBackend {
-    state: Arc<Mutex<RuntimeFakeCliState>>,
+  state: Arc<Mutex<RuntimeFakeCliState>>,
 }
 
 impl RuntimeFakeCliBackend {
-    fn new(state: Arc<Mutex<RuntimeFakeCliState>>) -> Self {
-        Self { state }
-    }
+  fn new(state: Arc<Mutex<RuntimeFakeCliState>>) -> Self {
+    Self { state }
+  }
 }
 
 impl CliBackend for RuntimeFakeCliBackend {
-    fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
-        let mut state = self.state.lock().unwrap();
-        state.env_reads += 1;
-        Ok(state.env.get(name).cloned())
-    }
+  fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
+    let mut state = self.state.lock().unwrap();
+    state.env_reads += 1;
+    Ok(state.env.get(name).cloned())
+  }
 
-    fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
-        let mut state = self.state.lock().unwrap();
-        state.stdout_writes += 1;
-        state.stdout.push(text.to_string());
-        Ok(())
-    }
+  fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
+    let mut state = self.state.lock().unwrap();
+    state.stdout_writes += 1;
+    state.stdout.push(text.to_string());
+    Ok(())
+  }
 
-    fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
-        let mut state = self.state.lock().unwrap();
-        state.stderr_writes += 1;
-        state.stderr.push(text.to_string());
-        Ok(())
-    }
+  fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
+    let mut state = self.state.lock().unwrap();
+    state.stderr_writes += 1;
+    state.stderr.push(text.to_string());
+    Ok(())
+  }
 }
 
 fn runtime_with_fake_cli(state: Arc<Mutex<RuntimeFakeCliState>>) -> MechRuntime {
-    RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(
-            RuntimeFakeCliBackend::new(state),
-        )))
-        .build()
-        .unwrap()
+  RuntimeBuilder::new()
+    .resource_provider(Box::new(CliResourceProvider::new(RuntimeFakeCliBackend::new(state))))
+    .build()
+    .unwrap()
 }
 
 #[derive(Debug, Clone, Default)]
 struct FakeCliBackend {
-    env: std::collections::HashMap<String, String>,
-    stdout: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    stderr: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    calls: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+  env: std::collections::HashMap<String, String>,
+  stdout: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+  stderr: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+  calls: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl FakeCliBackend {
-    fn with_env(mut self, name: &str, value: &str) -> Self {
-        self.env.insert(name.to_string(), value.to_string());
-        self
-    }
+  fn with_env(mut self, name: &str, value: &str) -> Self {
+    self.env.insert(name.to_string(), value.to_string());
+    self
+  }
 }
 
 impl CliBackend for FakeCliBackend {
-    fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
-        self.calls.lock().unwrap().push(format!("env:{name}"));
-        Ok(self.env.get(name).cloned())
-    }
+  fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
+    self.calls.lock().unwrap().push(format!("env:{name}"));
+    Ok(self.env.get(name).cloned())
+  }
 
-    fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
-        self.calls.lock().unwrap().push(format!("stdout:{text}"));
-        self.stdout.lock().unwrap().push(text.to_string());
-        Ok(())
-    }
+  fn write_stdout(&mut self, text: &str) -> mech_core::MResult<()> {
+    self.calls.lock().unwrap().push(format!("stdout:{text}"));
+    self.stdout.lock().unwrap().push(text.to_string());
+    Ok(())
+  }
 
-    fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
-        self.calls.lock().unwrap().push(format!("stderr:{text}"));
-        self.stderr.lock().unwrap().push(text.to_string());
-        Ok(())
-    }
+  fn write_stderr(&mut self, text: &str) -> mech_core::MResult<()> {
+    self.calls.lock().unwrap().push(format!("stderr:{text}"));
+    self.stderr.lock().unwrap().push(text.to_string());
+    Ok(())
+  }
 }
+
 
 #[test]
 fn cli_manifest_env_import_reads_through_runtime() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    state
-        .lock()
-        .unwrap()
-        .env
-        .insert("HOME".to_string(), "/tmp/home".to_string());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  state.lock().unwrap().env.insert("HOME".to_string(), "/tmp/home".to_string());
 
-    let mut runtime = runtime_with_fake_cli(state.clone());
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
+  let mut runtime = runtime_with_fake_cli(state.clone());
+  runtime
+    .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
+    .unwrap();
 
-    let result = runtime
-        .run_string(
-            "+> @env := cli/env
+  let result = runtime
+    .run_string("+> @env := cli/env
 @env/HOME
-",
-        )
-        .unwrap();
+")
+    .unwrap();
 
-    let result = match result {
-        Value::MutableReference(value) => value.borrow().clone(),
-        other => other,
-    };
-    match result {
-        Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/home"),
-        other => panic!("expected HOME string from cli env, got {:?}", other),
-    }
+  let result = match result {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  match result {
+    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/home"),
+    other => panic!("expected HOME string from cli env, got {:?}", other),
+  }
 
-    assert_eq!(state.lock().unwrap().env_reads, 1);
+  assert_eq!(state.lock().unwrap().env_reads, 1);
 }
 
 #[test]
 fn cli_manifest_stdout_send_line_writes_through_runtime() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    let mut runtime = runtime_with_fake_cli(state.clone());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
 
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
 
-    runtime
-        .run_string(
-            "+> @out := cli/stdout
+  runtime
+    .run_string("+> @out := cli/stdout
 @out/line <- \"hello\"
-",
-        )
-        .unwrap();
+")
+    .unwrap();
 
-    let state = state.lock().unwrap();
-    assert_eq!(state.stdout, vec!["hello\n".to_string()]);
-    assert_eq!(state.stdout_writes, 1);
+  let state = state.lock().unwrap();
+  assert_eq!(state.stdout, vec!["hello\n".to_string()]);
+  assert_eq!(state.stdout_writes, 1);
 }
 
 #[test]
 fn cli_manifest_stderr_send_text_writes_through_runtime() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    let mut runtime = runtime_with_fake_cli(state.clone());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
 
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stderr",
-            "text",
-        ))
-        .unwrap();
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text"))
+    .unwrap();
 
-    runtime
-        .run_string(
-            "+> @err := cli/stderr
+  runtime
+    .run_string("+> @err := cli/stderr
 @err/text <- \"warning\"
-",
-        )
-        .unwrap();
+")
+    .unwrap();
 
-    let state = state.lock().unwrap();
-    assert_eq!(state.stderr, vec!["warning".to_string()]);
-    assert_eq!(state.stderr_writes, 1);
+  let state = state.lock().unwrap();
+  assert_eq!(state.stderr, vec!["warning".to_string()]);
+  assert_eq!(state.stderr_writes, 1);
 }
 
 #[test]
 fn cli_stdout_assignment_errors_and_writes_nothing() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    let mut runtime = runtime_with_fake_cli(state.clone());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
 
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
 
-    let result = runtime.run_string(
-        "+> @out := cli/stdout
+  let result = runtime.run_string("+> @out := cli/stdout
 @out/line = \"hello\"
-",
-    );
+");
 
-    assert!(result.is_err());
-    let state = state.lock().unwrap();
-    assert!(state.stdout.is_empty());
-    assert_eq!(state.stdout_writes, 0);
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert!(state.stdout.is_empty());
+  assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]
 fn cli_stdout_define_errors_and_writes_nothing() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    let mut runtime = runtime_with_fake_cli(state.clone());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
 
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
 
-    let result = runtime.run_string(
-        "+> @out := cli/stdout
+  let result = runtime.run_string("+> @out := cli/stdout
 @out/line := \"hello\"
-",
-    );
+");
 
-    assert!(result.is_err());
-    let state = state.lock().unwrap();
-    assert!(state.stdout.is_empty());
-    assert_eq!(state.stdout_writes, 0);
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert!(state.stdout.is_empty());
+  assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]
 fn cli_env_send_errors() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    let mut runtime = runtime_with_fake_cli(state.clone());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
 
-    runtime
-        .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
+    .unwrap();
 
-    let result = runtime.run_string(
-        "+> @env := cli/env
+  let result = runtime.run_string("+> @env := cli/env
 @env/HOME <- \"x\"
-",
-    );
+");
 
-    assert!(result.is_err());
-    let state = state.lock().unwrap();
-    assert_eq!(state.env_reads, 0);
-    assert_eq!(state.stdout_writes, 0);
-    assert_eq!(state.stderr_writes, 0);
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert_eq!(state.env_reads, 0);
+  assert_eq!(state.stdout_writes, 0);
+  assert_eq!(state.stderr_writes, 0);
 }
 
 #[test]
 fn cli_stdout_missing_write_grant_fails_before_backend() {
-    let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
-    let mut runtime = runtime_with_fake_cli(state.clone());
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  let mut runtime = runtime_with_fake_cli(state.clone());
 
-    let result = runtime.run_string(
-        "+> @out := cli/stdout
+  let result = runtime.run_string("+> @out := cli/stdout
 @out/line <- \"hello\"
-",
-    );
+");
 
-    assert!(result.is_err());
-    let state = state.lock().unwrap();
-    assert!(state.stdout.is_empty());
-    assert_eq!(state.stdout_writes, 0);
+  assert!(result.is_err());
+  let state = state.lock().unwrap();
+  assert!(state.stdout.is_empty());
+  assert_eq!(state.stdout_writes, 0);
 }
 
 #[test]
 fn cli_host_env_manifest_import_reads_with_runtime_grant() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/mech-home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    runtime
-        .run_string("+> @env := cli/env\nhome := @env/HOME\n")
-        .unwrap();
-    let id = hash_str("home");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    match value {
-        Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/mech-home"),
-        other => panic!("expected string home, got {other:?}"),
-    }
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/mech-home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
+  let id = hash_str("home");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  match value {
+    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/mech-home"),
+    other => panic!("expected string home, got {other:?}"),
+  }
 }
 
 #[test]
 fn cli_host_stdout_send_writes_line_with_runtime_grant() {
-    let backend = FakeCliBackend::default();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
-    runtime
-        .run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n")
-        .unwrap();
-    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n").unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
 #[test]
 fn cli_host_stderr_send_writes_text_with_runtime_grant() {
-    let backend = FakeCliBackend::default();
-    let stderr = backend.stderr.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stderr",
-            "text",
-        ))
-        .unwrap();
-    runtime
-        .run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n")
-        .unwrap();
-    assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
+  let backend = FakeCliBackend::default();
+  let stderr = backend.stderr.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text")).unwrap();
+  runtime.run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n").unwrap();
+  assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
 }
 
 #[test]
 fn cli_host_stdout_assignment_errors_and_writes_nothing() {
-    let backend = FakeCliBackend::default();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
-    let result = runtime.run_string("+> @out := cli/stdout\n@out/line = \"hello\"\n");
-    assert!(result.is_err(), "stdout assignment should error");
-    assert!(
-        stdout.lock().unwrap().is_empty(),
-        "stdout assignment should not write"
-    );
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n@out/line = \"hello\"\n");
+  assert!(result.is_err(), "stdout assignment should error");
+  assert!(stdout.lock().unwrap().is_empty(), "stdout assignment should not write");
 }
 
 #[test]
 fn cli_host_stdout_definition_errors_and_writes_nothing() {
-    let backend = FakeCliBackend::default();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
-    let result = runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n");
-    assert!(result.is_err(), "stdout definition should error");
-    assert!(
-        stdout.lock().unwrap().is_empty(),
-        "stdout definition should not write"
-    );
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n@out/line := \"hello\"\n");
+  assert!(result.is_err(), "stdout definition should error");
+  assert!(stdout.lock().unwrap().is_empty(), "stdout definition should not write");
 }
 
 #[test]
 fn cli_host_env_send_errors() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    let result = runtime.run_string("+> @env := cli/env\n@env/HOME <- \"x\"\n");
-    assert!(result.is_err(), "env send should error");
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME")).unwrap();
+  let result = runtime.run_string("+> @env := cli/env\n@env/HOME <- \"x\"\n");
+  assert!(result.is_err(), "env send should error");
 }
 
 #[test]
 fn cli_host_missing_env_read_grant_fails_before_backend_call() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-    let calls = backend.calls.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    let result = runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n");
-    assert!(
-        result.is_err(),
-        "env read without runtime grant should fail"
-    );
-    assert!(
-        calls.lock().unwrap().is_empty(),
-        "backend should not be called without read grant"
-    );
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let calls = backend.calls.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  let result = runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n");
+  assert!(result.is_err(), "env read without runtime grant should fail");
+  assert!(calls.lock().unwrap().is_empty(), "backend should not be called without read grant");
 }
 
 #[test]
 fn cli_host_missing_stdout_write_grant_fails_before_backend_call() {
-    let backend = FakeCliBackend::default();
-    let calls = backend.calls.clone();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    let result = runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
-    assert!(
-        result.is_err(),
-        "stdout send without runtime grant should fail"
-    );
-    assert!(
-        calls.lock().unwrap().is_empty(),
-        "backend should not be called without write grant"
-    );
-    assert!(
-        stdout.lock().unwrap().is_empty(),
-        "stdout should not be written without grant"
-    );
+  let backend = FakeCliBackend::default();
+  let calls = backend.calls.clone();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
+  assert!(result.is_err(), "stdout send without runtime grant should fail");
+  assert!(calls.lock().unwrap().is_empty(), "backend should not be called without write grant");
+  assert!(stdout.lock().unwrap().is_empty(), "stdout should not be written without grant");
 }
 
 #[test]
 fn cli_host_missing_stderr_write_grant_fails_before_backend_call() {
-    let backend = FakeCliBackend::default();
-    let calls = backend.calls.clone();
-    let stderr = backend.stderr.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    let result = runtime.run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n");
-    assert!(
-        result.is_err(),
-        "stderr send without runtime grant should fail"
-    );
-    assert!(
-        calls.lock().unwrap().is_empty(),
-        "backend should not be called without write grant"
-    );
-    assert!(
-        stderr.lock().unwrap().is_empty(),
-        "stderr should not be written without grant"
-    );
-}
-
-#[test]
-fn cli_host_direct_env_declaration_reads_with_runtime_grant() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/direct-home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    runtime
-        .run_string("@env := cli://env{:read(HOME)}\nhome := @env/HOME\n")
-        .unwrap();
-    let id = hash_str("home");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    assert_string_value(value, "/tmp/direct-home");
-}
-
-#[test]
-fn cli_host_direct_stdout_declaration_sends_with_runtime_grant() {
-    let backend = FakeCliBackend::default();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
-    runtime
-        .run_string("@out := cli://stdout{:write(line)}\n@out/line <- \"hello\"\n")
-        .unwrap();
-    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
-}
-
-#[test]
-fn cli_host_direct_stderr_declaration_sends_with_runtime_grant() {
-    let backend = FakeCliBackend::default();
-    let stderr = backend.stderr.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stderr",
-            "text",
-        ))
-        .unwrap();
-    runtime
-        .run_string("@err := cli://stderr{:write(text)}\n@err/text <- \"warning\"\n")
-        .unwrap();
-    assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
-}
-
-#[test]
-fn cli_host_env_assignment_errors() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    let result = runtime.run_string("+> @env := cli/env\n@env/HOME = \"x\"\n");
-    assert!(result.is_err(), "env assignment should error");
-}
-
-#[test]
-fn cli_host_stdout_read_errors() {
-    let backend = FakeCliBackend::default();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://stdout", "line"))
-        .unwrap();
-    let result = runtime.run_string("+> @out := cli/stdout\nx := @out/line\n");
-    assert!(result.is_err(), "stdout read should error");
-}
-
-#[test]
-fn cli_context_module_read_exports_value() {
-    let root = setup_modules("+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n");
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/module-home");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-    let result = match result {
-        Value::MutableReference(value) => value.borrow().clone(),
-        other => other,
-    };
-    match result {
-        Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/module-home"),
-        other => panic!("expected string home, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_context_module_send_is_not_stripped() {
-    let root = setup_modules("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
-    let backend = FakeCliBackend::default();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    runtime.run_module(version).unwrap();
-    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
-}
-
-#[derive(Debug, Clone)]
-struct RecordingResourceProvider {
-    scheme: &'static str,
-    bases: Vec<String>,
-    values: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Value>>>,
-    writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
-}
-
-impl RecordingResourceProvider {
-    fn new(scheme: &'static str, bases: &[&str]) -> Self {
-        Self {
-            scheme,
-            bases: bases.iter().map(|base| base.to_string()).collect(),
-            values: Default::default(),
-            writes: Default::default(),
-        }
-    }
-
-    fn with_value(self, base: &str, path: &str, value: Value) -> Self {
-        self.values
-            .lock()
-            .unwrap()
-            .insert(format!("{base}|{path}"), value);
-        self
-    }
-}
-
-impl RuntimeResourceProvider for RecordingResourceProvider {
-    fn scheme(&self) -> &str {
-        self.scheme
-    }
-
-    fn base_uris(&self) -> Vec<String> {
-        self.bases.clone()
-    }
-
-    fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
-        self.values
-            .lock()
-            .unwrap()
-            .get(&format!("{}|{}", request.base_uri, request.path))
-            .cloned()
-            .ok_or_else(|| {
-                mech_core::MechError::new(
-                    RuntimeResourcePathNotFound {
-                        base_uri: request.base_uri,
-                        path: request.path,
-                    },
-                    None,
-                )
-            })
-    }
-
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
-        self.writes.lock().unwrap().push((
-            request.base_uri.clone(),
-            request.path.clone(),
-            request.value.clone(),
-        ));
-        self.values.lock().unwrap().insert(
-            format!("{}|{}", request.base_uri, request.path),
-            request.value,
-        );
-        Ok(())
-    }
-}
-
-fn assert_string_value(value: Value, expected: &str) {
-    let value = match value {
-        Value::MutableReference(value) => value.borrow().clone(),
-        other => other,
-    };
-    match value {
-        Value::String(value) => assert_eq!(&*value.borrow(), expected),
-        other => panic!("expected string value `{expected}`, got {other:?}"),
-    }
-}
-
-#[test]
-fn cli_context_direct_read_resolves_inside_formula_expression() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    runtime
-        .run_string("+> @env := cli/env\nmsg := \"HOME=\" + @env/HOME\n")
-        .unwrap();
-    let id = hash_str("msg");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    assert_string_value(value, "HOME=/tmp/home");
-}
-
-#[test]
-fn cli_context_standalone_expression_returns_env_value() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    let value = runtime
-        .run_string("+> @env := cli/env\n@env/HOME\n")
-        .unwrap();
-    assert_string_value(value, "/tmp/home");
-}
-
-#[test]
-fn docs_context_send_errors_and_does_not_write() {
-    let mut runtime = RuntimeBuilder::new()
-        .in_memory_docs(InMemoryDocsProvider::new())
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-
-    let result = runtime.run_string("@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title <- \"hello\"\n");
-    assert!(result.is_err(), "docs context send should error");
-
-    let read_result = runtime.run_string(
-        "@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n",
-    );
-    assert!(
-        read_result.is_err(),
-        "docs send should not write a readable value"
-    );
-    let error = format!("{:?}", read_result.err().unwrap());
-    assert!(
-        error.contains("RuntimeResourcePathNotFound"),
-        "expected missing docs path after failed send, got {error}"
-    );
-}
-
-#[test]
-fn docs_context_write_requires_runtime_grant_before_provider_write() {
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-    let writes = provider.writes.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-    let result = runtime.run_string(
-        "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
-    );
-    assert!(result.is_err(), "write without host grant should fail");
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(
-        error.contains("RuntimeCapabilityGrantDenied"),
-        "expected host grant denial, got {error}"
-    );
-    assert!(
-        writes.lock().unwrap().is_empty(),
-        "provider write should not be called without grant"
-    );
-}
-
-#[test]
-fn docs_context_write_with_runtime_grant_reaches_provider() {
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-    let writes = provider.writes.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    runtime
-        .run_string(
-            "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
-        )
-        .unwrap();
-    let writes = writes.lock().unwrap();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].0, "docs://manual");
-    assert_eq!(writes[0].1, "intro/title");
-    assert_string_value(writes[0].2.clone(), "hello");
-}
-
-#[test]
-fn browser_context_subroot_normalizes_to_provider_base_path() {
-    let provider = RecordingResourceProvider::new("browser", &["browser://dom"]).with_value(
-        "browser://dom",
-        "counter/text",
-        Value::String(Ref::new("count".to_string())),
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "browser://dom",
-            "counter/text",
-        ))
-        .unwrap();
-    runtime
-        .run_string("@ui := browser://dom/counter{:read(text)}\ntitle := @ui/text\n")
-        .unwrap();
-    let id = hash_str("title");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    assert_string_value(value, "count");
-}
-
-#[test]
-fn docs_context_subroot_normalizes_to_provider_base_path() {
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]).with_value(
-        "docs://manual",
-        "intro/title",
-        Value::String(Ref::new("Manual".to_string())),
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    runtime
-        .run_string("@manual := docs://manual/intro{:read(title)}\ntitle := @manual/title\n")
-        .unwrap();
-    let id = hash_str("title");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    assert_string_value(value, "Manual");
-}
-
-#[test]
-fn context_write_uses_active_runtime_context_subject() {
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-    let writes = provider.writes.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-    let mut context = runtime
-        .runtime_context()
-        .unwrap()
-        .with_subject("task://custom");
-
-    runtime
-        .grant_capability(runtime_write_grant_for(
-            "task://custom",
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
-        )
-        .unwrap();
-
-    assert_eq!(writes.lock().unwrap().len(), 1);
-}
-
-#[test]
-fn context_write_does_not_accept_grant_for_default_subject_when_context_subject_differs() {
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-    let writes = provider.writes.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-    runtime
-        .grant_capability(runtime_write_grant_for(
-            "task://main",
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    let mut context = runtime
-        .runtime_context()
-        .unwrap()
-        .with_subject("task://custom");
-
-    let result = runtime.run_string_with_context(
-        &mut context,
-        "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
-    );
-
-    assert!(result.is_err());
-    let error = format!("{:?}", result.err().unwrap());
-    assert!(error.contains("RuntimeCapabilityGrantDenied"));
-    assert!(writes.lock().unwrap().is_empty());
-}
-
-#[test]
-fn unqualified_fenced_context_import_is_available_to_program_execution() {
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/fenced-home");
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-    let mut context = runtime
-        .runtime_context()
-        .unwrap()
-        .with_subject("task://fenced");
-    runtime
-        .grant_capability(RuntimeCapabilityGrant {
-            subject: "task://fenced".to_string(),
-            resource: "cli://env".to_string(),
-            operations: vec![RuntimeCapabilityOperation::Read],
-            paths: vec!["HOME".to_string()],
-        })
-        .unwrap();
-
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "```mech
-+> @env := cli/env
-home := @env/HOME
-```
-",
-        )
-        .unwrap();
-
-    let id = hash_str("home");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    assert_string_value(value, "/tmp/fenced-home");
-}
-
-#[test]
-fn named_fenced_context_import_write_uses_context_registry() {
-    let root = setup_modules("~~~mech:bar\n+> @out := cli/stdout\n@out/line <- \"hello\"\n~~~\n");
-    let backend = FakeCliBackend::default();
-    let stdout = backend.stdout.clone();
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "cli://stdout",
-            "line",
-        ))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-
-    runtime
-        .run_module_scope(
-            version,
-            SourceScope::Interpreter(SourceInterpreterId {
-                namespace: hash_str("bar"),
-                namespace_str: "bar".to_string(),
-            }),
-        )
-        .unwrap();
-
-    assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
-}
-
-#[test]
-fn named_fenced_context_import_read_exports_value() {
-    let root =
-        setup_modules("~~~mech:bar\n+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n~~~\n");
-    let backend = FakeCliBackend::default().with_env("HOME", "/tmp/named-fence-home");
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap();
-
-    runtime
-        .grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME"))
-        .unwrap();
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-
-    let result = runtime
-        .run_module_scope(
-            version,
-            SourceScope::Interpreter(SourceInterpreterId {
-                namespace: hash_str("bar"),
-                namespace_str: "bar".to_string(),
-            }),
-        )
-        .unwrap();
-
-    assert_string_value(result, "/tmp/named-fence-home");
-}
-
-#[test]
-fn module_context_read_after_context_write_uses_execution_order() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"hello\"\nresult := @manual/intro/title\n<+ result\nresult\n",
-    );
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-
-    assert_string_value(result, "hello");
-}
-
-#[test]
-fn module_context_read_after_context_write_ignores_stale_provider_value() {
-    let root = setup_modules(
-        "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"new\"\nresult := @manual/intro/title\n<+ result\nresult\n",
-    );
-    let provider = RecordingResourceProvider::new("docs", &["docs://manual"]).with_value(
-        "docs://manual",
-        "intro/title",
-        Value::String(Ref::new("old".to_string())),
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .source_resolver(FileSourceResolver::new(&root))
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-
-    runtime
-        .grant_capability(runtime_context_write_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://manual",
-            "intro/title",
-        ))
-        .unwrap();
-
-    let version = runtime
-        .resolve_and_store_module_source("main.mec", module_options())
-        .unwrap()
-        .unwrap();
-    let result = runtime.run_module(version).unwrap();
-
-    assert_string_value(result, "new");
-}
-
-#[test]
-fn direct_context_read_resolves_inside_op_assign() {
-    let provider = RecordingResourceProvider::new("docs", &["docs://numbers"]).with_value(
-        "docs://numbers",
-        "increment",
-        Value::F64(Ref::new(2.0)),
-    );
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap();
-
-    runtime
-        .grant_capability(runtime_context_read_grant(
-            &runtime,
-            "docs://numbers",
-            "increment",
-        ))
-        .unwrap();
-
-    runtime.run_string("@numbers := docs://numbers{:read(increment)}\n~total := 1.0\ntotal += @numbers/increment\n").unwrap();
-
-    let id = hash_str("total");
-    let value = runtime
-        .program()
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(id)
-        .unwrap()
-        .borrow()
-        .clone();
-    match value {
-        Value::F64(value) => assert_eq!(*value.borrow(), 3.0),
-        other => panic!("expected f64 total, got {other:?}"),
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-struct CountingCliBackend {
-    env_reads: Arc<Mutex<usize>>,
-    stdout_writes: Arc<Mutex<usize>>,
-    stderr_writes: Arc<Mutex<usize>>,
-}
-
-impl CliBackend for CountingCliBackend {
-    fn env_var(&self, name: &str) -> mech_core::MResult<Option<String>> {
-        *self.env_reads.lock().unwrap() += 1;
-        Ok(Some(format!("value-{name}")))
-    }
-
-    fn write_stdout(&mut self, _text: &str) -> mech_core::MResult<()> {
-        *self.stdout_writes.lock().unwrap() += 1;
-        Ok(())
-    }
-
-    fn write_stderr(&mut self, _text: &str) -> mech_core::MResult<()> {
-        *self.stderr_writes.lock().unwrap() += 1;
-        Ok(())
-    }
-}
-
-fn cli_runtime_with_backend(backend: CountingCliBackend) -> MechRuntime {
-    RuntimeBuilder::new()
-        .resource_provider(Box::new(CliResourceProvider::new(backend)))
-        .build()
-        .unwrap()
+  let backend = FakeCliBackend::default();
+  let calls = backend.calls.clone();
+  let stderr = backend.stderr.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  let result = runtime.run_string("+> @err := cli/stderr\n@err/text <- \"warning\"\n");
+  assert!(result.is_err(), "stderr send without runtime grant should fail");
+  assert!(calls.lock().unwrap().is_empty(), "backend should not be called without write grant");
+  assert!(stderr.lock().unwrap().is_empty(), "stderr should not be written without grant");
 }
 
 #[test]
 fn default_cli_stdout_grant_allows_send() {
-    let backend = CountingCliBackend::default();
-    let writes = backend.stdout_writes.clone();
-    let mut runtime = cli_runtime_with_backend(backend);
-    let grant = runtime_context_write_grant(&runtime, "cli://stdout", "line");
-    runtime.grant_capability(grant).unwrap();
-
-    runtime
-        .run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n")
-        .unwrap();
-
-    assert_eq!(*writes.lock().unwrap(), 1);
-}
-
-#[test]
-fn missing_stdout_grant_fails_before_provider_write() {
-    let backend = CountingCliBackend::default();
-    let writes = backend.stdout_writes.clone();
-    let mut runtime = cli_runtime_with_backend(backend);
-
-    let result = runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
-
-    assert!(result.is_err());
-    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
-    assert_eq!(*writes.lock().unwrap(), 0);
-}
-
-#[test]
-fn missing_env_grant_fails_before_provider_read() {
-    let backend = CountingCliBackend::default();
-    let reads = backend.env_reads.clone();
-    let mut runtime = cli_runtime_with_backend(backend);
-
-    let result = runtime.run_string("+> @env := cli/env\nx := @env/PATH\n");
-
-    assert!(result.is_err());
-    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
-    assert_eq!(*reads.lock().unwrap(), 0);
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "text")).unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n").unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
 #[test]
 fn narrow_env_grant_permits_path_but_denies_home() {
-    let backend = CountingCliBackend::default();
-    let mut runtime = cli_runtime_with_backend(backend);
-    let grant = runtime_context_read_grant(&runtime, "cli://env", "PATH");
-    runtime.grant_capability(grant).unwrap();
-
-    runtime
-        .run_string("+> @env := cli/env\nx := @env/PATH\n")
-        .unwrap();
-    let result = runtime.run_string("+> @env := cli/env\nx := @env/HOME\n");
-    assert!(result.is_err());
-    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+  let backend = FakeCliBackend::default().with_env("PATH", "/bin").with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "PATH")).unwrap();
+  runtime.run_string("+> @env := cli/env\npath := @env/PATH\n").unwrap();
+  let result = runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n");
+  assert!(result.is_err());
+  assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
 }
 
 #[test]
 fn narrow_stdout_grant_permits_line_but_denies_text() {
-    let backend = CountingCliBackend::default();
-    let mut runtime = cli_runtime_with_backend(backend);
-    let grant = runtime_context_write_grant(&runtime, "cli://stdout", "line");
-    runtime.grant_capability(grant).unwrap();
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n").unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n@out/text <- \"bad\"\n");
+  assert!(result.is_err());
+  assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+}
 
-    runtime
-        .run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n")
-        .unwrap();
-    let result = runtime.run_string("+> @out := cli/stdout\n@out/text <- \"bad\"\n");
-    assert!(result.is_err());
-    assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+
+#[test]
+fn cli_host_direct_env_declaration_reads_with_runtime_grant() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/direct-home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  runtime.run_string("@env := cli://env{:read(HOME)}\nhome := @env/HOME\n").unwrap();
+  let id = hash_str("home");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "/tmp/direct-home");
+}
+
+#[test]
+fn cli_host_direct_stdout_declaration_sends_with_runtime_grant() {
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.run_string("@out := cli://stdout{:write(line)}\n@out/line <- \"hello\"\n").unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+}
+
+#[test]
+fn cli_host_direct_stderr_declaration_sends_with_runtime_grant() {
+  let backend = FakeCliBackend::default();
+  let stderr = backend.stderr.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stderr", "text")).unwrap();
+  runtime.run_string("@err := cli://stderr{:write(text)}\n@err/text <- \"warning\"\n").unwrap();
+  assert_eq!(stderr.lock().unwrap().as_slice(), &["warning".to_string()]);
+}
+
+#[test]
+fn cli_host_env_assignment_errors() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://env", "HOME")).unwrap();
+  let result = runtime.run_string("+> @env := cli/env\n@env/HOME = \"x\"\n");
+  assert!(result.is_err(), "env assignment should error");
+}
+
+#[test]
+fn cli_host_stdout_read_errors() {
+  let backend = FakeCliBackend::default();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\nx := @out/line\n");
+  assert!(result.is_err(), "stdout read should error");
+}
+
+#[test]
+fn cli_context_module_read_exports_value() {
+  let root = setup_modules("+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n");
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/module-home");
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+  let result = match result {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  match result {
+    Value::String(value) => assert_eq!(&*value.borrow(), "/tmp/module-home"),
+    other => panic!("expected string home, got {other:?}"),
+  }
+}
+
+#[test]
+fn cli_context_module_send_is_not_stripped() {
+  let root = setup_modules("+> @out := cli/stdout\n@out/line <- \"hello\"\n");
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  runtime.run_module(version).unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+}
+
+#[derive(Debug, Clone)]
+struct RecordingResourceProvider {
+  scheme: &'static str,
+  bases: Vec<String>,
+  values: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Value>>>,
+  writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
+}
+
+impl RecordingResourceProvider {
+  fn new(scheme: &'static str, bases: &[&str]) -> Self {
+    Self {
+      scheme,
+      bases: bases.iter().map(|base| base.to_string()).collect(),
+      values: Default::default(),
+      writes: Default::default(),
+    }
+  }
+
+  fn with_value(self, base: &str, path: &str, value: Value) -> Self {
+    self.values.lock().unwrap().insert(format!("{base}|{path}"), value);
+    self
+  }
+}
+
+impl RuntimeResourceProvider for RecordingResourceProvider {
+  fn scheme(&self) -> &str { self.scheme }
+
+  fn base_uris(&self) -> Vec<String> { self.bases.clone() }
+
+  fn read(&self, request: RuntimeResourceReadRequest) -> mech_core::MResult<Value> {
+    self.values
+      .lock()
+      .unwrap()
+      .get(&format!("{}|{}", request.base_uri, request.path))
+      .cloned()
+      .ok_or_else(|| mech_core::MechError::new(RuntimeResourcePathNotFound { base_uri: request.base_uri, path: request.path }, None))
+  }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
+    self.writes.lock().unwrap().push((request.base_uri.clone(), request.path.clone(), request.value.clone()));
+    self.values.lock().unwrap().insert(format!("{}|{}", request.base_uri, request.path), request.value);
+    Ok(())
+  }
+}
+
+fn assert_string_value(value: Value, expected: &str) {
+  let value = match value {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  match value {
+    Value::String(value) => assert_eq!(&*value.borrow(), expected),
+    other => panic!("expected string value `{expected}`, got {other:?}"),
+  }
+}
+
+#[test]
+fn cli_context_direct_read_resolves_inside_formula_expression() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  runtime.run_string("+> @env := cli/env\nmsg := \"HOME=\" + @env/HOME\n").unwrap();
+  let id = hash_str("msg");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "HOME=/tmp/home");
+}
+
+#[test]
+fn cli_context_standalone_expression_returns_env_value() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  let value = runtime.run_string("+> @env := cli/env\n@env/HOME\n").unwrap();
+  assert_string_value(value, "/tmp/home");
+}
+
+
+#[test]
+fn docs_context_send_errors_and_does_not_write() {
+  let mut runtime = RuntimeBuilder::new().in_memory_docs(InMemoryDocsProvider::new()).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+
+  let result = runtime.run_string("@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title <- \"hello\"\n");
+  assert!(result.is_err(), "docs context send should error");
+
+  let read_result = runtime.run_string("@manual := docs://manual{:read(intro/title)}\nresult := @manual/intro/title\n");
+  assert!(read_result.is_err(), "docs send should not write a readable value");
+  let error = format!("{:?}", read_result.err().unwrap());
+  assert!(error.contains("RuntimeResourcePathNotFound"), "expected missing docs path after failed send, got {error}");
+}
+
+#[test]
+fn docs_context_write_requires_runtime_grant_before_provider_write() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  let result = runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n");
+  assert!(result.is_err(), "write without host grant should fail");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected host grant denial, got {error}");
+  assert!(writes.lock().unwrap().is_empty(), "provider write should not be called without grant");
+}
+
+#[test]
+fn docs_context_write_with_runtime_grant_reaches_provider() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.run_string("@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n").unwrap();
+  let writes = writes.lock().unwrap();
+  assert_eq!(writes.len(), 1);
+  assert_eq!(writes[0].0, "docs://manual");
+  assert_eq!(writes[0].1, "intro/title");
+  assert_string_value(writes[0].2.clone(), "hello");
+}
+
+#[test]
+fn browser_context_subroot_normalizes_to_provider_base_path() {
+  let provider = RecordingResourceProvider::new("browser", &["browser://dom"])
+    .with_value("browser://dom", "counter/text", Value::String(Ref::new("count".to_string())));
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/text")).unwrap();
+  runtime.run_string("@ui := browser://dom/counter{:read(text)}\ntitle := @ui/text\n").unwrap();
+  let id = hash_str("title");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "count");
+}
+
+#[test]
+fn docs_context_subroot_normalizes_to_provider_base_path() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
+    .with_value("docs://manual", "intro/title", Value::String(Ref::new("Manual".to_string())));
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.run_string("@manual := docs://manual/intro{:read(title)}\ntitle := @manual/title\n").unwrap();
+  let id = hash_str("title");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "Manual");
+}
+
+
+#[test]
+fn context_write_uses_active_runtime_context_subject() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("task://custom");
+
+  runtime.grant_capability(runtime_write_grant_for("task://custom", "docs://manual", "intro/title")).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
+  ).unwrap();
+
+  assert_eq!(writes.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn context_write_does_not_accept_grant_for_default_subject_when_context_subject_differs() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let writes = provider.writes.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(provider)).build().unwrap();
+  runtime.grant_capability(runtime_write_grant_for("task://main", "docs://manual", "intro/title")).unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("task://custom");
+
+  let result = runtime.run_string_with_context(
+    &mut context,
+    "@manual := docs://manual{:write(intro/title)}\n@manual/intro/title = \"hello\"\n",
+  );
+
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"));
+  assert!(writes.lock().unwrap().is_empty());
+}
+
+#[test]
+fn unqualified_fenced_context_import_is_available_to_program_execution() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/fenced-home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  let mut context = runtime.runtime_context().unwrap().with_subject("task://fenced");
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject: "task://fenced".to_string(),
+    resource: "cli://env".to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec!["HOME".to_string()],
+  }).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "```mech
++> @env := cli/env
+home := @env/HOME
+```
+",
+  ).unwrap();
+
+  let id = hash_str("home");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  assert_string_value(value, "/tmp/fenced-home");
+}
+
+#[test]
+fn named_fenced_context_import_write_uses_context_registry() {
+  let root = setup_modules("~~~mech:bar\n+> @out := cli/stdout\n@out/line <- \"hello\"\n~~~\n");
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  runtime.run_module_scope(
+    version,
+    SourceScope::Interpreter(SourceInterpreterId {
+      namespace: hash_str("bar"),
+      namespace_str: "bar".to_string(),
+    }),
+  ).unwrap();
+
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+}
+
+#[test]
+fn named_fenced_context_import_read_exports_value() {
+  let root = setup_modules("~~~mech:bar\n+> @env := cli/env\nhome := @env/HOME\n<+ home\nhome\n~~~\n");
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/named-fence-home");
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  let result = runtime.run_module_scope(
+    version,
+    SourceScope::Interpreter(SourceInterpreterId {
+      namespace: hash_str("bar"),
+      namespace_str: "bar".to_string(),
+    }),
+  ).unwrap();
+
+  assert_string_value(result, "/tmp/named-fence-home");
+}
+
+#[test]
+fn module_context_read_after_context_write_uses_execution_order() {
+  let root = setup_modules(
+    "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"hello\"\nresult := @manual/intro/title\n<+ result\nresult\n",
+  );
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"]);
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+
+  assert_string_value(result, "hello");
+}
+
+#[test]
+fn module_context_read_after_context_write_ignores_stale_provider_value() {
+  let root = setup_modules(
+    "@manual := docs://manual{:read(intro/title), :write(intro/title)}\n@manual/intro/title = \"new\"\nresult := @manual/intro/title\n<+ result\nresult\n",
+  );
+  let provider = RecordingResourceProvider::new("docs", &["docs://manual"])
+    .with_value("docs://manual", "intro/title", Value::String(Ref::new("old".to_string())));
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version).unwrap();
+
+  assert_string_value(result, "new");
+}
+
+#[test]
+fn direct_context_read_resolves_inside_op_assign() {
+  let provider = RecordingResourceProvider::new("docs", &["docs://numbers"])
+    .with_value("docs://numbers", "increment", Value::F64(Ref::new(2.0)));
+  let mut runtime = RuntimeBuilder::new()
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://numbers", "increment")).unwrap();
+
+  runtime.run_string("@numbers := docs://numbers{:read(increment)}\n~total := 1.0\ntotal += @numbers/increment\n").unwrap();
+
+  let id = hash_str("total");
+  let value = runtime.program().interpreter().symbols().borrow().get(id).unwrap().borrow().clone();
+  match value {
+    Value::F64(value) => assert_eq!(*value.borrow(), 3.0),
+    other => panic!("expected f64 total, got {other:?}"),
+  }
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3257,3 +3257,39 @@ fn module_graph_preflight_blocks_current_stdout_before_dependency_denial() {
   assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected runtime grant denial, got {error}");
   assert!(stdout.lock().unwrap().is_empty(), "current module stdout write should be preflight-blocked");
 }
+
+#[test]
+fn module_graph_preflight_blocks_addressed_interpreter_import_write_before_denial() {
+  let root = setup_modules(
+    r#"~~~mech:foo
++> ./dep.mec
++> @env := cli/env
+home := @env/HOME
+<+ home
+~~~
+
+value := @foo/home
+"#,
+  );
+  std::fs::write(
+    root.join("dep.mec"),
+    "+> @out := cli/stdout\n@out/line <- \"must-not-write\"\n",
+  )
+  .unwrap();
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+
+  let result = runtime.run_module_with_context(&mut context, version);
+
+  let error = format!("{:?}", result.err().expect("addressed interpreter env grant denial should fail"));
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected runtime grant denial, got {error}");
+  assert!(stdout.lock().unwrap().is_empty(), "addressed interpreter dependency write should be preflight-blocked");
+}

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2749,6 +2749,34 @@ fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
 }
 
 
+
+#[test]
+fn cli_context_module_env_denial_preflights_before_stdout_write() {
+  let root = setup_modules(r#"+> @out := cli/stdout
++> @env := cli/env
+
+@out/line <- "must-not-write"
+x := @env/HOME
+"done"
+"#);
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+
+  let result = runtime.run_module(version);
+
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "got {error}");
+  assert_eq!(stdout.lock().unwrap().len(), 0, "stdout write should be preflighted before provider effects");
+}
+
 #[test]
 fn cli_host_direct_env_declaration_reads_with_runtime_grant() {
   let backend = FakeCliBackend::default().with_env("HOME", "/tmp/direct-home");

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2719,6 +2719,21 @@ fn nested_env_read_denial_preflights_before_stdout_write() {
 }
 
 #[test]
+fn function_define_env_read_denial_preflights_before_stdout_write() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n+> @env := cli/env\n@out/line <- \"must-not-write\"\nuses-env(root<string>) => <string>\n  | @env/HOME.\n");
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "got {error}");
+  assert!(stdout.lock().unwrap().is_empty());
+  // FSM traversal is covered structurally by preflight_fsm_implementation_context_capabilities;
+  // add a parser-level FSM fixture when the compact syntax is less brittle for this suite.
+}
+
+#[test]
 fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
   let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
   let mut config = RuntimeConfig::default();

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2706,6 +2706,33 @@ fn narrow_stdout_grant_permits_line_but_denies_text() {
   assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
 }
 
+#[test]
+fn nested_env_read_denial_preflights_before_stdout_write() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @env := cli/env\n+> @out := cli/stdout\n@out/line <- \"must-not-write\"\nx := [@env/HOME]\n");
+  assert!(result.is_err());
+  assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+  assert!(stdout.lock().unwrap().is_empty());
+}
+
+#[test]
+fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let mut config = RuntimeConfig::default();
+  config.diagnostics.profile_enabled = true;
+  let mut runtime = RuntimeBuilder::new().config(config).resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  let tree = mech_syntax::parser::parse("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
+  let result = runtime.run_tree_with_context(&mut context, &tree);
+  assert!(result.is_err());
+  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. })));
+  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramFailed { .. })));
+  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramProfiled { .. })));
+}
+
 
 #[test]
 fn cli_host_direct_env_declaration_reads_with_runtime_grant() {

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2781,16 +2781,11 @@ fn module_preflight_denial_emits_program_failed_event() {
     "stdout should not be written before denied env read is reported"
   );
   assert!(
-    context
+    !context
       .events
       .iter()
-      .any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. }))
-  );
-  assert!(
-    context
-      .events
-      .iter()
-      .any(|event| matches!(event.kind, RuntimeEventKind::ProgramFailed { .. }))
+      .any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. })),
+    "graph preflight should fail before module program execution starts"
   );
 }
 
@@ -3189,4 +3184,76 @@ fn direct_context_read_resolves_inside_op_assign() {
     Value::F64(value) => assert_eq!(*value.borrow(), 3.0),
     other => panic!("expected f64 total, got {other:?}"),
   }
+}
+
+
+#[test]
+fn cli_context_source_scope_denial_preflights_before_stdout_write() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "HOME")).unwrap();
+
+  let result = runtime.run_string(r#"+> @out := cli/stdout
+@env := cli://env{:read(PATH)}
+
+@out/line <- "must-not-write"
+home := @env/HOME
+"#);
+
+  let error = format!("{:?}", result.err().expect("source-level env denial should fail"));
+  assert!(error.contains("RuntimeResourceCapabilityDenied"), "expected source-level capability error, got {error}");
+  assert!(stdout.lock().unwrap().is_empty(), "stdout write should be preflight-blocked");
+}
+
+#[test]
+fn module_graph_preflight_blocks_dependency_stdout_before_main_env_denial() {
+  let root = setup_modules("+> ./dep.mec\n+> @env := cli/env\nhome := @env/HOME\n");
+  std::fs::write(
+    root.join("dep.mec"),
+    "+> @out := cli/stdout\n@out/line <- \"must-not-write\"\n",
+  )
+  .unwrap();
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+
+  let result = runtime.run_module_with_context(&mut context, version);
+
+  let error = format!("{:?}", result.err().expect("main env grant denial should fail"));
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected runtime grant denial, got {error}");
+  assert!(stdout.lock().unwrap().is_empty(), "dependency stdout write should be preflight-blocked");
+}
+
+#[test]
+fn module_graph_preflight_blocks_current_stdout_before_dependency_denial() {
+  let root = setup_modules("+> ./dep.mec\n+> @out := cli/stdout\n@out/line <- \"must-not-write\"\n");
+  std::fs::write(root.join("dep.mec"), "+> @env := cli/env\nhome := @env/HOME\n").unwrap();
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(backend)))
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+
+  let result = runtime.run_module_with_context(&mut context, version);
+
+  let error = format!("{:?}", result.err().expect("dependency env grant denial should fail"));
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected runtime grant denial, got {error}");
+  assert!(stdout.lock().unwrap().is_empty(), "current module stdout write should be preflight-blocked");
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2671,6 +2671,83 @@ fn cli_host_missing_stderr_write_grant_fails_before_backend_call() {
   assert!(stderr.lock().unwrap().is_empty(), "stderr should not be written without grant");
 }
 
+#[test]
+fn default_cli_stdout_grant_allows_send() {
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "text")).unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n").unwrap();
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+}
+
+#[test]
+fn narrow_env_grant_permits_path_but_denies_home() {
+  let backend = FakeCliBackend::default().with_env("PATH", "/bin").with_env("HOME", "/tmp/home");
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "cli://env", "PATH")).unwrap();
+  runtime.run_string("+> @env := cli/env\npath := @env/PATH\n").unwrap();
+  let result = runtime.run_string("+> @env := cli/env\nhome := @env/HOME\n");
+  assert!(result.is_err());
+  assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+}
+
+#[test]
+fn narrow_stdout_grant_permits_line_but_denies_text() {
+  let backend = FakeCliBackend::default();
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  runtime.run_string("+> @out := cli/stdout\n@out/line <- \"hello\"\n").unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n@out/text <- \"bad\"\n");
+  assert!(result.is_err());
+  assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+  assert_eq!(stdout.lock().unwrap().as_slice(), &["hello\n".to_string()]);
+}
+
+#[test]
+fn nested_env_read_denial_preflights_before_stdout_write() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @env := cli/env\n+> @out := cli/stdout\n@out/line <- \"must-not-write\"\nx := [@env/HOME]\n");
+  assert!(result.is_err());
+  assert!(format!("{:?}", result.err().unwrap()).contains("RuntimeCapabilityGrantDenied"));
+  assert!(stdout.lock().unwrap().is_empty());
+}
+
+#[test]
+fn function_define_env_read_denial_preflights_before_stdout_write() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let stdout = backend.stdout.clone();
+  let mut runtime = RuntimeBuilder::new().resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let result = runtime.run_string("+> @out := cli/stdout\n+> @env := cli/env\n@out/line <- \"must-not-write\"\nuses-env(root<string>) => <string>\n  | @env/HOME.\n");
+  assert!(result.is_err());
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "got {error}");
+  assert!(stdout.lock().unwrap().is_empty());
+  // FSM traversal is covered structurally by preflight_fsm_implementation_context_capabilities;
+  // add a parser-level FSM fixture when the compact syntax is less brittle for this suite.
+}
+
+#[test]
+fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
+  let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
+  let mut config = RuntimeConfig::default();
+  config.diagnostics.profile_enabled = true;
+  let mut runtime = RuntimeBuilder::new().config(config).resource_provider(Box::new(CliResourceProvider::new(backend))).build().unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  let tree = mech_syntax::parser::parse("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
+  let result = runtime.run_tree_with_context(&mut context, &tree);
+  assert!(result.is_err());
+  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. })));
+  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramFailed { .. })));
+  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramProfiled { .. })));
+}
+
 
 #[test]
 fn cli_host_direct_env_declaration_reads_with_runtime_grant() {

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2751,14 +2751,10 @@ fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
 
 
 #[test]
-fn cli_context_module_env_denial_preflights_before_stdout_write() {
-  let root = setup_modules(r#"+> @out := cli/stdout
-+> @env := cli/env
-
-@out/line <- "must-not-write"
-x := @env/HOME
-"done"
-"#);
+fn module_preflight_denial_emits_program_failed_event() {
+  let root = setup_modules(
+    "+> @out := cli/stdout\n+> @env := cli/env\n@out/line <- \"must-not-write\"\nhome := @env/HOME\n",
+  );
   let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
   let stdout = backend.stdout.clone();
   let mut runtime = RuntimeBuilder::new()
@@ -2766,15 +2762,36 @@ x := @env/HOME
     .resource_provider(Box::new(CliResourceProvider::new(backend)))
     .build()
     .unwrap();
-  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
-  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  runtime
+    .grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line"))
+    .unwrap();
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
 
-  let result = runtime.run_module(version);
+  let result = runtime.run_module_with_context(&mut context, version);
 
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("RuntimeCapabilityGrantDenied"), "got {error}");
-  assert_eq!(stdout.lock().unwrap().len(), 0, "stdout write should be preflighted before provider effects");
+  assert!(
+    stdout.lock().unwrap().is_empty(),
+    "stdout should not be written before denied env read is reported"
+  );
+  assert!(
+    context
+      .events
+      .iter()
+      .any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. }))
+  );
+  assert!(
+    context
+      .events
+      .iter()
+      .any(|event| matches!(event.kind, RuntimeEventKind::ProgramFailed { .. }))
+  );
 }
 
 #[test]

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -247,6 +247,46 @@ fn mech_run_explicit_stdout_profile_permits_stdout() {
   assert_success_contains(output, "stdout-profile-ok");
 }
 
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_capability_passthrough_file_runs_once() {
+  let root = temp_root("cap-passthrough-once");
+  let source = root.join("once.mec");
+  std::fs::write(
+    &source,
+    "+> @out := cli/stdout
+@out/line <- \"cap-passthrough-once\"
+\"done\"
+",
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  assert!(
+    output.status.success(),
+    "expected command to succeed:
+{}",
+    combined_output(&output)
+  );
+
+  let combined = combined_output(&output);
+  let count = combined.matches("cap-passthrough-once").count();
+  assert_eq!(
+    count, 1,
+    "source file should execute exactly once, got {count} occurrences:
+{combined}"
+  );
+}
+
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -188,26 +188,88 @@ fn assert_failure_contains(output: std::process::Output, expected: &str) -> Stri
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
-fn mech_run_deny_stdout_blocks_stdout_send() {
-  let root = temp_root("deny-stdout");
-  let source = root.join("cli_host.mec");
+fn mech_run_explicit_stdout_profile_permits_stdout() {
+  let root = temp_root("profile-stdout");
+  let source = root.join("stdout.mec");
   std::fs::write(
     &source,
-    "+> @out := cli/stdout\n@out/line <- \"sentinel-denied\"\n",
+    "+> @out := cli/stdout
+@out/line <- \"stdout-profile-ok\"
+",
   )
   .unwrap();
 
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
-    .arg("--deny-cli-stdout")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "stdout-profile-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_explicit_stdout_profile_denies_env_before_write() {
+  let root = temp_root("profile-stdout-deny-env");
+  let source = root.join("stdout_env.mec");
+  std::fs::write(
+    &source,
+    r#"+> @out := cli/stdout
++> @env := cli/env
+
+@out/line <- "must-not-write"
+x := @env/HOME
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
     .arg(&source)
     .output()
     .unwrap();
 
   let combined = assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
   assert!(
-    !combined.contains("sentinel-denied"),
+    !combined.contains("must-not-write"),
     "provider wrote denied string: {combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_unknown_capability_profile_fails() {
+  let root = temp_root("unknown-profile");
+  let source = root.join("stdout.mec");
+  std::fs::write(
+    &source,
+    "+> @out := cli/stdout
+@out/line <- \"should-not-run\"
+",
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":quxx")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "unknown CLI capability profile `:quxx`");
+  assert!(
+    !combined.contains("should-not-run"),
+    "program ran despite unknown profile: {combined}"
   );
 }
 

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -1,167 +1,320 @@
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn temp_root(name: &str) -> std::path::PathBuf {
-  let root = std::env::temp_dir().join(format!(
-    "mech-cli-host-{name}-{}",
-    std::time::SystemTime::now()
-      .duration_since(std::time::UNIX_EPOCH)
-      .unwrap()
-      .as_nanos()
-  ));
-  std::fs::create_dir_all(&root).unwrap();
-  root
+    let root = std::env::temp_dir().join(format!(
+        "mech-cli-host-{name}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    root
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn write_cli_host_source(root: &std::path::Path) -> std::path::PathBuf {
-  let source_path = root.join("cli_host.mec");
-  std::fs::write(
-    &source_path,
-    r#"+> @env := cli/env
+    let source_path = root.join("cli_host.mec");
+    std::fs::write(
+        &source_path,
+        r#"+> @env := cli/env
 +> @out := cli/stdout
 
 @out/line <- @env/MECH_CLI_HOST_TEST
 "done"
 "#,
-  )
-  .unwrap();
-  source_path
+    )
+    .unwrap();
+    source_path
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn assert_success_contains(output: std::process::Output, expected: &str) {
-  assert!(
-    output.status.success(),
-    "mech command failed\nstdout:\n{}\nstderr:\n{}",
-    String::from_utf8_lossy(&output.stdout),
-    String::from_utf8_lossy(&output.stderr),
-  );
+    assert!(
+        output.status.success(),
+        "mech command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
-  let stdout = String::from_utf8_lossy(&output.stdout);
-  assert!(
-    stdout.contains(expected),
-    "expected stdout to contain {expected:?}, got:\n{}",
-    stdout,
-  );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(expected),
+        "expected stdout to contain {expected:?}, got:\n{}",
+        stdout,
+    );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_file_execution_loads_cli_host_provider() {
-  let root = temp_root("file");
-  let source_path = write_cli_host_source(&root);
+    let root = temp_root("file");
+    let source_path = write_cli_host_source(&root);
 
-  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-    .arg(&source_path)
-    .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
-    .output()
-    .unwrap();
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg(&source_path)
+        .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
+        .output()
+        .unwrap();
 
-  assert_success_contains(output, "mech-cli-host-ok");
+    assert_success_contains(output, "mech-cli-host-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_subcommand_loads_cli_host_provider() {
-  let root = temp_root("run-subcommand");
-  let source_path = write_cli_host_source(&root);
+    let root = temp_root("run-subcommand");
+    let source_path = write_cli_host_source(&root);
 
-  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-    .arg("run")
-    .arg(&source_path)
-    .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
-    .output()
-    .unwrap();
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg(&source_path)
+        .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
+        .output()
+        .unwrap();
 
-  assert_success_contains(output, "mech-cli-host-ok");
+    assert_success_contains(output, "mech-cli-host-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_uses_config_run_paths() {
-  let root = temp_root("config-run");
-  write_cli_host_source(&root);
-  std::fs::write(
-    root.join("mech.mcfg"),
-    r#"config := {
+    let root = temp_root("config-run");
+    write_cli_host_source(&root);
+    std::fs::write(
+        root.join("mech.mcfg"),
+        r#"config := {
   run: {
     paths: ["cli_host.mec"]
   }
 }
 "#,
-  )
-  .unwrap();
-
-  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-    .arg("run")
-    .current_dir(&root)
-    .env("MECH_CLI_HOST_TEST", "mech-config-run-ok")
-    .output()
+    )
     .unwrap();
 
-  assert_success_contains(output, "mech-config-run-ok");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .current_dir(&root)
+        .env("MECH_CLI_HOST_TEST", "mech-config-run-ok")
+        .output()
+        .unwrap();
+
+    assert_success_contains(output, "mech-config-run-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_project_directory_uses_config_run_paths() {
-  let root = temp_root("project-run");
-  let project = root.join("project");
-  std::fs::create_dir_all(&project).unwrap();
-  write_cli_host_source(&project);
-  std::fs::write(
-    project.join("mech.mcfg"),
-    r#"config := {
+    let root = temp_root("project-run");
+    let project = root.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    write_cli_host_source(&project);
+    std::fs::write(
+        project.join("mech.mcfg"),
+        r#"config := {
   run: {
     paths: ["cli_host.mec"]
   }
 }
 "#,
-  )
-  .unwrap();
-
-  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-    .arg("project")
-    .current_dir(&root)
-    .env("MECH_CLI_HOST_TEST", "mech-project-run-ok")
-    .output()
+    )
     .unwrap();
 
-  assert_success_contains(output, "mech-project-run-ok");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("project")
+        .current_dir(&root)
+        .env("MECH_CLI_HOST_TEST", "mech-project-run-ok")
+        .output()
+        .unwrap();
+
+    assert_success_contains(output, "mech-project-run-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_profile_output_comes_from_runtime_event() {
-  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-    .arg("--time")
-    .arg("1 + 1")
-    .output()
-    .unwrap();
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("--time")
+        .arg("1 + 1")
+        .output()
+        .unwrap();
 
-  assert_success_contains(output, "Cycle Time:");
+    assert_success_contains(output, "Cycle Time:");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_without_inputs_and_without_config_errors() {
-  let root = temp_root("run-no-inputs");
+    let root = temp_root("run-no-inputs");
 
-  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-    .arg("run")
-    .arg("--no-config")
-    .current_dir(&root)
-    .output()
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg("--no-config")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "expected mech run to fail");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("no run inputs supplied"),
+        "expected clean no-input error, got:\n{}",
+        combined,
+    );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+fn combined_output(output: &std::process::Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+fn assert_failure_contains(output: std::process::Output, expected: &str) -> String {
+    assert!(!output.status.success(), "expected mech command to fail");
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains(expected),
+        "expected output to contain {expected:?}, got:\n{combined}"
+    );
+    combined
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_deny_stdout_blocks_stdout_send() {
+    let root = temp_root("deny-stdout");
+    let source = root.join("cli_host.mec");
+    std::fs::write(
+        &source,
+        "+> @out := cli/stdout\n@out/line <- \"sentinel-denied\"\n",
+    )
     .unwrap();
 
-  assert!(!output.status.success(), "expected mech run to fail");
-  let combined = format!(
-    "{}{}",
-    String::from_utf8_lossy(&output.stdout),
-    String::from_utf8_lossy(&output.stderr)
-  );
-  assert!(
-    combined.contains("no run inputs supplied"),
-    "expected clean no-input error, got:\n{}",
-    combined,
-  );
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg("--deny-cli-stdout")
+        .arg(&source)
+        .output()
+        .unwrap();
+
+    let combined = assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+    assert!(
+        !combined.contains("sentinel-denied"),
+        "provider wrote denied string: {combined}"
+    );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_config_can_deny_stdout() {
+    let root = temp_root("config-deny-stdout");
+    std::fs::write(
+        root.join("cli_host.mec"),
+        "+> @out := cli/stdout\n@out/line <- \"denied-by-config\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("mech.mcfg"),
+        r#"config := {
+  run: {
+    paths: ["cli_host.mec"]
+    cli: { stdout: { write: [] } }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+
+    assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_config_can_narrow_stdout_to_line() {
+    let root = temp_root("config-stdout-line");
+    std::fs::write(
+        root.join("line.mec"),
+        "+> @out := cli/stdout\n@out/line <- \"line-ok\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("text.mec"),
+        "+> @out := cli/stdout\n@out/text <- \"text-bad\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("mech.mcfg"),
+        r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+    )
+    .unwrap();
+
+    let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg("line.mec")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert_success_contains(ok, "line-ok");
+
+    let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg("text.mec")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_config_can_narrow_env_to_path() {
+    let root = temp_root("config-env-path");
+    std::fs::write(
+        root.join("path.mec"),
+        "+> @env := cli/env\nx := @env/PATH\n\"ok\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("home.mec"),
+        "+> @env := cli/env\nx := @env/HOME\n\"bad\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("mech.mcfg"),
+        r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+    )
+    .unwrap();
+
+    let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg("path.mec")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        ok.status.success(),
+        "PATH read failed:\n{}",
+        combined_output(&ok)
+    );
+
+    let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("run")
+        .arg("home.mec")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
 }

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -165,3 +165,248 @@ fn mech_run_without_inputs_and_without_config_errors() {
     combined,
   );
 }
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+fn combined_output(output: &std::process::Output) -> String {
+  format!(
+    "{}{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr)
+  )
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+fn assert_failure_contains(output: std::process::Output, expected: &str) -> String {
+  assert!(!output.status.success(), "expected mech command to fail");
+  let combined = combined_output(&output);
+  assert!(
+    combined.contains(expected),
+    "expected output to contain {expected:?}, got:\n{combined}"
+  );
+  combined
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_explicit_stdout_profile_permits_stdout() {
+  let root = temp_root("profile-stdout");
+  let source = root.join("stdout.mec");
+  std::fs::write(
+    &source,
+    "+> @out := cli/stdout
+@out/line <- \"stdout-profile-ok\"
+",
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "stdout-profile-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
+  let root = temp_root("profile-stdout-env");
+  let source = root.join("stdout_env.mec");
+  std::fs::write(
+    &source,
+    r#"+> @env := cli/env
++> @out := cli/stdout
+
+@out/line <- @env/MECH_CLI_HOST_TEST
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(":cli/env")
+    .arg(&source)
+    .env("MECH_CLI_HOST_TEST", "stdout-env-profile-ok")
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "stdout-env-profile-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_explicit_stdout_profile_denies_env_before_write() {
+  let root = temp_root("profile-stdout-deny-env");
+  let source = root.join("stdout_env.mec");
+  std::fs::write(
+    &source,
+    r#"+> @out := cli/stdout
++> @env := cli/env
+
+@out/line <- "must-not-write"
+x := @env/HOME
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+  assert!(
+    !combined.contains("must-not-write"),
+    "provider wrote denied string: {combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_unknown_capability_profile_fails() {
+  let root = temp_root("unknown-profile");
+  let source = root.join("stdout.mec");
+  std::fs::write(
+    &source,
+    "+> @out := cli/stdout
+@out/line <- \"should-not-run\"
+",
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":quxx")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "unknown CLI capability profile `:quxx`");
+  assert!(
+    !combined.contains("should-not-run"),
+    "program ran despite unknown profile: {combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_config_can_deny_stdout() {
+  let root = temp_root("config-deny-stdout");
+  std::fs::write(
+    root.join("cli_host.mec"),
+    "+> @out := cli/stdout\n@out/line <- \"denied-by-config\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := {
+  run: {
+    paths: ["cli_host.mec"]
+    cli: { stdout: { write: [] } }
+  }
+}
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_config_can_narrow_stdout_to_line() {
+  let root = temp_root("config-stdout-line");
+  std::fs::write(
+    root.join("line.mec"),
+    "+> @out := cli/stdout\n@out/line <- \"line-ok\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("text.mec"),
+    "+> @out := cli/stdout\n@out/text <- \"text-bad\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+  )
+  .unwrap();
+
+  let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("line.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert_success_contains(ok, "line-ok");
+
+  let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("text.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_config_can_narrow_env_to_path() {
+  let root = temp_root("config-env-path");
+  std::fs::write(
+    root.join("path.mec"),
+    "+> @env := cli/env\nx := @env/PATH\n\"ok\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("home.mec"),
+    "+> @env := cli/env\nx := @env/HOME\n\"bad\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+  )
+  .unwrap();
+
+  let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("path.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert!(
+    ok.status.success(),
+    "PATH read failed:\n{}",
+    combined_output(&ok)
+  );
+
+  let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("home.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
+}

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -249,7 +249,7 @@ fn mech_run_explicit_stdout_profile_permits_stdout() {
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
-fn mech_run_repeated_capabilities_args_accept_stdout_and_env_profiles() {
+fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
   let root = temp_root("profile-stdout-env");
   let source = root.join("stdout_env.mec");
   std::fs::write(
@@ -268,7 +268,6 @@ fn mech_run_repeated_capabilities_args_accept_stdout_and_env_profiles() {
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
-    .arg("--capabilities")
     .arg(":cli/env")
     .arg(&source)
     .env("MECH_CLI_HOST_TEST", "stdout-env-profile-ok")

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -188,6 +188,42 @@ fn assert_failure_contains(output: std::process::Output, expected: &str) -> Stri
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
+fn mech_run_inline_source_preserves_define_token() {
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("x")
+    .arg(":=")
+    .arg("1")
+    .output()
+    .unwrap();
+  assert!(
+    output.status.success(),
+    "inline source with := should not have := filtered out:\n{}",
+    combined_output(&output)
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_inline_source_preserves_colon_prefixed_token() {
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(":running")
+    .output()
+    .unwrap();
+  let combined = combined_output(&output);
+  assert!(
+    !combined.contains("unknown CLI capability profile"),
+    "colon-prefixed source token must not be treated as capability profile:\n{combined}"
+  );
+  assert!(
+    !combined.contains("No source files, project paths, or inline code were provided"),
+    "colon-prefixed source token must not be dropped from run inputs:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
 fn mech_run_explicit_stdout_profile_permits_stdout() {
   let root = temp_root("profile-stdout");
   let source = root.join("stdout.mec");
@@ -213,7 +249,7 @@ fn mech_run_explicit_stdout_profile_permits_stdout() {
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
-fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
+fn mech_run_repeated_capabilities_args_accept_stdout_and_env_profiles() {
   let root = temp_root("profile-stdout-env");
   let source = root.join("stdout_env.mec");
   std::fs::write(
@@ -232,6 +268,7 @@ fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
+    .arg("--capabilities")
     .arg(":cli/env")
     .arg(&source)
     .env("MECH_CLI_HOST_TEST", "stdout-env-profile-ok")

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -308,6 +308,7 @@ fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
+    .arg("--capabilities")
     .arg(":cli/env")
     .arg(&source)
     .env("MECH_CLI_HOST_TEST", "stdout-env-profile-ok")
@@ -315,6 +316,32 @@ fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
     .unwrap();
 
   assert_success_contains(output, "stdout-env-profile-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_capabilities_preserves_inline_colon_syntax() {
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg("x := 1")
+    .output()
+    .unwrap();
+
+  assert!(
+    output.status.success(),
+    "inline source after --capabilities should run successfully:
+{}",
+    combined_output(&output)
+  );
+  let combined = combined_output(&output);
+  assert!(
+    !combined.contains("unknown") && !combined.contains(":="),
+    "inline := token should not be parsed as a capability profile:
+{combined}"
+  );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
@@ -372,7 +399,7 @@ fn mech_run_unknown_capability_profile_fails() {
     .output()
     .unwrap();
 
-  let combined = assert_failure_contains(output, "unknown CLI capability profile `:quxx`");
+  let combined = assert_failure_contains(output, "invalid value ':quxx' for '--capabilities <CAPABILITY>'");
   assert!(
     !combined.contains("should-not-run"),
     "program ran despite unknown profile: {combined}"

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -1,320 +1,320 @@
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn temp_root(name: &str) -> std::path::PathBuf {
-    let root = std::env::temp_dir().join(format!(
-        "mech-cli-host-{name}-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&root).unwrap();
-    root
+  let root = std::env::temp_dir().join(format!(
+    "mech-cli-host-{name}-{}",
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_nanos()
+  ));
+  std::fs::create_dir_all(&root).unwrap();
+  root
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn write_cli_host_source(root: &std::path::Path) -> std::path::PathBuf {
-    let source_path = root.join("cli_host.mec");
-    std::fs::write(
-        &source_path,
-        r#"+> @env := cli/env
+  let source_path = root.join("cli_host.mec");
+  std::fs::write(
+    &source_path,
+    r#"+> @env := cli/env
 +> @out := cli/stdout
 
 @out/line <- @env/MECH_CLI_HOST_TEST
 "done"
 "#,
-    )
-    .unwrap();
-    source_path
+  )
+  .unwrap();
+  source_path
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn assert_success_contains(output: std::process::Output, expected: &str) {
-    assert!(
-        output.status.success(),
-        "mech command failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+  assert!(
+    output.status.success(),
+    "mech command failed\nstdout:\n{}\nstderr:\n{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr),
+  );
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains(expected),
-        "expected stdout to contain {expected:?}, got:\n{}",
-        stdout,
-    );
+  let stdout = String::from_utf8_lossy(&output.stdout);
+  assert!(
+    stdout.contains(expected),
+    "expected stdout to contain {expected:?}, got:\n{}",
+    stdout,
+  );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_file_execution_loads_cli_host_provider() {
-    let root = temp_root("file");
-    let source_path = write_cli_host_source(&root);
+  let root = temp_root("file");
+  let source_path = write_cli_host_source(&root);
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg(&source_path)
-        .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
-        .output()
-        .unwrap();
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg(&source_path)
+    .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
+    .output()
+    .unwrap();
 
-    assert_success_contains(output, "mech-cli-host-ok");
+  assert_success_contains(output, "mech-cli-host-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_subcommand_loads_cli_host_provider() {
-    let root = temp_root("run-subcommand");
-    let source_path = write_cli_host_source(&root);
+  let root = temp_root("run-subcommand");
+  let source_path = write_cli_host_source(&root);
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg(&source_path)
-        .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
-        .output()
-        .unwrap();
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source_path)
+    .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
+    .output()
+    .unwrap();
 
-    assert_success_contains(output, "mech-cli-host-ok");
+  assert_success_contains(output, "mech-cli-host-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_uses_config_run_paths() {
-    let root = temp_root("config-run");
-    write_cli_host_source(&root);
-    std::fs::write(
-        root.join("mech.mcfg"),
-        r#"config := {
+  let root = temp_root("config-run");
+  write_cli_host_source(&root);
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := {
   run: {
     paths: ["cli_host.mec"]
   }
 }
 "#,
-    )
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .current_dir(&root)
+    .env("MECH_CLI_HOST_TEST", "mech-config-run-ok")
+    .output()
     .unwrap();
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .current_dir(&root)
-        .env("MECH_CLI_HOST_TEST", "mech-config-run-ok")
-        .output()
-        .unwrap();
-
-    assert_success_contains(output, "mech-config-run-ok");
+  assert_success_contains(output, "mech-config-run-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_project_directory_uses_config_run_paths() {
-    let root = temp_root("project-run");
-    let project = root.join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    write_cli_host_source(&project);
-    std::fs::write(
-        project.join("mech.mcfg"),
-        r#"config := {
+  let root = temp_root("project-run");
+  let project = root.join("project");
+  std::fs::create_dir_all(&project).unwrap();
+  write_cli_host_source(&project);
+  std::fs::write(
+    project.join("mech.mcfg"),
+    r#"config := {
   run: {
     paths: ["cli_host.mec"]
   }
 }
 "#,
-    )
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("project")
+    .current_dir(&root)
+    .env("MECH_CLI_HOST_TEST", "mech-project-run-ok")
+    .output()
     .unwrap();
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("project")
-        .current_dir(&root)
-        .env("MECH_CLI_HOST_TEST", "mech-project-run-ok")
-        .output()
-        .unwrap();
-
-    assert_success_contains(output, "mech-project-run-ok");
+  assert_success_contains(output, "mech-project-run-ok");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_profile_output_comes_from_runtime_event() {
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("--time")
-        .arg("1 + 1")
-        .output()
-        .unwrap();
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("--time")
+    .arg("1 + 1")
+    .output()
+    .unwrap();
 
-    assert_success_contains(output, "Cycle Time:");
+  assert_success_contains(output, "Cycle Time:");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_without_inputs_and_without_config_errors() {
-    let root = temp_root("run-no-inputs");
+  let root = temp_root("run-no-inputs");
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg("--no-config")
-        .current_dir(&root)
-        .output()
-        .unwrap();
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--no-config")
+    .current_dir(&root)
+    .output()
+    .unwrap();
 
-    assert!(!output.status.success(), "expected mech run to fail");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        combined.contains("no run inputs supplied"),
-        "expected clean no-input error, got:\n{}",
-        combined,
-    );
+  assert!(!output.status.success(), "expected mech run to fail");
+  let combined = format!(
+    "{}{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr)
+  );
+  assert!(
+    combined.contains("no run inputs supplied"),
+    "expected clean no-input error, got:\n{}",
+    combined,
+  );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn combined_output(output: &std::process::Output) -> String {
-    format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    )
+  format!(
+    "{}{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr)
+  )
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn assert_failure_contains(output: std::process::Output, expected: &str) -> String {
-    assert!(!output.status.success(), "expected mech command to fail");
-    let combined = combined_output(&output);
-    assert!(
-        combined.contains(expected),
-        "expected output to contain {expected:?}, got:\n{combined}"
-    );
-    combined
+  assert!(!output.status.success(), "expected mech command to fail");
+  let combined = combined_output(&output);
+  assert!(
+    combined.contains(expected),
+    "expected output to contain {expected:?}, got:\n{combined}"
+  );
+  combined
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_deny_stdout_blocks_stdout_send() {
-    let root = temp_root("deny-stdout");
-    let source = root.join("cli_host.mec");
-    std::fs::write(
-        &source,
-        "+> @out := cli/stdout\n@out/line <- \"sentinel-denied\"\n",
-    )
+  let root = temp_root("deny-stdout");
+  let source = root.join("cli_host.mec");
+  std::fs::write(
+    &source,
+    "+> @out := cli/stdout\n@out/line <- \"sentinel-denied\"\n",
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-cli-stdout")
+    .arg(&source)
+    .output()
     .unwrap();
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg("--deny-cli-stdout")
-        .arg(&source)
-        .output()
-        .unwrap();
-
-    let combined = assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
-    assert!(
-        !combined.contains("sentinel-denied"),
-        "provider wrote denied string: {combined}"
-    );
+  let combined = assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+  assert!(
+    !combined.contains("sentinel-denied"),
+    "provider wrote denied string: {combined}"
+  );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_config_can_deny_stdout() {
-    let root = temp_root("config-deny-stdout");
-    std::fs::write(
-        root.join("cli_host.mec"),
-        "+> @out := cli/stdout\n@out/line <- \"denied-by-config\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        root.join("mech.mcfg"),
-        r#"config := {
+  let root = temp_root("config-deny-stdout");
+  std::fs::write(
+    root.join("cli_host.mec"),
+    "+> @out := cli/stdout\n@out/line <- \"denied-by-config\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := {
   run: {
     paths: ["cli_host.mec"]
     cli: { stdout: { write: [] } }
   }
 }
 "#,
-    )
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .current_dir(&root)
+    .output()
     .unwrap();
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .current_dir(&root)
-        .output()
-        .unwrap();
-
-    assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+  assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_config_can_narrow_stdout_to_line() {
-    let root = temp_root("config-stdout-line");
-    std::fs::write(
-        root.join("line.mec"),
-        "+> @out := cli/stdout\n@out/line <- \"line-ok\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        root.join("text.mec"),
-        "+> @out := cli/stdout\n@out/text <- \"text-bad\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        root.join("mech.mcfg"),
-        r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
-    )
-    .unwrap();
+  let root = temp_root("config-stdout-line");
+  std::fs::write(
+    root.join("line.mec"),
+    "+> @out := cli/stdout\n@out/line <- \"line-ok\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("text.mec"),
+    "+> @out := cli/stdout\n@out/text <- \"text-bad\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+  )
+  .unwrap();
 
-    let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg("line.mec")
-        .current_dir(&root)
-        .output()
-        .unwrap();
-    assert_success_contains(ok, "line-ok");
+  let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("line.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert_success_contains(ok, "line-ok");
 
-    let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg("text.mec")
-        .current_dir(&root)
-        .output()
-        .unwrap();
-    assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
+  let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("text.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
 fn mech_run_config_can_narrow_env_to_path() {
-    let root = temp_root("config-env-path");
-    std::fs::write(
-        root.join("path.mec"),
-        "+> @env := cli/env\nx := @env/PATH\n\"ok\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        root.join("home.mec"),
-        "+> @env := cli/env\nx := @env/HOME\n\"bad\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        root.join("mech.mcfg"),
-        r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
-    )
-    .unwrap();
+  let root = temp_root("config-env-path");
+  std::fs::write(
+    root.join("path.mec"),
+    "+> @env := cli/env\nx := @env/PATH\n\"ok\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("home.mec"),
+    "+> @env := cli/env\nx := @env/HOME\n\"bad\"\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+  )
+  .unwrap();
 
-    let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg("path.mec")
-        .current_dir(&root)
-        .output()
-        .unwrap();
-    assert!(
-        ok.status.success(),
-        "PATH read failed:\n{}",
-        combined_output(&ok)
-    );
+  let ok = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("path.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert!(
+    ok.status.success(),
+    "PATH read failed:\n{}",
+    combined_output(&ok)
+  );
 
-    let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
-        .arg("run")
-        .arg("home.mec")
-        .current_dir(&root)
-        .output()
-        .unwrap();
-    assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
+  let bad = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("home.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+  assert_failure_contains(bad, "RuntimeCapabilityGrantDenied");
 }


### PR DESCRIPTION
### Motivation
- Provide a default, limited CLI host authority envelope and allow it to be attenuated by config and CLI flags without expanding privileges. 
- Fail early for direct CLI runs by preflighting known context reads/writes/sends so provider effects do not occur when runtime grants are missing.

### Description
- Extend run config lowering (`src/runtime/src/config_profile/lower.rs`) with `RunCliHostConfig`, `RunCliEnvConfig`, `RunCliStreamConfig` and implement `lower_run_cli`, `lower_run_cli_env`, and `lower_run_cli_stream` with validation for env key shapes and allowed stream paths.
- Add `EffectiveCliHostGrants`, `CliHostGrantAttenuation`, and `effective_cli_host_grants` in `src/cli/config.rs` to compute the effective grants starting from the default envelope and applying config and CLI deny flags.
- Replace hard-coded CLI grant installation in `src/bin/mech.rs` with `grant_cli_runner_capabilities(runtime, &grants)` and make `new_cli_runtime` accept the effective `cli_grants`; add root/subcommand CLI flags `--deny-cli-env`, `--deny-cli-stdout`, and `--deny-cli-stderr` and a helper `cli_host_capability_args()` for reuse.
- Add a preflight layer in `src/runtime/src/runtime/execution.rs` (`preflight_context_capabilities` and helpers) and invoke it before direct execution in `run_string_with_context` and `run_tree_with_context` to statically validate known context read/write/send operations against installed runtime grants.
- Add tests: config-lowering tests in `src/runtime/src/config_profile/lower.rs`, effective-grants unit tests in `src/cli/config.rs`, runtime tests in `src/runtime/tests/module_smoke.rs` exercising default/narrow/missing grants with a counting CLI backend, and CLI integration tests in `tests/mech_cli_host.rs` for deny flags and config-based attenuation.

### Testing
- `cargo fmt` completed successfully.
- `cargo test --test mech_cli_host --features run,cli_host` passed (CLI integration tests for deny flags and config cases succeeded).
- `cargo test -p mech-runtime --test module_smoke` passed (runtime tests including preflight and counting-backend checks passed).
- `cargo test -p mech-host-cli --features provider` passed (CLI provider unit tests passed).
- `cargo test --all-targets --all-features` failed due to an existing no_std/all-features compile issue in `mech-core` (errors like `cannot find module or crate std in this scope` starting at `src/core/src/error.rs`), producing the final summary: `could not compile mech-core (lib) due to 117 previous errors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381ec8f99c832aa87c0dbe43ec3fef)