### PR TITLE
Support derived runtime contexts and bridge browser DOM grants into WASM runtime

### DIFF
--- a/src/runtime/src/context.rs
+++ b/src/runtime/src/context.rs
@@ -88,10 +88,16 @@ impl RuntimeContextRegistry {
     declarations: &[SourceContextDeclaration],
   ) -> MResult<Self> {
     let mut registry = Self::new();
+
     for declaration in declarations {
-      let binding = RuntimeContextBinding::from_source(scope.clone(), declaration)?;
+      let binding = RuntimeContextBinding::from_source_with_registry(
+        scope.clone(),
+        declaration,
+        &registry,
+      )?;
       registry.insert(binding)?;
     }
+
     Ok(registry)
   }
 
@@ -128,6 +134,15 @@ impl RuntimeContextBinding {
     scope: SourceScope,
     declaration: &SourceContextDeclaration,
   ) -> MResult<Self> {
+    let registry = RuntimeContextRegistry::new();
+    Self::from_source_with_registry(scope, declaration, &registry)
+  }
+
+  pub fn from_source_with_registry(
+    scope: SourceScope,
+    declaration: &SourceContextDeclaration,
+    registry: &RuntimeContextRegistry,
+  ) -> MResult<Self> {
     if declaration.name.is_empty() {
       return Err(MechError::new(
         RuntimeContextInvalidBinding {
@@ -152,23 +167,71 @@ impl RuntimeContextBinding {
         RuntimeContextBase::ResourceUri(uri.clone())
       }
       SourceContextBase::Context(name) => {
-        return Err(MechError::new(
-          RuntimeContextDerivedBaseUnsupported {
-            name: declaration.name.clone(),
-            base: name.clone(),
-          },
-          None,
-        ));
+        let base_binding = registry.get(name).ok_or_else(|| {
+          MechError::new(
+            RuntimeContextInvalidBinding {
+              name: declaration.name.clone(),
+              reason: format!(
+                "derived context `@{}` references unknown context `@{}`",
+                declaration.name, name,
+              ),
+            },
+            None,
+          )
+        })?;
+        base_binding.base.clone()
       }
     };
 
-    let mut capabilities = Vec::with_capacity(declaration.capabilities.len());
-    for capability in &declaration.capabilities {
-      capabilities.push(runtime_context_capability_from_source(
-        &declaration.name,
-        capability,
-      )?);
-    }
+    let capabilities = match &declaration.base {
+      SourceContextBase::Context(name) if declaration.capabilities.is_empty() => {
+        registry
+          .get(name)
+          .map(|binding| binding.capabilities.clone())
+          .unwrap_or_default()
+      }
+      SourceContextBase::Context(name) => {
+        let base_binding = registry.get(name).expect("derived base validated above");
+        let mut capabilities = Vec::with_capacity(declaration.capabilities.len());
+        for capability in &declaration.capabilities {
+          let requested = runtime_context_capability_from_source(
+            &declaration.name,
+            capability,
+          )?;
+          if !base_binding
+            .capabilities
+            .iter()
+            .any(|base| runtime_context_capability_contains(base, &requested))
+          {
+            return Err(MechError::new(
+              RuntimeContextInvalidBinding {
+                name: declaration.name.clone(),
+                reason: format!(
+                  "derived context `@{}` capability `{}({})` is not contained by base context `@{}`",
+                  declaration.name,
+                  requested.operation,
+                  runtime_context_scope_label(&requested.scope),
+                  name,
+                ),
+              },
+              None,
+            ));
+          }
+          capabilities.push(requested);
+        }
+        capabilities
+      }
+      _ => {
+        let mut capabilities = Vec::with_capacity(declaration.capabilities.len());
+        for capability in &declaration.capabilities {
+          capabilities.push(runtime_context_capability_from_source(
+            &declaration.name,
+            capability,
+          )?);
+        }
+        capabilities
+      }
+    };
 
     Ok(Self {
       name: declaration.name.clone(),
@@ -204,6 +267,40 @@ fn runtime_context_capability_from_source(
     operation: capability.operation.clone(),
     scope,
   })
+}
+
+pub fn runtime_context_capability_contains(
+  base: &RuntimeContextCapability,
+  requested: &RuntimeContextCapability,
+) -> bool {
+  base.operation == requested.operation
+    && runtime_context_scope_contains(&base.scope, &requested.scope)
+}
+
+pub fn runtime_context_scope_contains(
+  base_scope: &RuntimeContextCapabilityScope,
+  requested_scope: &RuntimeContextCapabilityScope,
+) -> bool {
+  match (base_scope, requested_scope) {
+    (RuntimeContextCapabilityScope::Wildcard, _) => true,
+    (RuntimeContextCapabilityScope::Path(_), RuntimeContextCapabilityScope::Wildcard) => false,
+    (RuntimeContextCapabilityScope::Path(base), RuntimeContextCapabilityScope::Path(requested)) => {
+      if base == requested {
+        return true;
+      }
+      let Some(prefix) = base.strip_suffix("/*") else {
+        return false;
+      };
+      requested.strip_prefix(prefix).is_some_and(|suffix| suffix.starts_with('/'))
+    }
+  }
+}
+
+fn runtime_context_scope_label(scope: &RuntimeContextCapabilityScope) -> String {
+  match scope {
+    RuntimeContextCapabilityScope::Wildcard => "*".to_string(),
+    RuntimeContextCapabilityScope::Path(path) => path.clone(),
+  }
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -286,7 +286,7 @@ impl MechRuntime {
   }
 
 
-  fn context_declarations_from_index_scope(
+  pub(crate) fn context_declarations_from_index_scope(
     &self,
     index: &SourceIndex,
     scope: &SourceScope,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -12,7 +12,7 @@
 // Both methods have corresponding _with_context versions that accept a mutable reference to a RuntimeContext, allowing for execution within the context of an active transaction. This ensures that any changes made during execution are properly staged within the transaction that if an error occurs, the transaction can be rolled back to maintain consistency.
 
 use super::*;
-use crate::SourceIndex;
+use crate::{SourceDeclaration, SourceIndex};
 use crate::RuntimeResourceWritePreflightRequest;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -291,38 +291,41 @@ impl MechRuntime {
     index: &SourceIndex,
     scope: &SourceScope,
   ) -> MResult<Vec<crate::SourceContextDeclaration>> {
-    let mut declarations = index
-      .contexts
-      .iter()
-      .filter(|ctx| &ctx.occurrence.scope == scope)
-      .map(|ctx| ctx.declaration.clone())
-      .collect::<Vec<_>>();
+    let mut declarations = Vec::new();
 
-    for import in index.imports.iter().filter(|import| &import.occurrence.scope == scope) {
-      let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
-        continue;
-      };
-      let module = import.declaration.module.as_deref().ok_or_else(|| {
-        MechError::new(RuntimeInvalidOperationError {
-          operation: "materialize_direct_manifest_context_imports",
-          reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
-        }, None)
-      })?;
-      let item = import.declaration.item.as_deref().ok_or_else(|| {
-        MechError::new(RuntimeInvalidOperationError {
-          operation: "materialize_direct_manifest_context_imports",
-          reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
-        }, None)
-      })?;
-      let export = self.module_manifests.context_export(module, item)?;
-      declarations.push(crate::SourceContextDeclaration {
-        name: alias.clone(),
-        base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
-        capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
-          operation: operation.clone(),
-          scope: crate::SourceContextCapabilityScope::Wildcard,
-        }).collect(),
-      });
+    for declaration in &index.declarations {
+      match declaration {
+        SourceDeclaration::Context(context) if &context.occurrence.scope == scope => {
+          declarations.push(context.declaration.clone());
+        }
+        SourceDeclaration::Import(import) if &import.occurrence.scope == scope => {
+          let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
+            continue;
+          };
+          let module = import.declaration.module.as_deref().ok_or_else(|| {
+            MechError::new(RuntimeInvalidOperationError {
+              operation: "materialize_direct_manifest_context_imports",
+              reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
+            }, None)
+          })?;
+          let item = import.declaration.item.as_deref().ok_or_else(|| {
+            MechError::new(RuntimeInvalidOperationError {
+              operation: "materialize_direct_manifest_context_imports",
+              reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
+            }, None)
+          })?;
+          let export = self.module_manifests.context_export(module, item)?;
+          declarations.push(crate::SourceContextDeclaration {
+            name: alias.clone(),
+            base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
+            capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
+              operation: operation.clone(),
+              scope: crate::SourceContextCapabilityScope::Wildcard,
+            }).collect(),
+          });
+        }
+        _ => {}
+      }
     }
 
     Ok(declarations)

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -15,9 +15,22 @@
 // - `active_module_version`: Retrieves the active version of a module, if any.
 
 use super::*;
+use crate::SourceIndex;
+
+fn source_index_for_module_record_source(
+  source: &mech_core::MechSourceCode,
+) -> MResult<Option<SourceIndex>> {
+  match source {
+    mech_core::MechSourceCode::Tree(tree) => Ok(Some(SourceIndex::from_program(tree))),
+    mech_core::MechSourceCode::String(source) => {
+      let tree = mech_syntax::parser::parse(source.trim())?;
+      Ok(Some(SourceIndex::from_program(&tree)))
+    }
+    _ => Ok(None),
+  }
+}
 
 impl MechRuntime {
-
   pub fn ensure_module(
     &mut self,
     name: &str,
@@ -35,6 +48,26 @@ impl MechRuntime {
   }
 
   fn materialize_manifest_context_imports(
+    &mut self,
+    record: &mut crate::RuntimeModuleRecord,
+  ) -> MResult<()> {
+    let Some(index) = source_index_for_module_record_source(&record.source)? else {
+      return self.materialize_manifest_context_imports_legacy(record);
+    };
+
+    let mut all_contexts = Vec::new();
+
+    for scope in &mut record.scopes {
+      let contexts = self.context_declarations_from_index_scope(&index, &scope.scope)?;
+      scope.contexts = contexts;
+      all_contexts.extend(scope.contexts.iter().cloned());
+    }
+
+    record.contexts = all_contexts;
+    Ok(())
+  }
+
+  fn materialize_manifest_context_imports_legacy(
     &mut self,
     record: &mut crate::RuntimeModuleRecord,
   ) -> MResult<()> {

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2309,6 +2309,78 @@ fn manifest_context_import_ordering_supports_derived_alias() {
 }
 
 #[test]
+fn stored_module_manifest_context_import_ordering_supports_derived_alias() {
+  let root = setup_modules(
+    "+> @ui := browser/dom\n\n@dom := @ui\n\nresult := @dom/counter/_text\n",
+  );
+
+  let mut runtime = runtime_with_root(&root);
+  runtime
+    .grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/_text"))
+    .unwrap();
+
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
+
+  let record = runtime.store().get_module_version(version).unwrap().unwrap();
+  let program_scope = record
+    .scopes
+    .iter()
+    .find(|scope| scope.scope == SourceScope::Program)
+    .unwrap();
+
+  let names = program_scope
+    .contexts
+    .iter()
+    .map(|context| context.name.as_str())
+    .collect::<Vec<_>>();
+
+  assert_eq!(names, vec!["ui", "dom"]);
+
+  let result = runtime.run_module(version);
+  assert!(result.is_err(), "without browser provider this should fail at provider lookup");
+
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    !error.contains("RuntimeContextInvalidBinding")
+      && !error.contains("RuntimeContextDerivedBaseUnsupported")
+      && !error.contains("references unknown context `@ui`"),
+    "derived manifest alias should be materialized before @dom, got {error}",
+  );
+  assert!(
+    error.contains("RuntimeResourceProviderNotFound")
+      || error.contains("BrowserResourceProvider")
+      || error.contains("provider"),
+    "expected to reach provider layer after successful context materialization, got {error}",
+  );
+}
+
+#[test]
+fn stored_module_derived_context_before_manifest_base_is_rejected() {
+  let root = setup_modules(
+    "@dom := @ui\n\n+> @ui := browser/dom\n\nx := 1\n",
+  );
+
+  let mut runtime = runtime_with_root(&root);
+  let version = runtime
+    .resolve_and_store_module_source("main.mec", module_options())
+    .unwrap()
+    .unwrap();
+
+  let result = runtime.run_module(version);
+  assert!(result.is_err());
+
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeContextInvalidBinding")
+      && error.contains("unknown context `@ui`"),
+    "derived alias before base should still fail, got {error}",
+  );
+}
+
+#[test]
 fn direct_runtime_manifest_context_import_read_uses_browser_binding_before_lowering() {
   let mut runtime = RuntimeBuilder::new().build().unwrap();
   runtime.grant_capability(runtime_context_read_grant(&runtime, "browser://dom", "counter/_text")).unwrap();

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -769,7 +769,7 @@ fn duplicate_context_registry_binding_rejected() {
 }
 
 #[test]
-fn derived_context_base_is_unsupported() {
+fn derived_context_unknown_base_is_rejected() {
   let declaration = SourceContextDeclaration {
     name: "manual".to_string(),
     base: SourceContextBase::Context("base".to_string()),
@@ -782,8 +782,37 @@ fn derived_context_base_is_unsupported() {
   let result = RuntimeContextRegistry::from_declarations(SourceScope::Program, &[declaration]);
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
-  assert!(error.contains("RuntimeContextDerivedBaseUnsupported"), "expected derived base error, got {error}");
+  assert!(error.contains("RuntimeContextInvalidBinding"), "expected invalid binding error, got {error}");
   assert!(error.contains("base"), "expected base context name in error, got {error}");
+}
+
+#[test]
+fn direct_runtime_derived_context_without_host_read_preflights() {
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  runtime.run_string("@base := docs://manual{:read(*)}\n@docs := @base\nx := 1\n").unwrap();
+}
+
+#[test]
+fn direct_runtime_derived_context_read_uses_alias() {
+  let mut runtime = RuntimeBuilder::new()
+    .resource_provider(Box::new(docs_provider_with("docs://manual", "intro/title", Value::String(Ref::new("Hello".to_string())))))
+    .build()
+    .unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://manual", "intro/title")).unwrap();
+  let result = runtime.run_string("@base := docs://manual{:read(intro/title)}\n@docs := @base\nresult := @docs/intro/title\n").unwrap();
+  match result {
+    Value::String(value) => assert_eq!(&*value.borrow(), "Hello"),
+    other => panic!("expected docs title string, got {other:?}"),
+  }
+}
+
+#[test]
+fn derived_context_cannot_expand_capabilities() {
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("@base := docs://manual{:read(intro/title)}\n@docs := @base{:write(intro/title)}\n");
+  assert!(result.is_err(), "derived write should not be allowed to expand read-only base");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(error.contains("RuntimeContextInvalidBinding"), "expected invalid binding error, got {error}");
 }
 
 #[test]
@@ -2270,6 +2299,13 @@ fn direct_runtime_normal_import_is_not_dropped() {
     Value::F64(value) => assert_eq!(*value.borrow(), 0.0),
     other => panic!("expected sin(0) to return 0.0, got {other:?}"),
   }
+}
+
+#[test]
+fn manifest_context_import_ordering_supports_derived_alias() {
+  let mut runtime = RuntimeBuilder::new().build().unwrap();
+  let result = runtime.run_string("+> @ui := browser/dom\n@dom := @ui\n");
+  assert!(result.is_ok(), "manifest context import should be available to later derived alias: {result:?}");
 }
 
 #[test]

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -10,6 +10,7 @@ use mech_host_browser::{BrowserHostConfig, BrowserResourceProvider};
 use mech_host_browser::{verify_browser_host_delegation, BrowserHostDelegationEnvelope};
 use mech_runtime::{
   ConfigProfileOptions, MechConfigDocument, MechRuntime, RuntimeConfig, parse_config_document,
+  RuntimeCapabilityGrant, RuntimeCapabilityOperation,
 };
 #[cfg(feature = "host_delegation_signing")]
 use mech_runtime::{HostDelegationKeyStore, HostDelegationPublicKey, HostDelegationVerificationRequest};
@@ -134,6 +135,50 @@ pub fn main() -> Result<(), JsValue> {
 }
 
 
+
+fn install_browser_runtime_grants(
+  runtime: &mut MechRuntime,
+  authority: &BrowserAuthority,
+) -> Result<(), JsValue> {
+  let subject = runtime
+    .runtime_context()
+    .map_err(|error| js_error(format!("failed to create runtime context: {error:?}")))?
+    .subject;
+
+  for entry in authority.dom_manifest() {
+    let mut operations = Vec::new();
+
+    if authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Read)
+      .is_ok()
+    {
+      operations.push(RuntimeCapabilityOperation::Read);
+    }
+
+    if authority
+      .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Write)
+      .is_ok()
+    {
+      operations.push(RuntimeCapabilityOperation::Write);
+    }
+
+    if operations.is_empty() {
+      continue;
+    }
+
+    runtime
+      .grant_capability(RuntimeCapabilityGrant {
+        subject: subject.clone(),
+        resource: BROWSER_DOM_PROVIDER_URI.to_string(),
+        operations,
+        paths: vec![entry.path.as_str().to_string()],
+      })
+      .map_err(|error| js_error(format!("failed to install browser DOM runtime grant: {error:?}")))?;
+  }
+
+  Ok(())
+}
+
 fn browser_host_from_config(document: Option<&MechConfigDocument>) -> BrowserHost {
   match document {
     Some(document) => BrowserHost::new(document.browser.clone()),
@@ -157,13 +202,15 @@ fn runtime_from_config_document(document: Option<&MechConfigDocument>) -> MechRu
   };
   runtime
     .register_resource_provider(Box::new(BrowserResourceProvider::new(
-      authority,
+      authority.clone(),
       WasmBrowserDomBackend::new(),
     )))
     .expect("failed to register browser resource provider");
   runtime
     .bind_resource_root("browser", "browser://dom/")
     .expect("failed to bind default browser DOM resource root");
+  install_browser_runtime_grants(&mut runtime, &authority)
+    .expect("failed to install browser runtime grants");
   runtime
 }
 
@@ -235,6 +282,7 @@ fn wasm_parts_from_delegated_host_config(
   runtime
     .bind_resource_root("browser", "browser://dom/")
     .map_err(|error| js_error(format!("failed to bind browser resource root: {error:?}")))?;
+  install_browser_runtime_grants(&mut runtime, &verified.authority.browser_authority)?;
   Ok((runtime, BrowserHost::new(verified.authority.browser_authority)))
 }
 
@@ -255,6 +303,7 @@ fn wasm_parts_from_host_config(config: JsValue) -> Result<(MechRuntime, BrowserH
   runtime
     .bind_resource_root("browser", "browser://dom/")
     .map_err(|error| js_error(format!("failed to bind browser resource root: {error:?}")))?;
+  install_browser_runtime_grants(&mut runtime, &authority)?;
   Ok((runtime, BrowserHost::new(authority)))
 }
 
@@ -383,6 +432,8 @@ impl WasmMech {
     runtime
       .bind_resource_root("browser", "browser://dom/")
       .expect("failed to bind default browser DOM resource root");
+    install_browser_runtime_grants(&mut runtime, self.browser_host.authority())
+      .expect("failed to install browser runtime grants");
     self.runtime = runtime;
   }
 
@@ -1776,6 +1827,25 @@ mod tests {
 }
 "##;
 
+
+  const DOM_READ_PATH_CONFIG: &str = r##"config := {
+  browser: {
+    dom: [
+      {path: "counter/_text", selector: "#counter", allow: ["read"]}
+    ]
+  }
+}
+"##;
+
+  const DOM_WRITE_PATH_CONFIG: &str = r##"config := {
+  browser: {
+    dom: [
+      {path: "counter/_text", selector: "#counter", allow: ["write"]}
+    ]
+  }
+}
+"##;
+
   const NETWORK_GET_CONFIG: &str = r#"config := {
   browser: {
     network: [
@@ -1832,6 +1902,38 @@ mod tests {
     let mech = WasmMech::try_from_config("test.mcfg", DOM_WRITE_CONFIG).unwrap();
 
     assert!(mech.can_write_dom("#mech-output"));
+  }
+
+
+  #[test]
+  fn browser_config_dom_read_installs_runtime_grant() {
+    let mut mech = WasmMech::try_from_config("test.mcfg", DOM_READ_PATH_CONFIG).unwrap();
+    let result = mech.runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+    if let Err(error) = result {
+      let error = format!("{error:?}");
+      assert!(!error.contains("RuntimeCapabilityGrantDenied"), "read should pass runtime grant preflight: {error}");
+    }
+  }
+
+  #[test]
+  fn browser_config_without_dom_read_runtime_grant_denies() {
+    let mut mech = WasmMech::try_from_config("test.mcfg", DOM_WRITE_PATH_CONFIG).unwrap();
+    let result = mech.runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+    let error = format!("{:?}", result.err().unwrap());
+    assert!(error.contains("RuntimeCapabilityGrantDenied"), "read should be denied without read grant: {error}");
+  }
+
+  #[test]
+  fn browser_config_dom_grants_are_operation_specific() {
+    let mut write_only = WasmMech::try_from_config("test.mcfg", DOM_WRITE_PATH_CONFIG).unwrap();
+    let read_result = write_only.runtime.run_string("+> @ui := browser/dom\ntitle := @ui/counter/_text\n");
+    let read_error = format!("{:?}", read_result.err().unwrap());
+    assert!(read_error.contains("RuntimeCapabilityGrantDenied"), "write-only grant must not allow reads: {read_error}");
+
+    let mut read_only = WasmMech::try_from_config("test.mcfg", DOM_READ_PATH_CONFIG).unwrap();
+    let write_result = read_only.runtime.run_string("+> @ui := browser/dom\n@ui/counter/_text = \"hello\"\n");
+    let write_error = format!("{:?}", write_result.err().unwrap());
+    assert!(write_error.contains("RuntimeCapabilityGrantDenied"), "read-only grant must not allow writes: {write_error}");
   }
 
   #[test]


### PR DESCRIPTION
### Motivation
- Direct-run preflight failed for derived context aliases because derived bases were rejected during binding creation; declarations must be resolved in-order so derived contexts can reference earlier bindings without bypassing preflight.
- Derived contexts must not be allowed to expand the operations/paths of their base; they should inherit or attenuate capabilities only if validated as subsets.
- Browser host config DOM permissions need to be visible to runtime preflight checks so WASM/browser runtimes can pass runtime-level capability preflight when the host config grants DOM access.

### Description
- Resolve context declarations in order by updating `RuntimeContextRegistry::from_declarations` to call `RuntimeContextBinding::from_source_with_registry` so each declaration can see prior bindings during construction.
- Add `RuntimeContextBinding::from_source_with_registry` that supports `SourceContextBase::Context(...)` lookups, returns clear invalid-binding errors for missing bases, inherits base capabilities when omitted, and validates that any explicit derived capabilities are subsets of the base using containment checks; it never allows expansion of operations or paths beyond the base.
- Add capability containment helpers `runtime_context_capability_contains`, `runtime_context_scope_contains`, and a `runtime_context_scope_label` helper to implement wildcard, exact path, and `prefix/*` descendant containment semantics.
- Preserve direct-run declaration order across explicit context declarations and manifest context imports by iterating `index.declarations` and materializing `Context` declarations and `Import` declarations (aliased as `Context`) in the original file order in `context_declarations_from_index_scope`.
- Bridge browser config grants into the runtime by adding `install_browser_runtime_grants` in `src/wasm/src/lib.rs` and calling it after the `BrowserResourceProvider` is registered and `browser://dom/` is bound in all WASM/browser runtime construction paths (`runtime_from_config_document`, `wasm_parts_from_host_config`, delegated host path, and `clear`), while preserving the provider-internal `BrowserAuthority` enforcement and leaving runtime-level `self.grants.allows(...)` checks intact.
- Add tests covering: derived-context preflight for direct-run, derived-context read via alias with runtime grant, rejection when derived context attempts capability expansion, manifest-import ordering for derived aliases, and browser-config DOM grant bridging and operation-specific behavior.

### Testing
- Ran runtime-focused tests: `cargo test -p mech-runtime --test module_smoke derived -- --nocapture`; module_smoke derived tests including `direct_runtime_derived_context_without_host_read_preflights`, `direct_runtime_derived_context_read_uses_alias`, `derived_context_cannot_expand_capabilities`, `derived_context_unknown_base_is_rejected`, and `manifest_context_import_ordering_supports_derived_alias` passed.
- Attempted WASM/browser tests: `cargo test -p mech-wasm browser_config -- --nocapture`; this was blocked by an unrelated compile-time error in `machines/combinatorics` (`NChooseK<T>` trait bound), so the WASM tests could not complete in this run.
- Verified incremental compilation and fixed small wasm call-site issues (authority clone) and ensured new helpers compile under test runs where possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c6f6c7044832ab90065ea4ce470ac)