### PR TITLE
Add generic host interface primitives and multi-provider resource routing

### DIFF
--- a/src/runtime/src/host_interface.rs
+++ b/src/runtime/src/host_interface.rs
@@ -1,0 +1,181 @@
+use crate::{ConfigValue, RuntimeCapabilityOperation, RuntimeResourceProvider};
+use mech_core::{MResult, MechError, MechErrorKind};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HostInstanceConfig {
+    pub name: String,
+    pub provider: String,
+    pub settings: ConfigValue,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunResourceGrantConfig {
+    pub target: String,
+    pub operations: Vec<RuntimeCapabilityOperation>,
+    pub paths: Vec<String>,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostManifestConfig {
+    pub provider: String,
+    pub contexts: Vec<HostContextManifest>,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostContextManifest {
+    pub name: String,
+    pub base_uri_template: String,
+    pub operations: Vec<RuntimeCapabilityOperation>,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaterializedHostInterface {
+    pub instance: String,
+    pub provider: String,
+    pub contexts: Vec<MaterializedHostContext>,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaterializedHostContext {
+    pub name: String,
+    pub base_uri: String,
+    pub operations: Vec<RuntimeCapabilityOperation>,
+}
+#[derive(Debug)]
+pub struct RuntimeHostInstallation {
+    pub interface: MaterializedHostInterface,
+    pub resource_providers: Vec<Box<dyn RuntimeResourceProvider>>,
+}
+
+pub trait RuntimeHostFactory: std::fmt::Debug {
+    fn provider_name(&self) -> &str;
+    fn manifest(&self) -> &HostManifestConfig;
+    fn validate_settings(&self, instance_name: &str, settings: &ConfigValue) -> MResult<()>;
+    fn instantiate(
+        &self,
+        instance_name: &str,
+        settings: &ConfigValue,
+    ) -> MResult<RuntimeHostInstallation>;
+}
+#[derive(Debug, Default)]
+pub struct RuntimeHostFactoryRegistry {
+    factories: BTreeMap<String, Box<dyn RuntimeHostFactory>>,
+}
+impl RuntimeHostFactoryRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn register(&mut self, factory: Box<dyn RuntimeHostFactory>) -> MResult<()> {
+        let provider = factory.provider_name().to_string();
+        if provider.trim().is_empty() {
+            return Err(err("provider name cannot be empty"));
+        }
+        if self.factories.contains_key(&provider) {
+            return Err(err(format!("duplicate host provider `{provider}`")));
+        }
+        self.factories.insert(provider, factory);
+        Ok(())
+    }
+    pub fn get(&self, provider: &str) -> MResult<&dyn RuntimeHostFactory> {
+        self.factories
+            .get(provider)
+            .map(|f| f.as_ref())
+            .ok_or_else(|| err(format!("missing provider implementation `{provider}`")))
+    }
+    pub fn instantiate(&self, config: &HostInstanceConfig) -> MResult<RuntimeHostInstallation> {
+        let factory = self.get(&config.provider)?;
+        factory.validate_settings(&config.name, &config.settings)?;
+        factory.instantiate(&config.name, &config.settings)
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct HostInterfaceCatalog {
+    interfaces: BTreeMap<String, MaterializedHostInterface>,
+}
+impl HostInterfaceCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn register(&mut self, interface: MaterializedHostInterface) -> MResult<()> {
+        if interface.instance.trim().is_empty() {
+            return Err(err("host instance name cannot be empty"));
+        }
+        if self.interfaces.contains_key(&interface.instance) {
+            return Err(err(format!(
+                "duplicate host instance `{}`",
+                interface.instance
+            )));
+        }
+        let mut seen = BTreeSet::new();
+        for c in &interface.contexts {
+            if !seen.insert(c.name.clone()) {
+                return Err(err(format!("duplicate host context `{}`", c.name)));
+            }
+        }
+        self.interfaces
+            .insert(interface.instance.clone(), interface);
+        Ok(())
+    }
+    pub fn resolve(&self, target: &str) -> MResult<&MaterializedHostContext> {
+        let (instance, context) = target.split_once('/').ok_or_else(|| {
+            err(format!(
+                "host target `{target}` must be <instance>/<context>"
+            ))
+        })?;
+        if instance.is_empty() || context.is_empty() || context.contains('/') {
+            return Err(err(format!(
+                "host target `{target}` must be <instance>/<context>"
+            )));
+        }
+        let interface = self
+            .interfaces
+            .get(instance)
+            .ok_or_else(|| err(format!("unknown host instance `{instance}`")))?;
+        interface
+            .contexts
+            .iter()
+            .find(|c| c.name == context)
+            .ok_or_else(|| {
+                err(format!(
+                    "unknown context `{context}` on host instance `{instance}`"
+                ))
+            })
+    }
+    pub fn instances(&self) -> impl Iterator<Item = &MaterializedHostInterface> {
+        self.interfaces.values()
+    }
+}
+#[derive(Clone, Debug)]
+pub struct RuntimeHostInterfaceError {
+    pub reason: String,
+}
+impl MechErrorKind for RuntimeHostInterfaceError {
+    fn name(&self) -> &str {
+        "RuntimeHostInterface"
+    }
+    fn message(&self) -> String {
+        self.reason.clone()
+    }
+}
+fn err(reason: impl Into<String>) -> MechError {
+    MechError::new(
+        RuntimeHostInterfaceError {
+            reason: reason.into(),
+        },
+        None,
+    )
+}
+pub fn materialize_host_manifest(
+    instance: &str,
+    manifest: &HostManifestConfig,
+) -> MaterializedHostInterface {
+    MaterializedHostInterface {
+        instance: instance.to_string(),
+        provider: manifest.provider.clone(),
+        contexts: manifest
+            .contexts
+            .iter()
+            .map(|c| MaterializedHostContext {
+                name: c.name.clone(),
+                base_uri: c.base_uri_template.replace("{instance}", instance),
+                operations: c.operations.clone(),
+            })
+            .collect(),
+    }
+}

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -1,82 +1,84 @@
 #![cfg_attr(feature = "no_std", no_std)]
 #![allow(warnings)]
 
-pub mod id;
 pub mod config;
 pub mod config_profile;
 #[cfg(feature = "host_delegation")]
 pub mod host_delegation;
 #[cfg(feature = "host_delegation_signing")]
 pub mod host_delegation_crypto;
+mod host_interface;
+pub mod id;
 mod resource;
 
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod runtime;
+pub mod actor;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod actor_behavior;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub mod capability;
 #[cfg(any(feature = "program", feature = "compiler"))]
 mod config_spec;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod store;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub mod resolver;
+pub mod context;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub mod event;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod context;
-#[cfg(any(feature = "program", feature = "compiler"))]
 pub mod host;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod module;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod resolver;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod runtime;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub mod scheduler;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod transaction;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub mod actor;
-#[cfg(any(feature = "program", feature = "compiler"))]
 pub mod service;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod actor_behavior;
+pub mod store;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod module;
+pub mod transaction;
 #[cfg(all(feature = "watcher", any(feature = "program", feature = "compiler")))]
 mod workspace;
 
-pub use self::id::*;
 pub use self::config::*;
 pub use self::config_profile::*;
 #[cfg(feature = "host_delegation")]
 pub use self::host_delegation::*;
 #[cfg(feature = "host_delegation_signing")]
 pub use self::host_delegation_crypto::*;
+pub use self::host_interface::*;
+pub use self::id::*;
 pub use self::resource::*;
 
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::runtime::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::config_spec::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::capability::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::store::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::resolver::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::event::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::context::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::host::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::scheduler::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::transaction::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
 pub use self::actor::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::service::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub use self::actor_behavior::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::capability::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::config_spec::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::context::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::event::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::host::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
 pub use self::module::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::resolver::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::runtime::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::scheduler::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::service::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::store::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::transaction::*;
 #[cfg(all(feature = "watcher", any(feature = "program", feature = "compiler")))]
 pub use self::workspace::*;

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -1,84 +1,86 @@
 #![cfg_attr(feature = "no_std", no_std)]
 #![allow(warnings)]
 
+pub mod id;
 pub mod config;
 pub mod config_profile;
 #[cfg(feature = "host_delegation")]
 pub mod host_delegation;
 #[cfg(feature = "host_delegation_signing")]
 pub mod host_delegation_crypto;
-mod host_interface;
-pub mod id;
 mod resource;
+#[cfg(any(feature = "program", feature = "compiler"))]
+mod host_interface;
 
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod actor;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub mod actor_behavior;
+pub mod runtime;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub mod capability;
 #[cfg(any(feature = "program", feature = "compiler"))]
 mod config_spec;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod context;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub mod event;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub mod host;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub mod module;
+pub mod store;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub mod resolver;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod runtime;
+pub mod event;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod context;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod host;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub mod scheduler;
 #[cfg(any(feature = "program", feature = "compiler"))]
+pub mod transaction;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub mod actor;
+#[cfg(any(feature = "program", feature = "compiler"))]
 pub mod service;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod store;
+pub mod actor_behavior;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub mod transaction;
+pub mod module;
 #[cfg(all(feature = "watcher", any(feature = "program", feature = "compiler")))]
 mod workspace;
 
+pub use self::id::*;
 pub use self::config::*;
 pub use self::config_profile::*;
 #[cfg(feature = "host_delegation")]
 pub use self::host_delegation::*;
 #[cfg(feature = "host_delegation_signing")]
 pub use self::host_delegation_crypto::*;
-pub use self::host_interface::*;
-pub use self::id::*;
 pub use self::resource::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::host_interface::*;
 
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::actor::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::actor_behavior::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::capability::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::config_spec::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::context::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::event::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::host::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::module::*;
-#[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::resolver::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub use self::runtime::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::scheduler::*;
+pub use self::config_spec::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
-pub use self::service::*;
+pub use self::capability::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
 pub use self::store::*;
 #[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::resolver::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::event::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::context::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::host::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::scheduler::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
 pub use self::transaction::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::actor::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::service::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::actor_behavior::*;
+#[cfg(any(feature = "program", feature = "compiler"))]
+pub use self::module::*;
 #[cfg(all(feature = "watcher", any(feature = "program", feature = "compiler")))]
 pub use self::workspace::*;

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -4,493 +4,619 @@ use mech_core::{MResult, MechError, MechErrorKind, Value};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeResourceReadRequest {
-    pub base_uri: String,
-    pub path: String,
-    pub context_name: String,
+  pub base_uri: String,
+  pub path: String,
+  pub context_name: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeResourceWriteIntent {
-    Assign,
-    Send,
+  Assign,
+  Send,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeResourceWritePreflightRequest {
-    pub base_uri: String,
-    pub path: String,
-    pub context_name: String,
-    pub intent: RuntimeResourceWriteIntent,
+  pub base_uri: String,
+  pub path: String,
+  pub context_name: String,
+  pub intent: RuntimeResourceWriteIntent,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RuntimeResourceWriteRequest {
-    pub base_uri: String,
-    pub path: String,
-    pub context_name: String,
-    pub value: Value,
-    pub intent: RuntimeResourceWriteIntent,
+  pub base_uri: String,
+  pub path: String,
+  pub context_name: String,
+  pub value: Value,
+  pub intent: RuntimeResourceWriteIntent,
 }
 
 pub trait RuntimeResourceProvider: std::fmt::Debug {
-    fn scheme(&self) -> &str;
+  fn scheme(&self) -> &str;
 
-    fn base_uris(&self) -> Vec<String> {
-        Vec::new()
-    }
+  fn base_uris(&self) -> Vec<String> { Vec::new() }
 
-    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
+  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
 
-    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-        Err(MechError::new(
-            RuntimeResourceWriteUnsupported {
-                scheme: self.scheme().to_string(),
-                base_uri: request.base_uri,
-                path: request.path,
-            },
-            None,
-        ))
-    }
+  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    Err(MechError::new(
+      RuntimeResourceWriteUnsupported {
+        scheme: self.scheme().to_string(),
+        base_uri: request.base_uri,
+        path: request.path,
+      },
+      None,
+    ))
+  }
 
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-        Err(MechError::new(
-            RuntimeResourceWriteUnsupported {
-                scheme: self.scheme().to_string(),
-                base_uri: request.base_uri,
-                path: request.path,
-            },
-            None,
-        ))
-    }
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    Err(MechError::new(
+      RuntimeResourceWriteUnsupported {
+        scheme: self.scheme().to_string(),
+        base_uri: request.base_uri,
+        path: request.path,
+      },
+      None,
+    ))
+  }
 }
 
 #[derive(Debug, Default)]
 pub struct RuntimeResourceRegistry {
-    providers: Vec<Box<dyn RuntimeResourceProvider>>,
+  providers: Vec<Box<dyn RuntimeResourceProvider>>,
 }
 
 impl RuntimeResourceRegistry {
-    pub fn new() -> Self {
-        Self::default()
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn register_provider(
+    &mut self,
+    provider: Box<dyn RuntimeResourceProvider>,
+  ) -> MResult<()> {
+    let scheme = provider.scheme().to_string();
+    if scheme.is_empty() {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: String::new(),
+          reason: "resource provider scheme cannot be empty".to_string(),
+        },
+        None,
+      ));
     }
-    pub fn register_provider(&mut self, provider: Box<dyn RuntimeResourceProvider>) -> MResult<()> {
-        let scheme = provider.scheme().to_string();
-        if scheme.is_empty() {
-            return Err(MechError::new(
-                RuntimeResourceInvalidUri {
-                    uri: String::new(),
-                    reason: "resource provider scheme cannot be empty".to_string(),
-                },
-                None,
-            ));
+
+    let bases = provider.base_uris();
+    if bases.is_empty() && self.providers.iter().any(|existing| {
+      existing.scheme() == scheme && existing.base_uris().is_empty()
+    }) {
+      return Err(MechError::new(
+        RuntimeResourceProviderConflict { scheme },
+        None,
+      ));
+    }
+
+    for base in &bases {
+      let base_scheme = resource_uri_scheme(base)?;
+      if base_scheme != scheme {
+        return Err(MechError::new(
+          RuntimeResourceInvalidUri {
+            uri: base.clone(),
+            reason: format!("provider base URI scheme must be `{scheme}`"),
+          },
+          None,
+        ));
+      }
+
+      for existing in &self.providers {
+        if existing.scheme() != scheme {
+          continue;
         }
-        let bases = provider.base_uris();
-        if bases.is_empty()
-            && self
-                .providers
-                .iter()
-                .any(|p| p.scheme() == scheme && p.base_uris().is_empty())
-        {
-            return Err(MechError::new(
-                RuntimeResourceProviderConflict { scheme },
-                None,
-            ));
+        if existing.base_uris().iter().any(|other| other == base) {
+          return Err(MechError::new(
+            RuntimeResourceProviderConflict { scheme: scheme.clone() },
+            None,
+          ));
         }
-        for base in &bases {
-            if resource_uri_scheme(base)? != scheme {
-                return Err(MechError::new(
-                    RuntimeResourceInvalidUri {
-                        uri: base.clone(),
-                        reason: format!("provider base URI scheme must be `{scheme}`"),
-                    },
-                    None,
-                ));
-            }
-            for existing in &self.providers {
-                if existing.scheme() == scheme
-                    && existing.base_uris().iter().any(|other| other == base)
-                {
-                    return Err(MechError::new(
-                        RuntimeResourceProviderConflict {
-                            scheme: scheme.clone(),
-                        },
-                        None,
-                    ));
-                }
-            }
+      }
+    }
+
+    self.providers.push(provider);
+    Ok(())
+  }
+
+  pub fn has_provider(&self, scheme: &str) -> bool {
+    self.providers.iter().any(|provider| provider.scheme() == scheme)
+  }
+
+  pub fn provider_base_uri_for(&self, candidate: &str) -> MResult<Option<String>> {
+    let Some((_, base_uri)) = self.select_provider(candidate)? else {
+      return Ok(None);
+    };
+    Ok(Some(base_uri.unwrap_or(resource_uri_origin(candidate)?.to_string())))
+  }
+
+  fn select_provider(&self, uri: &str) -> MResult<Option<(usize, Option<String>)>> {
+    let scheme = resource_uri_scheme(uri)?.to_string();
+    let mut fallback = None;
+    let mut best: Option<(usize, String)> = None;
+
+    for (idx, provider) in self.providers.iter().enumerate() {
+      if provider.scheme() != scheme {
+        continue;
+      }
+
+      let bases = provider.base_uris();
+      if bases.is_empty() {
+        fallback = Some(idx);
+        continue;
+      }
+
+      for base in bases {
+        if resource_base_matches(&base, uri) && best.as_ref().map_or(true, |(_, current)| base.len() > current.len()) {
+          best = Some((idx, base));
         }
-        self.providers.push(provider);
-        Ok(())
+      }
     }
-    pub fn has_provider(&self, scheme: &str) -> bool {
-        self.providers.iter().any(|p| p.scheme() == scheme)
-    }
-    pub fn provider_base_uri_for(&self, candidate: &str) -> MResult<Option<String>> {
-        let Some((_, base)) = self.select_provider(candidate)? else {
-            return Ok(None);
-        };
-        Ok(Some(
-            base.unwrap_or(resource_uri_origin(candidate)?.to_string()),
-        ))
-    }
-    fn select_provider(&self, uri: &str) -> MResult<Option<(usize, Option<String>)>> {
-        let scheme = resource_uri_scheme(uri)?.to_string();
-        let mut fallback = None;
-        let mut best: Option<(usize, String)> = None;
-        for (idx, provider) in self.providers.iter().enumerate() {
-            if provider.scheme() != scheme {
-                continue;
-            }
-            let bases = provider.base_uris();
-            if bases.is_empty() {
-                fallback = Some(idx);
-                continue;
-            }
-            for base in bases {
-                if resource_base_matches(&base, uri)
-                    && best.as_ref().map_or(true, |(_, b)| base.len() > b.len())
-                {
-                    best = Some((idx, base));
-                }
-            }
-        }
-        Ok(best
-            .map(|(i, b)| (i, Some(b)))
-            .or_else(|| fallback.map(|i| (i, None))))
-    }
-    pub fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-        let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
-        let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
-            return Err(MechError::new(
-                RuntimeResourceProviderNotFound {
-                    scheme,
-                    uri: request.base_uri,
-                },
-                None,
-            ));
-        };
-        self.providers[idx].read(request)
-    }
-    pub fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-        let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
-        let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
-            return Err(MechError::new(
-                RuntimeResourceProviderNotFound {
-                    scheme,
-                    uri: request.base_uri,
-                },
-                None,
-            ));
-        };
-        self.providers[idx].preflight_write(request)
-    }
-    pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-        let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
-        let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
-            return Err(MechError::new(
-                RuntimeResourceProviderNotFound {
-                    scheme,
-                    uri: request.base_uri,
-                },
-                None,
-            ));
-        };
-        self.providers[idx].write(request)
-    }
+
+    Ok(best.map(|(idx, base)| (idx, Some(base))).or_else(|| fallback.map(|idx| (idx, None))))
+  }
+
+  pub fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+    let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
+      return Err(MechError::new(
+        RuntimeResourceProviderNotFound {
+          scheme,
+          uri: request.base_uri,
+        },
+        None,
+      ));
+    };
+    self.providers[idx].read(request)
+  }
+
+  pub fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+    let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
+      return Err(MechError::new(
+        RuntimeResourceProviderNotFound {
+          scheme,
+          uri: request.base_uri,
+        },
+        None,
+      ));
+    };
+    self.providers[idx].preflight_write(request)
+  }
+
+  pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+    let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
+      return Err(MechError::new(
+        RuntimeResourceProviderNotFound {
+          scheme,
+          uri: request.base_uri,
+        },
+        None,
+      ));
+    };
+    self.providers[idx].write(request)
+  }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryDocsProvider {
-    documents: HashMap<String, HashMap<String, Value>>,
+  documents: HashMap<String, HashMap<String, Value>>,
 }
 
 impl InMemoryDocsProvider {
-    pub fn new() -> Self {
-        Self::default()
-    }
+  pub fn new() -> Self {
+    Self::default()
+  }
 
-    pub fn insert(
-        &mut self,
-        base_uri: impl Into<String>,
-        path: impl Into<String>,
-        value: Value,
-    ) -> MResult<()> {
-        let base_uri = base_uri.into();
-        let path = path.into();
-        let scheme = resource_uri_scheme(&base_uri)?;
-        if scheme != "docs" {
-            return Err(MechError::new(
-                RuntimeResourceInvalidUri {
-                    uri: base_uri,
-                    reason: "in-memory docs resources require the `docs` scheme".to_string(),
-                },
-                None,
-            ));
-        }
-        if path.is_empty() {
-            return Err(MechError::new(
-                RuntimeResourceInvalidUri {
-                    uri: base_uri,
-                    reason: "resource path cannot be empty".to_string(),
-                },
-                None,
-            ));
-        }
-        self.documents
-            .entry(base_uri)
-            .or_default()
-            .insert(path, value);
-        Ok(())
+  pub fn insert(
+    &mut self,
+    base_uri: impl Into<String>,
+    path: impl Into<String>,
+    value: Value,
+  ) -> MResult<()> {
+    let base_uri = base_uri.into();
+    let path = path.into();
+    let scheme = resource_uri_scheme(&base_uri)?;
+    if scheme != "docs" {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: base_uri,
+          reason: "in-memory docs resources require the `docs` scheme".to_string(),
+        },
+        None,
+      ));
     }
