### PR TITLE
Fix transactional mailbox FIFO and make runtime commit atomic

### DIFF
--- a/src/runtime/src/runtime/actor.rs
+++ b/src/runtime/src/runtime/actor.rs
@@ -7,6 +7,23 @@
 use super::*;
 
 impl MechRuntime {
+  fn first_visible_transaction_message(
+    &self,
+    transaction_id: TransactionId,
+    actor: ActorId,
+  ) -> MResult<Option<MessageRecord>> {
+    let Some(transaction) = self.active_transactions.get(&transaction_id) else {
+      return Ok(None);
+    };
+
+    for message in self.store.list_mailbox(actor)? {
+      if !transaction.is_message_ack_staged(actor, message.id) {
+        return Ok(Some(message));
+      }
+    }
+
+    Ok(transaction.peek_staged_enqueued_message(actor))
+  }
 
   pub fn put_actor(&mut self, actor: ActorRecord) -> MResult<ActorId> {
     let mut context = self.context_for_actor(&actor)?;
@@ -279,22 +296,30 @@ impl MechRuntime {
     if self.has_active_context_transaction(context) {
       let transaction_id = Self::context_transaction_id(context)?;
 
-      if let Some(message) = self
-        .active_transaction_mut(transaction_id)?
-        .pop_staged_enqueued_message(actor)
-      {
-        return Ok(Some(message));
-      }
-
-      let Some(message) = self.store.peek_message(actor)? else {
+      let Some(message) = self.first_visible_transaction_message(transaction_id, actor)? else {
         return Ok(None);
       };
 
-      self
-        .active_transaction_mut(transaction_id)?
-        .stage_message_ack(actor, message.id)?;
+      let is_staged_enqueue = self
+        .active_transactions
+        .get(&transaction_id)
+        .and_then(|transaction| transaction.peek_staged_enqueued_message(actor))
+        .map(|staged| staged.id == message.id)
+        .unwrap_or(false);
 
-      return Ok(Some(message));
+      if is_staged_enqueue {
+        return Ok(
+          self
+            .active_transaction_mut(transaction_id)?
+            .pop_staged_enqueued_message(actor),
+        );
+      } else {
+        self
+          .active_transaction_mut(transaction_id)?
+          .stage_message_ack(actor, message.id)?;
+
+        return Ok(Some(message));
+      }
     }
 
     self.store.pop_message(actor)
@@ -312,10 +337,8 @@ impl MechRuntime {
     context.validate()?;
 
     if let Some(transaction_id) = context.transaction {
-      if let Some(transaction) = self.active_transactions.get(&transaction_id) {
-        if let Some(message) = transaction.peek_staged_enqueued_message(actor) {
-          return Ok(Some(message));
-        }
+      if self.active_transactions.contains_key(&transaction_id) {
+        return self.first_visible_transaction_message(transaction_id, actor);
       }
     }
 
@@ -405,6 +428,23 @@ impl ActorBehaviorRuntime for MechRuntime {
 mod tests {
   use super::*;
   use crate::actor_behavior::{ActorBehaviorDriver, ActorBehaviorRuntime};
+
+  fn runtime_with_actor_and_messages(
+    payloads: &[&[u8]],
+  ) -> MechRuntime {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    runtime
+      .put_actor(ActorRecord::new(ActorId(1), "actor:1"))
+      .unwrap();
+
+    for payload in payloads {
+      runtime
+        .send_message(ActorId(1), "ping", payload.to_vec())
+        .unwrap();
+    }
+
+    runtime
+  }
 
   #[derive(Debug)]
   struct SleepingActorBehaviorDriver;
@@ -549,6 +589,122 @@ mod tests {
       runtime.pop_message(ActorId(1)).unwrap().unwrap().payload,
       b"two",
     );
+    assert!(runtime.pop_message(ActorId(1)).unwrap().is_none());
+  }
+
+  #[test]
+  fn transactional_pops_return_distinct_durable_messages_in_fifo_order() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"one", b"two"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    assert_eq!(
+      runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap().unwrap().payload,
+      b"one",
+    );
+    assert_eq!(
+      runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap().unwrap().payload,
+      b"two",
+    );
+  }
+
+  #[test]
+  fn transactional_pops_three_durable_messages_without_repetition() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"one", b"two", b"three"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    let payloads: Vec<Vec<u8>> = (0..3)
+      .map(|_| {
+        runtime
+          .pop_message_with_context(&mut context, ActorId(1))
+          .unwrap()
+          .unwrap()
+          .payload
+      })
+      .collect();
+
+    assert_eq!(payloads, vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()]);
+  }
+
+  #[test]
+  fn transactional_mailbox_returns_durable_before_staged_enqueue() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"durable"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .send_message_with_context(&mut context, ActorId(1), "ping", b"staged".to_vec())
+      .unwrap();
+
+    assert_eq!(
+      runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap().unwrap().payload,
+      b"durable",
+    );
+    assert_eq!(
+      runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap().unwrap().payload,
+      b"staged",
+    );
+  }
+
+  #[test]
+  fn transactional_peek_then_pop_returns_same_effective_head() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"one", b"two"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    let peeked = runtime.peek_message_with_context(&mut context, ActorId(1)).unwrap().unwrap();
+    let popped = runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap().unwrap();
+    assert_eq!(peeked.id, popped.id);
+    assert_eq!(popped.payload, b"one");
+  }
+
+  #[test]
+  fn transactional_staged_enqueues_fifo_after_durable_exhausted_then_none() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"durable"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime.send_message_with_context(&mut context, ActorId(1), "ping", b"staged-one".to_vec()).unwrap();
+    runtime.send_message_with_context(&mut context, ActorId(1), "ping", b"staged-two".to_vec()).unwrap();
+
+    let payloads: Vec<Option<Vec<u8>>> = (0..4)
+      .map(|_| runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap().map(|m| m.payload))
+      .collect();
+
+    assert_eq!(
+      payloads,
+      vec![
+        Some(b"durable".to_vec()),
+        Some(b"staged-one".to_vec()),
+        Some(b"staged-two".to_vec()),
+        None,
+      ],
+    );
+  }
+
+  #[test]
+  fn commit_removes_acknowledged_durable_messages_once() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"one", b"two", b"three"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap();
+    runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert_eq!(runtime.pop_message(ActorId(1)).unwrap().unwrap().payload, b"three");
+    assert!(runtime.pop_message(ActorId(1)).unwrap().is_none());
+  }
+
+  #[test]
+  fn abort_leaves_durable_messages_and_discards_staged_enqueues() {
+    let mut runtime = runtime_with_actor_and_messages(&[b"one", b"two"]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime.pop_message_with_context(&mut context, ActorId(1)).unwrap();
+    runtime.send_message_with_context(&mut context, ActorId(1), "ping", b"staged".to_vec()).unwrap();
+    runtime.abort_runtime_transaction(&mut context, "rollback").unwrap();
+
+    assert_eq!(runtime.pop_message(ActorId(1)).unwrap().unwrap().payload, b"one");
+    assert_eq!(runtime.pop_message(ActorId(1)).unwrap().unwrap().payload, b"two");
     assert!(runtime.pop_message(ActorId(1)).unwrap().is_none());
   }
 }

