### PR TITLE
Fix split inline input classification; add FSM-pipe/context pattern preflight & rewrites; add tests

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -70,10 +70,15 @@ pub fn classify_run_inputs(inputs: Vec<String>) -> RunInputMode {
     return RunInputMode::InlineSource(inputs[0].clone());
   }
 
+  let joined = inputs.join(" ");
+  if mech_syntax::parser::parse(joined.trim()).is_ok() {
+    return RunInputMode::InlineSource(joined);
+  }
+
   if inputs.iter().any(|input| is_intended_path(input)) {
     RunInputMode::Paths(inputs)
   } else {
-    RunInputMode::InlineSource(inputs.join(" "))
+    RunInputMode::InlineSource(joined)
   }
 }
 
@@ -426,8 +431,28 @@ mod tests {
   }
 
   #[test]
-  fn classifies_multiple_path_like_inputs_as_paths() {
-    let mode = classify_run_inputs(vec!["examples/foo.mec".to_string(), "bar.mec".to_string()]);
+  fn classifies_split_inline_context_read_with_slashes_as_inline_source() {
+    let mode = classify_run_inputs(vec![
+      "x".to_string(),
+      ":=".to_string(),
+      "@env/HOME".to_string(),
+    ]);
+    assert!(matches!(mode, RunInputMode::InlineSource(_)));
+  }
+
+  #[test]
+  fn classifies_split_inline_context_send_with_slashes_as_inline_source() {
+    let mode = classify_run_inputs(vec![
+      "@out/line".to_string(),
+      "<-".to_string(),
+      "\"hi\"".to_string(),
+    ]);
+    assert!(matches!(mode, RunInputMode::InlineSource(_)));
+  }
+
+  #[test]
+  fn classifies_unparseable_path_like_inputs_as_paths() {
+    let mode = classify_run_inputs(vec!["examples/foo.mec".to_string(), "\0".to_string()]);
     assert!(matches!(mode, RunInputMode::Paths(_)));
   }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -71,7 +71,7 @@ pub fn classify_run_inputs(inputs: Vec<String>) -> RunInputMode {
   }
 
   let joined = inputs.join(" ");
-  if mech_syntax::parser::parse(joined.trim()).is_ok() {
+  if parses_as_executable_run_source(&joined) {
     return RunInputMode::InlineSource(joined);
   }
 
@@ -79,6 +79,42 @@ pub fn classify_run_inputs(inputs: Vec<String>) -> RunInputMode {
     RunInputMode::Paths(inputs)
   } else {
     RunInputMode::InlineSource(joined)
+  }
+}
+
+fn parses_as_executable_run_source(input: &str) -> bool {
+  mech_syntax::parser::parse(input.trim())
+    .map(|program| program_contains_executable_run_source(&program))
+    .unwrap_or(false)
+}
+
+fn program_contains_executable_run_source(program: &Program) -> bool {
+  program.body.sections.iter().any(|section| {
+    section.elements.iter().any(section_element_contains_executable_run_source)
+  })
+}
+
+fn section_element_contains_executable_run_source(element: &SectionElement) -> bool {
+  match element {
+    SectionElement::MechCode(codes) => {
+      codes.iter().any(|(code, _)| mech_code_is_executable_run_source(code))
+    }
+    SectionElement::FencedMechCode(fenced) => {
+      fenced.code.iter().any(|(code, _)| mech_code_is_executable_run_source(code))
+    }
+    _ => false,
+  }
+}
+
+fn mech_code_is_executable_run_source(code: &MechCode) -> bool {
+  match code {
+    MechCode::Statement(_)
+    | MechCode::Expression(_)
+    | MechCode::FunctionDefine(_)
+    | MechCode::FsmImplementation(_)
+    | MechCode::FsmSpecification(_)
+    | MechCode::Import(_) => true,
+    MechCode::Comment(_) | MechCode::Error(_, _) => false,
   }
 }
 
@@ -451,8 +487,11 @@ mod tests {
   }
 
   #[test]
-  fn classifies_unparseable_path_like_inputs_as_paths() {
-    let mode = classify_run_inputs(vec!["examples/foo.mec".to_string(), "\0".to_string()]);
+  fn classifies_multiple_path_like_inputs_as_paths_even_if_joined_text_parses() {
+    let mode = classify_run_inputs(vec![
+      "examples/foo.mec".to_string(),
+      "bar.mec".to_string(),
+    ]);
     assert!(matches!(mode, RunInputMode::Paths(_)));
   }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -147,6 +147,9 @@ pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, en
       if semantics == PatternMatchSemantics::OptionGuard {
         #[cfg(feature = "bool")]
         if let Value::Bool(flag) = &expected {
+          if matches!(expr, Expression::Literal(Literal::Boolean(_))) {
+            return Ok(values_match(&deep_detach_value(&expected), &detached_value));
+          }
           return Ok(*flag.borrow());
         }
       }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -459,13 +459,9 @@ impl MechRuntime {
         Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
       }
       mech_core::Expression::FsmPipe(pipe) => {
-        let mut pipe = pipe.clone();
-        if let Some(args) = &pipe.start.args {
-          pipe.start.args = Some(args.iter().map(|(name, expression)| {
-            Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
-          }).collect::<MResult<Vec<_>>>()?);
-        }
-        Ok(mech_core::Expression::FsmPipe(pipe))
+        Ok(mech_core::Expression::FsmPipe(
+          self.resolve_context_reads_in_fsm_pipe(context, program, registry, pipe)?,
+        ))
       }
       mech_core::Expression::Literal(_) => Ok(expression.clone()),
       mech_core::Expression::Match(match_expression) => {
@@ -473,7 +469,7 @@ impl MechRuntime {
         match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
         match_expression.arms = match_expression.arms.iter().map(|arm| {
           Ok(mech_core::MatchArm {
-            pattern: arm.pattern.clone(),
+            pattern: self.resolve_context_reads_in_pattern(context, program, registry, &arm.pattern)?,
             guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
             expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
           })
@@ -762,6 +758,28 @@ impl MechRuntime {
     }
   }
 
+  fn resolve_context_reads_in_fsm_pipe(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pipe: &mech_core::FsmPipe,
+  ) -> MResult<mech_core::FsmPipe> {
+    let mut pipe = pipe.clone();
+
+    if let Some(args) = &pipe.start.args {
+      pipe.start.args = Some(args.iter().map(|(name, expression)| {
+        Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
+      }).collect::<MResult<Vec<_>>>()?);
+    }
+
+    pipe.transitions = pipe.transitions.iter()
+      .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+      .collect::<MResult<Vec<_>>>()?;
+
+    Ok(pipe)
+  }
+
   fn resolve_context_reads_in_fsm_implementation(
     &mut self,
     context: &RuntimeContext,
@@ -879,6 +897,11 @@ impl MechRuntime {
         let mut invariant = invariant.clone();
         invariant.expression = self.resolve_context_reads_in_expression(context, program, registry, &invariant.expression)?;
         Ok(mech_core::Statement::InvariantDefine(invariant))
+      }
+      mech_core::Statement::FsmDeclare(fsm) => {
+        let mut fsm = fsm.clone();
+        fsm.pipe = self.resolve_context_reads_in_fsm_pipe(context, program, registry, &fsm.pipe)?;
+        Ok(mech_core::Statement::FsmDeclare(fsm))
       }
       _ => Ok(statement.clone()),
     }
@@ -1274,8 +1297,30 @@ impl MechRuntime {
       mech_core::Statement::InvariantDefine(invariant) => {
         self.preflight_expression_context_reads(context, registry, &invariant.expression)
       }
+      mech_core::Statement::FsmDeclare(fsm) => {
+        self.preflight_fsm_pipe_context_capabilities(context, registry, &fsm.pipe)
+      }
       _ => Ok(()),
     }
+  }
+
+  fn preflight_fsm_pipe_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    pipe: &mech_core::FsmPipe,
+  ) -> MResult<()> {
+    if let Some(args) = &pipe.start.args {
+      for (_, expression) in args {
+        self.preflight_expression_context_reads(context, registry, expression)?;
+      }
+    }
+
+    for transition in &pipe.transitions {
+      self.preflight_transition_context_capabilities(context, registry, transition)?;
+    }
+
+    Ok(())
   }
 
   fn preflight_expression_context_reads(
@@ -1307,11 +1352,7 @@ impl MechRuntime {
         }
       }
       mech_core::Expression::FsmPipe(pipe) => {
-        if let Some(args) = &pipe.start.args {
-          for (_, expression) in args {
-            self.preflight_expression_context_reads(context, registry, expression)?;
-          }
-        }
+        self.preflight_fsm_pipe_context_capabilities(context, registry, pipe)?;
       }
       mech_core::Expression::Literal(_) => {}
       mech_core::Expression::Range(range) => {
@@ -1327,6 +1368,7 @@ impl MechRuntime {
       mech_core::Expression::Match(match_expression) => {
         self.preflight_expression_context_reads(context, registry, &match_expression.source)?;
         for arm in &match_expression.arms {
+          self.preflight_pattern_context_reads(context, registry, &arm.pattern)?;
           if let Some(guard) = &arm.guard {
             self.preflight_expression_context_reads(context, registry, guard)?;
           }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -469,7 +469,7 @@ impl MechRuntime {
         match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
         match_expression.arms = match_expression.arms.iter().map(|arm| {
           Ok(mech_core::MatchArm {
-            pattern: self.resolve_context_reads_in_pattern(context, program, registry, &arm.pattern)?,
+            pattern: self.resolve_context_reads_in_match_pattern(context, program, registry, &arm.pattern)?,
             guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
             expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
           })
@@ -727,6 +727,108 @@ impl MechRuntime {
         }))
       }
       mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+    }
+  }
+
+  fn resolve_context_reads_in_match_pattern(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<mech_core::Pattern> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+        self.resolve_context_reads_in_match_pattern_expression(context, program, registry, expression)?,
+      )),
+      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
+        name: tuple_struct.name.clone(),
+        patterns: tuple_struct.patterns.iter()
+          .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+        tuple.0.iter()
+          .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      ))),
+      mech_core::Pattern::Array(array) => {
+        let spread = if let Some(spread) = &array.spread {
+          Some(mech_core::PatternArraySpread {
+            kind: spread.kind.clone(),
+            binding: spread.binding.as_ref()
+              .map(|binding| self.resolve_context_reads_in_match_pattern(context, program, registry, binding).map(Box::new))
+              .transpose()?,
+          })
+        } else {
+          None
+        };
+        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+          prefix: array.prefix.iter()
+            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+          spread,
+          suffix: array.suffix.iter()
+            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        }))
+      }
+      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+    }
+  }
+
+  fn resolve_context_reads_in_match_pattern_expression(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<mech_core::Expression> {
+    if let mech_core::Expression::Var(var) = expression {
+      if let Some(var_context) = &var.context {
+        let target = var_context.to_string();
+        if let Some(binding) = registry.get(&target) {
+          let path = var.name.to_string();
+          let value = self.read_context_resource(context, binding, &path)?;
+          return self.context_pattern_value_expression(value);
+        }
+      }
+    }
+
+    self.resolve_context_reads_in_expression(context, program, registry, expression)
+  }
+
+  fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
+    let value = resolve_runtime_value(value);
+    match value {
+      Value::String(value) => {
+        let text = value.borrow().clone();
+        Ok(mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
+          text: mech_core::Token::new(
+            mech_core::TokenKind::String,
+            mech_core::SourceRange::default(),
+            text.chars().collect(),
+          ),
+        })))
+      }
+      #[cfg(feature = "bool")]
+      Value::Bool(value) => {
+        let flag = *value.borrow();
+        Ok(mech_core::Expression::Literal(mech_core::Literal::Boolean(mech_core::Token::new(
+          if flag { mech_core::TokenKind::True } else { mech_core::TokenKind::False },
+          mech_core::SourceRange::default(),
+          if flag { "true".chars().collect() } else { "false".chars().collect() },
+        ))))
+      }
+      Value::Empty => Ok(mech_core::Expression::Literal(mech_core::Literal::Empty(mech_core::Token::new(
+        mech_core::TokenKind::Empty,
+        mech_core::SourceRange::default(),
+        vec!['_'],
+      )))),
+      other => Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "context_match_pattern",
+        reason: format!("context match patterns currently support string, bool, and empty values; got {other:?}"),
+      }, None)),
     }
   }
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -747,11 +747,19 @@ impl MechRuntime {
           .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
           .collect::<MResult<Vec<_>>>()?,
       })),
