### PR TITLE
test(compiler): cover pointer register initialization

### DIFF
--- a/src/core/src/program/compiler/context.rs
+++ b/src/core/src/program/compiler/context.rs
@@ -293,3 +293,32 @@ impl MechErrorKind for FinalBufferLengthMismatchError {
     format!("Final buffer length mismatch: expected {}, got {}", self.expected, self.got)
   }
 }
+
+#[cfg(all(test, feature = "compiler"))]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn compile_context_initializes_pointer_register_once() {
+    let mut ctx = CompileCtx::new();
+    let pointer_a = 100usize;
+    let pointer_b = 200usize;
+
+    let (register_a, initializes_a) = ctx.register_for_ptr_with_initialization_status(pointer_a);
+    assert!(initializes_a);
+
+    let (register_a_again, initializes_a_again) = ctx.register_for_ptr_with_initialization_status(pointer_a);
+    assert_eq!(register_a_again, register_a);
+    assert!(!initializes_a_again);
+
+    let (register_b, initializes_b) = ctx.register_for_ptr_with_initialization_status(pointer_b);
+    assert_ne!(register_b, register_a);
+    assert!(initializes_b);
+
+    ctx.clear();
+
+    let (register_a_after_clear, initializes_a_after_clear) = ctx.register_for_ptr_with_initialization_status(pointer_a);
+    assert_eq!(register_a_after_clear, 0);
+    assert!(initializes_a_after_clear);
+  }
+}

--- a/src/core/src/stdlib.rs
+++ b/src/core/src/stdlib.rs
@@ -193,6 +193,33 @@ macro_rules! compile_varop {
   };
 }
 
