### PR TITLE
Fix runtime host context resolution; ensure inline resolver, rebase bundle shims, and include symlinked sources

### DIFF
--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -1271,6 +1271,8 @@ async fn main() -> Result<(), MechError> {
     )?;
 
     let mut runtime = new_cli_runtime(runtime_config, &cli_grants, configured_hosts, configured_run_grants)?;
+    let fs_kernel = fs_authority.kernel().clone();
+    runtime.set_source_resolver(FileSourceResolver::new(&std::env::current_dir()?).with_capabilities(fs_kernel.clone(), MECH_TOOL_SUBJECT));
 
     if let RunInputMode::InlineSource(source) = &run_input_mode {
       match run_cli_source(&mut runtime, source.trim()) {

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -101,9 +101,10 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
       .map_err(|error| Error::new(ErrorKind::Other, error.to_string()))?;
     write_bundle_file(&output_dir, "code", &relative, encoded.as_bytes())?;
 
-    let mut formatter = Formatter::new();
-    let html = formatter.format_html(&tree, stylesheet_string.clone(), shim_with_config.clone());
     let html_relative = relative.with_extension("html");
+    let source_shim = rebase_bundle_shim_for_depth(&shim_with_config, html_relative.components().count());
+    let mut formatter = Formatter::new();
+    let html = formatter.format_html(&tree, stylesheet_string.clone(), source_shim);
     write_bundle_file(&output_dir, "html", &html_relative, html.as_bytes())?;
   }
 
@@ -112,6 +113,20 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
     index_html,
     source_count: options.source_paths.len(),
   })