-      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-        tuple.0.iter()
-          .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
-          .collect::<MResult<Vec<_>>>()?,
-      ))),
+      mech_core::Pattern::Tuple(tuple) => {
+        if tuple.0.len() == 1 {
+          let pattern = self.resolve_context_reads_in_match_pattern(context, program, registry, &tuple.0[0])?;
+          if pattern != tuple.0[0] {
+            return Ok(pattern);
+          }
+        }
+        Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+          tuple.0.iter()
+            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        )))
+      }
       mech_core::Pattern::Array(array) => {
         let spread = if let Some(spread) = &array.spread {
           Some(mech_core::PatternArraySpread {
@@ -784,18 +792,72 @@ impl MechRuntime {
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<mech_core::Expression> {
-    if let mech_core::Expression::Var(var) = expression {
-      if let Some(var_context) = &var.context {
-        let target = var_context.to_string();
-        if let Some(binding) = registry.get(&target) {
-          let path = var.name.to_string();
-          let value = self.read_context_resource(context, binding, &path)?;
-          return self.context_pattern_value_expression(value);
-        }
-      }
+    if let Some(expression) = self.literalize_match_pattern_context_read_expression(
+      context,
+      registry,
+      expression,
+    )? {
+      return Ok(expression);
     }
 
     self.resolve_context_reads_in_expression(context, program, registry, expression)
+  }
+
+  fn literalize_match_pattern_context_read_expression(
+    &mut self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        self.literalize_match_pattern_context_read_var(context, registry, var)
+      }
+      mech_core::Expression::Formula(factor) => {
+        self.literalize_match_pattern_context_read_factor(context, registry, factor)
+      }
+      _ => Ok(None),
+    }
+  }
+
+  fn literalize_match_pattern_context_read_factor(
+    &mut self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.literalize_match_pattern_context_read_expression(context, registry, expression)
+      }
+      mech_core::Factor::Parenthetical(inner) => {
+        self.literalize_match_pattern_context_read_factor(context, registry, inner)
+      }
+      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
+        self.literalize_match_pattern_context_read_factor(context, registry, &term.lhs)
+      }
+      _ => Ok(None),
+    }
+  }
+
+  fn literalize_match_pattern_context_read_var(
+    &mut self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    var: &mech_core::Var,
+  ) -> MResult<Option<mech_core::Expression>> {
+    let Some(var_context) = &var.context else {
+      return Ok(None);
+    };
+
+    let target = var_context.to_string();
+    let Some(binding) = registry.get(&target) else {
+      return Ok(None);
+    };
+
+    let path = var.name.to_string();
+    let value = self.read_context_resource(context, binding, &path)?;
+    Ok(Some(self.context_pattern_value_expression(value)?))
   }
 
   fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2783,6 +2783,118 @@ fn function_define_env_read_denial_preflights_before_stdout_write() {
 }
 
 #[test]
+fn match_arm_pattern_context_read_fails_preflight_before_stdout_write() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@env := cli://env{:read(HOME)}
+@out/line <- \"must-not-write\"
+result := \"x\"?
+  | @env/HOME => true
+  | * => false.
+",
+  );
+
+  assert!(result.is_err(), "match arm context read should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeCapabilityGrantDenied") || error.contains("context_read"),
+    "expected context read preflight error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
+fn fsm_pipe_transition_context_read_fails_preflight_before_stdout_write() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@env := cli://env{:read(HOME)}
+@out/line <- \"must-not-write\"
+machine := #Machine() -> @env/HOME
+",
+  );
+
+  assert!(result.is_err(), "FSM pipe transition context read should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeCapabilityGrantDenied") || error.contains("context_read"),
+    "expected context read preflight error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
+fn fsm_declare_context_read_fails_preflight_before_stdout_write() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@env := cli://env{:read(HOME)}
+@out/line <- \"must-not-write\"
+#run := #Machine(@env/HOME)
+",
+  );
+
+  assert!(result.is_err(), "FSM declaration context read should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeCapabilityGrantDenied") || error.contains("context_read"),
+    "expected context read preflight error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
+fn match_arm_context_read_pattern_is_rewritten_when_allowed() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  state.lock().unwrap().env.insert(
+    "MECH_MATCH_PATTERN".to_string(),
+    "expected".to_string(),
+  );
+
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject,
+    resource: "cli://env".to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec!["MECH_MATCH_PATTERN".to_string()],
+  }).unwrap();
+
+  let result = runtime.run_string(
+    "@env := cli://env{:read(MECH_MATCH_PATTERN)}
+result := \"expected\"?
+  | @env/MECH_MATCH_PATTERN => true
+  | * => false.
+result
+",
+  ).unwrap();
+
+  let result = match result {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  assert_bool_true(result, "match arm context read pattern");
+}
+
+#[test]
 fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
   let backend = FakeCliBackend::default().with_env("HOME", "/tmp/home");
   let mut config = RuntimeConfig::default();

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2863,7 +2863,7 @@ fn fsm_declare_context_read_fails_preflight_before_stdout_write() {
 }
 
 #[test]
