### PR TITLE
Avoid running configured run.paths on bare mech and seed REPL from runtime program

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -693,6 +693,8 @@ async fn main() -> Result<(), MechError> {
   let uuid = generate_uuid();
   #[cfg(feature = "run")]
   let mut repl_runtime_config: Option<RuntimeConfig> = None;
+  #[cfg(all(feature = "run", feature = "repl"))]
+  let mut repl_seed_program: Option<MechProgram> = None;
 
   #[cfg(feature = "run")]
   {
@@ -779,9 +781,14 @@ async fn main() -> Result<(), MechError> {
       Ok(Value::Empty)
     };
 
-    if !repl_flag {
-      match &result {
-        Ok(r) => {
+    match &result {
+      Ok(r) if repl_flag => {
+        #[cfg(feature = "repl")]
+        {
+          repl_seed_program = Some(runtime.take_program());
+        }
+        #[cfg(not(feature = "repl"))]
+        {
           println!("{}", r.kind());
           #[cfg(feature = "pretty_print")]
           println!("{}", r.pretty_print());
@@ -789,11 +796,19 @@ async fn main() -> Result<(), MechError> {
           println!("{:#?}", r);
           std::process::exit(0);
         }
-        Err(err) => {
-          print_mech_error(err);
-          std::process::exit(1);
-        }
-      };
+      }
+      Ok(r) => {
+        println!("{}", r.kind());
+        #[cfg(feature = "pretty_print")]
+        println!("{}", r.pretty_print());
+        #[cfg(not(feature = "pretty_print"))]
+        println!("{:#?}", r);
+        std::process::exit(0);
+      }
+      Err(err) => {
+        print_mech_error(err);
+        std::process::exit(1);
+      }
     }
 
     #[cfg(windows)]
@@ -837,18 +852,22 @@ async fn main() -> Result<(), MechError> {
   #[cfg(all(feature = "repl", feature = "run"))]
   // TODO: move the REPL onto MechRuntime as a separate PR so CLI host contexts work interactively too.
   let mut repl = {
-    let config = repl_runtime_config.unwrap_or_else(RuntimeConfig::default);
-    let mut repl_program = MechProgram::new(MechProgramConfig {
-      name: config.name.clone(),
-      environment: MechProgramEnvironment::default(),
-    });
-    repl_program.configure(
-      config.diagnostics.debug_enabled,
-      config.diagnostics.trace_enabled,
-      config.diagnostics.profile_enabled,
-      config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
-    );
-    MechRepl::from(repl_program)
+    if let Some(program) = repl_seed_program {
+      MechRepl::from(program)
+    } else {
+      let config = repl_runtime_config.unwrap_or_else(RuntimeConfig::default);
+      let mut repl_program = MechProgram::new(MechProgramConfig {
+        name: config.name.clone(),
+        environment: MechProgramEnvironment::default(),
+      });
+      repl_program.configure(
+        config.diagnostics.debug_enabled,
+        config.diagnostics.trace_enabled,
+        config.diagnostics.profile_enabled,
+        config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+      );
+      MechRepl::from(repl_program)
+    }
   };
   #[cfg(all(feature = "repl", not(feature = "run")))]
   let mut repl = MechRepl::from(MechProgram::new(MechProgramConfig {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -264,6 +264,7 @@ pub fn effective_run_options(
     .unwrap_or_default();
 
   let mut effective_cli_paths = cli_paths;
+  let had_cli_selector = !effective_cli_paths.is_empty();
 
   if let Some(loaded) = config {
     if let Some(project_dir) = loaded.discovered_project_dir.as_ref() {
@@ -288,8 +289,10 @@ pub fn effective_run_options(
 
   let paths = if !effective_cli_paths.is_empty() {
     effective_cli_paths
-  } else {
+  } else if explicit_run_command || had_cli_selector {
     config_paths
+  } else {
+    Vec::new()
   };
 
   if paths.is_empty() {
@@ -631,6 +634,13 @@ mod config_tests {
   #[test]
   fn implicit_run_without_inputs_returns_none() {
     let options = effective_run_options(vec![], None, false).unwrap();
+    assert_eq!(options, None);
+  }
+
+  #[test]
+  fn implicit_run_without_cli_selector_ignores_config_run_paths() {
+    let config = loaded_config(r#"config := {run: {paths: ["foo.mec"]}}"#);
+    let options = effective_run_options(vec![], Some(&config), false).unwrap();
     assert_eq!(options, None);
   }
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1706,6 +1706,11 @@ impl MechRuntime {
     result
   }
 
+  pub fn take_program(&mut self) -> MechProgram {
+    let program_config = self.program.config.clone();
+    std::mem::replace(&mut self.program, MechProgram::new(program_config))
+  }
+
   pub fn out_string(&self) -> String {
     self.program.out_string()
   }

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -1,3 +1,9 @@
+#[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
+use std::io::Write;
+
+#[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
+use std::process::Stdio;
+
 #[cfg(all(feature = "run", feature = "cli_host"))]
 fn temp_root(name: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!(
@@ -9,6 +15,29 @@ fn temp_root(name: &str) -> std::path::PathBuf {
   ));
   std::fs::create_dir_all(&root).unwrap();
   root
+}
+
+#[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
+fn run_mech_with_stdin(
+  root: &std::path::Path,
+  args: &[&str],
+  input: &str,
+) -> std::process::Output {
+  let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .args(args)
+    .current_dir(root)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .unwrap();
+
+  {
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(input.as_bytes()).unwrap();
+  }
+
+  child.wait_with_output().unwrap()
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
@@ -127,6 +156,58 @@ fn mech_project_directory_uses_config_run_paths() {
     .unwrap();
 
   assert_success_contains(output, "mech-project-run-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
+#[test]
+fn bare_mech_with_run_paths_enters_repl_without_running_config_paths() {
+  let root = temp_root("bare-mech-config-repl");
+  write_cli_host_source(&root);
+  std::fs::write(
+    root.join("mech.mcfg"),
+    r#"config := {
+  run: {
+    paths: ["cli_host.mec"]
+  }
+}
+"#,
+  )
+  .unwrap();
+
+  let output = run_mech_with_stdin(&root, &[], ":quit\n");
+  let combined = combined_output(&output);
+
+  assert!(
+    output.status.success(),
+    "bare mech REPL should exit cleanly:
+{combined}"
+  );
+  assert!(
+    !combined.contains("MECH_CLI_HOST_TEST") && !combined.contains("mech-config-run-ok"),
+    "bare mech unexpectedly executed configured run.paths:
+{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
+#[test]
+fn repl_after_file_execution_preserves_loaded_program_state() {
+  let root = temp_root("repl-startup-state");
+  std::fs::write(root.join("startup.mec"), "x := 42\n").unwrap();
+
+  let output = run_mech_with_stdin(&root, &["startup.mec", "--repl"], "x\n:quit\n");
+  let combined = combined_output(&output);
+
+  assert!(
+    output.status.success(),
+    "REPL command failed:
+{combined}"
+  );
+  assert!(
+    combined.contains("42"),
+    "REPL did not see definition loaded from startup file:
+{combined}"
+  );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]


### PR DESCRIPTION
### Motivation

- Prevent bare `mech` (no args) from automatically executing configured `run.paths` in `mech.mcfg` while preserving existing behaviors for `mech run` and project directory selection. 
- Preserve the program state loaded by startup files so the interactive REPL can see definitions loaded during startup. 
- Add integration tests to cover both the bare-CLI behavior and REPL startup-state preservation.

### Description

- Adjusted `effective_run_options` in `src/cli/config.rs` to record a CLI selector presence via `let had_cli_selector = !effective_cli_paths.is_empty();` and changed path selection to return `Vec::new()` for the bare `mech` case unless `explicit_run_command` or a CLI selector was present, keeping project-selector and explicit-run behaviors intact. (adds unit test `implicit_run_without_cli_selector_ignores_config_run_paths`).
- Added `pub fn take_program(&mut self) -> MechProgram` to `impl MechRuntime` in `src/runtime/src/runtime/execution.rs` to safely extract the populated program while leaving a fresh program in the runtime. 
- Updated `src/bin/mech.rs` to seed the REPL from a `repl_seed_program: Option<MechProgram>`: capture the populated runtime program with `runtime.take_program()` when files run and `--repl` is requested, and construct the `MechRepl` from that seeded `MechProgram` when present; replaced the previous `if !repl_flag` block with a single `match` that exits on startup-file errors before REPL entry. 
- Added integration test helpers and tests in `tests/mech_cli_host.rs`: a `run_mech_with_stdin` helper plus `bare_mech_with_run_paths_enters_repl_without_running_config_paths` and `repl_after_file_execution_preserves_loaded_program_state` to exercise the changed behaviors.

### Testing

- Ran `cargo fmt` and formatting completed successfully.
- Ran `cargo test --test mech_cli_host --features run,cli_host` and all tests passed (19 tests).
- Ran `cargo test --test mech_cli_host --features run,cli_host,repl` and all tests passed (19 tests).
- Ran `cargo test -p mech-runtime --test module_smoke` and the module smoke suite passed (177 tests).
- Ran `cargo test -p mech-host-cli --features provider` and provider tests passed.

All automated test runs listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39e80f1e50832a9f22023a1af8d5d2)