### PR TITLE
Fix CLI host capability arg registration and runtime preflight

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -5,6 +5,8 @@ use mech_core::*;
 use mech_syntax::parser;
 #[cfg(feature = "run")]
 use mech_host_cli::{CliResourceProvider, StdCliBackend};
+#[cfg(feature = "run")]
+use clap::ArgMatches;
 
 #[cfg(feature = "run")]
 use mech_runtime::{
@@ -68,6 +70,24 @@ static STYLESHEET: &str = "No Embedded Stylesheet";
 pub struct Utf8ConversionError {
   pub source_error: String
 }
+
+#[cfg(feature = "run")]
+#[derive(Debug, Clone)]
+pub struct UnknownCliCapabilityProfile {
+  pub profile: String,
+}
+
+#[cfg(feature = "run")]
+impl MechErrorKind for UnknownCliCapabilityProfile {
+  fn name(&self) -> &str {
+    "UnknownCliCapabilityProfile"
+  }
+
+  fn message(&self) -> String {
+    format!("unknown CLI capability profile `{}`", self.profile)
+  }
+}
+
 impl MechErrorKind for Utf8ConversionError {
   fn name(&self) -> &str {
     "Utf8ConversionError"
@@ -116,13 +136,100 @@ async fn load_stylesheets(paths: &[String], fallback_url: &str) -> Result<String
 }
 
 #[cfg(feature = "run")]
-fn new_cli_runtime(config: RuntimeConfig) -> MResult<MechRuntime> {
+fn cli_host_capability_args() -> Vec<Arg> {
+  vec![
+    Arg::new("deny_default_capabilities")
+      .long("deny-default-capabilities")
+      .help("Disable default CLI host capability profiles for this run")
+      .global(true)
+      .action(ArgAction::SetTrue),
+    Arg::new("capabilities")
+      .long("capabilities")
+      .value_name("CAPABILITY")
+      .help("Enable named CLI host capability profiles for this run, e.g. :cli/stdout")
+      .global(true)
+      .num_args(1..)
+      .action(ArgAction::Append),
+  ]
+}
+
+#[cfg(feature = "run")]
+fn add_cli_host_capability_args(command: Command) -> Command {
+  command.args(cli_host_capability_args())
+}
+
+#[cfg(not(feature = "run"))]
+fn add_cli_host_capability_args(command: Command) -> Command {
+  command
+}
+
+#[cfg(feature = "run")]
+fn normalized_cli_args_for_capabilities() -> Vec<String> {
+  let mut normalized = Vec::new();
+  let mut args = std::env::args().peekable();
+  while let Some(arg) = args.next() {
+    if arg == "--capabilities" {
+      normalized.push(arg);
+      while let Some(next) = args.peek() {
+        if next.starts_with(':') {
+          normalized.push(args.next().unwrap());
+        } else {
+          if next != "--" {
+            normalized.push("--".to_string());
+          }
+          break;
+        }
+      }
+    } else {
+      normalized.push(arg);
+    }
+  }
+  normalized
+}
+
+#[cfg(not(feature = "run"))]
+fn normalized_cli_args_for_capabilities() -> Vec<String> {
+  std::env::args().collect()
+}
+
+#[cfg(feature = "run")]
+#[derive(Debug, Clone, Default)]
+struct CliHostCapabilitySelection {
+  deny_default_capabilities: bool,
+  capabilities: Vec<String>,
+}
+
+#[cfg(feature = "run")]
+fn cli_host_capability_selection(
+  cli_matches: &ArgMatches,
+  run_matches: Option<&ArgMatches>,
+) -> CliHostCapabilitySelection {
+  let deny_default_capabilities = cli_matches.get_flag("deny_default_capabilities")
+    || run_matches.map(|m| m.get_flag("deny_default_capabilities")).unwrap_or(false);
+  let mut capabilities = Vec::new();
+  for matches in [Some(cli_matches), run_matches].into_iter().flatten() {
+    if let Some(values) = matches.get_many::<String>("capabilities") {
+      for value in values {
+        if !capabilities.iter().any(|existing| existing == value) {
+          capabilities.push(value.to_string());
+        }
+      }
+    }
+  }
+  CliHostCapabilitySelection { deny_default_capabilities, capabilities }
+}
+
+#[cfg(feature = "run")]
+fn new_cli_runtime(config: RuntimeConfig, selection: &CliHostCapabilitySelection) -> MResult<MechRuntime> {
   let mut runtime = RuntimeBuilder::new()
     .config(config)
     .resource_provider(Box::new(CliResourceProvider::new(StdCliBackend)))
     .build()?;
 
-  grant_cli_runner_capabilities(&mut runtime)?;
+  if !selection.deny_default_capabilities {
+    grant_cli_runner_capabilities(&mut runtime)?;
+  }
+  grant_selected_cli_capabilities(&mut runtime, &selection.capabilities)?;
 
   Ok(runtime)
 }
@@ -186,6 +293,40 @@ fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<Value> {
   let result = runtime.run_string_with_context(&mut context, source);
   print_run_runtime_events(&context.events);
   result
+}
+
+#[cfg(feature = "run")]
+fn grant_cli_capability_profile(runtime: &mut MechRuntime, profile: &str) -> MResult<()> {
+  let subject = runtime.runtime_context()?.subject;
+  match profile {
+    ":cli/env" => runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://env".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: vec!["*".to_string()],
+    }),
+    ":cli/stdout" => runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://stdout".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: vec!["text".to_string(), "line".to_string()],
+    }),
+    ":cli/stderr" => runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: "cli://stderr".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: vec!["text".to_string(), "line".to_string()],
+    }),
+    unknown => Err(MechError::new(UnknownCliCapabilityProfile { profile: unknown.to_string() }, None)),
+  }
+}
+
+#[cfg(feature = "run")]
+fn grant_selected_cli_capabilities(runtime: &mut MechRuntime, capabilities: &[String]) -> MResult<()> {
+  for capability in capabilities {
+    grant_cli_capability_profile(runtime, capability)?;
+  }
+  Ok(())
 }
 
 #[cfg(feature = "run")]