--- a/src/runtime/src/runtime/actor.rs
+++ b/src/runtime/src/runtime/actor.rs
@@ -7,6 +7,7 @@
 use super::*;
 
 impl MechRuntime {
+
   fn first_visible_transaction_message(
     &self,
     transaction_id: TransactionId,
@@ -707,4 +708,5 @@ mod tests {
     assert_eq!(runtime.pop_message(ActorId(1)).unwrap().unwrap().payload, b"two");
     assert!(runtime.pop_message(ActorId(1)).unwrap().is_none());
   }
+
 }

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -1056,14 +1056,11 @@ impl MechRuntime {
     &self,
     context: &mut RuntimeContext,
     event: RuntimeEvent,
-  ) -> MResult<EventId> {
-    context.validate()?;
-
+  ) -> EventId {
     let id = event.id;
     context.push_event(event);
     self.trim_events_to_retention(&mut context.events);
-
-    Ok(id)
+    id
   }
 
   // ---------------------------------------------------------------------------

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -1052,6 +1052,20 @@ impl MechRuntime {
     Ok(id)
   }
 
+  fn push_persisted_event_to_context(
+    &self,
+    context: &mut RuntimeContext,
+    event: RuntimeEvent,
+  ) -> MResult<EventId> {
+    context.validate()?;
+
+    let id = event.id;
+    context.push_event(event);
+    self.trim_events_to_retention(&mut context.events);
+
+    Ok(id)
+  }
+
   // ---------------------------------------------------------------------------
   // Shutdown
   // ---------------------------------------------------------------------------

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -199,7 +199,7 @@ impl MechRuntime {
     self.active_transactions.remove(&transaction_id);
     context.transaction = None;
 
-    self.push_persisted_event_to_context(context, commit_event)?;
+    self.push_persisted_event_to_context(context, commit_event);
 
     Ok(id)
   }

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -130,6 +130,10 @@ impl MechRuntime {
 
     let transaction_id = Self::context_transaction_id(context)?;
 
+    let commit_event = self.make_event(RuntimeEventKind::TransactionCommitted {
+      transaction_id,
+    });
+
     let commit = {
       let transaction = self
         .active_transactions
@@ -170,8 +174,13 @@ impl MechRuntime {
         })
         .collect();
 
-      let staged_events = transaction.staged_events().cloned().collect();
-      let transaction_record = transaction.clone().into_record()?;
+      let mut staged_events: Vec<RuntimeEvent> =
+        transaction.staged_events().cloned().collect();
+      staged_events.push(commit_event.clone());
+
+      let mut transaction_snapshot = transaction.clone();
+      transaction_snapshot.record_event(commit_event.id)?;
+      let transaction_record = transaction_snapshot.into_record()?;
 
       RuntimeStoreCommit {
         transaction: transaction_record,
@@ -190,12 +199,7 @@ impl MechRuntime {
     self.active_transactions.remove(&transaction_id);
     context.transaction = None;
 
-    self.emit_event_immediate_to_context(
-      context,
-      RuntimeEventKind::TransactionCommitted {
-        transaction_id: id,
-      },
-    )?;
+    self.push_persisted_event_to_context(context, commit_event)?;
 
     Ok(id)
   }
@@ -504,9 +508,25 @@ mod tests {
       ),
       1,
     );
+    let commit_event_id = context
+      .events
+      .iter()
+      .find(|event| {
+        event.kind == (RuntimeEventKind::TransactionCommitted { transaction_id })
+      })
+      .map(|event| event.id)
+      .unwrap();
+    assert_eq!(
+      events
+        .iter()
+        .filter(|event| event.id == commit_event_id)
+        .count(),
+      1,
+    );
 
     let record = runtime.get_transaction(transaction_id).unwrap().unwrap();
     assert!(record.events.contains(&started_id));
+    assert!(record.events.contains(&commit_event_id));
     for event_id in &staged_event_ids {
       assert!(record.events.contains(event_id));
       assert_eq!(

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -99,6 +99,8 @@ pub trait MechStore: std::fmt::Debug + Send {
 
   fn peek_message(&self, actor: ActorId) -> MResult<Option<MessageRecord>>;
 
+  fn list_mailbox(&self, actor: ActorId) -> MResult<Vec<MessageRecord>>;
+
   fn ack_message(
     &mut self,
     actor: ActorId,
@@ -1189,6 +1191,18 @@ impl MechStore for InMemoryStore {
         .mailboxes
         .get(&actor)
         .and_then(|mailbox| mailbox.front().cloned()),
+    )
+  }
+
+  fn list_mailbox(&self, actor: ActorId) -> MResult<Vec<MessageRecord>> {
+    self.ensure_actor_exists(actor)?;
+
+    Ok(
+      self
+        .mailboxes
+        .get(&actor)
+        .map(|mailbox| mailbox.iter().cloned().collect())
+        .unwrap_or_default(),
     )
   }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect transactional mailbox semantics where repeated transactional pops could return the same durable message and staged enqueues could be returned before older durable messages.
- Ensure runtime transaction commit does not report failure after durable success by making the TransactionCommitted lifecycle event part of the same atomic store commit.

### Description
- Add a read-only durable mailbox API `list_mailbox(&self, actor: ActorId) -> MResult<Vec<MessageRecord>>` to `MechStore` and implement it in `InMemoryStore`. (durable FIFO view) 
- Implement `first_visible_transaction_message` and use it from `peek_message_with_context` and `pop_message_with_context` so transactional mailbox visibility: iterate durable FIFO, skip already-staged ack IDs, then fall back to staged enqueues; durable messages are only staged for ack (not removed) until commit and staged enqueues are returned in enqueue order.
- Make commit atomic by creating the `TransactionCommitted` event before calling `store.commit_runtime`, including that event in the `RuntimeStoreCommit.events` batch, and adding its ID to the transaction snapshot record so the single `commit_runtime` call durably persists both transaction state and the commit event.
- Add `push_persisted_event_to_context` helper that adds an already-persisted event to the caller `RuntimeContext` without writing to the store and apply it after successful commit instead of a second fallible `append_event`.
- Add focused regression tests for transactional mailbox behavior and commit behavior, and update assertions to verify the commit event is present exactly once in both the store and caller context.
- Files changed: `src/runtime/src/runtime/actor.rs`, `src/runtime/src/runtime/mod.rs`, `src/runtime/src/runtime/transaction.rs`, `src/runtime/src/store.rs`.

### Testing
- Ran unit and integration tests: `cargo test -p mech-runtime --lib` (passed), `cargo test -p mech-runtime --tests` (passed), `cargo test -p mech-runtime transaction` (passed), and `cargo test -p mech-runtime mailbox` (passed). All targeted tests and the full runtime test-suite passed.
- Verified `git diff --check` produced no errors and inspected diffs under `src/runtime` to confirm only the intended runtime files changed.
- New/updated tests covering: transactional FIFO pops (2 and 3 durable messages), durable-before-staged ordering, peek-then-pop consistency, staged enqueues FIFO after durable exhaustion and exhaustion yields `None`, commit removes durable messages exactly once, abort preserves durable messages and discards staged enqueues, and commit-event atomicity/visibility (all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b70e1b50832aa862019dfadbed19)