### PR TITLE
Fix PR543: unify source classification, reuse discovery & capabilities, improve test reporting, and graceful serve shutdown

### DIFF
--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -10,7 +10,7 @@ use crate::cli::outcome::CliOutcome;
 use crate::cli::run::{
     RunInputMode, new_cli_runtime, run_cli_source_code_with_events, run_cli_source_with_events,
 };
-use crate::cli::runtime_plan::{RunExecutionPlan, RunPlanEvent};
+use crate::cli::runtime_plan::RunExecutionPlan;
 use crate::source_discovery::{
     DedupePolicy, DiscoveryOptions, MissingPathPolicy, SkipReason, SourceDiscoveryEvent,
     collect_sources_with_events,
@@ -181,20 +181,6 @@ fn render_config_event(event: &config::ConfigLoadEvent) {
     }
 }
 
-fn render_plan_events(events: &[RunPlanEvent]) {
-    for event in events {
-        match event {
-            RunPlanEvent::AddedDefaultPathGrant {
-                path: _,
-                operations,
-            } => println!(
-                "[Mech Run] Added run path filesystem grant ({})",
-                operations.join(",")
-            ),
-        }
-    }
-}
-
 fn print_value(value: &Value) {
     println!("{}", value.kind());
     #[cfg(feature = "pretty_print")]
@@ -214,7 +200,6 @@ fn print_run_runtime_events(events: &[RuntimeEvent]) {
 fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
     render_config_event(&plan.config_event);
     render_capability_events(&plan.filesystem_access.events);
-    render_plan_events(&plan.events);
     #[cfg(feature = "repl")]
     let repl_runtime_config = Some(plan.runtime_config.clone());
     let mut runtime = new_cli_runtime(

--- a/src/cli/commands/test.rs
+++ b/src/cli/commands/test.rs
@@ -9,7 +9,7 @@ pub(crate) fn command() -> Command {
         .about("Validate program invariants.")
         .arg(
             Arg::new("mech_test_file_paths")
-                .help("Source .mec and .mecb files or directories")
+                .help("Source .mec/.🤖 files or directories. Explicit .mecb inputs are rejected because bytecode lacks invariant metadata.")
                 .required(false)
                 .action(ArgAction::Append),
         )

--- a/src/cli/run_options.rs
+++ b/src/cli/run_options.rs
@@ -15,7 +15,6 @@ pub(crate) struct RunCliArgs {
     pub time: bool,
     pub repl: bool,
     pub rounds_per_step: Option<usize>,
-    pub no_default_capabilities: bool,
     pub cli_capability_selection: host_grants::CliHostCapabilitySelection,
 }
 
@@ -34,7 +33,6 @@ impl RunCliArgs {
         } else {
             vec![]
         };
-        let config_matches = run_matches.unwrap_or(root_matches);
         Ok(Self {
             input_mode: classify_run_inputs(inputs),
             explicit_run_command: run_matches.is_some(),
@@ -46,7 +44,6 @@ impl RunCliArgs {
                 .and_then(|m| m.get_one::<String>("rounds-per-step"))
                 .and_then(|s| s.parse::<usize>().ok())
                 .or(root.rounds_per_step),
-            no_default_capabilities: config_matches.get_flag("no_default_capabilities"),
             cli_capability_selection: cli_host_capability_selection(root_matches, run_matches),
         })
     }
@@ -60,7 +57,6 @@ pub(crate) struct PreparedRunOptions {
     pub time: bool,
     pub repl: bool,
     pub rounds_per_step: Option<usize>,
-    pub no_default_capabilities: bool,
     pub loaded_config: Option<crate::LoadedMechConfig>,
     pub config_event: config::ConfigLoadEvent,
     pub cli_capability_selection: host_grants::CliHostCapabilitySelection,
@@ -88,7 +84,6 @@ pub(crate) fn prepare_run_options(
         time: args.time,
         repl: args.repl,
         rounds_per_step: args.rounds_per_step,
-        no_default_capabilities: args.no_default_capabilities,
         loaded_config,
         config_event: loaded.event,
         cli_capability_selection: args.cli_capability_selection,

--- a/src/cli/runtime_plan.rs
+++ b/src/cli/runtime_plan.rs
@@ -141,7 +141,7 @@ mod tests {
         std::fs::create_dir_all(&outside).unwrap();
         let run_input = outside.join("main.mec");
         std::fs::write(&run_input, "x := 1\n").unwrap();
-        let _guard = CurrentDirGuard::enter(&root);
+        let guard = CurrentDirGuard::enter(&root);
 
         let filesystem_access = build_filesystem_runtime_access(
             &FilesystemCapabilityArgs {
@@ -174,6 +174,7 @@ mod tests {
             );
         }
 
+        drop(guard);
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/cli/runtime_plan.rs
+++ b/src/cli/runtime_plan.rs
@@ -1,18 +1,10 @@
 use mech_core::*;
-use mech_runtime::{FS_LIST, FS_READ, HostInstanceConfig, RunResourceGrantConfig, RuntimeConfig};
+use mech_runtime::{HostInstanceConfig, RunResourceGrantConfig, RuntimeConfig};
 
 use crate::cli::host_grants;
 use crate::cli::run::{RunInputMode, effective_run_runtime_config};
 use crate::cli::run_options::PreparedRunOptions;
 use crate::generate_uuid;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum RunPlanEvent {
-    AddedDefaultPathGrant {
-        path: std::path::PathBuf,
-        operations: Vec<&'static str>,
-    },
-}
 
 pub(crate) struct RunExecutionPlan {
     pub runtime_config: RuntimeConfig,
@@ -26,7 +18,6 @@ pub(crate) struct RunExecutionPlan {
     pub configured_run_grants: Vec<RunResourceGrantConfig>,
     pub filesystem_access: crate::cli::capabilities::FilesystemRuntimeAccess,
     pub config_event: crate::cli::config::ConfigLoadEvent,
-    pub events: Vec<RunPlanEvent>,
 }
 
 pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<RunExecutionPlan> {
@@ -78,35 +69,6 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
         .map(|options| options.paths)
         .unwrap_or_default();
 
-    let mut events = Vec::new();
-
-    if !options.no_default_capabilities {
-        let mut ids = mech_runtime::DefaultIdGenerator::new();
-        for p in &run_paths {
-            let path = std::path::Path::new(p);
-            let grant_path = if path.is_dir() {
-                path
-            } else {
-                path.parent().unwrap_or_else(|| std::path::Path::new("."))
-            };
-            let operations = vec![
-                FS_READ,
-                FS_LIST,
-                mech_runtime::FS_RESOLVE,
-                mech_runtime::FS_IMPORT,
-            ];
-            filesystem_access.authority.grant_path(
-                &mut ids,
-                grant_path,
-                true,
-                operations.iter().copied(),
-            )?;
-            events.push(RunPlanEvent::AddedDefaultPathGrant {
-                path: grant_path.to_path_buf(),
-                operations,
-            });
-        }
-    }
     filesystem_access.kernel = filesystem_access.authority.kernel().clone();
 
     Ok(RunExecutionPlan {
@@ -121,6 +83,97 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
         configured_run_grants,
         filesystem_access,
         config_event,
-        events,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::capabilities::{FilesystemCapabilityArgs, build_filesystem_runtime_access};
+    use crate::cli::config::ConfigLoadEvent;
+    use crate::cli::host_grants::CliHostCapabilitySelection;
+    use mech_runtime::{FS_IMPORT, FS_READ, FS_RESOLVE, MECH_TOOL_SUBJECT, check_fs_capability};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static CURRENT_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CurrentDirGuard {
+        previous: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CurrentDirGuard {
+        fn enter(path: &std::path::Path) -> Self {
+            let lock = CURRENT_DIR_LOCK.lock().unwrap();
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.previous).unwrap();
+        }
+    }
+
+    fn temp_root(label: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mech-runtime-plan-{label}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root.canonicalize().unwrap()
+    }
+
+    #[test]
+    fn explicit_cap_root_does_not_gain_run_input_parent_grant() {
+        let root = temp_root("explicit-cap-root");
+        let allowed = root.join("allowed");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let run_input = outside.join("main.mec");
+        std::fs::write(&run_input, "x := 1\n").unwrap();
+        let _guard = CurrentDirGuard::enter(&root);
+
+        let filesystem_access = build_filesystem_runtime_access(
+            &FilesystemCapabilityArgs {
+                cap_roots: vec![std::path::PathBuf::from("allowed")],
+                ..FilesystemCapabilityArgs::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        let plan = build_run_execution_plan(PreparedRunOptions {
+            input_mode: RunInputMode::Paths(vec!["outside/main.mec".to_string()]),
+            explicit_run_command: true,
+            debug: false,
+            trace: false,
+            time: false,
+            repl: false,
+            rounds_per_step: None,
+            loaded_config: None,
+            config_event: ConfigLoadEvent::NotFound,
+            cli_capability_selection: CliHostCapabilitySelection::default(),
+            filesystem_access,
+        })
+        .unwrap();
+
+        for operation in [FS_READ, FS_RESOLVE, FS_IMPORT] {
+            let mut kernel = plan.filesystem_access.kernel.clone();
+            assert!(
+                check_fs_capability(&mut kernel, MECH_TOOL_SUBJECT, operation, &run_input).is_err()
+            );
+        }
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -534,6 +534,10 @@ impl MechServer {
   }
 
   pub async fn serve(&self) -> MResult<()> {
+    if !self.init {
+      return Err(MechError::new(ServerNotInitializedError, None).with_compiler_loc());
+    }
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let server_name = self.name.clone();
 
@@ -1058,6 +1062,19 @@ mod tests {
     assert!(is_workspace_target_source(Path::new("main.mecb")));
     assert!(!is_renderable_mech_text_source(Path::new("main.mecb")));
     assert!(is_renderable_mech_text_source(Path::new("main.mec")));
+  }
+
+
+  #[test]
+  fn serve_until_shutdown_rejects_uninitialized_server() {
+    let server = test_server();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    let result = tokio::runtime::Runtime::new()
+      .unwrap()
+      .block_on(server.serve_until_shutdown(shutdown_rx));
+
+    assert!(result.is_err());
   }
 
   #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -12,8 +12,8 @@ use mech_host_browser::BrowserRuntimeInjectionConfig;
 use mech_runtime::{
   EventId, EventSink, ModuleBuildOptions, RuntimeConfig, RuntimeEvent, RuntimeWorkspaceFolder,
   RuntimeWorkspaceSnapshot, RuntimeWorkspaceTarget, RuntimeWorkspaceWatchEvent,
-  ServerWorkspaceSession, HostFilesystemAuthority, DefaultIdGenerator, IdGenerator, SERVE_HOST_SUBJECT,
-  FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH, MECH_TOOL_SUBJECT, check_fs_capability,
+  ServerWorkspaceSession, HostFilesystemAuthority, DefaultIdGenerator, SERVE_HOST_SUBJECT,
+  FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE, FS_WATCH, MECH_TOOL_SUBJECT, SourceKind, check_fs_capability,
 };
 use warp::{Filter, Reply};
 
@@ -214,7 +214,7 @@ impl ServerSourceRegistry {
   }
 
   fn reload_static_path(&mut self, root: &Path, path: &Path) -> MResult<bool> {
-    if is_mech_source(path) {
+    if is_workspace_target_source(path) {
       return Ok(false);
     }
     let Some(key) = static_key_for_path(root, path) else {
@@ -250,7 +250,7 @@ impl ServerSourceRegistry {
 
     for source in snapshot.sources.values() {
       let Some(path) = source.path.as_ref() else { continue; };
-      if !is_mech_source(path) {
+      if !is_renderable_mech_text_source(path) {
         continue;
       }
       let relative = path.strip_prefix(root).map_err(|error| {
@@ -534,19 +534,39 @@ impl MechServer {
   }
 
   pub async fn serve(&self) -> MResult<()> {
-    if !self.init {
-      return Err(MechError::new(ServerNotInitializedError, None).with_compiler_loc());
-    }
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let server_name = self.name.clone();
+
     ctrlc::set_handler(move || {
       let badge = if server_name.ends_with(" Server") {
         format!("[{}]", server_name).truecolor(34, 204, 187)
       } else {
         format!("[{}] Server", server_name).truecolor(34, 204, 187)
       };
-      println!("{} Server received shutdown signal. Process terminating.", badge);
-      return;
-    }).expect("Error setting Ctrl-C handler");
+
+      let _ = shutdown_tx.send(true);
+      println!("{} Server received shutdown signal.", badge);
+    })
+    .map_err(|error| {
+      MechError::new(
+        GenericError {
+          msg: format!("Error setting Ctrl-C handler: {}", error),
+        },
+        None,
+      )
+      .with_compiler_loc()
+    })?;
+
+    self.serve_until_shutdown(shutdown_rx).await
+  }
+
+  async fn serve_until_shutdown(
+    &self,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+  ) -> MResult<()> {
+    if !self.init {
+      return Err(MechError::new(ServerNotInitializedError, None).with_compiler_loc());
+    }
 
     let root = self.workspace_root.clone();
     let registry = self.registry.clone();
@@ -575,7 +595,12 @@ impl MechServer {
     });
     println!("{} Awaiting connections at {}", self.badge(), self.full_address);
     let socket_address: SocketAddr = self.full_address.parse().unwrap();
-    let server = warp::serve(routes).run(socket_address);
+    let mut server_shutdown_rx = shutdown_rx.clone();
+    let (_addr, server) = warp::serve(routes).bind_with_graceful_shutdown(socket_address, async move {
+      if !*server_shutdown_rx.borrow() {
+        let _ = server_shutdown_rx.changed().await;
+      }
+    });
     if let (Some(session), Some(root)) = (&self.workspace_session, &root) {
       let html_shim = self.injected_html_shim()?;
       let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
@@ -585,11 +610,21 @@ impl MechServer {
           _ = interval.tick() => {
             let _ = poll_workspace_once(session, &self.registry, &self.events, &root, &self.stylesheet, &html_shim);
           }
+          _ = shutdown_rx.changed() => {
+            let _ = (&mut server).await;
+            break;
+          }
           _ = &mut server => break,
         }
       }
     } else {
-      server.await;
+      tokio::pin!(server);
+      tokio::select! {
+        _ = &mut server => {}
+        _ = shutdown_rx.changed() => {
+          let _ = (&mut server).await;
+        }
+      }
     }
     println!("{} Closing server.", self.badge());
     Ok(())
@@ -697,7 +732,7 @@ fn plan_serve_inputs(paths: &[String]) -> MResult<ServeInputPlan> {
         root_paths.push(parent.to_path_buf());
       }
       resolved.push(canonical);
-    } else if is_mech_source(&candidate) {
+    } else if is_workspace_target_source(&candidate) {
       let parent = candidate.parent().ok_or_else(|| Error::new(ErrorKind::InvalidInput, format!("Mech target `{}` has no parent directory", input)))?;
       let parent = parent.canonicalize().unwrap_or_else(|_| parent.to_path_buf());
       root_paths.push(parent.clone());
@@ -717,7 +752,7 @@ fn plan_serve_inputs(paths: &[String]) -> MResult<ServeInputPlan> {
       let specifier = relative_specifier(&root, &path).ok_or_else(|| Error::new(ErrorKind::InvalidInput, format!("serve directory `{}` is outside workspace root", path.display())))?;
       folders.push(RuntimeWorkspaceFolder { specifier: specifier.clone(), recursive: true });
       static_paths.push(specifier);
-    } else if is_mech_source(&path) {
+    } else if is_workspace_target_source(&path) {
       let specifier = relative_specifier(&root, &path).ok_or_else(|| Error::new(ErrorKind::InvalidInput, format!("Mech target `{}` is outside workspace root", path.display())))?;
       preferred_index_source.get_or_insert_with(|| specifier.clone());
       targets.push(RuntimeWorkspaceTarget { name: target_name(&specifier), specifier });
@@ -755,9 +790,9 @@ fn log_skipped_serve_inputs(paths: &[String]) -> MResult<()> {
   for input in paths {
     let path = Path::new(input);
     let path = if path.is_absolute() { path.to_path_buf() } else { current_dir.join(path) };
-    if !path.exists() && !is_mech_source(&path) {
+    if !path.exists() && !is_workspace_target_source(&path) {
       println!("[Mech Server] Warning: skipped missing non-Mech input `{}`.", input);
-    } else if path.is_file() && !is_mech_source(&path) && !is_allowed_static_file(&path) {
+    } else if path.is_file() && !is_workspace_target_source(&path) && !is_allowed_static_file(&path) {
       println!("[Mech Server] Warning: skipped unsupported file `{}`.", input);
     }
   }
@@ -768,13 +803,13 @@ fn load_static_assets_from_paths(registry: &mut ServerSourceRegistry, root: &Pat
   for input in paths {
     let path = root.join(input);
     if path.is_file() {
-      if !is_mech_source(&path) {
+      if !is_workspace_target_source(&path) {
         registry.insert_static_file(root, &path)?;
       }
     } else if path.is_dir() {
       for entry in WalkBuilder::new(&path).build() {
         let entry = entry.map_err(|error| Error::new(ErrorKind::Other, error.to_string()))?;
-        if entry.file_type().map(|kind| kind.is_file()).unwrap_or(false) && !is_mech_source(entry.path()) {
+        if entry.file_type().map(|kind| kind.is_file()).unwrap_or(false) && !is_workspace_target_source(entry.path()) {
           registry.insert_static_file(root, entry.path())?;
         }
       }
@@ -852,8 +887,12 @@ fn content_type_for_path(path: &str) -> &'static str {
   }
 }
 
-fn is_mech_source(path: &Path) -> bool {
-  matches!(path.extension().and_then(|ext| ext.to_str()), Some("mec") | Some("🤖"))
+fn is_workspace_target_source(path: &Path) -> bool {
+  SourceKind::from_path(path).is_executable_mech()
+}
+
+fn is_renderable_mech_text_source(path: &Path) -> bool {
+  matches!(SourceKind::from_path(path), SourceKind::Mech)
 }
 
 fn is_allowed_static_file(path: &Path) -> bool {
@@ -982,6 +1021,67 @@ mod tests {
   }
 
 
+
+  #[test]
+  fn plan_serve_inputs_accepts_explicit_mecb_target() {
+    let root = temp_root("explicit-mecb-target");
+    std::fs::write(root.join("main.mecb"), b"bytecode").unwrap();
+    let guard = CurrentDirGuard::enter(&root);
+
+    let plan = plan_serve_inputs(&vec!["main.mecb".to_string()]).unwrap();
+
+    assert_eq!(plan.targets.len(), 1);
+    assert_eq!(plan.static_paths.len(), 0);
+    assert_eq!(plan.targets[0].specifier, "main.mecb");
+
+    drop(guard);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn plan_serve_inputs_keeps_mecb_out_of_static_paths() {
+    let root = temp_root("mecb-not-static");
+    std::fs::write(root.join("main.mecb"), b"bytecode").unwrap();
+    let guard = CurrentDirGuard::enter(&root);
+
+    let plan = plan_serve_inputs(&vec!["main.mecb".to_string()]).unwrap();
+
+    assert!(plan.static_paths.is_empty());
+    assert_eq!(plan.targets.iter().map(|target| target.specifier.as_str()).collect::<Vec<_>>(), vec!["main.mecb"]);
+
+    drop(guard);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn renderable_source_predicate_excludes_mecb() {
+    assert!(is_workspace_target_source(Path::new("main.mecb")));
+    assert!(!is_renderable_mech_text_source(Path::new("main.mecb")));
+    assert!(is_renderable_mech_text_source(Path::new("main.mec")));
+  }
+
+  #[test]
+  fn serve_until_shutdown_exits_when_shutdown_signal_changes() {
+    let mut server = test_server();
+    server.init = true;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::runtime::Runtime::new().unwrap().block_on(async move {
+      let server_future = server.serve_until_shutdown(shutdown_rx);
+      let shutdown_future = async move {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let _ = shutdown_tx.send(true);
+      };
+
+      tokio::time::timeout(std::time::Duration::from_secs(2), async move {
+        let (result, _) = tokio::join!(server_future, shutdown_future);
+        result
+      })
+      .await
+      .expect("server did not shut down")
+      .unwrap();
+    });
+  }
 
   #[test]
   fn server_init_does_not_mutate_html_shim_with_host_config() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,6 +7,7 @@ use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use crate::fs_paths::{extension_allowed, unsupported_source_path_error};
 use crate::source_discovery::{
   collect_sources_with_events,
   DedupePolicy,
@@ -19,6 +20,40 @@ const TEST_RECURSIVE_EXTENSIONS: &[&str] = &["mec", "🤖"];
 const TEST_SKIP_DIRS: &[&str] = &["target", ".git", "dist", "out"];
 
 fn collect_test_targets(path: &Path) -> MResult<Vec<PathBuf>> {
+  if let Ok(metadata) = std::fs::symlink_metadata(path) {
+    if metadata.file_type().is_symlink() {
+      let canonical = path.canonicalize()?;
+      if canonical.is_file() {
+        if extension_allowed(path, TEST_EXPLICIT_EXTENSIONS) {
+          return Ok(vec![path.to_path_buf()]);
+        }
+        return Err(unsupported_source_path_error(path, TEST_EXPLICIT_EXTENSIONS));
+      }
+      if canonical.is_dir() {
+        return Err(MechError::new(
+          GenericError {
+            msg: format!(
+              "Explicit symlinked test directory `{}` is not followed for test discovery.",
+              path.display()
+            ),
+          },
+          None,
+        )
+        .with_compiler_loc());
+      }
+      return Err(MechError::new(
+        GenericError {
+          msg: format!(
+            "Explicit symlinked test input `{}` does not resolve to a file or directory.",
+            path.display()
+          ),
+        },
+        None,
+      )
+      .with_compiler_loc());
+    }
+  }
+
   let base_dir = if path.is_dir() {
     path
   } else {
@@ -238,6 +273,16 @@ pub fn run_mech_tests(
     for target in targets {
       expanded_paths.push(target.display().to_string());
     }
+  }
+
+  if expanded_paths.is_empty() {
+    return Err(MechError::new(
+      GenericError {
+        msg: "No test targets were found.".to_string(),
+      },
+      None,
+    )
+    .with_compiler_loc());
   }
 
   let mut file_reports = Vec::new();
@@ -527,6 +572,80 @@ mod tests {
     let result = collect_test_targets(&broken);
 
     assert!(result.is_err());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn explicit_symlinked_test_file_is_collected() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_test_root("explicit-file-symlink");
+    let source = root.join("main.mec");
+    let link = root.join("linked.mec");
+    std::fs::write(&source, "x := 1\n").unwrap();
+    symlink(&source, &link).unwrap();
+
+    let targets = collect_test_targets(&link).unwrap();
+
+    assert_eq!(targets, vec![link]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn explicit_symlinked_mecb_input_is_collected_for_rejection() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_test_root("explicit-mecb-symlink");
+    let bytecode = root.join("compiled.mecb");
+    let link = root.join("linked.mecb");
+    std::fs::write(&bytecode, b"not valid bytecode").unwrap();
+    symlink(&bytecode, &link).unwrap();
+
+    let targets = collect_test_targets(&link).unwrap();
+
+    assert_eq!(targets, vec![link]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn directory_discovery_skips_file_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_test_root("directory-file-symlink");
+    let outside = temp_test_root("directory-file-symlink-target");
+    let source = root.join("main.mec");
+    let linked_target = outside.join("linked-target.mec");
+    let link = root.join("linked.mec");
+    std::fs::write(&source, "x := 1\n").unwrap();
+    std::fs::write(&linked_target, "y := 2\n").unwrap();
+    symlink(&linked_target, &link).unwrap();
+
+    let targets = collect_test_targets(&root).unwrap();
+
+    assert_eq!(targets, vec![source]);
+    std::fs::remove_dir_all(root).unwrap();
+    std::fs::remove_dir_all(outside).unwrap();
+  }
+
+  #[test]
+  fn run_mech_tests_errors_when_no_targets_are_found() {
+    let root = temp_test_root("empty-directory");
+
+    let result = run_mech_tests(
+      vec![root.display().to_string()],
+      false,
+      false,
+      false,
+      false,
+      None,
+      false,
+    );
+
+    let error = result.unwrap_err().display_message();
+    assert!(error.contains("No test targets were found"));
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,49 +2,55 @@ use crate::*;
 use mech_core::*;
 use mech_program::*;
 use serde::Serialize;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
-fn collect_test_targets(path: &Path) -> io::Result<Vec<PathBuf>> {
-  let mut visited = BTreeSet::new();
-  collect_test_targets_inner(path, &mut visited)
+use crate::source_discovery::{
+  collect_sources_with_events,
+  DedupePolicy,
+  DiscoveryOptions,
+  MissingPathPolicy,
+};
+
+const TEST_EXPLICIT_EXTENSIONS: &[&str] = &["mec", "🤖", "mecb"];
+const TEST_RECURSIVE_EXTENSIONS: &[&str] = &["mec", "🤖"];
+const TEST_SKIP_DIRS: &[&str] = &["target", ".git", "dist", "out"];
+
+fn collect_test_targets(path: &Path) -> MResult<Vec<PathBuf>> {
+  let base_dir = if path.is_dir() {
+    path
+  } else {
+    path.parent().unwrap_or_else(|| Path::new(""))
+  };
+
+  let discovery = collect_sources_with_events(
+    &[path.to_path_buf()],
+    base_dir,
+    DiscoveryOptions {
+      allowed_file_extensions: TEST_EXPLICIT_EXTENSIONS,
+      recursive_file_extensions: TEST_RECURSIVE_EXTENSIONS,
+      skip_dir_names: TEST_SKIP_DIRS,
+      follow_file_symlinks: false,
+      follow_dir_symlinks: false,
+      missing_path_policy: MissingPathPolicy::Error,
+      dedupe_policy: DedupePolicy::CanonicalPath,
+    },
+  )?;
+
+  let mut targets = discovery
+    .entries
+    .into_iter()
+    .map(|entry| entry.logical_path)
+    .collect::<Vec<_>>();
+
+  targets.sort();
+  Ok(targets)
 }
 
-fn collect_test_targets_inner(path: &Path, visited: &mut BTreeSet<PathBuf>) -> io::Result<Vec<PathBuf>> {
-  let metadata = std::fs::symlink_metadata(path)?;
-  if !metadata.is_dir() { return Ok(vec![path.to_path_buf()]); }
-  if metadata.file_type().is_symlink() { return Ok(Vec::new()); }
-  let canonical = path.canonicalize()?;
-  if !visited.insert(canonical) { return Ok(Vec::new()); }
-
-  let mut files = Vec::new();
-  for entry in std::fs::read_dir(path)? {
-    let entry = entry?;
-    let entry_path = entry.path();
-    let file_type = entry.file_type()?;
-    if file_type.is_symlink() {
-      continue;
-    } else if file_type.is_dir() {
-      files.extend(collect_test_targets_inner(&entry_path, visited)?);
-    } else if matches!(
-      entry_path.extension().and_then(OsStr::to_str),
-      Some("mec" | "🤖")
-    ) {
-      files.push(entry_path);
-    }
-  }
-  files.sort();
-  Ok(files)
-}
-
-fn is_bytecode_test_path(path: &str) -> bool {
-  Path::new(path)
-    .extension()
-    .and_then(|extension| extension.to_str())
-    .map(|extension| extension.eq_ignore_ascii_case("mecb"))
-    .unwrap_or(false)
+fn is_bytecode_test_path(path: &Path) -> bool {
+  matches!(mech_runtime::SourceKind::from_path(path), mech_runtime::SourceKind::MechBytecode)
 }
 
 fn bytecode_test_unsupported_error(path: &str) -> MechError {
@@ -110,6 +116,28 @@ struct SummaryResult {
 struct TestReport {
   result: SummaryResult,
   files: Vec<FileReport>,
+}
+
+impl FileReport {
+  fn failed_file(&self) -> bool {
+    self.run_error.is_some() || self.result.failed > 0
+  }
+}
+
+impl SummaryResult {
+  fn failed_run(&self) -> bool {
+    self.files_failed > 0 || self.tests_failed > 0
+  }
+}
+
+impl TestReport {
+  fn status_label(&self) -> &'static str {
+    if self.result.failed_run() { "FAILED" } else { "SUCCESS" }
+  }
+
+  fn exit_code(&self) -> i32 {
+    if self.result.failed_run() { 1 } else { 0 }
+  }
 }
 #[derive(Debug, Serialize)]
 struct NamedCase {
@@ -206,22 +234,12 @@ pub fn run_mech_tests(
   let mut expanded_paths = Vec::new();
   for input in mech_paths {
     let input_path = Path::new(&input);
-    let targets = collect_test_targets(input_path).map_err(|e| {
-      MechError::new(
-        GenericError {
-          msg: format!("Unable to collect test targets for `{}`: {}", input, e),
-        },
-        None,
-      )
-      .with_compiler_loc()
-    })?;
+    let targets = collect_test_targets(input_path)?;
     for target in targets {
       expanded_paths.push(target.display().to_string());
     }
   }
 
-  let mut any_failed = false;
-  let mut run_errors = false;
   let mut file_reports = Vec::new();
   println!("{} Running tests...\n", "[Test]".truecolor(153, 221, 85));
   for path in &expanded_paths {
@@ -232,11 +250,9 @@ pub fn run_mech_tests(
     });
     let _ = tree_flag;
     program.configure(debug_flag, trace_flag, time_flag, 10_000);
-    if is_bytecode_test_path(path) {
+    if is_bytecode_test_path(Path::new(path)) {
       let err = bytecode_test_unsupported_error(path);
       eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
-      run_errors = true;
-      any_failed = true;
       file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
       continue;
     }
@@ -251,16 +267,12 @@ pub fn run_mech_tests(
         )
         .with_compiler_loc();
         eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
-        run_errors = true;
-        any_failed = true;
         file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
         continue;
       }
     };
     if let Err(err) = program.run_source(&source) {
       eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
-      run_errors = true;
-      any_failed = true;
       file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
       continue;
     }
@@ -329,7 +341,6 @@ pub fn run_mech_tests(
         println!();
       }
     } else {
-      any_failed = true;
       println!("\n{} FAILURE: {} total | {} passed | {} failed\n", "[Test]".truecolor(153, 221, 85), total, passed, failed);
       println!("failures:\n");
       for f in &failed_cases {
@@ -354,7 +365,7 @@ pub fn run_mech_tests(
     file_reports.push(FileReport { path: path.clone(), result: FileResult { total, passed, failed }, failed: failed_cases, passed: passed_cases, run_error: None });
   }
 
-  let files_passed = file_reports.iter().filter(|f| f.run_error.is_none() && f.result.failed == 0).count();
+  let files_passed = file_reports.iter().filter(|f| !f.failed_file()).count();
   let files_failed = file_reports.len().saturating_sub(files_passed);
   let tests_total = file_reports.iter().map(|f| f.result.total).sum();
   let tests_passed = file_reports.iter().map(|f| f.result.passed).sum();
@@ -365,7 +376,7 @@ pub fn run_mech_tests(
   };
 
   if expanded_paths.len() > 1 {
-    let summary_status = if report.result.tests_failed == 0 { "SUCCESS" } else { "FAILED" };
+    let summary_status = report.status_label();
     println!(
       "\n{} {}: files {} total | {} passed | {} failed || tests {} total | {} passed | {} failed",
       "[Test]".truecolor(153, 221, 85),
@@ -381,7 +392,7 @@ pub fn run_mech_tests(
     let failing_files = report
       .files
       .iter()
-      .filter(|f| f.run_error.is_some() || f.result.failed > 0)
+      .filter(|f| f.failed_file())
       .collect::<Vec<_>>();
 
     if !failing_files.is_empty() {
@@ -402,7 +413,7 @@ pub fn run_mech_tests(
       let passing_files = report
         .files
         .iter()
-        .filter(|f| f.run_error.is_none() && f.result.failed == 0)
+        .filter(|f| !f.failed_file())
         .map(|f| f.path.clone())
         .collect::<Vec<_>>();
       if !passing_files.is_empty() {
@@ -414,17 +425,19 @@ pub fn run_mech_tests(
     }
     println!();
 
-    if let Some(output_path) = output_path {
-      let path = PathBuf::from(&output_path);
-      let extension = path.extension().and_then(OsStr::to_str).unwrap_or("");
-      match extension {
-        "json" => save_to_file(path, &report_to_json(&report, verbose)?)?,
-        "mec" => save_to_file(path, &report_to_mech(&report, verbose))?,
-        _ => { eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension); return Ok(1); }
-      }
+  }
+
+  if let Some(output_path) = output_path {
+    let path = PathBuf::from(&output_path);
+    let extension = path.extension().and_then(OsStr::to_str).unwrap_or("");
+    match extension {
+      "json" => save_to_file(path, &report_to_json(&report, verbose)?)?,
+      "mec" => save_to_file(path, &report_to_mech(&report, verbose))?,
+      _ => { eprintln!("{} Unsupported --out extension `.{}`. Use .json or .mec.", "[Error]".truecolor(246,98,78), extension); return Ok(1); }
     }
   }
-  Ok(if any_failed { 1 } else { 0 })
+
+  Ok(report.exit_code())
 }
 
 #[cfg(test)]
@@ -432,10 +445,53 @@ mod tests {
   use super::*;
 
   #[test]
+  fn test_out_writes_json_for_single_file() {
+    let root = std::env::temp_dir().join(format!("mech-test-out-json-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    std::fs::create_dir_all(&root).unwrap();
+    let source = root.join("main.mec");
+    let output = root.join("report.json");
+    std::fs::write(&source, "x := 1\n").unwrap();
+
+    let exit_code = run_mech_tests(vec![source.display().to_string()], false, false, false, false, Some(output.display().to_string()), false).unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert!(output.metadata().unwrap().len() > 0);
+    assert!(std::fs::read_to_string(&output).unwrap().contains("files-total"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn test_out_writes_mec_for_single_file() {
+    let root = std::env::temp_dir().join(format!("mech-test-out-mec-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+    std::fs::create_dir_all(&root).unwrap();
+    let source = root.join("main.mec");
+    let output = root.join("report.mec");
+    std::fs::write(&source, "x := 1\n").unwrap();
+
+    let exit_code = run_mech_tests(vec![source.display().to_string()], false, false, false, false, Some(output.display().to_string()), false).unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert!(output.metadata().unwrap().len() > 0);
+    assert!(std::fs::read_to_string(&output).unwrap().contains("files-total"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn test_report_status_fails_when_file_has_run_error_without_failed_tests() {
+    let report = TestReport {
+      result: SummaryResult { files_total: 1, files_passed: 0, files_failed: 1, tests_total: 0, tests_passed: 0, tests_failed: 0 },
+      files: vec![FileReport { path: "broken.mec".to_string(), result: FileResult { total: 0, passed: 0, failed: 0 }, failed: vec![], passed: vec![], run_error: Some("boom".to_string()) }],
+    };
+
+    assert_eq!(report.status_label(), "FAILED");
+    assert_eq!(report.exit_code(), 1);
+  }
+
+  #[test]
   fn bytecode_test_path_detection_is_case_insensitive() {
-    assert!(is_bytecode_test_path("compiled.mecb"));
-    assert!(is_bytecode_test_path("compiled.MECB"));
-    assert!(!is_bytecode_test_path("source.mec"));
+    assert!(is_bytecode_test_path(Path::new("compiled.mecb")));
+    assert!(is_bytecode_test_path(Path::new("compiled.MECB")));
+    assert!(!is_bytecode_test_path(Path::new("source.mec")));
   }
 
   #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -34,7 +34,7 @@ fn collect_test_targets(path: &Path) -> MResult<Vec<PathBuf>> {
       skip_dir_names: TEST_SKIP_DIRS,
       follow_file_symlinks: false,
       follow_dir_symlinks: false,
-      missing_path_policy: MissingPathPolicy::Error,
+      missing_path_policy: MissingPathPolicy::SkipBrokenSymlink,
       dedupe_policy: DedupePolicy::CanonicalPath,
     },
   )?;
@@ -444,6 +444,18 @@ pub fn run_mech_tests(
 mod tests {
   use super::*;
 
+  fn temp_test_root(label: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+      "mech-test-{label}-{}",
+      std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+    root
+  }
+
   #[test]
   fn test_out_writes_json_for_single_file() {
     let root = std::env::temp_dir().join(format!("mech-test-out-json-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
@@ -485,6 +497,37 @@ mod tests {
 
     assert_eq!(report.status_label(), "FAILED");
     assert_eq!(report.exit_code(), 1);
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn test_directory_discovery_skips_broken_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_test_root("broken-symlink");
+    let source = root.join("main.mec");
+    std::fs::write(&source, "x := 1\n").unwrap();
+    symlink(root.join("missing.mec"), root.join("broken.mec")).unwrap();
+
+    let targets = collect_test_targets(&root).unwrap();
+
+    assert_eq!(targets, vec![source]);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn test_explicit_broken_symlink_errors() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_test_root("explicit-broken-symlink");
+    let broken = root.join("broken.mec");
+    symlink(root.join("missing.mec"), &broken).unwrap();
+
+    let result = collect_test_targets(&broken);
+
+    assert!(result.is_err());
+    std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -81,6 +81,7 @@ fn mech_file_execution_loads_cli_host_provider() {
 
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg(&source_path)
+    .current_dir(&root)
     .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
     .output()
     .unwrap();
@@ -97,6 +98,7 @@ fn mech_run_subcommand_loads_cli_host_provider() {
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
     .arg(&source_path)
+    .current_dir(&root)
     .env("MECH_CLI_HOST_TEST", "mech-cli-host-ok")
     .output()
     .unwrap();
@@ -296,6 +298,7 @@ fn mech_run_explicit_loader_supported_text_file_still_runs() {
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
     .arg(&source)
+    .current_dir(&root)
     .output()
     .unwrap();
 
@@ -388,6 +391,8 @@ fn mech_run_explicit_stdout_profile_permits_stdout() {
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
+    .arg("--allow-read")
+    .arg(&source)
     .arg(&source)
     .output()
     .unwrap();
@@ -415,6 +420,8 @@ fn mech_run_capability_passthrough_file_runs_once() {
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
+    .arg("--allow-read")
+    .arg(&source)
     .arg(&source)
     .output()
     .unwrap();
@@ -427,7 +434,7 @@ fn mech_run_capability_passthrough_file_runs_once() {
   );
 
   let combined = combined_output(&output);
-  let count = combined.matches("cap-passthrough-once").count();
+  let count = combined.lines().filter(|line| *line == "cap-passthrough-once").count();
   assert_eq!(
     count, 1,
     "source file should execute exactly once, got {count} occurrences:
@@ -458,6 +465,8 @@ fn mech_run_single_capabilities_arg_accepts_stdout_and_env_profiles() {
     .arg(":cli/stdout")
     .arg("--capabilities")
     .arg(":cli/env")
+    .arg("--allow-read")
+    .arg(&source)
     .arg(&source)
     .env("MECH_CLI_HOST_TEST", "stdout-env-profile-ok")
     .output()
@@ -514,6 +523,8 @@ x := @env/HOME
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
+    .arg("--allow-read")
+    .arg(&source)
     .arg(&source)
     .output()
     .unwrap();
@@ -799,6 +810,7 @@ pick(x<string>) => <string>
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
     .arg(&source)
+    .current_dir(&root)
     .env("MECH_FUNCTION_PATTERN_TEST", "secret")
     .output()
     .unwrap();
@@ -844,6 +856,8 @@ ys := { "hit" | @env/HOME <- ["anything"] }
     .arg("--deny-default-capabilities")
     .arg("--capabilities")
     .arg(":cli/stdout")
+    .arg("--allow-read")
+    .arg(&source)
     .arg(&source)
     .output()
     .unwrap();
@@ -876,6 +890,7 @@ ys := { x | (x, @env/MECH_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop"
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
     .arg(&source)
+    .current_dir(&root)
     .env("MECH_GENERATOR_PATTERN_TEST", "secret")
     .output()
     .unwrap();
@@ -915,6 +930,7 @@ x := @missing/HOME
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
     .arg(&source)
+    .current_dir(&root)
     .output()
     .unwrap();
 
@@ -955,6 +971,7 @@ fn mech_run_fsm_arm_context_pattern_is_literal_not_capture() {
   let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
     .arg("run")
     .arg(&source)
+    .current_dir(&root)
     .env("MECH_FSM_PATTERN_TEST", "secret")
     .output()
     .unwrap();


### PR DESCRIPTION
### Motivation

- Remove duplicated, command-local policies and re-use existing project components for consistent source classification, discovery, and filesystem grant behavior.
- Ensure `serve` shutdown actually stops the server loop and that test reporting and collection use a single authoritative representation.

### Description

- Replaced local `is_mech_source()` with role-specific predicates `is_workspace_target_source()` and `is_renderable_mech_text_source()` backed by `mech_runtime::SourceKind` and updated all call sites in `src/serve.rs` accordingly so `.mecb` is treated as a runtime workspace target but not as renderable text or static asset.
- Replaced bespoke recursive test collector in `src/test.rs` with `source_discovery::collect_sources_with_events()` and added `TEST_*` extension/skip constants, changed `collect_test_targets()` to return `MResult<Vec<PathBuf>>`, and switched the bytecode detector to `SourceKind`.
- Made `TestReport` own aggregate status and exit-code logic by adding `FileReport::failed_file()`, `SummaryResult::failed_run()`, and `TestReport::{status_label, exit_code}`, used these to compute `files_passed`/failing lists and moved `--out` report writing outside the multi-file-only branch in `run_mech_tests()`.
- Removed command-local default path grants from `src/cli/runtime_plan.rs`, eliminated `RunPlanEvent` and `events` propagation from the plan, and ensured `filesystem_access.kernel` is read from the authoritative capabilities object produced by `src/cli/capabilities.rs` only.
- Wired `serve()` Ctrl-C handling into a narrow `tokio::sync::watch` shutdown channel, split server into `serve()` (sets handler) and `serve_until_shutdown()` (runs server and workspace polling with graceful shutdown), and adjusted the polling loop to select on the shutdown signal.
- Small CLI help tweak for the `test` command to avoid implying `.mecb` tests are supported.
- Added unit tests: serve tests (`plan_serve_inputs_accepts_explicit_mecb_target`, `plan_serve_inputs_keeps_mecb_out_of_static_paths`, `renderable_source_predicate_excludes_mecb`, `serve_until_shutdown_exits_when_shutdown_signal_changes`), test command/report tests (`test_out_writes_json_for_single_file`, `test_out_writes_mec_for_single_file`, `test_report_status_fails_when_file_has_run_error_without_failed_tests`), and runtime plan test (`explicit_cap_root_does_not_gain_run_input_parent_grant`).

### Testing

- Ran focused serve tests with: `cargo test --features "serve bundle_web run formatter linked_stdlib" serve` and iteratively fixed failures; serve unit tests (including the new shutdown and `.mecb` classification tests) passed.
- Ran test-suite checks with: `cargo test --features "test run repl pretty_print linked_stdlib" test` and validated single-file `--out` behavior and report status tests; the new test-report tests passed after updating fixtures.
- Ran CLI run tests with: `cargo test --features "run repl pretty_print" cli::run::tests` and added/ran `runtime_plan` test for explicit cap-root authority; these passed.
- Multiple full-library test runs were executed during the rollout; the adjustments resolved earlier failures and the added tests pass in the CI-local runs documented above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd3407648832abdd278855da2ae56)