### PR TITLE
feat(interpreter): index remaining pure conversions

### DIFF
--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -200,6 +200,18 @@ pub fn execute_native_function_compiler(
   }
 }
 
+pub(crate) fn execute_initialized_indexed_compiler(
+  plan: &Plan,
+  compiler: &dyn NativeFunctionCompiler,
+  arguments: Vec<Value>,
+) -> MResult<Value> {
+  let function = compiler.compile(&arguments)?;
+  function.solve();
+  let output = function.out();
+  plan.register_function(function, &arguments)?;
+  Ok(output)
+}
+
 // Executes a user-defined function. Handles argument count validation,
 // optional matrix broadcasting, match-arm dispatch, and plain statement bodies.
 // Logs entry/exit (or failure) via the trace machinery.
@@ -944,9 +956,10 @@ impl MechErrorKind for FunctionInputTypeMismatchError {
   }
 }
 
-#[cfg(all(test, feature = "f64"))]
+#[cfg(all(test, feature = "functions", feature = "f64"))]
 mod native_dependency_tests {
   use super::*;
+  use std::sync::atomic::{AtomicUsize, Ordering};
 
   struct NativeDependencyTestCompiler;
 
@@ -979,6 +992,80 @@ mod native_dependency_tests {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
       Ok(0)
     }
+  }
+
+  struct IndexedInitializedCompiler {
+    output: Value,
+    solve_calls: Arc<AtomicUsize>,
+  }
+
+  struct IndexedInitializedFunction {
+    output: Value,
+    solve_calls: Arc<AtomicUsize>,
+  }
+
+  impl NativeFunctionCompiler for IndexedInitializedCompiler {
+    fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+      Ok(Box::new(IndexedInitializedFunction {
+        output: self.output.clone(),
+        solve_calls: self.solve_calls.clone(),
+      }))
+    }
+  }
+
+  impl MechFunctionImpl for IndexedInitializedFunction {
+    fn solve(&self) {
+      self.solve_calls.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn out(&self) -> Value {
+      self.output.clone()
+    }
+
+    fn to_string(&self) -> String {
+      "indexed-initialized-test".to_string()
+    }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for IndexedInitializedFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+      Ok(0)
+    }
+  }
+
+  #[test]
+  fn initialized_indexed_compiler_records_dependencies() {
+    let plan = Plan::new();
+    let input = Ref::new(1.0);
+    let input_cell = ReactiveCellId::new(input.id());
+    let output = Ref::new(2.0);
+    let output_cell = ReactiveCellId::new(output.id());
+    let solve_calls = Arc::new(AtomicUsize::new(0));
+
+    let result = execute_initialized_indexed_compiler(
+      &plan,
+      &IndexedInitializedCompiler {
+        output: Value::F64(output),
+        solve_calls: solve_calls.clone(),
+      },
+      vec![Value::F64(input)],
+    )
+    .unwrap();
+
+    assert!(result.reactive_cell_ids().contains(&output_cell));
+    assert_eq!(solve_calls.load(Ordering::SeqCst), 1);
+    let plan_borrow = plan.borrow();
+    let node = plan_borrow.node(0).unwrap();
+    assert_eq!(plan_borrow.len(), 1);
+    assert!(node.inputs.iter().any(|dependency| {
+      dependency.cell == input_cell
+        && dependency.kind == ReactiveDependencyKind::Reactive
+    }));
+    assert_eq!(plan_borrow.reactive_consumers_for(input_cell), &[0]);
+    assert!(plan_borrow.sampled_consumers_for(input_cell).is_empty());
+    assert!(node.outputs.contains(&output_cell));
+    assert!(!node.inputs.iter().any(|dependency| dependency.cell == output_cell));
   }
 
   #[derive(Debug, Clone)]
@@ -1021,7 +1108,7 @@ mod native_dependency_tests {
     let plan = plan.borrow();
     let node = plan.last().unwrap();
     assert!(plan.nodes.last().unwrap().inputs.iter().any(|dependency| dependency.cell == input_cell));
-    assert!(plan.nodes.last().unwrap().function.solve_result().unwrap_err().to_string().contains("DeferredNativeSolveError"));
+    assert!(plan.nodes.last().unwrap().function.solve_result().unwrap_err().kind_name().contains("DeferredNativeSolveError"));
     assert_eq!(plan.len(), 1);
   }
 

--- a/src/interpreter/src/literals.rs
+++ b/src/interpreter/src/literals.rs
@@ -133,11 +133,8 @@ pub fn typed_literal(ltrl: &Literal, knd_attn: &KindAnnotation, p: &Interpreter)
   let value = literal(ltrl,p)?;
   let kind = kind_annotation(&knd_attn.kind, p)?;
   let args = vec![value, kind.to_value(&p.state.borrow().kinds)?];