+    if path.is_empty() {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: base_uri,
+          reason: "resource path cannot be empty".to_string(),
+        },
+        None,
+      ));
+    }
+    self.documents.entry(base_uri).or_default().insert(path, value);
+    Ok(())
+  }
 
-    pub fn with_value(
-        mut self,
-        base_uri: impl Into<String>,
-        path: impl Into<String>,
-        value: Value,
-    ) -> MResult<Self> {
-        self.insert(base_uri, path, value)?;
-        Ok(self)
-    }
+  pub fn with_value(
+    mut self,
+    base_uri: impl Into<String>,
+    path: impl Into<String>,
+    value: Value,
+  ) -> MResult<Self> {
+    self.insert(base_uri, path, value)?;
+    Ok(self)
+  }
 }
 
 impl RuntimeResourceProvider for InMemoryDocsProvider {
-    fn scheme(&self) -> &str {
-        "docs"
+  fn scheme(&self) -> &str {
+    "docs"
+  }
+
+  fn base_uris(&self) -> Vec<String> {
+    self.documents.keys().cloned().collect()
+  }
+
+  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+    let Some(document) = self.documents.get(&request.base_uri) else {
+      return Err(MechError::new(
+        RuntimeResourcePathNotFound {
+          base_uri: request.base_uri,
+          path: request.path,
+        },
+        None,
+      ));
+    };
+    let Some(value) = document.get(&request.path) else {
+      return Err(MechError::new(
+        RuntimeResourcePathNotFound {
+          base_uri: request.base_uri,
+          path: request.path,
+        },
+        None,
+      ));
+    };
+    Ok(value.clone())
+  }
+
+  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    if request.intent == RuntimeResourceWriteIntent::Send {
+      return Err(MechError::new(
+        RuntimeResourceWriteUnsupported {
+          scheme: self.scheme().to_string(),
+          base_uri: request.base_uri,
+          path: request.path,
+        },
+        None,
+      ));
     }
 
-    fn base_uris(&self) -> Vec<String> {
-        self.documents.keys().cloned().collect()
+    let scheme = resource_uri_scheme(&request.base_uri)?;
+    if scheme != "docs" {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: request.base_uri,
+          reason: "in-memory docs resources require the `docs` scheme".to_string(),
+        },
+        None,
+      ));
     }
 