@@ -438,7 +579,9 @@ async fn main() -> Result<(), MechError> {
   #[cfg(all(feature = "bundle_web", not(feature = "serve")))]
   let cli_command = bundle_web::add_config_args(cli_command);
 
-  let cli_matches = cli_command.get_matches();
+  let cli_command = add_cli_host_capability_args(cli_command);
+
+  let cli_matches = cli_command.get_matches_from(normalized_cli_args_for_capabilities());
 
   let debug_flag = cli_matches.get_flag("debug");
   let tree_flag = cli_matches.get_flag("tree");
@@ -820,7 +963,8 @@ async fn main() -> Result<(), MechError> {
     )?;
     repl_runtime_config = Some(runtime_config.clone());
 
-    let mut runtime = new_cli_runtime(runtime_config)?;
+    let capability_selection = cli_host_capability_selection(&cli_matches, run_matches);
+    let mut runtime = new_cli_runtime(runtime_config, &capability_selection)?;
 
     if !run_inputs.is_empty() && !any_look_like_paths {
       let joined = run_inputs.join(" ");

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -968,6 +968,109 @@ impl MechRuntime {
     }
   }
 
+
+  fn preflight_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<()> {
+    fn collect_var_reads(expression: &mech_core::Expression, reads: &mut Vec<(String, String)>) {
+      match expression {
+        mech_core::Expression::Var(var) => {
+          if let Some(target) = &var.context {
+            reads.push((target.to_string(), var.name.to_string()));
+          }
+        }
+        mech_core::Expression::FunctionCall(call) => {
+          for (_, argument) in &call.args {
+            collect_var_reads(argument, reads);
+          }
+        }
+        mech_core::Expression::Match(match_expr) => {
+          collect_var_reads(&match_expr.source, reads);
+          for arm in &match_expr.arms {
+            if let Some(guard) = &arm.guard {
+              collect_var_reads(guard, reads);
+            }
+            collect_var_reads(&arm.expression, reads);
+          }
+        }
+        _ => {}
+      }
+    }
+
+    fn collect_statement_reads(statement: &mech_core::Statement, reads: &mut Vec<(String, String)>) {
+      match statement {
+        mech_core::Statement::VariableDefine(def) => collect_var_reads(&def.expression, reads),
+        mech_core::Statement::VariableAssign(assign) => collect_var_reads(&assign.expression, reads),
+        mech_core::Statement::ContextSend(send) => collect_var_reads(&send.expression, reads),
+        mech_core::Statement::OpAssign(assign) => collect_var_reads(&assign.expression, reads),
+        mech_core::Statement::TupleDestructure(destructure) => collect_var_reads(&destructure.expression, reads),
+        _ => {}
+      }
+    }
+
+    let registry = self.direct_context_registry_for_scope(tree, scope)?;
+    let mut reads = Vec::new();
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            for (code, _) in codes {
+              match code {
+                mech_core::MechCode::Statement(statement) => collect_statement_reads(statement, &mut reads),
+                mech_core::MechCode::Expression(expression) => collect_var_reads(expression, &mut reads),
+                _ => {}
+              }
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, scope) =>
+          {
+            for (code, _) in &fenced.code {
+              match code {
+                mech_core::MechCode::Statement(statement) => collect_statement_reads(statement, &mut reads),
+                mech_core::MechCode::Expression(expression) => collect_var_reads(expression, &mut reads),
+                _ => {}
+              }
+            }
+          }
+          _ => {}
+        }
+      }
+    }
+
+    for (target, path) in reads {
+      let Some(binding) = registry.get(&target) else {
+        continue;
+      };
+      let resolved = self.resolve_context_resource_request(binding, &path)?;
+      if !runtime_context_allows_read(binding, &resolved.context_path) {
+        return Err(MechError::new(RuntimeResourceCapabilityDenied {
+          context_name: binding.name.clone(),
+          operation: "read".to_string(),
+          path: resolved.context_path,
+        }, None));
+      }
+      if !self.grants.allows(
+        &context.subject,
+        &resolved.provider_base_uri,
+        &RuntimeCapabilityOperation::Read,
+        &resolved.provider_path,
+      ) {
+        return Err(MechError::new(RuntimeCapabilityGrantDenied {
+          subject: context.subject.clone(),
+          resource: resolved.provider_base_uri,
+          operation: RuntimeCapabilityOperation::Read,
+          path: resolved.provider_path,
+        }, None));
+      }
+    }
+
+    Ok(())
+  }
+
   fn run_tree_on_program(
     &mut self,
     context: &mut RuntimeContext,
@@ -1065,27 +1168,30 @@ impl MechRuntime {
     )?;
 
     let result = match mech_syntax::parser::parse(source.trim()) {
-      Ok(tree) => {
-        let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(
-          &mut self.program,
-          MechProgram::new(program_config),
-        );
+      Ok(tree) => match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
+        Ok(()) => {
+          let program_config = self.program.config.clone();
+          let mut program = std::mem::replace(
+            &mut self.program,
+            MechProgram::new(program_config),
+          );
 
-        self.register_runtime_program_host_functions(
-          context,
-          &mut program,
-        )?;
+          self.register_runtime_program_host_functions(
+            context,
+            &mut program,
+          )?;
 
-        let runtime_ptr: *mut MechRuntime = self;
-        let context_ptr: *mut RuntimeContext = context;
-        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+          let runtime_ptr: *mut MechRuntime = self;
+          let context_ptr: *mut RuntimeContext = context;
+          let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-        let result = self.run_tree_on_program(context, &mut program, &tree, None);
+          let result = self.run_tree_on_program(context, &mut program, &tree, None);
 
-        self.program = program;
-        result
-      }
+          self.program = program;
+          result
+        }
+        Err(error) => Err(error),
+      },
       Err(error) => Err(error),
     };
 