-  let convert_fxn = ConvertKind{}.compile(&args)?;
-  convert_fxn.solve();
-  let converted_result = convert_fxn.out();
-  p.state.borrow_mut().add_plan_step(convert_fxn);
-  Ok(converted_result)
+  let plan = p.plan();
+  execute_initialized_indexed_compiler(&plan, &ConvertKind {}, args)
 }
 
 #[cfg(feature = "atom")]

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -4,19 +4,6 @@ use paste::paste;
 #[cfg(feature = "variable_define")]
 use crate::stdlib::define::*;
 
-#[cfg(feature = "functions")]
-fn execute_indexed_statement_compiler(
-  plan: &Plan,
-  compiler: &dyn NativeFunctionCompiler,
-  arguments: Vec<Value>,
-) -> MResult<Value> {
-  let function = compiler.compile(&arguments)?;
-  function.solve();
-  let output = function.out();
-  plan.register_function(function, &arguments)?;
-  Ok(output)
-}
-
 // Statements
 // ----------------------------------------------------------------------------
 
@@ -567,30 +554,30 @@ pub fn variable_define(var_def: &VariableDefine, p: &Interpreter) -> MResult<Val
       (Value::MutableReference(v), ValueKind::Matrix(target_matrix_knd,_)) => {
         let value = v.borrow().clone();
         if value.is_matrix() {
-          result = execute_indexed_statement_compiler(&plan, &ConvertMatToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
+          result = execute_initialized_indexed_compiler(&plan, &ConvertMatToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
         } else {
           let value_kind = value.kind();
           if value_kind.deref_kind() != target_matrix_knd.as_ref().clone() && value_kind != *target_matrix_knd.clone() {
-            result = execute_indexed_statement_compiler(&plan, &ConvertKind{}, vec![result.clone(), Value::Kind(target_matrix_knd.as_ref().clone())])?;
+            result = execute_initialized_indexed_compiler(&plan, &ConvertKind{}, vec![result.clone(), Value::Kind(target_matrix_knd.as_ref().clone())])?;
           };
-          result = execute_indexed_statement_compiler(&plan, &ConvertScalarToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
+          result = execute_initialized_indexed_compiler(&plan, &ConvertScalarToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
         }
       }
       #[cfg(feature = "matrix")]
       (value, ValueKind::Matrix(target_matrix_knd,_)) => {
         if value.is_matrix() {
-          result = execute_indexed_statement_compiler(&plan, &ConvertMatToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
+          result = execute_initialized_indexed_compiler(&plan, &ConvertMatToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
         } else {
           let value_kind = value.kind();
           if value_kind.deref_kind() != target_matrix_knd.as_ref().clone() && value_kind != *target_matrix_knd.clone() {
-            result = execute_indexed_statement_compiler(&plan, &ConvertKind{}, vec![result.clone(), Value::Kind(target_matrix_knd.as_ref().clone())])?;
+            result = execute_initialized_indexed_compiler(&plan, &ConvertKind{}, vec![result.clone(), Value::Kind(target_matrix_knd.as_ref().clone())])?;
           };
-          result = execute_indexed_statement_compiler(&plan, &ConvertScalarToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
+          result = execute_initialized_indexed_compiler(&plan, &ConvertScalarToMat{}, vec![result.clone(), Value::Kind(target_knd.clone())])?;
         }
       }
       // Kind isn't checked
       x => {
-        result = execute_indexed_statement_compiler(&plan, &ConvertKind{}, vec![result.clone(), Value::Kind(target_knd)])?;
+        result = execute_initialized_indexed_compiler(&plan, &ConvertKind{}, vec![result.clone(), Value::Kind(target_knd)])?;
       },
     };
     let detached_result = detach_variable_value(&result);
@@ -1042,5 +1029,39 @@ impl MechErrorKind for UnableToConvertRecordError {
   }
   fn message(&self) -> String {
     format!("Unable to convert record of kind `{:?}` to record of kind `{:?}`", self.source_record_kind, self.target_record_kind)
+  }
+}
+
+#[cfg(all(
+  test,
+  feature = "variable_define",
+  feature = "f64",
+  feature = "string",
+  feature = "bool",
+))]
+mod variable_define_dependency_tests {
+  use super::*;
+
+  #[test]
+  fn var_define_registration_has_no_reactive_inputs() {
+    let plan = Plan::new();
+    let value = Ref::new(1.0);
+    let value_cell = ReactiveCellId::new(value.id());
+    let arguments = vec![
+      Value::F64(value),
+      Value::String(Ref::new("defined value".to_string())),
+      Value::Bool(Ref::new(false)),
+    ];
+    let function = VarDefine {}.compile(&arguments).unwrap();
+
+    plan.register_function(function, &[]).unwrap();
+
+    let plan_borrow = plan.borrow();
+    let node = plan_borrow.node(0).unwrap();
+    assert_eq!(plan_borrow.len(), 1);
+    assert!(node.inputs.is_empty());
+    assert!(plan_borrow.reactive_consumers.is_empty());
+    assert!(plan_borrow.sampled_consumers.is_empty());
+    assert!(node.outputs.contains(&value_cell));
   }
 }

--- a/src/interpreter/src/structures.rs
+++ b/src/interpreter/src/structures.rs
@@ -177,6 +177,7 @@ pub fn map(mp: &Map, env: Option<&Environment>, p: &Interpreter) -> MResult<Valu
 
 #[cfg(feature = "record")]
 pub fn record(rcrd: &Record, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let plan = p.plan();
   let mut data: IndexMap<u64,Value> = IndexMap::new();
   let cols: usize = rcrd.bindings.len();
   let mut kinds: Vec<ValueKind> = Vec::new();
@@ -193,14 +194,11 @@ pub fn record(rcrd: &Record, env: Option<&Environment>, p: &Interpreter) -> MRes
     kinds.push(knd.clone());
     #[cfg(feature = "convert")]
     if knd != val.kind() {
-      let fxn = ConvertKind{}.compile(&vec![val.clone(), Value::Kind(knd.clone())]);
-      match fxn {
-        Ok(convert_fxn) => {
-          convert_fxn.solve();
-          let converted_result = convert_fxn.out();
-          p.state.borrow_mut().add_plan_step(convert_fxn);
+      let arguments = vec![val.clone(), Value::Kind(knd.clone())];
+      match execute_initialized_indexed_compiler(&plan, &ConvertKind {}, arguments) {
+        Ok(converted_result) => {
           data.insert(name_hash, converted_result);
-        },
+        }
         Err(e) => {
           return Err(MechError::new(
             TableColumnKindMismatchError {


### PR DESCRIPTION
### Motivation
- Centralise the indexed initialization path for retained, non-assignment native conversion functions so all such conversions use one shared helper and registration path.

### Description
- Add one shared helper `execute_initialized_indexed_compiler(plan, compiler, arguments) -> MResult<Value>` in `src/interpreter/src/functions.rs` that compiles, runs `solve()` once, reads `out()`, registers the function with the exact arguments, and returns the output.
- Add unit test `initialized_indexed_compiler_records_dependencies` (under the native dependency tests) which provides a synthetic compiler/function and verifies solve was invoked once, the output cell is returned and recorded, the input is registered as a reactive dependency, consumer indexes match, and exactly one node exists.
- Replace the local statement helper `execute_indexed_statement_compiler` usage in `src/interpreter/src/statements.rs` by calling the shared `execute_initialized_indexed_compiler` for all prior call sites, preserving existing conversion branches/argument order and leaving `VarDefine` registration with `&[]` unchanged.
- Migrate `typed_literal()` in `src/interpreter/src/literals.rs` to build the same `args` vector and call the shared helper (removing the unindexed `add_plan_step()` usage), preserving argument order and semantics.
- Migrate record-field conversion in `src/interpreter/src/structures.rs` to obtain `plan = p.plan()` early and call the shared helper for per-field conversions, preserving field ordering and the `TableColumnKindMismatchError` translation and ensuring source field cells become reactive dependencies.
- Add unit test `var_define_registration_has_no_reactive_inputs` in `src/interpreter/src/statements.rs` which compiles `VarDefine`, registers it with `&[]`, and asserts the node has no inputs/consumers while the defined value is present in outputs.
- Ensure the shared helper is defined exactly once and remove the prior local helper function.

### Testing
- Ran `rg` checks to confirm the helper exists once and the old local helper name has no matches; both checks passed.
- Ran `cargo test -p mech-interpreter initialized_indexed_compiler -- --nocapture` and the new `initialized_indexed_compiler_records_dependencies` test passed.
- Ran `cargo test -p mech-interpreter var_define_registration -- --nocapture` and the new `var_define_registration_has_no_reactive_inputs` test passed.
- Ran `cargo test -p mech-interpreter` and the interpreter crate tests completed successfully (the larger workspace-wide tests and checks were started; some longer-running workspace compilation/test jobs were in progress when this report was produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c0264b900832aa0528038f48d0de1)