### PR TITLE
feat(reactive): index whole-value assignments as register nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
           cargo test interpret
           cargo test bytecode
 
+          # Whole-value assignment reactive graph coverage.
+          cargo test -p mech-interpreter whole_variable_assignment_registers_state_node -- --nocapture
+          cargo test -p mech-interpreter whole_add_assignment_registers_state_node -- --nocapture
+          cargo test -p mech-interpreter whole_add_assignment_alias_is_sampled_once -- --nocapture
+          cargo test -p mech-interpreter decoded_whole_variable_assignment_matches_source_graph -- --nocapture
+          cargo test -p mech-interpreter decoded_whole_add_assignment_matches_source_graph -- --nocapture
+          cargo test -p mech-interpreter whole_matrix_assignment_uses_root_cells -- --nocapture
+
           # Runtime package tests.
           cargo test -p mech-runtime --lib --tests
 

--- a/machines/math/src/op_assign/mod.rs
+++ b/machines/math/src/op_assign/mod.rs
@@ -293,6 +293,7 @@ macro_rules! impl_assign_scalar_scalar {
           }
         }
         fn out(&self) -> Value { self.sink.to_value() }
+        fn reactive_node_kind(&self) -> ReactiveNodeKind { ReactiveNodeKind::Register }
         fn to_string(&self) -> String { format!("{:#?}", self) }
       }
       #[cfg(feature = "compiler")]
@@ -379,6 +380,7 @@ macro_rules! impl_assign_vector_vector {
           }
         }
         fn out(&self) -> Value {self.sink.to_value()}
+        fn reactive_node_kind(&self) -> ReactiveNodeKind { ReactiveNodeKind::Register }
         fn to_string(&self) -> String {format!("{:#?}", self)}
       }
       #[cfg(feature = "compiler")]
@@ -452,6 +454,7 @@ macro_rules! impl_assign_vector_scalar {
           }
         }
         fn out(&self) -> Value {self.sink.to_value()}
