### PR TITLE
Add attenuable CLI host capabilities

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -116,13 +116,13 @@ async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String
 }
 
 #[cfg(feature = "run")]
-fn new_cli_runtime(config: RuntimeConfig) -> MResult<MechRuntime> {
+fn new_cli_runtime(config: RuntimeConfig, cli_grants: &config::EffectiveCliHostGrants) -> MResult<MechRuntime> {
   let mut runtime = RuntimeBuilder::new()
     .config(config)
     .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
     .build()?;
 
-  grant_cli_runner_capabilities(&mut runtime)?;
+  grant_cli_runner_capabilities(&mut runtime, cli_grants)?;
 
   Ok(runtime)
 }
@@ -189,29 +189,35 @@ fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
 }
 
 #[cfg(feature = "run")]
-fn grant_cli_runner_capabilities(runtime: &mut MechRuntime) -> MResult<()> {
+fn grant_cli_runner_capabilities(runtime: &mut MechRuntime, grants: &config::EffectiveCliHostGrants) -> MResult<()> {
   let subject = runtime.runtime_context()?.subject;
 
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: subject.clone(),
-    resource: "cli://env".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
-    paths: vec!["*".to_string()],
-  })?;
+  if !grants.env_read_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://env".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: grants.env_read_paths.clone(),
+    })?;
+  }
 
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject: subject.clone(),
-    resource: "cli://stdout".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec!["text".to_string(), "line".to_string()],
-  })?;
+  if !grants.stdout_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.clone(),
+      resource: "cli://stdout".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stdout_write_paths.clone(),
+    })?;
+  }
 
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject,
-    resource: "cli://stderr".to_string(),
-    operations: vec![RuntimeCapabilityOperation::Write],
-    paths: vec!["text".to_string(), "line".to_string()],
-  })?;
+  if !grants.stderr_write_paths.is_empty() {
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://stderr".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: grants.stderr_write_paths.clone(),
+    })?;
+  }
 
   Ok(())
 }
@@ -366,8 +372,32 @@ async fn main() -> Result<(), MechError> {
       .arg(Arg::new("trace")
         .long("trace")
         .help("Print trace output for state-machine arms and function calls")
+        .action(ArgAction::SetTrue))
+      .arg(Arg::new("deny_cli_env")
+        .long("deny-cli-env")
+        .help("Deny CLI environment access")
+        .action(ArgAction::SetTrue))
+      .arg(Arg::new("deny_cli_stdout")
+        .long("deny-cli-stdout")
+        .help("Deny CLI stdout access")
+        .action(ArgAction::SetTrue))
+      .arg(Arg::new("deny_cli_stderr")
+        .long("deny-cli-stderr")
+        .help("Deny CLI stderr access")
         .action(ArgAction::SetTrue)))
