### PR TITLE
Expose filesystem capabilities for `run` and preserve symlink paths in web bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           ./target/debug/mech test examples/working
 
           # Prelude-only no-default feature checks.
+          cargo build --bin mech --no-default-features --features run
           cargo build --no-default-features
           cargo build --no-default-features --features build
           cargo build --no-default-features --features test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
 
           # Prelude-only no-default feature checks.
           cargo build --bin mech --no-default-features --features run
+          cargo build --bin mech --no-default-features --features "run pretty_print"
           cargo build --no-default-features
           cargo build --no-default-features --features build
           cargo build --no-default-features --features test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
           ./target/debug/mech test examples/working
 
           # Prelude-only no-default feature checks.
-          cargo build --bin mech --no-default-features --features run
-          cargo build --bin mech --no-default-features --features "run pretty_print"
           cargo build --no-default-features
           cargo build --no-default-features --features build
           cargo build --no-default-features --features test
@@ -62,6 +60,28 @@ jobs:
           cargo test --features "run repl pretty_print" cli::run::tests
           cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli
           cargo check -p mech-host-cli --no-default-features
+
+  run-only:
+    name: Run-only CLI
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
+
+      - name: Build run-only CLI
+        run: cargo build --bin mech --no-default-features --features run
+
+      - name: Build run-only CLI with pretty print
+        run: cargo build --bin mech --no-default-features --features "run pretty_print"
 
   dynamic-modules:
     name: Dynamic modules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ base = ["baselib", "pretty_print", "serde", "compiler", "program", "mika",
       ]
 build = ["compiler", "mech-runtime", "mech-runtime/default"]
 repl = []
