### PR TITLE
Fix context reads in function and comprehension patterns

### DIFF
--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -36,7 +36,12 @@ pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter)
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
-pub fn pattern_match_value(pattern: &Pattern, value: &Value, env: &mut Environment) -> MResult<()> {
+pub fn pattern_match_value(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    p: &Interpreter,
+) -> MResult<()> {
     match pattern {
         Pattern::Wildcard => Ok(()),
         Pattern::Expression(expr) => match expr {
@@ -59,7 +64,22 @@ pub fn pattern_match_value(pattern: &Pattern, value: &Value, env: &mut Environme
                     }
                 }
             }
-            _ => todo!("Unsupported expression in pattern"),
+            _ => {
+                let expected = expression(expr, Some(env), p)?;
+                if detach_comprehension_value(&expected) == detach_comprehension_value(value) {
+                    Ok(())
+                } else {
+                    Err(MechError::new(
+                        PatternMatchError {
+                            var: "<expression>".to_string(),
+                            expected: expected.to_string(),
+                            found: value.to_string(),
+                        },
+                        None,
+                    )
+                    .with_compiler_loc())
+                }
+            }
         },
         #[cfg(feature = "tuple")]
         Pattern::Tuple(pat_tuple) => match value {
@@ -76,7 +96,7 @@ pub fn pattern_match_value(pattern: &Pattern, value: &Value, env: &mut Environme
                     .with_compiler_loc());
                 }
                 for (pttrn, val) in pat_tuple.0.iter().zip(values_brrw.elements.iter()) {
-                    pattern_match_value(pttrn, val, env)?;
+                    pattern_match_value(pttrn, val, env, p)?;
                 }
                 Ok(())
             }