+#[cfg(all(test, feature = "compiler", feature = "i64"))]
+mod tests {
+  use crate::*;
+
+  #[test]
+  fn pointer_register_scalar_initializes_once() {
+    let mut ctx = CompileCtx::new();
+    let ctx = &mut ctx;
+    let scalar_a = Ref::new(42i64);
+    let scalar_b = Ref::new(42i64);
+
+    let register_a = compile_register_brrw!(scalar_a, ctx);
+    let register_a_again = compile_register_brrw!(scalar_a, ctx);
+    let register_b = compile_register_brrw!(scalar_b, ctx);
+
+    assert_eq!(register_a_again, register_a);
+    assert_ne!(register_b, register_a);
+    assert_eq!(ctx.const_entries.len(), 2);
+
+    let const_loads = ctx.instrs.iter().filter_map(|instruction| match instruction {
+      EncodedInstr::ConstLoad { dst, const_id } => Some((*dst, *const_id)),
+      _ => None,
+    }).collect::<Vec<_>>();
+    assert_eq!(const_loads, vec![(register_a, 0), (register_b, 1)]);
+  }
+}
+
 #[macro_export]
 macro_rules! register_fxn_descriptor_inner_logic {
   // single type

--- a/src/interpreter/src/stdlib/horzcat.rs
+++ b/src/interpreter/src/stdlib/horzcat.rs
@@ -732,6 +732,84 @@ where
 #[cfg(feature = "row_vectord")]
 register_horizontal_concatenate_fxn!(HorizontalConcatenateRDN);
 
+#[cfg(all(test, feature = "compiler", feature = "matrixd", feature = "row_vectord", feature = "i64"))]
+mod compiler_tests {
+  use super::*;
+
+  fn matrix() -> Ref<DMatrix<i64>> {
+    Ref::new(DMatrix::from_vec(1, 1, vec![7i64]))
+  }
+
+  fn assert_single_matrix_load(ctx: &CompileCtx, matrix: &Ref<DMatrix<i64>>) -> Register {
+    let matrix_register = ctx.reg_map[&matrix.addr()];
+    assert_eq!(ctx.instrs.iter().filter(|instruction| matches!(instruction, EncodedInstr::ConstLoad { dst, .. } if *dst == matrix_register)).count(), 1);
+    matrix_register
+  }
+
+  #[test]
+  fn pointer_register_matrix_initializes_once() {
+    let mut ctx = CompileCtx::new();
+    let ctx = &mut ctx;
+    let matrix_a = matrix();
+    let matrix_b = matrix();
+
+    let register_a = compile_register_mat!(matrix_a, ctx);
+    let register_a_again = compile_register_mat!(matrix_a, ctx);
+    let register_b = compile_register_mat!(matrix_b, ctx);
+
+    assert_eq!(register_a_again, register_a);
+    assert_ne!(register_b, register_a);
+    assert_eq!(ctx.const_entries.len(), 2);
+    assert_eq!(ctx.instrs.iter().filter(|instruction| matches!(instruction, EncodedInstr::ConstLoad { dst, .. } if *dst == register_a)).count(), 1);
+    assert_eq!(ctx.instrs.iter().filter(|instruction| matches!(instruction, EncodedInstr::ConstLoad { dst, .. } if *dst == register_b)).count(), 1);
+  }
+
+  #[test]
+  fn horizontal_concatenate_four_args_reuses_repeated_matrix_register() {
+    let matrix = matrix();
+    let function = HorizontalConcatenateFourArgs {
+      e0: Box::new(matrix.clone()), e1: Box::new(matrix.clone()),
+      e2: Box::new(matrix.clone()), e3: Box::new(matrix.clone()),
+      out: Ref::new(DMatrix::from_element(1, 4, 0i64)),
+    };
+    let mut ctx = CompileCtx::new();
+    function.compile(&mut ctx).unwrap();
+
+    let matrix_register = assert_single_matrix_load(&ctx, &matrix);
+    assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::QuadOp { a, b, c, d, .. }) if [*a, *b, *c, *d] == [matrix_register; 4]));
+  }
+
+  #[test]
+  fn horizontal_concatenate_n_args_reuses_repeated_matrix_register() {
+    let matrix = matrix();
+    let function = HorizontalConcatenateNArgs {
+      e0: vec![Box::new(matrix.clone()), Box::new(matrix.clone())],
+      out: Ref::new(DMatrix::from_element(1, 2, 0i64)),
+    };
+    let mut ctx = CompileCtx::new();
+    function.compile(&mut ctx).unwrap();
+
+    let matrix_register = assert_single_matrix_load(&ctx, &matrix);
+    assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::VarArg { args, .. }) if args == &vec![matrix_register, matrix_register]));
+  }
+
+  #[test]
+  fn horizontal_concatenate_rdn_reuses_repeated_matrix_register() {
+    let matrix = matrix();
+    let scalar = Ref::new(9i64);
+    let function = HorizontalConcatenateRDN {
+      matrix: vec![(Box::new(matrix.clone()), 0), (Box::new(matrix.clone()), 1)],
+      scalar: vec![(scalar, 2)],
+      out: Ref::new(RowDVector::from_element(3, 0i64)),
+    };
+    let mut ctx = CompileCtx::new();
+    function.compile(&mut ctx).unwrap();
+
+    let matrix_register = assert_single_matrix_load(&ctx, &matrix);
+    assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::VarArg { args, .. }) if args[0] == matrix_register && args[1] == matrix_register));
+  }
+}
+
 // HorizontalConcatenateS1D ---------------------------------------------------
 
 #[cfg(feature = "matrixd")]

--- a/src/interpreter/src/stdlib/vertcat.rs
+++ b/src/interpreter/src/stdlib/vertcat.rs
@@ -526,6 +526,29 @@ where
 #[cfg(feature = "matrixd")]
 register_vertical_concatenate_fxn!(VerticalConcatenateNArgs);
 