-fn match_arm_context_read_pattern_is_rewritten_when_allowed() {
+fn match_arm_context_read_pattern_compares_value_when_allowed() {
   let (mut runtime, state) = runtime_with_recording_cli();
   state.lock().unwrap().env.insert(
     "MECH_MATCH_PATTERN".to_string(),
@@ -2878,7 +2878,7 @@ fn match_arm_context_read_pattern_is_rewritten_when_allowed() {
     paths: vec!["MECH_MATCH_PATTERN".to_string()],
   }).unwrap();
 
-  let result = runtime.run_string(
+  let matching = runtime.run_string(
     "@env := cli://env{:read(MECH_MATCH_PATTERN)}
 result := \"expected\"?
   | @env/MECH_MATCH_PATTERN => true
@@ -2887,11 +2887,26 @@ result
 ",
   ).unwrap();
 
-  let result = match result {
+  let matching = match matching {
     Value::MutableReference(value) => value.borrow().clone(),
     other => other,
   };
-  assert_bool_true(result, "match arm context read pattern");
+  assert_bool_true(matching, "match arm context read pattern should match equal value");
+
+  let mismatching = runtime.run_string(
+    "@env := cli://env{:read(MECH_MATCH_PATTERN)}
+mismatch := \"other\"?
+  | @env/MECH_MATCH_PATTERN => true
+  | * => false.
+mismatch
+",
+  ).unwrap();
+
+  let mismatching = match mismatching {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  assert_bool_false(mismatching, "match arm context read pattern should not bind mismatched value");
 }
 
 #[test]

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2943,6 +2943,60 @@ wrappedMismatch
     wrapped_mismatching,
     "wrapped match arm context read pattern should not bind mismatched value",
   );
+
+  let mut bool_runtime = RuntimeBuilder::new()
+    .in_memory_docs(InMemoryDocsProvider::new())
+    .build()
+    .unwrap();
+
+  bool_runtime.grant_capability(runtime_context_write_grant(
+    &bool_runtime,
+    "docs://manual",
+    "flag",
+  )).unwrap();
+  bool_runtime.grant_capability(runtime_context_read_grant(
+    &bool_runtime,
+    "docs://manual",
+    "flag",
+  )).unwrap();
+
+  let bool_matching = bool_runtime.run_string(
+    "@manual := docs://manual{:read(flag), :write(flag)}
+@manual/flag = false
+matched := false?
+  | @manual/flag => true
+  | * => false.
+matched
+",
+  ).unwrap();
+
+  let bool_matching = match bool_matching {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  assert_bool_true(
+    bool_matching,
+    "boolean context match pattern should compare false to false",
+  );
+
+  let bool_mismatching = bool_runtime.run_string(
+    "@manual := docs://manual{:read(flag), :write(flag)}
+@manual/flag = true
+mismatched := false?
+  | @manual/flag => true
+  | * => false.
+mismatched
+",
+  ).unwrap();
+
+  let bool_mismatching = match bool_mismatching {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  assert_bool_false(
+    bool_mismatching,
+    "boolean context match pattern should not match false to true",
+  );
 }
 
 #[test]

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2907,6 +2907,42 @@ mismatch
     other => other,
   };
   assert_bool_false(mismatching, "match arm context read pattern should not bind mismatched value");
+
+  let wrapped_matching = runtime.run_string(
+    "@env := cli://env{:read(MECH_MATCH_PATTERN)}
+wrapped := \"expected\"?
+  | (@env/MECH_MATCH_PATTERN) => true
+  | * => false.
+wrapped
+",
+  ).unwrap();
+
+  let wrapped_matching = match wrapped_matching {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  assert_bool_true(
+    wrapped_matching,
+    "wrapped match arm context read pattern should match equal value",
+  );
+
+  let wrapped_mismatching = runtime.run_string(
+    "@env := cli://env{:read(MECH_MATCH_PATTERN)}
+wrappedMismatch := \"other\"?
+  | (@env/MECH_MATCH_PATTERN) => true
+  | * => false.
+wrappedMismatch
+",
+  ).unwrap();
+
+  let wrapped_mismatching = match wrapped_mismatching {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  };
+  assert_bool_false(
+    wrapped_mismatching,
+    "wrapped match arm context read pattern should not bind mismatched value",
+  );
 }
 
 #[test]

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -606,3 +606,18 @@ fn mech_run_inline_context_send_is_not_treated_as_path() {
 
   assert_success_contains(output, "inline-context-ok");
 }
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_split_inline_context_read_is_not_treated_as_path() {
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("+> @env := cli/env\nx")
+    .arg(":=")
+    .arg("@env/MECH_SPLIT_INLINE_TEST")
+    .env("MECH_SPLIT_INLINE_TEST", "split-inline-ok")
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "split-inline-ok");
+}


### PR DESCRIPTION
### Motivation
- Ensure multi-token `mech run` invocations that form valid Mech source (including split inline context reads/sends) are classified as inline source rather than paths.
- Centralize traversal and rewrite logic for FSM pipe context reads so expression- and declaration-level handling is consistent.
- Preflight and rewrite match-arm patterns so context-addressed reads in patterns are validated and rewritten before execution.
- Add regression coverage for split inline inputs, FSM-pipe/declaration preflight, and match-arm pattern rewriting.

### Description
- Updated the multi-input branch of `classify_run_inputs` in `src/cli/run.rs` to join tokens, attempt a parse with `mech_syntax::parser::parse(joined.trim())`, and treat parseable input as `RunInputMode::InlineSource` before falling back to path detection; added two unit tests for split inline read/send cases and adjusted an existing path test.
- Added an integration CLI test in `tests/mech_cli_host.rs` to assert split inline `@env/...` read tokens are not treated as paths when invoking the `mech` binary.
- Added `preflight_fsm_pipe_context_capabilities` helper and integrated it into `preflight_expression_context_reads` and `preflight_statement_context_capabilities` in `src/runtime/src/runtime/execution.rs` so FSM pipe args and transitions are preflight-traversed; added handling for `Statement::FsmDeclare`.
- Added `resolve_context_reads_in_fsm_pipe` helper and integrated it into `resolve_context_reads_in_expression` and `resolve_context_reads_in_statement` so FSM pipe args and transitions are rewritten consistently during context-read lowering.
- Changed `Expression::Match` handling so each arm's `pattern` is traversed in preflight before the guard and result expression, and the `pattern` is rewritten via `resolve_context_reads_in_pattern` during rewrite.
- Added runtime regression tests in `src/runtime/tests/module_smoke.rs` covering: match-arm pattern preflight denial, FSM-pipe transition preflight denial, FSM declaration preflight denial, and positive match-pattern rewrite when reads are granted.

### Testing
- Ran `cargo test -p mech-runtime --test module_smoke` and the module smoke test suite completed successfully (all tests passed).
- Ran `cargo test --features "run repl pretty_print" cli::run::tests` and the CLI `classify_run_inputs` unit tests passed.
- Ran `cargo test --features "run repl pretty_print" --test mech_cli_host` and the CLI-host integration tests passed (including the new split-inline integration test).
- Ran `cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli` and `cargo check -p mech-host-cli --no-default-features`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3af0a169b4832aa4e6cd436e823bab)