@@ -113,7 +133,7 @@ fn comprehension_environments(
                     let collection = expression(expr, Some(env), &new_p)?;
                     for elmnt in comprehension_generator_values(&collection)? {
                         let mut new_env = env.clone();
-                        if pattern_match_value(pttrn, &elmnt, &mut new_env).is_ok() {
+                        if pattern_match_value(pttrn, &elmnt, &mut new_env, &new_p).is_ok() {
                             new_envs.push(new_env);
                         }
                     }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -641,7 +641,12 @@ impl MechRuntime {
     qualifier: &mech_core::ComprehensionQualifier,
   ) -> MResult<mech_core::ComprehensionQualifier> {
     match qualifier {
-      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => Ok(mech_core::ComprehensionQualifier::Generator((pattern.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+        Ok(mech_core::ComprehensionQualifier::Generator((
+          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
+          self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+        )))
+      }
       mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(context, program, registry, expression)?)),
       mech_core::ComprehensionQualifier::Let(var_def) => {
         let mut var_def = var_def.clone();
@@ -995,8 +1000,18 @@ impl MechRuntime {
         .map(|statement| self.resolve_context_reads_in_statement(context, program, registry, statement))
         .collect::<MResult<Vec<_>>>()?,
       match_arms: function.match_arms.iter().map(|arm| Ok(mech_core::FunctionMatchArm {
-        pattern: self.resolve_context_reads_in_pattern(context, program, registry, &arm.pattern)?,
-        expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
+        pattern: self.resolve_context_reads_in_match_pattern(
+          context,
+          program,
+          registry,
+          &arm.pattern,
+        )?,
+        expression: self.resolve_context_reads_in_expression(
+          context,
+          program,
+          registry,
+          &arm.expression,
+        )?,
       })).collect::<MResult<Vec<_>>>()?,
     })
   }
@@ -1690,8 +1705,11 @@ impl MechRuntime {
     qualifier: &mech_core::ComprehensionQualifier,
   ) -> MResult<()> {
     match qualifier {
-      mech_core::ComprehensionQualifier::Generator((_, expression))
-      | mech_core::ComprehensionQualifier::Filter(expression) => {
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+        self.preflight_pattern_context_reads(context, registry, pattern)?;
+        self.preflight_expression_context_reads(context, registry, expression)
+      }
+      mech_core::ComprehensionQualifier::Filter(expression) => {
         self.preflight_expression_context_reads(context, registry, expression)
       }
       mech_core::ComprehensionQualifier::Let(var_def) => {

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -621,3 +621,126 @@ fn mech_run_split_inline_context_read_is_not_treated_as_path() {
 
   assert_success_contains(output, "split-inline-ok");
 }
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_function_arm_context_pattern_is_literal_not_capture() {
+  let root = temp_root("function-context-pattern");
+  let source = root.join("function_context_pattern.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @env := cli/env
++> @out := cli/stdout
+
+pick(x<string>) => <string>
+  | @env/MECH_FUNCTION_PATTERN_TEST => "matched"
+  | * => "missed".
+
+@out/line <- pick("not-the-secret")
+@out/line <- pick(@env/MECH_FUNCTION_PATTERN_TEST)
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source)
+    .env("MECH_FUNCTION_PATTERN_TEST", "secret")
+    .output()
+    .unwrap();
+
+  let combined = combined_output(&output);
+  assert!(
+    output.status.success(),
+    "function context-pattern program failed:\n{combined}"
+  );
+  assert!(
+    combined.contains("missed"),
+    "nonmatching argument should hit wildcard arm:\n{combined}"
+  );
+  assert!(
+    combined.contains("matched"),
+    "matching argument should hit literal context arm:\n{combined}"
+  );
+  assert_eq!(
+    combined.matches("matched").count(),
+    1,
+    "context pattern must not capture every argument:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_generator_pattern_context_read_is_preflighted_before_send() {
+  let root = temp_root("generator-pattern-preflight");
+  let source = root.join("generator_pattern_preflight.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @out := cli/stdout
++> @env := cli/env
+
+@out/line <- "must-not-write"
+ys := { "hit" | @env/HOME <- ["anything"] }
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--deny-default-capabilities")
+    .arg("--capabilities")
+    .arg(":cli/stdout")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "RuntimeCapabilityGrantDenied");
+  assert!(
+    !combined.contains("must-not-write"),
+    "provider wrote before generator-pattern preflight failed:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_generator_context_pattern_is_literal_filter() {
+  let root = temp_root("generator-pattern-literal");
+  let source = root.join("generator_pattern_literal.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @env := cli/env
++> @out := cli/stdout
+
+ys := { x | (x, @env/MECH_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop", "other")] }
+@out/line <- ys
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source)
+    .env("MECH_GENERATOR_PATTERN_TEST", "secret")
+    .output()
+    .unwrap();
+
+  let combined = combined_output(&output);
+  assert!(
+    output.status.success(),
+    "generator context-pattern program failed:\n{combined}"
+  );
+  assert!(
+    combined.contains("keep"),
+    "literalized generator pattern should retain matching tuple:\n{combined}"
+  );
+  assert!(
+    !combined.contains("drop"),
+    "literalized generator pattern should reject nonmatching tuple:\n{combined}"
+  );
+}


### PR DESCRIPTION
### Motivation
- Fix incorrect rewriting of context reads inside function match-arm and comprehension generator patterns so pattern semantics remain literal and preflights run before side-effecting providers are invoked.

### Description
- In `src/runtime/src/runtime/execution.rs` changed function match-arm handling to literalize context reads using `resolve_context_reads_in_match_pattern` instead of `resolve_context_reads_in_pattern` so function arms follow match semantics. 
- In `src/runtime/src/runtime/execution.rs` made comprehension generator qualifiers preflight their `pattern` with `preflight_pattern_context_reads` and literalize generator-pattern context reads by using `resolve_context_reads_in_match_pattern` in `resolve_context_reads_in_comprehension_qualifier`. 
- In `src/interpreter/src/expressions.rs` extended `pattern_match_value` to accept an `&Interpreter` parameter, evaluate non-variable expression patterns via `expression(...)`, compare using `detach_comprehension_value`, and propagate `p` through recursive calls and the generator site in `comprehension_environments`. 
- Added three regression tests to `tests/mech_cli_host.rs` covering function-arm context-pattern literalization, generator-pattern preflight behavior, and generator-pattern literalization+filtering.

### Testing
- Ran `cargo test --features run,cli_host --test mech_cli_host` and observed all tests pass (24 passed; 0 failed). 
- Ran `cargo check -p mech-runtime -p mech-interpreter` and both crates checked successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b50277d20832abf4374d5615829ea)