### PR TITLE
Preserve deferred registers after post-commit errors

### DIFF
--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -787,10 +787,19 @@ impl ReactivePlan {
     &mut self,
     dirty_cells: &[ReactiveCellId],
   ) -> MResult<ReactivePlanSolveOutcome> {
+    let mut outcome = ReactivePlanSolveOutcome::default();
+    self.solve_dirty_cells_into(dirty_cells, &mut outcome)?;
+    Ok(outcome)
+  }
+
+  fn solve_dirty_cells_into(
+    &mut self,
+    dirty_cells: &[ReactiveCellId],
+    outcome: &mut ReactivePlanSolveOutcome,
+  ) -> MResult<()> {
     let dirty_cells = dirty_cells.iter().copied().collect::<HashSet<_>>();
     let mut work = BTreeSet::new();
     let mut processed = BTreeSet::new();
-    let mut outcome = ReactivePlanSolveOutcome::default();
 
     for cell in dirty_cells.iter().copied() {
       for node_id in self.reactive_consumers_for(cell) {
@@ -827,7 +836,7 @@ impl ReactivePlan {
       }
     }
 
-    Ok(outcome)
+    Ok(())
   }
 
   pub fn commit_pending_registers(&mut self, pending_nodes: &[ReactiveNodeId]) -> MResult<ReactiveRegisterCommitOutcome> {
@@ -899,10 +908,12 @@ impl ReactivePlan {
       }
     };
     state.pending_register_nodes.clear();
-    let after_commit = self.solve_dirty_cells(&register_commit.dirty_cells)?;
-    pending_register_nodes.clear();
-    pending_register_nodes.extend(after_commit.pending_register_nodes.iter().copied());
-    state.pending_register_nodes = pending_register_nodes;
+    let mut after_commit = ReactivePlanSolveOutcome::default();
+    if let Err(error) = self.solve_dirty_cells_into(&register_commit.dirty_cells, &mut after_commit) {
+      state.pending_register_nodes = after_commit.pending_register_nodes;
+      return Err(error);
+    }
+    state.pending_register_nodes = after_commit.pending_register_nodes.clone();
     Ok(ReactiveTurnOutcome {
       before_commit,
       register_commit,
@@ -1738,6 +1749,37 @@ mod reactive_turn_tests {
   #[test] fn reactive_turn_empty_is_noop() { let mut p=ReactivePlan::new();let mut s=ReactiveTurnState::default();assert_eq!(p.advance_reactive_turn(&mut s,&[]).unwrap(),ReactiveTurnOutcome::default());assert_eq!(s,ReactiveTurnState::default()); }
   #[test] fn reactive_turn_commit_failure_skips_post_commit_propagation() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);let(r,solve,stage,commit)=reg(&mut p,input.clone(),sink.clone(),true);let(_,down)=comb(&mut p,sink.clone(),Ref::new(2.),false);let mut s=ReactiveTurnState::default();let e=p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(e.kind_message().contains("stage failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow(),*down.borrow(),*sink.borrow()),(0,1,0,0,1.));assert_eq!(s.pending_register_nodes,vec![r]); }
   #[test] fn reactive_turn_post_commit_failure_does_not_requeue_committed_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);let(_,_,_,commit)=reg(&mut p,input.clone(),sink.clone(),false);let(_,down)=comb(&mut p,sink.clone(),Ref::new(2.),true);*input.borrow_mut()=10.;let mut s=ReactiveTurnState::default();assert!(p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).is_err());assert_eq!((*sink.borrow(),*commit.borrow(),*down.borrow()),(10.,1,1));assert!(s.pending_register_nodes.is_empty()); }
+  #[test]
+  fn reactive_turn_post_commit_failure_preserves_deferred_registers() {
+    let mut p = ReactivePlan::new();
+    let input = Ref::new(1.);
+    let a = Ref::new(1.);
+    let middle = Ref::new(2.);
+    let b = Ref::new(2.);
+    let (a_register, _, _, a_commits) = reg(&mut p, input.clone(), a.clone(), false);
+    let (_, middle_solves) = comb(&mut p, a.clone(), middle.clone(), false);
+    let (b_register, _, _, b_commits) = reg(&mut p, middle.clone(), b.clone(), false);
+    let (_, error_solves) = comb(&mut p, middle.clone(), Ref::new(0.), true);
+
+    *input.borrow_mut() = 10.;
+    let mut state = ReactiveTurnState::default();
+    let error = p
+      .advance_reactive_turn(&mut state, &input.to_value().reactive_root_cell_ids())
+      .unwrap_err();
+
+    assert!(error.kind_message().contains("solve failure"));
+    assert_eq!((*a.borrow(), *middle.borrow(), *b.borrow()), (10., 11., 2.));
+    assert_eq!((*a_commits.borrow(), *b_commits.borrow()), (1, 0));
+    assert_eq!((*middle_solves.borrow(), *error_solves.borrow()), (1, 1));
+    assert_eq!(state.pending_register_nodes, vec![b_register]);
+    assert!(!state.pending_register_nodes.contains(&a_register));
+
+    let retry = p.advance_reactive_turn(&mut state, &[]).unwrap();
+    assert_eq!(retry.register_commit.committed_nodes, vec![b_register]);
+    assert_eq!((*a_commits.borrow(), *b_commits.borrow()), (1, 1));
+    assert_eq!(*b.borrow(), 11.);
+    assert!(state.pending_register_nodes.is_empty());
+  }
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
 }


### PR DESCRIPTION
### Motivation
- Fix a bug where downstream register nodes discovered during post-commit propagation were lost if a later combinational node returned an error, preventing those registers from committing on the next turn.
- Maintain the public solver and turn APIs while enabling callers to preserve partial post-commit outcomes so only newly discovered downstream registers after a commit are carried forward.

### Description
- Add a private helper `fn solve_dirty_cells_into(&mut self, dirty_cells: &[ReactiveCellId], outcome: &mut ReactivePlanSolveOutcome) -> MResult<()>` and refactor traversal into it while keeping the public `pub fn solve_dirty_cells(&mut self, dirty_cells: &[ReactiveCellId]) -> MResult<ReactivePlanSolveOutcome>` signature unchanged.
- The helper preserves the existing deterministic `BTreeSet` work ordering, processed-node semantics, register-boundary behavior, and appends to the provided `outcome` so partial results remain available on error.
- Update `advance_reactive_turn` to create a dedicated `after_commit` outcome and call `solve_dirty_cells_into` for post-commit propagation; on propagation error copy only `after_commit.pending_register_nodes` into `ReactiveTurnState` and return the original error, and on success copy the full `after_commit.pending_register_nodes` into state.
- Add regression test `reactive_turn_post_commit_failure_preserves_deferred_registers` that constructs `input → register A → combinational middle → register B` with a later combinational consumer of `middle` that errors, ensuring B is discovered before the error and is preserved for the next turn.
- Do not restore or requeue already committed registers and do not change public shapes for `ReactiveTurnState`, `ReactiveTurnOutcome`, or solver/turn public signatures.

### Testing
- Ran the focused regression: `cargo test -p mech-core reactive_turn_post_commit_failure_preserves_deferred_registers -- --nocapture` and it passed (1 passed).
- Ran core reactive tests: `cargo test -p mech-core reactive_turn_ -- --nocapture` and all focused tests passed (11 passed).
- Ran interpreter reactive tests: `cargo test -p mech-interpreter reactive_turn_ -- --nocapture` and `cargo test -p mech-interpreter decoded_reactive_turn_ -- --nocapture` and all focused interpreter tests passed (3 and 1 passed respectively).
- Ran full core test suite: `cargo test -p mech-core` and it completed successfully (87 tests passed).
- Ran `cargo check -p mech-interpreter` and it completed successfully.
- All automated tests listed above passed; no failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e393cb560832ab829124e02e4a7e1)