### PR TITLE
Constrain CLI defaults with explicit run grants

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use clap::{Arg, ArgAction, Command};
 use crate::*;
 use mech_core::*;
+use mech_runtime::parse_host_context_target;
 
 pub fn add_config_args(command: Command) -> Command {
   command
@@ -113,8 +114,12 @@ pub fn effective_cli_host_grants(
   selection: CliHostCapabilitySelection,
 ) -> MResult<EffectiveCliHostGrants> {
   let mut grants = EffectiveCliHostGrants::empty();
+  let has_explicit_cli_config_grants = match config {
+    Some(config) => has_explicit_cli_run_grants(config)?,
+    None => false,
+  };
 
-  if selection.include_defaults {
+  if selection.include_defaults && !has_explicit_cli_config_grants {
     for profile in DEFAULT_CLI_CAPABILITY_PROFILES {
       grant_cli_profile(&mut grants, profile)?;
     }
@@ -124,9 +129,29 @@ pub fn effective_cli_host_grants(
     grant_cli_profile(&mut grants, profile)?;
   }
 
-  let _ = config;
-
   Ok(grants)
+}
+
+pub fn has_explicit_cli_run_grants(config: &LoadedMechConfig) -> MResult<bool> {
+  let Some(run) = config.document.run.as_ref() else {
+    return Ok(false);
+  };
+
+  let mut cli_instances = std::collections::BTreeSet::from(["cli".to_string()]);
+  for host in &config.document.hosts {
+    if host.provider == "cli" {
+      cli_instances.insert(host.name.clone());
+    }
+  }
+
+  for grant in &run.grants {
+    let (instance, context) = parse_host_context_target(&grant.target)?;
+    if cli_instances.contains(instance) && matches!(context, "env" | "stdout" | "stderr") {
+      return Ok(true);
+    }
+  }
+
+  Ok(false)
 }
 
 fn grant_cli_profile(
@@ -1059,51 +1084,55 @@ mod config_tests {
   }
 
   #[test]
-  fn config_can_narrow_selected_stdout_to_line() {
+  fn explicit_config_run_grants_suppress_implicit_defaults() {
     let root = temp_root("cli-stdout-line");
     let config = loaded_config_at(
       root.clone(),
-      r#"config := { run: { cli: { stdout: { write: ["line"] } } } }"#,
+      r#"config := { run: { grants: [{target: "cli/stdout", operations: ["write"], paths: ["line"]}] } }"#,
     );
-    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
-    assert_eq!(grants.stdout_write_paths, vec!["line".to_string()]);
+    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert!(grants.stdout_write_paths.is_empty());
+    assert!(grants.stderr_write_paths.is_empty());
     std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]
-  fn config_cannot_add_unselected_env() {
-    let root = temp_root("cli-env-unselected");
+  fn deny_default_capabilities_still_suppresses_defaults_without_config_grants() {
+    let grants = effective_cli_host_grants(
+      None,
+      CliHostCapabilitySelection {
+        include_defaults: false,
+        profiles: Vec::new(),
+      },
+    ).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert!(grants.stdout_write_paths.is_empty());
+    assert!(grants.stderr_write_paths.is_empty());
+  }
+
+  #[test]
+  fn explicit_cli_profiles_remain_additive_with_config_grants() {
+    let root = temp_root("cli-stdout-line-additive");
     let config = loaded_config_at(
       root.clone(),
-      r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+      r#"config := { run: { grants: [{target: "cli/stdout", operations: ["write"], paths: ["line"]}] } }"#,
     );
     let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
     assert!(grants.env_read_paths.is_empty());
     assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert!(grants.stderr_write_paths.is_empty());
     std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]
-  fn default_profiles_plus_config_env_path_narrows_env() {
-    let root = temp_root("cli-env-path");
+  fn explicit_cli_run_grants_detect_configured_cli_aliases() {
+    let root = temp_root("cli-alias-explicit");
     let config = loaded_config_at(
       root.clone(),
-      r#"config := { run: { cli: { env: { read: ["PATH"] } } } }"#,
+      r#"config := { hosts: [{name: "term", provider: "cli", settings: {}}] run: { grants: [{target: "term/stderr", operations: ["write"], paths: ["line"]}] } }"#,
     );
-    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
-    assert_eq!(grants.env_read_paths, vec!["PATH".to_string()]);
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn config_can_deny_selected_stdout_with_empty_list() {
-    let root = temp_root("cli-stdout-empty");
-    let config = loaded_config_at(
-      root.clone(),
-      r#"config := { run: { cli: { stdout: { write: [] } } } }"#,
-    );
-    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
-    assert!(grants.stdout_write_paths.is_empty());
+    assert!(has_explicit_cli_run_grants(&config).unwrap());
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -137,6 +137,14 @@ pub fn has_explicit_cli_run_grants(config: &LoadedMechConfig) -> MResult<bool> {
     return Ok(false);
   };
 
+  if !run.grants_specified {
+    return Ok(false);
+  }
+
+  if run.grants.is_empty() {
+    return Ok(true);
+  }
+
   let mut cli_instances = std::collections::BTreeSet::from(["cli".to_string()]);
   for host in &config.document.hosts {
     if host.provider == "cli" {
@@ -1081,6 +1089,64 @@ mod config_tests {
     )
     .unwrap_err();
     assert!(format!("{error:?}").contains("unknown CLI capability profile `:quxx`"));
+  }
+
+  fn assert_default_cli_grants(grants: &EffectiveCliHostGrants) {
+    assert_eq!(grants.env_read_paths, vec!["*".to_string()]);
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert_eq!(grants.stderr_write_paths, vec!["text".to_string(), "line".to_string()]);
+  }
+
+  #[test]
+  fn explicit_empty_config_run_grants_suppress_implicit_defaults() {
+    let root = temp_root("cli-empty-grants");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { grants: [] } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert!(grants.stdout_write_paths.is_empty());
+    assert!(grants.stderr_write_paths.is_empty());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn run_paths_without_grants_does_not_suppress_implicit_defaults() {
+    let root = temp_root("cli-run-paths-no-grants");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { paths: ["main.mec"] } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
+    assert_default_cli_grants(&grants);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn explicit_empty_run_grants_still_allow_explicit_cli_profiles_to_be_additive() {
+    let root = temp_root("cli-empty-grants-additive");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { run: { grants: [] } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), stdout_selection()).unwrap();
+    assert!(grants.env_read_paths.is_empty());
+    assert_eq!(grants.stdout_write_paths, vec!["text".to_string(), "line".to_string()]);
+    assert!(grants.stderr_write_paths.is_empty());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn non_cli_run_grants_do_not_suppress_cli_defaults() {
+    let root = temp_root("non-cli-grants-defaults");
+    let config = loaded_config_at(
+      root.clone(),
+      r#"config := { hosts: [{name: "ui", provider: "browser", settings: {}}] run: { grants: [{target: "ui/dom", operations: ["read"], paths: ["counter/_text"]}] } }"#,
+    );
+    let grants = effective_cli_host_grants(Some(&config), CliHostCapabilitySelection::default()).unwrap();
+    assert_default_cli_grants(&grants);
+    std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -623,4 +623,69 @@ mod tests {
     assert!(error.contains("reserved") || error.contains("provider"), "got {error}");
     assert!(error.contains("browser"), "got {error}");
   }
+
+  #[test]
+  fn explicit_config_cli_stdout_line_is_authoritative_without_deny_defaults() {
+    let document = parse_config_document(
+      "test.mcfg",
+      r#"config := { run: { grants: [{target: "cli/stdout", operations: ["write"], paths: ["line"]}] } }"#,
+      ConfigProfileOptions::default(),
+    ).unwrap();
+    let loaded = crate::LoadedMechConfig {
+      path: std::path::PathBuf::from("test.mcfg"),
+      base_dir: std::path::PathBuf::new(),
+      document: document.clone(),
+      discovered_project_dir: None,
+    };
+    let cli_grants = config::effective_cli_host_grants(
+      Some(&loaded),
+      config::CliHostCapabilitySelection::default(),
+    ).unwrap();
+    let run_grants = document.run.as_ref().unwrap().grants.as_slice();
+    let mut runtime = new_cli_runtime(
+      RuntimeConfig::default(),
+      &cli_grants,
+      &document.hosts,
+      run_grants,
+    ).unwrap();
+
+    runtime.run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n").unwrap();
+    assert!(runtime.run_string("+> @env := cli/env\nx := @env/HOME\n").is_err());
+    assert!(runtime.run_string("+> @err := cli/stderr\n@err/line <- \"bad\"\n").is_err());
+    assert!(runtime.run_string("+> @out := cli/stdout\n@out/text <- \"bad\"\n").is_err());
+  }
+
+  #[test]
+  fn explicit_cli_profile_remains_additive_with_config_grants() {
+    let document = parse_config_document(
+      "test.mcfg",
+      r#"config := { run: { grants: [{target: "cli/stdout", operations: ["write"], paths: ["line"]}] } }"#,
+      ConfigProfileOptions::default(),
+    ).unwrap();
+    let loaded = crate::LoadedMechConfig {
+      path: std::path::PathBuf::from("test.mcfg"),
+      base_dir: std::path::PathBuf::new(),
+      document: document.clone(),
+      discovered_project_dir: None,
+    };
+    let cli_grants = config::effective_cli_host_grants(
+      Some(&loaded),
+      config::CliHostCapabilitySelection {
+        include_defaults: true,
+        profiles: vec![":cli/stderr".to_string()],
+      },
+    ).unwrap();
+    let run_grants = document.run.as_ref().unwrap().grants.as_slice();
+    let mut runtime = new_cli_runtime(
+      RuntimeConfig::default(),
+      &cli_grants,
+      &document.hosts,
+      run_grants,
+    ).unwrap();
+
+    runtime.run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n").unwrap();
+    runtime.run_string("+> @err := cli/stderr\n@err/line <- \"ok\"\n").unwrap();
+    assert!(runtime.run_string("+> @env := cli/env\nx := @env/HOME\n").is_err());
+  }
+
 }

--- a/src/runtime/src/config_profile/lower.rs
+++ b/src/runtime/src/config_profile/lower.rs
@@ -59,6 +59,7 @@ pub struct ServeHostConfig {
 pub struct RunHostConfig {
     pub paths: Vec<PathBuf>,
     pub grants: Vec<RunResourceGrantConfig>,
+    pub grants_specified: bool,
 }
 
 
@@ -354,7 +355,10 @@ impl ConfigLowerer {
         for (key, value) in map {
             match key.as_str() {
                 "paths" => out.paths = expect_path_list("run.paths", value)?,
-                "grants" => out.grants = self.lower_run_grants(value)?,
+                "grants" => {
+                    out.grants = self.lower_run_grants(value)?;
+                    out.grants_specified = true;
+                }
                 other => return invalid(format!("unknown run field `{other}`")),
             }
         }


### PR DESCRIPTION
### Motivation

- Default CLI capability profiles were being applied even when a loaded config provided explicit `run.grants` for CLI hosts, which allowed implicit defaults to widen the runtime capability surface.
- The goal is to make explicit `run.grants` in config authoritative for CLI host instances (including configured CLI aliases) while still allowing explicit command-line profiles to remain additive and preserving `--deny-default-capabilities` behavior.

### Description

- Make `effective_cli_host_grants` consult the loaded `LoadedMechConfig` and skip applying implicit default CLI profiles when the config contains explicit CLI-targeted `run.grants`. (changed in `src/cli/config.rs`).
- Add `has_explicit_cli_run_grants(config: &LoadedMechConfig) -> MResult<bool>` to detect explicit `run.grants` whose target instance is `cli` or any configured CLI instance and whose context is `env`, `stdout`, or `stderr`, using `parse_host_context_target` to parse grant targets. (new helper in `src/cli/config.rs`).
- Preserve explicit CLI profile flags as additive by still applying `selection.profiles` after the config check, and keep installation of config `run.grants` in `new_cli_runtime` with `cli_grants_to_run_resource_grants` unchanged so config grants remain authoritative at runtime. (changes touch `src/cli/run.rs` usage/tests).
- Add and adjust unit/tests covering: suppression of implicit defaults when config `run.grants` exist, `--deny-default-capabilities` behavior when no config grants are present, additive explicit CLI profiles with config grants, and detection of configured CLI aliases. (tests updated/added in `src/cli/config.rs` and `src/cli/run.rs`).

### Testing

- Ran `cargo test -p mech --lib explicit_config --features run` which passed all relevant unit tests.
- Ran `cargo test -p mech-runtime --test module_smoke`, `cargo test -p mech-runtime --test generic_host`, and `cargo test -p mech-runtime --test layering`, all of which completed successfully.
- Ran `cargo test -p mech-host-cli`, `cargo check --features run`, and `cargo check --features bundle_web,serve`, all of which succeeded and produced no check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41dbd16860832ab70e5605b7cb4786)