### PR TITLE
Reject stdout assignments before execution

### DIFF
--- a/hosts/browser/src/provider.rs
+++ b/hosts/browser/src/provider.rs
@@ -3,7 +3,7 @@ use mech_core::{
   BrowserOperation, BROWSER_DOM_PROVIDER_URI, MResult, MechError, MechErrorKind, Ref, Value,
 };
 
-use mech_runtime::{RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent, RuntimeResourceWriteRequest};
+use mech_runtime::{RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest};
 
 pub trait BrowserDomBackend: std::fmt::Debug {
   fn read_dom_string(
@@ -89,11 +89,31 @@ impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B
     Ok(Value::String(Ref::new(self.backend.read_dom_string(entry, &path)?)))
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
     if request.intent != RuntimeResourceWriteIntent::Assign {
       return Err(browser_resource_provider_error(&request.base_uri, "browser DOM resources do not support send intent; use assignment"));
     }
     Self::validate_dom_base(&request.base_uri)?;
+    let path = Self::dom_path(request.path)?;
+    let Some(entry) = self.authority.dom_entry_for_path(&path) else {
+      return Err(browser_resource_provider_error(
+        path.as_str(),
+        "no configured DOM manifest entry for path",
+      ));
+    };
+    self
+      .authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Write)
+      .map_err(browser_capability_error)
+  }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    self.preflight_write(RuntimeResourceWritePreflightRequest {
+      base_uri: request.base_uri.clone(),
+      path: request.path.clone(),
+      context_name: request.context_name.clone(),
+      intent: request.intent,
+    })?;
     let path = Self::dom_path(request.path)?;
     let entry = self
       .authority
@@ -105,10 +125,6 @@ impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B
           "no configured DOM manifest entry for path",
         )
       })?;
-    self
-      .authority
-      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Write)
-      .map_err(browser_capability_error)?;
     let Value::String(value) = request.value else {
       return Err(browser_resource_provider_error(
         path.as_str(),

--- a/hosts/cli/src/provider.rs
+++ b/hosts/cli/src/provider.rs
@@ -3,7 +3,7 @@ use std::{env::VarError, io::Write};
 use mech_core::{MResult, MechError, MechErrorKind, Ref, Value};
 use mech_runtime::{
     RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
-    RuntimeResourceWriteRequest,
+    RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
 };
 
 pub trait CliBackend: std::fmt::Debug {
@@ -97,39 +97,49 @@ impl<B: CliBackend> RuntimeResourceProvider for CliResourceProvider<B> {
         }
     }
 
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
         match request.base_uri.as_str() {
             "cli://env" => Err(cli_error(
                 request.base_uri,
                 "cli env is read-only and does not support writes or sends",
             )),
             "cli://stdout" | "cli://stderr" => {
-                // The manifest grants stdout/stderr `write`; the provider currently accepts only
-                // send intents because context sends are represented as resource write requests.
                 if request.intent != RuntimeResourceWriteIntent::Send {
                     return Err(cli_error(
                         request.base_uri,
                         "stdout/stderr are send-only; use <-",
                     ));
                 }
-                let suffix = match request.path.as_str() {
-                    "text" => "",
-                    "line" => "\n",
-                    _ => {
-                        return Err(cli_error(
-                            request.base_uri,
-                            "stdout/stderr support only `text` and `line` paths",
-                        ));
-                    }
-                };
-                let text = value_to_text(&request.value) + suffix;
-                if request.base_uri == "cli://stdout" {
-                    self.backend.write_stdout(&text)
-                } else {
-                    self.backend.write_stderr(&text)
+                match request.path.as_str() {
+                    "text" | "line" => Ok(()),
+                    _ => Err(cli_error(
+                        request.base_uri,
+                        "stdout/stderr support only `text` and `line` paths",
+                    )),
                 }
             }
             other => Err(cli_error(other.to_string(), "unsupported cli resource")),
+        }
+    }
+
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        self.preflight_write(RuntimeResourceWritePreflightRequest {
+            base_uri: request.base_uri.clone(),
+            path: request.path.clone(),
+            context_name: request.context_name.clone(),
+            intent: request.intent,
+        })?;
+
+        let suffix = match request.path.as_str() {
+            "text" => "",
+            "line" => "\n",
+            _ => unreachable!("cli stdout/stderr path validated by preflight_write"),
+        };
+        let text = value_to_text(&request.value) + suffix;
+        if request.base_uri == "cli://stdout" {
+            self.backend.write_stdout(&text)
+        } else {
+            self.backend.write_stderr(&text)
         }
     }
 }

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -15,6 +15,14 @@ pub enum RuntimeResourceWriteIntent {
   Send,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeResourceWritePreflightRequest {
+  pub base_uri: String,
+  pub path: String,
+  pub context_name: String,
+  pub intent: RuntimeResourceWriteIntent,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RuntimeResourceWriteRequest {
   pub base_uri: String,
@@ -30,6 +38,10 @@ pub trait RuntimeResourceProvider: std::fmt::Debug {
   fn base_uris(&self) -> Vec<String> { Vec::new() }
 
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
+
+  fn preflight_write(&self, _request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    Ok(())
+  }
 
   fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
     Err(MechError::new(
@@ -112,6 +124,20 @@ impl RuntimeResourceRegistry {
       ));
     };
     provider.read(request)
+  }
+
+  pub fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+    let Some(provider) = self.providers.get(&scheme) else {
+      return Err(MechError::new(
+        RuntimeResourceProviderNotFound {
+          scheme,
+          uri: request.base_uri,
+        },
+        None,
+      ));
+    };
+    provider.preflight_write(request)
   }
 
   pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
@@ -212,7 +238,7 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
     Ok(value.clone())
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
     if request.intent == RuntimeResourceWriteIntent::Send {
       return Err(MechError::new(
         RuntimeResourceWriteUnsupported {
@@ -244,6 +270,17 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
         None,
       ));
     }
+
+    Ok(())
+  }
+
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    self.preflight_write(RuntimeResourceWritePreflightRequest {
+      base_uri: request.base_uri.clone(),
+      path: request.path.clone(),
+      context_name: request.context_name.clone(),
+      intent: request.intent,
+    })?;
 
     self.documents
       .entry(request.base_uri)

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -13,6 +13,7 @@
 
 use super::*;
 use crate::SourceIndex;
+use crate::RuntimeResourceWritePreflightRequest;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
@@ -1221,6 +1222,7 @@ impl MechRuntime {
             &path,
             RuntimeCapabilityOperation::Write,
             true,
+            Some(RuntimeResourceWriteIntent::Assign),
           )?;
         }
         self.preflight_expression_context_reads(context, registry, &assign.expression)?;
@@ -1251,6 +1253,7 @@ impl MechRuntime {
           &path,
           RuntimeCapabilityOperation::Write,
           true,
+          Some(RuntimeResourceWriteIntent::Send),
         )?;
 
         self.preflight_expression_context_reads(context, registry, &send.expression)?;
@@ -1291,6 +1294,7 @@ impl MechRuntime {
             &var.name.to_string(),
             RuntimeCapabilityOperation::Read,
             false,
+            None,
           )?;
         }
       }