-    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-        let Some(document) = self.documents.get(&request.base_uri) else {
-            return Err(MechError::new(
-                RuntimeResourcePathNotFound {
-                    base_uri: request.base_uri,
-                    path: request.path,
-                },
-                None,
-            ));
-        };
-        let Some(value) = document.get(&request.path) else {
-            return Err(MechError::new(
-                RuntimeResourcePathNotFound {
-                    base_uri: request.base_uri,
-                    path: request.path,
-                },
-                None,
-            ));
-        };
-        Ok(value.clone())
+    if request.path.is_empty() {
+      return Err(MechError::new(
+        RuntimeResourceInvalidUri {
+          uri: request.base_uri,
+          reason: "resource path cannot be empty".to_string(),
+        },
+        None,
+      ));
     }
 
-    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-        if request.intent == RuntimeResourceWriteIntent::Send {
-            return Err(MechError::new(
-                RuntimeResourceWriteUnsupported {
-                    scheme: self.scheme().to_string(),
-                    base_uri: request.base_uri,
-                    path: request.path,
-                },
-                None,
-            ));
-        }
+    Ok(())
+  }
 
-        let scheme = resource_uri_scheme(&request.base_uri)?;
-        if scheme != "docs" {
-            return Err(MechError::new(
-                RuntimeResourceInvalidUri {
-                    uri: request.base_uri,
-                    reason: "in-memory docs resources require the `docs` scheme".to_string(),
-                },
-                None,
-            ));
-        }
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    self.preflight_write(RuntimeResourceWritePreflightRequest {
+      base_uri: request.base_uri.clone(),
+      path: request.path.clone(),
+      context_name: request.context_name.clone(),
+      intent: request.intent,
+    })?;
 