+#[cfg(all(test, feature = "compiler", feature = "matrixd", feature = "i64"))]
+mod compiler_tests {
+  use super::*;
+
+  #[test]
+  fn vertical_concatenate_n_args_reuses_repeated_matrix_register() {
+    let matrix = Ref::new(DMatrix::from_vec(1, 1, vec![7i64]));
+    let out = Ref::new(DMatrix::from_element(2, 1, 0i64));
+    let function = VerticalConcatenateNArgs {
+      e0: vec![Box::new(matrix.clone()), Box::new(matrix.clone())],
+      out,
+    };
+    let mut ctx = CompileCtx::new();
+
+    function.compile(&mut ctx).unwrap();
+
+    let matrix_register = ctx.reg_map[&matrix.addr()];
+    assert_eq!(ctx.const_entries.len(), 2);
+    assert_eq!(ctx.instrs.iter().filter(|instruction| matches!(instruction, EncodedInstr::ConstLoad { dst, .. } if *dst == matrix_register)).count(), 1);
+    assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::VarArg { args, .. }) if args == &vec![matrix_register, matrix_register]));
+  }
+}
+
 // VerticalConcatenateVec -----------------------------------------------------
 
 macro_rules! vertical_concatenate {


### PR DESCRIPTION
### Motivation

- Add focused regression tests to verify CompileCtx pointer-backed register initialization happens only on first use and resets under `clear()`, preserving the compiler identity invariant.
- Ensure the compiler macros `compile_register_brrw!` and `compile_register_mat!` reuse the same register for repeated pointer-backed allocations and emit exactly one `ConstLoad`/constant entry per allocation identity.
- Cover the custom concatenation compilers (vertical/horizontal/mixed variants) to assert repeated matrix allocations reuse a single register and are initialized once.

### Description

- Added `compile_context_initializes_pointer_register_once` in `src/core/src/program/compiler/context.rs` to assert `register_for_ptr_with_initialization_status` reports initialization only on first lookup and that `clear()` resets initialization and register numbering behavior.
- Added `pointer_register_scalar_initializes_once` tests in `src/core/src/stdlib.rs` to exercise `compile_register_brrw!`, checking same-allocation reuse, single `ConstLoad`, and distinct registers for equal-valued distinct allocations.
- Added matrix and concatenation compiler tests in `src/interpreter/src/stdlib/vertcat.rs` and `src/interpreter/src/stdlib/horzcat.rs` to cover `compile_register_mat!` and the custom compiler paths `VerticalConcatenateNArgs`, `HorizontalConcatenateFourArgs`, `HorizontalConcatenateNArgs`, and `HorizontalConcatenateRDN`, asserting a single initialization load and correct emitted operand registers when an allocation is reused.
- No production logic was modified except for adding test-only modules guarded by `#[cfg(all(test, feature = "compiler", ...))]` and a small test fix to pass a mutable `CompileCtx` reference to macros.

### Testing

- Ran `export CARGO_TARGET_DIR=target/codex-pointer-register-coverage; cargo test -p mech-core compile_context_initializes_pointer_register_once -- --nocapture` and the `compile_context_initializes_pointer_register_once` test completed successfully.
- Ran `export CARGO_TARGET_DIR=target/codex-pointer-register-coverage; cargo test -p mech-core pointer_register_scalar_initializes_once -- --nocapture` which initially failed to compile due to the macro requiring a mutable `CompileCtx` binding; after correcting the test to pass `&mut ctx` the scalar test was re-run and passed.
- Started `export CARGO_TARGET_DIR=target/codex-pointer-register-coverage; cargo test -p mech-interpreter pointer_register_matrix_initializes_once -- --nocapture` to validate matrix and concatenation compiler coverage, but the interpreter-focused build was still compiling at the end of the run and the test result did not complete due to the long compilation/artifact lock; no final pass/fail is available for that specific interpreter test in this run.
- `git diff --check` was clean after changes and the modifications were committed as `test(compiler): cover pointer register initialization`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2553b1c0832aa23a0bf6d49806a8)