-run = ["mech-program/program", "cli", "cli_host"]
+run = ["mech-program/program", "cli", "cli_host", "project"]
 test = ["variable_define", "invariant_define", "symbol_table", "bool", "mech-runtime", "mech-runtime/default"]
 cli = []
 project = ["mech-runtime", "mech-runtime/default"]

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -534,7 +534,7 @@ impl MechErrorKind for Utf8ConversionError {
 
 #[cfg(feature = "bundle_web")]
 use mech::cli::bundle_web;
-#[cfg(feature = "serve")]
+#[cfg(any(feature = "serve", feature = "run"))]
 use mech::cli::capabilities;
 
 #[cfg(any(feature = "serve", feature = "run"))]

--- a/src/bin/mech.rs
+++ b/src/bin/mech.rs
@@ -820,7 +820,7 @@ async fn main() -> Result<(), MechError> {
   #[cfg(feature = "bundle_web")]
   let cli_command = cli_command.subcommand(bundle_web::bundle_web_command());
 
-  #[cfg(feature = "serve")]
+  #[cfg(any(feature = "serve", feature = "run"))]
   let cli_command = capabilities::add_filesystem_capability_args(cli_command);
 
   #[cfg(any(feature = "serve", feature = "run"))]

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -222,6 +222,10 @@ fn copy_project_static_assets_inner(
       continue;
     }
 
+    if !is_allowed_static_asset(&canonical_path) {
+      continue;
+    }
+
     let canonical_relative = canonical_path.strip_prefix(project_dir).map_err(|error| {
       Error::new(
         ErrorKind::InvalidInput,
@@ -229,10 +233,6 @@ fn copy_project_static_assets_inner(
       )
     })?;
     validate_safe_relative_path(canonical_relative)?;
-
-    if !is_allowed_static_asset(&canonical_path) {
-      continue;
-    }
 
     let relative = logical_path.strip_prefix(project_dir).map_err(|error| {
       Error::new(
@@ -641,6 +641,28 @@ mod tests {
 
     assert!(error.contains("bundle-web static asset target is outside project root"));
     assert!(!out.join("public/settings.json").exists());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn bundle_web_skips_non_static_symlinks_to_outside_project() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("non-static-symlinks-outside-project");
+    let project = root.join("project");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(root.join("README"), "outside readme\n").unwrap();
+    fs::write(root.join(".env"), "SECRET=true\n").unwrap();
+    unix_fs::symlink("../README", project.join("README")).unwrap();
+    unix_fs::symlink("../.env", project.join(".env")).unwrap();
+    let loaded = write_demo_project(&project);
+    let out = project.join("out");
+
+    bundle_web_project(options(&project, &out, loaded)).unwrap();
+
+    assert!(!out.join("README").exists());
+    assert!(!out.join(".env").exists());
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -222,6 +222,14 @@ fn copy_project_static_assets_inner(
       continue;
     }
 
+    let canonical_relative = canonical_path.strip_prefix(project_dir).map_err(|error| {
+      Error::new(
+        ErrorKind::InvalidInput,
+        format!("bundle-web static asset target is outside project root: {error}"),
+      )
+    })?;
+    validate_safe_relative_path(canonical_relative)?;
+
     if !is_allowed_static_asset(&canonical_path) {
       continue;
     }
@@ -589,6 +597,50 @@ mod tests {
     assert!(out.join("assets/favicon.ico").is_file());
     let index = fs::read_to_string(out.join("index.html")).unwrap();
     assert!(index.contains("./favicon.ico"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn bundle_web_rejects_static_file_symlink_target_outside_project() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("static-symlink-outside-target");
+    let project = root.join("project");
+    let secrets = root.join("secrets");
+    fs::create_dir_all(project.join("pkg")).unwrap();
+    fs::create_dir_all(project.join("public")).unwrap();
+    fs::create_dir_all(&secrets).unwrap();
+    fs::write(
+      project.join("demo.mcfg"),
+      r#"config := {
+  runtime: {name: "bundle-test"}
+  serve: {
+    paths: ["demo.mec"]
+    shim: "index.html"
+    wasm: "pkg"
+  }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+      project.join("index.html"),
+      r#"<!doctype html><html><head></head><body><script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec");</script></body></html>"#,
+    )
+    .unwrap();
+    fs::write(project.join("demo.mec"), "x := 1\n").unwrap();
+    fs::write(project.join("pkg/mech_wasm.js"), "export default async function init() {}\n").unwrap();
+    fs::write(project.join("pkg/mech_wasm_bg.wasm"), b"wasm").unwrap();
+    fs::write(secrets.join("settings.json"), r#"{"secret":true}"#).unwrap();
+    unix_fs::symlink("../../secrets/settings.json", project.join("public/settings.json")).unwrap();
+    let loaded = crate::load_mech_config_path(project.join("demo.mcfg"), Some(project.clone())).unwrap();
+    let out = project.join("out");
+
+    let error = format!("{:?}", bundle_web_project(options(&project, &out, loaded)).unwrap_err());
+
+    assert!(error.contains("bundle-web static asset target is outside project root"));
+    assert!(!out.join("public/settings.json").exists());
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/bundle_web.rs
+++ b/src/bundle_web.rs
@@ -203,12 +203,12 @@ fn copy_project_static_assets_inner(
   if !visited.insert(current_dir.clone()) { return Ok(()); }
   for entry in fs::read_dir(&current_dir)? {
     let entry = entry?;
-    let path = entry.path();
+    let logical_path = entry.path();
     let file_type = entry.file_type()?;
-    if file_type.is_symlink() && path.canonicalize().map(|target| target.is_dir()).unwrap_or(false) {
+    let canonical_path = logical_path.canonicalize()?;
+    if file_type.is_symlink() && canonical_path.is_dir() {
       continue;
     }
-    let canonical_path = path.canonicalize()?;
 
     if should_skip_static_asset_path(&canonical_path, output_dir, excluded_dirs) {
       continue;
@@ -226,10 +226,10 @@ fn copy_project_static_assets_inner(
       continue;
     }
 
-    let relative = canonical_path.strip_prefix(project_dir).map_err(|error| {
+    let relative = logical_path.strip_prefix(project_dir).map_err(|error| {
       Error::new(
         ErrorKind::InvalidInput,
-        format!("bundle-web static asset is outside project root: {error}"),
+        format!("bundle-web static asset path is outside project root: {error}"),
       )
     })?;
     validate_safe_relative_path(relative)?;
@@ -277,6 +277,7 @@ fn is_allowed_static_asset(path: &Path) -> bool {
         | "gif"
         | "svg"
         | "webp"
+        | "ico"
         | "md"
         | "csv"
         | "json"
@@ -562,6 +563,51 @@ mod tests {
     assert!(out.join("source/demo.mec").is_file());
     assert!(out.join("code/demo.mec").is_file());
     assert!(out.join("html/demo.html").is_file());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn bundle_web_preserves_static_file_symlink_output_identity() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("static-symlink-file-identity");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+    fs::create_dir_all(root.join("assets")).unwrap();
+    fs::write(root.join("assets/favicon.ico"), b"icon").unwrap();
+    unix_fs::symlink("assets/favicon.ico", root.join("favicon.ico")).unwrap();
+    fs::write(
+      root.join("index.html"),
+      r#"<!doctype html><html><head><link rel="icon" href="./favicon.ico"></head><body><script type="module">import init from "./pkg/mech_wasm.js"; const code = await fetch("./code/demo.mec");</script></body></html>"#,
+    )
+    .unwrap();
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    assert_eq!(fs::read(out.join("favicon.ico")).unwrap(), b"icon");
+    assert!(out.join("assets/favicon.ico").is_file());
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+    assert!(index.contains("./favicon.ico"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn bundle_web_skips_static_symlinked_directories() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = temp_root("static-symlink-dir-skip");
+    let loaded = write_demo_project(&root);
+    let out = root.join("out");
+    fs::create_dir_all(root.join("real_assets/nested")).unwrap();
+    fs::write(root.join("real_assets/nested/logo.svg"), "<svg></svg>\n").unwrap();
+    unix_fs::symlink("real_assets", root.join("linked_assets")).unwrap();
+
+    bundle_web_project(options(&root, &out, loaded)).unwrap();
+
+    assert!(out.join("real_assets/nested/logo.svg").is_file());
+    assert!(!out.join("linked_assets/nested/logo.svg").exists());
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "bundle_web")]
 pub mod bundle_web;
-#[cfg(feature = "serve")]
+#[cfg(any(feature = "serve", feature = "run"))]
 pub mod capabilities;
 #[cfg(any(feature = "serve", feature = "run"))]
 pub mod config;


### PR DESCRIPTION
### Motivation
- Allow run-only builds to construct HostFilesystemAuthority without enabling the `serve` feature so CLI filesystem helpers are available to `run`.
- Preserve the discovered (logical) filename for symlinked static files when bundling web output while still validating and copying from the canonical target for safety.
- Add CI coverage to prevent regressions of run-only builds.

### Description
- Expose the CLI capabilities module to both `serve` and `run` builds by changing `#[cfg(feature = "serve")] pub mod capabilities;` to `#[cfg(any(feature = "serve", feature = "run"))] pub mod capabilities;` and update usages in `src/bin/mech.rs` accordingly.
- Wire the `run` feature to include the `project` helpers in `Cargo.toml` so `LoadedMechConfig` and other project helpers are available to run-only builds.
- Update `src/bundle_web.rs` to track both `logical_path` (entry path) and `canonical_path` (resolved target) so the code uses the canonical path for validation and copying but uses the logical path for output path identity, and avoid recursing into symlinked directories.
- Add `.ico` to allowed static asset extensions and add two unit tests to `bundle_web` to verify that file symlinks preserve their output identity and symlinked directories are skipped.
- Add a CI step to build the run-only binary (`cargo build --bin mech --no-default-features --features run`) to the GitHub Actions workflow.

### Testing
- Ran `cargo build --bin mech --no-default-features --features run` which completed successfully.
- Ran `cargo build --bin mech --no-default-features --features "run pretty_print"` and `cargo build --bin mech --features linked_stdlib`, both completed successfully.
- Ran `cargo test --features "serve bundle_web run formatter linked_stdlib" bundle_web` and the bundle_web tests (including the new symlink tests) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45958b14d4832a9fbc1a8180eaf241)