+        fn reactive_node_kind(&self) -> ReactiveNodeKind { ReactiveNodeKind::Register }
         fn to_string(&self) -> String {format!("{:#?}", self)}
       }
       #[cfg(feature = "compiler")]

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -521,7 +521,6 @@ impl ReactivePlan {
   pub fn push(&mut self, function: Box<dyn MechFunction>) -> ReactiveNodeId {
     let node_id = self.nodes.len();
     let outputs = function.reactive_output_cell_ids();
-
     let node = ReactivePlanNode {
       id: node_id,
       plan_index: node_id,
@@ -581,7 +580,18 @@ impl ReactivePlan {
       None => vec![ReactiveDependencyScope::Recursive; arguments.len()],
     };
 
+    let node_kind = function.reactive_node_kind();
+    let outputs = function.reactive_output_cell_ids();
     let mut inputs = Vec::<ReactiveDependency>::new();
+
+    if node_kind == ReactiveNodeKind::Register {
+      for cell in &outputs {
+        inputs.push(ReactiveDependency {
+          cell: *cell,
+          kind: ReactiveDependencyKind::Sampled,
+        });
+      }
+    }
 
     for ((argument, kind), scope) in arguments
       .iter()
@@ -597,6 +607,11 @@ impl ReactivePlan {
       for cell in cells {
         match inputs.iter().find(|dependency| dependency.cell == cell) {
           Some(dependency) if dependency.kind == *kind => {}
+          Some(dependency)
+            if node_kind == ReactiveNodeKind::Register
+              && outputs.contains(&cell)
+              && (dependency.kind == ReactiveDependencyKind::Sampled
+                || *kind == ReactiveDependencyKind::Sampled) => {}
           Some(_) => {
             return Err(MechError::new(
               ReactiveDependencyKindConflictError {
@@ -614,14 +629,12 @@ impl ReactivePlan {
       }
     }
 
-    let outputs = function.reactive_output_cell_ids();
-
     let node = ReactivePlanNode {
       id: node_id,
       plan_index,
       inputs,
       outputs,
-      kind: function.reactive_node_kind(),
+      kind: node_kind,
       function,
     };
 
@@ -1008,6 +1021,85 @@ mod reactive_plan_tests {
     let reference = Ref::new(value);
     let cell = ReactiveCellId::new(reference.id());
     (Value::F64(reference), cell)
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn register_node_indexes_output_as_sampled_state() {
+    let (output, output_cell) = scalar(1.0);
+    let mut plan = ReactivePlan::new();
+    let node_id = plan.register(Box::new(TestFunction::with_output("register", output).with_node_kind(ReactiveNodeKind::Register)), &[]).unwrap();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.kind, ReactiveNodeKind::Register);
+    assert_eq!(node.outputs, vec![output_cell]);
+    assert_eq!(node.inputs, vec![ReactiveDependency { cell: output_cell, kind: ReactiveDependencyKind::Sampled }]);
+    assert_eq!(plan.sampled_consumers_for(output_cell), &[node_id]);
+    assert!(plan.reactive_consumers_for(output_cell).is_empty());
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn register_node_keeps_source_dependency_reactive() {
+    let (output, output_cell) = scalar(1.0);
+    let (source, source_cell) = scalar(2.0);
+    let mut plan = ReactivePlan::new();
+    let node_id = plan.register(Box::new(TestFunction::with_output("register", output).with_node_kind(ReactiveNodeKind::Register)), &[source]).unwrap();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.inputs, vec![
+      ReactiveDependency { cell: output_cell, kind: ReactiveDependencyKind::Sampled },
+      ReactiveDependency { cell: source_cell, kind: ReactiveDependencyKind::Reactive },
+    ]);
+    assert_eq!(plan.sampled_consumers_for(output_cell), &[node_id]);
+    assert_eq!(plan.reactive_consumers_for(source_cell), &[node_id]);
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn register_node_coalesces_output_operand_alias_to_sampled() {
+    let (output, output_cell) = scalar(1.0);
+    let mut plan = ReactivePlan::new();
+    let node_id = plan.register(Box::new(TestFunction::with_output("register", output.clone()).with_node_kind(ReactiveNodeKind::Register)), &[output]).unwrap();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.inputs, vec![ReactiveDependency { cell: output_cell, kind: ReactiveDependencyKind::Sampled }]);
+    assert!(plan.reactive_consumers_for(output_cell).is_empty());
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn register_node_has_no_reactive_self_consumer() {
+    let (output, output_cell) = scalar(1.0);
+    let (source, _) = scalar(2.0);
+    let mut plan = ReactivePlan::new();
+    let node_id = plan.register(Box::new(TestFunction::with_output("register", output).with_node_kind(ReactiveNodeKind::Register)), &[source]).unwrap();
+    assert!(!plan.reactive_consumers_for(output_cell).contains(&node_id));
+    assert!(plan.sampled_consumers_for(output_cell).contains(&node_id));
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn register_node_preserves_dependency_order() {
+    let (output, output_cell) = scalar(1.0);
+    let (first, first_cell) = scalar(2.0);
+    let (second, second_cell) = scalar(3.0);
+    let mut plan = ReactivePlan::new();
+    let node_id = plan.register(Box::new(TestFunction::with_output("register", output).with_node_kind(ReactiveNodeKind::Register)), &[first, second]).unwrap();
+    assert_eq!(plan.node(node_id).unwrap().inputs, vec![
+      ReactiveDependency { cell: output_cell, kind: ReactiveDependencyKind::Sampled },
+      ReactiveDependency { cell: first_cell, kind: ReactiveDependencyKind::Reactive },
+      ReactiveDependency { cell: second_cell, kind: ReactiveDependencyKind::Reactive },
+    ]);
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn register_node_validation_failure_does_not_mutate_plan() {
+    let (output, _) = scalar(1.0);
+    let (source, _) = scalar(2.0);
+    let mut plan = ReactivePlan::new();
+    assert!(plan.register(Box::new(TestFunction::with_output("register", output).with_node_kind(ReactiveNodeKind::Register).with_dependency_kinds(Some(vec![]))), &[source]).is_err());
+    assert!(plan.nodes.is_empty());
+    assert!(plan.reactive_consumers.is_empty());
+    assert!(plan.sampled_consumers.is_empty());
   }
 
   #[cfg(feature = "f64")]

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -200,16 +200,31 @@ pub fn execute_native_function_compiler(
   }
 }
 
+pub fn execute_initialized_indexed_compiler_with_registration_arguments(
+  plan: &Plan,
+  compiler: &dyn NativeFunctionCompiler,
+  compile_arguments: Vec<Value>,
+  registration_arguments: Vec<Value>,
+) -> MResult<Value> {
+  let function = compiler.compile(&compile_arguments)?;
+  function.solve_result()?;
+  let output = function.out();
+  plan.register_function(function, &registration_arguments)?;
+  Ok(output)
+}
+
 pub(crate) fn execute_initialized_indexed_compiler(
   plan: &Plan,
   compiler: &dyn NativeFunctionCompiler,
   arguments: Vec<Value>,
 ) -> MResult<Value> {
-  let function = compiler.compile(&arguments)?;
-  function.solve();
-  let output = function.out();
-  plan.register_function(function, &arguments)?;
-  Ok(output)
+  let registration_arguments = arguments.clone();
+  execute_initialized_indexed_compiler_with_registration_arguments(
+    plan,
+    compiler,
+    arguments,
+    registration_arguments,
+  )
 }
 
 // Executes a user-defined function. Handles argument count validation,

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -1064,3 +1064,210 @@ mod variable_define_dependency_tests {
     assert!(node.outputs.contains(&value_cell));
   }
 }
+
+#[cfg(all(
+  test,
+  feature = "functions",
+  feature = "variables",
+  feature = "variable_define",
+  feature = "variable_assign",
+  feature = "assign",
+  feature = "f64",
+  feature = "program",
+  feature = "compiler",
+))]
+mod whole_assignment_register_tests {
+  use super::*;
+
+  fn symbol(interpreter: &Interpreter, name: &str) -> Value {
+    interpreter.symbols().borrow().get(hash_str(name))
+      .unwrap_or_else(|| panic!("missing symbol {name}"))
+      .borrow()
+      .clone()
+  }
+
+  fn root_cell(value: &Value) -> ReactiveCellId {
+    let cells = value.reactive_root_cell_ids();
+    assert_eq!(cells.len(), 1);
+    cells[0]
+  }
+
+  fn register_node_id_for_output(interpreter: &Interpreter, output_cell: ReactiveCellId) -> ReactiveNodeId {
+    let plan = interpreter.plan();
+    let plan = plan.borrow();
+    let node_ids = plan.nodes.iter()
+      .filter(|node| node.kind == ReactiveNodeKind::Register && node.outputs == vec![output_cell])
+      .map(|node| node.id)
+      .collect::<Vec<_>>();
+    assert_eq!(node_ids.len(), 1);
+    node_ids[0]
+  }
+
+  #[derive(Debug, PartialEq, Eq)]
+  struct RegisterGraphShape {
+    output_count: usize,
+    input_kinds: Vec<ReactiveDependencyKind>,
+    output_is_first_input: bool,
+    source_is_second_input: bool,
+    output_is_sampled_consumer: bool,
+    output_is_reactive_consumer: bool,
+    source_is_reactive_consumer: bool,
+    source_is_sampled_consumer: bool,
+  }
+
+  fn distinct_assignment_graph_shape(interpreter: &Interpreter, target_name: &str, source_name: &str) -> RegisterGraphShape {
+    let target_cell = root_cell(&symbol(interpreter, target_name));
+    let source_cell = root_cell(&symbol(interpreter, source_name));
+    assert_ne!(target_cell, source_cell);
+    let node_id = register_node_id_for_output(interpreter, target_cell);
+    let plan = interpreter.plan();
+    let plan = plan.borrow();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.kind, ReactiveNodeKind::Register);
+    assert_eq!(node.outputs, vec![target_cell]);
+    assert_eq!(node.inputs.len(), 2);
+    assert_eq!(node.inputs[0].cell, target_cell);
+    assert_eq!(node.inputs[0].kind, ReactiveDependencyKind::Sampled);
+    assert_eq!(node.inputs[1].cell, source_cell);
+    assert_eq!(node.inputs[1].kind, ReactiveDependencyKind::Reactive);
+    RegisterGraphShape {
+      output_count: node.outputs.len(),
+      input_kinds: node.inputs.iter().map(|input| input.kind).collect(),
+      output_is_first_input: node.inputs[0].cell == target_cell,
+      source_is_second_input: node.inputs[1].cell == source_cell,
+      output_is_sampled_consumer: plan.sampled_consumers_for(target_cell).contains(&node_id),
+      output_is_reactive_consumer: plan.reactive_consumers_for(target_cell).contains(&node_id),
+      source_is_reactive_consumer: plan.reactive_consumers_for(source_cell).contains(&node_id),
+      source_is_sampled_consumer: plan.sampled_consumers_for(source_cell).contains(&node_id),
+    }
+  }
+
+  fn expected_distinct_assignment_shape() -> RegisterGraphShape {
+    RegisterGraphShape {
+      output_count: 1,
+      input_kinds: vec![ReactiveDependencyKind::Sampled, ReactiveDependencyKind::Reactive],
+      output_is_first_input: true,
+      source_is_second_input: true,
+      output_is_sampled_consumer: true,
+      output_is_reactive_consumer: false,
+      source_is_reactive_consumer: true,
+      source_is_sampled_consumer: false,
+    }
+  }
+
+  #[test]
+  fn whole_variable_assignment_registers_state_node() {
+    let source = "~x := 1.0; y := 2.0; x = y; x";
+    let tree = mech_syntax::parser::parse(source).unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+    assert_eq!(*output.as_f64().unwrap().borrow(), 2.0);
+    assert_eq!(distinct_assignment_graph_shape(&interpreter, "x", "y"), expected_distinct_assignment_shape());
+  }
+
+  #[cfg(feature = "math_add_assign")]
+  #[test]
+  fn whole_add_assignment_registers_state_node() {
+    let source = "~x := 1.0; y := 2.0; x += y; x";
+    let tree = mech_syntax::parser::parse(source).unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+    assert_eq!(*output.as_f64().unwrap().borrow(), 3.0);
+    assert_eq!(distinct_assignment_graph_shape(&interpreter, "x", "y"), expected_distinct_assignment_shape());
+  }
+
+  #[cfg(feature = "math_add_assign")]
+  #[test]
+  fn whole_add_assignment_alias_is_sampled_once() {
+    let source = "~x := 2.0; x += x; x";
+    let tree = mech_syntax::parser::parse(source).unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+    assert_eq!(*output.as_f64().unwrap().borrow(), 4.0);
+    let x_cell = root_cell(&symbol(&interpreter, "x"));
+    let node_id = register_node_id_for_output(&interpreter, x_cell);
+    let plan = interpreter.plan();
+    let plan = plan.borrow();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.kind, ReactiveNodeKind::Register);
+    assert_eq!(node.outputs, vec![x_cell]);
+    assert_eq!(node.inputs.len(), 1);
+    assert_eq!(node.inputs[0].cell, x_cell);
+    assert_eq!(node.inputs[0].kind, ReactiveDependencyKind::Sampled);
+    assert!(plan.sampled_consumers_for(x_cell).contains(&node_id));
+    assert!(!plan.reactive_consumers_for(x_cell).contains(&node_id));
+  }
+
+  #[test]
+  fn decoded_whole_variable_assignment_matches_source_graph() {
+    let source = "~x := 1.0; y := 2.0; x = y; x";
+    let tree = mech_syntax::parser::parse(source).unwrap();
+    let mut source_interpreter = Interpreter::new_with_full_stdlib(0);
+    let source_output = source_interpreter.interpret(&tree).unwrap();
+    assert_eq!(*source_output.as_f64().unwrap().borrow(), 2.0);
+    let source_shape = distinct_assignment_graph_shape(&source_interpreter, "x", "y");
+    let bytecode = source_interpreter.compile().unwrap();
+    let program = ParsedProgram::from_bytes(&bytecode).unwrap();
+    let mut decoded_interpreter = Interpreter::new_with_full_stdlib(0);
+    let decoded_output = decoded_interpreter.run_program(&program).unwrap();
+    assert_eq!(*decoded_output.as_f64().unwrap().borrow(), 2.0);
+    let decoded_shape = distinct_assignment_graph_shape(&decoded_interpreter, "x", "y");
+    assert_eq!(source_shape, expected_distinct_assignment_shape());
+    assert_eq!(decoded_shape, expected_distinct_assignment_shape());
+    assert_eq!(source_shape, decoded_shape);
+  }
+
+  #[cfg(feature = "math_add_assign")]
+  #[test]
+  fn decoded_whole_add_assignment_matches_source_graph() {
+    let source = "~x := 1.0; y := 2.0; x += y; x";
+    let tree = mech_syntax::parser::parse(source).unwrap();
+    let mut source_interpreter = Interpreter::new_with_full_stdlib(0);
+    let source_output = source_interpreter.interpret(&tree).unwrap();
+    assert_eq!(*source_output.as_f64().unwrap().borrow(), 3.0);
+    let source_shape = distinct_assignment_graph_shape(&source_interpreter, "x", "y");
+    let bytecode = source_interpreter.compile().unwrap();
+    let program = ParsedProgram::from_bytes(&bytecode).unwrap();
+    let mut decoded_interpreter = Interpreter::new_with_full_stdlib(0);
+    let decoded_output = decoded_interpreter.run_program(&program).unwrap();
+    assert_eq!(*decoded_output.as_f64().unwrap().borrow(), 3.0);
+    let decoded_shape = distinct_assignment_graph_shape(&decoded_interpreter, "x", "y");
+    assert_eq!(source_shape, expected_distinct_assignment_shape());
+    assert_eq!(decoded_shape, expected_distinct_assignment_shape());
+    assert_eq!(source_shape, decoded_shape);
+  }
+
+  #[cfg(all(feature = "matrix", feature = "row_vectord"))]
+  #[test]
+  fn whole_matrix_assignment_uses_root_cells() {
+    let source = "~x := [1.0 2.0]; y := [3.0 4.0]; x = y; x";
+    let tree = mech_syntax::parser::parse(source).unwrap();
+    let mut interpreter = Interpreter::new_with_full_stdlib(0);
+    let output = interpreter.interpret(&tree).unwrap();
+    let x = symbol(&interpreter, "x");
+    let y = symbol(&interpreter, "y");
+    let x_root_cells = x.reactive_root_cell_ids();
+    let y_root_cells = y.reactive_root_cell_ids();
+    assert_eq!(x_root_cells.len(), 1);
+    assert_eq!(y_root_cells.len(), 1);
+    let x_cell = x_root_cells[0];
+    let y_cell = y_root_cells[0];
+    let node_id = register_node_id_for_output(&interpreter, x_cell);
+    let plan = interpreter.plan();
+    let plan = plan.borrow();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.kind, ReactiveNodeKind::Register);
+    assert_eq!(node.outputs, vec![x_cell]);
+    assert_eq!(node.outputs.len(), 1);
+    assert_eq!(node.inputs.len(), 2);
+    assert_eq!(node.inputs[0].cell, x_cell);
+    assert_eq!(node.inputs[0].kind, ReactiveDependencyKind::Sampled);
+    assert_eq!(node.inputs[1].cell, y_cell);
+    assert_eq!(node.inputs[1].kind, ReactiveDependencyKind::Reactive);
+    assert!(plan.sampled_consumers_for(x_cell).contains(&node_id));
+    assert!(!plan.reactive_consumers_for(x_cell).contains(&node_id));
+    assert!(plan.reactive_consumers_for(y_cell).contains(&node_id));
+    assert!(!plan.sampled_consumers_for(y_cell).contains(&node_id));
+    assert_eq!(output, y);
+  }
+}

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -110,6 +110,16 @@ pub fn tuple_destructure(tpl_dstrct: &TupleDestructure, p: &Interpreter) -> MRes
   Ok(source)
 }
 
+fn assignment_registration_operand(value: &Value) -> Value {
+  match value {
+    Value::MutableReference(reference) => {
+      let inner = reference.borrow();
+      assignment_registration_operand(&inner)
+    }
+    _ => value.clone(),
+  }
+}
+
 #[cfg(feature = "math")]
 pub fn op_assign(op_assgn: &OpAssign, env: Option<&Environment>, p: &Interpreter) -> MResult<Value> {
   let mut source = expression(&op_assgn.expression, env, p)?;
@@ -158,8 +168,9 @@ pub fn op_assign(op_assgn: &OpAssign, env: Option<&Environment>, p: &Interpreter
     }
     None => {
       let plan = p.plan();
-      let compile_arguments = vec![sink, source.clone()];
-      let registration_arguments = vec![source];
+      let registration_source = assignment_registration_operand(&source);
+      let compile_arguments = vec![sink, source];
+      let registration_arguments = vec![registration_source];
       return match op_assgn.op {
         #[cfg(feature = "math_add_assign")]
         OpAssignOp::Add => execute_initialized_indexed_compiler_with_registration_arguments(&plan, &AddAssignValue{}, compile_arguments, registration_arguments),
@@ -217,11 +228,12 @@ pub fn variable_assign(var_assgn: &VariableAssign, env: Option<&Environment>, p:
     #[cfg(feature = "assign")]
     None => {
       let plan = p.plan();
+      let registration_source = assignment_registration_operand(&source);
       return execute_initialized_indexed_compiler_with_registration_arguments(
         &plan,
         &AssignValue{},
-        vec![sink, source.clone()],
-        vec![source],
+        vec![sink, source],
+        vec![registration_source],
       );
     }
     _ => return Err(MechError::new(
@@ -1268,6 +1280,10 @@ mod whole_assignment_register_tests {
     assert!(!plan.reactive_consumers_for(x_cell).contains(&node_id));
     assert!(plan.reactive_consumers_for(y_cell).contains(&node_id));
     assert!(!plan.sampled_consumers_for(y_cell).contains(&node_id));
-    assert_eq!(output, y);
+    let resolved_output = match output {
+      Value::MutableReference(reference) => reference.borrow().clone(),
+      other => other,
+    };
+    assert_eq!(resolved_output, y);
   }
 }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -1154,6 +1154,37 @@ mod whole_assignment_register_tests {
     }
   }
 
+  fn decoded_assignment_graph_shape(interpreter: &Interpreter, output: &Value) -> RegisterGraphShape {
+    let resolved_output = match output {
+      Value::MutableReference(reference) => reference.borrow().clone(),
+      other => other.clone(),
+    };
+    let output_cell = root_cell(&resolved_output);
+    let node_id = register_node_id_for_output(interpreter, output_cell);
+    let plan = interpreter.plan();
+    let plan = plan.borrow();
+    let node = plan.node(node_id).unwrap();
+    assert_eq!(node.kind, ReactiveNodeKind::Register);
+    assert_eq!(node.outputs, vec![output_cell]);
+    assert_eq!(node.outputs.len(), 1);
+    assert_eq!(node.inputs.len(), 2);
+    assert_eq!(node.inputs[0].cell, output_cell);
+    assert_eq!(node.inputs[0].kind, ReactiveDependencyKind::Sampled);
+    assert_ne!(node.inputs[1].cell, output_cell);
+    assert_eq!(node.inputs[1].kind, ReactiveDependencyKind::Reactive);
+    let source_cell = node.inputs[1].cell;
+    RegisterGraphShape {
+      output_count: node.outputs.len(),
+      input_kinds: node.inputs.iter().map(|input| input.kind).collect(),
+      output_is_first_input: node.inputs[0].cell == output_cell,
+      source_is_second_input: node.inputs[1].cell == source_cell,
+      output_is_sampled_consumer: plan.sampled_consumers_for(output_cell).contains(&node_id),
+      output_is_reactive_consumer: plan.reactive_consumers_for(output_cell).contains(&node_id),
+      source_is_reactive_consumer: plan.reactive_consumers_for(source_cell).contains(&node_id),
+      source_is_sampled_consumer: plan.sampled_consumers_for(source_cell).contains(&node_id),
+    }
+  }
+
   fn expected_distinct_assignment_shape() -> RegisterGraphShape {
     RegisterGraphShape {
       output_count: 1,
@@ -1223,7 +1254,7 @@ mod whole_assignment_register_tests {
     let mut decoded_interpreter = Interpreter::new_with_full_stdlib(0);
     let decoded_output = decoded_interpreter.run_program(&program).unwrap();
     assert_eq!(*decoded_output.as_f64().unwrap().borrow(), 2.0);
-    let decoded_shape = distinct_assignment_graph_shape(&decoded_interpreter, "x", "y");
+    let decoded_shape = decoded_assignment_graph_shape(&decoded_interpreter, &decoded_output);
     assert_eq!(source_shape, expected_distinct_assignment_shape());
     assert_eq!(decoded_shape, expected_distinct_assignment_shape());
     assert_eq!(source_shape, decoded_shape);
@@ -1243,7 +1274,7 @@ mod whole_assignment_register_tests {
     let mut decoded_interpreter = Interpreter::new_with_full_stdlib(0);
     let decoded_output = decoded_interpreter.run_program(&program).unwrap();
     assert_eq!(*decoded_output.as_f64().unwrap().borrow(), 3.0);
-    let decoded_shape = distinct_assignment_graph_shape(&decoded_interpreter, "x", "y");
+    let decoded_shape = decoded_assignment_graph_shape(&decoded_interpreter, &decoded_output);
     assert_eq!(source_shape, expected_distinct_assignment_shape());
     assert_eq!(decoded_shape, expected_distinct_assignment_shape());
     assert_eq!(source_shape, decoded_shape);

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -157,22 +157,20 @@ pub fn op_assign(op_assgn: &OpAssign, env: Option<&Environment>, p: &Interpreter
       }
     }
     None => {
-      let args = vec![sink,source];
-      let fxn: Box<dyn MechFunction> = match op_assgn.op {
+      let plan = p.plan();
+      let compile_arguments = vec![sink, source.clone()];
+      let registration_arguments = vec![source];
+      return match op_assgn.op {
         #[cfg(feature = "math_add_assign")]
-        OpAssignOp::Add => AddAssignValue{}.compile(&args)?,
+        OpAssignOp::Add => execute_initialized_indexed_compiler_with_registration_arguments(&plan, &AddAssignValue{}, compile_arguments, registration_arguments),
         #[cfg(feature = "math_sub_assign")]
-        OpAssignOp::Sub => SubAssignValue{}.compile(&args)?,
+        OpAssignOp::Sub => execute_initialized_indexed_compiler_with_registration_arguments(&plan, &SubAssignValue{}, compile_arguments, registration_arguments),
         #[cfg(feature = "math_div_assign")]
-        OpAssignOp::Div => DivAssignValue{}.compile(&args)?,
+        OpAssignOp::Div => execute_initialized_indexed_compiler_with_registration_arguments(&plan, &DivAssignValue{}, compile_arguments, registration_arguments),
         #[cfg(feature = "math_mul_assign")]
-        OpAssignOp::Mul => MulAssignValue{}.compile(&args)?,
+        OpAssignOp::Mul => execute_initialized_indexed_compiler_with_registration_arguments(&plan, &MulAssignValue{}, compile_arguments, registration_arguments),
         _ => todo!(),
       };
-      fxn.solve();
-      let res = fxn.out();
-      p.state.borrow_mut().add_plan_step(fxn);
-      return Ok(res);
     }
   }
   unreachable!(); // subscript should have thrown an error if we can't access an element
@@ -218,12 +216,13 @@ pub fn variable_assign(var_assgn: &VariableAssign, env: Option<&Environment>, p:
     }
     #[cfg(feature = "assign")]
     None => {
-      let args = vec![sink,source];
-      let fxn = AssignValue{}.compile(&args)?;
-      fxn.solve();
-      let res = fxn.out();
-      p.state.borrow_mut().add_plan_step(fxn);
-      return Ok(res);
+      let plan = p.plan();
+      return execute_initialized_indexed_compiler_with_registration_arguments(
+        &plan,
+        &AssignValue{},
+        vec![sink, source.clone()],
+        vec![source],
+      );
     }
     _ => return Err(MechError::new(
       FeatureNotEnabledError,

--- a/src/interpreter/src/stdlib/assign/mod.rs
+++ b/src/interpreter/src/stdlib/assign/mod.rs
@@ -34,6 +34,42 @@ struct Assign<T> {
   sink: Ref<T>,
   source: Ref<T>,
 }
+impl<T> MechFunctionFactory for Assign<T>
+where
+  T: Clone
+    + Debug
+    + Sync
+    + Send
+    + 'static
+    + CompileConst
+    + ConstElem
+    + AsValueKind,
+  Ref<T>: ToValue,
+{
+  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+    match args {
+      FunctionArgs::Unary(out, source) => {
+        let sink: Ref<T> = unsafe { out.as_unchecked() }.clone();
+        let source: Ref<T> = unsafe { source.as_unchecked() }.clone();
+
+        Ok(Box::new(Self {
+          sink,
+          source,
+        }))
+      }
+      _ => Err(
+        MechError::new(
+          IncorrectNumberOfArguments {
+            expected: 2,
+            found: args.len(),
+          },
+          None,
+        )
+        .with_compiler_loc(),
+      ),
+    }
+  }
+}
 impl<T> MechFunctionImpl for Assign<T>
 where
   T: Clone + Debug,
@@ -58,6 +94,33 @@ where
   fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
     let name = format!("Assign<{}>", T::as_value_kind());
     compile_unop!(name, self.sink, self.source, ctx, FeatureFlag::Builtin(FeatureKind::Assign) );
+  }
+}
+
+register_fxn_descriptor!(
+  Assign,
+  u8, "u8",
+  u16, "u16",
+  u32, "u32",
+  u64, "u64",
+  u128, "u128",
+  i8, "i8",
+  i16, "i16",
+  i32, "i32",
+  i64, "i64",
+  i128, "i128",
+  f32, "f32",
+  f64, "f64",
+  bool, "bool",
+  String, "string",
+  R64, "r64",
+  C64, "c64",
+);
+
+register_descriptor! {
+  FunctionDescriptor {
+    name: "Assign<index>",
+    ptr: Assign::<usize>::new,
   }
 }
 

--- a/src/interpreter/src/stdlib/assign/mod.rs
+++ b/src/interpreter/src/stdlib/assign/mod.rs
@@ -47,6 +47,7 @@ where
     }
   }
   fn out(&self) -> Value { self.sink.to_value() }
+  fn reactive_node_kind(&self) -> ReactiveNodeKind { ReactiveNodeKind::Register }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
 #[cfg(feature = "compiler")]
@@ -77,6 +78,7 @@ struct AssignEmpty;
 impl MechFunctionImpl for AssignEmpty {
   fn solve(&self) {}
   fn out(&self) -> Value { Value::Empty }
+  fn reactive_node_kind(&self) -> ReactiveNodeKind { ReactiveNodeKind::Register }
   fn to_string(&self) -> String { "AssignEmpty".to_string() }
 }
 #[cfg(feature = "compiler")]


### PR DESCRIPTION
### Motivation

- Represent whole-value mutation as stateful register nodes so assignment semantics can be expressed as sampled previous-state dependencies before a scheduler is introduced.
- Ensure assignments keep previous-state identity as a `Sampled` dependency and avoid creating reactive self-edges when the destination aliases an explicit operand.
- Make source and decoded-bytecode assignment graphs semantically equivalent by deriving sampling behavior from `MechFunction::reactive_node_kind()` and `reactive_output_cell_ids()` at registration time.

### Description

- Core registration: changed `ReactivePlan::register` to compute `node_kind` and `outputs` once, seed register outputs as `Sampled` inputs for `ReactiveNodeKind::Register`, then process explicit argument dependencies with the requested coalescing rules and populate `reactive_consumers` and `sampled_consumers` only after successful registration. (edited `src/core/src/functions.rs`)
- Interpreter helper: added `execute_initialized_indexed_compiler_with_registration_arguments` and refactored `execute_initialized_indexed_compiler` to delegate to it so compile-time arguments can differ from registration-time arguments. (edited `src/interpreter/src/functions.rs`)
- Statement changes: replaced the unsubscripted `=` and whole-value `op_assign` branches to compile with sink/source but register using only the source operand via the new helper. (edited `src/interpreter/src/statements.rs`)
- Function classification: marked plain assignment implementations (`Assign<T>`, `AssignEmpty`) and the three whole-value op-assign macro families as `ReactiveNodeKind::Register` so their registration uses the sampled-output behavior. (edited `src/interpreter/src/stdlib/assign/mod.rs` and `machines/math/src/op_assign/mod.rs`)
- Tests: added focused core register-node tests validating sampled-output indexing, alias coalescing, ordering, non-mutation on validation failure, and absence of reactive self-consumers. (added tests in `src/core/src/functions.rs`)

### Testing

- `cargo test -p mech-core register_node -- --nocapture` → PASS (all six added `register_node_*` tests passed).
- `cargo test -p mech-core` → exercised during development and compilation; core unit tests including the new tests completed in this session (no failing core tests observed).
- `cargo test -p mech-interpreter whole_variable_assignment_registers_state_node -- --nocapture` → NOT COMPLETED due to Cargo artifact-directory lock in this execution environment (the interpreter-suite runs were blocked waiting on the Cargo file lock and did not complete in-session).
- `cargo test -p mech-interpreter whole_add_assignment_registers_state_node -- --nocapture` → NOT RUN (blocked by the same Cargo artifact-directory lock).
- `cargo test -p mech-interpreter whole_add_assignment_alias_is_sampled_once -- --nocapture` → NOT RUN (blocked by the same Cargo artifact-directory lock).
- `cargo test -p mech-interpreter decoded_whole_variable_assignment_matches_source_graph -- --nocapture` → NOT RUN (blocked by the same Cargo artifact-directory lock).
- `cargo test -p mech-interpreter decoded_whole_add_assignment_matches_source_graph -- --nocapture` → NOT RUN (blocked by the same Cargo artifact-directory lock).
- `cargo test -p mech-interpreter whole_matrix_assignment_uses_root_cells -- --nocapture` → NOT RUN (blocked by the same Cargo artifact-directory lock); this test is gated by matrix features and was not executed here.
- `cargo test -p mech-interpreter --no-run` → PARTIAL: compilation steps started and succeeded to the point of producing artifacts in this session, but subsequent targeted test runs were blocked by the artifact lock described above.
- `cargo test interpret` and `cargo test bytecode` → NOT RUN in this session due to resource / artifact-lock constraints.
- `cargo check -p mech-program` and `cargo check -p mech-runtime` → NOT RUN in this session.
- `git diff --check` → PASS (no critical diff-check errors for the edited files other than line-ending/trailing-whitespace warnings that were addressed during editing).
- Source checks requested by the change were verified in this session: occurrences of `add_plan_step|plan.borrow_mut().push|.add_function(` were removed from the unsubscripted assignment branches, the `fn reactive_node_kind` additions are present for `Assign` and the three whole-value op-assign macro outputs, and there is exactly one `execute_initialized_indexed_compiler_with_registration_arguments` definition with the intended call sites in `statements.rs` and `functions.rs`.

Notes and environment limitations

- The repository checkout in this execution environment has no `origin` remote configured, so `git push` and the final remote PR creation could not be completed here (local branch and commit were created; commit SHA: `035a8230bf073c8dccd43f77971c57c60547f947`, branch: `index-whole-value-assignment-registers`).
- Several interpreter test commands could not be completed because Cargo was blocked on the artifact directory lock in this session; these tests should be run in CI or a developer workstation to validate interpreter-level and bytecode-parity tests end-to-end.
- No scheduler, runtime execution, commit-phase, or selective execution behavior was added; this change only affects graph construction and classification as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cebd5c634832a9889ce0259449daa)