-        if request.path.is_empty() {
-            return Err(MechError::new(
-                RuntimeResourceInvalidUri {
-                    uri: request.base_uri,
-                    reason: "resource path cannot be empty".to_string(),
-                },
-                None,
-            ));
-        }
+    self.documents
+      .entry(request.base_uri)
+      .or_default()
+      .insert(request.path, request.value);
 
-        Ok(())
-    }
-
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-        self.preflight_write(RuntimeResourceWritePreflightRequest {
-            base_uri: request.base_uri.clone(),
-            path: request.path.clone(),
-            context_name: request.context_name.clone(),
-            intent: request.intent,
-        })?;
-
-        self.documents
-            .entry(request.base_uri)
-            .or_default()
-            .insert(request.path, request.value);
-
-        Ok(())
-    }
+    Ok(())
+  }
 }
 
 pub fn resource_base_matches(base: &str, candidate: &str) -> bool {
-    candidate == base
-        || candidate
-            .strip_prefix(base)
-            .is_some_and(|suffix| suffix.starts_with('/'))
+  candidate == base || candidate.strip_prefix(base).is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn resource_uri_origin(uri: &str) -> MResult<&str> {
-    let scheme = resource_uri_scheme(uri)?;
-    let rest = &uri[scheme.len() + 3..];
-    let authority_end = rest.find('/').unwrap_or(rest.len());
-    if authority_end == 0 {
-        return Err(MechError::new(
-            RuntimeResourceInvalidUri {
-                uri: uri.to_string(),
-                reason: "resource URI authority cannot be empty".to_string(),
-            },
-            None,
-        ));
-    }
-    Ok(&uri[..scheme.len() + 3 + authority_end])
+  let scheme = resource_uri_scheme(uri)?;
+  let rest = &uri[scheme.len() + 3..];
+  let authority_end = rest.find('/').unwrap_or(rest.len());
+  if authority_end == 0 {
+    return Err(MechError::new(
+      RuntimeResourceInvalidUri {
+        uri: uri.to_string(),
+        reason: "resource URI authority cannot be empty".to_string(),
+      },
+      None,
+    ));
+  }
+  Ok(&uri[..scheme.len() + 3 + authority_end])
 }
 
 fn resource_uri_scheme(uri: &str) -> MResult<&str> {
-    let Some((scheme, _rest)) = uri.split_once("://") else {
-        return Err(MechError::new(
-            RuntimeResourceInvalidUri {
-                uri: uri.to_string(),
-                reason: "resource URI must contain `://`".to_string(),
-            },
-            None,
-        ));
-    };
-    if scheme.is_empty() {
-        return Err(MechError::new(
-            RuntimeResourceInvalidUri {
-                uri: uri.to_string(),
-                reason: "resource URI scheme cannot be empty".to_string(),
-            },
-            None,
-        ));
-    }
-    Ok(scheme)
+  let Some((scheme, _rest)) = uri.split_once("://") else {
+    return Err(MechError::new(
+      RuntimeResourceInvalidUri {
+        uri: uri.to_string(),
+        reason: "resource URI must contain `://`".to_string(),
+      },
+      None,
+    ));
+  };
+  if scheme.is_empty() {
+    return Err(MechError::new(
+      RuntimeResourceInvalidUri {
+        uri: uri.to_string(),
+        reason: "resource URI scheme cannot be empty".to_string(),
+      },
+      None,
+    ));
+  }
+  Ok(scheme)
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceInvalidUri {
-    pub uri: String,
-    pub reason: String,
+  pub uri: String,
+  pub reason: String,
 }
 
 impl MechErrorKind for RuntimeResourceInvalidUri {
-    fn name(&self) -> &str {
-        "RuntimeResourceInvalidUri"
-    }
+  fn name(&self) -> &str {
+    "RuntimeResourceInvalidUri"
+  }
 
-    fn message(&self) -> String {
-        format!("invalid resource URI `{}`: {}", self.uri, self.reason)
-    }
+  fn message(&self) -> String {
+    format!("invalid resource URI `{}`: {}", self.uri, self.reason)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceProviderNotFound {
-    pub scheme: String,
-    pub uri: String,
+  pub scheme: String,
+  pub uri: String,
 }
 
 impl MechErrorKind for RuntimeResourceProviderNotFound {
-    fn name(&self) -> &str {
-        "RuntimeResourceProviderNotFound"
-    }
+  fn name(&self) -> &str {
+    "RuntimeResourceProviderNotFound"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "no runtime resource provider registered for scheme `{}` while reading `{}`",
-            self.scheme, self.uri,
-        )
-    }
+  fn message(&self) -> String {
+    format!(
+      "no runtime resource provider registered for scheme `{}` while reading `{}`",
+      self.scheme,
+      self.uri,
+    )
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceWriteUnsupported {
-    pub scheme: String,
-    pub base_uri: String,
-    pub path: String,
+  pub scheme: String,
+  pub base_uri: String,
+  pub path: String,
 }
 
 impl MechErrorKind for RuntimeResourceWriteUnsupported {
-    fn name(&self) -> &str {
-        "RuntimeResourceWriteUnsupported"
-    }
+  fn name(&self) -> &str {
+    "RuntimeResourceWriteUnsupported"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "runtime resource provider for scheme `{}` does not support writes to `{}` under `{}`",
-            self.scheme, self.path, self.base_uri,
-        )
-    }
+  fn message(&self) -> String {
+    format!(
+      "runtime resource provider for scheme `{}` does not support writes to `{}` under `{}`",
+      self.scheme,
+      self.path,
+      self.base_uri,
+    )
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceProviderConflict {
-    pub scheme: String,
+  pub scheme: String,
 }
 
 impl MechErrorKind for RuntimeResourceProviderConflict {
-    fn name(&self) -> &str {
-        "RuntimeResourceProviderConflict"
-    }
+  fn name(&self) -> &str {
+    "RuntimeResourceProviderConflict"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "runtime resource provider for scheme `{}` is already registered",
-            self.scheme
-        )
-    }
+  fn message(&self) -> String {
+    format!("runtime resource provider for scheme `{}` is already registered", self.scheme)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourcePathNotFound {
-    pub base_uri: String,
-    pub path: String,
+  pub base_uri: String,
+  pub path: String,
 }
 
 impl MechErrorKind for RuntimeResourcePathNotFound {
-    fn name(&self) -> &str {
-        "RuntimeResourcePathNotFound"
-    }
+  fn name(&self) -> &str {
+    "RuntimeResourcePathNotFound"
+  }
 
-    fn message(&self) -> String {
-        format!(
-            "resource path `{}` was not found under `{}`",
-            self.path, self.base_uri
-        )
-    }
+  fn message(&self) -> String {
+    format!("resource path `{}` was not found under `{}`", self.path, self.base_uri)
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceCapabilityDenied {
-    pub context_name: String,
-    pub operation: String,
-    pub path: String,
+  pub context_name: String,
+  pub operation: String,
+  pub path: String,
 }
 
 impl MechErrorKind for RuntimeResourceCapabilityDenied {
-    fn name(&self) -> &str {
-        "RuntimeResourceCapabilityDenied"
+  fn name(&self) -> &str {
+    "RuntimeResourceCapabilityDenied"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "context `{}` does not allow `{}` on `{}`",
+      self.context_name,
+      self.operation,
+      self.path,
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  #[derive(Debug)]
+  struct RecordingProvider {
+    scheme: &'static str,
+    bases: Vec<String>,
+    reads: Rc<RefCell<Vec<String>>>,
+    writes: Rc<RefCell<Vec<String>>>,
+  }
+
+  impl RecordingProvider {
+    fn new(
+      scheme: &'static str,
+      bases: Vec<&str>,
+      reads: Rc<RefCell<Vec<String>>>,
+      writes: Rc<RefCell<Vec<String>>>,
+    ) -> Self {
+      Self {
+        scheme,
+        bases: bases.into_iter().map(ToString::to_string).collect(),
+        reads,
+        writes,
+      }
+    }
+  }
+
+  impl RuntimeResourceProvider for RecordingProvider {
+    fn scheme(&self) -> &str { self.scheme }
+
+    fn base_uris(&self) -> Vec<String> { self.bases.clone() }
+
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+      self.reads.borrow_mut().push(request.base_uri);
+      Ok(Value::from("ok".to_string()))
     }
 
-    fn message(&self) -> String {
-        format!(
-            "context `{}` does not allow `{}` on `{}`",
-            self.context_name, self.operation, self.path,
-        )
+    fn preflight_write(&self, _request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+      Ok(())
     }
+
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+      self.writes.borrow_mut().push(request.base_uri);
+      Ok(())
+    }
+  }
+
+  fn requests(base_uri: &str) -> (RuntimeResourceReadRequest, RuntimeResourceWriteRequest) {
+    (
+      RuntimeResourceReadRequest {
+        base_uri: base_uri.to_string(),
+        path: "path".to_string(),
+        context_name: "ctx".to_string(),
+      },
+      RuntimeResourceWriteRequest {
+        base_uri: base_uri.to_string(),
+        path: "path".to_string(),
+        context_name: "ctx".to_string(),
+        value: Value::from("value".to_string()),
+        intent: RuntimeResourceWriteIntent::Assign,
+      },
+    )
+  }
+
+  #[test]
+  fn routes_same_scheme_to_distinct_base_providers() {
+    let left_reads = Rc::new(RefCell::new(Vec::new()));
+    let left_writes = Rc::new(RefCell::new(Vec::new()));
+    let right_reads = Rc::new(RefCell::new(Vec::new()));
+    let right_writes = Rc::new(RefCell::new(Vec::new()));
+    let mut registry = RuntimeResourceRegistry::new();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://left-arm"], left_reads.clone(), left_writes.clone()))).unwrap();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://right-arm"], right_reads.clone(), right_writes.clone()))).unwrap();
+
+    registry.read(requests("robot://left-arm").0).unwrap();
+    registry.write(requests("robot://right-arm").1).unwrap();
+
+    assert_eq!(left_reads.borrow().as_slice(), &["robot://left-arm".to_string()]);
+    assert!(left_writes.borrow().is_empty());
+    assert!(right_reads.borrow().is_empty());
+    assert_eq!(right_writes.borrow().as_slice(), &["robot://right-arm".to_string()]);
+  }
+
+  #[test]
+  fn longest_base_wins_over_shorter_base() {
+    let short_reads = Rc::new(RefCell::new(Vec::new()));
+    let short_writes = Rc::new(RefCell::new(Vec::new()));
+    let long_reads = Rc::new(RefCell::new(Vec::new()));
+    let long_writes = Rc::new(RefCell::new(Vec::new()));
+    let mut registry = RuntimeResourceRegistry::new();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://arm"], short_reads.clone(), short_writes.clone()))).unwrap();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://arm/elbow"], long_reads.clone(), long_writes.clone()))).unwrap();
+
+    registry.read(requests("robot://arm/elbow").0).unwrap();
+
+    assert!(short_reads.borrow().is_empty());
+    assert_eq!(long_reads.borrow().as_slice(), &["robot://arm/elbow".to_string()]);
+  }
+
+  #[test]
+  fn rejects_duplicate_base_uri() {
+    let mut registry = RuntimeResourceRegistry::new();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://arm"], Rc::new(RefCell::new(Vec::new())), Rc::new(RefCell::new(Vec::new()))))).unwrap();
+    assert!(registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://arm"], Rc::new(RefCell::new(Vec::new())), Rc::new(RefCell::new(Vec::new()))))).is_err());
+  }
+
+  #[test]
+  fn rejects_duplicate_fallback_provider() {
+    let mut registry = RuntimeResourceRegistry::new();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec![], Rc::new(RefCell::new(Vec::new())), Rc::new(RefCell::new(Vec::new()))))).unwrap();
+    assert!(registry.register_provider(Box::new(RecordingProvider::new("robot", vec![], Rc::new(RefCell::new(Vec::new())), Rc::new(RefCell::new(Vec::new()))))).is_err());
+  }
+
+  #[test]
+  fn returns_provider_not_found_without_matching_base_or_fallback() {
+    let mut registry = RuntimeResourceRegistry::new();
+    registry.register_provider(Box::new(RecordingProvider::new("robot", vec!["robot://left-arm"], Rc::new(RefCell::new(Vec::new())), Rc::new(RefCell::new(Vec::new()))))).unwrap();
+
+    let err = registry.read(requests("robot://right-arm").0).unwrap_err();
+    assert_eq!(err.kind_name(), "RuntimeResourceProviderNotFound");
+  }
 }

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -4,449 +4,493 @@ use mech_core::{MResult, MechError, MechErrorKind, Value};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeResourceReadRequest {
-  pub base_uri: String,
-  pub path: String,
-  pub context_name: String,
+    pub base_uri: String,
+    pub path: String,
+    pub context_name: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeResourceWriteIntent {
-  Assign,
-  Send,
+    Assign,
+    Send,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeResourceWritePreflightRequest {
-  pub base_uri: String,
-  pub path: String,
-  pub context_name: String,
-  pub intent: RuntimeResourceWriteIntent,
+    pub base_uri: String,
+    pub path: String,
+    pub context_name: String,
+    pub intent: RuntimeResourceWriteIntent,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RuntimeResourceWriteRequest {
-  pub base_uri: String,
-  pub path: String,
-  pub context_name: String,
-  pub value: Value,
-  pub intent: RuntimeResourceWriteIntent,
+    pub base_uri: String,
+    pub path: String,
+    pub context_name: String,
+    pub value: Value,
+    pub intent: RuntimeResourceWriteIntent,
 }
 
 pub trait RuntimeResourceProvider: std::fmt::Debug {
-  fn scheme(&self) -> &str;
+    fn scheme(&self) -> &str;
 
-  fn base_uris(&self) -> Vec<String> { Vec::new() }
+    fn base_uris(&self) -> Vec<String> {
+        Vec::new()
+    }
 
-  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value>;
 
-  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-    Err(MechError::new(
-      RuntimeResourceWriteUnsupported {
-        scheme: self.scheme().to_string(),
-        base_uri: request.base_uri,
-        path: request.path,
-      },
-      None,
-    ))
-  }
+    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+        Err(MechError::new(
+            RuntimeResourceWriteUnsupported {
+                scheme: self.scheme().to_string(),
+                base_uri: request.base_uri,
+                path: request.path,
+            },
+            None,
+        ))
+    }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-    Err(MechError::new(
-      RuntimeResourceWriteUnsupported {
-        scheme: self.scheme().to_string(),
-        base_uri: request.base_uri,
-        path: request.path,
-      },
-      None,
-    ))
-  }
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        Err(MechError::new(
+            RuntimeResourceWriteUnsupported {
+                scheme: self.scheme().to_string(),
+                base_uri: request.base_uri,
+                path: request.path,
+            },
+            None,
+        ))
+    }
 }
 
 #[derive(Debug, Default)]
 pub struct RuntimeResourceRegistry {
-  providers: HashMap<String, Box<dyn RuntimeResourceProvider>>,
+    providers: Vec<Box<dyn RuntimeResourceProvider>>,
 }
 
 impl RuntimeResourceRegistry {
-  pub fn new() -> Self {
-    Self::default()
-  }
-
-  pub fn register_provider(
-    &mut self,
-    provider: Box<dyn RuntimeResourceProvider>,
-  ) -> MResult<()> {
-    let scheme = provider.scheme().to_string();
-    if scheme.is_empty() {
-      return Err(MechError::new(
-        RuntimeResourceInvalidUri {
-          uri: String::new(),
-          reason: "resource provider scheme cannot be empty".to_string(),
-        },
-        None,
-      ));
+    pub fn new() -> Self {
+        Self::default()
     }
-    if self.providers.contains_key(&scheme) {
-      return Err(MechError::new(
-        RuntimeResourceProviderConflict { scheme },
-        None,
-      ));
+    pub fn register_provider(&mut self, provider: Box<dyn RuntimeResourceProvider>) -> MResult<()> {
+        let scheme = provider.scheme().to_string();
+        if scheme.is_empty() {
+            return Err(MechError::new(
+                RuntimeResourceInvalidUri {
+                    uri: String::new(),
+                    reason: "resource provider scheme cannot be empty".to_string(),
+                },
+                None,
+            ));
+        }
+        let bases = provider.base_uris();
+        if bases.is_empty()
+            && self
+                .providers
+                .iter()
+                .any(|p| p.scheme() == scheme && p.base_uris().is_empty())
+        {
+            return Err(MechError::new(
+                RuntimeResourceProviderConflict { scheme },
+                None,
+            ));
+        }
+        for base in &bases {
+            if resource_uri_scheme(base)? != scheme {
+                return Err(MechError::new(
+                    RuntimeResourceInvalidUri {
+                        uri: base.clone(),
+                        reason: format!("provider base URI scheme must be `{scheme}`"),
+                    },
+                    None,
+                ));
+            }
+            for existing in &self.providers {
+                if existing.scheme() == scheme
+                    && existing.base_uris().iter().any(|other| other == base)
+                {
+                    return Err(MechError::new(
+                        RuntimeResourceProviderConflict {
+                            scheme: scheme.clone(),
+                        },
+                        None,
+                    ));
+                }
+            }
+        }
+        self.providers.push(provider);
+        Ok(())
     }
-    self.providers.insert(scheme, provider);
-    Ok(())
-  }
-
-  pub fn has_provider(&self, scheme: &str) -> bool {
-    self.providers.contains_key(scheme)
-  }
-
-  pub fn provider_base_uri_for(&self, candidate: &str) -> MResult<Option<String>> {
-    let scheme = resource_uri_scheme(candidate)?.to_string();
-    let Some(provider) = self.providers.get(&scheme) else {
-      return Ok(None);
-    };
-
-    let mut matches = provider
-      .base_uris()
-      .into_iter()
-      .filter(|base| resource_base_matches(base, candidate))
-      .collect::<Vec<_>>();
-    matches.sort_by_key(|base| std::cmp::Reverse(base.len()));
-    if let Some(base) = matches.into_iter().next() {
-      return Ok(Some(base));
+    pub fn has_provider(&self, scheme: &str) -> bool {
+        self.providers.iter().any(|p| p.scheme() == scheme)
     }
-
-    Ok(Some(resource_uri_origin(candidate)?.to_string()))
-  }
-
-  pub fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
-    let Some(provider) = self.providers.get(&scheme) else {
-      return Err(MechError::new(
-        RuntimeResourceProviderNotFound {
-          scheme,
-          uri: request.base_uri,
-        },
-        None,
-      ));
-    };
-    provider.read(request)
-  }
-
-  pub fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
-    let Some(provider) = self.providers.get(&scheme) else {
-      return Err(MechError::new(
-        RuntimeResourceProviderNotFound {
-          scheme,
-          uri: request.base_uri,
-        },
-        None,
-      ));
-    };
-    provider.preflight_write(request)
-  }
-
-  pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-    let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
-    let Some(provider) = self.providers.get_mut(&scheme) else {
-      return Err(MechError::new(
-        RuntimeResourceProviderNotFound {
-          scheme,
-          uri: request.base_uri,
-        },
-        None,
-      ));
-    };
-    provider.write(request)
-  }
+    pub fn provider_base_uri_for(&self, candidate: &str) -> MResult<Option<String>> {
+        let Some((_, base)) = self.select_provider(candidate)? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            base.unwrap_or(resource_uri_origin(candidate)?.to_string()),
+        ))
+    }
+    fn select_provider(&self, uri: &str) -> MResult<Option<(usize, Option<String>)>> {
+        let scheme = resource_uri_scheme(uri)?.to_string();
+        let mut fallback = None;
+        let mut best: Option<(usize, String)> = None;
+        for (idx, provider) in self.providers.iter().enumerate() {
+            if provider.scheme() != scheme {
+                continue;
+            }
+            let bases = provider.base_uris();
+            if bases.is_empty() {
+                fallback = Some(idx);
+                continue;
+            }
+            for base in bases {
+                if resource_base_matches(&base, uri)
+                    && best.as_ref().map_or(true, |(_, b)| base.len() > b.len())
+                {
+                    best = Some((idx, base));
+                }
+            }
+        }
+        Ok(best
+            .map(|(i, b)| (i, Some(b)))
+            .or_else(|| fallback.map(|i| (i, None))))
+    }
+    pub fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+        let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+        let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
+            return Err(MechError::new(
+                RuntimeResourceProviderNotFound {
+                    scheme,
+                    uri: request.base_uri,
+                },
+                None,
+            ));
+        };
+        self.providers[idx].read(request)
+    }
+    pub fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+        let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+        let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
+            return Err(MechError::new(
+                RuntimeResourceProviderNotFound {
+                    scheme,
+                    uri: request.base_uri,
+                },
+                None,
+            ));
+        };
+        self.providers[idx].preflight_write(request)
+    }
+    pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
+        let Some((idx, _)) = self.select_provider(&request.base_uri)? else {
+            return Err(MechError::new(
+                RuntimeResourceProviderNotFound {
+                    scheme,
+                    uri: request.base_uri,
+                },
+                None,
+            ));
+        };
+        self.providers[idx].write(request)
+    }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryDocsProvider {
-  documents: HashMap<String, HashMap<String, Value>>,
+    documents: HashMap<String, HashMap<String, Value>>,
 }
 
 impl InMemoryDocsProvider {
-  pub fn new() -> Self {
-    Self::default()
-  }
-
-  pub fn insert(
-    &mut self,
-    base_uri: impl Into<String>,
-    path: impl Into<String>,
-    value: Value,
-  ) -> MResult<()> {
-    let base_uri = base_uri.into();
-    let path = path.into();
-    let scheme = resource_uri_scheme(&base_uri)?;
-    if scheme != "docs" {
-      return Err(MechError::new(
-        RuntimeResourceInvalidUri {
-          uri: base_uri,
-          reason: "in-memory docs resources require the `docs` scheme".to_string(),
-        },
-        None,
-      ));
+    pub fn new() -> Self {
+        Self::default()
     }
-    if path.is_empty() {
-      return Err(MechError::new(
-        RuntimeResourceInvalidUri {
-          uri: base_uri,
-          reason: "resource path cannot be empty".to_string(),
-        },
-        None,
-      ));
-    }
-    self.documents.entry(base_uri).or_default().insert(path, value);
-    Ok(())
-  }
 
-  pub fn with_value(
-    mut self,
-    base_uri: impl Into<String>,
-    path: impl Into<String>,
-    value: Value,
-  ) -> MResult<Self> {
-    self.insert(base_uri, path, value)?;
-    Ok(self)
-  }
+    pub fn insert(
+        &mut self,
+        base_uri: impl Into<String>,
+        path: impl Into<String>,
+        value: Value,
+    ) -> MResult<()> {
+        let base_uri = base_uri.into();
+        let path = path.into();
+        let scheme = resource_uri_scheme(&base_uri)?;
+        if scheme != "docs" {
+            return Err(MechError::new(
+                RuntimeResourceInvalidUri {
+                    uri: base_uri,
+                    reason: "in-memory docs resources require the `docs` scheme".to_string(),
+                },
+                None,
+            ));
+        }
+        if path.is_empty() {
+            return Err(MechError::new(
+                RuntimeResourceInvalidUri {
+                    uri: base_uri,
+                    reason: "resource path cannot be empty".to_string(),
+                },
+                None,
+            ));
+        }
+        self.documents
+            .entry(base_uri)
+            .or_default()
+            .insert(path, value);
+        Ok(())
+    }
+
+    pub fn with_value(
+        mut self,
+        base_uri: impl Into<String>,
+        path: impl Into<String>,
+        value: Value,
+    ) -> MResult<Self> {
+        self.insert(base_uri, path, value)?;
+        Ok(self)
+    }
 }
 
 impl RuntimeResourceProvider for InMemoryDocsProvider {
-  fn scheme(&self) -> &str {
-    "docs"
-  }
-
-  fn base_uris(&self) -> Vec<String> {
-    self.documents.keys().cloned().collect()
-  }
-
-  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-    let Some(document) = self.documents.get(&request.base_uri) else {
-      return Err(MechError::new(
-        RuntimeResourcePathNotFound {
-          base_uri: request.base_uri,
-          path: request.path,
-        },
-        None,
-      ));
-    };
-    let Some(value) = document.get(&request.path) else {
-      return Err(MechError::new(
-        RuntimeResourcePathNotFound {
-          base_uri: request.base_uri,
-          path: request.path,
-        },
-        None,
-      ));
-    };
-    Ok(value.clone())
-  }
-
-  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-    if request.intent == RuntimeResourceWriteIntent::Send {
-      return Err(MechError::new(
-        RuntimeResourceWriteUnsupported {
-          scheme: self.scheme().to_string(),
-          base_uri: request.base_uri,
-          path: request.path,
-        },
-        None,
-      ));
+    fn scheme(&self) -> &str {
+        "docs"
     }
 
-    let scheme = resource_uri_scheme(&request.base_uri)?;
-    if scheme != "docs" {
-      return Err(MechError::new(
-        RuntimeResourceInvalidUri {
-          uri: request.base_uri,
-          reason: "in-memory docs resources require the `docs` scheme".to_string(),
-        },
-        None,
-      ));
+    fn base_uris(&self) -> Vec<String> {
+        self.documents.keys().cloned().collect()
     }
 
-    if request.path.is_empty() {
-      return Err(MechError::new(
-        RuntimeResourceInvalidUri {
-          uri: request.base_uri,
-          reason: "resource path cannot be empty".to_string(),
-        },
-        None,
-      ));
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+        let Some(document) = self.documents.get(&request.base_uri) else {
+            return Err(MechError::new(
+                RuntimeResourcePathNotFound {
+                    base_uri: request.base_uri,
+                    path: request.path,
+                },
+                None,
+            ));
+        };
+        let Some(value) = document.get(&request.path) else {
+            return Err(MechError::new(
+                RuntimeResourcePathNotFound {
+                    base_uri: request.base_uri,
+                    path: request.path,
+                },
+                None,
+            ));
+        };
+        Ok(value.clone())
     }
 
-    Ok(())
-  }
+    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+        if request.intent == RuntimeResourceWriteIntent::Send {
+            return Err(MechError::new(
+                RuntimeResourceWriteUnsupported {
+                    scheme: self.scheme().to_string(),
+                    base_uri: request.base_uri,
+                    path: request.path,
+                },
+                None,
+            ));
+        }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-    self.preflight_write(RuntimeResourceWritePreflightRequest {
-      base_uri: request.base_uri.clone(),
-      path: request.path.clone(),
-      context_name: request.context_name.clone(),
-      intent: request.intent,
-    })?;
+        let scheme = resource_uri_scheme(&request.base_uri)?;
+        if scheme != "docs" {
+            return Err(MechError::new(
+                RuntimeResourceInvalidUri {
+                    uri: request.base_uri,
+                    reason: "in-memory docs resources require the `docs` scheme".to_string(),
+                },
+                None,
+            ));
+        }
 
-    self.documents
-      .entry(request.base_uri)
-      .or_default()
-      .insert(request.path, request.value);
+        if request.path.is_empty() {
+            return Err(MechError::new(
+                RuntimeResourceInvalidUri {
+                    uri: request.base_uri,
+                    reason: "resource path cannot be empty".to_string(),
+                },
+                None,
+            ));
+        }
 
-    Ok(())
-  }
+        Ok(())
+    }
+
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        self.preflight_write(RuntimeResourceWritePreflightRequest {
+            base_uri: request.base_uri.clone(),
+            path: request.path.clone(),
+            context_name: request.context_name.clone(),
+            intent: request.intent,
+        })?;
+
+        self.documents
+            .entry(request.base_uri)
+            .or_default()
+            .insert(request.path, request.value);
+
+        Ok(())
+    }
 }
 
 pub fn resource_base_matches(base: &str, candidate: &str) -> bool {
-  candidate == base || candidate.strip_prefix(base).is_some_and(|suffix| suffix.starts_with('/'))
+    candidate == base
+        || candidate
+            .strip_prefix(base)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn resource_uri_origin(uri: &str) -> MResult<&str> {
-  let scheme = resource_uri_scheme(uri)?;
-  let rest = &uri[scheme.len() + 3..];
-  let authority_end = rest.find('/').unwrap_or(rest.len());
-  if authority_end == 0 {
-    return Err(MechError::new(
-      RuntimeResourceInvalidUri {
-        uri: uri.to_string(),
-        reason: "resource URI authority cannot be empty".to_string(),
-      },
-      None,
-    ));
-  }
-  Ok(&uri[..scheme.len() + 3 + authority_end])
+    let scheme = resource_uri_scheme(uri)?;
+    let rest = &uri[scheme.len() + 3..];
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    if authority_end == 0 {
+        return Err(MechError::new(
+            RuntimeResourceInvalidUri {
+                uri: uri.to_string(),
+                reason: "resource URI authority cannot be empty".to_string(),
+            },
+            None,
+        ));
+    }
+    Ok(&uri[..scheme.len() + 3 + authority_end])
 }
 
 fn resource_uri_scheme(uri: &str) -> MResult<&str> {
-  let Some((scheme, _rest)) = uri.split_once("://") else {
-    return Err(MechError::new(
-      RuntimeResourceInvalidUri {
-        uri: uri.to_string(),
-        reason: "resource URI must contain `://`".to_string(),
-      },
-      None,
-    ));
-  };
-  if scheme.is_empty() {
-    return Err(MechError::new(
-      RuntimeResourceInvalidUri {
-        uri: uri.to_string(),
-        reason: "resource URI scheme cannot be empty".to_string(),
-      },
-      None,
-    ));
-  }
-  Ok(scheme)
+    let Some((scheme, _rest)) = uri.split_once("://") else {
+        return Err(MechError::new(
+            RuntimeResourceInvalidUri {
+                uri: uri.to_string(),
+                reason: "resource URI must contain `://`".to_string(),
+            },
+            None,
+        ));
+    };
+    if scheme.is_empty() {
+        return Err(MechError::new(
+            RuntimeResourceInvalidUri {
+                uri: uri.to_string(),
+                reason: "resource URI scheme cannot be empty".to_string(),
+            },
+            None,
+        ));
+    }
+    Ok(scheme)
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceInvalidUri {
-  pub uri: String,
-  pub reason: String,
+    pub uri: String,
+    pub reason: String,
 }
 
 impl MechErrorKind for RuntimeResourceInvalidUri {
-  fn name(&self) -> &str {
-    "RuntimeResourceInvalidUri"
-  }
+    fn name(&self) -> &str {
+        "RuntimeResourceInvalidUri"
+    }
 
-  fn message(&self) -> String {
-    format!("invalid resource URI `{}`: {}", self.uri, self.reason)
-  }
+    fn message(&self) -> String {
+        format!("invalid resource URI `{}`: {}", self.uri, self.reason)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceProviderNotFound {
-  pub scheme: String,
-  pub uri: String,
+    pub scheme: String,
+    pub uri: String,
 }
 
 impl MechErrorKind for RuntimeResourceProviderNotFound {
-  fn name(&self) -> &str {
-    "RuntimeResourceProviderNotFound"
-  }
+    fn name(&self) -> &str {
+        "RuntimeResourceProviderNotFound"
+    }
 
-  fn message(&self) -> String {
-    format!(
-      "no runtime resource provider registered for scheme `{}` while reading `{}`",
-      self.scheme,
-      self.uri,
-    )
-  }
+    fn message(&self) -> String {
+        format!(
+            "no runtime resource provider registered for scheme `{}` while reading `{}`",
+            self.scheme, self.uri,
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceWriteUnsupported {
-  pub scheme: String,
-  pub base_uri: String,
-  pub path: String,
+    pub scheme: String,
+    pub base_uri: String,
+    pub path: String,
 }
 
 impl MechErrorKind for RuntimeResourceWriteUnsupported {
-  fn name(&self) -> &str {
-    "RuntimeResourceWriteUnsupported"
-  }
+    fn name(&self) -> &str {
+        "RuntimeResourceWriteUnsupported"
+    }
 
-  fn message(&self) -> String {
-    format!(
-      "runtime resource provider for scheme `{}` does not support writes to `{}` under `{}`",
-      self.scheme,
-      self.path,
-      self.base_uri,
-    )
-  }
+    fn message(&self) -> String {
+        format!(
+            "runtime resource provider for scheme `{}` does not support writes to `{}` under `{}`",
+            self.scheme, self.path, self.base_uri,
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceProviderConflict {
-  pub scheme: String,
+    pub scheme: String,
 }
 
 impl MechErrorKind for RuntimeResourceProviderConflict {
-  fn name(&self) -> &str {
-    "RuntimeResourceProviderConflict"
-  }
+    fn name(&self) -> &str {
+        "RuntimeResourceProviderConflict"
+    }
 
-  fn message(&self) -> String {
-    format!("runtime resource provider for scheme `{}` is already registered", self.scheme)
-  }
+    fn message(&self) -> String {
+        format!(
+            "runtime resource provider for scheme `{}` is already registered",
+            self.scheme
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourcePathNotFound {
-  pub base_uri: String,
-  pub path: String,
+    pub base_uri: String,
+    pub path: String,
 }
 
 impl MechErrorKind for RuntimeResourcePathNotFound {
-  fn name(&self) -> &str {
-    "RuntimeResourcePathNotFound"
-  }
+    fn name(&self) -> &str {
+        "RuntimeResourcePathNotFound"
+    }
 
-  fn message(&self) -> String {
-    format!("resource path `{}` was not found under `{}`", self.path, self.base_uri)
-  }
+    fn message(&self) -> String {
+        format!(
+            "resource path `{}` was not found under `{}`",
+            self.path, self.base_uri
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeResourceCapabilityDenied {
-  pub context_name: String,
-  pub operation: String,
-  pub path: String,
+    pub context_name: String,
+    pub operation: String,
+    pub path: String,
 }
 
 impl MechErrorKind for RuntimeResourceCapabilityDenied {
-  fn name(&self) -> &str {
-    "RuntimeResourceCapabilityDenied"
-  }
+    fn name(&self) -> &str {
+        "RuntimeResourceCapabilityDenied"
+    }
 
-  fn message(&self) -> String {
-    format!(
-      "context `{}` does not allow `{}` on `{}`",
-      self.context_name,
-      self.operation,
-      self.path,
-    )
-  }
+    fn message(&self) -> String {
+        format!(
+            "context `{}` does not allow `{}` on `{}`",
+            self.context_name, self.operation, self.path,
+        )
+    }
 }


### PR DESCRIPTION
### Motivation

- Remove host-specific assumptions in the central runtime by introducing a generic host/interface model that can accommodate new hosts without branching ConfigLowerer. 
- Allow multiple resource providers to share a URI scheme when they advertise distinct base URIs so providers can be added without colliding on scheme alone.

### Description

- Add a new runtime host-interface module that defines `HostInstanceConfig`, `RunResourceGrantConfig`, `HostManifestConfig`, `HostContextManifest`, `MaterializedHostInterface`, `MaterializedHostContext`, `RuntimeHostInstallation`, and a `materialize_host_manifest` helper. 
- Add `RuntimeHostFactory` trait and `RuntimeHostFactoryRegistry` to register provider-specific factories that validate settings and instantiate host installations. 
- Add `HostInterfaceCatalog` for registering materialized host interfaces, rejecting duplicate instance/context names, resolving `<instance>/<context>` targets, and enumerating instances. 
- Replace the scheme->provider map in `RuntimeResourceRegistry` with a list-based registry, add provider `base_uris()` checks, and implement routing that selects the provider with the longest matching advertised base URI (with an optional scheme-level fallback). 
- Export the new `host_interface` API from `mech-runtime` and wire the new module into the runtime crate public API surface.

### Testing

- Ran `cargo fmt --all -- --check` and formatting checks passed. 
- Ran `cargo check -p mech-runtime -p mech-host-cli -p mech-host-browser` and the workspace packages successfully compiled. 
- Ran `git diff --check` to verify no trivial whitespace/merge issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dfa830474832a95ede7f9e66ac575)