### PR TITLE
Fix classification of single-token formulas containing '/' as inline source

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,5 +7,5 @@ pub mod config;
 #[cfg(feature = "run")]
 pub mod run;
 
-#[cfg(all(test, any(feature = "serve", feature = "bundle_web")))]
+#[cfg(all(test, any(feature = "serve", feature = "bundle_web", feature = "run")))]
 pub(crate) static CURRENT_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -61,7 +61,7 @@ pub fn classify_run_inputs(inputs: Vec<String>) -> RunInputMode {
     if Path::new(&inputs[0]).exists() {
       return RunInputMode::Paths(inputs);
     }
-    if parses_as_context_addressed_source(&inputs[0]) {
+    if parses_as_executable_run_source(&inputs[0]) {
       return RunInputMode::InlineSource(inputs[0].clone());
     }
     if is_intended_path(&inputs[0]) {
@@ -463,6 +463,12 @@ mod tests {
   #[test]
   fn classifies_single_plain_inline_expression_as_inline_source() {
     let mode = classify_run_inputs(vec!["x := 1".to_string()]);
+    assert!(matches!(mode, RunInputMode::InlineSource(_)));
+  }
+
+  #[test]
+  fn classifies_single_formula_with_slash_as_inline_source() {
+    let mode = classify_run_inputs(vec!["1 / 2".to_string()]);
     assert!(matches!(mode, RunInputMode::InlineSource(_)));
   }
 

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -257,6 +257,23 @@ fn combined_output(output: &std::process::Output) -> String {
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_single_quoted_formula_with_slash_is_inline_source() {
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("1 / 2")
+    .output()
+    .unwrap();
+
+  assert!(
+    output.status.success(),
+    "single quoted inline formula with slash should execute as source, not be read as a path:
+{}",
+    combined_output(&output)
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
 fn assert_failure_contains(output: std::process::Output, expected: &str) -> String {
   assert!(!output.status.success(), "expected mech command to fail");
   let combined = combined_output(&output);


### PR DESCRIPTION
### Motivation
- Single-argument `run` inputs that are inline formulas containing `/` were being misclassified as paths; the intent is to treat parsable Mech source as inline code unless an actual existing path is present.

### Description
- In `classify_run_inputs` the single-input branch now checks `Path::new(&inputs[0]).exists()` first, then calls `parses_as_executable_run_source(&inputs[0])` and returns `RunInputMode::InlineSource` when it parses, and only after that calls `is_intended_path(&inputs[0])`, preserving the rule that an actual existing path wins.
- Replaced the earlier `parses_as_context_addressed_source` check in the single-token branch with `parses_as_executable_run_source` to mirror the multi-token logic.
- Added a unit test `classifies_single_formula_with_slash_as_inline_source` in the `#[cfg(test)] mod tests` in `src/cli/run.rs` that asserts `"1 / 2"` is classified as `RunInputMode::InlineSource`.
- Added a CLI integration test `mech_run_single_quoted_formula_with_slash_is_inline_source` in `tests/mech_cli_host.rs` (gated by `#[cfg(all(feature = "run", feature = "cli_host"))]`) that asserts `mech run "1 / 2"` executes as inline source.

### Testing
- Ran `cargo test -p mech --features run,cli_host cli::run::tests::classifies_single_formula_with_slash_as_inline_source`, which passed.
- Ran `cargo test --features run,cli_host mech_run_single_quoted_formula_with_slash_is_inline_source`, which passed.
- Ran `cargo test -p mech --features run,cli_host cli::run::tests`, which passed (all run::tests succeeded).
- Ran `git diff --check`, which reported no issues, and `cargo fmt --check`, which failed due to unrelated repository-wide formatting differences outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c41cd7990832aa058a490472cf903)