+}
+
+fn rebase_bundle_shim_for_depth(shim: &str, depth: usize) -> String {
+  if depth == 0 {
+    return shim.to_string();
+  }
+  let prefix = "../".repeat(depth);
+  let mut rebased = shim.to_string();
+  for asset in ["pkg/", "style.css", "code/", "source/"] {
+    let from = format!("./{asset}");
+    let to = format!("{prefix}{asset}");
+    rebased = rebased.replace(&from, &to);
+  }
+  rebased
 }
 
 fn read_stylesheets(paths: &[PathBuf]) -> MResult<String> {
@@ -744,5 +759,22 @@ mod tests {
     let has_config = walk_has_mcfg(&out);
     assert!(!has_config);
     fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn source_page_shim_rebases_relative_bundle_assets_by_depth() {
+    let shim = r#"<script type="module">import init from "./pkg/mech_wasm.js"; await fetch("./style.css"); await fetch("./code/demo.mec"); await fetch("./source/demo.mec");</script>"#;
+
+    let root = rebase_bundle_shim_for_depth(shim, 0);
+    assert!(root.contains("./pkg/mech_wasm.js"));
+    assert!(root.contains("./style.css"));
+
+    let one = rebase_bundle_shim_for_depth(shim, 1);
+    assert!(one.contains("../pkg/mech_wasm.js"));
+    assert!(one.contains("../style.css"));
+
+    let two = rebase_bundle_shim_for_depth(shim, 2);
+    assert!(two.contains("../../pkg/mech_wasm.js"));
+    assert!(two.contains("../../style.css"));
   }
 }

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -86,8 +86,8 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
   let injection = options
     .host_config_injection
     .unwrap_or_else(|| HostAuthorityInjection::BrowserUnsigned(host_config));
-  let shim_with_config = crate::inject_host_authority_injection_script(&shim_string, &injection)?;
-  fs::write(&index_html, &shim_with_config)?;
+  let root_shim_with_config = crate::inject_host_authority_injection_script(&shim_string, &injection)?;
+  fs::write(&index_html, &root_shim_with_config)?;
 
   for source_path in &options.source_paths {
     let source_path = source_path.canonicalize()?;
@@ -102,7 +102,9 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
     write_bundle_file(&output_dir, "code", &relative, encoded.as_bytes())?;
 
     let html_relative = relative.with_extension("html");
-    let source_shim = rebase_bundle_shim_for_depth(&shim_with_config, html_relative.components().count());
+    let depth = html_relative.components().count();
+    let rebased_shim = rebase_bundle_shim_for_depth(&shim_string, depth);
+    let source_shim = crate::inject_host_authority_injection_script(&rebased_shim, &injection)?;
     let mut formatter = Formatter::new();
     let html = formatter.format_html(&tree, stylesheet_string.clone(), source_shim);
     write_bundle_file(&output_dir, "html", &html_relative, html.as_bytes())?;
@@ -776,5 +778,54 @@ mod tests {
     let two = rebase_bundle_shim_for_depth(shim, 2);
     assert!(two.contains("../../pkg/mech_wasm.js"));
     assert!(two.contains("../../style.css"));
+  }
+
+  #[test]
+  fn bundle_web_rebases_source_shim_before_injecting_host_config() {
+    let root = temp_root("rebase-before-inject");
+    let _ = write_demo_project(&root);
+    fs::write(
+      root.join("demo.mcfg"),
+      r#"config := {
+  runtime: {name: "bundle-test"}
+  serve: {
+    paths: ["demo.mec"]
+    shim: "index.html"
+    wasm: "pkg"
+  }
+  run: {
+    grants: [
+      {
+        target: "browser/dom"
+        operations: ["read"]
+        paths: ["./source/foo", "./code/foo"]
+      }
+    ]
+  }
+}
+"#,
+    )
+    .unwrap();
+    let loaded = crate::load_mech_config_path(root.join("demo.mcfg"), Some(root.to_path_buf())).unwrap();
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "./pkg/mech_wasm.js"; await fetch("./style.css");</script></body></html>"#,
+    )
+    .unwrap();
+    let out = root.join("out");
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+    assert!(index.contains("./pkg/mech_wasm.js"));
+    assert!(index.contains("./style.css"));
+    let source = fs::read_to_string(out.join("html/demo.html")).unwrap();
+    assert!(source.contains("../pkg/mech_wasm.js"));
+    assert!(source.contains("../style.css"));
+    assert!(source.contains("./source/foo"));
+    assert!(source.contains("./code/foo"));
+    assert!(!source.contains("../source/foo"));
+    assert!(!source.contains("../code/foo"));
+    fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -90,9 +90,10 @@ pub fn bundle_web_project(options: BundleWebOptions) -> MResult<BundleWebResult>
   fs::write(&index_html, &root_shim_with_config)?;
 
   for source_path in &options.source_paths {
-    let source_path = source_path.canonicalize()?;
-    let relative = relative_source_path(&source_path, &base_dir, &project_dir)?;
-    let source_text = fs::read_to_string(&source_path)?;
+    let logical_source_path = source_path;
+    let read_source_path = source_path.canonicalize()?;
+    let relative = relative_source_path(logical_source_path, &base_dir, &project_dir)?;
+    let source_text = fs::read_to_string(&read_source_path)?;
     let tree = parser::parse(&source_text)?;
 
     write_bundle_file(&output_dir, "source", &relative, source_text.as_bytes())?;
@@ -826,6 +827,31 @@ mod tests {
     assert!(source.contains("./code/foo"));
     assert!(!source.contains("../source/foo"));
     assert!(!source.contains("../code/foo"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn bundle_web_uses_symlink_path_as_source_route_identity() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("symlink-route-identity");
+    let loaded = write_demo_project(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("shared")).unwrap();
+    fs::write(root.join("shared/lib.mec"), "answer := 42\n").unwrap();
+    unix_fs::symlink("../shared/lib.mec", root.join("src/link.mec")).unwrap();
+    let out = root.join("out");
+    let mut options = options(&root, &out, loaded);
+    options.source_paths = vec![root.join("src/link.mec")];
+
+    bundle_web_project(options).unwrap();
+
+    assert!(out.join("source/src/link.mec").is_file());
+    assert!(out.join("code/src/link.mec").is_file());
+    assert!(out.join("html/src/link.html").is_file());
+    assert!(!out.join("source/shared/lib.mec").exists());
+    assert!(!out.join("html/shared/lib.html").exists());
     fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/cli/bundle_web.rs
+++ b/src/cli/bundle_web.rs
@@ -24,11 +24,27 @@ fn expand_serve_source_paths(base_dir: &Path, paths: &[PathBuf]) -> MResult<Vec<
 }
 
 fn collect_serve_source_path(path: &Path, visited: &mut BTreeSet<PathBuf>, out: &mut Vec<PathBuf>) -> MResult<()> {
-  let metadata = std::fs::symlink_metadata(path)?;
-  if metadata.file_type().is_symlink() { return Ok(()); }
+  let metadata = match std::fs::symlink_metadata(path) {
+    Ok(metadata) => metadata,
+    Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+    Err(error) => return Err(error.into()),
+  };
+  if metadata.file_type().is_symlink() {
+    let target = match path.canonicalize() {
+      Ok(target) => target,
+      Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+      Err(error) => return Err(error.into()),
+    };
+    if target.is_dir() { return Ok(()); }
+    if target.is_file() {
+      require_file("serve.paths", &target)?;
+      if is_mech_source(&target) { out.push(target); }
+    }
+    return Ok(());
+  }
   if metadata.is_file() {
     require_file("serve.paths", path)?;
-    if is_mech_source(path) { out.push(path.to_path_buf()); }
+    if is_mech_source(path) { out.push(path.canonicalize()?); }
     return Ok(());
   }
   if !metadata.is_dir() { return Ok(()); }
@@ -514,6 +530,26 @@ mod tests {
     assert_eq!(options.shim_path, root.join("override.html"));
     assert!(options.stylesheet_paths.contains(&root.join("override.css")));
     assert_eq!(options.wasm_pkg, root.join("override-pkg"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn source_collection_includes_file_symlinks_but_skips_directory_symlinks_and_broken_links() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("symlink-sources");
+    let project = root.join("project");
+    let src = project.join("src");
+    std::fs::create_dir_all(src.join("cycle")).unwrap();
+    std::fs::write(src.join("real.mec"), "x := 1\n").unwrap();
+    unix_fs::symlink(src.join("real.mec"), src.join("link.mec")).unwrap();
+    unix_fs::symlink(&src, src.join("cycle/dir-link")).unwrap();
+    unix_fs::symlink(src.join("missing.mec"), src.join("broken.mec")).unwrap();
+
+    let paths = expand_serve_source_paths(&project, &[PathBuf::from("src/link.mec"), PathBuf::from("src")]).unwrap();
+
+    assert_eq!(paths, vec![src.join("real.mec").canonicalize().unwrap()]);
     std::fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/cli/bundle_web.rs
+++ b/src/cli/bundle_web.rs
@@ -26,7 +26,12 @@ fn expand_serve_source_paths(base_dir: &Path, paths: &[PathBuf]) -> MResult<Vec<
 fn collect_serve_source_path(path: &Path, visited: &mut BTreeSet<PathBuf>, out: &mut Vec<PathBuf>) -> MResult<()> {
   let metadata = match std::fs::symlink_metadata(path) {
     Ok(metadata) => metadata,
-    Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+    Err(error) if error.kind() == ErrorKind::NotFound => {
+      return Err(Error::new(
+        ErrorKind::InvalidInput,
+        format!("serve.paths entry does not exist: {}", path.display()),
+      ).into());
+    }
     Err(error) => return Err(error.into()),
   };
   if metadata.file_type().is_symlink() {
@@ -530,6 +535,29 @@ mod tests {
     assert_eq!(options.shim_path, root.join("override.html"));
     assert!(options.stylesheet_paths.contains(&root.join("override.css")));
     assert_eq!(options.wasm_pkg, root.join("override-pkg"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn source_collection_errors_for_missing_serve_path() {
+    let root = temp_root("missing-serve-path");
+    let error = format!("{:?}", expand_serve_source_paths(&root, &[PathBuf::from("missing.mec")]).unwrap_err());
+
+    assert!(error.contains("serve.paths entry does not exist"));
+    assert!(error.contains("missing.mec"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn source_collection_errors_for_missing_serve_path_after_existing_directory() {
+    let root = temp_root("missing-serve-path-after-dir");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/demo.mec"), "x := 1\n").unwrap();
+
+    let error = format!("{:?}", expand_serve_source_paths(&root, &[PathBuf::from("src"), PathBuf::from("missing.mec")]).unwrap_err());
+
+    assert!(error.contains("serve.paths entry does not exist"));
+    assert!(error.contains("missing.mec"));
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/cli/bundle_web.rs
+++ b/src/cli/bundle_web.rs
@@ -30,6 +30,22 @@ fn push_serve_source_file(logical_path: &Path, read_path: &Path, seen_files: &mu
   Ok(())
 }
 
+fn normalize_link_logical_path(path: &Path) -> MResult<PathBuf> {
+  let parent = path.parent().ok_or_else(|| {
+    Error::new(
+      ErrorKind::InvalidInput,
+      format!("serve.paths symlink has no parent: {}", path.display()),
+    )
+  })?;
+  let file_name = path.file_name().ok_or_else(|| {
+    Error::new(
+      ErrorKind::InvalidInput,
+      format!("serve.paths symlink has no file name: {}", path.display()),
+    )
+  })?;
+  Ok(parent.canonicalize()?.join(file_name))
+}
+
 fn collect_serve_source_path(
   path: &Path,
   visited_dirs: &mut BTreeSet<PathBuf>,
@@ -55,19 +71,25 @@ fn collect_serve_source_path(
     if target.is_dir() { return Ok(()); }
     if target.is_file() {
       require_file("serve.paths", &target)?;
-      if is_mech_source(&target) { push_serve_source_file(path, &target, seen_files, out)?; }
+      if is_mech_source(&target) {
+        let logical = normalize_link_logical_path(path)?;
+        push_serve_source_file(&logical, &target, seen_files, out)?;
+      }
     }
     return Ok(());
   }
   if metadata.is_file() {
     require_file("serve.paths", path)?;
-    if is_mech_source(path) { push_serve_source_file(path, path, seen_files, out)?; }
+    if is_mech_source(path) {
+      let logical = path.canonicalize()?;
+      push_serve_source_file(&logical, &logical, seen_files, out)?;
+    }
     return Ok(());
   }
   if !metadata.is_dir() { return Ok(()); }
   let canonical = path.canonicalize()?;
-  if !visited_dirs.insert(canonical) { return Ok(()); }
-  let mut entries = std::fs::read_dir(path)?.collect::<Result<Vec<_>, _>>()?;
+  if !visited_dirs.insert(canonical.clone()) { return Ok(()); }
+  let mut entries = std::fs::read_dir(&canonical)?.collect::<Result<Vec<_>, _>>()?;
   entries.sort_by_key(|entry| entry.path());
   for entry in entries { collect_serve_source_path(&entry.path(), visited_dirs, seen_files, out)?; }
   Ok(())
@@ -570,6 +592,117 @@ mod tests {
 
     assert!(error.contains("serve.paths entry does not exist"));
     assert!(error.contains("missing.mec"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn source_collection_normalizes_file_path_with_parent_components() {
+    let root = temp_root("normalize-file-parent-components");
+    let app = root.join("app");
+    let config = root.join("config");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(app.join("demo.mec"), "x := 1\n").unwrap();
+
+    let paths = expand_serve_source_paths(&config, &[PathBuf::from("../app/demo.mec")]).unwrap();
+
+    assert_eq!(paths, vec![app.join("demo.mec").canonicalize().unwrap()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn source_collection_normalizes_directory_children_with_parent_components() {
+    let root = temp_root("normalize-dir-parent-components");
+    let app = root.join("app");
+    let config = root.join("config");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(app.join("src/demo.mec"), "x := 1\n").unwrap();
+
+    let paths = expand_serve_source_paths(&config, &[PathBuf::from("../app/src")]).unwrap();
+
+    assert_eq!(paths, vec![app.join("src/demo.mec").canonicalize().unwrap()]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_with_config_outside_project_normalizes_file_serve_path() {
+    let root = temp_root("bundle-normalized-file");
+    let app = root.join("app");
+    let config = root.join("config");
+    std::fs::create_dir_all(app.join("pkg")).unwrap();
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(app.join("index.html"), "<html><head></head><body><script type=\"module\">import init from \"./pkg/mech_wasm.js\"; await fetch(\"./style.css\");</script></body></html>").unwrap();
+    std::fs::write(app.join("demo.mec"), "x := 1\n").unwrap();
+    std::fs::write(app.join("pkg/mech_wasm.js"), "export default async function init() {}\n").unwrap();
+    std::fs::write(app.join("pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    std::fs::write(config.join("style.css"), "body {}\n").unwrap();
+    std::fs::write(
+      config.join("demo.mcfg"),
+      r#"config := {
+  runtime: {name: "bundle-normalized-file"}
+  serve: {
+    paths: ["../app/demo.mec"]
+    shim: "../app/index.html"
+    stylesheets: ["style.css"]
+    wasm: "../app/pkg"
+  }
+}
+"#,
+    )
+    .unwrap();
+    let _guard = CurrentDirGuard::enter(&root);
+    let matches = bundle_matches(&["mech", "--config", "config/demo.mcfg", "bundle-web", "app", "--out", "out"]);
+    let loaded = load_bundle_web_config(&matches).unwrap();
+    let options = effective_bundle_web_options(&matches, loaded).unwrap();
+
+    crate::bundle_web_project(options).unwrap();
+
+    assert!(root.join("out/source/demo.mec").is_file());
+    assert!(root.join("out/code/demo.mec").is_file());
+    assert!(root.join("out/html/demo.html").is_file());
+    assert!(!root.join("out/source/../app/demo.mec").exists());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn bundle_web_with_config_outside_project_normalizes_directory_serve_path() {
+    let root = temp_root("bundle-normalized-dir");
+    let app = root.join("app");
+    let config = root.join("config");
+    std::fs::create_dir_all(app.join("pkg")).unwrap();
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(app.join("index.html"), "<html><head></head><body><script type=\"module\">import init from \"./pkg/mech_wasm.js\"; await fetch(\"./style.css\");</script></body></html>").unwrap();
+    std::fs::write(app.join("src/demo.mec"), "x := 1\n").unwrap();
+    std::fs::write(app.join("pkg/mech_wasm.js"), "export default async function init() {}\n").unwrap();
+    std::fs::write(app.join("pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    std::fs::write(config.join("style.css"), "body {}\n").unwrap();
+    std::fs::write(
+      config.join("demo.mcfg"),
+      r#"config := {
+  runtime: {name: "bundle-normalized-dir"}
+  serve: {
+    paths: ["../app/src"]
+    shim: "../app/index.html"
+    stylesheets: ["style.css"]
+    wasm: "../app/pkg"
+  }
+}
+"#,
+    )
+    .unwrap();
+    let _guard = CurrentDirGuard::enter(&root);
+    let matches = bundle_matches(&["mech", "--config", "config/demo.mcfg", "bundle-web", "app", "--out", "out"]);
+    let loaded = load_bundle_web_config(&matches).unwrap();
+    let options = effective_bundle_web_options(&matches, loaded).unwrap();
+
+    crate::bundle_web_project(options).unwrap();
+
+    assert!(root.join("out/source/src/demo.mec").is_file());
+    assert!(root.join("out/code/src/demo.mec").is_file());
+    assert!(root.join("out/html/src/demo.html").is_file());
+    assert!(!root.join("out/source/../app/src/demo.mec").exists());
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/cli/bundle_web.rs
+++ b/src/cli/bundle_web.rs
@@ -12,18 +12,30 @@ use crate::{
 };
 
 fn expand_serve_source_paths(base_dir: &Path, paths: &[PathBuf]) -> MResult<Vec<PathBuf>> {
-  let mut visited = BTreeSet::new();
+  let mut visited_dirs = BTreeSet::new();
+  let mut seen_files = BTreeSet::new();
   let mut out = Vec::new();
   for path in paths {
     let resolved = resolve_config_path(base_dir, path);
-    collect_serve_source_path(&resolved, &mut visited, &mut out)?;
+    collect_serve_source_path(&resolved, &mut visited_dirs, &mut seen_files, &mut out)?;
   }
-  out.sort();
-  out.dedup();
   Ok(out)
 }
 
-fn collect_serve_source_path(path: &Path, visited: &mut BTreeSet<PathBuf>, out: &mut Vec<PathBuf>) -> MResult<()> {
+fn push_serve_source_file(logical_path: &Path, read_path: &Path, seen_files: &mut BTreeSet<PathBuf>, out: &mut Vec<PathBuf>) -> MResult<()> {
+  let canonical_file = read_path.canonicalize()?;
+  if seen_files.insert(canonical_file) {
+    out.push(logical_path.to_path_buf());
+  }
+  Ok(())
+}
+
+fn collect_serve_source_path(
+  path: &Path,
+  visited_dirs: &mut BTreeSet<PathBuf>,
+  seen_files: &mut BTreeSet<PathBuf>,
+  out: &mut Vec<PathBuf>,
+) -> MResult<()> {
   let metadata = match std::fs::symlink_metadata(path) {
     Ok(metadata) => metadata,
     Err(error) if error.kind() == ErrorKind::NotFound => {
@@ -43,21 +55,21 @@ fn collect_serve_source_path(path: &Path, visited: &mut BTreeSet<PathBuf>, out: 
     if target.is_dir() { return Ok(()); }
     if target.is_file() {
       require_file("serve.paths", &target)?;
-      if is_mech_source(&target) { out.push(target); }
+      if is_mech_source(&target) { push_serve_source_file(path, &target, seen_files, out)?; }
     }
     return Ok(());
   }
   if metadata.is_file() {
     require_file("serve.paths", path)?;
-    if is_mech_source(path) { out.push(path.canonicalize()?); }
+    if is_mech_source(path) { push_serve_source_file(path, path, seen_files, out)?; }
     return Ok(());
   }
   if !metadata.is_dir() { return Ok(()); }
   let canonical = path.canonicalize()?;
-  if !visited.insert(canonical) { return Ok(()); }
+  if !visited_dirs.insert(canonical) { return Ok(()); }
   let mut entries = std::fs::read_dir(path)?.collect::<Result<Vec<_>, _>>()?;
   entries.sort_by_key(|entry| entry.path());
-  for entry in entries { collect_serve_source_path(&entry.path(), visited, out)?; }
+  for entry in entries { collect_serve_source_path(&entry.path(), visited_dirs, seen_files, out)?; }
   Ok(())
 }
 
@@ -577,7 +589,28 @@ mod tests {
 
     let paths = expand_serve_source_paths(&project, &[PathBuf::from("src/link.mec"), PathBuf::from("src")]).unwrap();
 
-    assert_eq!(paths, vec![src.join("real.mec").canonicalize().unwrap()]);
+    assert_eq!(paths, vec![src.join("link.mec")]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn source_collection_dedupes_file_symlinks_by_canonical_target() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("symlink-dedupe");
+    let project = root.join("project");
+    let src = project.join("src");
+    let shared = project.join("shared");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(&shared).unwrap();
+    std::fs::write(shared.join("lib.mec"), "x := 1\n").unwrap();
+    unix_fs::symlink("../shared/lib.mec", src.join("link-a.mec")).unwrap();
+    unix_fs::symlink("../shared/lib.mec", src.join("link-b.mec")).unwrap();
+
+    let paths = expand_serve_source_paths(&project, &[PathBuf::from("src")]).unwrap();
+
+    assert_eq!(paths, vec![src.join("link-a.mec")]);
     std::fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -2772,6 +2772,10 @@ impl MechRuntime {
 
   #[cfg(feature = "functions")]
   pub fn step(&mut self, count: u64) -> MResult<()> {
+    let mut context = self.runtime_context()?;
+    let runtime_ptr: *mut MechRuntime = self;
+    let context_ptr: *mut RuntimeContext = &mut context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
     self.program.step(count)
   }
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -2773,10 +2773,32 @@ impl MechRuntime {
   #[cfg(feature = "functions")]
   pub fn step(&mut self, count: u64) -> MResult<()> {
     let mut context = self.runtime_context()?;
+    self.step_with_context(&mut context, count)
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn step_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    count: u64,
+  ) -> MResult<()> {
+    context.validate()?;
+    context.charge_step()?;
+
+    let program_config = self.program.config.clone();
+    let mut program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config),
+    );
+
     let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = &mut context;
+    let context_ptr: *mut RuntimeContext = context;
     let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-    self.program.step(count)
+
+    let result = program.step(count);
+
+    self.program = program;
+    result
   }
 
   pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
@@ -3417,7 +3439,14 @@ fn exports_for_scope<'a>(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::{
+    BasicCapability, BasicOperation, BasicResource, BasicSubject, ClosureHostFunction,
+  };
   use mech_core::Ref;
+  use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  };
 
   #[test]
   fn runtime_has_interpreter_finds_root_interpreter() {
@@ -3489,5 +3518,80 @@ mod tests {
       .get(ans_id)
       .map(|value| value.borrow().clone());
     assert_eq!(bound, Some(value));
+  }
+
+  #[cfg(feature = "functions")]
+  #[test]
+  fn step_with_context_recomputes_runtime_host_function_with_provided_context() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_host = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new(
+        "demo/echo",
+        move |_services, context, args| {
+          assert_eq!(context.subject, "program:step-host-test");
+          calls_for_host.fetch_add(1, Ordering::SeqCst);
+          match &args[0] {
+            Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+            Value::MutableReference(value) => match &*value.borrow() {
+              Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+              other => panic!("expected F64 mutable reference, got {:?}", other),
+            },
+            other => panic!("expected F64 argument, got {:?}", other),
+          }
+        },
+      ))
+      .unwrap();
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(1),
+        &BasicSubject::new("program:step-host-test"),
+        &BasicResource::new("host:demo/echo"),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
+
+    let mut context = runtime
+      .runtime_context()
+      .unwrap()
+      .with_subject("program:step-host-test");
+    runtime
+      .run_string_with_context(&mut context, "x := 1\ny := demo/echo(x) + 0")
+      .unwrap();
+    let x = runtime
+      .program()
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(hash_str("x"))
+      .map(|value| value.borrow().clone())
+      .expect("expected x to be bound");
+    let x_ref = match x {
+      Value::F64(value) => value,
+      other => panic!("expected x to be F64, got {:?}", other),
+    };
+    *x_ref.borrow_mut() = 2.0;
+    runtime.step_with_context(&mut context, 3).unwrap();
+
+    *x_ref.borrow_mut() = 2.0;
+    let function = RuntimeHostNativeFunction {
+      name: "demo/echo".to_string(),
+      host_name: "demo/echo".to_string(),
+      arguments: vec![Value::F64(x_ref.clone())],
+      value: Ref::new(Value::F64(Ref::new(1.0))),
+    };
+    let calls_before_solve = calls.load(Ordering::SeqCst);
+    let runtime_ptr: *mut MechRuntime = &mut runtime;
+    let context_ptr: *mut RuntimeContext = &mut context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+    function.solve();
+
+    assert!(calls.load(Ordering::SeqCst) > calls_before_solve);
+    let y = function.out();
+    match y {
+      Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
+      other => panic!("expected F64(2.0), got {:?}", other),
+    }
   }
 }

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -189,7 +189,7 @@ impl NativeFunctionCompiler for RuntimeHostNativeFunctionCompiler {
     &self,
     arguments: &Vec<Value>,
   ) -> MResult<Box<dyn mech_core::MechFunction>> {
-    let (value, target) = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+    let value = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
       let target = slot.borrow().ok_or_else(|| {
         MechError::new(
           RuntimeProgramHostNotActiveError {
@@ -209,7 +209,7 @@ impl NativeFunctionCompiler for RuntimeHostNativeFunctionCompiler {
           HostCall::new(&self.host_name, arguments.clone()),
         )
       }?;
-      Ok::<(Value, RuntimeProgramHostTarget), MechError>((value, target))
+      Ok::<Value, MechError>(value)
     })?;
 
     Ok(Box::new(RuntimeHostNativeFunction {
@@ -217,7 +217,6 @@ impl NativeFunctionCompiler for RuntimeHostNativeFunctionCompiler {
       host_name: self.host_name.clone(),
       arguments: arguments.clone(),
       value: Ref::new(value),
-      target,
     }))
   }
 }
@@ -228,18 +227,41 @@ pub struct RuntimeHostNativeFunction {
   pub host_name: String,
   pub arguments: Vec<Value>,
   pub value: Ref<Value>,
-  pub target: RuntimeProgramHostTarget,
 }
 
 impl MechFunctionImpl for RuntimeHostNativeFunction {
   fn solve(&self) {
-    if let Ok(value) = unsafe {
-      (&mut *self.target.runtime).call_host_with_context(
-        &mut *self.target.context,
-        HostCall::new(&self.host_name, self.arguments.clone()),
-      )
-    } {
-      *self.value.borrow_mut() = value;
+    let result = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      let Some(target) = *slot.borrow() else {
+        return Err(MechError::new(
+          RuntimeProgramHostNotActiveError {
+            function: self.name.clone(),
+          },
+          None,
+        ));
+      };
+
+      // Safety: callers install the active runtime-program host target around
+      // program execution/stepping. Runtime host functions intentionally do not
+      // retain the original context pointer because persisted programs may be
+      // solved later with a different active RuntimeContext.
+      unsafe {
+        (&mut *target.runtime).call_host_with_context(
+          &mut *target.context,
+          HostCall::new(&self.host_name, self.arguments.clone()),
+        )
+      }
+    });
+
+    match result {
+      Ok(value) => *self.value.borrow_mut() = value,
+      Err(error) => {
+        eprintln!(
+          "[Mech Runtime Host Error] function `{}` failed during solve; preserving previous output: {:?}",
+          self.name,
+          error,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation

- Prevent runtime host functions from retaining a compile-time `RuntimeContext` pointer which can be stale when a persisted program is solved later, and ensure host calls use the active runtime/context during solve/step.
- Ensure inline-source execution uses the same capability-aware file resolver as path-mode so inline imports resolve the same way under capability flags.
- Make the bundle web shim work for generated source pages living at different depths and include symlinked .mec files when collecting serve sources.

### Description

- Runtime host: `RuntimeHostNativeFunction` no longer stores the original `RuntimeContext` pointer; `compile()` keeps only stable data (`mech_name`, `host_name`, `arguments`, and an output `Ref`) and resolves the active runtime/program host target via `ACTIVE_RUNTIME_PROGRAM_HOST` during `solve()` to call the host, logging and preserving previous output on error instead of dereferencing stale pointers (file: `src/runtime/src/runtime/host.rs`).
- Step guard: `step()` installs the `ActiveRuntimeProgramHostGuard` around persisted `program.step(...)` so solves during stepping have an active runtime/context (file: `src/runtime/src/runtime/execution.rs`).
- CLI inline resolver: the CLI runtime now configures and installs the capability-aware `FileSourceResolver` immediately after building the runtime so the inline-source branch runs with the resolver/capability kernel installed (file: `src/bin/mech.rs`).
- Bundle shim rebasing: added `rebase_bundle_shim_for_depth()` and use it when rendering generated `html/<source>.html` pages so relative `./pkg/...`, `./style.css`, `./code/...`, and `./source/...` references are rebased with the correct `../` depth while keeping root index.html unchanged (file: `src/bundle_web.rs`).
- Symlinked Mech sources: source collection for bundle/serve was updated to include symlinked files (canonicalized) while skipping symlinked directories and tolerating broken symlinks, preserving traversal safety and canonical dedupe (file: `src/cli/bundle_web.rs`).
- Tests: added unit tests around bundle shim rebasing and symlink source collection; adjusted existing code formatting and small related helpers.
- Non-goal: dynamic unary view shape recompute was intentionally not changed (tracked separately as #563).

### Testing

- Ran `cargo test -p mech-runtime --lib --tests` and the runtime unit tests passed (all runtime tests passed in the run).
- Ran `cargo test --features "serve bundle_web run formatter linked_stdlib" bundle_web` and the `bundle_web` test suite passed (added shim rebase test passed).
- Ran `cargo test --features "run repl pretty_print" --test mech_cli_host` and the CLI/run-related tests passed.
- Built the CLI: `cargo build --bin mech --features linked_stdlib` completed successfully.
- Ran `cargo test interpret` and the large interpreter test suite passed (interpret tests finished with all tests passing).
- Smoke/validation: CLI inline/path resolution and bundle tests were exercised; invalid absolute inline invocation in one ad-hoc smoke run was a CLI classification issue (not a change regression) and did not indicate regressions in the implemented fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4525ca4160832ab0934822df55e234)