### PR TITLE
feat(interpreter): index remaining structural paths

### DIFF
--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -540,6 +540,33 @@ mod indexed_expression_registration_tests {
   }
 }
 
+#[cfg(all(test, feature = "functions", feature = "f64", feature = "u64", feature = "convert", feature = "kind_annotation", feature = "variable_define", feature = "variables"))]
+mod variable_kind_cast_dependency_tests {
+  use super::*;
+
+  #[test]
+  fn variable_kind_cast_is_indexed() {
+    let tree = mech_syntax::parser::parse("value := 1; value<f64>").unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+    assert_eq!(*output.as_f64().unwrap().borrow(), 1.0);
+    let output_cell = output.reactive_root_cell_ids()[0];
+    let plan = interpreter.plan();
+    let plan = plan.borrow();
+    let (node_id, node) = (0..plan.len()).find_map(|node_id| {
+      let node = plan.node(node_id).unwrap();
+      (node.outputs.contains(&output_cell) && !node.inputs.is_empty()).then_some((node_id, node))
+    }).expect("converted variable read should be registered in the plan");
+    assert!(node.inputs.iter().all(|dependency| dependency.kind == ReactiveDependencyKind::Reactive));
+    assert!(node.outputs.contains(&output_cell));
+    assert!(!node.inputs.iter().any(|dependency| dependency.cell == output_cell));
+    for dependency in &node.inputs {
+      assert!(plan.reactive_consumers_for(dependency.cell).contains(&node_id));
+      assert!(plan.sampled_consumers_for(dependency.cell).is_empty());
+    }
+  }
+}
+
 #[cfg(feature = "range")]
 pub fn range(rng: &RangeExpression, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
   let plan = p.plan();
@@ -1139,6 +1166,7 @@ pub fn subscript(
 
 #[cfg(feature = "symbol_table")]
 pub fn var(v: &Var, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+    let plan = p.plan();
     let maybe_cast_to_kind = |value: Value| -> MResult<Value> {
         match &v.kind {
             Some(kind_anntn) => {
@@ -1146,11 +1174,11 @@ pub fn var(v: &Var, env: Option<&Environment>, p: &Interpreter) -> MResult<Value
                     let state_brrw = p.state.borrow();
                     kind_annotation(&kind_anntn.kind, p)?.to_value_kind(&state_brrw.kinds)?
                 };
-                let convert_fxn = ConvertKind {}.compile(&vec![value, Value::Kind(target_kind)])?;
-                convert_fxn.solve();
-                let out = convert_fxn.out();
-                p.state.borrow_mut().add_plan_step(convert_fxn);
-                Ok(out)
+                execute_initialized_indexed_compiler(
+                    &plan,
+                    &ConvertKind {},
+                    vec![value, Value::Kind(target_kind)],
+                )
             }
             None => Ok(value),
         }

--- a/src/interpreter/src/structures.rs
+++ b/src/interpreter/src/structures.rs
@@ -243,6 +243,9 @@ pub struct ValueSet {
 impl MechFunctionImpl for ValueSet {
   fn solve(&self) {}
   fn out(&self) -> Value { Value::Set(self.out.clone()) }
+  fn reactive_dependency_scopes(&self, argument_count: usize) -> Option<Vec<ReactiveDependencyScope>> {
+    Some(vec![ReactiveDependencyScope::None; argument_count])
+  }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
 #[cfg(feature = "set")]
@@ -303,7 +306,8 @@ register_descriptor!{
 }
 
 #[cfg(feature = "set")]
-pub fn set(m: &Set, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> { 
+pub fn set(m: &Set, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
+  let plan = p.plan();
   let mut elements = Vec::new();
   for el in &m.elements {
     let result = expression(el, env, p)?;
@@ -333,13 +337,7 @@ pub fn set(m: &Set, env: Option<&Environment>, p: &Interpreter) -> MResult<Value
   }
   #[cfg(feature = "functions")]
   {
-    let new_fxn = SetDefine { kind: element_kind.clone() }.compile(&elements)?;
-    new_fxn.solve();
-    let out = new_fxn.out();
-    let plan = p.plan();
-    let mut plan_brrw = plan.borrow_mut();
-    plan_brrw.push(new_fxn);
-    Ok(out)
+    execute_initialized_indexed_compiler(&plan, &SetDefine { kind: element_kind }, elements)
   }
   #[cfg(not(feature = "functions"))]
   {
@@ -755,5 +753,82 @@ mod matrix_dependency_tests {
     let output = interpreter.run_program(&program).unwrap();
     assert_eq!(output, Value::MatrixF64(Matrix::from_vec(vec![1.0, 3.0, 2.0, 4.0], 2, 2)));
     assert_matrix_literal_chain(&interpreter.plan());
+  }
+}
+
+#[cfg(all(test, feature = "set", feature = "f64", feature = "functions", feature = "program", feature = "compiler"))]
+mod set_dependency_tests {
+  use super::*;
+
+  fn scalar(value: f64) -> (Value, ReactiveCellId) {
+    let reference = Ref::new(value);
+    let cell = ReactiveCellId::new(reference.id());
+    (Value::F64(reference), cell)
+  }
+
+  fn set_members(value: &Value) -> Vec<ReactiveCellId> {
+    match value {
+      Value::Set(set) => set.borrow().elements.iter().flat_map(Value::reactive_root_cell_ids).collect(),
+      other => panic!("expected set, found {:?}", other),
+    }
+  }
+
+  fn assert_structural_set_node(plan: &Plan, output: &Value) {
+    let output_cell = output.reactive_root_cell_ids()[0];
+    let member_cells = set_members(output);
+    let plan = plan.borrow();
+    let (node_id, node) = (0..plan.len()).find_map(|node_id| {
+      let node = plan.node(node_id).unwrap();
+      node.outputs.contains(&output_cell).then_some((node_id, node))
+    }).expect("set structural node should be registered");
+    assert!(node.inputs.is_empty());
+    assert_eq!(node.outputs.as_slice(), &[output_cell]);
+    for member_cell in member_cells {
+      assert!(!node.outputs.contains(&member_cell));
+      assert!(!plan.reactive_consumers_for(member_cell).contains(&node_id));
+      assert!(!plan.sampled_consumers_for(member_cell).contains(&node_id));
+    }
+  }
+
+  #[test]
+  fn set_define_registration_ignores_element_dependencies() {
+    let plan = Plan::new();
+    let (first, first_cell) = scalar(1.0);
+    let (second, second_cell) = scalar(2.0);
+    let output = execute_initialized_indexed_compiler(&plan, &SetDefine { kind: ValueKind::F64 }, vec![first, second]).unwrap();
+    let output_cell = output.reactive_root_cell_ids()[0];
+    let plan = plan.borrow();
+    let node = plan.node(0).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert!(node.inputs.is_empty());
+    assert!(plan.reactive_consumers_for(first_cell).is_empty());
+    assert!(plan.reactive_consumers_for(second_cell).is_empty());
+    assert!(plan.sampled_consumers_for(first_cell).is_empty());
+    assert!(plan.sampled_consumers_for(second_cell).is_empty());
+    assert_eq!(node.outputs.as_slice(), &[output_cell]);
+    assert!(!node.outputs.contains(&first_cell));
+    assert!(!node.outputs.contains(&second_cell));
+  }
+
+  #[test]
+  fn source_set_literal_registers_structural_node() {
+    let tree = mech_syntax::parser::parse("{1.0, 2.0}").unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+    assert_eq!(output.to_string(), "{1, 2}");
+    assert_structural_set_node(&interpreter.plan(), &output);
+  }
+
+  #[test]
+  fn decoded_set_literal_registers_structural_node() {
+    let tree = mech_syntax::parser::parse("{1.0, 2.0}").unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let source_output = interpreter.interpret(&tree).unwrap();
+    let bytecode = interpreter.compile().unwrap();
+    let program = ParsedProgram::from_bytes(&bytecode).unwrap();
+    interpreter.clear_plan();
+    let decoded_output = interpreter.run_program(&program).unwrap();
+    assert_eq!(decoded_output, source_output);
+    assert_structural_set_node(&interpreter.plan(), &decoded_output);
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure kind conversions performed while reading variables and structural set construction are indexed into the reactive plan so structural nodes express the intended dependency policy.
- Prevent evaluated set members from becoming retained reactive dependencies of the structural `ValueSet` node while keeping set outputs root-only.
- Add targeted tests to assert indexed conversion registration and structural set-node metadata for both source and decoded bytecode paths.

### Description

- Replace ad-hoc `ConvertKind` compile/solve/read/add_plan_step sequence in `var()` with `execute_initialized_indexed_compiler`, capturing the plan once near `var()` entry and invoking `execute_initialized_indexed_compiler(&plan, &ConvertKind {}, vec![value, Value::Kind(target_kind)])` to register the conversion in the indexed plan (file: `src/interpreter/src/expressions.rs`).
- Mark `ValueSet` as structural by overriding `MechFunctionImpl::reactive_dependency_scopes` to return `Some(vec![ReactiveDependencyScope::None; argument_count])`, ensuring element arguments do not register as retained reactive dependencies (file: `src/interpreter/src/structures.rs`).
- Change source set construction to use `execute_initialized_indexed_compiler(&plan, &SetDefine { kind: element_kind }, elements)` so that the evaluated elements are compiled/solved and the retained `ValueSet` is registered via the indexed helper (file: `src/interpreter/src/structures.rs`).
- Add tests:
  - `variable_kind_cast_is_indexed` (in `expressions.rs`) to assert a variable-read kind conversion is registered in the plan with reactive inputs, root-only output, and no sampled consumers.
  - `set_define_registration_ignores_element_dependencies` (in `structures.rs`) to assert `SetDefine`/`ValueSet` registration produces a zero-input structural node whose outputs contain only the outer set cell and not member cells.
  - `source_set_literal_registers_structural_node` and `decoded_set_literal_registers_structural_node` (in `structures.rs`) to assert source and decoded bytecode set literals produce the same structural metadata and results.
- Only modified `src/interpreter/src/expressions.rs` and `src/interpreter/src/structures.rs` as requested; no core API changes introduced.

### Testing

- Ran source checks (`rg`) to verify old `add_plan_step(convert_fxn)` patterns are absent from `var()`, to verify the `ValueSet` reactive-scope override exists, and to verify there is a single indexed-helper call for `SetDefine` in `set()`; these searches returned the expected matches.
- Ran `git diff --check` and fixed a trailing-whitespace issue reported for `structures.rs`; after fix the check passed.
- Exercised the new targeted interpreter tests with `cargo test -p mech-interpreter variable_kind_cast_is_indexed` and the three new `set_*` tests; an initial type mismatch in the test assertion was detected and corrected (`*output.as_f64().unwrap().borrow()`), after which the targeted tests were re-run in the environment but long-running compilation in the container prevented a conclusive end-to-end test result within this session.
- Validation steps and targeted checks (linters/grep, `git diff --check`, and attempts to run the new `cargo test` targets) were performed; the code compiles locally up to the point recorded and the failing test state encountered during iteration was fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c505e8054832ab2ed277db1fd37b7)