### PR TITLE
Use injected HTML shim for generated .mec pages and return errors for strict-compare compilation

### DIFF
--- a/machines/compare/src/seq.rs
+++ b/machines/compare/src/seq.rs
@@ -27,7 +27,12 @@ impl MechFunctionImpl for StrictEqValue {
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for StrictEqValue {
   fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
-    todo!()
+    Err(MechError::new(
+      GenericError {
+        msg: "bytecode compilation for dynamic strict equality is not supported yet".to_string(),
+      },
+      None,
+    ).with_compiler_loc())
   }
 }
 

--- a/machines/compare/src/sneq.rs
+++ b/machines/compare/src/sneq.rs
@@ -27,7 +27,12 @@ impl MechFunctionImpl for StrictNotEqValue {
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for StrictNotEqValue {
   fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
-    todo!()
+    Err(MechError::new(
+      GenericError {
+        msg: "bytecode compilation for dynamic strict inequality is not supported yet".to_string(),
+      },
+      None,
+    ).with_compiler_loc())
   }
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -410,14 +410,18 @@ impl MechServer {
     }
   }
 
-  pub async fn init(&mut self) -> MResult<()> {
-    let html_shim = if let Some(injection) = &self.host_config_injection {
-      inject_host_authority_injection_script(&self.html_shim, injection)?
+  fn injected_html_shim(&self) -> MResult<String> {
+    if let Some(injection) = &self.host_config_injection {
+      inject_host_authority_injection_script(&self.html_shim, injection)
     } else if let Some(host_config) = &self.host_config {
-      inject_browser_host_config_script(&self.html_shim, host_config)?
+      inject_browser_host_config_script(&self.html_shim, host_config)
     } else {
-      self.html_shim.clone()
-    };
+      Ok(self.html_shim.clone())
+    }
+  }
+
+  pub async fn init(&mut self) -> MResult<()> {
+    let html_shim = self.injected_html_shim()?;
     let mut registry = self.registry.write().unwrap();
     let html = asset(html_shim.as_bytes(), "text/html", None);
     let css = asset(self.stylesheet.as_bytes(), "text/css", None);
@@ -514,7 +518,8 @@ impl MechServer {
           println!("{} Capability denied: {}", self.badge(), diagnostic.message);
         }
       }
-      self.registry.write().unwrap().sync_workspace_snapshot(&root, snapshot, &self.stylesheet, &self.html_shim)?;
+      let html_shim = self.injected_html_shim()?;
+      self.registry.write().unwrap().sync_workspace_snapshot(&root, snapshot, &self.stylesheet, &html_shim)?;
     }
     let registry = self.registry.read().unwrap();
     for key in registry.source_keys() {
@@ -575,12 +580,13 @@ impl MechServer {
     let socket_address: SocketAddr = self.full_address.parse().unwrap();
     let server = warp::serve(routes).run(socket_address);
     if let (Some(session), Some(root)) = (&self.workspace_session, &root) {
+      let html_shim = self.injected_html_shim()?;
       let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
       tokio::pin!(server);
       loop {
         tokio::select! {
           _ = interval.tick() => {
-            let _ = poll_workspace_once(session, &self.registry, &self.events, &root, &self.stylesheet, &self.html_shim);
+            let _ = poll_workspace_once(session, &self.registry, &self.events, &root, &self.stylesheet, &html_shim);
           }
           _ = &mut server => break,
         }
@@ -998,6 +1004,30 @@ mod tests {
 
 
   #[test]
+  fn generated_mech_html_uses_injected_host_config_shim() {
+    let root = temp_root("generated-host-config-shim");
+    std::fs::write(root.join("index.mec"), "x := 1\n").unwrap();
+
+    let guard = CurrentDirGuard::enter(&root);
+    let mut server = test_server();
+    server.html_shim = "<html><head></head><body></body></html>".to_string();
+    server.host_config = Some(empty_host_config());
+
+    tokio::runtime::Runtime::new().unwrap().block_on(server.init()).unwrap();
+    server.load_workspace(&vec!["index.mec".to_string()]).unwrap();
+
+    let registry = server.registry.read().unwrap();
+    let html = String::from_utf8(registry.get_route("/").unwrap().bytes).unwrap();
+
+    assert!(html.contains("window.__MECH_HOST_CONFIG ="));
+    assert_eq!(html.matches("window.__MECH_HOST_CONFIG =").count(), 1);
+
+    drop(registry);
+    drop(guard);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
   fn wasm_host_config_constructor_export_is_declared() {
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/wasm/src/lib.rs");
     let source = std::fs::read_to_string(&source_path)
@@ -1363,21 +1393,29 @@ mod tests {
     std::fs::write(root.join("main.mec"), "x := 1\n").unwrap();
     let guard = CurrentDirGuard::enter(&root);
     let mut server = test_server();
+    server.html_shim = "<html><head></head><body></body></html>".to_string();
+    server.host_config = Some(empty_host_config());
     tokio::runtime::Runtime::new().unwrap().block_on(server.init()).unwrap();
     server.load_workspace(&vec!["main.mec".to_string()]).unwrap();
     std::fs::write(root.join("main.mec"), "x := 2\n").unwrap();
     let session = server.workspace_session.as_ref().unwrap();
     let mut session = session.lock().unwrap();
     session.refresh(module_options()).unwrap();
+    let html_shim = server.injected_html_shim().unwrap();
     server.registry.write().unwrap().sync_workspace_snapshot(
       &root,
       session.snapshot().unwrap(),
       &server.stylesheet,
-      &server.html_shim,
+      &html_shim,
     ).unwrap();
     drop(session);
-    let raw = server.registry.read().unwrap().get_route("source/main.mec").unwrap();
+    let registry = server.registry.read().unwrap();
+    let raw = registry.get_route("source/main.mec").unwrap();
     assert!(String::from_utf8(raw.bytes).unwrap().contains("x := 2"));
+    let html = String::from_utf8(registry.get_route("main.mec").unwrap().bytes).unwrap();
+    assert!(html.contains("window.__MECH_HOST_CONFIG ="));
+    assert_eq!(html.matches("window.__MECH_HOST_CONFIG =").count(), 1);
+    drop(registry);
     drop(guard);
     std::fs::remove_dir_all(root).unwrap();
   }

--- a/tests/bytecode.rs
+++ b/tests/bytecode.rs
@@ -132,3 +132,26 @@ bytecode_test!(bytecode_define_table, "x := |x<f64> y<u64>| 1 2 | 3 4 |", Value:
 ))));
 bytecode_test!(bytecode_define_table_eq, "x := |x<f64> y<bool>| 1 true | 3 false |; y := |x<f64> y<bool>| 1 true | 3 false |; x == y", Value::Bool(Ref::new(true)));
 //bytecode_test!(bytecode_set_union, "x := {1 2 3}; y := {3 4 5}; x ∪ y", Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)),Value::F64(Ref::new(2.0)),Value::F64(Ref::new(3.0)),Value::F64(Ref::new(4.0)),Value::F64(Ref::new(5.0))]))));
+fn compile_bytecode_strict_compare_returns_error_without_panic(source: &str, expected_message: &str) {
+  let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let mut prgrm = MechProgram::new(MechProgramConfig {
+      name: "strict_compare_no_panic".to_string(),
+      environment: MechProgramEnvironment::default(),
+    });
+    prgrm.run_string(source).unwrap();
+    prgrm.compile_bytecode()
+  }));
+  let compile_result = result.expect("strict compare bytecode compilation should not panic");
+  let error = compile_result.expect_err("strict compare bytecode compilation should return an error");
+  assert!(error.full_chain_message().contains(expected_message), "unexpected error: {:?}", error);
+}
+
+#[test]
+fn bytecode_strict_equality_returns_error_without_panic() {
+  compile_bytecode_strict_compare_returns_error_without_panic("x := 1 === 1", "dynamic strict equality");
+}
+
+#[test]
+fn bytecode_strict_inequality_returns_error_without_panic() {
+  compile_bytecode_strict_compare_returns_error_without_panic("x := 1 !== 2", "dynamic strict inequality");
+}


### PR DESCRIPTION
### Motivation
- Ensure generated and reload-produced `.mec` HTML use the same injected browser shim (so `window.__MECH_HOST_CONFIG` is present) without mutating the original `self.html_shim`. 
- Prevent release-blocking panics from `todo!()` in the strict equality/inequality compiler paths by returning a typed `MechError` fallback.

### Description
- Add `MechServer::injected_html_shim()` that returns the shim with the proper host/delegation injection without mutating `self.html_shim` and use it in `init()`, `load_workspace()` (when calling `sync_workspace_snapshot`), and `serve()` (watch/poll path). (file: `src/serve.rs`, adds helper and replaces duplicated logic)
- Add a regression test `generated_mech_html_uses_injected_host_config_shim` to `src/serve.rs` proving generated `/` HTML contains exactly one `window.__MECH_HOST_CONFIG =`. (file: `src/serve.rs`, tests)
- Update the manual-refresh/watch test to use the injected shim when calling `sync_workspace_snapshot` and assert the refreshed generated HTML contains exactly one `window.__MECH_HOST_CONFIG =`. (file: `src/serve.rs`, tests)
- Replace `todo!()` in `StrictEqValue::compile()` and `StrictNotEqValue::compile()` with returning `MechError::new(GenericError { msg: ... })...` describing that dynamic strict (in)equality bytecode compilation is not supported yet. (files: `machines/compare/src/seq.rs`, `machines/compare/src/sneq.rs`)
- Add bytecode/compiler regression tests that wrap `compile_bytecode()` in `std::panic::catch_unwind` and assert compilation returns an `Err` whose message contains the expected `dynamic strict equality` / `dynamic strict inequality` text, proving these code paths no longer panic. (file: `tests/bytecode.rs`)

### Testing
- Ran `cargo test -p mech serve::tests::server_init_does_not_mutate_html_shim_with_host_config` and it passed. 
- Ran `cargo test -p mech serve::tests::generated_mech_html_uses_injected_host_config_shim` and it passed. 
- Ran `cargo test -p mech --test bytecode` (unit tests including the new strict-compare compile tests) and they passed. 
- Attempted `cargo test` for the `mech-compare` crate with feature selection and via its manifest; feature-selection invocations are blocked by workspace/package layout and a direct manifest run hit a linker test-harness issue (`undefined symbol: main`), so those specific external-feature permutations could not be executed here. 
- Ran `cargo test --features "run repl pretty_print" --test mech_cli_host` and `cargo test -p mech-runtime --lib --tests` and both succeeded. 
- Verified with `grep -R "todo!()" machines/compare/src/seq.rs machines/compare/src/sneq.rs src/serve.rs` and it returned nothing for the touched paths, confirming no `todo!()` remains.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41fd3eb828832a9933e95c7794cf96)