-    .subcommand(Command::new("serve")
+    .arg(Arg::new("deny_cli_env")
+        .long("deny-cli-env")
+        .help("Deny CLI environment access")
+        .action(ArgAction::SetTrue))
+      .arg(Arg::new("deny_cli_stdout")
+        .long("deny-cli-stdout")
+        .help("Deny CLI stdout access")
+        .action(ArgAction::SetTrue))
+      .arg(Arg::new("deny_cli_stderr")
+        .long("deny-cli-stderr")
+        .help("Deny CLI stderr access")
+        .action(ArgAction::SetTrue))
+      .subcommand(Command::new("serve")
       .about("Serve Mech program over an HTTP server.")
       .arg(Arg::new("mech_serve_file_paths")
         .help("Source .mec and .mecb files")
@@ -810,6 +840,18 @@ async fn main() -> Result<(), MechError> {
     let config_inputs = if any_look_like_paths { run_inputs.as_slice() } else { &[] };
     let loaded_config = config::load_run_cli_config(config_matches, config_inputs)?;
 
+    let run_deny_cli_env = cli_matches.get_flag("deny_cli_env") || run_matches.map(|m| m.get_flag("deny_cli_env")).unwrap_or(false);
+    let run_deny_cli_stdout = cli_matches.get_flag("deny_cli_stdout") || run_matches.map(|m| m.get_flag("deny_cli_stdout")).unwrap_or(false);
+    let run_deny_cli_stderr = cli_matches.get_flag("deny_cli_stderr") || run_matches.map(|m| m.get_flag("deny_cli_stderr")).unwrap_or(false);
+    let cli_grants = config::effective_cli_host_grants(
+      loaded_config.as_ref(),
+      config::CliHostGrantAttenuation {
+        deny_env: run_deny_cli_env,
+        deny_stdout: run_deny_cli_stdout,
+        deny_stderr: run_deny_cli_stderr,
+      },
+    )?;
+
     let runtime_config = effective_run_runtime_config(
       loaded_config.as_ref(),
       format!("program-{}", uuid),
@@ -820,7 +862,7 @@ async fn main() -> Result<(), MechError> {
     )?;
     repl_runtime_config = Some(runtime_config.clone());
 
-    let mut runtime = new_cli_runtime(runtime_config)?;
+    let mut runtime = new_cli_runtime(runtime_config, &cli_grants)?;
 
     if !run_inputs.is_empty() && !any_look_like_paths {
       let joined = run_inputs.join(" ");

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -75,6 +75,58 @@ pub struct EffectiveServeOptions {
   pub wasm_pkg: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectiveCliHostGrants {
+  pub env_read_paths: Vec<String>,
+  pub stdout_write_paths: Vec<String>,
+  pub stderr_write_paths: Vec<String>,
+}
+
+impl Default for EffectiveCliHostGrants {
+  fn default() -> Self {
+    Self {
+      env_read_paths: vec!["*".to_string()],
+      stdout_write_paths: vec!["text".to_string(), "line".to_string()],
+      stderr_write_paths: vec!["text".to_string(), "line".to_string()],
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CliHostGrantAttenuation {
+  pub deny_env: bool,
+  pub deny_stdout: bool,
+  pub deny_stderr: bool,
+}
+
+pub fn effective_cli_host_grants(
+  config: Option<&LoadedMechConfig>,
+  attenuation: CliHostGrantAttenuation,
+) -> MResult<EffectiveCliHostGrants> {
+  let mut grants = EffectiveCliHostGrants::default();
+  if let Some(run) = config.and_then(|loaded| loaded.document.run.as_ref()) {
+    if let Some(paths) = &run.cli.env.read {
+      grants.env_read_paths = paths.clone();
+    }
+    if let Some(paths) = &run.cli.stdout.write {
+      grants.stdout_write_paths = paths.clone();
+    }
+    if let Some(paths) = &run.cli.stderr.write {
+      grants.stderr_write_paths = paths.clone();
+    }
+  }
+  if attenuation.deny_env {
+    grants.env_read_paths.clear();
+  }
+  if attenuation.deny_stdout {
+    grants.stdout_write_paths.clear();
+  }
+  if attenuation.deny_stderr {
+    grants.stderr_write_paths.clear();
+  }
+  Ok(grants)
+}
+
 pub fn effective_run_options(
   cli_paths: Vec<String>,
   config: Option<&LoadedMechConfig>,
@@ -419,6 +471,43 @@ mod config_tests {
 
   fn run_error_text(result: MResult<Option<EffectiveRunOptions>>) -> String {
     format!("{:?}", result.unwrap_err())
+  }
+
+
+  #[test]
+  fn default_cli_host_grants_allow_cli_envelope() {
+    let grants = effective_cli_host_grants(None, CliHostGrantAttenuation::default()).unwrap();
+    assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert_eq!(grants.stderr_write_paths, vec!["text".to_string(), "line".to_string()]);
+  }
+
+  #[test]
+  fn config_narrows_stdout_grant_to_line() {
+    let config = loaded_config(r#"config := {run: {cli: {stdout: {write: ["line"]}}}}"#);
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
+  }
+
+  #[test]
+  fn config_denies_stdout_grant_with_empty_list() {
+    let config = loaded_config(r#"config := {run: {cli: {stdout: {write: []}}}}"#);
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    assert!(grants.stdout_write_paths.is_empty());
+  }
+
+  #[test]
+  fn config_narrows_env_grant_to_path() {
+    let config = loaded_config(r#"config := {run: {cli: {env: {read: ["PATH"]}}}}"#);
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation::default()).unwrap();
+    assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
+  }
+
+  #[test]
+  fn cli_deny_stdout_clears_config_stdout_grant() {
+    let config = loaded_config(r#"config := {run: {cli: {stdout: {write: ["line"]}}}}"#);
+    let grants = effective_cli_host_grants(Some(&config), CliHostGrantAttenuation { deny_stdout: true, ..CliHostGrantAttenuation::default() }).unwrap();
+    assert!(grants.stdout_write_paths.is_empty());
   }
 
   #[test]

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -61,6 +61,24 @@ pub struct ServeHostConfig {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RunHostConfig {
     pub paths: Vec<PathBuf>,
+    pub cli: RunCliHostConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliHostConfig {
+    pub env: RunCliEnvConfig,
+    pub stdout: RunCliStreamConfig,
+    pub stderr: RunCliStreamConfig,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliEnvConfig {
+    pub read: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunCliStreamConfig {
+    pub write: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -286,10 +304,49 @@ impl ConfigLowerer {
         for (key, value) in map {
             match key.as_str() {
                 "paths" => out.paths = expect_path_list("run.paths", value)?,
+                "cli" => out.cli = self.lower_run_cli(value)?,
                 other => return invalid(format!("unknown run field `{other}`")),
             }
         }
 
+        Ok(out)
+    }
+
+    fn lower_run_cli(&self, value: &ConfigValue) -> MResult<RunCliHostConfig> {
+        let map = expect_map("run.cli", value)?;
+        let mut out = RunCliHostConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "env" => out.env = self.lower_run_cli_env(value)?,
+                "stdout" => out.stdout = self.lower_run_cli_stream("run.cli.stdout", value)?,
+                "stderr" => out.stderr = self.lower_run_cli_stream("run.cli.stderr", value)?,
+                other => return invalid(format!("unknown run.cli field `{other}`")),
+            }
+        }
+        Ok(out)
+    }
+
+    fn lower_run_cli_env(&self, value: &ConfigValue) -> MResult<RunCliEnvConfig> {
+        let map = expect_map("run.cli.env", value)?;
+        let mut out = RunCliEnvConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "read" => out.read = Some(expect_cli_env_paths("run.cli.env.read", value)?),
+                other => return invalid(format!("unknown run.cli.env field `{other}`")),
+            }
+        }
+        Ok(out)
+    }
+
+    fn lower_run_cli_stream(&self, where_: &str, value: &ConfigValue) -> MResult<RunCliStreamConfig> {
+        let map = expect_map(where_, value)?;
+        let mut out = RunCliStreamConfig::default();
+        for (key, value) in map {
+            match key.as_str() {
+                "write" => out.write = Some(expect_cli_stream_paths(&format!("{where_}.write"), value)?),
+                other => return invalid(format!("unknown {where_} field `{other}`")),
+            }
+        }
         Ok(out)
     }
 
@@ -645,6 +702,31 @@ fn expect_string_list(where_: &str, value: &ConfigValue) -> MResult<Vec<String>>
         .collect()
 }
 
+fn expect_cli_env_paths(where_: &str, value: &ConfigValue) -> MResult<Vec<String>> {
+    let paths = expect_string_list(where_, value)?;
+    for path in &paths {
+        if path == "*" {
+            continue;
+        }
+        let mut chars = path.chars();
+        let Some(first) = chars.next() else { return invalid(format!("{where_} contains invalid env key `{path}`")); };
+        if !(first == '_' || first.is_ascii_alphabetic()) || !chars.all(|c| c == '_' || c.is_ascii_alphanumeric()) {
+            return invalid(format!("{where_} contains invalid env key `{path}`"));
+        }
+    }
+    Ok(paths)
+}
+
+fn expect_cli_stream_paths(where_: &str, value: &ConfigValue) -> MResult<Vec<String>> {
+    let paths = expect_string_list(where_, value)?;
+    for path in &paths {
+        if path != "text" && path != "line" {
+            return invalid(format!("{where_} contains invalid stream path `{path}`"));
+        }
+    }
+    Ok(paths)
+}
+
 fn expect_browser_operations_for_resource(
     where_: &str,
     value: &ConfigValue,
@@ -735,6 +817,43 @@ mod tests {
             run.paths,
             vec![PathBuf::from("foo.mec"), PathBuf::from("bar.mec")]
         );
+    }
+
+
+    #[test]
+    fn run_cli_stdout_empty_write_lowers() {
+        let doc = parse(r#"config := {run: {cli: {stdout: {write: []}}}}"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.stdout.write, Some(vec![]));
+    }
+
+    #[test]
+    fn run_cli_stdout_line_write_lowers() {
+        let doc = parse(r#"config := {run: {cli: {stdout: {write: ["line"]}}}}"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.stdout.write, Some(vec!["line".to_string()]));
+    }
+
+    #[test]
+    fn run_cli_env_path_read_lowers() {
+        let doc = parse(r#"config := {run: {cli: {env: {read: ["PATH"]}}}}"#).unwrap();
+        assert_eq!(doc.run.unwrap().cli.env.read, Some(vec!["PATH".to_string()]));
+    }
+
+    #[test]
+    fn invalid_run_cli_stdout_path_fails() {
+        let err = parse(r#"config := {run: {cli: {stdout: {write: ["html"]}}}}"#).unwrap_err();
+        assert!(format!("{:?}", err).contains("invalid stream path `html`"));
+    }
+
+    #[test]
+    fn invalid_run_cli_env_key_fails() {
+        let err = parse(r#"config := {run: {cli: {env: {read: ["1HOME"]}}}}"#).unwrap_err();
+        assert!(format!("{:?}", err).contains("invalid env key `1HOME`"));
+    }
+
+    #[test]
+    fn unknown_run_cli_field_fails() {
+        let err = parse(r#"config := {run: {cli: {bad: {}}}}"#).unwrap_err();
+        assert!(format!("{:?}", err).contains("unknown run.cli field `bad`"));
     }
 
     #[test]

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -968,6 +968,99 @@ impl MechRuntime {
     }
   }
 
+
+  fn preflight_context_access(
+    &self,
+    context: &RuntimeContext,
+    binding: &RuntimeContextBinding,
+    operation: RuntimeCapabilityOperation,
+    path: &str,
+  ) -> MResult<()> {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    let context_allowed = match operation {
+      RuntimeCapabilityOperation::Read => runtime_context_allows_read(binding, &resolved.context_path),
+      RuntimeCapabilityOperation::Write => runtime_context_allows_write(binding, &resolved.context_path),
+      RuntimeCapabilityOperation::Custom(_) => true,
+    };
+    if !context_allowed {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: match operation { RuntimeCapabilityOperation::Read => "read", RuntimeCapabilityOperation::Write => "write", RuntimeCapabilityOperation::Custom(_) => "custom" }.to_string(),
+        path: resolved.context_path,
+      }, None));
+    }
+    if !self.grants.allows(&context.subject, &resolved.provider_base_uri, &operation, &resolved.provider_path) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: context.subject.clone(),
+        resource: resolved.provider_base_uri,
+        operation,
+        path: resolved.provider_path,
+      }, None));
+    }
+    Ok(())
+  }
+
+  fn preflight_context_reads_in_expression(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<()> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        if let Some(var_context) = &var.context {
+          if let Some(binding) = registry.get(&var_context.to_string()) {
+            self.preflight_context_access(context, binding, RuntimeCapabilityOperation::Read, &var.name.to_string())?;
+          }
+        }
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_direct_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    tree: &mech_core::Program,
+    registry: &RuntimeContextRegistry,
+  ) -> MResult<()> {
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        let codes: Vec<&(mech_core::MechCode, Option<mech_core::Comment>)> = match element {
+          mech_core::SectionElement::MechCode(codes) => codes.iter().collect(),
+          mech_core::SectionElement::FencedMechCode(fenced) => fenced.code.iter().collect(),
+          _ => Vec::new(),
+        };
+        for (code, _) in codes {
+          match code {
+            mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+              if let Some(context_name) = &send.target.context {
+                if let Some(binding) = registry.get(&context_name.to_string()) {
+                  self.preflight_context_access(context, binding, RuntimeCapabilityOperation::Write, &send.target.name.to_string())?;
+                }
+              }
+              self.preflight_context_reads_in_expression(context, registry, &send.expression)?;
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+              if let Some(context_name) = &assign.target.context {
+                if let Some(binding) = registry.get(&context_name.to_string()) {
+                  self.preflight_context_access(context, binding, RuntimeCapabilityOperation::Write, &assign.target.name.to_string())?;
+                }
+              }
+              self.preflight_context_reads_in_expression(context, registry, &assign.expression)?;
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+              self.preflight_context_reads_in_expression(context, registry, &var_def.expression)?;
+            }
+            _ => {}
+          }
+        }
+      }
+    }
+    Ok(())
+  }
+
   fn run_tree_on_program(
     &mut self,
     context: &mut RuntimeContext,
@@ -978,6 +1071,7 @@ impl MechRuntime {
     let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
     let skip_non_context_imports = scope_hint.is_some();
     let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
+    self.preflight_direct_context_capabilities(context, tree, &registry)?;
     let mut result = Value::Empty;
     let mut pending = Vec::new();
 


### PR DESCRIPTION
### Motivation
- Provide an attenuable CLI host authority envelope for native `mech run` so the CLI can start with a safe default and only have authority removed by config or flags. 
- Ensure known direct (parsed) context reads/writes/sends are validated before provider side effects to fail early on denied operations. 
- Expose CLI denial switches on the CLI to allow operators to remove CLI host authority at invocation time.

### Description
- Extend the run config types and lowering in `src/runtime/src/config_profile/lower.rs` to add `RunCliHostConfig`, `RunCliEnvConfig`, and `RunCliStreamConfig`, add `run.cli` lowering and validators for env keys and stream paths, and add unit tests for valid/invalid config cases. 
- Add `EffectiveCliHostGrants` and `CliHostGrantAttenuation` plus `effective_cli_host_grants` in `src/cli/config.rs` to compute grants by starting from the default CLI envelope, applying config narrowing, then applying CLI deny attenuation. 
- Update CLI runtime creation and grant installation in `src/bin/mech.rs` to accept `cli_grants`, install only non-empty grants (skip `cli://env`, `cli://stdout`, `cli://stderr` when their lists are empty), and add root + `run` flags `--deny-cli-env`, `--deny-cli-stdout`, and `--deny-cli-stderr` with OR-merging between root and subcommand flags. 
- Add static preflight checks in `src/runtime/src/runtime/execution.rs` (`preflight_context_access`, `preflight_context_reads_in_expression`, `preflight_direct_context_capabilities`) and invoke `preflight_direct_context_capabilities` at the start of `run_tree_on_program` so known direct context ops are denied before provider side effects while leaving runtime/provider enforcement intact. 
- Added and updated unit tests covering config lowering and effective grant computation and wired changes into the CLI flow; committed as `Add attenuable CLI host capabilities`.

### Testing
- Ran `git diff --check` (no problems) and recorded diffs against the intended base branch. 
- Ran `cargo check -p mech-runtime -q` which completed successfully. 
- Ran `cargo check --bin mech --features run,cli_host` which completed successfully. 
- Started `cargo test -p mech-runtime config_profile::lower::tests::run_cli_stdout_line_write_lowers` (unit test compile/run began) but it was interrupted by long dependency compilation in this environment and did not complete to a final pass within the run; the tests were added and locally exercise the new lowering and grant logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3863a8da20832aa382aa9d0b56e382)