### PR TITLE
feat(interpreter): index matrix construction dependencies

### DIFF
--- a/src/interpreter/src/structures.rs
+++ b/src/interpreter/src/structures.rs
@@ -612,12 +612,7 @@ pub fn matrix(m: &Mat, env: Option<&Environment>, p: &Interpreter) -> MResult<Va
       return Ok(Value::MatrixValue(Matrix::from_vec(values, row_count, cols)));
     }
 
-    let new_fxn = MatrixVertCat{}.compile(&col)?;
-    new_fxn.solve();
-    let out = new_fxn.out();
-    let mut plan_brrw = plan.borrow_mut();
-    plan_brrw.push(new_fxn);
-    return Ok(out);
+    return execute_initialized_indexed_compiler(&plan, &MatrixVertCat {}, col);
   }
   return Err(MechError::new(
     FeatureNotEnabledError,
@@ -654,14 +649,111 @@ pub fn matrix_row(r: &MatrixRow, env: Option<&Environment>, p: &Interpreter) -> 
   if saw_empty && row.iter().all(|value| value.shape() == vec![1, 1]) {
     return Ok(Value::MatrixValue(Matrix::from_vec(row, 1, r.columns.len())));
   }
-  let new_fxn = MatrixHorzCat{}.compile(&row)?;
-  new_fxn.solve();
-  let out = new_fxn.out();
-  let mut plan_brrw = plan.borrow_mut();
-  plan_brrw.push(new_fxn);
-  Ok(out)
+  execute_initialized_indexed_compiler(&plan, &MatrixHorzCat {}, row)
+}
+pub fn matrix_column(r: &MatrixColumn, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  expression(&r.element, env, p)
 }
 
-pub fn matrix_column(r: &MatrixColumn, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> { 
-  expression(&r.element, env, p)
+#[cfg(all(test, feature = "f64", feature = "matrix_horzcat", feature = "matrix_vertcat", feature = "program", feature = "compiler"))]
+mod matrix_dependency_tests {
+  use super::*;
+
+  fn scalar(value: f64) -> (Value, ReactiveCellId) {
+    let reference = Ref::new(value);
+    let cell = ReactiveCellId::new(reference.id());
+    (Value::F64(reference), cell)
+  }
+
+  fn assert_matrix_literal_chain(plan: &Plan) {
+    let plan = plan.borrow();
+    assert_eq!(plan.len(), 3);
+
+    let first_row = plan.node(0).unwrap();
+    let second_row = plan.node(1).unwrap();
+    let vertical = plan.node(2).unwrap();
+    assert!(!first_row.inputs.is_empty());
+    assert!(!second_row.inputs.is_empty());
+    assert!(!vertical.inputs.is_empty());
+
+    assert!(first_row.outputs.iter().all(|output| !vertical.outputs.contains(output)));
+    assert!(second_row.outputs.iter().all(|output| !vertical.outputs.contains(output)));
+    assert!(vertical.inputs.iter().all(|dependency| dependency.kind == ReactiveDependencyKind::Reactive));
+    assert!(!vertical.outputs.is_empty());
+  }
+
+  #[test]
+  fn indexed_matrix_horzcat_records_dependencies() {
+    let plan = Plan::new();
+    let (first, first_cell) = scalar(1.0);
+    let (second, second_cell) = scalar(2.0);
+
+    let output = execute_initialized_indexed_compiler(
+      &plan,
+      &MatrixHorzCat {},
+      vec![first, second],
+    ).unwrap();
+    let output_cell = output.reactive_cell_ids()[0];
+    let plan = plan.borrow();
+    let node = plan.node(0).unwrap();
+
+    assert_eq!(plan.len(), 1);
+    assert_eq!(node.inputs.iter().map(|dependency| dependency.cell).collect::<Vec<_>>(), vec![first_cell, second_cell]);
+    assert!(node.inputs.iter().all(|dependency| dependency.kind == ReactiveDependencyKind::Reactive));
+    assert_eq!(plan.reactive_consumers_for(first_cell), &[0]);
+    assert_eq!(plan.reactive_consumers_for(second_cell), &[0]);
+    assert!(node.outputs.contains(&output_cell));
+    assert!(!node.inputs.iter().any(|dependency| dependency.cell == output_cell));
+  }
+
+  #[test]
+  fn indexed_matrix_vertcat_records_dependencies() {
+    let plan = Plan::new();
+    let (first, _) = scalar(1.0);
+    let (second, _) = scalar(2.0);
+    let first_row = execute_initialized_indexed_compiler(&plan, &MatrixHorzCat {}, vec![first]).unwrap();
+    let second_row = execute_initialized_indexed_compiler(&plan, &MatrixHorzCat {}, vec![second]).unwrap();
+    let first_cell = first_row.reactive_cell_ids()[0];
+    let second_cell = second_row.reactive_cell_ids()[0];
+
+    let output = execute_initialized_indexed_compiler(
+      &plan,
+      &MatrixVertCat {},
+      vec![first_row, second_row],
+    ).unwrap();
+    let output_cell = output.reactive_cell_ids()[0];
+    let plan = plan.borrow();
+    let node = plan.node(2).unwrap();
+
+    assert_eq!(node.inputs.iter().map(|dependency| dependency.cell).collect::<Vec<_>>(), vec![first_cell, second_cell]);
+    assert!(node.inputs.iter().all(|dependency| dependency.kind == ReactiveDependencyKind::Reactive));
+    assert_eq!(plan.reactive_consumers_for(first_cell), &[2]);
+    assert_eq!(plan.reactive_consumers_for(second_cell), &[2]);
+    assert!(node.outputs.contains(&output_cell));
+    assert!(!node.inputs.iter().any(|dependency| dependency.cell == output_cell));
+  }
+
+  #[test]
+  fn indexed_matrix_literal_builds_dependency_chain() {
+    let tree = mech_syntax::parser::parse("[1.0 2.0; 3.0 4.0]").unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+
+    assert_eq!(output, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
+    assert_matrix_literal_chain(&interpreter.plan());
+  }
+
+  #[test]
+  fn decoded_matrix_literal_preserves_dependency_chain() {
+    let tree = mech_syntax::parser::parse("[1.0 2.0; 3.0 4.0]").unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    interpreter.interpret(&tree).unwrap();
+    let bytecode = interpreter.compile().unwrap();
+    let program = ParsedProgram::from_bytes(&bytecode).unwrap();
+
+    interpreter.clear_plan();
+    let output = interpreter.run_program(&program).unwrap();
+    assert_eq!(output, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
+    assert_matrix_literal_chain(&interpreter.plan());
+  }
 }


### PR DESCRIPTION
### Motivation
- Make retained constructors used for ordinary matrix literals dependency-indexed so matrix construction participates in the reactive dependency plan. 
- Replace ad-hoc compile/solve/push sequences with the shared indexed helper to keep constructor registration consistent with other indexed initializations. 
- Cover both source interpretation and decoded-bytecode flows for horizontal and vertical concatenation constructors.

### Description
- Replaced the unindexed `compile`/`solve`/`plan.push(new_fxn)` pattern for horizontal and vertical concatenation with `execute_initialized_indexed_compiler(&plan, &MatrixHorzCat {}, row)` and `execute_initialized_indexed_compiler(&plan, &MatrixVertCat {}, col)` in `src/interpreter/src/structures.rs` while preserving existing composite, empty, and dimension-mismatch branches. 
- Added a test module (guarded by appropriate features) in `src/interpreter/src/structures.rs` that implements the four required tests: `indexed_matrix_horzcat_records_dependencies`, `indexed_matrix_vertcat_records_dependencies`, `indexed_matrix_literal_builds_dependency_chain`, and `decoded_matrix_literal_preserves_dependency_chain`.
- Left unrelated families (sets, variable defines, etc.) untouched as requested and used the existing shared helper `execute_initialized_indexed_compiler` rather than adding new helpers.
- Ensured there are no remaining unindexed `plan.push(new_fxn)` insertions for matrix constructors in `structures.rs`.

### Testing
- Ran the targeted unit tests for the new coverage: `indexed_matrix_horzcat`, `indexed_matrix_vertcat`, `indexed_matrix_literal`, and `decoded_matrix_literal`, and each passed locally (all assertions in the added tests succeeded). 
- Ran `cargo test -p mech-interpreter` to exercise the interpreter test suite and observed successful results for the interpreter package tests that exercise the new behavior. 
- Performed a source check (`rg`) to confirm there is no remaining unindexed `new_fxn` insertion for matrix constructors in `src/interpreter/src/structures.rs` and the four new test names are present. 
- A broader `cargo test bytecode` run was started in the environment for additional bytecode validation; local focused and package tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c0cebb278832a9583fded8b7a1770)