@@ -1520,6 +1524,7 @@ impl MechRuntime {
     path: &str,
     operation: RuntimeCapabilityOperation,
     require_context_binding: bool,
+    write_intent: Option<RuntimeResourceWriteIntent>,
   ) -> MResult<()> {
     let Some(binding) = registry.get(context_name) else {
       if require_context_binding {
@@ -1563,6 +1568,16 @@ impl MechRuntime {
         None,
       ));
     }
+
+    if let Some(intent) = write_intent {
+      self.resources.preflight_write(RuntimeResourceWritePreflightRequest {
+        base_uri: resolved.provider_base_uri,
+        path: resolved.provider_path,
+        context_name: binding.name.clone(),
+        intent,
+      })?;
+    }
+
     Ok(())
   }
 

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3375,6 +3375,31 @@ fn unknown_context_send_target_fails_preflight_before_writes() {
   );
 }
 #[test]
+fn context_assignment_to_send_only_cli_stream_fails_preflight_before_writes() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@out/line <- \"must-not-write\"
+@out/line = \"done\"
+",
+  );
+
+  assert!(result.is_err(), "stdout assignment should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("send-only") || error.contains("use <-"),
+    "expected send-only assignment error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
 fn context_send_inside_function_body_fails_runtime_preflight() {
   let (mut runtime, state) = runtime_with_recording_cli();
   grant_runtime_stdout_line(&mut runtime);


### PR DESCRIPTION
### Motivation
- Prevent resource backend side effects during preflight by validating write intent at the provider level before any mutation or host I/O occurs. 
- Ensure provider-specific write contracts (e.g. CLI stdout/stderr are send-only, browser DOM is assignment-only) are enforced consistently and early during context preflight.

### Description
- Add `RuntimeResourceWritePreflightRequest` and a default `preflight_write` hook to `RuntimeResourceProvider`, and dispatch it from `RuntimeResourceRegistry::preflight_write` before writes. 
- Move non-value validation for `InMemoryDocsProvider` into `preflight_write` and simplify `write` to call preflight first and then perform the mutation. 
- Implement `preflight_write` for the CLI provider to enforce the CLI write contract: reject all writes to `cli://env`, accept only `Send` intent for `cli://stdout`/`cli://stderr`, and accept only `text`/`line` paths, with `write` delegating to preflight for validation. 
- Implement `preflight_write` for the browser provider to enforce assignment-only DOM writes, validate DOM base and path resolution, require a configured manifest entry and DOM write authority, and keep value-type checks in `write`. 
- Extend `preflight_context_access` to accept an optional `write_intent: Option<RuntimeResourceWriteIntent>` and have callers pass `Some(Assign)`, `Some(Send)`, or `None` as appropriate; after grant checks the runtime now calls `resources.preflight_write(...)` when `write_intent` is provided. 
- Add a regression test `context_assignment_to_send_only_cli_stream_fails_preflight_before_writes` to assert stdout assignment is rejected during preflight and that no stdout was written.

### Testing
- Ran `cargo test -p mech-runtime --test module_smoke` and the test suite passed. 
- Ran `cargo test -p mech-host-cli --features provider --test provider` and the provider tests passed. 
- Ran `cargo test --features "run repl pretty_print" --test mech_cli_host` and those tests passed. 
- Ran `cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli` and `cargo check -p mech-host-cli --no-default-features` and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae3519f3c832aa8e14a902cec58b1)