### PR TITLE
Fix vertical concatenation feature coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,36 @@ jobs:
           cargo test -p mech-interpreter reactive_turn_ -- --nocapture
           cargo test -p mech-interpreter decoded_reactive_turn_ -- --nocapture
 
+          # Pointer-register initialization identity coverage.
+          cargo test \
+            -p mech-core \
+            compile_context_initializes_pointer_register_once \
+            -- --nocapture
+          cargo test \
+            -p mech-core \
+            pointer_register_scalar_initializes_once \
+            -- --nocapture
+          cargo test \
+            -p mech-interpreter \
+            pointer_register_matrix_initializes_once \
+            -- --nocapture
+          cargo test \
+            -p mech-interpreter \
+            horizontal_concatenate_four_args_reuses_repeated_matrix_register \
+            -- --nocapture
+          cargo test \
+            -p mech-interpreter \
+            horizontal_concatenate_n_args_reuses_repeated_matrix_register \
+            -- --nocapture
+          cargo test \
+            -p mech-interpreter \
+            horizontal_concatenate_rdn_reuses_repeated_matrix_register \
+            -- --nocapture
+          cargo test \
+            -p mech-interpreter \
+            vertical_concatenate_n_args_reuses_repeated_matrix_register \
+            -- --nocapture
+
           # Runtime package tests.
           cargo test -p mech-runtime --lib --tests
 

--- a/src/interpreter/src/stdlib/horzcat.rs
+++ b/src/interpreter/src/stdlib/horzcat.rs
@@ -797,6 +797,7 @@ mod compiler_tests {
   fn horizontal_concatenate_rdn_reuses_repeated_matrix_register() {
     let matrix = matrix();
     let scalar = Ref::new(9i64);
+    let scalar_addr = scalar.addr();
     let function = HorizontalConcatenateRDN {
       matrix: vec![(Box::new(matrix.clone()), 0), (Box::new(matrix.clone()), 1)],
       scalar: vec![(scalar, 2)],
@@ -806,7 +807,8 @@ mod compiler_tests {
     function.compile(&mut ctx).unwrap();
 
     let matrix_register = assert_single_matrix_load(&ctx, &matrix);
-    assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::VarArg { args, .. }) if args[0] == matrix_register && args[1] == matrix_register));
+    let scalar_register = ctx.reg_map[&scalar_addr];
+    assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::VarArg { args, .. }) if args == &vec![matrix_register, matrix_register, scalar_register]));
   }
 }
 

--- a/src/interpreter/src/stdlib/vertcat.rs
+++ b/src/interpreter/src/stdlib/vertcat.rs
@@ -514,7 +514,7 @@ where
     for e in &self.e0 {
       mat_regs.push(compile_register_mat!(e, ctx));
     }
-    ctx.features.insert(FeatureFlag::Builtin(FeatureKind::HorzCat));
+    ctx.features.insert(FeatureFlag::Builtin(FeatureKind::VertCat));
     ctx.emit_varop(
       hash_str(&format!("VerticalConcatenateNArgs<{}>", T::as_value_kind())),
       registers[0],
@@ -546,6 +546,8 @@ mod compiler_tests {
     assert_eq!(ctx.const_entries.len(), 2);
     assert_eq!(ctx.instrs.iter().filter(|instruction| matches!(instruction, EncodedInstr::ConstLoad { dst, .. } if *dst == matrix_register)).count(), 1);
     assert!(matches!(ctx.instrs.last(), Some(EncodedInstr::VarArg { args, .. }) if args == &vec![matrix_register, matrix_register]));
+    assert!(ctx.features.contains(&FeatureFlag::Builtin(FeatureKind::VertCat)));
+    assert!(!ctx.features.contains(&FeatureFlag::Builtin(FeatureKind::HorzCat)));
   }
 }
 


### PR DESCRIPTION
### Motivation

- Correct an incorrect compiler feature declaration for the vertical concatenation implementation and strengthen regression coverage to ensure pointer-register identity and argument-ordering are tested.
- Add explicit CI commands so the targeted pointer-register initialization and concatenation regression tests run deterministically in CI.

### Description

- In `VerticalConcatenateNArgs::compile` replace `FeatureFlag::Builtin(FeatureKind::HorzCat)` with `FeatureFlag::Builtin(FeatureKind::VertCat)` while preserving emitted `VarArg`, operation ID, register ordering, output register, and pointer-register initialization behavior.
- Extend `vertical_concatenate_n_args_reuses_repeated_matrix_register` to assert the isolated `CompileCtx` contains `FeatureFlag::Builtin(FeatureKind::VertCat)` and does not contain `FeatureFlag::Builtin(FeatureKind::HorzCat)` while keeping the existing repeated-register, single-`ConstLoad`, and duplicated-argument assertions.
- Update `horizontal_concatenate_rdn_reuses_repeated_matrix_register` to retain the scalar allocation identity, obtain its compiled register, and assert the emitted `VarArg` argument list exactly equals `[matrix_register, matrix_register, scalar_register]` while preserving the single matrix-load assertion and production ordering.
- Add a grouped block of explicit cargo test commands to `.github/workflows/ci.yml` under the comment `Pointer-register initialization identity coverage.` to run the seven targeted pointer-register and concatenation regression tests.

### Testing

- Ran `cargo test -p mech-core compile_context_initializes_pointer_register_once -- --nocapture` and it passed (1 passed, 0 failed).
- Ran `cargo test -p mech-core pointer_register_scalar_initializes_once -- --nocapture` and it passed (1 passed, 0 failed).
- Started `cargo test -p mech-interpreter pointer_register_matrix_initializes_once -- --nocapture` but the interpreter package build/tests were still compiling when the task ended and produced no test result locally.
- The remaining interpreter-focused tests in the sequential local run (`horizontal_concatenate_four_args_reuses_repeated_matrix_register`, `horizontal_concatenate_n_args_reuses_repeated_matrix_register`, `horizontal_concatenate_rdn_reuses_repeated_matrix_register`, `vertical_concatenate_n_args_reuses_repeated_matrix_register`, and `decoded_reactive_turn_reuses_compiled_plan`) were queued and did not complete locally; CI now includes explicit commands to run them.
- `cargo fmt --check` reported repository-wide formatting differences unrelated to this focused patch and made no changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2de91e58832a84afd78a6667de11)