@@ -1167,7 +1273,10 @@ impl MechRuntime {
     let context_ptr: *mut RuntimeContext = context;
     let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-    let result = self.run_tree_on_program(context, &mut program, tree, None);
+    let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program) {
+      Ok(()) => self.run_tree_on_program(context, &mut program, tree, None),
+      Err(error) => Err(error),
+    };
 
     self.program = program;
 
@@ -1474,8 +1583,10 @@ impl MechRuntime {
 
     let result = match source {
       MechSourceCode::String(source) => {
-        mech_syntax::parser::parse(source.trim())
-          .and_then(|tree| self.run_tree_on_program(context, program, &tree, Some(&execution_scope)))
+        mech_syntax::parser::parse(source.trim()).and_then(|tree| {
+          self.preflight_context_capabilities(context, &tree, &execution_scope)?;
+          self.run_tree_on_program(context, program, &tree, Some(&execution_scope))
+        })
       }
       other => program.run_source(other),
     };

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3068,3 +3068,24 @@ fn direct_context_read_resolves_inside_op_assign() {
     other => panic!("expected f64 total, got {other:?}"),
   }
 }
+
+#[test]
+fn cli_module_preflight_denies_later_read_before_stdout_write() {
+  let root = setup_modules("+> @out := cli/stdout\n+> @env := cli/env\n\n@out/line <- \"must-not-write\"\nx := @env/HOME\n\"done\"\n");
+  let state = Arc::new(Mutex::new(RuntimeFakeCliState::default()));
+  state.lock().unwrap().env.insert("HOME".to_string(), "/tmp/denied".to_string());
+  let mut runtime = RuntimeBuilder::new()
+    .source_resolver(FileSourceResolver::new(&root))
+    .resource_provider(Box::new(CliResourceProvider::new(RuntimeFakeCliBackend::new(state.clone()))))
+    .build()
+    .unwrap();
+
+  runtime.grant_capability(runtime_context_write_grant(&runtime, "cli://stdout", "line")).unwrap();
+  let version = runtime.resolve_and_store_module_source("main.mec", module_options()).unwrap().unwrap();
+  let result = runtime.run_module(version);
+
+  assert!(result.is_err(), "missing env read grant should fail");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeCapabilityGrantDenied"), "expected host grant denial, got {error}");
+  assert_eq!(state.lock().unwrap().stdout_writes, 0, "module preflight should prevent earlier stdout write");
+}

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -165,3 +165,76 @@ fn mech_run_without_inputs_and_without_config_errors() {
     combined,
   );
 }
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_accepts_single_cli_host_capability_arg_without_clap_panic() {
+  let root = temp_root("cap-single");
+  let source_path = root.join("stdout_only.mec");
+  std::fs::write(
+    &source_path,
+    r#"+> @out := cli/stdout
+@out/line <- "stdout-only-ok"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(&source_path)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "stdout-only-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_accepts_multi_value_cli_host_capability_arg() {
+  let root = temp_root("cap-multi");
+  let source_path = write_cli_host_source(&root);
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(":cli/env")
+    .arg(&source_path)
+    .env("MECH_CLI_HOST_TEST", "multi-capability-ok")
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "multi-capability-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_unknown_cli_host_capability_profile_errors() {
+  let root = temp_root("cap-unknown");
+  let source_path = write_cli_host_source(&root);
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":quxx")
+    .arg(&source_path)
+    .output()
+    .unwrap();
+
+  assert!(!output.status.success(), "unknown profile should fail");
+  let combined = format!(
+    "{}{}",
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr)
+  );
+  assert!(
+    combined.contains("unknown CLI capability profile `:quxx`"),
+    "expected unknown profile error, got:\n{}",
+    combined,
+  );
+}


