### PR TITLE
Enforce preflight failure for undeclared direct context reads and default resource write preflight

### DIFF
--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -39,8 +39,15 @@ pub trait RuntimeResourceProvider: std::fmt::Debug {
 
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
 
-  fn preflight_write(&self, _request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-    Ok(())
+  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    Err(MechError::new(
+      RuntimeResourceWriteUnsupported {
+        scheme: self.scheme().to_string(),
+        base_uri: request.base_uri,
+        path: request.path,
+      },
+      None,
+    ))
   }
 
   fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -189,6 +189,13 @@ fn direct_context_target(context_name: &str, path: &str) -> String {
   format!("@{}/{}", context_name, path)
 }
 
+fn undeclared_direct_context_target_error(context_name: &str) -> MechError {
+  MechError::new(RuntimeInvalidOperationError {
+    operation: "direct_context_target",
+    reason: format!("context target `@{context_name}` is not declared or imported"),
+  }, None)
+}
+
 #[allow(dead_code)]
 fn runtime_context_allows_write(
   binding: &RuntimeContextBinding,
@@ -443,7 +450,7 @@ impl MechRuntime {
         };
         let target = var_context.to_string();
         let Some(binding) = registry.get(&target) else {
-          return Ok(expression.clone());
+          return Err(undeclared_direct_context_target_error(&target));
         };
         let path = var.name.to_string();
         let value = self.read_context_resource(context, binding, &path)?;
@@ -487,15 +494,15 @@ impl MechRuntime {
         Ok(mech_core::Expression::Range(Box::new(range)))
       }
       mech_core::Expression::Slice(slice) => {
-        if slice
-          .context
-          .as_ref()
-          .is_some_and(|context| registry.contains(&context.to_string()))
-        {
-          return Err(MechError::new(RuntimeInvalidOperationError {
-            operation: "context_read",
-            reason: "context-addressed slices are not supported".to_string(),
-          }, None));
+        if let Some(context_name) = &slice.context {
+          let context_name = context_name.to_string();
+          if registry.contains(&context_name) {
+            return Err(MechError::new(RuntimeInvalidOperationError {
+              operation: "context_read",
+              reason: "context-addressed slices are not supported".to_string(),
+            }, None));
+          }
+          return Err(undeclared_direct_context_target_error(&context_name));
         }
         Ok(mech_core::Expression::Slice(
           self.resolve_context_reads_in_slice(context, program, registry, slice)?,
@@ -1517,7 +1524,7 @@ impl MechRuntime {
             &context_name.to_string(),
             &var.name.to_string(),
             RuntimeCapabilityOperation::Read,
-            false,
+            true,
             None,
           )?;
         }
@@ -1555,15 +1562,15 @@ impl MechRuntime {
         }
       }
       mech_core::Expression::Slice(slice) => {
-        if slice
-          .context
-          .as_ref()
-          .is_some_and(|context| registry.contains(&context.to_string()))
-        {
-          return Err(MechError::new(RuntimeInvalidOperationError {
-            operation: "context_read",
-            reason: "context-addressed slices are not supported".to_string(),
-          }, None));
+        if let Some(context_name) = &slice.context {
+          let context_name = context_name.to_string();
+          if registry.contains(&context_name) {
+            return Err(MechError::new(RuntimeInvalidOperationError {
+              operation: "context_read",
+              reason: "context-addressed slices are not supported".to_string(),
+            }, None));
+          }
+          return Err(undeclared_direct_context_target_error(&context_name));
         }
         self.preflight_slice_context_reads(context, registry, slice)?;
       }
@@ -1752,10 +1759,7 @@ impl MechRuntime {
   ) -> MResult<()> {
     let Some(binding) = registry.get(context_name) else {
       if require_context_binding {
-        return Err(MechError::new(RuntimeInvalidOperationError {
-          operation: "direct_context_target",
-          reason: format!("context target `@{context_name}` is not declared or imported"),
-        }, None));
+        return Err(undeclared_direct_context_target_error(context_name));
       }
       return Ok(());
     };

--- a/src/runtime/tests/resource_preflight.rs
+++ b/src/runtime/tests/resource_preflight.rs
@@ -1,0 +1,39 @@
+use mech_core::{MResult, Value};
+use mech_runtime::{
+  RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
+  RuntimeResourceWritePreflightRequest,
+};
+
+#[derive(Debug)]
+struct ReadOnlyProvider;
+
+impl RuntimeResourceProvider for ReadOnlyProvider {
+  fn scheme(&self) -> &str {
+    "readonly"
+  }
+
+  fn base_uris(&self) -> Vec<String> {
+    vec!["readonly://root".to_string()]
+  }
+
+  fn read(&self, _request: RuntimeResourceReadRequest) -> MResult<Value> {
+    Ok(Value::Empty)
+  }
+}
+
+#[test]
+fn default_resource_preflight_rejects_unsupported_write() {
+  let provider = ReadOnlyProvider;
+  let err = provider.preflight_write(RuntimeResourceWritePreflightRequest {
+    base_uri: "readonly://root".to_string(),
+    path: "value".to_string(),
+    context_name: "ro".to_string(),
+    intent: RuntimeResourceWriteIntent::Assign,
+  }).unwrap_err();
+
+  let msg = format!("{:?}", err);
+  assert!(
+    msg.contains("RuntimeResourceWriteUnsupported"),
+    "default preflight should mirror default write unsupported error, got: {msg}"
+  );
+}

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -744,3 +744,33 @@ ys := { x | (x, @env/MECH_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop"
     "literalized generator pattern should reject nonmatching tuple:\n{combined}"
   );
 }
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_undeclared_context_read_is_preflighted_before_send() {
+  let root = temp_root("undeclared-context-read");
+  let source = root.join("undeclared_context_read.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @out := cli/stdout
+
+@out/line <- "must-not-write"
+x := @missing/HOME
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "direct_context_target");
+  assert!(
+    !combined.contains("must-not-write"),
+    "provider wrote before undeclared context read failed preflight:\n{combined}"
+  );
+}


### PR DESCRIPTION
### Motivation
- Prevent undeclared direct-context reads from leaking provider writes by failing them during preflight and resolution rather than allowing a later provider send. 
- Ensure providers that do not implement write preflight mirror the default `write` unsupported error to avoid surprising successful preflights.

### Description
- Add `undeclared_direct_context_target_error` helper in `src/runtime/src/runtime/execution.rs` and use it from `preflight_context_access` and resolution paths to centralize the `direct_context_target` error.
- Make `resolve_context_reads_in_expression` return the undeclared-direct-target error for `Expression::Var` when the context is not in the registry, and reject context-addressed `Slice` expressions with known-context unsupported error or undeclared-direct-target error for unknown contexts.
- Change `preflight_expression_context_reads` to require a context binding (`require_context_binding = true`) for `Expression::Var` so undeclared direct-context reads fail during preflight before any provider write/send occurs, and apply the same explicit handling to `Slice` expressions.
- Change the default `RuntimeResourceProvider::preflight_write` in `src/runtime/src/resource.rs` to return `RuntimeResourceWriteUnsupported` to match the default `write` implementation for providers that do not override preflight.
- Add regression tests: a CLI host test in `tests/mech_cli_host.rs` verifying undeclared context reads fail preflight before provider writes, and a runtime unit test `src/runtime/tests/resource_preflight.rs` verifying the default provider `preflight_write` rejects unsupported writes.

### Testing
- Ran `cargo test --features run,cli_host --test mech_cli_host`, and the test suite passed (all tests in that target succeeded). 
- Ran `cargo test -p mech-runtime default_resource_preflight_rejects_unsupported_write`, and the new runtime test passed. 
- Ran `cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli`, and checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd17078c4832a88b40ba62129fe27)