### PR TITLE
feat(core): use root cells for reactive outputs

### DIFF
--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -149,6 +149,19 @@ pub trait MechFunctionImpl {
   fn reactive_output_values(&self) -> Vec<Value> {
     vec![self.out()]
   }
+  fn reactive_output_cell_ids(&self) -> Vec<ReactiveCellId> {
+    let mut cells = Vec::new();
+
+    for output in self.reactive_output_values() {
+      for cell in output.reactive_root_cell_ids() {
+        if !cells.contains(&cell) {
+          cells.push(cell);
+        }
+      }
+    }
+
+    cells
+  }
   fn reactive_node_kind(&self) -> ReactiveNodeKind {
     ReactiveNodeKind::Combinational
   }
@@ -472,15 +485,7 @@ impl ReactivePlan {
 
   pub fn push(&mut self, function: Box<dyn MechFunction>) -> ReactiveNodeId {
     let node_id = self.nodes.len();
-    let mut outputs = Vec::<ReactiveCellId>::new();
-
-    for output in function.reactive_output_values() {
-      for cell in output.reactive_cell_ids() {
-        if !outputs.contains(&cell) {
-          outputs.push(cell);
-        }
-      }
-    }
+    let outputs = function.reactive_output_cell_ids();
 
     let node = ReactivePlanNode {
       id: node_id,
@@ -547,15 +552,7 @@ impl ReactivePlan {
       }
     }
 
-    let mut outputs = Vec::<ReactiveCellId>::new();
-
-    for output in function.reactive_output_values() {
-      for cell in output.reactive_cell_ids() {
-        if !outputs.contains(&cell) {
-          outputs.push(cell);
-        }
-      }
-    }
+    let outputs = function.reactive_output_cell_ids();
 
     let node = ReactivePlanNode {
       id: node_id,
@@ -846,6 +843,49 @@ mod reactive_plan_tests {
     plan.push(Box::new(TestFunction::new("second")));
 
     assert_eq!(plan.len(), plan.nodes.len());
+  }
+
+  #[cfg(all(feature = "set", feature = "f64"))]
+  fn set_output() -> (Value, ReactiveCellId, ReactiveCellId, ReactiveCellId) {
+    let first = Ref::new(1.0);
+    let second = Ref::new(2.0);
+    let mut members = indexmap::IndexSet::new();
+    members.insert(Value::F64(first.clone()));
+    members.insert(Value::F64(second.clone()));
+    let set = Ref::new(MechSet { kind: ValueKind::F64, num_elements: 2, set: members });
+
+    (
+      Value::Set(set.clone()),
+      ReactiveCellId::new(set.id()),
+      ReactiveCellId::new(first.id()),
+      ReactiveCellId::new(second.id()),
+    )
+  }
+
+  #[cfg(all(feature = "set", feature = "f64"))]
+  #[test]
+  fn reactive_plan_push_records_root_output_cells() {
+    let (output, outer, first, second) = set_output();
+    let mut plan = ReactivePlan::new();
+    plan.push(Box::new(TestFunction::with_output("set", output)));
+
+    assert_eq!(plan.nodes.len(), 1);
+    assert_eq!(plan.nodes[0].outputs, vec![outer]);
+    assert!(!plan.nodes[0].outputs.contains(&first));
+    assert!(!plan.nodes[0].outputs.contains(&second));
+  }
+
+  #[cfg(all(feature = "set", feature = "f64"))]
+  #[test]
+  fn reactive_plan_register_records_root_output_cells() {
+    let (output, outer, first, second) = set_output();
+    let mut plan = ReactivePlan::new();
+    let node_id = plan.register(Box::new(TestFunction::with_output("set", output)), &[]).unwrap();
+    let node = plan.node(node_id).unwrap();
+
+    assert_eq!(node.outputs, vec![outer]);
+    assert!(!node.outputs.contains(&first));
+    assert!(!node.outputs.contains(&second));
   }
 
   #[cfg(feature = "f64")]

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -771,6 +771,101 @@ impl Hash for Value {
   }
 }
 impl Value {
+  pub fn reactive_root_cell_ids(&self) -> Vec<ReactiveCellId> {
+    match self {
+      #[cfg(feature = "u8")]
+      Value::U8(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "u16")]
+      Value::U16(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "u32")]
+      Value::U32(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "u64")]
+      Value::U64(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "u128")]
+      Value::U128(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "i8")]
+      Value::I8(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "i16")]
+      Value::I16(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "i32")]
+      Value::I32(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "i64")]
+      Value::I64(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "i128")]
+      Value::I128(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "f32")]
+      Value::F32(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "f64")]
+      Value::F64(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(any(feature = "string", feature = "variable_define"))]
+      Value::String(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(any(feature = "bool", feature = "variable_define"))]
+      Value::Bool(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "complex")]
+      Value::C64(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "rational")]
+      Value::R64(v) => vec![ReactiveCellId::new(v.id())],
+      Value::Index(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "atom")]
+      Value::Atom(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "enum")]
+      Value::Enum(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "set")]
+      Value::Set(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "map")]
+      Value::Map(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "record")]
+      Value::Record(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "table")]
+      Value::Table(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "tuple")]
+      Value::Tuple(v) => vec![ReactiveCellId::new(v.id())],
+      #[cfg(feature = "matrix")]
+      Value::MatrixIndex(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "bool"))]
+      Value::MatrixBool(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "u8"))]
+      Value::MatrixU8(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "u16"))]
+      Value::MatrixU16(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "u32"))]
+      Value::MatrixU32(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "u64"))]
+      Value::MatrixU64(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "u128"))]
+      Value::MatrixU128(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "i8"))]
+      Value::MatrixI8(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "i16"))]
+      Value::MatrixI16(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "i32"))]
+      Value::MatrixI32(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "i64"))]
+      Value::MatrixI64(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "i128"))]
+      Value::MatrixI128(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "f32"))]
+      Value::MatrixF32(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "f64"))]
+      Value::MatrixF64(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "string"))]
+      Value::MatrixString(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "rational"))]
+      Value::MatrixR64(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(all(feature = "matrix", feature = "complex"))]
+      Value::MatrixC64(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      #[cfg(feature = "matrix")]
+      Value::MatrixValue(v) => vec![ReactiveCellId::new(v.addr() as u64)],
+      Value::MutableReference(v) => vec![ReactiveCellId::new(v.id())],
+      Value::Typed(value, _) => value.reactive_root_cell_ids(),
+      Value::Id(_)
+      | Value::Kind(_)
+      | Value::IndexAll
+      | Value::EmptyKind(_)
+      | Value::Empty => Vec::new(),
+    }
+  }
+
   pub fn reactive_cell_ids(&self) -> Vec<ReactiveCellId> {
     let mut ids = Vec::new();
     let mut seen = HashSet::new();
@@ -2997,6 +3092,32 @@ mod reactive_cell_tests {
     let outer = Ref::new(Value::F64(scalar.clone()));
     let value = Value::MutableReference(outer.clone());
 
+    assert_eq!(value.reactive_cell_ids(), cell_ids(&[outer.id(), scalar.id()]));
+  }
+
+  #[cfg(all(feature = "set", feature = "f64"))]
+  #[test]
+  fn reactive_root_cells_exclude_nested_container_cells() {
+    let first = Ref::new(1.0);
+    let second = Ref::new(2.0);
+    let mut members = IndexSet::new();
+    members.insert(Value::F64(first.clone()));
+    members.insert(Value::F64(second.clone()));
+    let set = Ref::new(MechSet { kind: ValueKind::F64, num_elements: 2, set: members });
+    let value = Value::Set(set.clone());
+
+    assert_eq!(value.reactive_root_cell_ids(), cell_ids(&[set.id()]));
+    assert_eq!(value.reactive_cell_ids(), cell_ids(&[set.id(), first.id(), second.id()]));
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn mutable_reference_root_cell_is_outer_only() {
+    let scalar = Ref::new(1.0);
+    let outer = Ref::new(Value::F64(scalar.clone()));
+    let value = Value::MutableReference(outer.clone());
+
+    assert_eq!(value.reactive_root_cell_ids(), cell_ids(&[outer.id()]));
     assert_eq!(value.reactive_cell_ids(), cell_ids(&[outer.id(), scalar.id()]));
   }
 


### PR DESCRIPTION
### Motivation

- Ensure function outputs are recorded as the immediate storage cells they produce (the “root” cell) while keeping recursive dependency discovery for inputs unchanged.
- Prevent nested member cells of containers (sets, maps, records, tuples, tables, enums, matrix values, mutable references) from being registered as function outputs so the reactive graph records only outer container identities.

### Description

- Add `Value::reactive_root_cell_ids()` which returns only the immediate storage identity for each `Value` variant and delegates to the wrapped value for `Typed` values, leaving `Value::reactive_cell_ids()` recursive and unchanged.
- Add a default `MechFunctionImpl::reactive_output_cell_ids()` that collects root cell ids from `self.reactive_output_values()` and deduplicates them.
- Update `ReactivePlan::push()` and `ReactivePlan::register()` to use `function.reactive_output_cell_ids()` for node outputs instead of recursively expanding outputs with `reactive_cell_ids()`; input dependency extraction continues to use `argument.reactive_cell_ids()` unchanged.
- Add focused tests: `reactive_root_cells_exclude_nested_container_cells`, `mutable_reference_root_cell_is_outer_only`, `reactive_plan_push_records_root_output_cells`, and `reactive_plan_register_records_root_output_cells` to validate root-only output behavior and plan registration.
- Files modified: `src/core/src/value.rs`, `src/core/src/functions.rs`.

### Testing

- Ran source checks required by the task (`rg`): the `fn reactive_root_cell_ids` and `fn reactive_output_cell_ids` definitions exist and `ReactivePlan` no longer recursively expands outputs—checks passed.
- Ran `git diff --check` and it reported no blocking issues.
- Ran unit tests: `cargo test -p mech-core reactive_root -- --nocapture`, `cargo test -p mech-core root_output -- --nocapture`, and `cargo test -p mech-core`; all executed successfully (new and existing `mech-core` tests passed).
- Ran workspace checks `cargo check -p mech-interpreter` and `cargo check -p mech-program` (builds encountered transient package-cache / artifact-lock waits in this environment but completed without errors when executed); no compiler errors were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c31c8500c832ab739a35136bf11d8)