### PR DESCRIPTION
### Motivation

- Fix a Clap duplicate-argument panic by ensuring CLI host capability flags are registered exactly once at the root and parsed as global options. 
- Prevent provider side-effects from occurring before capability checks by routing preflight failures into the existing program result flow. 
- Add targeted tests to cover CLI capability flag parsing and a module preflight regression to guard against regressions.

### Description

- Register the CLI host capability arguments once using `cli_host_capability_args()` and attach them via a single `add_cli_host_capability_args(cli_command)` call on the root command, and normalize parsing with `normalized_cli_args_for_capabilities()`. 
- Introduce `cli_host_capability_selection(...)`, make `new_cli_runtime(...)` accept the selection, and grant selected capability profiles via `grant_cli_capability_profile(...)` without reintroducing host-specific deny flags. 
- Add `preflight_context_capabilities(...)` and invoke it from `run_string_with_context`, `run_tree_with_context`, and `run_module_source_on_program` so preflight failures become the `result` and module execution preflights before any provider writes. 
- Add tests: CLI integration tests in `tests/mech_cli_host.rs` for single/multi-value `--capabilities` and unknown-profile behavior, and a runtime module test in `src/runtime/tests/module_smoke.rs` that verifies denied reads block earlier stdout writes.

### Testing

- Commit: `bbed26a5b2133506f9c914dfffa6bbdc14b85e8b`. 
- Changed files: `src/bin/mech.rs`, `src/runtime/src/runtime/execution.rs`, `src/runtime/tests/module_smoke.rs`, and `tests/mech_cli_host.rs`. 
- Diff stat: 4 files changed, 374 insertions(+), 25 deletions(-). 
- Confirmations: there is exactly one root-level CLI host capability arg registration via `add_cli_host_capability_args(cli_command)`, `--capabilities` values are parsed without being appended to `run_inputs`, `run_string_with_context` preflight failures are propagated through the existing `ProgramFailed`/`ProgramProfiled` handling, and module execution now preflights before provider effects. 
- Automated test runs: `cargo check --features run,cli_host --bin mech` succeeded, `cargo test --test mech_cli_host --features run,cli_host` succeeded (all tests passed), `cargo test -p mech-runtime --test module_smoke` succeeded (all tests passed), and `cargo test -p mech-host-cli --features provider` succeeded, and `git diff --check` reported no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39556016d4832a8000b74e8021373d)