### PR TITLE
Implement fixed and patterned activation scopes across the live runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,12 @@ jobs:
           cargo test -p mech-interpreter dirty_scheduler_updates_only_reachable_combinational_nodes -- --nocapture
           cargo test -p mech-interpreter dirty_scheduler_stops_at_register_boundary -- --nocapture
 
+          # Patterned activation and transactional rollback coverage.
+          cargo test -p mech-core reactive_plan_rollback_ -- --nocapture
+          cargo test -p mech-core plan_rollback_ -- --nocapture
+          cargo test -p mech-interpreter activation_capture_slot_ -- --nocapture
+          cargo test -p mech-interpreter activation_pattern_ -- --nocapture
+
           # Two-phase register staging and atomic commit coverage.
           cargo test -p mech-core reactive_register_commit_ -- --nocapture
           cargo test -p mech-interpreter register_commit_ -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           rustup toolchain install nightly-2026-03-03 --profile minimal
           rustup default nightly-2026-03-03
 
-      - name: Build and test
+      - name: Check feature boundaries and examples
         run: |
           # Linked-stdlib CLI build for examples that import named modules.
           cargo build --bin mech --features linked_stdlib
@@ -49,168 +49,70 @@ jobs:
           cargo check -p mech-interpreter --no-default-features --features program
           cargo check -p mech-program --no-default-features --features program
 
-          cargo test interpret
-          cargo test bytecode
+      - name: Disk report at end
+        if: always()
+        run: bash scripts/ci-disk-report.sh
 
-          # Whole-value assignment reactive graph coverage.
-          cargo test -p mech-interpreter whole_variable_assignment_registers_state_node -- --nocapture
-          cargo test -p mech-interpreter whole_add_assignment_registers_state_node -- --nocapture
-          cargo test -p mech-interpreter whole_add_assignment_alias_is_sampled_once -- --nocapture
-          cargo test -p mech-interpreter decoded_whole_variable_assignment_matches_source_graph -- --nocapture
-          cargo test -p mech-interpreter decoded_whole_add_assignment_matches_source_graph -- --nocapture
-          cargo test -p mech-interpreter whole_matrix_assignment_uses_root_cells -- --nocapture
+  cargo-language:
+    name: Cargo language tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          # Deterministic dirty-cell scheduler coverage.
-          cargo test -p mech-core reactive_dirty_scheduler_ -- --nocapture
-          cargo test -p mech-interpreter dirty_scheduler_updates_only_reachable_combinational_nodes -- --nocapture
-          cargo test -p mech-interpreter dirty_scheduler_stops_at_register_boundary -- --nocapture
+      - name: Disk report at start
+        run: bash scripts/ci-disk-report.sh
 
-          # Patterned activation and transactional rollback coverage.
-          cargo test -p mech-core reactive_plan_rollback_ -- --nocapture
-          cargo test -p mech-core plan_rollback_ -- --nocapture
-          cargo test -p mech-interpreter activation_capture_slot_ -- --nocapture
-          cargo test -p mech-interpreter activation_pattern_ -- --nocapture
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
 
-          # Two-phase register staging and atomic commit coverage.
-          cargo test -p mech-core reactive_register_commit_ -- --nocapture
-          cargo test -p mech-interpreter register_commit_ -- --nocapture
-          cargo test -p mech-core reactive_turn_ -- --nocapture
-          interpreter_state_tests="$(
-            cargo test \
-              -p mech-interpreter \
-              --lib \
-              reactive_turn_interpreter_state_ \
-              -- --list
-          )"
-          printf '%s\n' "$interpreter_state_tests"
-          for test_name in \
-            reactive_turn_interpreter_state_persists_between_calls \
-            reactive_turn_interpreter_state_clear_plan_resets_pending \
-            reactive_turn_interpreter_state_clone_preserves_pending
-          do
-            if ! grep -Fq "${test_name}: test" <<<"$interpreter_state_tests"; then
-              echo "::error::missing interpreter test ${test_name}"
-              exit 1
-            fi
-          done
-          cargo test \
-            -p mech-interpreter \
-            --lib \
-            reactive_turn_interpreter_state_ \
-            -- --nocapture
-          decoded_symbol_tests="$(
-            cargo test \
-              -p mech-interpreter \
-              --lib \
-              decoded_variable_definition_symbol_metadata_ \
-              -- --list
-          )"
-          printf '%s\n' "$decoded_symbol_tests"
-          if ! grep -Fq "decoded_variable_definition_symbol_metadata_round_trips: test" <<<"$decoded_symbol_tests"
-          then
-            echo "::error::missing decoded variable-definition symbol metadata test"
-            exit 1
-          fi
-          cargo test \
-            -p mech-interpreter \
-            --lib \
-            decoded_variable_definition_symbol_metadata_ \
-            -- --nocapture
-          cargo test -p mech-interpreter reactive_turn_ -- --nocapture
-          cargo test -p mech-interpreter decoded_reactive_turn_ -- --nocapture
-          program_turn_tests="$(
-            cargo test \
-              -p mech-program \
-              --lib \
-              program_reactive_turn_ \
-              -- --list
-          )"
-          printf '%s\n' "$program_turn_tests"
-          for test_name in \
-            program_reactive_turn_updates_only_reachable_branch \
-            program_reactive_turn_batches_inputs_into_one_turn \
-            program_reactive_turn_preserves_deferred_registers_between_calls \
-            program_reactive_turn_legacy_update_api_does_not_execute_plan \
-            program_reactive_turn_preflight_failure_mutates_nothing \
-            program_reactive_turn_rejects_root_alias_duplicate \
-            program_reactive_turn_empty_batch_is_noop \
-            program_reactive_turn_orders_nested_interpreters_deterministically \
-            program_reactive_turn_decoded_plan_reuses_identity
-          do
-            if ! grep -Fq "${test_name}: test" <<<"$program_turn_tests"; then
-              echo "::error::missing program test ${test_name}"
-              exit 1
-            fi
-          done
-          cargo test \
-            -p mech-program \
-            --lib \
-            program_reactive_turn_ \
-            -- --nocapture
+      - name: Run root interpreter and bytecode tests
+        run: |
+          cargo test --test interpreter --test bytecode
+          cargo test --lib bytecode
 
-          # Pointer-register initialization identity coverage.
-          cargo test \
-            -p mech-core \
-            compile_context_initializes_pointer_register_once \
-            -- --nocapture
-          cargo test \
-            -p mech-core \
-            pointer_register_scalar_initializes_once \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            pointer_register_matrix_initializes_once \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_four_args_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_n_args_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_rdn_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            vertical_concatenate_n_args_reuses_repeated_matrix_register \
-            -- --nocapture
+      - name: Run complete core and interpreter suites
+        run: cargo test -p mech-core -p mech-interpreter
 
-          # Runtime package tests.
-          runtime_turn_tests="$(
-            cargo test \
-              -p mech-runtime \
-              --lib \
-              runtime_reactive_host_input_ \
-              -- --list
-          )"
+      - name: Run complete program library suite
+        run: cargo test -p mech-program --lib
 
-          printf '%s\n' "$runtime_turn_tests"
+      - name: Disk report at end
+        if: always()
+        run: bash scripts/ci-disk-report.sh
 
-          for test_name in \
-            runtime_reactive_host_input_batches_bound_updates_into_one_turn \
-            runtime_reactive_host_input_executes_only_reachable_branch \
-            runtime_reactive_host_input_preserves_deferred_registers_across_packets \
-            runtime_reactive_host_input_unbound_packet_does_not_advance_pending_registers \
-            runtime_reactive_host_input_preflight_failure_mutates_nothing \
-            runtime_reactive_host_input_turn_failure_preserves_admitted_inputs
-          do
-            grep -Fq \
-              "${test_name}: test" \
-              <<<"$runtime_turn_tests" \
-              || {
-                echo \
-                  "::error::missing runtime reactive host-input test ${test_name}"
-                exit 1
-              }
-          done
+  cargo-runtime:
+    name: Cargo runtime and host tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          # The complete runtime suite executes the six guarded tests.
-          cargo test -p mech-runtime --lib --tests
+      - name: Disk report at start
+        run: bash scripts/ci-disk-report.sh
 
-          # CLI host and context-send regression coverage.
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
+
+      - name: Run complete runtime suite
+        run: cargo test -p mech-runtime --lib --tests
+
+      - name: Run CLI host and context-send regression coverage
+        run: |
           cargo test -p mech-syntax --test context_parser
           cargo test -p mech-host-cli --features provider --test provider
           cargo test --features "run repl pretty_print" --test mech_cli_host
@@ -220,10 +122,6 @@ jobs:
 
       - name: Disk report at end
         if: always()
-        run: bash scripts/ci-disk-report.sh
-
-      - name: Disk report on failure
-        if: failure()
         run: bash scripts/ci-disk-report.sh
 
   project-native:

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -161,7 +161,7 @@ fn mech_code_contains_context_addressed_source(code: &MechCode) -> bool {
     match code {
         MechCode::ActivationScope(scope) => {
             expression_contains_context_addressed_source(&scope.trigger)
-                || scope.body.iter().any(|(body_code, _)| mech_code_contains_context_addressed_source(body_code))
+                || activation_body_contains_context_addressed_source(&scope.body)
         }
         MechCode::Import(import) => matches!(import.alias, Some(ModuleImportAlias::Context(_))),
         MechCode::Statement(statement) => statement_contains_context_addressed_source(statement),
@@ -180,6 +180,30 @@ fn mech_code_contains_context_addressed_source(code: &MechCode) -> bool {
         }
         MechCode::FsmImplementation(fsm) => fsm_contains_context_addressed_source(fsm),
         _ => false,
+    }
+}
+
+fn activation_body_contains_context_addressed_source(body: &ActivationBody) -> bool {
+    match body {
+        ActivationBody::Block(codes) => codes
+            .iter()
+            .any(|(code, _)| mech_code_contains_context_addressed_source(code)),
+        ActivationBody::PatternArms(arms) => arms.iter().any(|arm| {
+            pattern_contains_context_addressed_source(&arm.pattern)
+                || arm
+                    .guard
+                    .as_ref()
+                    .map(expression_contains_context_addressed_source)
+                    .unwrap_or(false)
+                || match &arm.body {
+                    ActivationArmBody::Block(codes) => codes
+                        .iter()
+                        .any(|(code, _)| mech_code_contains_context_addressed_source(code)),
+                    ActivationArmBody::Expression(expression) => {
+                        expression_contains_context_addressed_source(expression)
+                    }
+                }
+        }),
     }
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -118,7 +118,8 @@ fn section_element_contains_executable_run_source(element: &SectionElement) -> b
 
 fn mech_code_is_executable_run_source(code: &MechCode) -> bool {
     match code {
-        MechCode::Statement(_)
+        MechCode::ActivationScope(_)
+        | MechCode::Statement(_)
         | MechCode::Expression(_)
         | MechCode::FunctionDefine(_)
         | MechCode::FsmImplementation(_)
@@ -158,6 +159,10 @@ fn section_element_contains_context_addressed_source(element: &SectionElement) -
 
 fn mech_code_contains_context_addressed_source(code: &MechCode) -> bool {
     match code {
+        MechCode::ActivationScope(scope) => {
+            expression_contains_context_addressed_source(&scope.trigger)
+                || scope.body.iter().any(|(body_code, _)| mech_code_contains_context_addressed_source(body_code))
+        }
         MechCode::Import(import) => matches!(import.alias, Some(ModuleImportAlias::Context(_))),
         MechCode::Statement(statement) => statement_contains_context_addressed_source(statement),
         MechCode::Expression(expression) => {

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -940,6 +940,31 @@ impl ReactivePlan {
     self.pattern_activation_registrations.push(registration);
   }
 
+  /// Records an input that is read when another reactive cause schedules the
+  /// node. Updating this cell alone must not schedule the node.
+  pub fn add_sampled_dependency(
+    &mut self,
+    node_id: ReactiveNodeId,
+    cell: ReactiveCellId,
+  ) -> bool {
+    let Some(node) = self.nodes.get_mut(node_id) else {
+      return false;
+    };
+    if let Some(existing) = node.inputs.iter().find(|dependency| dependency.cell == cell) {
+      return existing.kind == ReactiveDependencyKind::Sampled
+        || existing.kind == ReactiveDependencyKind::Reactive;
+    }
+    node.inputs.push(ReactiveDependency {
+      cell,
+      kind: ReactiveDependencyKind::Sampled,
+    });
+    let consumers = self.sampled_consumers.entry(cell).or_default();
+    if !consumers.contains(&node_id) {
+      consumers.push(node_id);
+    }
+    true
+  }
+
   pub fn reactive_consumers_for(&self, cell: ReactiveCellId) -> &[ReactiveNodeId] {
     self.reactive_consumers
       .get(&cell)

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -621,10 +621,32 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct ReactivePlanCheckpoint { node_len:usize, pattern_activation_registration_len:usize }
-#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct PlanCheckpoint { reactive:ReactivePlanCheckpoint, activation_registration_depth:usize }
-#[derive(Debug,Clone)] pub struct ReactivePlanRollbackInvariantError { pub checkpoint_nodes:usize,pub current_nodes:usize,pub checkpoint_registrations:usize,pub current_registrations:usize }
-impl MechErrorKind for ReactivePlanRollbackInvariantError { fn name(&self)->&str{"ReactivePlanRollbackInvariant"} fn message(&self)->String{format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.",self.current_nodes,self.current_registrations,self.checkpoint_nodes,self.checkpoint_registrations)} }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReactivePlanCheckpoint {
+  node_len: usize,
+  pattern_activation_registration_len: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlanCheckpoint {
+  reactive: ReactivePlanCheckpoint,
+  activation_registration_depth: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactivePlanRollbackInvariantError {
+  pub checkpoint_nodes: usize,
+  pub current_nodes: usize,
+  pub checkpoint_registrations: usize,
+  pub current_registrations: usize,
+}
+
+impl MechErrorKind for ReactivePlanRollbackInvariantError {
+  fn name(&self) -> &str { "ReactivePlanRollbackInvariant" }
+  fn message(&self) -> String {
+    format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.", self.current_nodes, self.current_registrations, self.checkpoint_nodes, self.checkpoint_registrations)
+  }
+}
 
 impl ReactivePlan {
   fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -648,10 +648,38 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
   }
 }
 
+#[derive(Debug, Clone)]
+pub struct ActivationRegistrationRollbackInvariantError { pub checkpoint_depth: usize, pub current_depth: usize }
+impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
+  fn name(&self) -> &str { "ActivationRegistrationRollbackInvariant" }
+  fn message(&self) -> String { format!("Cannot roll the activation registration stack back from depth {} to future depth {}.", self.current_depth, self.checkpoint_depth) }
+}
+
 impl ReactivePlan {
-  fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }
-  pub fn checkpoint(&self)->ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len:self.nodes.len(), pattern_activation_registration_len:self.pattern_activation_registrations.len() } }
-  pub fn rollback(&mut self, checkpoint:ReactivePlanCheckpoint)->MResult<()> { if checkpoint.node_len>self.nodes.len()||checkpoint.pattern_activation_registration_len>self.pattern_activation_registrations.len(){return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.node_len,current_nodes:self.nodes.len(),checkpoint_registrations:checkpoint.pattern_activation_registration_len,current_registrations:self.pattern_activation_registrations.len()},None))} self.nodes.truncate(checkpoint.node_len);self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);self.rebuild_consumer_indexes();Ok(()) }
+  fn rebuild_consumer_indexes(&mut self) {
+    self.reactive_consumers.clear();
+    self.sampled_consumers.clear();
+    for node in &self.nodes {
+      for dependency in &node.inputs {
+        let consumers = match dependency.kind { ReactiveDependencyKind::Reactive => &mut self.reactive_consumers, ReactiveDependencyKind::Sampled => &mut self.sampled_consumers };
+        let consumers = consumers.entry(dependency.cell).or_default();
+        if !consumers.contains(&node.id) { consumers.push(node.id); }
+      }
+    }
+  }
+  fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
+    if checkpoint.node_len > self.nodes.len() || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len() {
+      return Err(MechError::new(ReactivePlanRollbackInvariantError { checkpoint_nodes: checkpoint.node_len, current_nodes: self.nodes.len(), checkpoint_registrations: checkpoint.pattern_activation_registration_len, current_registrations: self.pattern_activation_registrations.len() }, None));
+    }
+    Ok(())
+  }
+  fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
+    self.nodes.truncate(checkpoint.node_len);
+    self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);
+    self.rebuild_consumer_indexes();
+  }
+  pub fn checkpoint(&self) -> ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len: self.nodes.len(), pattern_activation_registration_len: self.pattern_activation_registrations.len() } }
+  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> { self.validate_rollback(checkpoint)?; self.apply_rollback(checkpoint); Ok(()) }
 
   pub fn new() -> Self {
     Self {
@@ -1048,9 +1076,15 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
-  pub fn checkpoint(&self)->PlanCheckpoint { PlanCheckpoint { reactive:self.0.borrow().checkpoint(),activation_registration_depth:self.1.borrow().len() } }
-  pub fn rollback(&self, checkpoint:PlanCheckpoint)->MResult<()> { {let mut scopes=self.1.borrow_mut();if checkpoint.activation_registration_depth>scopes.len(){let p=self.0.borrow();return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.reactive.node_len,current_nodes:p.nodes.len(),checkpoint_registrations:checkpoint.reactive.pattern_activation_registration_len,current_registrations:p.pattern_activation_registrations.len()},None))}scopes.truncate(checkpoint.activation_registration_depth);}self.0.borrow_mut().rollback(checkpoint.reactive) }
-  pub fn activation_registration_depth(&self)->usize {self.1.borrow().len()}
+  pub fn checkpoint(&self) -> PlanCheckpoint { PlanCheckpoint { reactive: self.0.borrow().checkpoint(), activation_registration_depth: self.1.borrow().len() } }
+  pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
+    { let reactive = self.0.borrow(); reactive.validate_rollback(checkpoint.reactive)?; }
+    { let scopes = self.1.borrow(); let current_depth = scopes.len(); if checkpoint.activation_registration_depth > current_depth { return Err(MechError::new(ActivationRegistrationRollbackInvariantError { checkpoint_depth: checkpoint.activation_registration_depth, current_depth }, None)); } }
+    self.0.borrow_mut().apply_rollback(checkpoint.reactive);
+    self.1.borrow_mut().truncate(checkpoint.activation_registration_depth);
+    Ok(())
+  }
+  pub fn activation_registration_depth(&self) -> usize { self.1.borrow().len() }
 
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
@@ -1883,6 +1917,32 @@ mod reactive_turn_tests {
   }
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
+
+  #[test]
+  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
+    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
+    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+  }
+  #[test]
+  fn reactive_plan_rollback_truncates_pattern_registrations() {
+    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  }
+  #[test]
+  fn plan_rollback_restores_activation_registration_depth() {
+    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
+  }
+  #[test]
+  fn plan_rollback_invalid_checkpoint_is_atomic() {
+    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
+    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  }
+
 }
 
 // Function Registry

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -649,37 +649,84 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
 }
 
 #[derive(Debug, Clone)]
-pub struct ActivationRegistrationRollbackInvariantError { pub checkpoint_depth: usize, pub current_depth: usize }
+pub struct ActivationRegistrationRollbackInvariantError {
+  pub checkpoint_depth: usize,
+  pub current_depth: usize,
+}
+
 impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
-  fn name(&self) -> &str { "ActivationRegistrationRollbackInvariant" }
-  fn message(&self) -> String { format!("Cannot roll the activation registration stack back from depth {} to future depth {}.", self.current_depth, self.checkpoint_depth) }
+  fn name(&self) -> &str {
+    "ActivationRegistrationRollbackInvariant"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Cannot roll the activation registration stack back from depth {} to future depth {}.",
+      self.current_depth,
+      self.checkpoint_depth,
+    )
+  }
 }
 
 impl ReactivePlan {
   fn rebuild_consumer_indexes(&mut self) {
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
+
     for node in &self.nodes {
       for dependency in &node.inputs {
-        let consumers = match dependency.kind { ReactiveDependencyKind::Reactive => &mut self.reactive_consumers, ReactiveDependencyKind::Sampled => &mut self.sampled_consumers };
+        let consumers = match dependency.kind {
+          ReactiveDependencyKind::Reactive => &mut self.reactive_consumers,
+          ReactiveDependencyKind::Sampled => &mut self.sampled_consumers,
+        };
+
         let consumers = consumers.entry(dependency.cell).or_default();
-        if !consumers.contains(&node.id) { consumers.push(node.id); }
+
+        if !consumers.contains(&node.id) {
+          consumers.push(node.id);
+        }
       }
     }
   }
+
   fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
-    if checkpoint.node_len > self.nodes.len() || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len() {
-      return Err(MechError::new(ReactivePlanRollbackInvariantError { checkpoint_nodes: checkpoint.node_len, current_nodes: self.nodes.len(), checkpoint_registrations: checkpoint.pattern_activation_registration_len, current_registrations: self.pattern_activation_registrations.len() }, None));
+    if checkpoint.node_len > self.nodes.len()
+      || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len()
+    {
+      return Err(MechError::new(
+        ReactivePlanRollbackInvariantError {
+          checkpoint_nodes: checkpoint.node_len,
+          current_nodes: self.nodes.len(),
+          checkpoint_registrations: checkpoint.pattern_activation_registration_len,
+          current_registrations: self.pattern_activation_registrations.len(),
+        },
+        None,
+      ));
     }
+
     Ok(())
   }
+
   fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
     self.nodes.truncate(checkpoint.node_len);
-    self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);
+    self
+      .pattern_activation_registrations
+      .truncate(checkpoint.pattern_activation_registration_len);
     self.rebuild_consumer_indexes();
   }
-  pub fn checkpoint(&self) -> ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len: self.nodes.len(), pattern_activation_registration_len: self.pattern_activation_registrations.len() } }
-  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> { self.validate_rollback(checkpoint)?; self.apply_rollback(checkpoint); Ok(()) }
+
+  pub fn checkpoint(&self) -> ReactivePlanCheckpoint {
+    ReactivePlanCheckpoint {
+      node_len: self.nodes.len(),
+      pattern_activation_registration_len: self.pattern_activation_registrations.len(),
+    }
+  }
+
+  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
+    self.validate_rollback(checkpoint)?;
+    self.apply_rollback(checkpoint);
+    Ok(())
+  }
 
   pub fn new() -> Self {
     Self {
@@ -1076,15 +1123,46 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
-  pub fn checkpoint(&self) -> PlanCheckpoint { PlanCheckpoint { reactive: self.0.borrow().checkpoint(), activation_registration_depth: self.1.borrow().len() } }
+  pub fn checkpoint(&self) -> PlanCheckpoint {
+    PlanCheckpoint {
+      reactive: self.0.borrow().checkpoint(),
+      activation_registration_depth: self.1.borrow().len(),
+    }
+  }
+
   pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
-    { let reactive = self.0.borrow(); reactive.validate_rollback(checkpoint.reactive)?; }
-    { let scopes = self.1.borrow(); let current_depth = scopes.len(); if checkpoint.activation_registration_depth > current_depth { return Err(MechError::new(ActivationRegistrationRollbackInvariantError { checkpoint_depth: checkpoint.activation_registration_depth, current_depth }, None)); } }
+    {
+      let reactive = self.0.borrow();
+      reactive.validate_rollback(checkpoint.reactive)?;
+    }
+
+    {
+      let scopes = self.1.borrow();
+      let current_depth = scopes.len();
+
+      if checkpoint.activation_registration_depth > current_depth {
+        return Err(MechError::new(
+          ActivationRegistrationRollbackInvariantError {
+            checkpoint_depth: checkpoint.activation_registration_depth,
+            current_depth,
+          },
+          None,
+        ));
+      }
+    }
+
     self.0.borrow_mut().apply_rollback(checkpoint.reactive);
-    self.1.borrow_mut().truncate(checkpoint.activation_registration_depth);
+    self
+      .1
+      .borrow_mut()
+      .truncate(checkpoint.activation_registration_depth);
+
     Ok(())
   }
-  pub fn activation_registration_depth(&self) -> usize { self.1.borrow().len() }
+
+  pub fn activation_registration_depth(&self) -> usize {
+    self.1.borrow().len()
+  }
 
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
@@ -1839,6 +1917,30 @@ mod reactive_plan_tests {
   fn reactive_dirty_scheduler_stops_on_error() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,ao,ac)=scheduler_node(&mut p,"A",&[d.clone()],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l.clone(),true);let(_,_,bc)=scheduler_node(&mut p,"B",&[ao],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);let e=p.solve_dirty_cells(&d.reactive_root_cell_ids()).unwrap_err();assert!(e.kind_message().contains("A"));assert_eq!(*ac.borrow(),1);assert_eq!(*bc.borrow(),0); }
   #[cfg(feature = "f64")] #[test]
   fn reactive_dirty_scheduler_empty_dirty_set_is_noop() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,_,c)=scheduler_node(&mut p,"A",&[d],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);assert_eq!(p.solve_dirty_cells(&[]).unwrap(),ReactivePlanSolveOutcome::default());assert_eq!(*c.borrow(),0); }
+  #[test]
+  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
+    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
+    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+  }
+  #[test]
+  fn reactive_plan_rollback_truncates_pattern_registrations() {
+    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  }
+  #[test]
+  fn plan_rollback_restores_activation_registration_depth() {
+    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
+  }
+  #[test]
+  fn plan_rollback_invalid_checkpoint_is_atomic() {
+    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
+    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  }
 }
 
 
@@ -1918,30 +2020,7 @@ mod reactive_turn_tests {
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
 
-  #[test]
-  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
-    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
-    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
-    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
-    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
-  }
-  #[test]
-  fn reactive_plan_rollback_truncates_pattern_registrations() {
-    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
-  }
-  #[test]
-  fn plan_rollback_restores_activation_registration_depth() {
-    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
-  }
-  #[test]
-  fn plan_rollback_invalid_checkpoint_is_atomic() {
-    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
-    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
-    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-  }
+
 
 }
 

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -231,8 +231,25 @@ pub trait MechFunction: MechFunctionImpl {}
 #[cfg(not(feature = "compiler"))]
 impl<T> MechFunction for T where T: MechFunctionImpl {}
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GuardFunctionSafety {
+  /// Compilation constructs only the static graph (including kind and shape
+  /// selection) without executing function behavior or reading live contents;
+  /// reactive solving is deferred to the guard pulse.
+  PureStatic,
+  /// Compilation may execute work or lacks an explicit purity contract.
+  Unsupported,
+}
+
 pub trait NativeFunctionCompiler {
   fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>>;
+
+  /// Whether this compiler can be elaborated into a static activation-guard
+  /// graph without executing eager or effectful work. Native compilers are
+  /// rejected by default and must opt in explicitly.
+  fn guard_safety(&self) -> GuardFunctionSafety {
+    GuardFunctionSafety::Unsupported
+  }
 }
 
 
@@ -247,6 +264,10 @@ impl StaticNativeFunctionCompiler {
 impl NativeFunctionCompiler for StaticNativeFunctionCompiler {
   fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
     self.inner.compile(arguments)
+  }
+
+  fn guard_safety(&self) -> GuardFunctionSafety {
+    self.inner.guard_safety()
   }
 }
 
@@ -1358,6 +1379,27 @@ impl PrettyPrint for Plan {
 mod reactive_plan_tests {
   use super::*;
 
+  struct PureStaticTestCompiler;
+  struct DefaultTestCompiler;
+
+  impl NativeFunctionCompiler for DefaultTestCompiler {
+    fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+      unreachable!("safety metadata test must not compile the function")
+    }
+  }
+
+  impl NativeFunctionCompiler for PureStaticTestCompiler {
+    fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+      unreachable!("safety metadata test must not compile the function")
+    }
+
+    fn guard_safety(&self) -> GuardFunctionSafety {
+      GuardFunctionSafety::PureStatic
+    }
+  }
+
+  static PURE_STATIC_TEST_COMPILER: PureStaticTestCompiler = PureStaticTestCompiler;
+
   struct TestFunction {
     name: &'static str,
     output: Value,
@@ -1445,6 +1487,20 @@ mod reactive_plan_tests {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
       Ok(0)
     }
+  }
+
+  #[test]
+  fn native_compiler_guard_safety_defaults_to_unsupported() {
+    let compiler = DefaultTestCompiler;
+
+    assert_eq!(compiler.guard_safety(), GuardFunctionSafety::Unsupported);
+  }
+
+  #[test]
+  fn static_native_compiler_preserves_guard_safety_metadata() {
+    let compiler = StaticNativeFunctionCompiler::new(&PURE_STATIC_TEST_COMPILER);
+
+    assert_eq!(compiler.guard_safety(), GuardFunctionSafety::PureStatic);
   }
 
   #[test]

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -409,6 +409,29 @@ impl MechFunctionCompiler for UserFunction {
 
 pub type ReactiveNodeId = usize;
 
+/// Read-only registration information for a patterned activation.
+///
+/// This belongs to the plan, rather than to a turn, so consumers can inspect
+/// the statically registered dispatch graph without relying on transient
+/// scheduler state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationRegistration {
+  pub scope_pulse_node: ReactiveNodeId,
+  pub selector_node: ReactiveNodeId,
+  pub arms: Vec<PatternActivationArmRegistration>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationArmRegistration {
+  pub matcher_node: ReactiveNodeId,
+  pub finalizer_node: ReactiveNodeId,
+  pub gate_node: ReactiveNodeId,
+  pub pulse_cell: ReactiveCellId,
+  /// Half-open range of plan nodes registered for this arm's body.
+  pub body_node_start: usize,
+  pub body_node_end: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReactiveDependencyKind {
   Reactive,
@@ -491,6 +514,7 @@ pub struct ReactivePlan {
   pub nodes: Vec<ReactivePlanNode>,
   pub reactive_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pub sampled_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
+  pattern_activation_registrations: Vec<PatternActivationRegistration>,
 }
 
 #[derive(Debug, Clone)]
@@ -594,6 +618,7 @@ impl ReactivePlan {
       nodes: Vec::new(),
       reactive_consumers: HashMap::new(),
       sampled_consumers: HashMap::new(),
+      pattern_activation_registrations: Vec::new(),
     }
   }
 
@@ -609,6 +634,7 @@ impl ReactivePlan {
     self.nodes.clear();
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
+    self.pattern_activation_registrations.clear();
   }
 
   pub fn iter(&self) -> impl Iterator<Item = &Box<dyn MechFunction>> {
@@ -789,6 +815,14 @@ impl ReactivePlan {
 
   pub fn node(&self, node_id: ReactiveNodeId) -> Option<&ReactivePlanNode> {
     self.nodes.get(node_id)
+  }
+
+  pub fn pattern_activation_registrations(&self) -> &[PatternActivationRegistration] {
+    &self.pattern_activation_registrations
+  }
+
+  pub fn register_pattern_activation(&mut self, registration: PatternActivationRegistration) {
+    self.pattern_activation_registrations.push(registration);
   }
 
   pub fn reactive_consumers_for(&self, cell: ReactiveCellId) -> &[ReactiveNodeId] {
@@ -1022,6 +1056,10 @@ impl Plan {
 
   pub fn get_functions(&self) -> std::cell::Ref<'_, ReactivePlan> {
     self.0.borrow()
+  }
+
+  pub fn pattern_activation_registrations(&self) -> std::cell::Ref<'_, Vec<PatternActivationRegistration>> {
+    std::cell::Ref::map(self.0.borrow(), |plan| &plan.pattern_activation_registrations)
   }
 
   pub fn len(&self) -> usize {

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -424,13 +424,27 @@ pub struct PatternActivationRegistration {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PatternActivationArmRegistration {
   pub matcher_node: ReactiveNodeId,
+  /// The structural-only finalizer for an unguarded arm, or the unmatched
+  /// finalization path for a guarded arm.
   pub finalizer_node: ReactiveNodeId,
+  pub guard: Option<PatternActivationGuardRegistration>,
   pub gate_node: ReactiveNodeId,
   pub pulse_cell: ReactiveCellId,
   /// Half-open range of plan nodes registered for this arm's body.
   pub body_node_start: usize,
   pub body_node_end: usize,
   pub captures: Vec<PatternActivationCaptureRegistration>,
+}
+
+/// Static graph information for one guarded patterned-activation arm.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationGuardRegistration {
+  pub match_gate_node: ReactiveNodeId,
+  pub guard_finalizer_node: ReactiveNodeId,
+  /// Half-open range containing the ordinary guard-expression graph followed
+  /// by its guard finalizer.
+  pub guard_node_start: usize,
+  pub guard_node_end: usize,
 }
 
 /// Stable storage made available to a single patterned activation arm.
@@ -959,6 +973,31 @@ impl ReactivePlan {
       kind: ReactiveDependencyKind::Sampled,
     });
     let consumers = self.sampled_consumers.entry(cell).or_default();
+    if !consumers.contains(&node_id) {
+      consumers.push(node_id);
+    }
+    true
+  }
+
+  /// Records a cell that schedules this node. This is also used to repair
+  /// legacy combinational expression nodes that were appended directly while
+  /// an activation-registration scope was active.
+  pub fn add_reactive_dependency(
+    &mut self,
+    node_id: ReactiveNodeId,
+    cell: ReactiveCellId,
+  ) -> bool {
+    let Some(node) = self.nodes.get_mut(node_id) else {
+      return false;
+    };
+    if let Some(existing) = node.inputs.iter().find(|dependency| dependency.cell == cell) {
+      return existing.kind == ReactiveDependencyKind::Reactive;
+    }
+    node.inputs.push(ReactiveDependency {
+      cell,
+      kind: ReactiveDependencyKind::Reactive,
+    });
+    let consumers = self.reactive_consumers.entry(cell).or_default();
     if !consumers.contains(&node_id) {
       consumers.push(node_id);
     }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -1919,10 +1919,23 @@ mod reactive_plan_tests {
   fn reactive_dirty_scheduler_empty_dirty_set_is_noop() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,_,c)=scheduler_node(&mut p,"A",&[d],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);assert_eq!(p.solve_dirty_cells(&[]).unwrap(),ReactivePlanSolveOutcome::default());assert_eq!(*c.borrow(),0); }
   #[test]
   fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
-    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
-    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
-    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
-    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+    let reactive_input = Value::Index(Ref::new(1));
+    let sampled_input = Value::Index(Ref::new(2));
+    let reactive_cell = reactive_input.reactive_root_cell_ids()[0];
+    let sampled_cell = sampled_input.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new();
+    let base = plan.register(Box::new(TestFunction::new("base")), &[reactive_input]).unwrap();
+    let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[sampled_input]).unwrap();
+    plan.rollback(checkpoint).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan.nodes[0].id, base);
+    assert_eq!(plan.nodes[0].plan_index, 0);
+    assert_eq!(plan.nodes[0].inputs, vec![ReactiveDependency { cell: reactive_cell, kind: ReactiveDependencyKind::Reactive }]);
+    assert_eq!(plan.reactive_consumers_for(reactive_cell), &[base]);
+    assert!(plan.sampled_consumers_for(sampled_cell).is_empty());
+    assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail)));
+    assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
   }
   #[test]
   fn reactive_plan_rollback_truncates_pattern_registrations() {
@@ -1938,7 +1951,9 @@ mod reactive_plan_tests {
     let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
     let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
     assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    let valid_reactive_checkpoint = { let reactive_plan = plan.borrow(); reactive_plan.checkpoint() };
+    let invalid_scope_checkpoint = PlanCheckpoint { reactive: valid_reactive_checkpoint, activation_registration_depth: depth_before + 1 };
+    let error = plan.rollback(invalid_scope_checkpoint).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
     assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
   }
 }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -621,7 +621,16 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct ReactivePlanCheckpoint { node_len:usize, pattern_activation_registration_len:usize }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct PlanCheckpoint { reactive:ReactivePlanCheckpoint, activation_registration_depth:usize }
+#[derive(Debug,Clone)] pub struct ReactivePlanRollbackInvariantError { pub checkpoint_nodes:usize,pub current_nodes:usize,pub checkpoint_registrations:usize,pub current_registrations:usize }
+impl MechErrorKind for ReactivePlanRollbackInvariantError { fn name(&self)->&str{"ReactivePlanRollbackInvariant"} fn message(&self)->String{format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.",self.current_nodes,self.current_registrations,self.checkpoint_nodes,self.checkpoint_registrations)} }
+
 impl ReactivePlan {
+  fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }
+  pub fn checkpoint(&self)->ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len:self.nodes.len(), pattern_activation_registration_len:self.pattern_activation_registrations.len() } }
+  pub fn rollback(&mut self, checkpoint:ReactivePlanCheckpoint)->MResult<()> { if checkpoint.node_len>self.nodes.len()||checkpoint.pattern_activation_registration_len>self.pattern_activation_registrations.len(){return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.node_len,current_nodes:self.nodes.len(),checkpoint_registrations:checkpoint.pattern_activation_registration_len,current_registrations:self.pattern_activation_registrations.len()},None))} self.nodes.truncate(checkpoint.node_len);self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);self.rebuild_consumer_indexes();Ok(()) }
+
   pub fn new() -> Self {
     Self {
       nodes: Vec::new(),
@@ -1017,6 +1026,10 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
+  pub fn checkpoint(&self)->PlanCheckpoint { PlanCheckpoint { reactive:self.0.borrow().checkpoint(),activation_registration_depth:self.1.borrow().len() } }
+  pub fn rollback(&self, checkpoint:PlanCheckpoint)->MResult<()> { {let mut scopes=self.1.borrow_mut();if checkpoint.activation_registration_depth>scopes.len(){let p=self.0.borrow();return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.reactive.node_len,current_nodes:p.nodes.len(),checkpoint_registrations:checkpoint.reactive.pattern_activation_registration_len,current_registrations:p.pattern_activation_registrations.len()},None))}scopes.truncate(checkpoint.activation_registration_depth);}self.0.borrow_mut().rollback(checkpoint.reactive) }
+  pub fn activation_registration_depth(&self)->usize {self.1.borrow().len()}
+
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
   }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -430,6 +430,15 @@ pub struct PatternActivationArmRegistration {
   /// Half-open range of plan nodes registered for this arm's body.
   pub body_node_start: usize,
   pub body_node_end: usize,
+  pub captures: Vec<PatternActivationCaptureRegistration>,
+}
+
+/// Stable storage made available to a single patterned activation arm.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationCaptureRegistration {
+  pub id: u64,
+  pub kind: ValueKind,
+  pub cell: ReactiveCellId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -466,6 +466,12 @@ pub struct ReactiveTurnOutcome {
   pub after_commit: ReactivePlanSolveOutcome,
 }
 
+#[derive(Clone, Debug)]
+pub struct ActivationRegistrationScope {
+  pub trigger_cells: Vec<ReactiveCellId>,
+  pub local_combinational_cells: Vec<ReactiveCellId>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReactiveDependency {
   pub cell: ReactiveCellId,
@@ -644,6 +650,15 @@ impl ReactivePlan {
     function: Box<dyn MechFunction>,
     arguments: &[Value],
   ) -> MResult<ReactiveNodeId> {
+    self.register_with_activation(function, arguments, None)
+  }
+
+  pub fn register_with_activation(
+    &mut self,
+    function: Box<dyn MechFunction>,
+    arguments: &[Value],
+    activation: Option<&ActivationRegistrationScope>,
+  ) -> MResult<ReactiveNodeId> {
     let node_id = self.nodes.len();
     let plan_index = node_id;
     let function_description = function.to_string();
@@ -710,13 +725,14 @@ impl ReactivePlan {
       };
 
       for cell in cells {
+        let kind = activation.map_or(*kind, |scope| if scope.trigger_cells.contains(&cell) || scope.local_combinational_cells.contains(&cell) { ReactiveDependencyKind::Reactive } else { ReactiveDependencyKind::Sampled });
         match inputs.iter().find(|dependency| dependency.cell == cell) {
-          Some(dependency) if dependency.kind == *kind => {}
+          Some(dependency) if dependency.kind == kind => {}
           Some(dependency)
             if node_kind == ReactiveNodeKind::Register
               && outputs.contains(&cell)
               && (dependency.kind == ReactiveDependencyKind::Sampled
-                || *kind == ReactiveDependencyKind::Sampled) => {}
+                || kind == ReactiveDependencyKind::Sampled) => {}
           Some(_) => {
             return Err(MechError::new(
               ReactiveDependencyKindConflictError {
@@ -728,9 +744,15 @@ impl ReactivePlan {
           }
           None => inputs.push(ReactiveDependency {
             cell,
-            kind: *kind,
+            kind,
           }),
         }
+      }
+    }
+
+    if let Some(scope) = activation {
+      for cell in &scope.trigger_cells {
+        if !inputs.iter().any(|dependency| dependency.cell == *cell) { inputs.push(ReactiveDependency { cell: *cell, kind: ReactiveDependencyKind::Reactive }); }
       }
     }
 
@@ -936,10 +958,10 @@ impl core::ops::IndexMut<usize> for ReactivePlan {
   }
 }
 
-pub struct Plan(pub Ref<ReactivePlan>);
+pub struct Plan(pub Ref<ReactivePlan>, pub Ref<Vec<ActivationRegistrationScope>>);
 
 impl Clone for Plan {
-  fn clone(&self) -> Self { Plan(self.0.clone()) }
+  fn clone(&self) -> Self { Plan(self.0.clone(), self.1.clone()) }
 }
 
 impl fmt::Debug for Plan {
@@ -953,7 +975,7 @@ impl fmt::Debug for Plan {
 
 impl Plan {
   pub fn new() -> Self {
-    Self(Ref::new(ReactivePlan::new()))
+    Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
   }
 
   pub fn borrow(&self) -> std::cell::Ref<'_, ReactivePlan> {
@@ -968,17 +990,14 @@ impl Plan {
     self.0.borrow_mut().push(function)
   }
 
-  pub fn register_function(
-    &self,
-    function: Box<dyn MechFunction>,
-    arguments: &[Value],
-  ) -> MResult<ReactiveNodeId> {
-    self.0
-      .borrow_mut()
-      .register(
-        function,
-        arguments,
-      )
+  pub fn activation_registration_active(&self) -> bool { !self.1.borrow().is_empty() }
+  pub fn push_activation_registration_scope(&self, trigger_cells: Vec<ReactiveCellId>) { self.1.borrow_mut().push(ActivationRegistrationScope { trigger_cells, local_combinational_cells: Vec::new() }); }
+  pub fn pop_activation_registration_scope(&self) { self.1.borrow_mut().pop(); }
+  pub fn register_function(&self, function: Box<dyn MechFunction>, arguments: &[Value]) -> MResult<ReactiveNodeId> {
+    let scope = self.1.borrow().last().cloned(); let kind = function.reactive_node_kind(); let outputs = function.reactive_output_cell_ids();
+    let node = self.0.borrow_mut().register_with_activation(function, arguments, scope.as_ref())?;
+    if scope.is_some() && kind == ReactiveNodeKind::Combinational { if let Some(active) = self.1.borrow_mut().last_mut() { for cell in outputs { if !active.local_combinational_cells.contains(&cell) { active.local_combinational_cells.push(cell); } } } }
+    Ok(node)
   }
 
   pub fn solve_dirty_cells(

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -559,6 +559,7 @@ pub struct ReactivePlan {
   pub reactive_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pub sampled_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pattern_activation_registrations: Vec<PatternActivationRegistration>,
+  activation_sampled_cells: Vec<Vec<ReactiveCellId>>,
 }
 
 #[derive(Debug, Clone)]
@@ -769,6 +770,7 @@ impl ReactivePlan {
       reactive_consumers: HashMap::new(),
       sampled_consumers: HashMap::new(),
       pattern_activation_registrations: Vec::new(),
+      activation_sampled_cells: Vec::new(),
     }
   }
 
@@ -785,6 +787,7 @@ impl ReactivePlan {
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
     self.pattern_activation_registrations.clear();
+    self.activation_sampled_cells.clear();
   }
 
   pub fn iter(&self) -> impl Iterator<Item = &Box<dyn MechFunction>> {
@@ -1236,7 +1239,13 @@ impl Plan {
       }
     }
 
-    self.0.borrow_mut().apply_rollback(checkpoint.reactive);
+    {
+      let mut reactive = self.0.borrow_mut();
+      reactive.apply_rollback(checkpoint.reactive);
+      reactive
+        .activation_sampled_cells
+        .truncate(checkpoint.activation_registration_depth);
+    }
     self
       .1
       .borrow_mut()
@@ -1266,12 +1275,48 @@ impl Plan {
   }
 
   pub fn activation_registration_active(&self) -> bool { !self.1.borrow().is_empty() }
-  pub fn push_activation_registration_scope(&self, trigger_cells: Vec<ReactiveCellId>) { self.1.borrow_mut().push(ActivationRegistrationScope { trigger_cells, local_combinational_cells: Vec::new() }); }
-  pub fn pop_activation_registration_scope(&self) { self.1.borrow_mut().pop(); }
+  pub fn push_activation_registration_scope(&self, trigger_cells: Vec<ReactiveCellId>) {
+    self.push_activation_registration_scope_with_sampled_cells(
+      trigger_cells,
+      Vec::new(),
+    );
+  }
+  pub fn push_activation_registration_scope_with_sampled_cells(&self, trigger_cells: Vec<ReactiveCellId>, sampled_cells: Vec<ReactiveCellId>) {
+    self.1.borrow_mut().push(ActivationRegistrationScope {
+      trigger_cells,
+      local_combinational_cells: Vec::new(),
+    });
+    self
+      .0
+      .borrow_mut()
+      .activation_sampled_cells
+      .push(sampled_cells);
+  }
+  pub fn pop_activation_registration_scope(&self) {
+    self.1.borrow_mut().pop();
+    self.0.borrow_mut().activation_sampled_cells.pop();
+  }
   pub fn register_function(&self, function: Box<dyn MechFunction>, arguments: &[Value]) -> MResult<ReactiveNodeId> {
     let scope = self.1.borrow().last().cloned(); let kind = function.reactive_node_kind(); let outputs = function.reactive_output_cell_ids();
+    let sampled_cells = self
+      .0
+      .borrow()
+      .activation_sampled_cells
+      .last()
+      .cloned()
+      .unwrap_or_default();
     let node = self.0.borrow_mut().register_with_activation(function, arguments, scope.as_ref())?;
-    if scope.is_some() && kind == ReactiveNodeKind::Combinational { if let Some(active) = self.1.borrow_mut().last_mut() { for cell in outputs { if !active.local_combinational_cells.contains(&cell) { active.local_combinational_cells.push(cell); } } } }
+    if scope.is_some() && kind == ReactiveNodeKind::Combinational {
+      if let Some(active) = self.1.borrow_mut().last_mut() {
+        for cell in outputs {
+          if !sampled_cells.contains(&cell)
+            && !active.local_combinational_cells.contains(&cell)
+          {
+            active.local_combinational_cells.push(cell);
+          }
+        }
+      }
+    }
     Ok(node)
   }
 
@@ -1974,6 +2019,70 @@ mod reactive_plan_tests {
     let node = plan.node(node_id).unwrap();
     assert_eq!(node.kind, ReactiveNodeKind::Register);
     assert!(node.outputs.contains(&output_cell));
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn activation_registration_does_not_promote_preexisting_alias_cells() {
+    let trigger = Value::F64(Ref::new(0.0));
+    let sampled = Value::F64(Ref::new(1.0));
+    let local = Value::F64(Ref::new(2.0));
+    let trigger_cell = trigger.reactive_root_cell_ids()[0];
+    let sampled_cell = sampled.reactive_root_cell_ids()[0];
+    let local_cell = local.reactive_root_cell_ids()[0];
+    let plan = Plan::new();
+
+    plan.push_activation_registration_scope_with_sampled_cells(
+      vec![trigger_cell],
+      sampled.reactive_cell_ids(),
+    );
+    plan
+      .register_function(
+        Box::new(TestFunction::with_output("sampled alias", sampled.clone())),
+        &[],
+      )
+      .unwrap();
+    let sampled_consumer = plan
+      .register_function(
+        Box::new(TestFunction::new("sampled consumer")),
+        &[sampled],
+      )
+      .unwrap();
+    plan
+      .register_function(
+        Box::new(TestFunction::with_output("local producer", local.clone())),
+        &[],
+      )
+      .unwrap();
+    let local_consumer = plan
+      .register_function(
+        Box::new(TestFunction::new("local consumer")),
+        &[local],
+      )
+      .unwrap();
+    plan.pop_activation_registration_scope();
+
+    let plan = plan.borrow();
+    assert_eq!(
+      plan.node(sampled_consumer)
+        .unwrap()
+        .inputs
+        .iter()
+        .find(|dependency| dependency.cell == sampled_cell)
+        .unwrap()
+        .kind,
+      ReactiveDependencyKind::Sampled,
+    );
+    assert_eq!(
+      plan.node(local_consumer)
+        .unwrap()
+        .inputs
+        .iter()
+        .find(|dependency| dependency.cell == local_cell)
+        .unwrap()
+        .kind,
+      ReactiveDependencyKind::Reactive,
+    );
   }
 
   #[cfg(feature = "f64")]

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1007,18 +1007,54 @@ impl MechCode {
 pub struct ActivationScope {
   pub operator: Token,
   pub trigger: Expression,
-  pub body: Vec<(MechCode, Option<Comment>)>,
+  pub body: ActivationBody,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ActivationBody {
+  Block(Vec<(MechCode, Option<Comment>)>),
+  PatternArms(Vec<ActivationArm>),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ActivationArm {
+  pub pattern: Pattern,
+  pub guard: Option<Expression>,
+  pub body: ActivationArmBody,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ActivationArmBody {
+  Block(Vec<(MechCode, Option<Comment>)>),
+  Expression(Expression),
 }
 
 impl ActivationScope {
   pub fn tokens(&self) -> Vec<Token> {
     let mut tokens = vec![self.operator.clone()];
     tokens.append(&mut self.trigger.tokens());
-    for (code, comment) in &self.body {
-      tokens.append(&mut code.tokens());
-      if let Some(comment) = comment { tokens.append(&mut comment.tokens()); }
+    match &self.body {
+      ActivationBody::Block(body) => append_activation_block_tokens(&mut tokens, body),
+      ActivationBody::PatternArms(arms) => for arm in arms {
+        tokens.append(&mut arm.pattern.tokens());
+        if let Some(guard) = &arm.guard { tokens.append(&mut guard.tokens()); }
+        match &arm.body {
+          ActivationArmBody::Block(body) => append_activation_block_tokens(&mut tokens, body),
+          ActivationArmBody::Expression(expression) => tokens.append(&mut expression.tokens()),
+        }
+      },
     }
     tokens
+  }
+}
+
+fn append_activation_block_tokens(tokens: &mut Vec<Token>, body: &[(MechCode, Option<Comment>)]) {
+  for (code, comment) in body {
+    tokens.append(&mut code.tokens());
+    if let Some(comment) = comment { tokens.append(&mut comment.tokens()); }
   }
 }
 

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1982,6 +1982,22 @@ impl Identifier {
   }
 }
 
+/// Constructs an identifier reserved for sampled runtime pattern values. The
+/// leading NUL cannot be produced by Mech source syntax, so source names always
+/// retain ordinary binding semantics.
+pub fn internal_pattern_value_identifier(name: &str) -> Identifier {
+  let mut chars = Vec::with_capacity(name.chars().count() + 1);
+  chars.push('\0');
+  chars.extend(name.chars());
+  Identifier {
+    name: Token::new(TokenKind::Identifier, SourceRange::default(), chars),
+  }
+}
+
+pub fn is_internal_pattern_value_identifier(identifier: &Identifier) -> bool {
+  identifier.name.chars.first() == Some(&'\0')
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Emoji {

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -93,7 +93,7 @@ pub trait Recoverable: Sized {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TokenKind {
-  AbstractSigil, Alpha, Ampersand, Any, Apostrophe, AssignOperator, Asterisk, AsyncTransitionOperator, At,
+  AbstractSigil, ActivationScope, Alpha, Ampersand, Any, Apostrophe, AssignOperator, Asterisk, AsyncTransitionOperator, At,
   Backslash, Bar, BoxDrawing,
   Caret, CarriageReturn, CarriageReturnNewLine, Colon, CodeBlock, Comma,
   Dash, DefineOperator, Digit, Dollar,
@@ -970,6 +970,7 @@ impl ModuleImport {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MechCode {
   Comment(Comment),
+  ActivationScope(ActivationScope),
   Expression(Expression),
   FsmImplementation(FsmImplementation),
   FsmSpecification(FsmSpecification),
@@ -988,6 +989,7 @@ impl Recoverable for MechCode {
 impl MechCode {
   pub fn tokens(&self) -> Vec<Token> {
     match self {
+      MechCode::ActivationScope(x) => x.tokens(),
       MechCode::Expression(x) => x.tokens(),
       MechCode::Statement(x) => x.tokens(),
       MechCode::Comment(x) => x.tokens(),
@@ -997,6 +999,25 @@ impl MechCode {
       MechCode::Import(x) => x.tokens(),
       MechCode::Error(t,_) => vec![t.clone()],
     }
+  }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ActivationScope {
+  pub trigger: Expression,
+  pub body: Vec<(MechCode, Option<Comment>)>,
+}
+
+impl ActivationScope {
+  pub fn tokens(&self) -> Vec<Token> {
+    let mut tokens = vec![Token { kind: TokenKind::ActivationScope, chars: vec!['~', '>'], src_range: self.trigger.tokens().first().map(|t| t.src_range.clone()).unwrap_or_default() }];
+    tokens.append(&mut self.trigger.tokens());
+    for (code, comment) in &self.body {
+      tokens.append(&mut code.tokens());
+      if let Some(comment) = comment { tokens.append(&mut comment.tokens()); }
+    }
+    tokens
   }
 }
 

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -93,7 +93,7 @@ pub trait Recoverable: Sized {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TokenKind {
-  AbstractSigil, ActivationScope, Alpha, Ampersand, Any, Apostrophe, AssignOperator, Asterisk, AsyncTransitionOperator, At,
+  AbstractSigil, Alpha, Ampersand, Any, Apostrophe, AssignOperator, Asterisk, AsyncTransitionOperator, At,
   Backslash, Bar, BoxDrawing,
   Caret, CarriageReturn, CarriageReturnNewLine, Colon, CodeBlock, Comma,
   Dash, DefineOperator, Digit, Dollar,
@@ -1005,13 +1005,14 @@ impl MechCode {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ActivationScope {
+  pub operator: Token,
   pub trigger: Expression,
   pub body: Vec<(MechCode, Option<Comment>)>,
 }
 
 impl ActivationScope {
   pub fn tokens(&self) -> Vec<Token> {
-    let mut tokens = vec![Token { kind: TokenKind::ActivationScope, chars: vec!['~', '>'], src_range: self.trigger.tokens().first().map(|t| t.src_range.clone()).unwrap_or_default() }];
+    let mut tokens = vec![self.operator.clone()];
     tokens.append(&mut self.trigger.tokens());
     for (code, comment) in &self.body {
       tokens.append(&mut code.tokens());

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -1022,7 +1022,7 @@ impl ConstElem for Value {
     }
   }
   fn value_kind(&self) -> ValueKind {
-    self.value_kind()
+    self.kind()
   }
   fn align() -> u8 {
     1
@@ -1185,6 +1185,19 @@ impl ConstElem for ValueKind {
         }
         let row_count = cursor.read_u32::<LittleEndian>().expect("read table row count") as usize;
         ValueKind::Table(fields, row_count)
+      }
+      #[cfg(feature = "tuple")]
+      27 => {
+        let element_count = cursor.read_u32::<LittleEndian>().expect("read tuple kind length") as usize;
+        let mut elements = Vec::with_capacity(element_count);
+        for _ in 0..element_count {
+          let kind = ValueKind::from_le(&bytes[cursor.position() as usize..]);
+          let mut encoded = Vec::new();
+          kind.write_le(&mut encoded);
+          cursor.set_position(cursor.position() + encoded.len() as u64);
+          elements.push(kind);
+        }
+        ValueKind::Tuple(elements)
       }
       #[cfg(feature = "set")]
       29 => {

--- a/src/core/src/program/program.rs
+++ b/src/core/src/program/program.rs
@@ -460,6 +460,14 @@ impl ParsedProgram {
           let table = MechTable::from_le(&data);
           Value::Table(Ref::new(table))
         }
+        #[cfg(feature = "tuple")]
+        TypeTag::Tuple => {
+          if data.len() < 4 {
+            return Err(MechError::new(ConstantTooShortError { type_name: "tuple" }, None).with_compiler_loc());
+          }
+          let tuple = MechTuple::from_le(&data);
+          Value::Tuple(Ref::new(tuple))
+        }
         _ => {
           return Err(
             MechError::new(

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -5,8 +5,13 @@ use crate::*;
 
 pub type SymbolTableRef= Ref<SymbolTable>;
 
-#[derive(Clone, Debug)]
-pub struct SymbolTableSnapshot { symbols: HashMap<u64, ValRef>, mutable_variables: HashMap<u64, ValRef>, dictionary: Dictionary, reverse_lookup: HashMap<*const Ref<Value>, u64> }
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SymbolTableSnapshot {
+  symbols: HashMap<u64, ValRef>,
+  mutable_variables: HashMap<u64, ValRef>,
+  dictionary: Dictionary,
+  reverse_lookup: HashMap<*const Ref<Value>, u64>,
+}
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
@@ -17,8 +22,21 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
-  pub fn snapshot(&self) -> SymbolTableSnapshot { SymbolTableSnapshot { symbols:self.symbols.clone(), mutable_variables:self.mutable_variables.clone(), dictionary:self.dictionary.borrow().clone(), reverse_lookup:self.reverse_lookup.clone() } }
-  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) { self.symbols=snapshot.symbols; self.mutable_variables=snapshot.mutable_variables; *self.dictionary.borrow_mut()=snapshot.dictionary; self.reverse_lookup=snapshot.reverse_lookup; }
+  pub fn snapshot(&self) -> SymbolTableSnapshot {
+    SymbolTableSnapshot {
+      symbols: self.symbols.clone(),
+      mutable_variables: self.mutable_variables.clone(),
+      dictionary: self.dictionary.borrow().clone(),
+      reverse_lookup: self.reverse_lookup.clone(),
+    }
+  }
+
+  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) {
+    self.symbols = snapshot.symbols;
+    self.mutable_variables = snapshot.mutable_variables;
+    *self.dictionary.borrow_mut() = snapshot.dictionary;
+    self.reverse_lookup = snapshot.reverse_lookup;
+  }
 
 
   pub fn new() -> SymbolTable {
@@ -56,6 +74,35 @@ impl SymbolTable {
     cell.clone()
   }
 
+}
+
+#[cfg(test)]
+mod snapshot_tests {
+  use super::*;
+
+  #[test]
+  fn symbol_table_snapshot_restores_all_indexes_and_identity() {
+    let mut table = SymbolTable::new();
+    let outer = hash_str("outer");
+    let temporary = hash_str("temporary");
+    let outer_ref = table.insert(outer, Value::Index(Ref::new(1)), true);
+    table.dictionary.borrow_mut().insert(outer, "outer".to_string());
+    let outer_addr = outer_ref.addr();
+    let original_snapshot = table.snapshot();
+
+    table.insert(outer, Value::Index(Ref::new(2)), false);
+    table.insert(temporary, Value::Index(Ref::new(3)), false);
+    table.dictionary.borrow_mut().insert(outer, "changed".to_string());
+    table.dictionary.borrow_mut().insert(temporary, "temporary".to_string());
+    assert_ne!(table.snapshot(), original_snapshot);
+
+    table.restore(original_snapshot.clone());
+    assert_eq!(table.snapshot(), original_snapshot);
+    assert!(!table.contains(temporary));
+    assert!(table.get_mutable(outer).is_some());
+    assert_eq!(table.get(outer).unwrap().addr(), outer_addr);
+    assert_eq!(table.get_symbol_name_by_id(outer).as_deref(), Some("outer"));
+  }
 }
 
 #[cfg(feature = "pretty_print")]

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -1,9 +1,12 @@
 use crate::*;
 
-// Symbol Table 
+// Symbol Table
 // ----------------------------------------------------------------------------
 
 pub type SymbolTableRef= Ref<SymbolTable>;
+
+#[derive(Clone, Debug)]
+pub struct SymbolTableSnapshot { symbols: HashMap<u64, ValRef>, mutable_variables: HashMap<u64, ValRef>, dictionary: Dictionary, reverse_lookup: HashMap<*const Ref<Value>, u64> }
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
@@ -14,6 +17,9 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
+  pub fn snapshot(&self) -> SymbolTableSnapshot { SymbolTableSnapshot { symbols:self.symbols.clone(), mutable_variables:self.mutable_variables.clone(), dictionary:self.dictionary.borrow().clone(), reverse_lookup:self.reverse_lookup.clone() } }
+  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) { self.symbols=snapshot.symbols; self.mutable_variables=snapshot.mutable_variables; *self.dictionary.borrow_mut()=snapshot.dictionary; self.reverse_lookup=snapshot.reverse_lookup; }
+
 
   pub fn new() -> SymbolTable {
     Self {

--- a/src/core/src/structures/matrix.rs
+++ b/src/core/src/structures/matrix.rs
@@ -509,9 +509,64 @@ impl<T> Matrix<T> {
   }
 }
 
-impl<T> Matrix<T> 
+impl<T> Matrix<T>
 where T: Debug + Clone + PartialEq + 'static
 {
+
+  /// Returns whether `replace_payload_from` can update this matrix without
+  /// replacing its reactive root.
+  pub fn can_replace_payload_from(&self, source: &Matrix<T>) -> bool {
+    let rows = source.rows();
+    let cols = source.cols();
+    match self {
+      #[cfg(feature = "row_vectord")]
+      Matrix::RowDVector(_) => rows == 1,
+      #[cfg(feature = "vectord")]
+      Matrix::DVector(_) => cols == 1,
+      #[cfg(feature = "matrixd")]
+      Matrix::DMatrix(_) => true,
+      _ => self.shape() == source.shape(),
+    }
+  }
+
+  /// Replaces the payload stored by this matrix without replacing its reactive
+  /// root. Dynamic matrices may change dimensions; fixed matrices require the
+  /// source shape to remain identical.
+  pub fn replace_payload_from(&self, source: &Matrix<T>) -> bool {
+    if !self.can_replace_payload_from(source) {
+      return false;
+    }
+    let rows = source.rows();
+    let cols = source.cols();
+    let elements = source.as_vec();
+    match self {
+      #[cfg(feature = "row_vectord")]
+      Matrix::RowDVector(destination) if rows == 1 => {
+        destination
+          .borrow_mut()
+          .clone_from(&RowDVector::from_vec(elements));
+        true
+      }
+      #[cfg(feature = "vectord")]
+      Matrix::DVector(destination) if cols == 1 => {
+        destination
+          .borrow_mut()
+          .clone_from(&DVector::from_vec(elements));
+        true
+      }
+      #[cfg(feature = "matrixd")]
+      Matrix::DMatrix(destination) => {
+        destination
+          .borrow_mut()
+          .clone_from(&DMatrix::from_vec(rows, cols, elements));
+        true
+      }
+      _ => {
+        self.set(elements);
+        true
+      }
+    }
+  }
 
   pub fn append(&mut self, other: &Matrix<T>) -> MResult<()> {
     match (&self, &other) {

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1254,6 +1254,8 @@ impl Value {
       Value::Set(r) => &*(r as *const Ref<MechSet> as *const Ref<T>),
       #[cfg(feature = "table")]
       Value::Table(r) => &*(r as *const Ref<MechTable> as *const Ref<T>),
+      #[cfg(feature = "tuple")]
+      Value::Tuple(r) => &*(r as *const Ref<MechTuple> as *const Ref<T>),
       x => panic!("Unsupported type for as_unchecked: {:?}.", x),
     }
   }

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1062,6 +1062,250 @@ pub fn val_ref_reactive_cell_ids(value: &ValRef) -> Vec<ReactiveCellId> {
   ids
 }
 impl Value {
+  /// Recursively snapshots this value into storage that is detached from the
+  /// source's reactive cells.
+  ///
+  /// Mutable references are unwrapped, while typed values retain their kind
+  /// annotation. Container metadata is preserved and nested values are
+  /// detached recursively.
+  pub fn deep_snapshot(&self) -> Value {
+    match self {
+      #[cfg(feature = "u8")]
+      Value::U8(value) => Value::U8(Ref::new(*value.borrow())),
+      #[cfg(feature = "u16")]
+      Value::U16(value) => Value::U16(Ref::new(*value.borrow())),
+      #[cfg(feature = "u32")]
+      Value::U32(value) => Value::U32(Ref::new(*value.borrow())),
+      #[cfg(feature = "u64")]
+      Value::U64(value) => Value::U64(Ref::new(*value.borrow())),
+      #[cfg(feature = "u128")]
+      Value::U128(value) => Value::U128(Ref::new(*value.borrow())),
+      #[cfg(feature = "i8")]
+      Value::I8(value) => Value::I8(Ref::new(*value.borrow())),
+      #[cfg(feature = "i16")]
+      Value::I16(value) => Value::I16(Ref::new(*value.borrow())),
+      #[cfg(feature = "i32")]
+      Value::I32(value) => Value::I32(Ref::new(*value.borrow())),
+      #[cfg(feature = "i64")]
+      Value::I64(value) => Value::I64(Ref::new(*value.borrow())),
+      #[cfg(feature = "i128")]
+      Value::I128(value) => Value::I128(Ref::new(*value.borrow())),
+      #[cfg(feature = "f32")]
+      Value::F32(value) => Value::F32(Ref::new(*value.borrow())),
+      #[cfg(feature = "f64")]
+      Value::F64(value) => Value::F64(Ref::new(*value.borrow())),
+      #[cfg(feature = "complex")]
+      Value::C64(value) => Value::C64(Ref::new(value.borrow().clone())),
+      #[cfg(feature = "rational")]
+      Value::R64(value) => Value::R64(Ref::new(value.borrow().clone())),
+      #[cfg(any(feature = "string", feature = "variable_define"))]
+      Value::String(value) => Value::String(Ref::new(value.borrow().clone())),
+      #[cfg(any(feature = "bool", feature = "variable_define"))]
+      Value::Bool(value) => Value::Bool(Ref::new(*value.borrow())),
+      #[cfg(feature = "atom")]
+      Value::Atom(value) => Value::Atom(Ref::new(value.borrow().clone())),
+      #[cfg(feature = "matrix")]
+      Value::MatrixIndex(value) => Value::MatrixIndex(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "bool"))]
+      Value::MatrixBool(value) => Value::MatrixBool(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u8"))]
+      Value::MatrixU8(value) => Value::MatrixU8(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u16"))]
+      Value::MatrixU16(value) => Value::MatrixU16(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u32"))]
+      Value::MatrixU32(value) => Value::MatrixU32(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u64"))]
+      Value::MatrixU64(value) => Value::MatrixU64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u128"))]
+      Value::MatrixU128(value) => Value::MatrixU128(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i8"))]
+      Value::MatrixI8(value) => Value::MatrixI8(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i16"))]
+      Value::MatrixI16(value) => Value::MatrixI16(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i32"))]
+      Value::MatrixI32(value) => Value::MatrixI32(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i64"))]
+      Value::MatrixI64(value) => Value::MatrixI64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i128"))]
+      Value::MatrixI128(value) => Value::MatrixI128(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "f32"))]
+      Value::MatrixF32(value) => Value::MatrixF32(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "f64"))]
+      Value::MatrixF64(value) => Value::MatrixF64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "string"))]
+      Value::MatrixString(value) => Value::MatrixString(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "rational"))]
+      Value::MatrixR64(value) => Value::MatrixR64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "complex"))]
+      Value::MatrixC64(value) => Value::MatrixC64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(feature = "matrix")]
+      Value::MatrixValue(value) => Value::MatrixValue(Matrix::from_vec(
+        value
+          .as_vec()
+          .iter()
+          .map(Value::deep_snapshot)
+          .collect(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(feature = "set")]
+      Value::Set(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.set = snapshot
+          .set
+          .iter()
+          .map(Value::deep_snapshot)
+          .collect();
+        Value::Set(Ref::new(snapshot))
+      }
+      #[cfg(feature = "map")]
+      Value::Map(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.map = snapshot
+          .map
+          .iter()
+          .map(|(key, value)| (key.deep_snapshot(), value.deep_snapshot()))
+          .collect();
+        Value::Map(Ref::new(snapshot))
+      }
+      #[cfg(feature = "record")]
+      Value::Record(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.data = snapshot
+          .data
+          .iter()
+          .map(|(id, value)| (*id, value.deep_snapshot()))
+          .collect();
+        Value::Record(Ref::new(snapshot))
+      }
+      #[cfg(feature = "table")]
+      Value::Table(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.data = snapshot
+          .data
+          .iter()
+          .map(|(id, (kind, values))| {
+            let values = Matrix::from_vec(
+              values
+                .as_vec()
+                .iter()
+                .map(Value::deep_snapshot)
+                .collect(),
+              values.rows(),
+              values.cols(),
+            );
+            (*id, (kind.clone(), values))
+          })
+          .collect();
+        Value::Table(Ref::new(snapshot))
+      }
+      #[cfg(feature = "tuple")]
+      Value::Tuple(value) => Value::Tuple(Ref::new(
+        MechTuple::from_vec(
+          value
+            .borrow()
+            .elements
+            .iter()
+            .map(|value| value.deep_snapshot())
+            .collect(),
+        ),
+      )),
+      #[cfg(feature = "enum")]
+      Value::Enum(value) => {
+        let value = value.borrow();
+        Value::Enum(Ref::new(MechEnum {
+          id: value.id,
+          variants: value
+            .variants
+            .iter()
+            .map(|(id, payload)| {
+              (*id, payload.as_ref().map(Value::deep_snapshot))
+            })
+            .collect(),
+          names: value.names.clone(),
+        }))
+      }
+      Value::Id(value) => Value::Id(*value),
+      Value::Index(value) => Value::Index(Ref::new(*value.borrow())),
+      Value::MutableReference(value) => value.borrow().deep_snapshot(),
+      Value::Typed(value, kind) => {
+        Value::Typed(Box::new(value.deep_snapshot()), kind.clone())
+      }
+      Value::Kind(kind) => Value::Kind(kind.clone()),
+      Value::IndexAll => Value::IndexAll,
+      Value::EmptyKind(kind) => Value::EmptyKind(kind.clone()),
+      Value::Empty => Value::Empty,
+    }
+  }
+
   #[cfg(feature = "matrix")]
   fn infer_matrix_value_kind(matrix: &Matrix<Value>) -> ValueKind {
     let mut base_kind: Option<ValueKind> = None;
@@ -3156,6 +3400,39 @@ mod reactive_cell_tests {
     let record = Ref::new(MechRecord { cols: 1, kinds: vec![ValueKind::Tuple(vec![ValueKind::F64, ValueKind::F64])], data, field_names: HashMap::new() });
 
     assert_eq!(Value::Record(record.clone()).reactive_cell_ids(), cell_ids(&[record.id(), tuple.id(), a.id(), b.id()]));
+  }
+
+  #[cfg(all(feature = "record", feature = "tuple", feature = "f64"))]
+  #[test]
+  fn deep_snapshot_detaches_nested_record_and_tuple_cells() {
+    let live = Ref::new(1.0);
+    let value = Value::Record(Ref::new(MechRecord::new(vec![(
+      "position",
+      Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+        Value::F64(live.clone()),
+        Value::F64(Ref::new(2.0)),
+      ]))),
+    )])));
+
+    let snapshot = value.deep_snapshot();
+    *live.borrow_mut() = 9.0;
+
+    let Value::Record(snapshot) = snapshot else {
+      panic!("expected record snapshot");
+    };
+    let position = {
+      let snapshot = snapshot.borrow();
+      let Value::Tuple(position) = snapshot.data.get(&hash_str("position")).unwrap() else {
+        panic!("expected tuple field");
+      };
+      position.clone()
+    };
+    let position = position.borrow();
+    let Value::F64(x) = position.elements[0].as_ref() else {
+      panic!("expected scalar tuple element");
+    };
+    assert_eq!(*x.borrow(), 1.0);
+    assert_ne!(x.as_ptr(), live.as_ptr());
   }
 
   #[cfg(all(feature = "map", feature = "set", feature = "f64"))]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -16,23 +16,52 @@ activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cel
 #[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
 #[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
 fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
-fn slot(v:&Value)->Option<Value> { match detached(v) {
-  Value::F64(_)=>Some(Value::F64(Ref::new(0.))), Value::F32(_)=>Some(Value::F32(Ref::new(0.))),
-  Value::I64(_)=>Some(Value::I64(Ref::new(0))), Value::I32(_)=>Some(Value::I32(Ref::new(0))), Value::I16(_)=>Some(Value::I16(Ref::new(0))), Value::I8(_)=>Some(Value::I8(Ref::new(0))),
-  Value::U64(_)=>Some(Value::U64(Ref::new(0))), Value::U32(_)=>Some(Value::U32(Ref::new(0))), Value::U16(_)=>Some(Value::U16(Ref::new(0))), Value::U8(_)=>Some(Value::U8(Ref::new(0))),
-  Value::Bool(_)=>Some(Value::Bool(Ref::new(false))), Value::String(_)=>Some(Value::String(Ref::new(String::new()))), Value::Index(_)=>Some(Value::Index(Ref::new(0))), Value::Atom(a)=>Some(Value::Atom(Ref::new(a.borrow().clone()))), _=>None } }
-fn compile(pat:&Pattern, sample:&Value, i:&Interpreter, caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern> { match pat {
- Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}),
- Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash(); if let Some(n)=caps.iter().position(|c|c.id==id){return Ok(CompiledActivationPattern::Capture{capture_index:n})}; let value=slot(sample).ok_or_else(||MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))?; caps.push(Capture{id,kind:sample.kind(),slot:value}); Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})},
- Pattern::Tuple(t)=> {let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; let e=&tv.borrow().elements; if e.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(e.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
- Pattern::TupleStruct(t)=> { let tag=t.name.hash(); let payload=match detached(sample) { Value::Enum(e)=>{let e=e.borrow(); e.variants.iter().find(|(id,_)|*id==tag).and_then(|(_,x)|x.as_ref()).cloned().into_iter().collect::<Vec<_>>()}, Value::Tuple(x)=>{let x=x.borrow(); if x.elements.first().map(|v|matches!(detached(v),Value::Atom(a) if a.borrow().id()==tag)).unwrap_or(false){x.elements.iter().skip(1).map(|v|(**v).clone()).collect()}else{Vec::new()}}, _=>Vec::new()}; if payload.len()!=t.patterns.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::TupleStruct{tag,payload:t.patterns.iter().zip(payload.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
- _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens())) }}
-fn matches_pattern(p:&CompiledActivationPattern,v:&Value, proposed:&mut Vec<Option<Value>>)->bool {match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}},CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false},CompiledActivationPattern::TupleStruct{tag,payload}=>match detached(v){Value::Enum(e)=>{let e=e.borrow();match e.variants.iter().find(|(id,_)|id==tag){Some((_,Some(v))) if payload.len()==1=>matches_pattern(&payload[0],v,proposed),Some((_,None))=>payload.is_empty(),_=>false}},Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==payload.len()+1&&matches!(detached(&t.elements[0]),Value::Atom(a) if a.borrow().id()==*tag)&&payload.iter().zip(t.elements.iter().skip(1)).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}}}
-macro_rules! copy_slot {($s:expr,$v:expr,$($x:ident),*)=>{match ($s,$v){$((Value::$x(a),Value::$x(b))=>{*a.borrow_mut()=*b.borrow();Ok(())},)* _=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}}
-fn commit(s:&Value,v:&Value)->MResult<()> {copy_slot!(s,detached(v),F64,F32,I64,I32,I16,I8,U64,U32,U16,U8,Bool,String,Index,Atom)}
+fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) { let source=source.borrow(); destination.borrow_mut().clone_from(&*source); }
+fn create_capture_slot(sample:&Value)->MResult<Value>{match detached(sample){
+#[cfg(feature="u8")] Value::U8(v)=>Ok(Value::U8(Ref::new(*v.borrow()))),
+#[cfg(feature="u16")] Value::U16(v)=>Ok(Value::U16(Ref::new(*v.borrow()))),
+#[cfg(feature="u32")] Value::U32(v)=>Ok(Value::U32(Ref::new(*v.borrow()))),
+#[cfg(feature="u64")] Value::U64(v)=>Ok(Value::U64(Ref::new(*v.borrow()))),
+#[cfg(feature="u128")] Value::U128(v)=>Ok(Value::U128(Ref::new(*v.borrow()))),
+#[cfg(feature="i8")] Value::I8(v)=>Ok(Value::I8(Ref::new(*v.borrow()))),
+#[cfg(feature="i16")] Value::I16(v)=>Ok(Value::I16(Ref::new(*v.borrow()))),
+#[cfg(feature="i32")] Value::I32(v)=>Ok(Value::I32(Ref::new(*v.borrow()))),
+#[cfg(feature="i64")] Value::I64(v)=>Ok(Value::I64(Ref::new(*v.borrow()))),
+#[cfg(feature="i128")] Value::I128(v)=>Ok(Value::I128(Ref::new(*v.borrow()))),
+#[cfg(feature="f32")] Value::F32(v)=>Ok(Value::F32(Ref::new(*v.borrow()))),
+#[cfg(feature="f64")] Value::F64(v)=>Ok(Value::F64(Ref::new(*v.borrow()))),
+#[cfg(feature="complex")] Value::C64(v)=>Ok(Value::C64(Ref::new(v.borrow().clone()))),
+#[cfg(feature="rational")] Value::R64(v)=>Ok(Value::R64(Ref::new(v.borrow().clone()))),
+#[cfg(any(feature="bool",feature="variable_define"))] Value::Bool(v)=>Ok(Value::Bool(Ref::new(*v.borrow()))),
+#[cfg(any(feature="string",feature="variable_define"))] Value::String(v)=>Ok(Value::String(Ref::new(v.borrow().clone()))),
+Value::Index(v)=>Ok(Value::Index(Ref::new(*v.borrow()))),
+#[cfg(feature="atom")] Value::Atom(v)=>Ok(Value::Atom(Ref::new(v.borrow().clone()))),
+_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
+fn commit_capture_slot(destination:&Value,source:&Value)->MResult<()>{let source=detached(source);match(destination,&source){
+#[cfg(feature="u8")] (Value::U8(a),Value::U8(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u16")] (Value::U16(a),Value::U16(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u32")] (Value::U32(a),Value::U32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u64")] (Value::U64(a),Value::U64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u128")] (Value::U128(a),Value::U128(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i8")] (Value::I8(a),Value::I8(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i16")] (Value::I16(a),Value::I16(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i32")] (Value::I32(a),Value::I32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i64")] (Value::I64(a),Value::I64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i128")] (Value::I128(a),Value::I128(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="f32")] (Value::F32(a),Value::F32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="f64")] (Value::F64(a),Value::F64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="complex")] (Value::C64(a),Value::C64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="rational")] (Value::R64(a),Value::R64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(any(feature="bool",feature="variable_define"))] (Value::Bool(a),Value::Bool(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(any(feature="string",feature="variable_define"))] (Value::String(a),Value::String(b))=>{clone_ref_value(a,b);Ok(())},
+(Value::Index(a),Value::Index(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="atom")] (Value::Atom(a),Value::Atom(b))=>{clone_ref_value(a,b);Ok(())},
+_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
+fn compile(pat:&Pattern,sample:&Value,i:&Interpreter,caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern>{match pat { Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}), Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash();if let Some(n)=caps.iter().position(|c|c.id==id){Ok(CompiledActivationPattern::Capture{capture_index:n})}else{let value=create_capture_slot(sample).map_err(|e|e.with_tokens(pat.tokens()))?;caps.push(Capture{id,kind:sample.kind(),slot:value});Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})}}, #[cfg(feature="tuple")] Pattern::Tuple(t)=>{let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))};let tv=tv.borrow();if tv.elements.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(tv.elements.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})}, _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens()))}}
+fn matches_pattern(p:&CompiledActivationPattern,v:&Value,proposed:&mut Vec<Option<Value>>)->bool{match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}}, #[cfg(feature="tuple")] CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}, CompiledActivationPattern::TupleStruct{..}=>false, #[cfg(not(feature="tuple"))] CompiledActivationPattern::Tuple{..}=>false}}
 fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
 struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
-struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
+struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit_capture_slot(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
 struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
 struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
 struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1214,4 +1214,690 @@ mod tests {
             commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
     }
+
+    type PlanSnapshot = (
+        usize,
+        Vec<(
+            ReactiveNodeId,
+            usize,
+            ReactiveNodeKind,
+            Vec<u64>,
+            Vec<(u64, ReactiveDependencyKind)>,
+        )>,
+        Vec<(u64, Vec<ReactiveNodeId>)>,
+        Vec<(u64, Vec<ReactiveNodeId>)>,
+        Vec<PatternActivationRegistration>,
+        usize,
+    );
+
+    fn interpret(source: &str) -> Interpreter {
+        let tree = mech_syntax::parser::parse(source).unwrap();
+        let mut interpreter = Interpreter::new_with_full_stdlib(0);
+        interpreter.interpret(&tree).unwrap();
+        interpreter
+    }
+
+    fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MResult<Value> {
+        let tree = mech_syntax::parser::parse(source).unwrap();
+        interpreter.interpret(&tree)
+    }
+
+    fn symbol_ref(interpreter: &Interpreter, name: &str) -> ValRef {
+        interpreter
+            .symbols()
+            .borrow()
+            .get(hash_str(name))
+            .unwrap_or_else(|| panic!("missing symbol `{name}`"))
+    }
+    fn symbol(interpreter: &Interpreter, name: &str) -> Value {
+        symbol_ref(interpreter, name).borrow().clone()
+    }
+    fn root_cell(interpreter: &Interpreter, name: &str) -> ReactiveCellId {
+        symbol(interpreter, name).reactive_root_cell_ids()[0]
+    }
+    fn registration(interpreter: &Interpreter) -> PatternActivationRegistration {
+        let plan = interpreter.plan();
+        let registrations = plan.pattern_activation_registrations();
+        assert_eq!(registrations.len(), 1);
+        registrations[0].clone()
+    }
+    fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
+        let plan = interpreter.plan();
+        let depth = plan.activation_registration_depth();
+        let plan = plan.borrow();
+        let nodes = plan
+            .nodes
+            .iter()
+            .map(|node| {
+                (
+                    node.id,
+                    node.plan_index,
+                    node.kind,
+                    node.outputs.iter().map(|cell| cell.get()).collect(),
+                    node.inputs
+                        .iter()
+                        .map(|dependency| (dependency.cell.get(), dependency.kind))
+                        .collect(),
+                )
+            })
+            .collect();
+        let mut reactive = plan
+            .reactive_consumers
+            .iter()
+            .map(|(cell, nodes)| (cell.get(), nodes.clone()))
+            .collect::<Vec<_>>();
+        reactive.sort_by_key(|(cell, _)| *cell);
+        let mut sampled = plan
+            .sampled_consumers
+            .iter()
+            .map(|(cell, nodes)| (cell.get(), nodes.clone()))
+            .collect::<Vec<_>>();
+        sampled.sort_by_key(|(cell, _)| *cell);
+        (
+            plan.len(),
+            nodes,
+            reactive,
+            sampled,
+            plan.pattern_activation_registrations().to_vec(),
+            depth,
+        )
+    }
+    fn turn_executed_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .executed_nodes
+            .iter()
+            .chain(outcome.after_commit.executed_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn turn_changed_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .changed_nodes
+            .iter()
+            .chain(outcome.after_commit.changed_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn turn_unchanged_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .unchanged_nodes
+            .iter()
+            .chain(outcome.after_commit.unchanged_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn body_output_f64(interpreter: &Interpreter, arm_index: usize) -> f64 {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm_index];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        for id in (arm.body_node_start..arm.body_node_end).rev() {
+            if let Ok(value) = plan.node(id).unwrap().function.out().as_f64() {
+                return *value.borrow();
+            }
+        }
+        panic!("no f64 output")
+    }
+    fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
+        match symbol(interpreter, "event") {
+            Value::Enum(event) => {
+                let id = event.borrow().id;
+                let names = interpreter
+                    .state
+                    .borrow()
+                    .enums
+                    .get(&id)
+                    .unwrap()
+                    .names
+                    .clone();
+                *event.borrow_mut() = MechEnum {
+                    id,
+                    variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
+                    names,
+                };
+            }
+            Value::Tuple(_) => set_atom_tuple_event(interpreter, variant, payload),
+            _ => panic!("event is neither enum nor tagged tuple"),
+        }
+    }
+    fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
+        let Value::Tuple(event) = symbol(interpreter, "event") else {
+            panic!("event is not tuple")
+        };
+        *event.borrow_mut() = MechTuple::from_vec(vec![
+            Value::Atom(Ref::new(MechAtom::from_name(tag))),
+            Value::F64(Ref::new(payload)),
+        ]);
+    }
+    fn set_tuple_event(interpreter: &Interpreter, values: Vec<Value>) {
+        let Value::Tuple(event) = symbol(interpreter, "event") else {
+            panic!("event is not tuple")
+        };
+        *event.borrow_mut() = MechTuple::from_vec(values);
+    }
+    fn selected_arm_index(
+        registration: &PatternActivationRegistration,
+        outcome: &ReactiveTurnOutcome,
+    ) -> usize {
+        let changed = turn_changed_nodes(outcome);
+        registration
+            .arms
+            .iter()
+            .position(|arm| changed.contains(&arm.gate_node))
+            .expect("no selected gate")
+    }
+    fn assert_dispatch_turn(
+        interpreter: &Interpreter,
+        topology: &PlanSnapshot,
+        outcome: &ReactiveTurnOutcome,
+        expected_arm: usize,
+        output: f64,
+    ) {
+        let registration = registration(interpreter);
+        let executed = turn_executed_nodes(outcome);
+        let changed = turn_changed_nodes(outcome);
+        let unchanged = turn_unchanged_nodes(outcome);
+        assert_eq!(
+            executed
+                .iter()
+                .filter(|id| **id == registration.scope_pulse_node)
+                .count(),
+            1
+        );
+        assert_eq!(
+            executed
+                .iter()
+                .filter(|id| **id == registration.selector_node)
+                .count(),
+            1
+        );
+        assert_eq!(selected_arm_index(&registration, outcome), expected_arm);
+        for (index, arm) in registration.arms.iter().enumerate() {
+            for node in [arm.matcher_node, arm.finalizer_node, arm.gate_node] {
+                assert_eq!(executed.iter().filter(|id| **id == node).count(), 1);
+            }
+            if index == expected_arm {
+                assert!(changed.contains(&arm.gate_node));
+                assert!(!unchanged.contains(&arm.gate_node));
+                for node in arm.body_node_start..arm.body_node_end {
+                    assert_eq!(executed.iter().filter(|id| **id == node).count(), 1);
+                }
+            } else {
+                assert!(unchanged.contains(&arm.gate_node));
+                assert!(!changed.contains(&arm.gate_node));
+                for node in arm.body_node_start..arm.body_node_end {
+                    assert!(!executed.contains(&node));
+                }
+            }
+        }
+        assert_eq!(body_output_f64(interpreter, expected_arm), output);
+        assert_eq!(&plan_snapshot(interpreter), topology);
+    }
+
+    const ENUM_ACTIVATION: &str = r#"event := (:pressed, 0.0)
+
+~> event
+  | :pressed(x) => {
+      selected := x + 0.0
+    }
+  | :released(x) => {
+      selected := x + 1000.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn load_enum_activation() -> (
+        Interpreter,
+        ReactiveCellId,
+        PatternActivationRegistration,
+        PlanSnapshot,
+    ) {
+        let interpreter = interpret(ENUM_ACTIVATION);
+        let trigger = root_cell(&interpreter, "event");
+        let registration = registration(&interpreter);
+        assert_eq!(registration.arms.len(), 3);
+        assert_eq!(registration.arms[0].captures.len(), 1);
+        assert_eq!(registration.arms[1].captures.len(), 1);
+        assert!(registration.arms[2].captures.is_empty());
+        assert!(!interpreter.symbols().borrow().contains(hash_str("x")));
+        assert!(
+            !interpreter
+                .symbols()
+                .borrow()
+                .contains(hash_str("selected"))
+        );
+        let topology = plan_snapshot(&interpreter);
+        (interpreter, trigger, registration, topology)
+    }
+
+    #[test]
+    fn activation_pattern_selects_pressed_released_and_wildcard() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        for (name, payload, arm, output) in [
+            ("pressed", 10., 0, 10.),
+            ("released", 20., 1, 1020.),
+            ("other", 30., 2, -1.),
+        ] {
+            set_enum_event(&i, name, payload);
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, arm, output);
+        }
+    }
+    #[test]
+    fn activation_pattern_enum_arms_compile_independent_of_initial_variant() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        assert_eq!(r.arms[1].captures[0].kind, ValueKind::F64);
+        set_enum_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+    }
+    #[test]
+    fn activation_pattern_enum_payload_capture_is_available() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        let cell = r.arms[0].captures[0].cell;
+        assert!(
+            i.plan().borrow().nodes[r.arms[0].body_node_start..r.arms[0].body_node_end]
+                .iter()
+                .any(|n| n.inputs.iter().any(|d| d.cell == cell))
+        );
+        set_enum_event(&i, "pressed", 10.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 10.);
+    }
+    #[test]
+    fn activation_pattern_equal_packets_dispatch_repeatedly() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        set_enum_event(&i, "pressed", 30.);
+        for _ in 0..2 {
+            let o = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &o, 0, 30.);
+        }
+    }
+    #[test]
+    fn activation_pattern_unselected_arm_nodes_do_not_execute() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        set_enum_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+        let executed = turn_executed_nodes(&o);
+        for arm in [&r.arms[0], &r.arms[2]] {
+            for node in arm.body_node_start..arm.body_node_end {
+                assert!(!executed.contains(&node));
+            }
+        }
+    }
+    #[test]
+    fn activation_pattern_switching_arms_does_not_grow_plan() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        for (name, payload) in [
+            ("pressed", 10.),
+            ("released", 20.),
+            ("other", 30.),
+            ("pressed", 30.),
+            ("pressed", 30.),
+        ] {
+            set_enum_event(&i, name, payload);
+            i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+    #[test]
+    fn activation_pattern_capture_storage_identity_is_stable() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        let captures = r
+            .arms
+            .iter()
+            .flat_map(|arm| arm.captures.iter())
+            .map(|capture| (capture.id, capture.kind.clone(), capture.cell))
+            .collect::<Vec<_>>();
+        for (name, payload) in [("pressed", 10.), ("released", 20.), ("other", 30.)] {
+            set_enum_event(&i, name, payload);
+            i.advance_reactive_turn(&[trigger]).unwrap();
+            let current = registration(&i)
+                .arms
+                .iter()
+                .flat_map(|arm| arm.captures.iter())
+                .map(|capture| (capture.id, capture.kind.clone(), capture.cell))
+                .collect::<Vec<_>>();
+            assert_eq!(current, captures);
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+
+    const ATOM_TUPLE_ACTIVATION: &str = r#"
+event := (:pressed, 0.0)
+~> event
+  | :pressed(x) => {
+      selected := x + 0.0
+    }
+  | :released(x) => {
+      selected := x + 1000.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn load_atom_tuple_activation() -> (
+        Interpreter,
+        ReactiveCellId,
+        PatternActivationRegistration,
+        PlanSnapshot,
+    ) {
+        let i = interpret(ATOM_TUPLE_ACTIVATION);
+        let trigger = root_cell(&i, "event");
+        let r = registration(&i);
+        let topology = plan_snapshot(&i);
+        (i, trigger, r, topology)
+    }
+    #[test]
+    fn activation_pattern_atom_tagged_tuple_selects_arm() {
+        let (mut i, trigger, _, topology) = load_atom_tuple_activation();
+        for (tag, payload, arm, output) in [
+            ("pressed", 10., 0, 10.),
+            ("released", 20., 1, 1020.),
+            ("other", 30., 2, -1.),
+        ] {
+            set_atom_tuple_event(&i, tag, payload);
+            let o = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &o, arm, output);
+        }
+    }
+    #[test]
+    fn activation_pattern_atom_tagged_tuple_captures_payload() {
+        let (mut i, trigger, r, topology) = load_atom_tuple_activation();
+        assert_eq!(r.arms[0].captures[0].kind, ValueKind::F64);
+        let cell = r.arms[0].captures[0].cell;
+        assert!(
+            i.plan().borrow().nodes[r.arms[0].body_node_start..r.arms[0].body_node_end]
+                .iter()
+                .any(|n| n.inputs.iter().any(|d| d.cell == cell))
+        );
+        set_atom_tuple_event(&i, "pressed", 10.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 10.);
+    }
+    #[test]
+    fn activation_pattern_atom_tuple_arms_compile_independent_of_initial_tag() {
+        let (mut i, trigger, r, topology) = load_atom_tuple_activation();
+        assert_eq!(r.arms[0].captures[0].kind, ValueKind::F64);
+        assert_eq!(r.arms[1].captures[0].kind, ValueKind::F64);
+        set_atom_tuple_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+    }
+
+    const FLAT_TUPLE_ACTIVATION: &str = r#"
+event := (1.0, 2.0)
+~> event
+  | (x, y) => {
+      selected := x * 10.0 + y
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    const NESTED_TUPLE_ACTIVATION: &str = r#"
+event := ((1.0, 2.0), 3.0)
+~> event
+  | ((x, y), z) => {
+      selected := x * 100.0 + y * 10.0 + z
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    const REPEATED_CAPTURE_ACTIVATION: &str = r#"
+event := (1.0, 1.0)
+~> event
+  | (x, x) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn tuple_fixture(source: &str) -> (Interpreter, ReactiveCellId, PlanSnapshot) {
+        let i = interpret(source);
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        (i, trigger, topology)
+    }
+    #[test]
+    fn activation_pattern_tuple_captures_elements() {
+        let (mut i, trigger, topology) = tuple_fixture(FLAT_TUPLE_ACTIVATION);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 34.);
+    }
+    #[test]
+    fn activation_pattern_nested_tuple_captures_elements() {
+        let (mut i, trigger, topology) = tuple_fixture(NESTED_TUPLE_ACTIVATION);
+        set_tuple_event(
+            &i,
+            vec![
+                Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                    Value::F64(Ref::new(4.)),
+                    Value::F64(Ref::new(5.)),
+                ]))),
+                Value::F64(Ref::new(6.)),
+            ],
+        );
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 456.);
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_requires_equal_values() {
+        let (mut i, trigger, topology) = tuple_fixture(REPEATED_CAPTURE_ACTIVATION);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(2.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 2.);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(3.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, -1.);
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_kind_mismatch_is_structured() {
+        let mut i = interpret("event := (1.0, \"one\")");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, x) => {
+      selected := x
+    }\n  | * => {
+      selected := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("x")));
+        assert!(!i.symbols().borrow().contains(hash_str("selected")));
+    }
+
+    #[test]
+    fn activation_pattern_capture_does_not_leak() {
+        let (mut i, trigger, topology) = tuple_fixture(FLAT_TUPLE_ACTIVATION);
+        for name in ["x", "y", "selected"] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 34.);
+    }
+    #[test]
+    fn activation_pattern_capture_shadows_and_restores_outer_symbol() {
+        let mut i = interpret("event := (1.0, 2.0)\nx := 99.0");
+        let outer = symbol_ref(&i, "x");
+        let address = outer.addr();
+        interpret_more(
+            &mut i,
+            "~> event\n  | (x, y) => {
+      selected := x + y
+    }\n  | * => {
+      selected := -1.0
+    }",
+        )
+        .unwrap();
+        assert_eq!(*symbol(&i, "x").as_f64().unwrap().borrow(), 99.);
+        assert_eq!(symbol_ref(&i, "x").addr(), address);
+        assert!(!i.symbols().borrow().contains(hash_str("y")));
+        assert!(!i.symbols().borrow().contains(hash_str("selected")));
+        let topology = plan_snapshot(&i);
+        let trigger = root_cell(&i, "event");
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 7.);
+    }
+    #[test]
+    fn activation_pattern_arm_definitions_do_not_leak_between_arms() {
+        let mut i = interpret("event := (1.0, 2.0)");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, y) => {
+      first-local := x + y
+    }\n  | (a, b) => {
+      second-local := first-local + a + b
+    }\n  | * => {
+      fallback := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "UndefinedVariable");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        for name in [
+            "first-local",
+            "second-local",
+            "fallback",
+            "x",
+            "y",
+            "a",
+            "b",
+        ] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+    }
+
+    fn failed_elaboration_fixture() -> (
+        Interpreter,
+        SymbolTableSnapshot,
+        Dictionary,
+        PlanSnapshot,
+        ValRef,
+        usize,
+    ) {
+        let i = interpret("event := (1.0, 2.0)\nouter := 99.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let outer = symbol_ref(&i, "outer");
+        let address = outer.addr();
+        (i, symbols, dictionary, topology, outer, address)
+    }
+    fn assert_failed_elaboration_restored() -> (
+        Interpreter,
+        SymbolTableSnapshot,
+        Dictionary,
+        PlanSnapshot,
+        usize,
+    ) {
+        let (mut i, symbols, dictionary, topology, outer, address) = failed_elaboration_fixture();
+        let error=interpret_more(&mut i,"~> event\n  | (x, y) => {\n      local-atom := :temporary\n      local-first := x + y\n      local-failure := function-that-does-not-exist(local-first)\n    }\n  | * => {
+      fallback := 0.0
+    }").unwrap_err();
+        assert!(error.kind_name().contains("Function"));
+        assert!(!i.dictionary().borrow().contains_key(&hash_str("temporary")));
+        for name in [
+            "local-atom",
+            "local-first",
+            "local-failure",
+            "fallback",
+            "x",
+            "y",
+        ] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+        assert_eq!(*symbol(&i, "outer").as_f64().unwrap().borrow(), 99.);
+        assert_eq!(symbol_ref(&i, "outer").addr(), address);
+        drop(outer);
+        (i, symbols, dictionary, topology, address)
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_symbol_table() {
+        let (i, symbols, _, _, _) = assert_failed_elaboration_restored();
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_program_dictionary() {
+        let (i, _, dictionary, _, _) = assert_failed_elaboration_restored();
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_plan() {
+        let (i, _, _, topology, _) = assert_failed_elaboration_restored();
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+    #[test]
+    fn activation_pattern_preflight_error_does_not_modify_plan() {
+        let mut i = interpret("event := (1.0, \"one\")");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, x) => {
+      selected := x
+    }\n  | * => {
+      selected := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+    #[test]
+    fn activation_pattern_recursive_preflight_rejects_nested_activation() {
+        let mut i = interpret("event := 1.0\ntick := 0.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | 1.0 => {\n      ~> tick {\n        nested := 1.0\n      }\n    }\n  | * => {\n      fallback := 0.0\n    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternDefinitionUnsupported");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("nested")));
+        assert!(!i.symbols().borrow().contains(hash_str("fallback")));
+    }
+    #[test]
+    fn activation_pattern_recursive_preflight_rejects_context_declaration() {
+        let mut i = interpret("event := 1.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | 1.0 => {
+      @temporary := test://resource
+    }\n  | * => {
+      fallback := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternDefinitionUnsupported");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("fallback")));
+    }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,99 +1,59 @@
-#![cfg(all(
-  feature = "functions",
-  feature = "symbol_table",
-))]
-
-//! Static scheduling support for patterned activation scopes.
-//!
-//! The small dispatch nodes in this file deliberately contain no syntax and
-//! are registered once while a source tree is elaborated.  A reactive turn
-//! only moves generation counters through that already-built graph.
-
+#![cfg(all(feature = "functions", feature = "symbol_table"))]
+//! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
 
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternExpressionUnsupported;
-impl MechErrorKind for ActivationPatternExpressionUnsupported { fn name(&self)->&str{"ActivationPatternExpressionUnsupported"} fn message(&self)->String{"This activation pattern is not supported.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternCaptureKindUnsupported;
-impl MechErrorKind for ActivationPatternCaptureKindUnsupported { fn name(&self)->&str{"ActivationPatternCaptureKindUnsupported"} fn message(&self)->String{"The capture kind cannot be inferred from the activation trigger.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternArmsNonExhaustive;
-impl MechErrorKind for ActivationPatternArmsNonExhaustive { fn name(&self)->&str{"ActivationPatternArmsNonExhaustive"} fn message(&self)->String{"Patterned activations require a final unguarded wildcard arm.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternWildcardMustBeLast;
-impl MechErrorKind for ActivationPatternWildcardMustBeLast { fn name(&self)->&str{"ActivationPatternWildcardMustBeLast"} fn message(&self)->String{"The wildcard activation arm must be last.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternGuardMustBePure;
-impl MechErrorKind for ActivationPatternGuardMustBePure { fn name(&self)->&str{"ActivationPatternGuardMustBePure"} fn message(&self)->String{"Patterned activation guards must be pure.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternRegisterWriteUnsupported;
-impl MechErrorKind for ActivationPatternRegisterWriteUnsupported { fn name(&self)->&str{"ActivationPatternRegisterWriteUnsupported"} fn message(&self)->String{"Patterned activation register writes are not supported.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternContextEffectUnsupported;
-impl MechErrorKind for ActivationPatternContextEffectUnsupported { fn name(&self)->&str{"ActivationPatternContextEffectUnsupported"} fn message(&self)->String{"Patterned activation context effects are not supported.".into()} }
+macro_rules! activation_error {($n:ident,$m:expr)=>{#[derive(Debug,Clone)] pub(crate) struct $n; impl MechErrorKind for $n {fn name(&self)->&str{stringify!($n)} fn message(&self)->String{$m.into()}}};}
+activation_error!(ActivationPatternExpressionUnsupported,"This activation pattern is not supported.");
+activation_error!(ActivationPatternCaptureKindUnsupported,"The capture kind cannot be inferred from the activation trigger.");
+activation_error!(ActivationPatternArmsNonExhaustive,"Patterned activations require a final unguarded wildcard arm.");
+activation_error!(ActivationPatternWildcardMustBeLast,"The wildcard activation arm must be last.");
+activation_error!(ActivationPatternGuardMustBePure,"Patterned activation guards are not supported yet.");
+activation_error!(ActivationPatternRegisterWriteUnsupported,"Patterned activation register writes are not supported.");
+activation_error!(ActivationPatternContextEffectUnsupported,"Patterned activation context effects are not supported.");
+activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cells disagree with the resolved trigger.");
 
-#[derive(Clone, Debug)]
-enum CompiledActivationPattern { Wildcard, Literal(Value) }
+#[derive(Clone,Debug)] enum CompiledActivationPattern { Wildcard, Literal{expected:Value}, Capture{capture_index:usize}, Tuple{elements:Vec<Self>}, TupleStruct{tag:u64,payload:Vec<Self>} }
+#[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
+#[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
+fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
+fn slot(v:&Value)->Option<Value> { match detached(v) {
+  Value::F64(_)=>Some(Value::F64(Ref::new(0.))), Value::F32(_)=>Some(Value::F32(Ref::new(0.))),
+  Value::I64(_)=>Some(Value::I64(Ref::new(0))), Value::I32(_)=>Some(Value::I32(Ref::new(0))), Value::I16(_)=>Some(Value::I16(Ref::new(0))), Value::I8(_)=>Some(Value::I8(Ref::new(0))),
+  Value::U64(_)=>Some(Value::U64(Ref::new(0))), Value::U32(_)=>Some(Value::U32(Ref::new(0))), Value::U16(_)=>Some(Value::U16(Ref::new(0))), Value::U8(_)=>Some(Value::U8(Ref::new(0))),
+  Value::Bool(_)=>Some(Value::Bool(Ref::new(false))), Value::String(_)=>Some(Value::String(Ref::new(String::new()))), Value::Index(_)=>Some(Value::Index(Ref::new(0))), Value::Atom(a)=>Some(Value::Atom(Ref::new(a.borrow().clone()))), _=>None } }
+fn compile(pat:&Pattern, sample:&Value, i:&Interpreter, caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern> { match pat {
+ Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}),
+ Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash(); if let Some(n)=caps.iter().position(|c|c.id==id){return Ok(CompiledActivationPattern::Capture{capture_index:n})}; let value=slot(sample).ok_or_else(||MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))?; caps.push(Capture{id,kind:sample.kind(),slot:value}); Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})},
+ Pattern::Tuple(t)=> {let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; let e=&tv.borrow().elements; if e.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(e.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
+ Pattern::TupleStruct(t)=> { let tag=t.name.hash(); let payload=match detached(sample) { Value::Enum(e)=>{let e=e.borrow(); e.variants.iter().find(|(id,_)|*id==tag).and_then(|(_,x)|x.as_ref()).cloned().into_iter().collect::<Vec<_>>()}, Value::Tuple(x)=>{let x=x.borrow(); if x.elements.first().map(|v|matches!(detached(v),Value::Atom(a) if a.borrow().id()==tag)).unwrap_or(false){x.elements.iter().skip(1).map(|v|(**v).clone()).collect()}else{Vec::new()}}, _=>Vec::new()}; if payload.len()!=t.patterns.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::TupleStruct{tag,payload:t.patterns.iter().zip(payload.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
+ _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens())) }}
+fn matches_pattern(p:&CompiledActivationPattern,v:&Value, proposed:&mut Vec<Option<Value>>)->bool {match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}},CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false},CompiledActivationPattern::TupleStruct{tag,payload}=>match detached(v){Value::Enum(e)=>{let e=e.borrow();match e.variants.iter().find(|(id,_)|id==tag){Some((_,Some(v))) if payload.len()==1=>matches_pattern(&payload[0],v,proposed),Some((_,None))=>payload.is_empty(),_=>false}},Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==payload.len()+1&&matches!(detached(&t.elements[0]),Value::Atom(a) if a.borrow().id()==*tag)&&payload.iter().zip(t.elements.iter().skip(1)).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}}}
+macro_rules! copy_slot {($s:expr,$v:expr,$($x:ident),*)=>{match ($s,$v){$((Value::$x(a),Value::$x(b))=>{*a.borrow_mut()=*b.borrow();Ok(())},)* _=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}}
+fn commit(s:&Value,v:&Value)->MResult<()> {copy_slot!(s,detached(v),F64,F32,I64,I32,I16,I8,U64,U32,U16,U8,Bool,String,Index,Atom)}
+fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
+struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
+struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
+struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
+struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
+struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}
 
-fn compile_pattern(pattern: &Pattern, interpreter: &Interpreter) -> MResult<CompiledActivationPattern> {
-  match pattern {
-    Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
-    Pattern::Expression(Expression::Literal(literal)) => Ok(CompiledActivationPattern::Literal(crate::literal(literal, interpreter)?)),
-    // A variable is deliberately not treated as a catch-all: doing so loses
-    // the type and stable backing reference required for a capture slot.
-    Pattern::Expression(Expression::Var(_)) => Err(MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(pattern.tokens())),
-    _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None).with_tokens(pattern.tokens())),
-  }
-}
+#[cfg(feature="compiler")] macro_rules! interpreter_only {($t:ty)=>{impl MechFunctionCompiler for $t { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }};}
+#[cfg(feature="compiler")] interpreter_only!(ScopePulse);
+#[cfg(feature="compiler")] interpreter_only!(Matcher);
+#[cfg(feature="compiler")] interpreter_only!(Finalize);
+#[cfg(feature="compiler")] interpreter_only!(Select);
+#[cfg(feature="compiler")] interpreter_only!(Gate);
 
-fn generation() -> (Ref<usize>, Value) { let cell=Ref::new(0usize); let value=Value::Index(cell.clone()); (cell,value) }
-
-struct ScopePulse { out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for ScopePulse { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for ScopePulse {
-  fn solve(&self) {}
-  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
-  fn out(&self)->Value { Value::Index(self.out.clone()) }
-  fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>> { Some(vec![ReactiveDependencyScope::Root]) }
-  fn to_string(&self)->String{"ActivationPatternScopePulse".into()}
-}
-struct Matcher { pattern: CompiledActivationPattern, trigger: Value, matched: Ref<bool>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Matcher { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Matcher {
-  fn solve(&self) {}
-  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.matched.borrow_mut()=match &self.pattern { CompiledActivationPattern::Wildcard=>true, CompiledActivationPattern::Literal(value)=>value==&self.trigger }; *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
-  fn out(&self)->Value{Value::Index(self.out.clone())}
-  fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}
-  fn to_string(&self)->String{"ActivationPatternMatcher".into()}
-}
-struct Finalize { matched: Ref<bool>, eligible: Ref<bool>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Finalize { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Finalize { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmFinalize".into()} }
-struct Select { eligible: Vec<Ref<bool>>, selected: Ref<usize>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Select { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Select { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternSelectArm".into()} }
-struct Gate { arm: usize, selected: Ref<usize>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Gate { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Gate { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if *self.selected.borrow()==self.arm {*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} else {Ok(ReactiveSolveStatus::Unchanged)}} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmGate".into()} }
-
-/// Elaborates the static, combinational dispatch graph for literal and
-/// wildcard patterned activation arms.  Unsupported destructuring is rejected
-/// during elaboration rather than deferred to a reactive turn.
-pub(crate) fn elaborate_patterned_activation(scope: &ActivationScope, arms: &[ActivationArm], trigger: Value, trigger_cells: Vec<ReactiveCellId>, interpreter: &Interpreter) -> MResult<Value> {
-  let final_arm=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
-  if !matches!(final_arm.pattern,Pattern::Wildcard) || final_arm.guard.is_some() { return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens())); }
-  if arms[..arms.len()-1].iter().any(|arm|matches!(arm.pattern,Pattern::Wildcard)) { return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens())); }
-  if arms.iter().any(|arm|arm.guard.is_some()) { return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens())); }
-  for arm in arms { if let ActivationArmBody::Block(body)=&arm.body { for (code,_) in body { match code { MechCode::Statement(Statement::VariableAssign(_)) | MechCode::Statement(Statement::OpAssign(_)) => return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())), MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())), _=>{} } } } }
-  let patterns=arms.iter().map(|arm|compile_pattern(&arm.pattern,interpreter)).collect::<MResult<Vec<_>>>()?;
-  let plan=interpreter.plan();
-  let (scope_generation,scope_value)=generation();
-  let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_generation}), &[trigger.clone()])?;
-  let mut matcher_nodes=Vec::new(); let mut completions=Vec::new(); let mut matched=Vec::new();
-  for pattern in patterns { let (complete,complete_value)=generation(); let flag=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Matcher{pattern,trigger:trigger.clone(),matched:flag.clone(),out:complete}), &[scope_value.clone(),trigger.clone()])?; matcher_nodes.push(id); completions.push(complete_value); matched.push(flag); }
-  let mut finalizer_nodes=Vec::new(); let mut eligible=Vec::new(); let mut arm_complete=Vec::new();
-  for (flag, complete) in matched.iter().zip(completions.iter()) { let (done,done_value)=generation(); let ok=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Finalize{matched:flag.clone(),eligible:ok.clone(),out:done}), &[complete.clone()])?; finalizer_nodes.push(id); eligible.push(ok); arm_complete.push(done_value); }
-  let (selection,selection_value)=generation(); let selected=Ref::new(usize::MAX); let selector_node=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:selection}), &arm_complete)?;
-  let mut gate_nodes=Vec::new(); let mut pulses=Vec::new();
-  for arm in 0..arms.len() { let (pulse,pulse_value)=generation(); let id=plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:pulse}), &[selection_value.clone()])?; gate_nodes.push(id); pulses.push(pulse_value); }
-  let mut registrations=Vec::new();
-  for (arm,pulse) in arms.iter().zip(pulses.iter()) { let start=plan.len(); plan.push_activation_registration_scope(pulse.reactive_root_cell_ids()); let result=match &arm.body { ActivationArmBody::Block(body)=>{for (code,_) in body { crate::mech_code(code,interpreter)?; } Ok(())}, ActivationArmBody::Expression(expression)=>{crate::expression(expression,None,interpreter).map(|_|())} }; plan.pop_activation_registration_scope(); result?; registrations.push((start,plan.len())); }
-  let registration=PatternActivationRegistration { scope_pulse_node:scope_node, selector_node, arms:(0..arms.len()).map(|i|PatternActivationArmRegistration{matcher_node:matcher_nodes[i],finalizer_node:finalizer_nodes[i],gate_node:gate_nodes[i],pulse_cell:pulses[i].reactive_root_cell_ids()[0],body_node_start:registrations[i].0,body_node_end:registrations[i].1}).collect() };
-  plan.borrow_mut().register_pattern_activation(registration);
-  let _=trigger_cells; // The scope pulse's Root dependency is the trigger's root storage.
-  Ok(Value::Empty)
+pub(crate) fn elaborate_patterned_activation(scope:&ActivationScope,arms:&[ActivationArm],trigger:Value,trigger_cells:Vec<ReactiveCellId>,i:&Interpreter)->MResult<Value>{
+ let last=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
+ if !matches!(last.pattern,Pattern::Wildcard)||last.guard.is_some(){return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))} if arms[..arms.len()-1].iter().any(|x|matches!(x.pattern,Pattern::Wildcard)){return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens()))} if arms.iter().any(|x|x.guard.is_some()){return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens()))}
+ for arm in arms {if let ActivationArmBody::Block(body)=&arm.body{for(code,_)in body{match code{MechCode::Statement(Statement::VariableAssign(_))|MechCode::Statement(Statement::OpAssign(_))=>return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())),MechCode::Statement(Statement::ContextSend(_))=>return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())),_=>{}}}}}
+ let mut compiled=Vec::new();for arm in arms{let mut captures=Vec::new();let pattern=compile(&arm.pattern,&trigger,i,&mut captures)?;compiled.push(CompiledArm{pattern,captures})}
+ if trigger.reactive_root_cell_ids()!=trigger_cells{return Err(MechError::new(ActivationPatternTriggerInvariant,None).with_tokens(scope.tokens()))}
+ let plan=i.plan();let(scope_gen,scope_v)=generation();let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_gen}),&[trigger.clone()])?;
+ let(mut matcher_nodes,mut completions,mut matched)=(Vec::new(),Vec::new(),Vec::new());for arm in &compiled{let(o,v)=generation();let f=Ref::new(false);let n=plan.borrow_mut().register(Box::new(Matcher{pattern:arm.pattern.clone(),trigger:trigger.clone(),captures:arm.captures.clone(),matched:f.clone(),out:o}),&[scope_v.clone(),trigger.clone()])?;matcher_nodes.push(n);completions.push(v);matched.push(f)}
+ let(mut finalizers,mut eligible,mut done)=(Vec::new(),Vec::new(),Vec::new());for(f,c)in matched.iter().zip(completions.iter()){let(o,v)=generation();let e=Ref::new(false);finalizers.push(plan.borrow_mut().register(Box::new(Finalize{matched:f.clone(),eligible:e.clone(),out:o}),&[c.clone()])?);eligible.push(e);done.push(v)} let(o,selection)=generation();let selected=Ref::new(usize::MAX);let selector=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:o}),&done)?;
+ let(mut gates,mut pulses)=(Vec::new(),Vec::new());for arm in 0..arms.len(){let(o,v)=generation();gates.push(plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:o}),&[selection.clone()])?);pulses.push(v)}
+ let mut ranges=Vec::new();for(arm,compiled_arm)in arms.iter().zip(compiled.iter()){let symbols=i.symbols();let mut s=symbols.borrow_mut();let old=compiled_arm.captures.iter().map(|c|(c.id,s.symbols.get(&c.id).cloned(),s.mutable_variables.get(&c.id).cloned())).collect::<Vec<_>>();for c in &compiled_arm.captures{s.insert(c.id,c.slot.clone(),false);}drop(s);let start=plan.len();plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());let result=match &arm.body{ActivationArmBody::Block(b)=>{for(c,_)in b{crate::mech_code(c,i)?;}Ok(())},ActivationArmBody::Expression(e)=>crate::expression(e,None,i).map(|_|())};plan.pop_activation_registration_scope();let mut s=symbols.borrow_mut();for(id,oldv,oldm)in old{s.symbols.remove(&id);s.mutable_variables.remove(&id);if let Some(v)=oldv{s.symbols.insert(id,v);}if let Some(v)=oldm{s.mutable_variables.insert(id,v);}}drop(s);result?;ranges.push((start,plan.len()))}
+ let registration=PatternActivationRegistration{scope_pulse_node:scope_node,selector_node:selector,arms:(0..arms.len()).map(|n|PatternActivationArmRegistration{matcher_node:matcher_nodes[n],finalizer_node:finalizers[n],gate_node:gates[n],pulse_cell:pulses[n].reactive_root_cell_ids()[0],body_node_start:ranges[n].0,body_node_end:ranges[n].1,captures:compiled[n].captures.iter().map(|c|PatternActivationCaptureRegistration{id:c.id,kind:c.kind.clone(),cell:c.slot.reactive_root_cell_ids()[0]}).collect()}).collect()};plan.borrow_mut().register_pattern_activation(registration);Ok(Value::Empty)
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -17,10 +17,6 @@ macro_rules! activation_error {
     };
 }
 activation_error!(
-    ActivationPatternExpressionUnsupported,
-    "This activation pattern is not supported."
-);
-activation_error!(
     ActivationPatternCaptureKindUnsupported,
     "The capture kind cannot be inferred from the activation trigger."
 );
@@ -49,28 +45,6 @@ activation_error!(
     "Activation trigger root cells disagree with the resolved trigger."
 );
 
-#[derive(Clone, Debug)]
-enum CompiledActivationPattern {
-    Wildcard,
-    Literal {
-        expected: Value,
-    },
-    Capture {
-        capture_index: usize,
-    },
-    Tuple {
-        elements: Vec<CompiledActivationPattern>,
-    },
-    EnumVariant {
-        enum_id: u64,
-        variant_id: u64,
-        payload: Option<Box<CompiledActivationPattern>>,
-    },
-    AtomTuple {
-        tag_id: u64,
-        payload: Vec<CompiledActivationPattern>,
-    },
-}
 #[derive(Clone)]
 struct ActivationPatternCapture {
     id: u64,
@@ -80,7 +54,7 @@ struct ActivationPatternCapture {
 }
 #[derive(Clone)]
 struct PreflightActivationArm {
-    pattern: CompiledActivationPattern,
+    pattern: CompiledPattern,
     captures: Vec<ActivationPatternCapture>,
 }
 struct PreflightPatternedActivation {
@@ -247,257 +221,54 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
         )),
     }
 }
-fn compile_activation_literal(l: &Literal, i: &Interpreter) -> MResult<Value> {
-    match l {
-        Literal::Empty(_) => Ok(Value::Empty),
-        #[cfg(feature = "bool")]
-        Literal::Boolean(t) => Ok(crate::boolean(t)),
-        #[cfg(feature = "string")]
-        Literal::String(v) => Ok(crate::string(v)),
-        #[cfg(feature = "atom")]
-        Literal::Atom(a) => Ok(Value::Atom(Ref::new(MechAtom::new(a.name.hash())))),
-        Literal::Number(Number::Real(RealNumber::TypedInteger(_)))
-        | Literal::TypedLiteral(_)
-        | Literal::Kind(_) => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
-        Literal::Number(n) => crate::number(n, i),
-        _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+
+fn capture_kinds_are_storage_compatible(destination: &ValueKind, source: &ValueKind) -> bool {
+    let destination = destination.deref_kind();
+    let source = source.deref_kind();
+    #[cfg(feature = "atom")]
+    if matches!(
+        (&destination, &source),
+        (ValueKind::Atom(_, _), ValueKind::Atom(_, _))
+    ) {
+        return true;
     }
+    destination == source
 }
-#[cfg(feature = "enum")]
-fn compile_enum_variant_pattern(
-    t: &PatternTupleStruct,
-    enum_id: u64,
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let variant_id = t.name.hash();
-    let def = i
-        .state
-        .borrow()
-        .enums
-        .get(&enum_id)
-        .cloned()
-        .ok_or_else(|| {
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
-        })?;
-    let declared = def
-        .variants
-        .iter()
-        .find(|(id, _)| *id == variant_id)
-        .map(|(_, p)| p.clone())
-        .ok_or_else(|| {
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
-        })?;
-    let payload = match (t.patterns.as_slice(), declared) {
-        ([], None) => None,
-        ([p], Some(Value::Kind(k))) => Some(Box::new(compile_activation_pattern(p, &k, i, c)?)),
-        _ => {
-            return Err(
+
+struct ReactiveBindingSink<'a> {
+    captures: &'a [ActivationPatternCapture],
+}
+
+impl PatternBindingSink for ReactiveBindingSink<'_> {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()> {
+        if !pattern_match.matched {
+            return Ok(());
+        }
+
+        // Validate every destination before mutating any stable capture cell.
+        for binding in &pattern_match.bindings {
+            let capture = self.captures.get(binding.index).ok_or_else(|| {
                 MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                    .with_tokens(t.tokens()),
-            );
-        }
-    };
-    Ok(CompiledActivationPattern::EnumVariant {
-        enum_id,
-        variant_id,
-        payload,
-    })
-}
-#[cfg(all(feature = "tuple", feature = "atom"))]
-fn compile_atom_tuple_pattern(
-    t: &PatternTupleStruct,
-    kinds: &[ValueKind],
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let Some(first) = kinds.first() else {
-        return Err(
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
-        );
-    };
-    if !matches!(first.deref_kind(), ValueKind::Atom(_, _)) || t.patterns.len() != kinds.len() - 1 {
-        return Err(
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
-        );
-    };
-    let payload = t
-        .patterns
-        .iter()
-        .zip(kinds.iter().skip(1))
-        .map(|(p, k)| compile_activation_pattern(p, k, i, c))
-        .collect::<MResult<_>>()?;
-    Ok(CompiledActivationPattern::AtomTuple {
-        tag_id: t.name.hash(),
-        payload,
-    })
-}
-fn compile_activation_pattern(
-    p: &Pattern,
-    kind: &ValueKind,
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let kind = kind.deref_kind();
-    match p {
-        Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
-        Pattern::Expression(Expression::Literal(l)) => {
-            let expected = compile_activation_literal(l, i)?;
-            if expected.kind().deref_kind() != kind {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
+            })?;
+            let source = detached(&binding.value);
+            if capture.id != binding.id
+                || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
+                || std::mem::discriminant(&capture.slot) != std::mem::discriminant(&source)
+            {
+                return Err(MechError::new(
+                    ActivationPatternCaptureKindUnsupported,
+                    None,
+                ));
             }
-            Ok(CompiledActivationPattern::Literal { expected })
         }
-        Pattern::Expression(Expression::Var(v)) => {
-            let id = v.name.hash();
-            if let Some(n) = c.iter().position(|x| x.id == id) {
-                if c[n].kind.deref_kind() != kind {
-                    return Err(
-                        MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                            .with_tokens(p.tokens()),
-                    );
-                }
-                return Ok(CompiledActivationPattern::Capture { capture_index: n });
-            }
-            let slot =
-                create_capture_slot_for_kind(&kind).map_err(|e| e.with_tokens(p.tokens()))?;
-            c.push(ActivationPatternCapture {
-                id,
-                name: v.name.to_string(),
-                kind,
-                slot,
-            });
-            Ok(CompiledActivationPattern::Capture {
-                capture_index: c.len() - 1,
-            })
+
+        for binding in &pattern_match.bindings {
+            commit_capture_slot(&self.captures[binding.index].slot, &binding.value)?;
         }
-        #[cfg(feature = "tuple")]
-        Pattern::Tuple(t) => {
-            let ValueKind::Tuple(k) = kind else {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
-            };
-            if t.0.len() != k.len() {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
-            }
-            Ok(CompiledActivationPattern::Tuple {
-                elements: t
-                    .0
-                    .iter()
-                    .zip(k.iter())
-                    .map(|(p, k)| compile_activation_pattern(p, k, i, c))
-                    .collect::<MResult<_>>()?,
-            })
-        }
-        Pattern::TupleStruct(t) => match kind {
-            #[cfg(feature = "enum")]
-            ValueKind::Enum(id, _) => compile_enum_variant_pattern(t, id, i, c),
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            ValueKind::Tuple(k) => compile_atom_tuple_pattern(t, &k, i, c),
-            _ => Err(
-                MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                    .with_tokens(p.tokens()),
-            ),
-        },
-        _ => {
-            Err(MechError::new(ActivationPatternExpressionUnsupported, None)
-                .with_tokens(p.tokens()))
-        }
+        Ok(())
     }
 }
-fn matches_pattern(
-    p: &CompiledActivationPattern,
-    v: &Value,
-    proposed: &mut Vec<Option<Value>>,
-) -> bool {
-    match p {
-        CompiledActivationPattern::Wildcard => true,
-        CompiledActivationPattern::Literal { expected } => expected == &detached(v),
-        CompiledActivationPattern::Capture { capture_index } => {
-            let x = detached(v);
-            match &proposed[*capture_index] {
-                Some(y) => y == &x,
-                None => {
-                    proposed[*capture_index] = Some(x);
-                    true
-                }
-            }
-        }
-        #[cfg(feature = "tuple")]
-        CompiledActivationPattern::Tuple { elements } => match detached(v) {
-            Value::Tuple(t) => {
-                let t = t.borrow();
-                t.elements.len() == elements.len()
-                    && elements
-                        .iter()
-                        .zip(t.elements.iter())
-                        .all(|(p, v)| matches_pattern(p, v, proposed))
-            }
-            _ => false,
-        },
-        CompiledActivationPattern::EnumVariant {
-            enum_id,
-            variant_id,
-            payload,
-        } => {
-            #[cfg(feature = "enum")]
-            {
-                let Value::Enum(e) = detached(v) else {
-                    return false;
-                };
-                let e = e.borrow();
-                if e.id != *enum_id || e.variants.len() != 1 {
-                    return false;
-                }
-                let (id, value) = &e.variants[0];
-                id == variant_id
-                    && match (payload, value) {
-                        (None, None) => true,
-                        (Some(p), Some(v)) => matches_pattern(p, v, proposed),
-                        _ => false,
-                    }
-            }
-            #[cfg(not(feature = "enum"))]
-            {
-                false
-            }
-        }
-        CompiledActivationPattern::AtomTuple { tag_id, payload } => {
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            {
-                let Value::Tuple(t) = detached(v) else {
-                    return false;
-                };
-                let t = t.borrow();
-                if t.elements.len() != payload.len() + 1 {
-                    return false;
-                }
-                let Value::Atom(tag) = detached(&t.elements[0]) else {
-                    return false;
-                };
-                tag.borrow().id() == *tag_id
-                    && payload
-                        .iter()
-                        .zip(t.elements.iter().skip(1))
-                        .all(|(p, v)| matches_pattern(p, v, proposed))
-            }
-            #[cfg(not(all(feature = "tuple", feature = "atom")))]
-            {
-                false
-            }
-        }
-        #[cfg(not(feature = "tuple"))]
-        CompiledActivationPattern::Tuple { .. } => false,
-    }
-}
+
 fn generation() -> (Ref<usize>, Value) {
     let r = Ref::new(0);
     (r.clone(), Value::Index(r))
@@ -522,8 +293,9 @@ impl MechFunctionImpl for ScopePulse {
     }
 }
 struct Matcher {
-    pattern: CompiledActivationPattern,
+    pattern: CompiledPattern,
     trigger: Value,
+    expression_values: Vec<Value>,
     captures: Vec<ActivationPatternCapture>,
     matched: Ref<bool>,
     out: Ref<usize>,
@@ -531,27 +303,28 @@ struct Matcher {
 impl MechFunctionImpl for Matcher {
     fn solve(&self) {}
     fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
-        let mut p = vec![None; self.captures.len()];
-        let ok = matches_pattern(&self.pattern, &self.trigger, &mut p);
-        if ok {
-            for (c, v) in self.captures.iter().zip(p.iter()) {
-                if let Some(v) = v {
-                    commit_capture_slot(&c.slot, v)?
-                }
-            }
+        let pattern_match = match_compiled_pattern_with_values(
+            &self.pattern,
+            &self.trigger,
+            &self.expression_values,
+        )?;
+        ReactiveBindingSink {
+            captures: &self.captures,
         }
-        *self.matched.borrow_mut() = ok;
+        .commit(&pattern_match)?;
+        *self.matched.borrow_mut() = pattern_match.matched;
         *self.out.borrow_mut() += 1;
         Ok(ReactiveSolveStatus::Changed)
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
     }
-    fn reactive_dependency_kinds(&self, _: usize) -> Option<Vec<ReactiveDependencyKind>> {
-        Some(vec![
-            ReactiveDependencyKind::Reactive,
-            ReactiveDependencyKind::Sampled,
-        ])
+    fn reactive_dependency_kinds(&self, argument_count: usize) -> Option<Vec<ReactiveDependencyKind>> {
+        let mut kinds = vec![ReactiveDependencyKind::Sampled; argument_count];
+        if let Some(scope_pulse) = kinds.first_mut() {
+            *scope_pulse = ReactiveDependencyKind::Reactive;
+        }
+        Some(kinds)
     }
     fn to_string(&self) -> String {
         "ActivationPatternMatcher".into()
@@ -687,8 +460,25 @@ fn preflight_patterned_activation(
     let trigger_kind = trigger.kind().deref_kind();
     let mut compiled = Vec::new();
     for a in arms {
-        let mut captures = Vec::new();
-        let pattern = compile_activation_pattern(&a.pattern, &trigger_kind, i, &mut captures)?;
+        let pattern = compile_pattern(&a.pattern, Some(&trigger_kind), i)?;
+        let captures = pattern
+            .binding_specs()
+            .into_iter()
+            .map(|binding| {
+                let kind = binding.kind.ok_or_else(|| {
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(a.pattern.tokens())
+                })?;
+                let slot = create_capture_slot_for_kind(&kind)
+                    .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
+                Ok(ActivationPatternCapture {
+                    id: binding.id,
+                    name: binding.name,
+                    kind,
+                    slot,
+                })
+            })
+            .collect::<MResult<Vec<_>>>()?;
         compiled.push(PreflightActivationArm { pattern, captures });
     }
     Ok(PreflightPatternedActivation {
@@ -1007,23 +797,38 @@ fn elaborate_patterned_activation_inner(
     }
     let compiled = preflight.arms;
     let plan = i.plan();
+    let pattern_expression_values = compiled
+        .iter()
+        .map(|arm| {
+            arm.pattern
+                .expressions()
+                .iter()
+                .map(|expression| crate::expression(expression, None, i))
+                .collect::<MResult<Vec<_>>>()
+        })
+        .collect::<MResult<Vec<_>>>()?;
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
         .borrow_mut()
         .register(Box::new(ScopePulse { out: scope_gen }), &[trigger.clone()])?;
     let (mut matcher_nodes, mut completions, mut matched) = (Vec::new(), Vec::new(), Vec::new());
-    for arm in &compiled {
+    for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
         let (o, v) = generation();
         let f = Ref::new(false);
+        let mut inputs = Vec::with_capacity(2 + expression_values.len());
+        inputs.push(scope_v.clone());
+        inputs.push(trigger.clone());
+        inputs.extend(expression_values.iter().cloned());
         let n = plan.borrow_mut().register(
             Box::new(Matcher {
                 pattern: arm.pattern.clone(),
                 trigger: trigger.clone(),
+                expression_values: expression_values.clone(),
                 captures: arm.captures.clone(),
                 matched: f.clone(),
                 out: o,
             }),
-            &[scope_v.clone(), trigger.clone()],
+            &inputs,
         )?;
         matcher_nodes.push(n);
         completions.push(v);
@@ -1206,6 +1011,46 @@ mod tests {
         assert_eq!(slot.reactive_root_cell_ids(), cells);
     }
 
+    #[cfg(feature = "atom")]
+    #[test]
+    fn activation_atom_capture_accepts_a_new_atom_value() {
+        let mut interpreter = interpret(
+            r#"
+event := :first
+~> event
+  | captured => {
+      selected := captured
+    }
+  | * => {
+      selected := :fallback
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        let registration = registration(&interpreter);
+        let Value::Atom(event) = symbol(&interpreter, "event") else {
+            panic!("event is not an atom")
+        };
+        *event.borrow_mut() = MechAtom::from_name("second");
+
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&registration, &outcome), 0);
+        let selected_atom = {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            (registration.arms[0].body_node_start..registration.arms[0].body_node_end)
+                .rev()
+                .find_map(|node| match detached(&plan.node(node).unwrap().function.out()) {
+                    Value::Atom(atom) => Some(atom.borrow().id()),
+                    _ => None,
+                })
+                .expect("no atom output in selected arm body")
+        };
+        assert_eq!(selected_atom, hash_str("second"));
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn activation_capture_slot_rejects_kind_mismatch() {
@@ -1360,6 +1205,30 @@ mod tests {
             names,
         };
     }
+    fn set_unit_enum_event(interpreter: &Interpreter, variant: &str) {
+        let event_value = symbol(interpreter, "event");
+        if let Value::Atom(event) = &event_value {
+            *event.borrow_mut() = MechAtom::from_name(variant);
+            return;
+        }
+        let Value::Enum(event) = event_value else {
+            panic!("event is neither an atom nor an enum");
+        };
+        let enum_id = event.borrow().id;
+        let names = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .expect("event enum definition is missing")
+            .names
+            .clone();
+        *event.borrow_mut() = MechEnum {
+            id: enum_id,
+            variants: vec![(hash_str(variant), None)],
+            names,
+        };
+    }
     fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
         let Value::Tuple(event) = symbol(interpreter, "event") else {
             panic!("event is not tuple")
@@ -1374,6 +1243,13 @@ mod tests {
             panic!("event is not tuple")
         };
         *event.borrow_mut() = MechTuple::from_vec(values);
+    }
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    fn set_f64_matrix_event(interpreter: &Interpreter, values: Vec<f64>) {
+        let Value::MatrixF64(event) = symbol(interpreter, "event") else {
+            panic!("event is not an f64 matrix")
+        };
+        event.set(values);
     }
     fn selected_arm_index(
         registration: &PatternActivationRegistration,
@@ -1570,6 +1446,28 @@ event<event-kind> := :pressed(0.0)
             assert_eq!(plan_snapshot(&i), topology);
         }
     }
+
+    #[test]
+    fn activation_pattern_matches_payload_free_enum_variant() {
+        let mut i = interpret(
+            r#"
+<signal> := :ready | :other
+event<signal> := :other
+~> event
+  | :ready => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        set_unit_enum_event(&i, "ready");
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+    }
     #[test]
     fn activation_pattern_capture_storage_identity_is_stable() {
         let (mut i, trigger, r, topology) = load_enum_activation();
@@ -1724,8 +1622,166 @@ event := (1.0, 1.0)
         let o = i.advance_reactive_turn(&[trigger]).unwrap();
         assert_dispatch_turn(&i, &topology, &o, 1, -1.);
     }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
-    fn activation_pattern_repeated_capture_kind_mismatch_is_structured() {
+    fn activation_array_pattern_samples_expression_only_on_trigger() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 1.0]
+threshold := 2.0
+~> event
+  | [x, threshold + 0.0, x] => {
+      selected := x + 100.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let registration = registration(&i);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let dependency_nodes = turn_executed_nodes(&dependency_turn);
+        assert!(!dependency_nodes.contains(&registration.scope_pulse_node));
+        assert!(!dependency_nodes.contains(&registration.selector_node));
+        for arm in &registration.arms {
+            assert!(!dependency_nodes.contains(&arm.matcher_node));
+            assert!(!dependency_nodes.contains(&arm.finalizer_node));
+            assert!(!dependency_nodes.contains(&arm.gate_node));
+        }
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 104.0);
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 5.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_pattern_supports_prefix_suffix_and_anonymous_spread() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0 1.0]
+~> event
+  | [x, ..., x] => {
+      selected := x + 10.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 11.0);
+
+        set_f64_matrix_event(&i, vec![1.0, 2.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_rest_segment_accepts_nested_array_pattern() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0 4.0]
+~> event
+  | [head | [second, ..., last]] => {
+      selected := head * 100.0 + second * 10.0 + last
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 124.0);
+    }
+
+    #[cfg(feature = "u64")]
+    #[test]
+    fn activation_typed_literal_pattern_uses_shared_value_matching() {
+        let mut i = interpret(
+            r#"
+event := 1u64
+~> event
+  | 1u64 => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+    }
+
+    #[test]
+    fn activation_whole_composite_capture_fails_before_plan_mutation() {
+        let mut i = interpret("event := (1.0, 2.0)");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | whole => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("whole")));
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_rest_capture_reports_storage_gap_before_plan_mutation() {
+        let mut i = interpret("event := [1.0 2.0 3.0]");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | [head | rest] => {
+      selected := head
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("head")));
+        assert!(!i.symbols().borrow().contains(hash_str("rest")));
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_kind_mismatch_uses_canonical_error() {
         let mut i = interpret("event := (1.0, \"one\")");
         let topology = plan_snapshot(&i);
         let error = interpret_more(
@@ -1737,7 +1793,7 @@ event := (1.0, 1.0)
     }",
         )
         .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(error.kind_name(), "PatternCompileError");
         assert_eq!(plan_snapshot(&i), topology);
         assert!(!i.symbols().borrow().contains(hash_str("x")));
         assert!(!i.symbols().borrow().contains(hash_str("selected")));
@@ -1883,7 +1939,7 @@ event := (1.0, 1.0)
     }",
         )
         .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(error.kind_name(), "PatternCompileError");
         assert_eq!(plan_snapshot(&i), topology);
     }
     #[test]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -81,7 +81,19 @@ fn detached(v: &Value) -> Value {
 fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
     destination.borrow_mut().clone_from(&*source.borrow())
 }
-fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
+#[cfg(feature = "matrix")]
+fn capture_matrix_dimensions(shape: &[usize]) -> MResult<(usize, usize)> {
+    match shape {
+        [] => Ok((1, 0)),
+        [rows, cols] => Ok((*rows, *cols)),
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+
+fn create_capture_slot_for_kind(kind: &ValueKind, interpreter: &Interpreter) -> MResult<Value> {
     match kind.deref_kind() {
         #[cfg(feature = "u8")]
         ValueKind::U8 => Ok(Value::U8(Ref::new(0))),
@@ -118,13 +130,309 @@ fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
         ValueKind::Index => Ok(Value::Index(Ref::new(0))),
         #[cfg(feature = "atom")]
         ValueKind::Atom(id, _) => Ok(Value::Atom(Ref::new(MechAtom::new(id)))),
+        #[cfg(feature = "tuple")]
+        ValueKind::Tuple(kinds) => Ok(Value::Tuple(Ref::new(MechTuple::from_vec(
+            kinds
+                .iter()
+                .map(|kind| create_capture_slot_for_kind(kind, interpreter))
+                .collect::<MResult<Vec<_>>>()?,
+        )))),
+        #[cfg(feature = "enum")]
+        ValueKind::Enum(id, _) => Ok(Value::Enum(Ref::new(MechEnum {
+            id,
+            variants: Vec::new(),
+            names: interpreter.dictionary(),
+        }))),
+        #[cfg(feature = "record")]
+        ValueKind::Record(fields) => {
+            let values = fields
+                .iter()
+                .map(|(name, kind)| {
+                    Ok(((hash_str(name), name.clone()), create_capture_slot_for_kind(kind, interpreter)?))
+                })
+                .collect::<MResult<Vec<_>>>()?;
+            Ok(Value::Record(Ref::new(MechRecord::from_vec(values))))
+        }
+        #[cfg(feature = "map")]
+        ValueKind::Map(key_kind, value_kind) => Ok(Value::Map(Ref::new(MechMap {
+            key_kind: *key_kind,
+            value_kind: *value_kind,
+            num_elements: 0,
+            map: Default::default(),
+        }))),
+        #[cfg(feature = "set")]
+        ValueKind::Set(element_kind, size) => Ok(Value::Set(Ref::new(MechSet::new(
+            *element_kind,
+            size.unwrap_or(0),
+        )))),
+        #[cfg(feature = "table")]
+        ValueKind::Table(columns, rows) => {
+            let mut names = Vec::with_capacity(columns.len());
+            let mut kinds = Vec::with_capacity(columns.len());
+            let mut values = Vec::with_capacity(columns.len());
+            for (name, kind) in columns {
+                names.push(name);
+                kinds.push(kind.clone());
+                let default = create_capture_slot_for_kind(&kind, interpreter)?;
+                values.push(vec![default; rows]);
+            }
+            Ok(Value::Table(Ref::new(MechTable::new_table(
+                names, kinds, values,
+            ))))
+        }
+        #[cfg(feature = "matrix")]
+        ValueKind::Matrix(element_kind, shape) => {
+            let (rows, cols) = capture_matrix_dimensions(&shape)?;
+            let count = rows.saturating_mul(cols);
+            match *element_kind {
+                ValueKind::Index => Ok(Value::MatrixIndex(Matrix::from_vec(
+                    vec![0; count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "bool")]
+                ValueKind::Bool => Ok(Value::MatrixBool(Matrix::from_vec(
+                    vec![false; count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "u8")]
+                ValueKind::U8 => Ok(Value::MatrixU8(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u16")]
+                ValueKind::U16 => Ok(Value::MatrixU16(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u32")]
+                ValueKind::U32 => Ok(Value::MatrixU32(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u64")]
+                ValueKind::U64 => Ok(Value::MatrixU64(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u128")]
+                ValueKind::U128 => Ok(Value::MatrixU128(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i8")]
+                ValueKind::I8 => Ok(Value::MatrixI8(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i16")]
+                ValueKind::I16 => Ok(Value::MatrixI16(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i32")]
+                ValueKind::I32 => Ok(Value::MatrixI32(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i64")]
+                ValueKind::I64 => Ok(Value::MatrixI64(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i128")]
+                ValueKind::I128 => Ok(Value::MatrixI128(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "f32")]
+                ValueKind::F32 => Ok(Value::MatrixF32(Matrix::from_vec(vec![0.0; count], rows, cols))),
+                #[cfg(feature = "f64")]
+                ValueKind::F64 => Ok(Value::MatrixF64(Matrix::from_vec(vec![0.0; count], rows, cols))),
+                #[cfg(feature = "string")]
+                ValueKind::String => Ok(Value::MatrixString(Matrix::from_vec(
+                    vec![String::new(); count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "rational")]
+                ValueKind::R64 => Ok(Value::MatrixR64(Matrix::from_vec(
+                    vec![R64::default(); count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "complex")]
+                ValueKind::C64 => Ok(Value::MatrixC64(Matrix::from_vec(
+                    vec![C64::default(); count],
+                    rows,
+                    cols,
+                ))),
+                element_kind => {
+                    let default = create_capture_slot_for_kind(&element_kind, interpreter)
+                        .unwrap_or(Value::EmptyKind(element_kind));
+                    Ok(Value::MatrixValue(Matrix::from_vec(
+                        vec![default; count],
+                        rows,
+                        cols,
+                    )))
+                }
+            }
+        }
         _ => Err(MechError::new(
             ActivationPatternCaptureKindUnsupported,
             None,
         )),
     }
 }
+
+fn capture_slot_accepts_payload(destination: &Value, source: &Value) -> bool {
+    let source = detached(source);
+    match (destination, &source) {
+        #[cfg(feature = "tuple")]
+        (Value::Tuple(destination), Value::Tuple(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.elements.len() == source.elements.len()
+                && destination
+                    .elements
+                    .iter()
+                    .zip(&source.elements)
+                    .all(|(destination, source)| {
+                        capture_slot_accepts_payload(destination, source)
+                    })
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(destination), Value::Enum(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            if destination.id != source.id || destination.variants.is_empty() {
+                return destination.id == source.id;
+            }
+            let same_variants = destination.variants.len() == source.variants.len()
+                && destination
+                    .variants
+                    .iter()
+                    .zip(&source.variants)
+                    .all(|((destination_id, _), (source_id, _))| {
+                        destination_id == source_id
+                    });
+            !same_variants
+                || destination.variants.iter().zip(&source.variants).all(
+                    |((_, destination), (_, source))| match (destination, source) {
+                        (Some(destination), Some(source)) => {
+                            capture_slot_accepts_payload(destination, source)
+                        }
+                        (None, None) => true,
+                        _ => false,
+                    },
+                )
+        }
+        #[cfg(feature = "record")]
+        (Value::Record(destination), Value::Record(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.data.len() == source.data.len()
+                && destination.data.iter().zip(&source.data).all(
+                    |((destination_id, destination), (source_id, source))| {
+                        destination_id == source_id
+                            && capture_slot_accepts_payload(destination, source)
+                    },
+                )
+        }
+        #[cfg(feature = "map")]
+        (Value::Map(destination), Value::Map(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            if destination.map.is_empty() || destination.map.len() != source.map.len() {
+                return true;
+            }
+            let same_keys = destination
+                .map
+                .keys()
+                .zip(source.map.keys())
+                .all(|(destination, source)| destination == source);
+            !same_keys
+                || destination
+                    .map
+                    .values()
+                    .zip(source.map.values())
+                    .all(|(destination, source)| {
+                        capture_slot_accepts_payload(destination, source)
+                    })
+        }
+        #[cfg(feature = "table")]
+        (Value::Table(destination), Value::Table(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.rows == source.rows
+                && destination.data.len() == source.data.len()
+                && destination.data.iter().zip(&source.data).all(
+                    |(
+                        (destination_id, (destination_kind, destination)),
+                        (source_id, (source_kind, source)),
+                    )| {
+                        destination_id == source_id
+                            && destination_kind == source_kind
+                            && destination.can_replace_payload_from(source)
+                    },
+                )
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixIndex(destination), Value::MatrixIndex(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        (Value::MatrixBool(destination), Value::MatrixBool(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        (Value::MatrixU8(destination), Value::MatrixU8(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        (Value::MatrixU16(destination), Value::MatrixU16(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        (Value::MatrixU32(destination), Value::MatrixU32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        (Value::MatrixU64(destination), Value::MatrixU64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        (Value::MatrixU128(destination), Value::MatrixU128(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        (Value::MatrixI8(destination), Value::MatrixI8(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        (Value::MatrixI16(destination), Value::MatrixI16(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        (Value::MatrixI32(destination), Value::MatrixI32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        (Value::MatrixI64(destination), Value::MatrixI64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        (Value::MatrixI128(destination), Value::MatrixI128(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        (Value::MatrixF32(destination), Value::MatrixF32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        (Value::MatrixF64(destination), Value::MatrixF64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        (Value::MatrixString(destination), Value::MatrixString(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        (Value::MatrixR64(destination), Value::MatrixR64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        (Value::MatrixC64(destination), Value::MatrixC64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixValue(destination), Value::MatrixValue(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        (destination, source) => {
+            std::mem::discriminant(destination) == std::mem::discriminant(source)
+        }
+    }
+}
+
 fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
+    if !capture_slot_accepts_payload(destination, source) {
+        return Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        ));
+    }
     match (destination, &detached(source)) {
         #[cfg(feature = "u8")]
         (Value::U8(a), Value::U8(b)) => {
@@ -215,6 +523,124 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
             clone_ref_value(a, b);
             Ok(())
         }
+        #[cfg(feature = "tuple")]
+        (Value::Tuple(a), Value::Tuple(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for (destination, source) in a.elements.iter().zip(&b.elements) {
+                commit_capture_slot(destination, source)?;
+            }
+            Ok(())
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(a), Value::Enum(b)) => {
+            let preserve_payload_cells = {
+                let a = a.borrow();
+                let b = b.borrow();
+                !a.variants.is_empty()
+                    && a.variants.len() == b.variants.len()
+                    && a.variants
+                        .iter()
+                        .zip(&b.variants)
+                        .all(|((a, _), (b, _))| a == b)
+            };
+            if preserve_payload_cells {
+                let a = a.borrow();
+                let b = b.borrow();
+                for ((_, destination), (_, source)) in a.variants.iter().zip(&b.variants) {
+                    if let (Some(destination), Some(source)) = (destination, source) {
+                        commit_capture_slot(destination, source)?;
+                    }
+                }
+            } else {
+                clone_ref_value(a, b);
+            }
+            Ok(())
+        }
+        #[cfg(feature = "record")]
+        (Value::Record(a), Value::Record(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for ((_, destination), (_, source)) in a.data.iter().zip(&b.data) {
+                commit_capture_slot(destination, source)?;
+            }
+            Ok(())
+        }
+        #[cfg(feature = "map")]
+        (Value::Map(a), Value::Map(b)) => {
+            let preserve_value_cells = {
+                let a = a.borrow();
+                let b = b.borrow();
+                !a.map.is_empty()
+                    && a.map.len() == b.map.len()
+                    && a.map.keys().zip(b.map.keys()).all(|(a, b)| a == b)
+            };
+            if preserve_value_cells {
+                let a = a.borrow();
+                let b = b.borrow();
+                for ((_, destination), (_, source)) in a.map.iter().zip(&b.map) {
+                    commit_capture_slot(destination, source)?;
+                }
+            } else {
+                clone_ref_value(a, b);
+            }
+            Ok(())
+        }
+        #[cfg(feature = "set")]
+        (Value::Set(a), Value::Set(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "table")]
+        (Value::Table(a), Value::Table(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for ((_, (_, destination)), (_, (_, source))) in a.data.iter().zip(&b.data) {
+                if !destination.replace_payload_from(source) {
+                    return Err(MechError::new(
+                        ActivationPatternCaptureKindUnsupported,
+                        None,
+                    ));
+                }
+            }
+            Ok(())
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixIndex(a), Value::MatrixIndex(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        (Value::MatrixBool(a), Value::MatrixBool(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        (Value::MatrixU8(a), Value::MatrixU8(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        (Value::MatrixU16(a), Value::MatrixU16(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        (Value::MatrixU32(a), Value::MatrixU32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        (Value::MatrixU64(a), Value::MatrixU64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        (Value::MatrixU128(a), Value::MatrixU128(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        (Value::MatrixI8(a), Value::MatrixI8(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        (Value::MatrixI16(a), Value::MatrixI16(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        (Value::MatrixI32(a), Value::MatrixI32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        (Value::MatrixI64(a), Value::MatrixI64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        (Value::MatrixI128(a), Value::MatrixI128(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        (Value::MatrixF32(a), Value::MatrixF32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        (Value::MatrixF64(a), Value::MatrixF64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        (Value::MatrixString(a), Value::MatrixString(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        (Value::MatrixR64(a), Value::MatrixR64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        (Value::MatrixC64(a), Value::MatrixC64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(feature = "matrix")]
+        (Value::MatrixValue(a), Value::MatrixValue(b)) if a.replace_payload_from(b) => Ok(()),
         _ => Err(MechError::new(
             ActivationPatternCaptureKindUnsupported,
             None,
@@ -229,6 +655,23 @@ fn capture_kinds_are_storage_compatible(destination: &ValueKind, source: &ValueK
     if matches!(
         (&destination, &source),
         (ValueKind::Atom(_, _), ValueKind::Atom(_, _))
+    ) {
+        return true;
+    }
+    #[cfg(feature = "enum")]
+    if matches!(
+        (&destination, &source),
+        (ValueKind::Enum(destination, _), ValueKind::Enum(source, _)) if destination == source
+    ) {
+        return true;
+    }
+    #[cfg(feature = "matrix")]
+    if matches!(
+        (&destination, &source),
+        (
+            ValueKind::Matrix(destination_element, destination_shape),
+            ValueKind::Matrix(source_element, _)
+        ) if destination_shape.is_empty() && destination_element == source_element
     ) {
         return true;
     }
@@ -253,7 +696,7 @@ impl PatternBindingSink for ReactiveBindingSink<'_> {
             let source = detached(&binding.value);
             if capture.id != binding.id
                 || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
-                || std::mem::discriminant(&capture.slot) != std::mem::discriminant(&source)
+                || !capture_slot_accepts_payload(&capture.slot, &source)
             {
                 return Err(MechError::new(
                     ActivationPatternCaptureKindUnsupported,
@@ -469,7 +912,7 @@ fn preflight_patterned_activation(
                     MechError::new(ActivationPatternCaptureKindUnsupported, None)
                         .with_tokens(a.pattern.tokens())
                 })?;
-                let slot = create_capture_slot_for_kind(&kind)
+                let slot = create_capture_slot_for_kind(&kind, i)
                     .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
                 Ok(ActivationPatternCapture {
                     id: binding.id,
@@ -783,7 +1226,17 @@ fn elaborate_patterned_arm_body(
     }
     symbols.borrow_mut().restore(symbol_snapshot);
     body_result?;
-    Ok((body_node_start, plan.len()))
+    let body_node_end = plan.len();
+    {
+        let mut plan = plan.borrow_mut();
+        for node in body_node_start..body_node_end {
+            for capture in captures {
+                let cell = capture.slot.reactive_root_cell_ids()[0];
+                debug_assert!(plan.add_sampled_dependency(node, cell));
+            }
+        }
+    }
+    Ok((body_node_start, body_node_end))
 }
 
 fn elaborate_patterned_activation_inner(
@@ -797,6 +1250,8 @@ fn elaborate_patterned_activation_inner(
     }
     let compiled = preflight.arms;
     let plan = i.plan();
+    let _persistent_user_function_plan =
+        crate::functions::PersistentUserFunctionPlanScope::enter(i);
     let pattern_expression_values = compiled
         .iter()
         .map(|arm| {
@@ -807,6 +1262,15 @@ fn elaborate_patterned_activation_inner(
                 .collect::<MResult<Vec<_>>>()
         })
         .collect::<MResult<Vec<_>>>()?;
+    drop(_persistent_user_function_plan);
+    for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
+        let pattern_match =
+            match_compiled_pattern_with_values(&arm.pattern, &trigger, expression_values)?;
+        ReactiveBindingSink {
+            captures: &arm.captures,
+        }
+        .commit(&pattern_match)?;
+    }
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
         .borrow_mut()
@@ -936,6 +1400,7 @@ pub(crate) fn elaborate_patterned_activation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
         let mut cases = Vec::new();
@@ -988,8 +1453,9 @@ mod tests {
 
     #[test]
     fn activation_capture_slot_supports_all_enabled_scalar_kinds() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
         for (kind, source) in scalar_capture_cases() {
-            let slot = create_capture_slot_for_kind(&kind).unwrap();
+            let slot = create_capture_slot_for_kind(&kind, &interpreter).unwrap();
             let cells_before = slot.reactive_root_cell_ids();
             assert_eq!(cells_before.len(), 1);
             commit_capture_slot(&slot, &source).unwrap();
@@ -1001,7 +1467,8 @@ mod tests {
     #[cfg(any(feature = "string", feature = "variable_define"))]
     #[test]
     fn activation_capture_slot_preserves_identity_across_updates() {
-        let slot = create_capture_slot_for_kind(&ValueKind::String).unwrap();
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let slot = create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap();
         let cells = slot.reactive_root_cell_ids();
         commit_capture_slot(&slot, &Value::String(Ref::new("first".to_string()))).unwrap();
         assert_eq!(slot, Value::String(Ref::new("first".to_string())));
@@ -1009,6 +1476,108 @@ mod tests {
         commit_capture_slot(&slot, &Value::String(Ref::new("second".to_string()))).unwrap();
         assert_eq!(slot, Value::String(Ref::new("second".to_string())));
         assert_eq!(slot.reactive_root_cell_ids(), cells);
+    }
+
+    #[cfg(all(
+        feature = "tuple",
+        feature = "enum",
+        feature = "record",
+        feature = "map",
+        feature = "set",
+        feature = "table",
+        feature = "string",
+        feature = "f64"
+    ))]
+    #[test]
+    fn activation_capture_slots_support_enabled_composite_value_kinds() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let enum_id = hash_str("capture-enum");
+        let variant_id = hash_str("payload");
+        let names = Ref::new(HashMap::from([
+            (enum_id, "capture-enum".to_string()),
+            (variant_id, "payload".to_string()),
+        ]));
+        let cases = vec![
+            Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                Value::F64(Ref::new(1.0)),
+                Value::String(Ref::new("tuple".to_string())),
+            ]))),
+            Value::Enum(Ref::new(MechEnum {
+                id: enum_id,
+                variants: vec![(variant_id, Some(Value::F64(Ref::new(2.0))))],
+                names,
+            })),
+            Value::Record(Ref::new(MechRecord::new(vec![
+                ("field", Value::F64(Ref::new(3.0))),
+            ]))),
+            Value::Map(Ref::new(MechMap::from_vec(vec![(
+                Value::String(Ref::new("key".to_string())),
+                Value::F64(Ref::new(4.0)),
+            )]))),
+            Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new(
+                "member".to_string(),
+            ))]))),
+            Value::Table(Ref::new(MechTable::new_table(
+                vec!["column".to_string()],
+                vec![ValueKind::F64],
+                vec![vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(6.0))]],
+            ))),
+        ];
+
+        for source in cases {
+            let kind = source.kind();
+            let slot = create_capture_slot_for_kind(&kind, &interpreter).unwrap();
+            let cells = slot.reactive_root_cell_ids();
+            assert_eq!(cells.len(), 1, "missing stable root for {kind}");
+            commit_capture_slot(&slot, &source).unwrap();
+            assert_eq!(slot, source);
+            assert_eq!(slot.reactive_root_cell_ids(), cells);
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "string"))]
+    #[test]
+    fn activation_capture_commit_validates_every_binding_before_mutation() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let number = ActivationPatternCapture {
+            id: hash_str("number"),
+            name: "number".to_string(),
+            kind: ValueKind::F64,
+            slot: create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap(),
+        };
+        let text = ActivationPatternCapture {
+            id: hash_str("text"),
+            name: "text".to_string(),
+            kind: ValueKind::String,
+            slot: create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap(),
+        };
+        let captures = vec![number, text];
+        let attempted = PatternMatch {
+            matched: true,
+            bindings: vec![
+                PatternBinding {
+                    index: 0,
+                    id: hash_str("number"),
+                    name: "number".to_string(),
+                    kind: ValueKind::F64,
+                    value: Value::F64(Ref::new(9.0)),
+                },
+                PatternBinding {
+                    index: 1,
+                    id: hash_str("text"),
+                    name: "text".to_string(),
+                    kind: ValueKind::F64,
+                    value: Value::F64(Ref::new(10.0)),
+                },
+            ],
+        };
+
+        let error = ReactiveBindingSink { captures: &captures }
+            .commit(&attempted)
+            .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(captures[0].slot, Value::F64(Ref::new(0.0)));
+        assert_eq!(captures[1].slot, Value::String(Ref::new(String::new())));
     }
 
     #[cfg(feature = "atom")]
@@ -1054,7 +1623,8 @@ event := :first
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn activation_capture_slot_rejects_kind_mismatch() {
-        let slot = create_capture_slot_for_kind(&ValueKind::F64).unwrap();
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let slot = create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap();
         let error =
             commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
@@ -1185,6 +1755,19 @@ event := :first
             }
         }
         panic!("no f64 output")
+    }
+    fn body_output(interpreter: &Interpreter, arm_index: usize) -> Value {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm_index];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        detached(
+            &plan
+                .node(arm.body_node_end - 1)
+                .expect("missing activation body node")
+                .function
+                .out(),
+        )
     }
     fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
         let Value::Enum(event) = symbol(interpreter, "event") else {
@@ -1669,6 +2252,49 @@ threshold := 2.0
 
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
+    fn activation_pattern_samples_current_user_function_output_on_trigger() {
+        let mut i = interpret(
+            r#"
+sample(value<f64>) => <f64>
+  | value + 0.0.
+
+event := [1.0 2.0 1.0]
+threshold := 2.0
+~> event
+  | [x, sample(threshold), x] => {
+      selected := x + 100.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let activation = registration(&i);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let dependency_nodes = turn_executed_nodes(&dependency_turn);
+        assert!(!dependency_nodes.contains(&activation.scope_pulse_node));
+        assert!(!dependency_nodes.contains(&activation.selector_node));
+        for arm in &activation.arms {
+            assert!(!dependency_nodes.contains(&arm.matcher_node));
+            assert!(!dependency_nodes.contains(&arm.finalizer_node));
+            assert!(!dependency_nodes.contains(&arm.gate_node));
+        }
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 104.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
     fn activation_array_pattern_supports_prefix_suffix_and_anonymous_spread() {
         let mut i = interpret(
             r#"
@@ -1736,49 +2362,142 @@ event := 1u64
     }
 
     #[test]
-    fn activation_whole_composite_capture_fails_before_plan_mutation() {
-        let mut i = interpret("event := (1.0, 2.0)");
-        let topology = plan_snapshot(&i);
-        let error = interpret_more(
-            &mut i,
+    fn activation_whole_composite_capture_is_stable_and_visible_to_the_body() {
+        let mut i = interpret(
             r#"
+event := (1.0, 2.0)
 ~> event
   | whole => {
-      selected := 1.0
+      selected := whole
+    }
+  | * => {
+      selected := (-1.0, -1.0)
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let capture = &activation.arms[0].captures[0];
+        assert_eq!(capture.kind, ValueKind::Tuple(vec![ValueKind::F64, ValueKind::F64]));
+        let body_inputs = i.plan().borrow().nodes
+            [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+            .iter()
+            .flat_map(|node| node.inputs.iter().map(|dependency| dependency.cell))
+            .collect::<Vec<_>>();
+        assert!(
+            body_inputs.contains(&capture.cell),
+            "capture cell {:?} is absent from body inputs {:?}",
+            capture.cell,
+            body_inputs
+        );
+        let topology = plan_snapshot(&i);
+        for values in [[3.0, 4.0], [5.0, 6.0]] {
+            set_tuple_event(
+                &i,
+                values
+                    .into_iter()
+                    .map(|value| Value::F64(Ref::new(value)))
+                    .collect(),
+            );
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            assert_eq!(
+                body_output(&i, 0),
+                Value::Tuple(Ref::new(MechTuple::from_vec(
+                    values
+                        .into_iter()
+                        .map(|value| Value::F64(Ref::new(value)))
+                        .collect(),
+                )))
+            );
+            assert_eq!(registration(&i).arms[0].captures[0].cell, capture.cell);
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+
+    #[test]
+    fn activation_whole_tuple_capture_keeps_element_access_attached() {
+        let mut i = interpret(
+            r#"
+event := (1.0, 2.0)
+~> event
+  | whole => {
+      selected := whole.1 * 10.0 + whole.2
     }
   | * => {
       selected := -1.0
     }
 "#,
-        )
-        .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(plan_snapshot(&i), topology);
-        assert!(!i.symbols().borrow().contains(hash_str("whole")));
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        for (values, expected) in [([3.0, 4.0], 34.0), ([5.0, 6.0], 56.0)] {
+            set_tuple_event(
+                &i,
+                values
+                    .into_iter()
+                    .map(|value| Value::F64(Ref::new(value)))
+                    .collect(),
+            );
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, 0, expected);
+        }
     }
 
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
-    fn activation_array_rest_capture_reports_storage_gap_before_plan_mutation() {
-        let mut i = interpret("event := [1.0 2.0 3.0]");
-        let topology = plan_snapshot(&i);
-        let error = interpret_more(
-            &mut i,
+    fn activation_array_rest_capture_preserves_kind_payload_and_identity() {
+        let mut i = interpret(
             r#"
+event := [1.0 2.0 3.0 4.0 5.0]
 ~> event
   | [head | rest] => {
-      selected := head
+      selected := rest
     }
   | * => {
-      selected := -1.0
+      selected := [-1.0]
     }
 "#,
-        )
-        .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(plan_snapshot(&i), topology);
-        assert!(!i.symbols().borrow().contains(hash_str("head")));
-        assert!(!i.symbols().borrow().contains(hash_str("rest")));
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let rest_capture = &activation.arms[0].captures[1];
+        assert_eq!(
+            rest_capture.kind,
+            ValueKind::Matrix(Box::new(ValueKind::F64), Vec::new())
+        );
+        assert!(
+            i.plan().borrow().nodes
+                [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+                .iter()
+                .any(|node| node
+                    .inputs
+                    .iter()
+                    .any(|dependency| dependency.cell == rest_capture.cell))
+        );
+        let topology = plan_snapshot(&i);
+        let Value::MatrixF64(event) = symbol(&i, "event") else {
+            panic!("event is not an f64 matrix")
+        };
+        for values in [
+            vec![10.0, 20.0, 30.0, 40.0, 50.0],
+            vec![11.0, 21.0, 31.0, 41.0, 51.0, 61.0],
+        ] {
+            let source = Matrix::from_vec(values.clone(), 1, values.len());
+            assert!(event.replace_payload_from(&source));
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            let Value::MatrixF64(rest) = body_output(&i, 0) else {
+                panic!("rest output is not an f64 matrix")
+            };
+            assert_eq!(rest.shape(), vec![1, values.len() - 1]);
+            assert_eq!(rest.as_vec(), values[1..]);
+            assert_eq!(
+                registration(&i).arms[0].captures[1].cell,
+                rest_capture.cell
+            );
+            assert_eq!(plan_snapshot(&i), topology);
+        }
     }
     #[test]
     fn activation_pattern_repeated_capture_kind_mismatch_uses_canonical_error() {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -23,11 +23,11 @@ activation_error!(
 );
 activation_error!(
     ActivationPatternArmsNonExhaustive,
-    "Patterned activations require a final unguarded wildcard arm."
+    "Patterned activations require a final unguarded irrefutable arm."
 );
 activation_error!(
     ActivationPatternWildcardMustBeLast,
-    "The wildcard activation arm must be last."
+    "An unguarded wildcard activation arm must be last."
 );
 activation_error!(
     ActivationPatternGuardMustBePure,
@@ -43,7 +43,11 @@ activation_error!(
 );
 activation_error!(
     ActivationPatternRegisterWriteUnsupported,
-    "Patterned activation register writes are not supported."
+    "Patterned activation register writes must target a whole local register."
+);
+activation_error!(
+    ActivationScopeTriggerWriteUnsupported,
+    "An activation scope cannot assign to its own trigger."
 );
 activation_error!(
     ActivationPatternContextEffectUnsupported,
@@ -980,6 +984,74 @@ interpreter_only!(Select);
 #[cfg(feature = "compiler")]
 interpreter_only!(Gate);
 
+fn pattern_is_irrefutable(pattern: &CompiledPattern, trigger_kind: &ValueKind) -> bool {
+    fn check(
+        pattern: &CompiledPattern,
+        trigger_kind: &ValueKind,
+        bindings: &mut HashSet<usize>,
+    ) -> bool {
+        match pattern {
+            CompiledPattern::Wildcard => true,
+            CompiledPattern::Binding { binding_index, .. } => {
+                bindings.insert(*binding_index)
+            }
+            CompiledPattern::ExpressionValue { .. }
+            | CompiledPattern::EnumVariant { .. }
+            | CompiledPattern::AtomTuple { .. } => false,
+            CompiledPattern::Tuple { elements } => {
+                let ValueKind::Tuple(kinds) = trigger_kind.deref_kind() else {
+                    return false;
+                };
+                elements.len() == kinds.len()
+                    && elements
+                        .iter()
+                        .zip(&kinds)
+                        .all(|(element, kind)| check(element, kind, bindings))
+            }
+            CompiledPattern::Array {
+                prefix,
+                spread,
+                suffix,
+            } => {
+                let ValueKind::Matrix(element_kind, shape) = trigger_kind.deref_kind() else {
+                    return false;
+                };
+                let minimum_len = prefix.len() + suffix.len();
+                let known_len = (!shape.is_empty()).then(|| shape.iter().product::<usize>());
+                match (known_len, spread) {
+                    (Some(len), None) if len != minimum_len => return false,
+                    (Some(len), Some(_)) if len < minimum_len => return false,
+                    (None, None) => return false,
+                    (None, Some(_)) if minimum_len != 0 => return false,
+                    _ => {}
+                }
+                if !prefix
+                    .iter()
+                    .chain(suffix)
+                    .all(|element| check(element, &element_kind, bindings))
+                {
+                    return false;
+                }
+                spread
+                    .as_ref()
+                    .and_then(|spread| spread.binding.as_deref())
+                    .map_or(true, |binding| {
+                        let middle_shape = known_len
+                            .map(|len| vec![1, len - minimum_len])
+                            .unwrap_or_default();
+                        check(
+                            binding,
+                            &ValueKind::Matrix(element_kind, middle_shape),
+                            bindings,
+                        )
+                    })
+            }
+        }
+    }
+
+    check(pattern, trigger_kind, &mut HashSet::new())
+}
+
 fn preflight_patterned_activation(
     scope: &ActivationScope,
     arms: &[ActivationArm],
@@ -987,27 +1059,23 @@ fn preflight_patterned_activation(
     trigger_cells: &[ReactiveCellId],
     i: &Interpreter,
 ) -> MResult<PreflightPatternedActivation> {
-    let last = arms.last().ok_or_else(|| {
+    arms.last().ok_or_else(|| {
         MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
     })?;
-    if !matches!(last.pattern, Pattern::Wildcard) || last.guard.is_some() {
-        return Err(
-            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
-        );
-    }
-    if arms[..arms.len() - 1]
-        .iter()
-        .any(|a| matches!(a.pattern, Pattern::Wildcard))
-    {
-        return Err(
-            MechError::new(ActivationPatternWildcardMustBeLast, None).with_tokens(scope.tokens())
-        );
-    }
+    let trigger_id = match &scope.trigger {
+        Expression::Var(var) => var.name.hash(),
+        _ => {
+            return Err(
+                MechError::new(ActivationPatternTriggerInvariant, None)
+                    .with_tokens(scope.trigger.tokens()),
+            );
+        }
+    };
     for arm in arms {
         if let Some(guard) = &arm.guard {
             validate_patterned_guard_expression(guard, i)?;
         }
-        validate_patterned_arm_body(&arm.body)?;
+        validate_patterned_arm_body(&arm.body, trigger_id, trigger_cells, i)?;
     }
     if trigger.reactive_root_cell_ids() != trigger_cells {
         return Err(
@@ -1041,6 +1109,23 @@ fn preflight_patterned_activation(
             .collect::<MResult<Vec<_>>>()?;
         compiled.push(PreflightActivationArm { pattern, captures });
     }
+    let last = arms.last().unwrap();
+    if last.guard.is_some()
+        || !pattern_is_irrefutable(&compiled.last().unwrap().pattern, &trigger_kind)
+    {
+        return Err(
+            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms[..arms.len() - 1]
+        .iter()
+        .any(|arm| arm.guard.is_none() && matches!(arm.pattern, Pattern::Wildcard))
+    {
+        return Err(
+            MechError::new(ActivationPatternWildcardMustBeLast, None)
+                .with_tokens(scope.tokens()),
+        );
+    }
     Ok(PreflightPatternedActivation {
         trigger_kind,
         arms: compiled,
@@ -1051,22 +1136,34 @@ fn validation_error(kind: impl MechErrorKind + 'static, tokens: Vec<Token>) -> M
     Err(MechError::new(kind, None).with_tokens(tokens))
 }
 
-fn validate_patterned_arm_body(body: &ActivationArmBody) -> MResult<()> {
+fn validate_patterned_arm_body(
+    body: &ActivationArmBody,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+) -> MResult<()> {
     match body {
         ActivationArmBody::Block(body) => {
             for (code, _) in body {
-                validate_patterned_code(code)?;
+                validate_patterned_code(code, trigger_id, trigger_cells, interpreter)?;
             }
             Ok(())
         }
         ActivationArmBody::Expression(expression) => validate_patterned_expression(expression),
     }
 }
-fn validate_patterned_code(code: &MechCode) -> MResult<()> {
+fn validate_patterned_code(
+    code: &MechCode,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+) -> MResult<()> {
     match code {
         MechCode::Comment(_) => Ok(()),
         MechCode::Expression(expression) => validate_patterned_expression(expression),
-        MechCode::Statement(statement) => validate_patterned_statement(statement),
+        MechCode::Statement(statement) => {
+            validate_patterned_statement(statement, trigger_id, trigger_cells, interpreter)
+        }
         MechCode::ActivationScope(_)
         | MechCode::FunctionDefine(_)
         | MechCode::FsmSpecification(_)
@@ -1077,7 +1174,46 @@ fn validate_patterned_code(code: &MechCode) -> MResult<()> {
         }
     }
 }
-fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
+fn validate_patterned_register_write(
+    target: &SliceRef,
+    expression: &Expression,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+    tokens: Vec<Token>,
+) -> MResult<()> {
+    if target.context.is_some() {
+        return validation_error(ActivationPatternContextEffectUnsupported, tokens);
+    }
+    let target_id = target.name.hash();
+    let aliases_trigger = interpreter
+        .symbols()
+        .borrow()
+        .get(target_id)
+        .is_some_and(|value| {
+            value
+                .borrow()
+                .reactive_root_cell_ids()
+                .iter()
+                .any(|cell| trigger_cells.contains(cell))
+        });
+    if target_id == trigger_id || aliases_trigger {
+        return validation_error(ActivationScopeTriggerWriteUnsupported, tokens);
+    }
+    // Indexed assignment implementations still mutate eagerly and do not
+    // implement the reactive-register staging contract.
+    if target.subscript.is_some() {
+        return validation_error(ActivationPatternRegisterWriteUnsupported, tokens);
+    }
+    validate_patterned_expression(expression)
+}
+
+fn validate_patterned_statement(
+    statement: &Statement,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+) -> MResult<()> {
     match statement {
         Statement::VariableDefine(definition)
             if !definition.mutable && definition.var.context.is_none() =>
@@ -1093,22 +1229,20 @@ fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
         Statement::VariableDefine(_) => {
             validation_error(ActivationPatternDefinitionUnsupported, statement.tokens())
         }
-        Statement::VariableAssign(assignment) if assignment.target.context.is_some() => {
-            validation_error(
-                ActivationPatternContextEffectUnsupported,
-                statement.tokens(),
-            )
-        }
-        Statement::VariableAssign(_) => validation_error(
-            ActivationPatternRegisterWriteUnsupported,
+        Statement::VariableAssign(assignment) => validate_patterned_register_write(
+            &assignment.target,
+            &assignment.expression,
+            trigger_id,
+            trigger_cells,
+            interpreter,
             statement.tokens(),
         ),
-        Statement::OpAssign(assignment) if assignment.target.context.is_some() => validation_error(
-            ActivationPatternContextEffectUnsupported,
-            statement.tokens(),
-        ),
-        Statement::OpAssign(_) => validation_error(
-            ActivationPatternRegisterWriteUnsupported,
+        Statement::OpAssign(assignment) => validate_patterned_register_write(
+            &assignment.target,
+            &assignment.expression,
+            trigger_id,
+            trigger_cells,
+            interpreter,
             statement.tokens(),
         ),
         Statement::ContextSend(_) => validation_error(
@@ -1562,6 +1696,22 @@ struct ElaboratedPatternGuard {
     node_end: usize,
 }
 
+pub(crate) fn activation_scope_entry_cells(
+    interpreter: &Interpreter,
+) -> Vec<ReactiveCellId> {
+    let symbols = interpreter.symbols();
+    let symbols = symbols.borrow();
+    let mut cells = Vec::new();
+    for symbol in symbols.symbols.values() {
+        for cell in symbol.borrow().reactive_cell_ids() {
+            if !cells.contains(&cell) {
+                cells.push(cell);
+            }
+        }
+    }
+    cells
+}
+
 fn elaborate_patterned_arm_guard(
     guard: &Expression,
     captures: &[ActivationPatternCapture],
@@ -1587,7 +1737,10 @@ fn elaborate_patterned_arm_guard(
     }
     let node_start = plan.len();
     let pulse_cells = pulse.reactive_root_cell_ids();
-    plan.push_activation_registration_scope(pulse_cells.clone());
+    plan.push_activation_registration_scope_with_sampled_cells(
+        pulse_cells.clone(),
+        activation_scope_entry_cells(interpreter),
+    );
     let result = (|| -> MResult<ElaboratedPatternGuard> {
         let _deferred_expression_solves =
             crate::expressions::DeferredExpressionSolveScope::enter(interpreter);
@@ -1680,7 +1833,10 @@ fn elaborate_patterned_arm_body(
         }
     }
     let body_node_start = plan.len();
-    plan.push_activation_registration_scope(pulse.reactive_root_cell_ids());
+    plan.push_activation_registration_scope_with_sampled_cells(
+        pulse.reactive_root_cell_ids(),
+        activation_scope_entry_cells(interpreter),
+    );
     let body_result = (|| -> MResult<()> {
         match &arm.body {
             ActivationArmBody::Block(body) => {
@@ -1946,6 +2102,63 @@ mod tests {
         fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
             self.compile_calls.fetch_add(1, Ordering::SeqCst);
             panic!("unsupported guard compiler must not run during preflight")
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct PatternRegisterStageFailure;
+    impl MechErrorKind for PatternRegisterStageFailure {
+        fn name(&self) -> &str {
+            "PatternRegisterStageFailure"
+        }
+        fn message(&self) -> String {
+            "intentional patterned register staging failure".to_string()
+        }
+    }
+
+    struct FailingPatternRegister {
+        sink: Ref<f64>,
+        solve_calls: Arc<AtomicUsize>,
+        stage_calls: Arc<AtomicUsize>,
+    }
+    impl MechFunctionImpl for FailingPatternRegister {
+        fn solve(&self) {
+            self.solve_calls.fetch_add(1, Ordering::SeqCst);
+            *self.sink.borrow_mut() = -999.0;
+        }
+        fn stage_register(&self) -> MResult<Box<dyn ReactiveRegisterCommit>> {
+            self.stage_calls.fetch_add(1, Ordering::SeqCst);
+            Err(MechError::new(PatternRegisterStageFailure, None))
+        }
+        fn out(&self) -> Value {
+            Value::F64(self.sink.clone())
+        }
+        fn reactive_node_kind(&self) -> ReactiveNodeKind {
+            ReactiveNodeKind::Register
+        }
+        fn to_string(&self) -> String {
+            "FailingPatternRegister".to_string()
+        }
+    }
+    #[cfg(feature = "compiler")]
+    impl MechFunctionCompiler for FailingPatternRegister {
+        fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+            Err(MechError::new(PatternRegisterStageFailure, None))
+        }
+    }
+
+    struct FailingPatternRegisterCompiler {
+        sink: Ref<f64>,
+        solve_calls: Arc<AtomicUsize>,
+        stage_calls: Arc<AtomicUsize>,
+    }
+    impl NativeFunctionCompiler for FailingPatternRegisterCompiler {
+        fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+            Ok(Box::new(FailingPatternRegister {
+                sink: self.sink.clone(),
+                solve_calls: self.solve_calls.clone(),
+                stage_calls: self.stage_calls.clone(),
+            }))
         }
     }
 
@@ -2268,6 +2481,18 @@ event := :first
     fn root_cell(interpreter: &Interpreter, name: &str) -> ReactiveCellId {
         symbol(interpreter, name).reactive_root_cell_ids()[0]
     }
+    fn f64_symbol(interpreter: &Interpreter, name: &str) -> f64 {
+        *symbol(interpreter, name)
+            .as_f64()
+            .unwrap_or_else(|_| panic!("symbol `{name}` is not f64"))
+            .borrow()
+    }
+    fn set_f64_symbol(interpreter: &Interpreter, name: &str, value: f64) {
+        *symbol(interpreter, name)
+            .as_f64()
+            .unwrap_or_else(|_| panic!("symbol `{name}` is not f64"))
+            .borrow_mut() = value;
+    }
     fn registration(interpreter: &Interpreter) -> PatternActivationRegistration {
         let plan = interpreter.plan();
         let registrations = plan.pattern_activation_registrations();
@@ -2321,6 +2546,20 @@ event := :first
         };
         let value = *generation.borrow();
         value
+    }
+    fn arm_register_nodes(
+        interpreter: &Interpreter,
+        registration: &PatternActivationRegistration,
+        arm: usize,
+    ) -> Vec<ReactiveNodeId> {
+        let arm = &registration.arms[arm];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        plan.nodes[arm.body_node_start..arm.body_node_end]
+            .iter()
+            .filter(|node| node.kind == ReactiveNodeKind::Register)
+            .map(|node| node.id)
+            .collect()
     }
     fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
         let plan = interpreter.plan();
@@ -2537,6 +2776,564 @@ event := :first
         }
         assert_eq!(body_output_f64(interpreter, expected_arm), output);
         assert_eq!(&plan_snapshot(interpreter), topology);
+    }
+
+    #[test]
+    fn activation_final_binding_is_exhaustive_and_guarded_binding_falls_through_to_it() {
+        let mut interpreter = interpret(
+            r#"
+physics-tick := 0.25
+~position-y := -1.0
+~velocity-y := 0.0
+floor := 0.0
+restitution := 0.5
+gravity := 4.0
+
+~> physics-tick
+  | dt, position-y >= floor => {
+      velocity-y = -velocity-y * restitution
+      position-y = floor
+    }
+  | dt => {
+      velocity-y = velocity-y + gravity * dt
+      position-y = position-y + velocity-y * dt
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "physics-tick");
+        let activation = registration(&interpreter);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(activation.arms.len(), 2);
+        assert!(activation.arms[0].guard.is_some());
+        assert!(activation.arms[1].guard.is_none());
+        assert_eq!(activation.arms[0].captures.len(), 1);
+        assert_eq!(activation.arms[1].captures.len(), 1);
+        let arm_registers = (0..activation.arms.len())
+            .map(|arm| arm_register_nodes(&interpreter, &activation, arm))
+            .collect::<Vec<_>>();
+        assert!(arm_registers.iter().all(|registers| registers.len() == 2));
+        assert_eq!(
+            (
+                f64_symbol(&interpreter, "position-y"),
+                f64_symbol(&interpreter, "velocity-y"),
+            ),
+            (-1.0, 0.0),
+        );
+
+        let fallback = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &fallback), 1);
+        assert_eq!(fallback.register_commit.committed_nodes, arm_registers[1]);
+        assert_eq!(
+            (
+                f64_symbol(&interpreter, "position-y"),
+                f64_symbol(&interpreter, "velocity-y"),
+            ),
+            (-1.0, 1.0),
+        );
+        assert_eq!(
+            committed_capture_value(&interpreter, 1, 0),
+            Value::F64(Ref::new(0.25)),
+        );
+        assert_eq!(plan_snapshot(&interpreter), topology);
+
+        set_f64_symbol(&interpreter, "position-y", 1.0);
+        let guarded = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &guarded), 0);
+        assert_eq!(guarded.register_commit.committed_nodes, arm_registers[0]);
+        assert_eq!(
+            (
+                f64_symbol(&interpreter, "position-y"),
+                f64_symbol(&interpreter, "velocity-y"),
+            ),
+            (0.0, -0.5),
+        );
+        assert_eq!(
+            committed_capture_value(&interpreter, 0, 0),
+            Value::F64(Ref::new(0.25)),
+        );
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_guarded_wildcard_may_precede_an_exhaustive_binding() {
+        let mut interpreter = interpret(
+            r#"
+event := 2.0
+ready := false
+
+~> event
+  | *, ready == true => {
+      selected := -1.0
+    }
+  | value => {
+      selected := value
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&interpreter, &topology, &outcome, 1, 2.0);
+    }
+
+    #[test]
+    fn activation_final_irrefutable_tuple_is_exhaustive() {
+        let mut interpreter = interpret(
+            r#"
+event := (1.0, 2.0)
+~> event
+  | (tick, dt) => {
+      selected := tick * 10.0 + dt
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        set_tuple_event(
+            &interpreter,
+            vec![Value::F64(Ref::new(3.0)), Value::F64(Ref::new(4.0))],
+        );
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&interpreter, &topology, &outcome, 0, 34.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_final_irrefutable_fixed_matrix_pattern_is_exhaustive() {
+        let mut interpreter = interpret(
+            r#"
+event := [1.0 2.0]
+~> event
+  | [left, right] => {
+      selected := left * 10.0 + right
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        set_f64_matrix_event(&interpreter, vec![3.0, 4.0]);
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&interpreter, &topology, &outcome, 0, 34.0);
+    }
+
+    #[test]
+    fn activation_final_refutable_pattern_is_non_exhaustive() {
+        for pattern in ["1.0", "(x, x)"] {
+            let mut interpreter = if pattern == "1.0" {
+                interpret("event := 1.0")
+            } else {
+                interpret("event := (1.0, 1.0)")
+            };
+            let topology = plan_snapshot(&interpreter);
+            let error = interpret_more(
+                &mut interpreter,
+                &format!(
+                    "~> event\n  | {pattern} => {{\n      selected := 1.0\n    }}"
+                ),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind_name(), "ActivationPatternArmsNonExhaustive");
+            assert_eq!(plan_snapshot(&interpreter), topology);
+        }
+
+        let mut interpreter = interpret("event := 1.0");
+        let topology = plan_snapshot(&interpreter);
+        let error = interpret_more(
+            &mut interpreter,
+            r#"
+~> event
+  | value, value > 0.0 => {
+      selected := value
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternArmsNonExhaustive");
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_unguarded_wildcard_before_the_final_arm_is_rejected() {
+        let mut interpreter = interpret("event := 1.0");
+        let topology = plan_snapshot(&interpreter);
+        let error = interpret_more(
+            &mut interpreter,
+            r#"
+~> event
+  | * => {
+      selected := 1.0
+    }
+  | value => {
+      selected := value
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternWildcardMustBeLast");
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_selected_arm_commits_register_batch_and_other_arms_schedule_nothing() {
+        let mut interpreter = interpret(
+            r#"
+event := 0.0
+~x := 1.0
+~y := 10.0
+
+~> event
+  | first, first > 10.0 => {
+      x = first
+      y += first
+    }
+  | second, second > 0.0 => {
+      x = second * 2.0
+      y = second + 1.0
+    }
+  | * => {
+      x = -1.0
+      y = -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let activation = registration(&interpreter);
+        let topology = plan_snapshot(&interpreter);
+        let arm_registers = (0..activation.arms.len())
+            .map(|arm| arm_register_nodes(&interpreter, &activation, arm))
+            .collect::<Vec<_>>();
+        assert!(arm_registers.iter().all(|registers| registers.len() == 2));
+        {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            for (arm_index, registers) in arm_registers.iter().enumerate() {
+                for register in registers {
+                    let node = plan.node(*register).unwrap();
+                    assert!(node.inputs.iter().any(|dependency| {
+                        dependency.cell == activation.arms[arm_index].pulse_cell
+                            && dependency.kind == ReactiveDependencyKind::Reactive
+                    }));
+                    for (other_arm, registration) in activation.arms.iter().enumerate() {
+                        if other_arm != arm_index {
+                            assert!(!node.inputs.iter().any(|dependency| {
+                                dependency.cell == registration.pulse_cell
+                                    && dependency.kind == ReactiveDependencyKind::Reactive
+                            }));
+                        }
+                    }
+                    for capture in &activation.arms[arm_index].captures {
+                        assert!(node.inputs.iter().any(|dependency| {
+                            dependency.cell == capture.cell
+                                && dependency.kind == ReactiveDependencyKind::Sampled
+                        }));
+                    }
+                }
+            }
+        }
+
+        // Initial dispatch selects the fallback only to seed captures. No arm
+        // body is pulsed while the static graph is being registered.
+        assert_eq!(
+            (f64_symbol(&interpreter, "x"), f64_symbol(&interpreter, "y")),
+            (1.0, 10.0)
+        );
+        assert!(!interpreter.has_pending_reactive_registers());
+        for arm in 0..activation.arms.len() {
+            assert_eq!(arm_pulse_generation(&interpreter, arm), 0);
+        }
+
+        // Both guarded arms are eligible, so source order selects arm zero.
+        // The matching-but-losing arm must not schedule either register.
+        set_f64_symbol(&interpreter, "event", 20.0);
+        let first = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &first), 0);
+        assert_eq!(first.before_commit.pending_register_nodes, arm_registers[0]);
+        assert_eq!(first.register_commit.staged_nodes, arm_registers[0]);
+        assert_eq!(first.register_commit.committed_nodes, arm_registers[0]);
+        assert_eq!(
+            (f64_symbol(&interpreter, "x"), f64_symbol(&interpreter, "y")),
+            (20.0, 30.0)
+        );
+        for register in arm_registers[1].iter().chain(&arm_registers[2]) {
+            assert!(!first.before_commit.pending_register_nodes.contains(register));
+            assert!(!first.register_commit.staged_nodes.contains(register));
+            assert!(!first.register_commit.committed_nodes.contains(register));
+            assert!(!first.after_commit.pending_register_nodes.contains(register));
+        }
+
+        // Arm zero still matches, but its false guard must leave its register
+        // nodes dormant. Arm one's capture is consumed by both writes from
+        // this same trigger.
+        set_f64_symbol(&interpreter, "event", 5.0);
+        let second = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &second), 1);
+        assert_eq!(second.before_commit.pending_register_nodes, arm_registers[1]);
+        assert_eq!(second.register_commit.staged_nodes, arm_registers[1]);
+        assert_eq!(second.register_commit.committed_nodes, arm_registers[1]);
+        assert_eq!(
+            (f64_symbol(&interpreter, "x"), f64_symbol(&interpreter, "y")),
+            (10.0, 6.0)
+        );
+        assert_eq!(
+            committed_capture_value(&interpreter, 1, 0),
+            Value::F64(Ref::new(5.0))
+        );
+        for register in arm_registers[0].iter().chain(&arm_registers[2]) {
+            assert!(!second.before_commit.pending_register_nodes.contains(register));
+            assert!(!second.register_commit.staged_nodes.contains(register));
+            assert!(!second.register_commit.committed_nodes.contains(register));
+            assert!(!second.after_commit.pending_register_nodes.contains(register));
+        }
+        assert!(!interpreter.has_pending_reactive_registers());
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_equal_trigger_packets_produce_distinct_register_transitions_without_plan_growth() {
+        let mut interpreter = interpret(
+            r#"
+event := 2.0
+~count := 0.0
+
+~> event
+  | amount => {
+      count += amount
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let activation = registration(&interpreter);
+        let registers = arm_register_nodes(&interpreter, &activation, 0);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(registers.len(), 1);
+        assert_eq!(f64_symbol(&interpreter, "count"), 0.0);
+
+        for (expected_count, expected_pulse) in [(2.0, 1usize), (4.0, 2usize)] {
+            let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            assert_eq!(outcome.before_commit.pending_register_nodes, registers);
+            assert_eq!(outcome.register_commit.staged_nodes, registers);
+            assert_eq!(outcome.register_commit.committed_nodes, registers);
+            assert_eq!(f64_symbol(&interpreter, "count"), expected_count);
+            assert_eq!(arm_pulse_generation(&interpreter, 0), expected_pulse);
+            assert_eq!(plan_snapshot(&interpreter), topology);
+        }
+    }
+
+    #[test]
+    fn activation_arm_alias_of_live_input_remains_sampled_until_trigger() {
+        let mut interpreter = Interpreter::new_with_full_stdlib(0);
+        let outer_id = hash_str("outer");
+        {
+            let symbols = interpreter.symbols();
+            let mut symbols = symbols.borrow_mut();
+            symbols.insert(outer_id, Value::F64(Ref::new(1.0)), true);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(outer_id, "outer".to_string());
+        }
+        interpreter
+            .dictionary()
+            .borrow_mut()
+            .insert(outer_id, "outer".to_string());
+        interpret_more(
+            &mut interpreter,
+            r#"
+event := 0.0
+~state := 0.0
+
+~> event
+  | tick => {
+      sampled := outer
+      state = sampled
+    }
+"#,
+        )
+        .unwrap();
+
+        let trigger = root_cell(&interpreter, "event");
+        let outer = root_cell(&interpreter, "outer");
+        let activation = registration(&interpreter);
+        let registers = arm_register_nodes(&interpreter, &activation, 0);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(registers.len(), 1);
+        assert_eq!(f64_symbol(&interpreter, "state"), 0.0);
+        {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            let register = plan.node(registers[0]).unwrap();
+            assert!(register.inputs.iter().any(|dependency| {
+                dependency.cell == outer
+                    && dependency.kind == ReactiveDependencyKind::Sampled
+            }));
+            assert!(register.inputs.iter().any(|dependency| {
+                dependency.cell == activation.arms[0].pulse_cell
+                    && dependency.kind == ReactiveDependencyKind::Reactive
+            }));
+        }
+
+        set_f64_symbol(&interpreter, "outer", 5.0);
+        let sampled_only = interpreter.advance_reactive_turn(&[outer]).unwrap();
+        assert!(!sampled_only
+            .before_commit
+            .pending_register_nodes
+            .contains(&registers[0]));
+        assert!(!sampled_only
+            .register_commit
+            .committed_nodes
+            .contains(&registers[0]));
+        assert_eq!(f64_symbol(&interpreter, "state"), 0.0);
+
+        let tick = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &tick), 0);
+        assert_eq!(tick.register_commit.committed_nodes, registers);
+        assert_eq!(f64_symbol(&interpreter, "state"), 5.0);
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_failed_multi_register_staging_mutates_nothing() {
+        let mut interpreter = interpret(
+            r#"
+event := 0.0
+~first := 1.0
+~second := 2.0
+"#,
+        );
+        let second_sink = symbol(&interpreter, "second").as_f64().unwrap().clone();
+        let solve_calls = Arc::new(AtomicUsize::new(0));
+        let stage_calls = Arc::new(AtomicUsize::new(0));
+        interpreter
+            .functions()
+            .borrow_mut()
+            .insert_function_compiler(
+                "test/failing-pattern-register",
+                Arc::new(FailingPatternRegisterCompiler {
+                    sink: second_sink,
+                    solve_calls: solve_calls.clone(),
+                    stage_calls: stage_calls.clone(),
+                }),
+            );
+        interpret_more(
+            &mut interpreter,
+            r#"
+~> event
+  | value => {
+      first = value
+      test/failing-pattern-register()
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#,
+        )
+        .unwrap();
+
+        let trigger = root_cell(&interpreter, "event");
+        let activation = registration(&interpreter);
+        let registers = arm_register_nodes(&interpreter, &activation, 0);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(registers.len(), 2);
+        assert_eq!(
+            (f64_symbol(&interpreter, "first"), f64_symbol(&interpreter, "second")),
+            (1.0, 2.0)
+        );
+        assert_eq!(solve_calls.load(Ordering::SeqCst), 0);
+
+        set_f64_symbol(&interpreter, "event", 9.0);
+        let error = interpreter.advance_reactive_turn(&[trigger]).unwrap_err();
+        assert_eq!(error.kind_name(), "PatternRegisterStageFailure");
+        assert_eq!(stage_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(solve_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            (f64_symbol(&interpreter, "first"), f64_symbol(&interpreter, "second")),
+            (1.0, 2.0)
+        );
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_patterned_body_rejects_writes_to_its_trigger() {
+        for assignment in ["event = event + 1.0", "event += 1.0"] {
+            let mut interpreter = interpret("~event := 1.0");
+            let topology = plan_snapshot(&interpreter);
+            let error = interpret_more(
+                &mut interpreter,
+                &format!(
+                    r#"
+~> event
+  | * => {{
+      {assignment}
+    }}
+"#
+                ),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind_name(), "ActivationScopeTriggerWriteUnsupported");
+            assert_eq!(f64_symbol(&interpreter, "event"), 1.0);
+            assert_eq!(plan_snapshot(&interpreter), topology);
+            assert_eq!(interpreter.plan().activation_registration_depth(), 0);
+        }
+    }
+
+    #[test]
+    fn activation_patterned_body_rejects_writes_through_a_trigger_alias() {
+        let mut interpreter = interpret(
+            r#"
+~event := 1.0
+alias := event
+"#,
+        );
+        let topology = plan_snapshot(&interpreter);
+        let error = interpret_more(
+            &mut interpreter,
+            r#"
+~> alias
+  | * => {
+      event += 1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationScopeTriggerWriteUnsupported");
+        assert_eq!(f64_symbol(&interpreter, "event"), 1.0);
+        assert_eq!(plan_snapshot(&interpreter), topology);
+        assert_eq!(interpreter.plan().activation_registration_depth(), 0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_patterned_body_rejects_eager_subscript_writes() {
+        for assignment in ["values[1] = 3.0", "values[1] += 3.0"] {
+            let mut interpreter = interpret(
+                r#"
+event := 0.0
+~values := [1.0 2.0]
+"#,
+            );
+            let topology = plan_snapshot(&interpreter);
+            let values_before = symbol(&interpreter, "values");
+            let error = interpret_more(
+                &mut interpreter,
+                &format!(
+                    r#"
+~> event
+  | * => {{
+      {assignment}
+    }}
+"#
+                ),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind_name(), "ActivationPatternRegisterWriteUnsupported");
+            assert_eq!(symbol(&interpreter, "values"), values_before);
+            assert_eq!(plan_snapshot(&interpreter), topology);
+            assert_eq!(interpreter.plan().activation_registration_depth(), 0);
+        }
     }
 
     const ENUM_ACTIVATION: &str = r#"

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1127,3 +1127,91 @@ pub(crate) fn elaborate_patterned_activation(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
+        let mut cases = Vec::new();
+        #[cfg(feature = "u8")]
+        cases.push((ValueKind::U8, Value::U8(Ref::new(8))));
+        #[cfg(feature = "u16")]
+        cases.push((ValueKind::U16, Value::U16(Ref::new(16))));
+        #[cfg(feature = "u32")]
+        cases.push((ValueKind::U32, Value::U32(Ref::new(32))));
+        #[cfg(feature = "u64")]
+        cases.push((ValueKind::U64, Value::U64(Ref::new(64))));
+        #[cfg(feature = "u128")]
+        cases.push((ValueKind::U128, Value::U128(Ref::new(128))));
+        #[cfg(feature = "i8")]
+        cases.push((ValueKind::I8, Value::I8(Ref::new(-8))));
+        #[cfg(feature = "i16")]
+        cases.push((ValueKind::I16, Value::I16(Ref::new(-16))));
+        #[cfg(feature = "i32")]
+        cases.push((ValueKind::I32, Value::I32(Ref::new(-32))));
+        #[cfg(feature = "i64")]
+        cases.push((ValueKind::I64, Value::I64(Ref::new(-64))));
+        #[cfg(feature = "i128")]
+        cases.push((ValueKind::I128, Value::I128(Ref::new(-128))));
+        #[cfg(feature = "f32")]
+        cases.push((ValueKind::F32, Value::F32(Ref::new(3.25))));
+        #[cfg(feature = "f64")]
+        cases.push((ValueKind::F64, Value::F64(Ref::new(6.5))));
+        #[cfg(feature = "complex")]
+        cases.push((ValueKind::C64, Value::C64(Ref::new(C64::new(3.0, 4.0)))));
+        #[cfg(feature = "rational")]
+        cases.push((ValueKind::R64, Value::R64(Ref::new(R64::new(3, 4)))));
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        cases.push((ValueKind::Bool, Value::Bool(Ref::new(true))));
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        cases.push((
+            ValueKind::String,
+            Value::String(Ref::new("captured".to_string())),
+        ));
+        cases.push((ValueKind::Index, Value::Index(Ref::new(42))));
+        #[cfg(feature = "atom")]
+        {
+            let atom = MechAtom::from_name("captured");
+            cases.push((
+                ValueKind::Atom(atom.id(), atom.name()),
+                Value::Atom(Ref::new(atom)),
+            ));
+        }
+        cases
+    }
+
+    #[test]
+    fn activation_capture_slot_supports_all_enabled_scalar_kinds() {
+        for (kind, source) in scalar_capture_cases() {
+            let slot = create_capture_slot_for_kind(&kind).unwrap();
+            let cells_before = slot.reactive_root_cell_ids();
+            assert_eq!(cells_before.len(), 1);
+            commit_capture_slot(&slot, &source).unwrap();
+            assert_eq!(slot, source);
+            assert_eq!(slot.reactive_root_cell_ids(), cells_before);
+        }
+    }
+
+    #[cfg(any(feature = "string", feature = "variable_define"))]
+    #[test]
+    fn activation_capture_slot_preserves_identity_across_updates() {
+        let slot = create_capture_slot_for_kind(&ValueKind::String).unwrap();
+        let cells = slot.reactive_root_cell_ids();
+        commit_capture_slot(&slot, &Value::String(Ref::new("first".to_string()))).unwrap();
+        assert_eq!(slot, Value::String(Ref::new("first".to_string())));
+        assert_eq!(slot.reactive_root_cell_ids(), cells);
+        commit_capture_slot(&slot, &Value::String(Ref::new("second".to_string()))).unwrap();
+        assert_eq!(slot, Value::String(Ref::new("second".to_string())));
+        assert_eq!(slot.reactive_root_cell_ids(), cells);
+    }
+
+    #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
+    #[test]
+    fn activation_capture_slot_rejects_kind_mismatch() {
+        let slot = create_capture_slot_for_kind(&ValueKind::F64).unwrap();
+        let error =
+            commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+    }
+}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "functions", feature = "symbol_table"))]
 //! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
+use std::collections::HashSet;
 
 macro_rules! activation_error {
     ($n:ident,$m:expr) => {
@@ -30,7 +31,15 @@ activation_error!(
 );
 activation_error!(
     ActivationPatternGuardMustBePure,
-    "Patterned activation guards are not supported yet."
+    "Patterned activation guards must elaborate to a static pure expression graph."
+);
+activation_error!(
+    ActivationPatternGuardDependencyInvariant,
+    "The activation guard graph could not be attached to its match pulse."
+);
+activation_error!(
+    ActivationPatternBodyDependencyInvariant,
+    "The activation arm body could not sample its committed captures."
 );
 activation_error!(
     ActivationPatternRegisterWriteUnsupported,
@@ -819,6 +828,69 @@ impl MechFunctionImpl for Finalize {
         "ActivationPatternArmFinalize".into()
     }
 }
+struct MatchGate {
+    matched: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for MatchGate {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        if *self.matched.borrow() {
+            *self.out.borrow_mut() += 1;
+            Ok(ReactiveSolveStatus::Changed)
+        } else {
+            Ok(ReactiveSolveStatus::Unchanged)
+        }
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternGuardMatchGate".into()
+    }
+}
+struct UnmatchedFinalize {
+    matched: Ref<bool>,
+    eligible: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for UnmatchedFinalize {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        if *self.matched.borrow() {
+            Ok(ReactiveSolveStatus::Unchanged)
+        } else {
+            *self.eligible.borrow_mut() = false;
+            *self.out.borrow_mut() += 1;
+            Ok(ReactiveSolveStatus::Changed)
+        }
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternGuardUnmatchedFinalize".into()
+    }
+}
+struct GuardFinalize {
+    guard: Ref<bool>,
+    eligible: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for GuardFinalize {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.eligible.borrow_mut() = *self.guard.borrow();
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternGuardFinalize".into()
+    }
+}
 struct Select {
     eligible: Vec<Ref<bool>>,
     selected: Ref<usize>,
@@ -898,6 +970,12 @@ interpreter_only!(Matcher);
 #[cfg(feature = "compiler")]
 interpreter_only!(Finalize);
 #[cfg(feature = "compiler")]
+interpreter_only!(MatchGate);
+#[cfg(feature = "compiler")]
+interpreter_only!(UnmatchedFinalize);
+#[cfg(feature = "compiler")]
+interpreter_only!(GuardFinalize);
+#[cfg(feature = "compiler")]
 interpreter_only!(Select);
 #[cfg(feature = "compiler")]
 interpreter_only!(Gate);
@@ -925,12 +1003,10 @@ fn preflight_patterned_activation(
             MechError::new(ActivationPatternWildcardMustBeLast, None).with_tokens(scope.tokens())
         );
     }
-    if arms.iter().any(|a| a.guard.is_some()) {
-        return Err(
-            MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
-        );
-    }
     for arm in arms {
+        if let Some(guard) = &arm.guard {
+            validate_patterned_guard_expression(guard, i)?;
+        }
         validate_patterned_arm_body(&arm.body)?;
     }
     if trigger.reactive_root_cell_ids() != trigger_cells {
@@ -1085,6 +1161,252 @@ fn validate_patterned_expression(expression: &Expression) -> MResult<()> {
         }
     }
 }
+
+fn validate_patterned_guard_expression(
+    expression: &Expression,
+    interpreter: &Interpreter,
+) -> MResult<()> {
+    validate_patterned_expression(expression)?;
+    if guard_expression_has_eager_control_flow(
+        expression,
+        interpreter,
+        &mut HashSet::new(),
+    ) {
+        validation_error(ActivationPatternGuardMustBePure, expression.tokens())
+    } else {
+        Ok(())
+    }
+}
+
+fn guard_expression_has_eager_control_flow(
+    expression: &Expression,
+    interpreter: &Interpreter,
+    visiting_functions: &mut HashSet<u64>,
+) -> bool {
+    match expression {
+        Expression::Literal(_) | Expression::Var(_) => false,
+        Expression::Slice(slice) => slice
+            .subscript
+            .iter()
+            .any(|subscript| {
+                guard_subscript_has_eager_control_flow(
+                    subscript,
+                    interpreter,
+                    visiting_functions,
+                )
+            }),
+        Expression::Formula(factor) => {
+            guard_factor_has_eager_control_flow(factor, interpreter, visiting_functions)
+        }
+        Expression::FunctionCall(call) => {
+            if call.args.iter().any(|(_, expression)| {
+                guard_expression_has_eager_control_flow(
+                    expression,
+                    interpreter,
+                    visiting_functions,
+                )
+            }) {
+                return true;
+            }
+            let function_id = call.name.hash();
+            let user_function = interpreter
+                .functions()
+                .borrow()
+                .user_functions
+                .get(&function_id)
+                .cloned();
+            let Some(user_function) = user_function else {
+                return false;
+            };
+            if !visiting_functions.insert(function_id) {
+                return true;
+            }
+            let eager = match user_function.code.match_arms.as_slice() {
+                [arm] if matches!(arm.pattern, Pattern::Wildcard) => {
+                    guard_expression_has_eager_control_flow(
+                        &arm.expression,
+                        interpreter,
+                        visiting_functions,
+                    )
+                }
+                _ => true,
+            };
+            visiting_functions.remove(&function_id);
+            eager
+        }
+        Expression::Match(_)
+        | Expression::SetComprehension(_)
+        | Expression::MatrixComprehension(_)
+        | Expression::FsmPipe(_) => true,
+        Expression::Range(range) => {
+            guard_range_has_eager_control_flow(range, interpreter, visiting_functions)
+        }
+        Expression::Structure(structure) => {
+            guard_structure_has_eager_control_flow(structure, interpreter, visiting_functions)
+        }
+    }
+}
+
+fn guard_factor_has_eager_control_flow(
+    factor: &Factor,
+    interpreter: &Interpreter,
+    visiting_functions: &mut HashSet<u64>,
+) -> bool {
+    match factor {
+        Factor::Expression(expression) => guard_expression_has_eager_control_flow(
+            expression,
+            interpreter,
+            visiting_functions,
+        ),
+        Factor::Negate(factor)
+        | Factor::Not(factor)
+        | Factor::Parenthetical(factor)
+        | Factor::Transpose(factor) => {
+            guard_factor_has_eager_control_flow(factor, interpreter, visiting_functions)
+        }
+        Factor::Term(term) => {
+            guard_factor_has_eager_control_flow(
+                &term.lhs,
+                interpreter,
+                visiting_functions,
+            ) || term.rhs.iter().any(|(_, factor)| {
+                guard_factor_has_eager_control_flow(
+                    factor,
+                    interpreter,
+                    visiting_functions,
+                )
+            })
+        }
+    }
+}
+
+fn guard_range_has_eager_control_flow(
+    range: &RangeExpression,
+    interpreter: &Interpreter,
+    visiting_functions: &mut HashSet<u64>,
+) -> bool {
+    guard_factor_has_eager_control_flow(&range.start, interpreter, visiting_functions)
+        || range
+            .increment
+            .as_ref()
+            .map_or(false, |(_, increment)| {
+                guard_factor_has_eager_control_flow(
+                    increment,
+                    interpreter,
+                    visiting_functions,
+                )
+            })
+        || guard_factor_has_eager_control_flow(
+            &range.terminal,
+            interpreter,
+            visiting_functions,
+        )
+}
+
+fn guard_subscript_has_eager_control_flow(
+    subscript: &Subscript,
+    interpreter: &Interpreter,
+    visiting_functions: &mut HashSet<u64>,
+) -> bool {
+    match subscript {
+        Subscript::Brace(subscripts) | Subscript::Bracket(subscripts) => subscripts
+            .iter()
+            .any(|subscript| {
+                guard_subscript_has_eager_control_flow(
+                    subscript,
+                    interpreter,
+                    visiting_functions,
+                )
+            }),
+        Subscript::Formula(factor) => {
+            guard_factor_has_eager_control_flow(factor, interpreter, visiting_functions)
+        }
+        Subscript::Range(range) => {
+            guard_range_has_eager_control_flow(range, interpreter, visiting_functions)
+        }
+        Subscript::All | Subscript::Dot(_) | Subscript::DotInt(_) | Subscript::Swizzle(_) => false,
+    }
+}
+
+fn guard_structure_has_eager_control_flow(
+    structure: &Structure,
+    interpreter: &Interpreter,
+    visiting_functions: &mut HashSet<u64>,
+) -> bool {
+    match structure {
+        Structure::Empty => false,
+        Structure::Map(map) => map.elements.iter().any(|mapping| {
+            guard_expression_has_eager_control_flow(
+                &mapping.key,
+                interpreter,
+                visiting_functions,
+            ) || guard_expression_has_eager_control_flow(
+                &mapping.value,
+                interpreter,
+                visiting_functions,
+            )
+        }),
+        Structure::Matrix(matrix) => matrix.rows.iter().any(|row| {
+            row.columns
+                .iter()
+                .any(|column| {
+                    guard_expression_has_eager_control_flow(
+                        &column.element,
+                        interpreter,
+                        visiting_functions,
+                    )
+                })
+        }),
+        Structure::Record(record) => record
+            .bindings
+            .iter()
+            .any(|binding| {
+                guard_expression_has_eager_control_flow(
+                    &binding.value,
+                    interpreter,
+                    visiting_functions,
+                )
+            }),
+        Structure::Set(set) => set
+            .elements
+            .iter()
+            .any(|expression| {
+                guard_expression_has_eager_control_flow(
+                    expression,
+                    interpreter,
+                    visiting_functions,
+                )
+            }),
+        Structure::Table(table) => table.rows.iter().any(|row| {
+            row.columns
+                .iter()
+                .any(|column| {
+                    guard_expression_has_eager_control_flow(
+                        &column.element,
+                        interpreter,
+                        visiting_functions,
+                    )
+                })
+        }),
+        Structure::Tuple(tuple) => tuple
+            .elements
+            .iter()
+            .any(|expression| {
+                guard_expression_has_eager_control_flow(
+                    expression,
+                    interpreter,
+                    visiting_functions,
+                )
+            }),
+        Structure::TupleStruct(tuple) => {
+            guard_expression_has_eager_control_flow(
+                &tuple.value,
+                interpreter,
+                visiting_functions,
+            )
+        }
+    }
+}
 fn validate_patterned_pattern(pattern: &Pattern) -> MResult<()> {
     match pattern {
         Pattern::Expression(expression) => validate_patterned_expression(expression),
@@ -1225,6 +1547,108 @@ fn validate_patterned_qualifier(qualifier: &ComprehensionQualifier) -> MResult<(
     }
 }
 
+struct ElaboratedPatternGuard {
+    finalizer_node: ReactiveNodeId,
+    node_start: usize,
+    node_end: usize,
+}
+
+fn elaborate_patterned_arm_guard(
+    guard: &Expression,
+    captures: &[ActivationPatternCapture],
+    pulse: &Value,
+    eligible: &Ref<bool>,
+    completion: Ref<usize>,
+    interpreter: &Interpreter,
+) -> MResult<ElaboratedPatternGuard> {
+    let symbols = interpreter.symbols();
+    let symbol_snapshot = symbols.borrow().snapshot();
+    let plan = interpreter.plan();
+    let original_scope_depth = plan.activation_registration_depth();
+    {
+        let mut symbols = symbols.borrow_mut();
+        for capture in captures {
+            symbols.mutable_variables.remove(&capture.id);
+            symbols.insert(capture.id, capture.proposed.clone(), false);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(capture.id, capture.name.clone());
+        }
+    }
+    let node_start = plan.len();
+    let pulse_cells = pulse.reactive_root_cell_ids();
+    plan.push_activation_registration_scope(pulse_cells.clone());
+    let result = (|| -> MResult<ElaboratedPatternGuard> {
+        let _deferred_expression_solves =
+            crate::expressions::DeferredExpressionSolveScope::enter(interpreter);
+        let _persistent_user_function_plan =
+            crate::functions::PersistentUserFunctionPlanScope::enter(interpreter);
+        let guard_value = crate::expression(guard, None, interpreter)?;
+        let guard_ref = crate::expressions::validate_guard_expression_result(
+            guard_value.clone(),
+            guard.tokens(),
+        )?;
+        let finalizer_node = plan.register_function(
+            Box::new(GuardFinalize {
+                guard: guard_ref,
+                eligible: eligible.clone(),
+                out: completion,
+            }),
+            &[guard_value],
+        )?;
+        let node_end = plan.len();
+        {
+            let plan_borrow = plan.borrow();
+            if plan_borrow.nodes[node_start..node_end]
+                .iter()
+                .any(|node| node.kind != ReactiveNodeKind::Combinational)
+            {
+                return Err(
+                    MechError::new(ActivationPatternGuardMustBePure, None)
+                        .with_tokens(guard.tokens()),
+                );
+            }
+        }
+        {
+            let Some(pulse_cell) = pulse_cells.first().copied() else {
+                return Err(
+                    MechError::new(ActivationPatternGuardDependencyInvariant, None)
+                        .with_tokens(guard.tokens()),
+                );
+            };
+            let mut plan_borrow = plan.borrow_mut();
+            for node in node_start..node_end {
+                if !plan_borrow.add_reactive_dependency(node, pulse_cell) {
+                    return Err(
+                        MechError::new(ActivationPatternGuardDependencyInvariant, None)
+                            .with_tokens(guard.tokens()),
+                    );
+                }
+                for capture in captures {
+                    let capture_cell = capture.proposed.reactive_root_cell_ids()[0];
+                    if !plan_borrow.add_sampled_dependency(node, capture_cell) {
+                        return Err(
+                            MechError::new(ActivationPatternGuardDependencyInvariant, None)
+                                .with_tokens(guard.tokens()),
+                        );
+                    }
+                }
+            }
+        }
+        Ok(ElaboratedPatternGuard {
+            finalizer_node,
+            node_start,
+            node_end,
+        })
+    })();
+    while plan.activation_registration_depth() > original_scope_depth {
+        plan.pop_activation_registration_scope();
+    }
+    symbols.borrow_mut().restore(symbol_snapshot);
+    result
+}
+
 fn elaborate_patterned_arm_body(
     arm: &ActivationArm,
     captures: &[ActivationPatternCapture],
@@ -1273,7 +1697,12 @@ fn elaborate_patterned_arm_body(
         for node in body_node_start..body_node_end {
             for capture in captures {
                 let cell = capture.committed.reactive_root_cell_ids()[0];
-                debug_assert!(plan.add_sampled_dependency(node, cell));
+                if !plan.add_sampled_dependency(node, cell) {
+                    return Err(MechError::new(
+                        ActivationPatternBodyDependencyInvariant,
+                        None,
+                    ));
+                }
             }
         }
     }
@@ -1304,18 +1733,17 @@ fn elaborate_patterned_activation_inner(
         })
         .collect::<MResult<Vec<_>>>()?;
     drop(_persistent_user_function_plan);
-    let mut initially_matched = Vec::with_capacity(compiled.len());
+    // Seed proposal storage before guard graphs are elaborated. Composite
+    // guard expressions may need the current proposal shape to compile, but
+    // eligibility and selection are still determined by the runtime graph
+    // initialization below.
     for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
         let pattern_match =
             match_compiled_pattern_with_values(&arm.pattern, &trigger, expression_values)?;
-        initially_matched.push(pattern_match.matched);
         ReactiveBindingSink {
             captures: &arm.captures,
         }
         .commit(&pattern_match)?;
-    }
-    if let Some(selected) = initially_matched.iter().position(|matched| *matched) {
-        commit_proposed_captures(&compiled[selected].captures)?;
     }
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
@@ -1344,20 +1772,60 @@ fn elaborate_patterned_activation_inner(
         completions.push(v);
         matched.push(f);
     }
-    let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
-    for (f, c) in matched.iter().zip(completions.iter()) {
-        let (o, v) = generation();
+    let (mut finalizers, mut guards, mut eligible, mut done) =
+        (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+    for n in 0..arms.len() {
         let e = Ref::new(false);
-        finalizers.push(plan.borrow_mut().register(
-            Box::new(Finalize {
-                matched: f.clone(),
-                eligible: e.clone(),
-                out: o,
-            }),
-            &[c.clone()],
-        )?);
+        if let Some(guard) = &arms[n].guard {
+            let (match_gate_out, match_gate_pulse) = generation();
+            let match_gate_node = plan.borrow_mut().register(
+                Box::new(MatchGate {
+                    matched: matched[n].clone(),
+                    out: match_gate_out,
+                }),
+                &[completions[n].clone()],
+            )?;
+            let (unmatched_out, unmatched_done) = generation();
+            let unmatched_finalizer = plan.borrow_mut().register(
+                Box::new(UnmatchedFinalize {
+                    matched: matched[n].clone(),
+                    eligible: e.clone(),
+                    out: unmatched_out,
+                }),
+                &[completions[n].clone()],
+            )?;
+            let (guard_out, guard_done) = generation();
+            let elaborated = elaborate_patterned_arm_guard(
+                guard,
+                &compiled[n].captures,
+                &match_gate_pulse,
+                &e,
+                guard_out,
+                i,
+            )?;
+            finalizers.push(unmatched_finalizer);
+            guards.push(Some(PatternActivationGuardRegistration {
+                match_gate_node,
+                guard_finalizer_node: elaborated.finalizer_node,
+                guard_node_start: elaborated.node_start,
+                guard_node_end: elaborated.node_end,
+            }));
+            done.push(unmatched_done);
+            done.push(guard_done);
+        } else {
+            let (out, arm_done) = generation();
+            finalizers.push(plan.borrow_mut().register(
+                Box::new(Finalize {
+                    matched: matched[n].clone(),
+                    eligible: e.clone(),
+                    out,
+                }),
+                &[completions[n].clone()],
+            )?);
+            guards.push(None);
+            done.push(arm_done);
+        }
         eligible.push(e);
-        done.push(v);
     }
     let (o, selection) = generation();
     let selected = Ref::new(usize::MAX);
@@ -1369,6 +1837,13 @@ fn elaborate_patterned_activation_inner(
         }),
         &done,
     )?;
+    let private_scope_cell = scope_v.reactive_root_cell_ids()[0];
+    plan.solve_dirty_cells(&[private_scope_cell])?;
+    let initially_selected = *selected.borrow();
+    if initially_selected >= compiled.len() {
+        return Err(MechError::new(ActivationPatternArmsNonExhaustive, None));
+    }
+    commit_proposed_captures(&compiled[initially_selected].captures)?;
     let (mut gates, mut pulses) = (Vec::new(), Vec::new());
     for arm in 0..arms.len() {
         let (o, v) = generation();
@@ -1399,6 +1874,7 @@ fn elaborate_patterned_activation_inner(
             .map(|n| PatternActivationArmRegistration {
                 matcher_node: matcher_nodes[n],
                 finalizer_node: finalizers[n],
+                guard: guards[n].clone(),
                 gate_node: gates[n],
                 pulse_cell: pulses[n].reactive_root_cell_ids()[0],
                 body_node_start: ranges[n].0,
@@ -1810,6 +2286,17 @@ event := :first
             .skip(1)
             .nth(capture)
             .expect("missing proposed capture output")
+    }
+    fn arm_pulse_generation(interpreter: &Interpreter, arm: usize) -> usize {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm];
+        let Value::Index(generation) =
+            node_output_for_cell(interpreter, arm.gate_node, arm.pulse_cell)
+        else {
+            panic!("activation arm pulse is not an index")
+        };
+        let value = *generation.borrow();
+        value
     }
     fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
         let plan = interpreter.plan();
@@ -2480,6 +2967,370 @@ event := (1.0, 1.0)
         assert_dispatch_turn(&i, &topology, &o, 1, -1.);
     }
 
+    #[test]
+    fn activation_guards_fall_through_in_source_order_and_commit_only_the_selected_arm() {
+        let mut i = interpret(
+            r#"
+event := 0.0
+~> event
+  | first, first > 10.0 => {
+      selected := first + 100.0
+    }
+  | second, second > 0.0 => {
+      selected := second + 200.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let activation = registration(&i);
+        assert!(activation.arms[0].guard.is_some());
+        assert!(activation.arms[1].guard.is_some());
+        assert!(activation.arms[2].guard.is_none());
+
+        let Value::F64(event) = symbol(&i, "event") else {
+            panic!("event is not f64")
+        };
+        *event.borrow_mut() = 20.0;
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 120.0);
+        let changed = turn_changed_nodes(&outcome);
+        let unchanged = turn_unchanged_nodes(&outcome);
+        for arm in &activation.arms[..2] {
+            let guard = arm.guard.as_ref().unwrap();
+            assert!(changed.contains(&guard.match_gate_node));
+            assert!(changed.contains(&guard.guard_finalizer_node));
+            assert!(unchanged.contains(&arm.finalizer_node));
+        }
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(20.0)));
+        assert_eq!(committed_capture_value(&i, 1, 0), Value::F64(Ref::new(0.0)));
+
+        *event.borrow_mut() = 5.0;
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, 205.0);
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(20.0)));
+        assert_eq!(committed_capture_value(&i, 1, 0), Value::F64(Ref::new(5.0)));
+
+        *event.borrow_mut() = -5.0;
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 2, -1.0);
+        assert_eq!(proposed_capture_value(&i, 0, 0), Value::F64(Ref::new(-5.0)));
+        assert_eq!(proposed_capture_value(&i, 1, 0), Value::F64(Ref::new(-5.0)));
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(20.0)));
+        assert_eq!(committed_capture_value(&i, 1, 0), Value::F64(Ref::new(5.0)));
+    }
+
+    #[test]
+    fn activation_guard_outer_dependencies_are_sampled_until_the_next_trigger() {
+        let mut i = interpret(
+            r#"
+event := (:pressed, 0.0)
+threshold := 10.0
+~> event
+  | :pressed(x), x > threshold => {
+      selected := x + 0.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let activation = registration(&i);
+        let guard = activation.arms[0].guard.as_ref().unwrap();
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let executed = turn_executed_nodes(&dependency_turn);
+        assert!(!executed.contains(&activation.scope_pulse_node));
+        assert!(!executed.contains(&guard.match_gate_node));
+        assert!(!executed.contains(&guard.guard_finalizer_node));
+        for node in guard.guard_node_start..guard.guard_node_end {
+            assert!(!executed.contains(&node));
+        }
+        assert_eq!(plan_snapshot(&i), topology);
+
+        set_atom_tuple_event(&i, "pressed", 5.0);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 5.0);
+    }
+
+    #[test]
+    fn activation_guard_user_function_refreshes_on_each_matching_trigger() {
+        let mut i = interpret(
+            r#"
+passes(value<f64>, limit<f64>) => <bool>
+  | value > limit.
+
+event := (:pressed, 0.0)
+threshold := 5.0
+~> event
+  | :pressed(x), passes(x, threshold) => {
+      selected := x + 0.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        {
+            let functions = i.functions();
+            let functions = functions.borrow();
+            let passes = functions.user_functions.get(&hash_str("passes")).unwrap();
+            assert_eq!(passes.code.match_arms.len(), 1);
+            assert!(matches!(passes.code.match_arms[0].pattern, Pattern::Wildcard));
+        }
+
+        set_atom_tuple_event(&i, "pressed", 6.0);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 6.0);
+
+        set_atom_tuple_event(&i, "pressed", 4.0);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        assert!(turn_executed_nodes(&dependency_turn).is_empty());
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 4.0);
+    }
+
+    #[test]
+    fn activation_guard_initialization_commits_the_first_eligible_arm_without_pulsing_a_body() {
+        let i = interpret(
+            r#"
+event := 5.0
+~> event
+  | first, first > 10.0 => {
+      selected := first + 100.0
+    }
+  | second, second > 0.0 => {
+      selected := second + 200.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+
+        assert_eq!(proposed_capture_value(&i, 0, 0), Value::F64(Ref::new(5.0)));
+        assert_eq!(proposed_capture_value(&i, 1, 0), Value::F64(Ref::new(5.0)));
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(0.0)));
+        assert_eq!(committed_capture_value(&i, 1, 0), Value::F64(Ref::new(5.0)));
+        assert_eq!(body_output_f64(&i, 1), 205.0);
+        for arm in 0..3 {
+            assert_eq!(arm_pulse_generation(&i, arm), 0);
+        }
+    }
+
+    #[test]
+    fn activation_guard_equal_packets_dispatch_again_without_changing_topology() {
+        let mut i = interpret(
+            r#"
+event := 20.0
+~> event
+  | value, value > 10.0 => {
+      selected := value + 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        for expected_pulse in [1usize, 2] {
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, 0, 21.0);
+            let guard = registration(&i).arms[0].guard.clone().unwrap();
+            let executed = turn_executed_nodes(&outcome);
+            for guard_node in guard.guard_node_start..guard.guard_node_end {
+                assert_eq!(
+                    executed.iter().filter(|node| **node == guard_node).count(),
+                    1
+                );
+            }
+            assert_eq!(arm_pulse_generation(&i, 0), expected_pulse);
+        }
+    }
+
+    #[test]
+    fn activation_guard_non_boolean_result_rolls_back_plan_and_symbols() {
+        let mut i = interpret("event := 1.0\nouter := 9.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | x, x + 1.0 => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind_name(), "InvalidGuardExpression");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert_eq!(i.plan().activation_registration_depth(), 0);
+    }
+
+    #[test]
+    fn activation_guard_rejects_eager_nested_match_control_flow() {
+        let mut i = interpret("event := 1.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let topology = plan_snapshot(&i);
+
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | x, (x? | 0.0 => false | * => true.) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind_name(), "ActivationPatternGuardMustBePure");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+
+    #[test]
+    fn activation_guard_rejects_user_function_pattern_dispatch_that_cannot_refresh_statically() {
+        let mut i = interpret(
+            r#"
+passes(value<f64>) => <bool>
+  | 0.0 => false
+  | * => true.
+
+event := 1.0
+"#,
+        );
+        let topology = plan_snapshot(&i);
+
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | x, passes(x) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind_name(), "ActivationPatternGuardMustBePure");
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+
+    #[test]
+    fn activation_unmatched_guard_skips_runtime_error_and_guard_error_commits_nothing() {
+        let mut i = interpret(
+            r#"
+event := (:pressed, 1.0)
+text := "abc"
+~index := 1.0
+~> event
+  | :pressed(x), text[index] == "a" => {
+      selected := x + 0.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+
+        set_atom_tuple_event(&i, "pressed", 2.0);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 2.0);
+        let committed_before = committed_capture_value(&i, 0, 0);
+        let pulse_before = arm_pulse_generation(&i, 0);
+        let body_before = body_output_f64(&i, 0);
+
+        let Value::F64(index) = symbol(&i, "index") else {
+            panic!("index is not f64")
+        };
+        *index.borrow_mut() = 4.0;
+        set_atom_tuple_event(&i, "other", 3.0);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+        let guard = registration(&i).arms[0].guard.clone().unwrap();
+        let executed = turn_executed_nodes(&outcome);
+        let changed = turn_changed_nodes(&outcome);
+        let unchanged = turn_unchanged_nodes(&outcome);
+        assert!(executed.contains(&guard.match_gate_node));
+        assert!(unchanged.contains(&guard.match_gate_node));
+        assert!(changed.contains(&registration(&i).arms[0].finalizer_node));
+        for node in guard.guard_node_start..guard.guard_node_end {
+            assert!(!executed.contains(&node));
+        }
+
+        let pulses_before_error = (0..2)
+            .map(|arm| arm_pulse_generation(&i, arm))
+            .collect::<Vec<_>>();
+        let bodies_before_error = (0..2)
+            .map(|arm| body_output_f64(&i, arm))
+            .collect::<Vec<_>>();
+        set_atom_tuple_event(&i, "pressed", 3.0);
+        let error = i.advance_reactive_turn(&[trigger]).unwrap_err();
+        assert_eq!(error.kind_name(), "IndexOutOfBounds");
+        assert_eq!(proposed_capture_value(&i, 0, 0), Value::F64(Ref::new(3.0)));
+        assert_eq!(committed_capture_value(&i, 0, 0), committed_before);
+        assert_eq!(arm_pulse_generation(&i, 0), pulse_before);
+        assert_eq!(body_output_f64(&i, 0), body_before);
+        assert_eq!(
+            (0..2)
+                .map(|arm| arm_pulse_generation(&i, arm))
+                .collect::<Vec<_>>(),
+            pulses_before_error
+        );
+        assert_eq!(
+            (0..2)
+                .map(|arm| body_output_f64(&i, arm))
+                .collect::<Vec<_>>(),
+            bodies_before_error
+        );
+        assert_eq!(plan_snapshot(&i), topology);
+
+        *index.borrow_mut() = 1.0;
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 3.0);
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(3.0)));
+    }
+
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
     fn activation_pattern_expression_uses_outer_symbol_when_capture_name_collides() {
@@ -2518,6 +3369,100 @@ event := [1.0 10.0]
             proposed_cell
         );
         assert_eq!(registration(&i).arms[0].captures[0].cell, committed_cell);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_guard_capture_shadows_outer_name_while_pattern_expression_keeps_outer_name() {
+        let mut i = interpret(
+            r#"
+x := 9.0
+event := [1.0 10.0]
+
+~> event
+  | [x, x + 1.0], x < 2.0 => {
+      selected := x + 0.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let outer_cell = root_cell(&i, "x");
+        let activation = registration(&i);
+        let proposed_cell = proposed_capture_value(&i, 0, 0).reactive_root_cell_ids()[0];
+        let committed_cell = activation.arms[0].captures[0].cell;
+        assert_ne!(outer_cell, proposed_cell);
+        assert_ne!(outer_cell, committed_cell);
+        assert_ne!(proposed_cell, committed_cell);
+        let guard = activation.arms[0].guard.as_ref().unwrap();
+        {
+            let plan = i.plan();
+            let plan = plan.borrow();
+            let guard_pulse_cell = plan.node(guard.match_gate_node).unwrap().outputs[0];
+            for node in &plan.nodes[guard.guard_node_start..guard.guard_node_end] {
+                assert!(node.inputs.iter().any(|dependency| {
+                    dependency.cell == guard_pulse_cell
+                        && dependency.kind == ReactiveDependencyKind::Reactive
+                }));
+                assert!(node.inputs.iter().any(|dependency| {
+                    dependency.cell == proposed_cell
+                        && dependency.kind == ReactiveDependencyKind::Sampled
+                }));
+                assert!(!node
+                    .inputs
+                    .iter()
+                    .any(|dependency| dependency.cell == committed_cell));
+            }
+        }
+        let topology = plan_snapshot(&i);
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+        assert_eq!(symbol(&i, "x"), Value::F64(Ref::new(9.0)));
+        assert_eq!(proposed_capture_value(&i, 0, 0), Value::F64(Ref::new(1.0)));
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(1.0)));
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_guard_composite_rest_proposal_commits_only_when_the_guard_passes() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0]
+~> event
+  | [head | rest], head < rest[1] && rest[2] > rest[1] => {
+      selected := head + 0.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+
+        set_f64_matrix_event(&i, vec![4.0, 5.0, 6.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&registration(&i), &outcome), 0);
+        assert_eq!(body_output_f64(&i, 0), 4.0);
+        assert_eq!(plan_snapshot(&i), topology);
+        let committed_before = committed_capture_value(&i, 0, 1);
+        let pulse_before = arm_pulse_generation(&i, 0);
+
+        set_f64_matrix_event(&i, vec![7.0, 6.0, 5.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+        let Value::MatrixF64(proposed_rest) = proposed_capture_value(&i, 0, 1) else {
+            panic!("proposed rest is not an f64 matrix")
+        };
+        assert_eq!(proposed_rest.as_vec(), vec![6.0, 5.0]);
+        assert_eq!(committed_capture_value(&i, 0, 1), committed_before);
+        assert_eq!(arm_pulse_generation(&i, 0), pulse_before);
+        assert_eq!(body_output_f64(&i, 0), 4.0);
+        assert_eq!(plan_snapshot(&i), topology);
     }
 
     #[cfg(all(feature = "matrix", feature = "f64"))]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1231,14 +1231,14 @@ mod tests {
     );
 
     fn interpret(source: &str) -> Interpreter {
-        let tree = mech_syntax::parser::parse(source).unwrap();
+        let tree = mech_syntax::parser::parse(source.trim_start()).unwrap();
         let mut interpreter = Interpreter::new_with_full_stdlib(0);
         interpreter.interpret(&tree).unwrap();
         interpreter
     }
 
     fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MResult<Value> {
-        let tree = mech_syntax::parser::parse(source).unwrap();
+        let tree = mech_syntax::parser::parse(source.trim_start()).unwrap();
         interpreter.interpret(&tree)
     }
 
@@ -1342,26 +1342,23 @@ mod tests {
         panic!("no f64 output")
     }
     fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
-        match symbol(interpreter, "event") {
-            Value::Enum(event) => {
-                let id = event.borrow().id;
-                let names = interpreter
-                    .state
-                    .borrow()
-                    .enums
-                    .get(&id)
-                    .unwrap()
-                    .names
-                    .clone();
-                *event.borrow_mut() = MechEnum {
-                    id,
-                    variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
-                    names,
-                };
-            }
-            Value::Tuple(_) => set_atom_tuple_event(interpreter, variant, payload),
-            _ => panic!("event is neither enum nor tagged tuple"),
-        }
+        let Value::Enum(event) = symbol(interpreter, "event") else {
+            panic!("event is not an enum");
+        };
+        let enum_id = event.borrow().id;
+        let names = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .expect("event enum definition is missing")
+            .names
+            .clone();
+        *event.borrow_mut() = MechEnum {
+            id: enum_id,
+            variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
+            names,
+        };
     }
     fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
         let Value::Tuple(event) = symbol(interpreter, "event") else {
@@ -1437,7 +1434,12 @@ mod tests {
         assert_eq!(&plan_snapshot(interpreter), topology);
     }
 
-    const ENUM_ACTIVATION: &str = r#"event := (:pressed, 0.0)
+    const ENUM_ACTIVATION: &str = r#"
+<Event> := :pressed(f64)
+  | :released(f64)
+  | :other(f64)
+
+event := :pressed(0.0)
 
 ~> event
   | :pressed(x) => {
@@ -1457,11 +1459,34 @@ mod tests {
         PlanSnapshot,
     ) {
         let interpreter = interpret(ENUM_ACTIVATION);
+        assert!(matches!(symbol(&interpreter, "event"), Value::Enum(_)));
+        let enum_id = match symbol(&interpreter, "event") {
+            Value::Enum(event) => event.borrow().id,
+            value => panic!("expected enum event, found {:?}", value.kind()),
+        };
+        let enum_definition = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .cloned()
+            .expect("event enum definition is missing");
+        for variant in ["pressed", "released", "other"] {
+            assert!(
+                enum_definition
+                    .variants
+                    .iter()
+                    .any(|(variant_id, _)| *variant_id == hash_str(variant)),
+                "missing enum variant `{variant}`"
+            );
+        }
         let trigger = root_cell(&interpreter, "event");
         let registration = registration(&interpreter);
         assert_eq!(registration.arms.len(), 3);
         assert_eq!(registration.arms[0].captures.len(), 1);
         assert_eq!(registration.arms[1].captures.len(), 1);
+        assert_eq!(registration.arms[0].captures[0].kind, ValueKind::F64);
+        assert_eq!(registration.arms[1].captures[0].kind, ValueKind::F64);
         assert!(registration.arms[2].captures.is_empty());
         assert!(!interpreter.symbols().borrow().contains(hash_str("x")));
         assert!(
@@ -1885,6 +1910,7 @@ event := (1.0, 1.0)
         let symbols = i.symbols().borrow().snapshot();
         let dictionary = i.dictionary().borrow().clone();
         let topology = plan_snapshot(&i);
+        let context_bindings = i.context_bindings.borrow().clone();
         let error = interpret_more(
             &mut i,
             "~> event\n  | 1.0 => {
@@ -1898,6 +1924,13 @@ event := (1.0, 1.0)
         assert_eq!(i.symbols().borrow().snapshot(), symbols);
         assert_eq!(*i.dictionary().borrow(), dictionary);
         assert_eq!(plan_snapshot(&i), topology);
+        assert_eq!(*i.context_bindings.borrow(), context_bindings);
+        assert!(
+            !i.context_bindings
+                .borrow()
+                .contains_key(&hash_str("temporary"))
+        );
+        assert!(i.plan().pattern_activation_registrations().is_empty());
         assert!(!i.symbols().borrow().contains(hash_str("fallback")));
     }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1435,11 +1435,11 @@ mod tests {
     }
 
     const ENUM_ACTIVATION: &str = r#"
-<Event> := :pressed(f64)
-  | :released(f64)
-  | :other(f64)
+<event-kind> := :pressed<f64>
+  | :released<f64>
+  | :other<f64>
 
-event := :pressed(0.0)
+event<event-kind> := :pressed(0.0)
 
 ~> event
   | :pressed(x) => {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -50,7 +50,8 @@ struct ActivationPatternCapture {
     id: u64,
     name: String,
     kind: ValueKind,
-    slot: Value,
+    proposed: Value,
+    committed: Value,
 }
 #[derive(Clone)]
 struct PreflightActivationArm {
@@ -696,7 +697,7 @@ impl PatternBindingSink for ReactiveBindingSink<'_> {
             let source = detached(&binding.value);
             if capture.id != binding.id
                 || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
-                || !capture_slot_accepts_payload(&capture.slot, &source)
+                || !capture_slot_accepts_payload(&capture.proposed, &source)
             {
                 return Err(MechError::new(
                     ActivationPatternCaptureKindUnsupported,
@@ -706,10 +707,31 @@ impl PatternBindingSink for ReactiveBindingSink<'_> {
         }
 
         for binding in &pattern_match.bindings {
-            commit_capture_slot(&self.captures[binding.index].slot, &binding.value)?;
+            commit_capture_slot(&self.captures[binding.index].proposed, &binding.value)?;
         }
         Ok(())
     }
+}
+
+fn commit_proposed_captures(captures: &[ActivationPatternCapture]) -> MResult<()> {
+    // Preflight the complete batch so a later incompatible destination cannot
+    // leave an arm body observing only some captures from the current trigger.
+    for capture in captures {
+        let proposed = detached(&capture.proposed);
+        if !capture_kinds_are_storage_compatible(&capture.kind, &proposed.kind())
+            || !capture_slot_accepts_payload(&capture.committed, &proposed)
+        {
+            return Err(MechError::new(
+                ActivationPatternCaptureKindUnsupported,
+                None,
+            ));
+        }
+    }
+
+    for capture in captures {
+        commit_capture_slot(&capture.committed, &capture.proposed)?;
+    }
+    Ok(())
 }
 
 fn generation() -> (Ref<usize>, Value) {
@@ -761,6 +783,11 @@ impl MechFunctionImpl for Matcher {
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
+    }
+    fn reactive_output_values(&self) -> Vec<Value> {
+        let mut outputs = vec![self.out()];
+        outputs.extend(self.captures.iter().map(|capture| capture.proposed.clone()));
+        outputs
     }
     fn reactive_dependency_kinds(&self, argument_count: usize) -> Option<Vec<ReactiveDependencyKind>> {
         let mut kinds = vec![ReactiveDependencyKind::Sampled; argument_count];
@@ -818,12 +845,14 @@ impl MechFunctionImpl for Select {
 struct Gate {
     arm: usize,
     selected: Ref<usize>,
+    captures: Vec<ActivationPatternCapture>,
     out: Ref<usize>,
 }
 impl MechFunctionImpl for Gate {
     fn solve(&self) {}
     fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
         if *self.selected.borrow() == self.arm {
+            commit_proposed_captures(&self.captures)?;
             *self.out.borrow_mut() += 1;
             Ok(ReactiveSolveStatus::Changed)
         } else {
@@ -832,6 +861,15 @@ impl MechFunctionImpl for Gate {
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
+    }
+    fn reactive_output_values(&self) -> Vec<Value> {
+        let mut outputs = vec![self.out()];
+        outputs.extend(
+            self.captures
+                .iter()
+                .map(|capture| capture.committed.clone()),
+        );
+        outputs
     }
     fn to_string(&self) -> String {
         "ActivationPatternArmGate".into()
@@ -912,13 +950,16 @@ fn preflight_patterned_activation(
                     MechError::new(ActivationPatternCaptureKindUnsupported, None)
                         .with_tokens(a.pattern.tokens())
                 })?;
-                let slot = create_capture_slot_for_kind(&kind, i)
+                let proposed = create_capture_slot_for_kind(&kind, i)
+                    .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
+                let committed = create_capture_slot_for_kind(&kind, i)
                     .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
                 Ok(ActivationPatternCapture {
                     id: binding.id,
                     name: binding.name,
                     kind,
-                    slot,
+                    proposed,
+                    committed,
                 })
             })
             .collect::<MResult<Vec<_>>>()?;
@@ -1184,6 +1225,33 @@ fn validate_patterned_qualifier(qualifier: &ComprehensionQualifier) -> MResult<(
     }
 }
 
+fn elaborate_patterned_expression_values(
+    arm: &PreflightActivationArm,
+    interpreter: &Interpreter,
+) -> MResult<Vec<Value>> {
+    let symbols = interpreter.symbols();
+    let symbol_snapshot = symbols.borrow().snapshot();
+    {
+        let mut symbols = symbols.borrow_mut();
+        for capture in &arm.captures {
+            symbols.mutable_variables.remove(&capture.id);
+            symbols.insert(capture.id, capture.proposed.clone(), false);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(capture.id, capture.name.clone());
+        }
+    }
+    let result = arm
+        .pattern
+        .expressions()
+        .iter()
+        .map(|expression| crate::expression(expression, None, interpreter))
+        .collect::<MResult<Vec<_>>>();
+    symbols.borrow_mut().restore(symbol_snapshot);
+    result
+}
+
 fn elaborate_patterned_arm_body(
     arm: &ActivationArm,
     captures: &[ActivationPatternCapture],
@@ -1198,7 +1266,7 @@ fn elaborate_patterned_arm_body(
         let mut symbols = symbols.borrow_mut();
         for capture in captures {
             symbols.mutable_variables.remove(&capture.id);
-            symbols.insert(capture.id, capture.slot.clone(), false);
+            symbols.insert(capture.id, capture.committed.clone(), false);
             symbols
                 .dictionary
                 .borrow_mut()
@@ -1231,7 +1299,7 @@ fn elaborate_patterned_arm_body(
         let mut plan = plan.borrow_mut();
         for node in body_node_start..body_node_end {
             for capture in captures {
-                let cell = capture.slot.reactive_root_cell_ids()[0];
+                let cell = capture.committed.reactive_root_cell_ids()[0];
                 debug_assert!(plan.add_sampled_dependency(node, cell));
             }
         }
@@ -1254,22 +1322,21 @@ fn elaborate_patterned_activation_inner(
         crate::functions::PersistentUserFunctionPlanScope::enter(i);
     let pattern_expression_values = compiled
         .iter()
-        .map(|arm| {
-            arm.pattern
-                .expressions()
-                .iter()
-                .map(|expression| crate::expression(expression, None, i))
-                .collect::<MResult<Vec<_>>>()
-        })
+        .map(|arm| elaborate_patterned_expression_values(arm, i))
         .collect::<MResult<Vec<_>>>()?;
     drop(_persistent_user_function_plan);
+    let mut initially_matched = Vec::with_capacity(compiled.len());
     for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
         let pattern_match =
             match_compiled_pattern_with_values(&arm.pattern, &trigger, expression_values)?;
+        initially_matched.push(pattern_match.matched);
         ReactiveBindingSink {
             captures: &arm.captures,
         }
         .commit(&pattern_match)?;
+    }
+    if let Some(selected) = initially_matched.iter().position(|matched| *matched) {
+        commit_proposed_captures(&compiled[selected].captures)?;
     }
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
@@ -1330,6 +1397,7 @@ fn elaborate_patterned_activation_inner(
             Box::new(Gate {
                 arm,
                 selected: selected.clone(),
+                captures: compiled[arm].captures.clone(),
                 out: o,
             }),
             &[selection.clone()],
@@ -1362,7 +1430,7 @@ fn elaborate_patterned_activation_inner(
                     .map(|c| PatternActivationCaptureRegistration {
                         id: c.id,
                         kind: c.kind.clone(),
-                        cell: c.slot.reactive_root_cell_ids()[0],
+                        cell: c.committed.reactive_root_cell_ids()[0],
                     })
                     .collect(),
             })
@@ -1543,13 +1611,15 @@ mod tests {
             id: hash_str("number"),
             name: "number".to_string(),
             kind: ValueKind::F64,
-            slot: create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap(),
+            proposed: create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap(),
+            committed: create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap(),
         };
         let text = ActivationPatternCapture {
             id: hash_str("text"),
             name: "text".to_string(),
             kind: ValueKind::String,
-            slot: create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap(),
+            proposed: create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap(),
+            committed: create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap(),
         };
         let captures = vec![number, text];
         let attempted = PatternMatch {
@@ -1572,12 +1642,61 @@ mod tests {
             ],
         };
 
-        let error = ReactiveBindingSink { captures: &captures }
-            .commit(&attempted)
-            .unwrap_err();
+        let error = ReactiveBindingSink {
+            captures: &captures,
+        }
+        .commit(&attempted)
+        .unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(captures[0].slot, Value::F64(Ref::new(0.0)));
-        assert_eq!(captures[1].slot, Value::String(Ref::new(String::new())));
+        assert_eq!(captures[0].proposed, Value::F64(Ref::new(0.0)));
+        assert_eq!(captures[1].proposed, Value::String(Ref::new(String::new())));
+        assert_eq!(captures[0].committed, Value::F64(Ref::new(0.0)));
+        assert_eq!(
+            captures[1].committed,
+            Value::String(Ref::new(String::new()))
+        );
+    }
+
+    #[cfg(all(feature = "f64", feature = "string"))]
+    #[test]
+    fn activation_capture_gate_validates_entire_commit_before_mutation_or_pulse() {
+        let captures = vec![
+            ActivationPatternCapture {
+                id: hash_str("number"),
+                name: "number".to_string(),
+                kind: ValueKind::F64,
+                proposed: Value::F64(Ref::new(9.0)),
+                committed: Value::F64(Ref::new(1.0)),
+            },
+            ActivationPatternCapture {
+                id: hash_str("text"),
+                name: "text".to_string(),
+                kind: ValueKind::String,
+                proposed: Value::F64(Ref::new(10.0)),
+                committed: Value::String(Ref::new("before".to_string())),
+            },
+        ];
+        let selected = Ref::new(0);
+        let pulse = Ref::new(0);
+        let gate = Gate {
+            arm: 0,
+            selected,
+            captures: captures.clone(),
+            out: pulse.clone(),
+        };
+
+        let error = gate.solve_reactive().unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(captures[0].committed, Value::F64(Ref::new(1.0)));
+        assert_eq!(
+            captures[1].committed,
+            Value::String(Ref::new("before".to_string()))
+        );
+        assert_eq!(
+            *pulse.borrow(),
+            0,
+            "body pulse must follow a successful commit"
+        );
     }
 
     #[cfg(feature = "atom")]
@@ -1675,6 +1794,43 @@ event := :first
         let registrations = plan.pattern_activation_registrations();
         assert_eq!(registrations.len(), 1);
         registrations[0].clone()
+    }
+    fn node_output_for_cell(
+        interpreter: &Interpreter,
+        node: ReactiveNodeId,
+        cell: ReactiveCellId,
+    ) -> Value {
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        plan.node(node)
+            .expect("missing activation dispatch node")
+            .function
+            .reactive_output_values()
+            .into_iter()
+            .find(|value| value.reactive_root_cell_ids().contains(&cell))
+            .unwrap_or_else(|| panic!("node {node} does not expose cell {cell:?}"))
+    }
+    fn committed_capture_value(interpreter: &Interpreter, arm: usize, capture: usize) -> Value {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm];
+        node_output_for_cell(interpreter, arm.gate_node, arm.captures[capture].cell)
+    }
+    fn proposed_capture_value(interpreter: &Interpreter, arm: usize, capture: usize) -> Value {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm];
+        arm.captures
+            .get(capture)
+            .expect("missing capture registration");
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        plan.node(arm.matcher_node)
+            .expect("missing activation matcher")
+            .function
+            .reactive_output_values()
+            .into_iter()
+            .skip(1)
+            .nth(capture)
+            .expect("missing proposed capture output")
     }
     fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
         let plan = interpreter.plan();
@@ -2012,6 +2168,145 @@ event<event-kind> := :pressed(0.0)
             for node in arm.body_node_start..arm.body_node_end {
                 assert!(!executed.contains(&node));
             }
+        }
+    }
+    #[test]
+    fn activation_only_selected_arm_commits_matching_captures() {
+        let mut i = interpret(
+            r#"
+event := 1.0
+~> event
+  | first => {
+      selected := first
+    }
+  | later => {
+      rejected := later
+    }
+  | * => {
+      fallback := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let later_before = committed_capture_value(&i, 1, 0);
+        let committed_cell = activation.arms[0].captures[0].cell;
+        let proposed_cell = proposed_capture_value(&i, 0, 0).reactive_root_cell_ids()[0];
+        assert_ne!(proposed_cell, committed_cell);
+        {
+            let plan = i.plan();
+            let plan = plan.borrow();
+            assert!(
+                plan.nodes[activation.arms[0].matcher_node]
+                    .outputs
+                    .contains(&proposed_cell)
+            );
+            assert!(
+                !plan.nodes[activation.arms[0].matcher_node]
+                    .outputs
+                    .contains(&committed_cell)
+            );
+            assert!(
+                plan.nodes[activation.arms[0].gate_node]
+                    .outputs
+                    .contains(&committed_cell)
+            );
+            let body_inputs = plan.nodes
+                [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+                .iter()
+                .flat_map(|node| node.inputs.iter().map(|dependency| dependency.cell))
+                .collect::<Vec<_>>();
+            assert!(body_inputs.contains(&committed_cell));
+            assert!(!body_inputs.contains(&proposed_cell));
+        }
+        let Value::F64(event) = symbol(&i, "event") else {
+            panic!("event is not f64")
+        };
+        *event.borrow_mut() = 5.0;
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+
+        assert_eq!(selected_arm_index(&activation, &outcome), 0);
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(5.0)));
+        assert_eq!(proposed_capture_value(&i, 1, 0), Value::F64(Ref::new(5.0)));
+        assert_eq!(committed_capture_value(&i, 1, 0), later_before);
+        let executed = turn_executed_nodes(&outcome);
+        for node in activation.arms[1].body_node_start..activation.arms[1].body_node_end {
+            assert!(!executed.contains(&node));
+        }
+    }
+    #[test]
+    fn activation_failed_repeated_binding_leaves_proposed_and_committed_unchanged() {
+        let mut i = interpret(
+            r#"
+event := (1.0, 1.0)
+~> event
+  | (x, x) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let proposed_before = proposed_capture_value(&i, 0, 0);
+        let committed_before = committed_capture_value(&i, 0, 0);
+        set_tuple_event(
+            &i,
+            vec![Value::F64(Ref::new(2.0)), Value::F64(Ref::new(3.0))],
+        );
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+
+        assert_eq!(selected_arm_index(&activation, &outcome), 1);
+        assert_eq!(proposed_capture_value(&i, 0, 0), proposed_before);
+        assert_eq!(committed_capture_value(&i, 0, 0), committed_before);
+        let executed = turn_executed_nodes(&outcome);
+        for node in activation.arms[0].body_node_start..activation.arms[0].body_node_end {
+            assert!(!executed.contains(&node));
+        }
+    }
+    #[test]
+    fn activation_non_selected_composite_capture_keeps_last_committed_value() {
+        let mut i = interpret(
+            r#"
+event := (0.0, 1.0)
+~> event
+  | (1.0, x) => {
+      selected := x
+    }
+  | later => {
+      rejected := later.2
+    }
+  | * => {
+      fallback := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let committed_before = committed_capture_value(&i, 1, 0);
+        set_tuple_event(
+            &i,
+            vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(10.0))],
+        );
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+
+        assert_eq!(selected_arm_index(&activation, &outcome), 0);
+        assert_eq!(committed_capture_value(&i, 1, 0), committed_before);
+        assert_eq!(
+            proposed_capture_value(&i, 1, 0),
+            Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                Value::F64(Ref::new(1.0)),
+                Value::F64(Ref::new(10.0)),
+            ])))
+        );
+        let executed = turn_executed_nodes(&outcome);
+        for node in activation.arms[1].body_node_start..activation.arms[1].body_node_end {
+            assert!(!executed.contains(&node));
         }
     }
     #[test]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -109,10 +109,34 @@ fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
 }
 fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
     match kind.deref_kind() {
+        #[cfg(feature = "u8")]
+        ValueKind::U8 => Ok(Value::U8(Ref::new(0))),
+        #[cfg(feature = "u16")]
+        ValueKind::U16 => Ok(Value::U16(Ref::new(0))),
+        #[cfg(feature = "u32")]
+        ValueKind::U32 => Ok(Value::U32(Ref::new(0))),
+        #[cfg(feature = "u64")]
+        ValueKind::U64 => Ok(Value::U64(Ref::new(0))),
+        #[cfg(feature = "u128")]
+        ValueKind::U128 => Ok(Value::U128(Ref::new(0))),
+        #[cfg(feature = "i8")]
+        ValueKind::I8 => Ok(Value::I8(Ref::new(0))),
+        #[cfg(feature = "i16")]
+        ValueKind::I16 => Ok(Value::I16(Ref::new(0))),
+        #[cfg(feature = "i32")]
+        ValueKind::I32 => Ok(Value::I32(Ref::new(0))),
+        #[cfg(feature = "i64")]
+        ValueKind::I64 => Ok(Value::I64(Ref::new(0))),
+        #[cfg(feature = "i128")]
+        ValueKind::I128 => Ok(Value::I128(Ref::new(0))),
         #[cfg(feature = "f64")]
         ValueKind::F64 => Ok(Value::F64(Ref::new(0.0))),
         #[cfg(feature = "f32")]
         ValueKind::F32 => Ok(Value::F32(Ref::new(0.0))),
+        #[cfg(feature = "complex")]
+        ValueKind::C64 => Ok(Value::C64(Ref::new(C64::default()))),
+        #[cfg(feature = "rational")]
+        ValueKind::R64 => Ok(Value::R64(Ref::new(R64::default()))),
         #[cfg(any(feature = "bool", feature = "variable_define"))]
         ValueKind::Bool => Ok(Value::Bool(Ref::new(false))),
         #[cfg(any(feature = "string", feature = "variable_define"))]
@@ -128,6 +152,56 @@ fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
 }
 fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
     match (destination, &detached(source)) {
+        #[cfg(feature = "u8")]
+        (Value::U8(a), Value::U8(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u16")]
+        (Value::U16(a), Value::U16(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u32")]
+        (Value::U32(a), Value::U32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u64")]
+        (Value::U64(a), Value::U64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u128")]
+        (Value::U128(a), Value::U128(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i8")]
+        (Value::I8(a), Value::I8(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i16")]
+        (Value::I16(a), Value::I16(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i32")]
+        (Value::I32(a), Value::I32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i64")]
+        (Value::I64(a), Value::I64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i128")]
+        (Value::I128(a), Value::I128(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
         #[cfg(feature = "f64")]
         (Value::F64(a), Value::F64(b)) => {
             clone_ref_value(a, b);
@@ -135,6 +209,16 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
         }
         #[cfg(feature = "f32")]
         (Value::F32(a), Value::F32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "complex")]
+        (Value::C64(a), Value::C64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "rational")]
+        (Value::R64(a), Value::R64(b)) => {
             clone_ref_value(a, b);
             Ok(())
         }
@@ -592,33 +676,8 @@ fn preflight_patterned_activation(
             MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
         );
     }
-    for a in arms {
-        if let ActivationArmBody::Block(body) = &a.body {
-            for (code, _) in body {
-                match code {
-                    MechCode::Statement(Statement::VariableAssign(_))
-                    | MechCode::Statement(Statement::OpAssign(_)) => {
-                        return Err(MechError::new(
-                            ActivationPatternRegisterWriteUnsupported,
-                            None,
-                        )
-                        .with_tokens(code.tokens()));
-                    }
-                    MechCode::Statement(Statement::ContextSend(_)) => {
-                        return Err(MechError::new(
-                            ActivationPatternContextEffectUnsupported,
-                            None,
-                        )
-                        .with_tokens(code.tokens()));
-                    }
-                    MechCode::Statement(Statement::VariableDefine(d)) if d.mutable => {
-                        return Err(MechError::new(ActivationPatternDefinitionUnsupported, None)
-                            .with_tokens(code.tokens()));
-                    }
-                    _ => {}
-                }
-            }
-        }
+    for arm in arms {
+        validate_patterned_arm_body(&arm.body)?;
     }
     if trigger.reactive_root_cell_ids() != trigger_cells {
         return Err(
@@ -638,14 +697,314 @@ fn preflight_patterned_activation(
     })
 }
 
+fn validation_error(kind: impl MechErrorKind + 'static, tokens: Vec<Token>) -> MResult<()> {
+    Err(MechError::new(kind, None).with_tokens(tokens))
+}
+
+fn validate_patterned_arm_body(body: &ActivationArmBody) -> MResult<()> {
+    match body {
+        ActivationArmBody::Block(body) => {
+            for (code, _) in body {
+                validate_patterned_code(code)?;
+            }
+            Ok(())
+        }
+        ActivationArmBody::Expression(expression) => validate_patterned_expression(expression),
+    }
+}
+fn validate_patterned_code(code: &MechCode) -> MResult<()> {
+    match code {
+        MechCode::Comment(_) => Ok(()),
+        MechCode::Expression(expression) => validate_patterned_expression(expression),
+        MechCode::Statement(statement) => validate_patterned_statement(statement),
+        MechCode::ActivationScope(_)
+        | MechCode::FunctionDefine(_)
+        | MechCode::FsmSpecification(_)
+        | MechCode::FsmImplementation(_)
+        | MechCode::Import(_)
+        | MechCode::Error(_, _) => {
+            validation_error(ActivationPatternDefinitionUnsupported, code.tokens())
+        }
+    }
+}
+fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
+    match statement {
+        Statement::VariableDefine(definition)
+            if !definition.mutable && definition.var.context.is_none() =>
+        {
+            validate_patterned_expression(&definition.expression)
+        }
+        Statement::VariableDefine(definition) if definition.var.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                statement.tokens(),
+            )
+        }
+        Statement::VariableDefine(_) => {
+            validation_error(ActivationPatternDefinitionUnsupported, statement.tokens())
+        }
+        Statement::VariableAssign(assignment) if assignment.target.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                statement.tokens(),
+            )
+        }
+        Statement::VariableAssign(_) => validation_error(
+            ActivationPatternRegisterWriteUnsupported,
+            statement.tokens(),
+        ),
+        Statement::OpAssign(assignment) if assignment.target.context.is_some() => validation_error(
+            ActivationPatternContextEffectUnsupported,
+            statement.tokens(),
+        ),
+        Statement::OpAssign(_) => validation_error(
+            ActivationPatternRegisterWriteUnsupported,
+            statement.tokens(),
+        ),
+        Statement::ContextSend(_) => validation_error(
+            ActivationPatternContextEffectUnsupported,
+            statement.tokens(),
+        ),
+        _ => validation_error(ActivationPatternDefinitionUnsupported, statement.tokens()),
+    }
+}
+fn validate_patterned_expression(expression: &Expression) -> MResult<()> {
+    match expression {
+        Expression::Literal(_) | Expression::Var(_) => Ok(()),
+        Expression::Slice(slice) => validate_patterned_slice(slice),
+        Expression::Formula(factor) => validate_patterned_factor(factor),
+        Expression::FunctionCall(call) => {
+            for (_, expression) in &call.args {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Expression::Match(matched) => {
+            validate_patterned_expression(&matched.source)?;
+            for arm in &matched.arms {
+                validate_patterned_pattern(&arm.pattern)?;
+                if let Some(guard) = &arm.guard {
+                    validate_patterned_expression(guard)?;
+                }
+                validate_patterned_expression(&arm.expression)?;
+            }
+            Ok(())
+        }
+        Expression::Range(range) => validate_patterned_range(range),
+        Expression::Structure(structure) => validate_patterned_structure(structure),
+        Expression::SetComprehension(comprehension) => {
+            validate_patterned_expression(&comprehension.expression)?;
+            for qualifier in &comprehension.qualifiers {
+                validate_patterned_qualifier(qualifier)?;
+            }
+            Ok(())
+        }
+        Expression::MatrixComprehension(comprehension) => {
+            validate_patterned_expression(&comprehension.expression)?;
+            for qualifier in &comprehension.qualifiers {
+                validate_patterned_qualifier(qualifier)?;
+            }
+            Ok(())
+        }
+        Expression::FsmPipe(_) => {
+            validation_error(ActivationPatternDefinitionUnsupported, expression.tokens())
+        }
+    }
+}
+fn validate_patterned_pattern(pattern: &Pattern) -> MResult<()> {
+    match pattern {
+        Pattern::Expression(expression) => validate_patterned_expression(expression),
+        Pattern::Tuple(tuple) => {
+            for pattern in &tuple.0 {
+                validate_patterned_pattern(pattern)?;
+            }
+            Ok(())
+        }
+        Pattern::TupleStruct(tuple) => {
+            for pattern in &tuple.patterns {
+                validate_patterned_pattern(pattern)?;
+            }
+            Ok(())
+        }
+        Pattern::Array(array) => {
+            for pattern in array.prefix.iter().chain(&array.suffix) {
+                validate_patterned_pattern(pattern)?;
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    validate_patterned_pattern(binding)?;
+                }
+            }
+            Ok(())
+        }
+        Pattern::Wildcard => Ok(()),
+    }
+}
+fn validate_patterned_factor(factor: &Factor) -> MResult<()> {
+    match factor {
+        Factor::Expression(expression) => validate_patterned_expression(expression),
+        Factor::Negate(factor)
+        | Factor::Not(factor)
+        | Factor::Parenthetical(factor)
+        | Factor::Transpose(factor) => validate_patterned_factor(factor),
+        Factor::Term(term) => {
+            validate_patterned_factor(&term.lhs)?;
+            for (_, factor) in &term.rhs {
+                validate_patterned_factor(factor)?;
+            }
+            Ok(())
+        }
+    }
+}
+fn validate_patterned_range(range: &RangeExpression) -> MResult<()> {
+    validate_patterned_factor(&range.start)?;
+    if let Some((_, increment)) = &range.increment {
+        validate_patterned_factor(increment)?;
+    }
+    validate_patterned_factor(&range.terminal)
+}
+fn validate_patterned_slice(slice: &Slice) -> MResult<()> {
+    for subscript in &slice.subscript {
+        validate_patterned_subscript(subscript)?;
+    }
+    Ok(())
+}
+fn validate_patterned_subscript(subscript: &Subscript) -> MResult<()> {
+    match subscript {
+        Subscript::Brace(subscripts) | Subscript::Bracket(subscripts) => {
+            for subscript in subscripts {
+                validate_patterned_subscript(subscript)?;
+            }
+            Ok(())
+        }
+        Subscript::Formula(factor) => validate_patterned_factor(factor),
+        Subscript::Range(range) => validate_patterned_range(range),
+        Subscript::All | Subscript::Dot(_) | Subscript::DotInt(_) | Subscript::Swizzle(_) => Ok(()),
+    }
+}
+fn validate_patterned_structure(structure: &Structure) -> MResult<()> {
+    match structure {
+        Structure::Empty => Ok(()),
+        Structure::Map(map) => {
+            for mapping in &map.elements {
+                validate_patterned_expression(&mapping.key)?;
+                validate_patterned_expression(&mapping.value)?;
+            }
+            Ok(())
+        }
+        Structure::Matrix(matrix) => {
+            for row in &matrix.rows {
+                for column in &row.columns {
+                    validate_patterned_expression(&column.element)?;
+                }
+            }
+            Ok(())
+        }
+        Structure::Record(record) => {
+            for binding in &record.bindings {
+                validate_patterned_expression(&binding.value)?;
+            }
+            Ok(())
+        }
+        Structure::Set(set) => {
+            for expression in &set.elements {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Structure::Table(table) => {
+            for row in &table.rows {
+                for column in &row.columns {
+                    validate_patterned_expression(&column.element)?;
+                }
+            }
+            Ok(())
+        }
+        Structure::Tuple(tuple) => {
+            for expression in &tuple.elements {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Structure::TupleStruct(tuple) => validate_patterned_expression(&tuple.value),
+    }
+}
+fn validate_patterned_qualifier(qualifier: &ComprehensionQualifier) -> MResult<()> {
+    match qualifier {
+        ComprehensionQualifier::Generator((pattern, expression)) => {
+            validate_patterned_pattern(pattern)?;
+            validate_patterned_expression(expression)
+        }
+        ComprehensionQualifier::Filter(expression) => validate_patterned_expression(expression),
+        ComprehensionQualifier::Let(definition) if definition.mutable => {
+            validation_error(ActivationPatternDefinitionUnsupported, definition.tokens())
+        }
+        ComprehensionQualifier::Let(definition) if definition.var.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                definition.tokens(),
+            )
+        }
+        ComprehensionQualifier::Let(definition) => {
+            validate_patterned_expression(&definition.expression)
+        }
+    }
+}
+
+fn elaborate_patterned_arm_body(
+    arm: &ActivationArm,
+    captures: &[ActivationPatternCapture],
+    pulse: &Value,
+    interpreter: &Interpreter,
+) -> MResult<(usize, usize)> {
+    let symbols = interpreter.symbols();
+    let symbol_snapshot = symbols.borrow().snapshot();
+    let plan = interpreter.plan();
+    let original_scope_depth = plan.activation_registration_depth();
+    {
+        let mut symbols = symbols.borrow_mut();
+        for capture in captures {
+            symbols.mutable_variables.remove(&capture.id);
+            symbols.insert(capture.id, capture.slot.clone(), false);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(capture.id, capture.name.clone());
+        }
+    }
+    let body_node_start = plan.len();
+    plan.push_activation_registration_scope(pulse.reactive_root_cell_ids());
+    let body_result = (|| -> MResult<()> {
+        match &arm.body {
+            ActivationArmBody::Block(body) => {
+                for (code, _) in body {
+                    crate::mech_code(code, interpreter)?;
+                }
+                Ok(())
+            }
+            ActivationArmBody::Expression(expression) => {
+                crate::expression(expression, None, interpreter)?;
+                Ok(())
+            }
+        }
+    })();
+    while plan.activation_registration_depth() > original_scope_depth {
+        plan.pop_activation_registration_scope();
+    }
+    symbols.borrow_mut().restore(symbol_snapshot);
+    body_result?;
+    Ok((body_node_start, plan.len()))
+}
+
 fn elaborate_patterned_activation_inner(
-    scope: &ActivationScope,
     arms: &[ActivationArm],
     trigger: Value,
-    trigger_cells: Vec<ReactiveCellId>,
+    preflight: PreflightPatternedActivation,
     i: &Interpreter,
 ) -> MResult<Value> {
-    let preflight = preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, i)?;
+    if trigger.kind().deref_kind() != preflight.trigger_kind {
+        return Err(MechError::new(ActivationPatternTriggerInvariant, None));
+    }
     let compiled = preflight.arms;
     let plan = i.plan();
     let (scope_gen, scope_v) = generation();
@@ -668,7 +1027,7 @@ fn elaborate_patterned_activation_inner(
         )?;
         matcher_nodes.push(n);
         completions.push(v);
-        matched.push(f)
+        matched.push(f);
     }
     let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
     for (f, c) in matched.iter().zip(completions.iter()) {
@@ -683,7 +1042,7 @@ fn elaborate_patterned_activation_inner(
             &[c.clone()],
         )?);
         eligible.push(e);
-        done.push(v)
+        done.push(v);
     }
     let (o, selection) = generation();
     let selected = Ref::new(usize::MAX);
@@ -706,34 +1065,16 @@ fn elaborate_patterned_activation_inner(
             }),
             &[selection.clone()],
         )?);
-        pulses.push(v)
+        pulses.push(v);
     }
     let mut ranges = Vec::new();
-    for (arm, compiled_arm) in arms.iter().zip(compiled.iter()) {
-        let symbols = i.symbols();
-        let snapshot = symbols.borrow().snapshot();
-        {
-            let mut s = symbols.borrow_mut();
-            for c in &compiled_arm.captures {
-                s.insert(c.id, c.slot.clone(), false);
-                s.dictionary.borrow_mut().insert(c.id, c.name.clone());
-            }
-        }
-        let start = plan.len();
-        plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());
-        let result = match &arm.body {
-            ActivationArmBody::Block(b) => {
-                for (c, _) in b {
-                    crate::mech_code(c, i)?;
-                }
-                Ok(())
-            }
-            ActivationArmBody::Expression(e) => crate::expression(e, None, i).map(|_| ()),
-        };
-        plan.pop_activation_registration_scope();
-        symbols.borrow_mut().restore(snapshot);
-        result?;
-        ranges.push((start, plan.len()))
+    for (arm, compiled_arm) in arms.iter().zip(&compiled) {
+        ranges.push(elaborate_patterned_arm_body(
+            arm,
+            &compiled_arm.captures,
+            &pulses[ranges.len()],
+            i,
+        )?);
     }
     let registration = PatternActivationRegistration {
         scope_pulse_node: scope_node,
@@ -769,13 +1110,20 @@ pub(crate) fn elaborate_patterned_activation(
     trigger_cells: Vec<ReactiveCellId>,
     interpreter: &Interpreter,
 ) -> MResult<Value> {
+    let preflight =
+        preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, interpreter)?;
     let plan = interpreter.plan();
     let checkpoint = plan.checkpoint();
-    match elaborate_patterned_activation_inner(scope, arms, trigger, trigger_cells, interpreter) {
+    let program_dictionary = interpreter.state.borrow().dictionary.clone();
+    let dictionary_snapshot = program_dictionary.borrow().clone();
+    match elaborate_patterned_activation_inner(arms, trigger, preflight, interpreter) {
         Ok(value) => Ok(value),
         Err(error) => {
-            plan.rollback(checkpoint)?;
-            Err(error)
+            *program_dictionary.borrow_mut() = dictionary_snapshot;
+            match plan.rollback(checkpoint) {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(rollback_error),
+            }
         }
     }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,0 +1,28 @@
+//! Patterned activation elaboration.
+//!
+//! This module is deliberately kept separate from `mechdown`: activation
+//! scheduling is interpreter infrastructure rather than syntax dispatch.
+//! Fixed-body scopes continue to use the established registration path while
+//! patterned scopes are elaborated here as the activation graph grows.
+
+use crate::*;
+
+/// Describes the internal generation cells used by a patterned activation.
+///
+/// Keeping this descriptor independent of syntax is important: the reactive
+/// plan owns these cells for the lifetime of the loaded program, so a dispatch
+/// never needs to create or rebuild plan nodes.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PatternActivationGenerations {
+    pub scope: Option<ReactiveCellId>,
+    pub selection: Option<ReactiveCellId>,
+    pub arms: Vec<PatternActivationArmGenerations>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PatternActivationArmGenerations {
+    pub matched: Option<ReactiveCellId>,
+    pub guard_start: Option<ReactiveCellId>,
+    pub complete: Option<ReactiveCellId>,
+    pub pulse: Option<ReactiveCellId>,
+}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,3 +1,8 @@
+#![cfg(all(
+  feature = "functions",
+  feature = "symbol_table",
+))]
+
 //! Static scheduling support for patterned activation scopes.
 //!
 //! The small dispatch nodes in this file deliberately contain no syntax and

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -2,87 +2,780 @@
 //! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
 
-macro_rules! activation_error {($n:ident,$m:expr)=>{#[derive(Debug,Clone)] pub(crate) struct $n; impl MechErrorKind for $n {fn name(&self)->&str{stringify!($n)} fn message(&self)->String{$m.into()}}};}
-activation_error!(ActivationPatternExpressionUnsupported,"This activation pattern is not supported.");
-activation_error!(ActivationPatternCaptureKindUnsupported,"The capture kind cannot be inferred from the activation trigger.");
-activation_error!(ActivationPatternArmsNonExhaustive,"Patterned activations require a final unguarded wildcard arm.");
-activation_error!(ActivationPatternWildcardMustBeLast,"The wildcard activation arm must be last.");
-activation_error!(ActivationPatternGuardMustBePure,"Patterned activation guards are not supported yet.");
-activation_error!(ActivationPatternRegisterWriteUnsupported,"Patterned activation register writes are not supported.");
-activation_error!(ActivationPatternContextEffectUnsupported,"Patterned activation context effects are not supported.");
-activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cells disagree with the resolved trigger.");
+macro_rules! activation_error {
+    ($n:ident,$m:expr) => {
+        #[derive(Debug, Clone)]
+        pub(crate) struct $n;
+        impl MechErrorKind for $n {
+            fn name(&self) -> &str {
+                stringify!($n)
+            }
+            fn message(&self) -> String {
+                $m.into()
+            }
+        }
+    };
+}
+activation_error!(
+    ActivationPatternExpressionUnsupported,
+    "This activation pattern is not supported."
+);
+activation_error!(
+    ActivationPatternCaptureKindUnsupported,
+    "The capture kind cannot be inferred from the activation trigger."
+);
+activation_error!(
+    ActivationPatternArmsNonExhaustive,
+    "Patterned activations require a final unguarded wildcard arm."
+);
+activation_error!(
+    ActivationPatternWildcardMustBeLast,
+    "The wildcard activation arm must be last."
+);
+activation_error!(
+    ActivationPatternGuardMustBePure,
+    "Patterned activation guards are not supported yet."
+);
+activation_error!(
+    ActivationPatternRegisterWriteUnsupported,
+    "Patterned activation register writes are not supported."
+);
+activation_error!(
+    ActivationPatternContextEffectUnsupported,
+    "Patterned activation context effects are not supported."
+);
+activation_error!(
+    ActivationPatternTriggerInvariant,
+    "Activation trigger root cells disagree with the resolved trigger."
+);
 
-#[derive(Clone,Debug)] enum CompiledActivationPattern { Wildcard, Literal{expected:Value}, Capture{capture_index:usize}, Tuple{elements:Vec<Self>}, TupleStruct{tag:u64,payload:Vec<Self>} }
-#[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
-#[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
-fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
-fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) { let source=source.borrow(); destination.borrow_mut().clone_from(&*source); }
-fn create_capture_slot(sample:&Value)->MResult<Value>{match detached(sample){
-#[cfg(feature="u8")] Value::U8(v)=>Ok(Value::U8(Ref::new(*v.borrow()))),
-#[cfg(feature="u16")] Value::U16(v)=>Ok(Value::U16(Ref::new(*v.borrow()))),
-#[cfg(feature="u32")] Value::U32(v)=>Ok(Value::U32(Ref::new(*v.borrow()))),
-#[cfg(feature="u64")] Value::U64(v)=>Ok(Value::U64(Ref::new(*v.borrow()))),
-#[cfg(feature="u128")] Value::U128(v)=>Ok(Value::U128(Ref::new(*v.borrow()))),
-#[cfg(feature="i8")] Value::I8(v)=>Ok(Value::I8(Ref::new(*v.borrow()))),
-#[cfg(feature="i16")] Value::I16(v)=>Ok(Value::I16(Ref::new(*v.borrow()))),
-#[cfg(feature="i32")] Value::I32(v)=>Ok(Value::I32(Ref::new(*v.borrow()))),
-#[cfg(feature="i64")] Value::I64(v)=>Ok(Value::I64(Ref::new(*v.borrow()))),
-#[cfg(feature="i128")] Value::I128(v)=>Ok(Value::I128(Ref::new(*v.borrow()))),
-#[cfg(feature="f32")] Value::F32(v)=>Ok(Value::F32(Ref::new(*v.borrow()))),
-#[cfg(feature="f64")] Value::F64(v)=>Ok(Value::F64(Ref::new(*v.borrow()))),
-#[cfg(feature="complex")] Value::C64(v)=>Ok(Value::C64(Ref::new(v.borrow().clone()))),
-#[cfg(feature="rational")] Value::R64(v)=>Ok(Value::R64(Ref::new(v.borrow().clone()))),
-#[cfg(any(feature="bool",feature="variable_define"))] Value::Bool(v)=>Ok(Value::Bool(Ref::new(*v.borrow()))),
-#[cfg(any(feature="string",feature="variable_define"))] Value::String(v)=>Ok(Value::String(Ref::new(v.borrow().clone()))),
-Value::Index(v)=>Ok(Value::Index(Ref::new(*v.borrow()))),
-#[cfg(feature="atom")] Value::Atom(v)=>Ok(Value::Atom(Ref::new(v.borrow().clone()))),
-_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
-fn commit_capture_slot(destination:&Value,source:&Value)->MResult<()>{let source=detached(source);match(destination,&source){
-#[cfg(feature="u8")] (Value::U8(a),Value::U8(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u16")] (Value::U16(a),Value::U16(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u32")] (Value::U32(a),Value::U32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u64")] (Value::U64(a),Value::U64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u128")] (Value::U128(a),Value::U128(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i8")] (Value::I8(a),Value::I8(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i16")] (Value::I16(a),Value::I16(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i32")] (Value::I32(a),Value::I32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i64")] (Value::I64(a),Value::I64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i128")] (Value::I128(a),Value::I128(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="f32")] (Value::F32(a),Value::F32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="f64")] (Value::F64(a),Value::F64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="complex")] (Value::C64(a),Value::C64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="rational")] (Value::R64(a),Value::R64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(any(feature="bool",feature="variable_define"))] (Value::Bool(a),Value::Bool(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(any(feature="string",feature="variable_define"))] (Value::String(a),Value::String(b))=>{clone_ref_value(a,b);Ok(())},
-(Value::Index(a),Value::Index(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="atom")] (Value::Atom(a),Value::Atom(b))=>{clone_ref_value(a,b);Ok(())},
-_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
-fn compile(pat:&Pattern,sample:&Value,i:&Interpreter,caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern>{match pat { Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}), Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash();if let Some(n)=caps.iter().position(|c|c.id==id){Ok(CompiledActivationPattern::Capture{capture_index:n})}else{let value=create_capture_slot(sample).map_err(|e|e.with_tokens(pat.tokens()))?;caps.push(Capture{id,kind:sample.kind(),slot:value});Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})}}, #[cfg(feature="tuple")] Pattern::Tuple(t)=>{let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))};let tv=tv.borrow();if tv.elements.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(tv.elements.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})}, _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens()))}}
-fn matches_pattern(p:&CompiledActivationPattern,v:&Value,proposed:&mut Vec<Option<Value>>)->bool{match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}}, #[cfg(feature="tuple")] CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}, CompiledActivationPattern::TupleStruct{..}=>false, #[cfg(not(feature="tuple"))] CompiledActivationPattern::Tuple{..}=>false}}
-fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
-struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
-struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit_capture_slot(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
-struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
-struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
-struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}
+#[derive(Clone, Debug)]
+enum CompiledActivationPattern {
+    Wildcard,
+    Literal {
+        expected: Value,
+    },
+    Capture {
+        capture_index: usize,
+    },
+    Tuple {
+        elements: Vec<CompiledActivationPattern>,
+    },
+    EnumVariant {
+        enum_id: u64,
+        variant_id: u64,
+        payload: Option<Box<CompiledActivationPattern>>,
+    },
+    AtomTuple {
+        tag_id: u64,
+        payload: Vec<CompiledActivationPattern>,
+    },
+}
+#[derive(Clone)]
+struct ActivationPatternCapture {
+    id: u64,
+    name: String,
+    kind: ValueKind,
+    slot: Value,
+}
+#[derive(Clone)]
+struct PreflightActivationArm {
+    pattern: CompiledActivationPattern,
+    captures: Vec<ActivationPatternCapture>,
+}
+struct PreflightPatternedActivation {
+    trigger_kind: ValueKind,
+    arms: Vec<PreflightActivationArm>,
+}
+#[derive(Debug, Clone)]
+pub(crate) struct ActivationPatternDefinitionUnsupported;
+impl MechErrorKind for ActivationPatternDefinitionUnsupported {
+    fn name(&self) -> &str {
+        "ActivationPatternDefinitionUnsupported"
+    }
+    fn message(&self) -> String {
+        "This definition or declaration is not supported inside a patterned activation arm."
+            .to_string()
+    }
+}
+fn detached(v: &Value) -> Value {
+    match v {
+        Value::MutableReference(r) => detached(&r.borrow()),
+        _ => v.clone(),
+    }
+}
+fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
+    destination.borrow_mut().clone_from(&*source.borrow())
+}
+fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
+    match kind.deref_kind() {
+        #[cfg(feature = "f64")]
+        ValueKind::F64 => Ok(Value::F64(Ref::new(0.0))),
+        #[cfg(feature = "f32")]
+        ValueKind::F32 => Ok(Value::F32(Ref::new(0.0))),
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        ValueKind::Bool => Ok(Value::Bool(Ref::new(false))),
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        ValueKind::String => Ok(Value::String(Ref::new(String::new()))),
+        ValueKind::Index => Ok(Value::Index(Ref::new(0))),
+        #[cfg(feature = "atom")]
+        ValueKind::Atom(id, _) => Ok(Value::Atom(Ref::new(MechAtom::new(id)))),
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
+    match (destination, &detached(source)) {
+        #[cfg(feature = "f64")]
+        (Value::F64(a), Value::F64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "f32")]
+        (Value::F32(a), Value::F32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        (Value::Bool(a), Value::Bool(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        (Value::String(a), Value::String(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        (Value::Index(a), Value::Index(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "atom")]
+        (Value::Atom(a), Value::Atom(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+fn compile_activation_literal(l: &Literal, i: &Interpreter) -> MResult<Value> {
+    match l {
+        Literal::Empty(_) => Ok(Value::Empty),
+        #[cfg(feature = "bool")]
+        Literal::Boolean(t) => Ok(crate::boolean(t)),
+        #[cfg(feature = "string")]
+        Literal::String(v) => Ok(crate::string(v)),
+        #[cfg(feature = "atom")]
+        Literal::Atom(a) => Ok(Value::Atom(Ref::new(MechAtom::new(a.name.hash())))),
+        Literal::Number(Number::Real(RealNumber::TypedInteger(_)))
+        | Literal::TypedLiteral(_)
+        | Literal::Kind(_) => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+        Literal::Number(n) => crate::number(n, i),
+        _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+    }
+}
+#[cfg(feature = "enum")]
+fn compile_enum_variant_pattern(
+    t: &PatternTupleStruct,
+    enum_id: u64,
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let variant_id = t.name.hash();
+    let def = i
+        .state
+        .borrow()
+        .enums
+        .get(&enum_id)
+        .cloned()
+        .ok_or_else(|| {
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
+        })?;
+    let declared = def
+        .variants
+        .iter()
+        .find(|(id, _)| *id == variant_id)
+        .map(|(_, p)| p.clone())
+        .ok_or_else(|| {
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
+        })?;
+    let payload = match (t.patterns.as_slice(), declared) {
+        ([], None) => None,
+        ([p], Some(Value::Kind(k))) => Some(Box::new(compile_activation_pattern(p, &k, i, c)?)),
+        _ => {
+            return Err(
+                MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                    .with_tokens(t.tokens()),
+            );
+        }
+    };
+    Ok(CompiledActivationPattern::EnumVariant {
+        enum_id,
+        variant_id,
+        payload,
+    })
+}
+#[cfg(all(feature = "tuple", feature = "atom"))]
+fn compile_atom_tuple_pattern(
+    t: &PatternTupleStruct,
+    kinds: &[ValueKind],
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let Some(first) = kinds.first() else {
+        return Err(
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
+        );
+    };
+    if !matches!(first.deref_kind(), ValueKind::Atom(_, _)) || t.patterns.len() != kinds.len() - 1 {
+        return Err(
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
+        );
+    };
+    let payload = t
+        .patterns
+        .iter()
+        .zip(kinds.iter().skip(1))
+        .map(|(p, k)| compile_activation_pattern(p, k, i, c))
+        .collect::<MResult<_>>()?;
+    Ok(CompiledActivationPattern::AtomTuple {
+        tag_id: t.name.hash(),
+        payload,
+    })
+}
+fn compile_activation_pattern(
+    p: &Pattern,
+    kind: &ValueKind,
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let kind = kind.deref_kind();
+    match p {
+        Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
+        Pattern::Expression(Expression::Literal(l)) => {
+            let expected = compile_activation_literal(l, i)?;
+            if expected.kind().deref_kind() != kind {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            }
+            Ok(CompiledActivationPattern::Literal { expected })
+        }
+        Pattern::Expression(Expression::Var(v)) => {
+            let id = v.name.hash();
+            if let Some(n) = c.iter().position(|x| x.id == id) {
+                if c[n].kind.deref_kind() != kind {
+                    return Err(
+                        MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                            .with_tokens(p.tokens()),
+                    );
+                }
+                return Ok(CompiledActivationPattern::Capture { capture_index: n });
+            }
+            let slot =
+                create_capture_slot_for_kind(&kind).map_err(|e| e.with_tokens(p.tokens()))?;
+            c.push(ActivationPatternCapture {
+                id,
+                name: v.name.to_string(),
+                kind,
+                slot,
+            });
+            Ok(CompiledActivationPattern::Capture {
+                capture_index: c.len() - 1,
+            })
+        }
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(t) => {
+            let ValueKind::Tuple(k) = kind else {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            };
+            if t.0.len() != k.len() {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            }
+            Ok(CompiledActivationPattern::Tuple {
+                elements: t
+                    .0
+                    .iter()
+                    .zip(k.iter())
+                    .map(|(p, k)| compile_activation_pattern(p, k, i, c))
+                    .collect::<MResult<_>>()?,
+            })
+        }
+        Pattern::TupleStruct(t) => match kind {
+            #[cfg(feature = "enum")]
+            ValueKind::Enum(id, _) => compile_enum_variant_pattern(t, id, i, c),
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            ValueKind::Tuple(k) => compile_atom_tuple_pattern(t, &k, i, c),
+            _ => Err(
+                MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                    .with_tokens(p.tokens()),
+            ),
+        },
+        _ => {
+            Err(MechError::new(ActivationPatternExpressionUnsupported, None)
+                .with_tokens(p.tokens()))
+        }
+    }
+}
+fn matches_pattern(
+    p: &CompiledActivationPattern,
+    v: &Value,
+    proposed: &mut Vec<Option<Value>>,
+) -> bool {
+    match p {
+        CompiledActivationPattern::Wildcard => true,
+        CompiledActivationPattern::Literal { expected } => expected == &detached(v),
+        CompiledActivationPattern::Capture { capture_index } => {
+            let x = detached(v);
+            match &proposed[*capture_index] {
+                Some(y) => y == &x,
+                None => {
+                    proposed[*capture_index] = Some(x);
+                    true
+                }
+            }
+        }
+        #[cfg(feature = "tuple")]
+        CompiledActivationPattern::Tuple { elements } => match detached(v) {
+            Value::Tuple(t) => {
+                let t = t.borrow();
+                t.elements.len() == elements.len()
+                    && elements
+                        .iter()
+                        .zip(t.elements.iter())
+                        .all(|(p, v)| matches_pattern(p, v, proposed))
+            }
+            _ => false,
+        },
+        CompiledActivationPattern::EnumVariant {
+            enum_id,
+            variant_id,
+            payload,
+        } => {
+            #[cfg(feature = "enum")]
+            {
+                let Value::Enum(e) = detached(v) else {
+                    return false;
+                };
+                let e = e.borrow();
+                if e.id != *enum_id || e.variants.len() != 1 {
+                    return false;
+                }
+                let (id, value) = &e.variants[0];
+                id == variant_id
+                    && match (payload, value) {
+                        (None, None) => true,
+                        (Some(p), Some(v)) => matches_pattern(p, v, proposed),
+                        _ => false,
+                    }
+            }
+            #[cfg(not(feature = "enum"))]
+            {
+                false
+            }
+        }
+        CompiledActivationPattern::AtomTuple { tag_id, payload } => {
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            {
+                let Value::Tuple(t) = detached(v) else {
+                    return false;
+                };
+                let t = t.borrow();
+                if t.elements.len() != payload.len() + 1 {
+                    return false;
+                }
+                let Value::Atom(tag) = detached(&t.elements[0]) else {
+                    return false;
+                };
+                tag.borrow().id() == *tag_id
+                    && payload
+                        .iter()
+                        .zip(t.elements.iter().skip(1))
+                        .all(|(p, v)| matches_pattern(p, v, proposed))
+            }
+            #[cfg(not(all(feature = "tuple", feature = "atom")))]
+            {
+                false
+            }
+        }
+        #[cfg(not(feature = "tuple"))]
+        CompiledActivationPattern::Tuple { .. } => false,
+    }
+}
+fn generation() -> (Ref<usize>, Value) {
+    let r = Ref::new(0);
+    (r.clone(), Value::Index(r))
+}
+struct ScopePulse {
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for ScopePulse {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn reactive_dependency_scopes(&self, _: usize) -> Option<Vec<ReactiveDependencyScope>> {
+        Some(vec![ReactiveDependencyScope::Root])
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternScopePulse".into()
+    }
+}
+struct Matcher {
+    pattern: CompiledActivationPattern,
+    trigger: Value,
+    captures: Vec<ActivationPatternCapture>,
+    matched: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Matcher {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        let mut p = vec![None; self.captures.len()];
+        let ok = matches_pattern(&self.pattern, &self.trigger, &mut p);
+        if ok {
+            for (c, v) in self.captures.iter().zip(p.iter()) {
+                if let Some(v) = v {
+                    commit_capture_slot(&c.slot, v)?
+                }
+            }
+        }
+        *self.matched.borrow_mut() = ok;
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn reactive_dependency_kinds(&self, _: usize) -> Option<Vec<ReactiveDependencyKind>> {
+        Some(vec![
+            ReactiveDependencyKind::Reactive,
+            ReactiveDependencyKind::Sampled,
+        ])
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternMatcher".into()
+    }
+}
+struct Finalize {
+    matched: Ref<bool>,
+    eligible: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Finalize {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.eligible.borrow_mut() = *self.matched.borrow();
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternArmFinalize".into()
+    }
+}
+struct Select {
+    eligible: Vec<Ref<bool>>,
+    selected: Ref<usize>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Select {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.selected.borrow_mut() = self
+            .eligible
+            .iter()
+            .position(|x| *x.borrow())
+            .unwrap_or(usize::MAX);
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternSelectArm".into()
+    }
+}
+struct Gate {
+    arm: usize,
+    selected: Ref<usize>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Gate {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        if *self.selected.borrow() == self.arm {
+            *self.out.borrow_mut() += 1;
+            Ok(ReactiveSolveStatus::Changed)
+        } else {
+            Ok(ReactiveSolveStatus::Unchanged)
+        }
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternArmGate".into()
+    }
+}
 
-#[cfg(feature="compiler")] macro_rules! interpreter_only {($t:ty)=>{impl MechFunctionCompiler for $t { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }};}
-#[cfg(feature="compiler")] interpreter_only!(ScopePulse);
-#[cfg(feature="compiler")] interpreter_only!(Matcher);
-#[cfg(feature="compiler")] interpreter_only!(Finalize);
-#[cfg(feature="compiler")] interpreter_only!(Select);
-#[cfg(feature="compiler")] interpreter_only!(Gate);
+#[cfg(feature = "compiler")]
+macro_rules! interpreter_only {
+    ($t:ty) => {
+        impl MechFunctionCompiler for $t {
+            fn compile(&self, _: &mut CompileCtx) -> MResult<Register> {
+                Err(MechError::new(
+                    GenericError {
+                        msg: "Activation pattern dispatch is interpreter-only.".into(),
+                    },
+                    None,
+                ))
+            }
+        }
+    };
+}
+#[cfg(feature = "compiler")]
+interpreter_only!(ScopePulse);
+#[cfg(feature = "compiler")]
+interpreter_only!(Matcher);
+#[cfg(feature = "compiler")]
+interpreter_only!(Finalize);
+#[cfg(feature = "compiler")]
+interpreter_only!(Select);
+#[cfg(feature = "compiler")]
+interpreter_only!(Gate);
 
-pub(crate) fn elaborate_patterned_activation(scope:&ActivationScope,arms:&[ActivationArm],trigger:Value,trigger_cells:Vec<ReactiveCellId>,i:&Interpreter)->MResult<Value>{
- let last=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
- if !matches!(last.pattern,Pattern::Wildcard)||last.guard.is_some(){return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))} if arms[..arms.len()-1].iter().any(|x|matches!(x.pattern,Pattern::Wildcard)){return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens()))} if arms.iter().any(|x|x.guard.is_some()){return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens()))}
- for arm in arms {if let ActivationArmBody::Block(body)=&arm.body{for(code,_)in body{match code{MechCode::Statement(Statement::VariableAssign(_))|MechCode::Statement(Statement::OpAssign(_))=>return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())),MechCode::Statement(Statement::ContextSend(_))=>return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())),_=>{}}}}}
- let mut compiled=Vec::new();for arm in arms{let mut captures=Vec::new();let pattern=compile(&arm.pattern,&trigger,i,&mut captures)?;compiled.push(CompiledArm{pattern,captures})}
- if trigger.reactive_root_cell_ids()!=trigger_cells{return Err(MechError::new(ActivationPatternTriggerInvariant,None).with_tokens(scope.tokens()))}
- let plan=i.plan();let(scope_gen,scope_v)=generation();let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_gen}),&[trigger.clone()])?;
- let(mut matcher_nodes,mut completions,mut matched)=(Vec::new(),Vec::new(),Vec::new());for arm in &compiled{let(o,v)=generation();let f=Ref::new(false);let n=plan.borrow_mut().register(Box::new(Matcher{pattern:arm.pattern.clone(),trigger:trigger.clone(),captures:arm.captures.clone(),matched:f.clone(),out:o}),&[scope_v.clone(),trigger.clone()])?;matcher_nodes.push(n);completions.push(v);matched.push(f)}
- let(mut finalizers,mut eligible,mut done)=(Vec::new(),Vec::new(),Vec::new());for(f,c)in matched.iter().zip(completions.iter()){let(o,v)=generation();let e=Ref::new(false);finalizers.push(plan.borrow_mut().register(Box::new(Finalize{matched:f.clone(),eligible:e.clone(),out:o}),&[c.clone()])?);eligible.push(e);done.push(v)} let(o,selection)=generation();let selected=Ref::new(usize::MAX);let selector=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:o}),&done)?;
- let(mut gates,mut pulses)=(Vec::new(),Vec::new());for arm in 0..arms.len(){let(o,v)=generation();gates.push(plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:o}),&[selection.clone()])?);pulses.push(v)}
- let mut ranges=Vec::new();for(arm,compiled_arm)in arms.iter().zip(compiled.iter()){let symbols=i.symbols();let mut s=symbols.borrow_mut();let old=compiled_arm.captures.iter().map(|c|(c.id,s.symbols.get(&c.id).cloned(),s.mutable_variables.get(&c.id).cloned())).collect::<Vec<_>>();for c in &compiled_arm.captures{s.insert(c.id,c.slot.clone(),false);}drop(s);let start=plan.len();plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());let result=match &arm.body{ActivationArmBody::Block(b)=>{for(c,_)in b{crate::mech_code(c,i)?;}Ok(())},ActivationArmBody::Expression(e)=>crate::expression(e,None,i).map(|_|())};plan.pop_activation_registration_scope();let mut s=symbols.borrow_mut();for(id,oldv,oldm)in old{s.symbols.remove(&id);s.mutable_variables.remove(&id);if let Some(v)=oldv{s.symbols.insert(id,v);}if let Some(v)=oldm{s.mutable_variables.insert(id,v);}}drop(s);result?;ranges.push((start,plan.len()))}
- let registration=PatternActivationRegistration{scope_pulse_node:scope_node,selector_node:selector,arms:(0..arms.len()).map(|n|PatternActivationArmRegistration{matcher_node:matcher_nodes[n],finalizer_node:finalizers[n],gate_node:gates[n],pulse_cell:pulses[n].reactive_root_cell_ids()[0],body_node_start:ranges[n].0,body_node_end:ranges[n].1,captures:compiled[n].captures.iter().map(|c|PatternActivationCaptureRegistration{id:c.id,kind:c.kind.clone(),cell:c.slot.reactive_root_cell_ids()[0]}).collect()}).collect()};plan.borrow_mut().register_pattern_activation(registration);Ok(Value::Empty)
+fn preflight_patterned_activation(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: &Value,
+    trigger_cells: &[ReactiveCellId],
+    i: &Interpreter,
+) -> MResult<PreflightPatternedActivation> {
+    let last = arms.last().ok_or_else(|| {
+        MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+    })?;
+    if !matches!(last.pattern, Pattern::Wildcard) || last.guard.is_some() {
+        return Err(
+            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms[..arms.len() - 1]
+        .iter()
+        .any(|a| matches!(a.pattern, Pattern::Wildcard))
+    {
+        return Err(
+            MechError::new(ActivationPatternWildcardMustBeLast, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms.iter().any(|a| a.guard.is_some()) {
+        return Err(
+            MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
+        );
+    }
+    for a in arms {
+        if let ActivationArmBody::Block(body) = &a.body {
+            for (code, _) in body {
+                match code {
+                    MechCode::Statement(Statement::VariableAssign(_))
+                    | MechCode::Statement(Statement::OpAssign(_)) => {
+                        return Err(MechError::new(
+                            ActivationPatternRegisterWriteUnsupported,
+                            None,
+                        )
+                        .with_tokens(code.tokens()));
+                    }
+                    MechCode::Statement(Statement::ContextSend(_)) => {
+                        return Err(MechError::new(
+                            ActivationPatternContextEffectUnsupported,
+                            None,
+                        )
+                        .with_tokens(code.tokens()));
+                    }
+                    MechCode::Statement(Statement::VariableDefine(d)) if d.mutable => {
+                        return Err(MechError::new(ActivationPatternDefinitionUnsupported, None)
+                            .with_tokens(code.tokens()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if trigger.reactive_root_cell_ids() != trigger_cells {
+        return Err(
+            MechError::new(ActivationPatternTriggerInvariant, None).with_tokens(scope.tokens())
+        );
+    }
+    let trigger_kind = trigger.kind().deref_kind();
+    let mut compiled = Vec::new();
+    for a in arms {
+        let mut captures = Vec::new();
+        let pattern = compile_activation_pattern(&a.pattern, &trigger_kind, i, &mut captures)?;
+        compiled.push(PreflightActivationArm { pattern, captures });
+    }
+    Ok(PreflightPatternedActivation {
+        trigger_kind,
+        arms: compiled,
+    })
+}
+
+fn elaborate_patterned_activation_inner(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: Value,
+    trigger_cells: Vec<ReactiveCellId>,
+    i: &Interpreter,
+) -> MResult<Value> {
+    let preflight = preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, i)?;
+    let compiled = preflight.arms;
+    let plan = i.plan();
+    let (scope_gen, scope_v) = generation();
+    let scope_node = plan
+        .borrow_mut()
+        .register(Box::new(ScopePulse { out: scope_gen }), &[trigger.clone()])?;
+    let (mut matcher_nodes, mut completions, mut matched) = (Vec::new(), Vec::new(), Vec::new());
+    for arm in &compiled {
+        let (o, v) = generation();
+        let f = Ref::new(false);
+        let n = plan.borrow_mut().register(
+            Box::new(Matcher {
+                pattern: arm.pattern.clone(),
+                trigger: trigger.clone(),
+                captures: arm.captures.clone(),
+                matched: f.clone(),
+                out: o,
+            }),
+            &[scope_v.clone(), trigger.clone()],
+        )?;
+        matcher_nodes.push(n);
+        completions.push(v);
+        matched.push(f)
+    }
+    let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
+    for (f, c) in matched.iter().zip(completions.iter()) {
+        let (o, v) = generation();
+        let e = Ref::new(false);
+        finalizers.push(plan.borrow_mut().register(
+            Box::new(Finalize {
+                matched: f.clone(),
+                eligible: e.clone(),
+                out: o,
+            }),
+            &[c.clone()],
+        )?);
+        eligible.push(e);
+        done.push(v)
+    }
+    let (o, selection) = generation();
+    let selected = Ref::new(usize::MAX);
+    let selector = plan.borrow_mut().register(
+        Box::new(Select {
+            eligible: eligible.clone(),
+            selected: selected.clone(),
+            out: o,
+        }),
+        &done,
+    )?;
+    let (mut gates, mut pulses) = (Vec::new(), Vec::new());
+    for arm in 0..arms.len() {
+        let (o, v) = generation();
+        gates.push(plan.borrow_mut().register(
+            Box::new(Gate {
+                arm,
+                selected: selected.clone(),
+                out: o,
+            }),
+            &[selection.clone()],
+        )?);
+        pulses.push(v)
+    }
+    let mut ranges = Vec::new();
+    for (arm, compiled_arm) in arms.iter().zip(compiled.iter()) {
+        let symbols = i.symbols();
+        let snapshot = symbols.borrow().snapshot();
+        {
+            let mut s = symbols.borrow_mut();
+            for c in &compiled_arm.captures {
+                s.insert(c.id, c.slot.clone(), false);
+                s.dictionary.borrow_mut().insert(c.id, c.name.clone());
+            }
+        }
+        let start = plan.len();
+        plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());
+        let result = match &arm.body {
+            ActivationArmBody::Block(b) => {
+                for (c, _) in b {
+                    crate::mech_code(c, i)?;
+                }
+                Ok(())
+            }
+            ActivationArmBody::Expression(e) => crate::expression(e, None, i).map(|_| ()),
+        };
+        plan.pop_activation_registration_scope();
+        symbols.borrow_mut().restore(snapshot);
+        result?;
+        ranges.push((start, plan.len()))
+    }
+    let registration = PatternActivationRegistration {
+        scope_pulse_node: scope_node,
+        selector_node: selector,
+        arms: (0..arms.len())
+            .map(|n| PatternActivationArmRegistration {
+                matcher_node: matcher_nodes[n],
+                finalizer_node: finalizers[n],
+                gate_node: gates[n],
+                pulse_cell: pulses[n].reactive_root_cell_ids()[0],
+                body_node_start: ranges[n].0,
+                body_node_end: ranges[n].1,
+                captures: compiled[n]
+                    .captures
+                    .iter()
+                    .map(|c| PatternActivationCaptureRegistration {
+                        id: c.id,
+                        kind: c.kind.clone(),
+                        cell: c.slot.reactive_root_cell_ids()[0],
+                    })
+                    .collect(),
+            })
+            .collect(),
+    };
+    plan.borrow_mut().register_pattern_activation(registration);
+    Ok(Value::Empty)
+}
+
+pub(crate) fn elaborate_patterned_activation(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: Value,
+    trigger_cells: Vec<ReactiveCellId>,
+    interpreter: &Interpreter,
+) -> MResult<Value> {
+    let plan = interpreter.plan();
+    let checkpoint = plan.checkpoint();
+    match elaborate_patterned_activation_inner(scope, arms, trigger, trigger_cells, interpreter) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            plan.rollback(checkpoint)?;
+            Err(error)
+        }
+    }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1167,7 +1167,7 @@ fn validate_patterned_guard_expression(
     interpreter: &Interpreter,
 ) -> MResult<()> {
     validate_patterned_expression(expression)?;
-    if guard_expression_has_eager_control_flow(
+    if guard_expression_is_not_static_pure(
         expression,
         interpreter,
         &mut HashSet::new(),
@@ -1178,7 +1178,7 @@ fn validate_patterned_guard_expression(
     }
 }
 
-fn guard_expression_has_eager_control_flow(
+fn guard_expression_is_not_static_pure(
     expression: &Expression,
     interpreter: &Interpreter,
     visiting_functions: &mut HashSet<u64>,
@@ -1189,18 +1189,18 @@ fn guard_expression_has_eager_control_flow(
             .subscript
             .iter()
             .any(|subscript| {
-                guard_subscript_has_eager_control_flow(
+                guard_subscript_is_not_static_pure(
                     subscript,
                     interpreter,
                     visiting_functions,
                 )
             }),
         Expression::Formula(factor) => {
-            guard_factor_has_eager_control_flow(factor, interpreter, visiting_functions)
+            guard_factor_is_not_static_pure(factor, interpreter, visiting_functions)
         }
         Expression::FunctionCall(call) => {
             if call.args.iter().any(|(_, expression)| {
-                guard_expression_has_eager_control_flow(
+                guard_expression_is_not_static_pure(
                     expression,
                     interpreter,
                     visiting_functions,
@@ -1209,21 +1209,30 @@ fn guard_expression_has_eager_control_flow(
                 return true;
             }
             let function_id = call.name.hash();
-            let user_function = interpreter
-                .functions()
-                .borrow()
-                .user_functions
+            let functions = interpreter.functions();
+            let functions = functions.borrow();
+            let user_function = functions.user_functions.get(&function_id).cloned();
+            let has_precompiled_function = functions.functions.contains_key(&function_id);
+            let native_guard_safety = functions
+                .function_compilers
                 .get(&function_id)
-                .cloned();
+                .map(|compiler| compiler.guard_safety());
+            drop(functions);
             let Some(user_function) = user_function else {
-                return false;
+                if has_precompiled_function {
+                    return true;
+                }
+                return match native_guard_safety {
+                    Some(GuardFunctionSafety::PureStatic) | None => false,
+                    Some(GuardFunctionSafety::Unsupported) => true,
+                };
             };
             if !visiting_functions.insert(function_id) {
                 return true;
             }
             let eager = match user_function.code.match_arms.as_slice() {
                 [arm] if matches!(arm.pattern, Pattern::Wildcard) => {
-                    guard_expression_has_eager_control_flow(
+                    guard_expression_is_not_static_pure(
                         &arm.expression,
                         interpreter,
                         visiting_functions,
@@ -1239,21 +1248,21 @@ fn guard_expression_has_eager_control_flow(
         | Expression::MatrixComprehension(_)
         | Expression::FsmPipe(_) => true,
         Expression::Range(range) => {
-            guard_range_has_eager_control_flow(range, interpreter, visiting_functions)
+            guard_range_is_not_static_pure(range, interpreter, visiting_functions)
         }
         Expression::Structure(structure) => {
-            guard_structure_has_eager_control_flow(structure, interpreter, visiting_functions)
+            guard_structure_is_not_static_pure(structure, interpreter, visiting_functions)
         }
     }
 }
 
-fn guard_factor_has_eager_control_flow(
+fn guard_factor_is_not_static_pure(
     factor: &Factor,
     interpreter: &Interpreter,
     visiting_functions: &mut HashSet<u64>,
 ) -> bool {
     match factor {
-        Factor::Expression(expression) => guard_expression_has_eager_control_flow(
+        Factor::Expression(expression) => guard_expression_is_not_static_pure(
             expression,
             interpreter,
             visiting_functions,
@@ -1262,15 +1271,15 @@ fn guard_factor_has_eager_control_flow(
         | Factor::Not(factor)
         | Factor::Parenthetical(factor)
         | Factor::Transpose(factor) => {
-            guard_factor_has_eager_control_flow(factor, interpreter, visiting_functions)
+            guard_factor_is_not_static_pure(factor, interpreter, visiting_functions)
         }
         Factor::Term(term) => {
-            guard_factor_has_eager_control_flow(
+            guard_factor_is_not_static_pure(
                 &term.lhs,
                 interpreter,
                 visiting_functions,
             ) || term.rhs.iter().any(|(_, factor)| {
-                guard_factor_has_eager_control_flow(
+                guard_factor_is_not_static_pure(
                     factor,
                     interpreter,
                     visiting_functions,
@@ -1280,30 +1289,30 @@ fn guard_factor_has_eager_control_flow(
     }
 }
 
-fn guard_range_has_eager_control_flow(
+fn guard_range_is_not_static_pure(
     range: &RangeExpression,
     interpreter: &Interpreter,
     visiting_functions: &mut HashSet<u64>,
 ) -> bool {
-    guard_factor_has_eager_control_flow(&range.start, interpreter, visiting_functions)
+    guard_factor_is_not_static_pure(&range.start, interpreter, visiting_functions)
         || range
             .increment
             .as_ref()
             .map_or(false, |(_, increment)| {
-                guard_factor_has_eager_control_flow(
+                guard_factor_is_not_static_pure(
                     increment,
                     interpreter,
                     visiting_functions,
                 )
             })
-        || guard_factor_has_eager_control_flow(
+        || guard_factor_is_not_static_pure(
             &range.terminal,
             interpreter,
             visiting_functions,
         )
 }
 
-fn guard_subscript_has_eager_control_flow(
+fn guard_subscript_is_not_static_pure(
     subscript: &Subscript,
     interpreter: &Interpreter,
     visiting_functions: &mut HashSet<u64>,
@@ -1312,23 +1321,23 @@ fn guard_subscript_has_eager_control_flow(
         Subscript::Brace(subscripts) | Subscript::Bracket(subscripts) => subscripts
             .iter()
             .any(|subscript| {
-                guard_subscript_has_eager_control_flow(
+                guard_subscript_is_not_static_pure(
                     subscript,
                     interpreter,
                     visiting_functions,
                 )
             }),
         Subscript::Formula(factor) => {
-            guard_factor_has_eager_control_flow(factor, interpreter, visiting_functions)
+            guard_factor_is_not_static_pure(factor, interpreter, visiting_functions)
         }
         Subscript::Range(range) => {
-            guard_range_has_eager_control_flow(range, interpreter, visiting_functions)
+            guard_range_is_not_static_pure(range, interpreter, visiting_functions)
         }
         Subscript::All | Subscript::Dot(_) | Subscript::DotInt(_) | Subscript::Swizzle(_) => false,
     }
 }
 
-fn guard_structure_has_eager_control_flow(
+fn guard_structure_is_not_static_pure(
     structure: &Structure,
     interpreter: &Interpreter,
     visiting_functions: &mut HashSet<u64>,
@@ -1336,11 +1345,11 @@ fn guard_structure_has_eager_control_flow(
     match structure {
         Structure::Empty => false,
         Structure::Map(map) => map.elements.iter().any(|mapping| {
-            guard_expression_has_eager_control_flow(
+            guard_expression_is_not_static_pure(
                 &mapping.key,
                 interpreter,
                 visiting_functions,
-            ) || guard_expression_has_eager_control_flow(
+            ) || guard_expression_is_not_static_pure(
                 &mapping.value,
                 interpreter,
                 visiting_functions,
@@ -1350,7 +1359,7 @@ fn guard_structure_has_eager_control_flow(
             row.columns
                 .iter()
                 .any(|column| {
-                    guard_expression_has_eager_control_flow(
+                    guard_expression_is_not_static_pure(
                         &column.element,
                         interpreter,
                         visiting_functions,
@@ -1361,7 +1370,7 @@ fn guard_structure_has_eager_control_flow(
             .bindings
             .iter()
             .any(|binding| {
-                guard_expression_has_eager_control_flow(
+                guard_expression_is_not_static_pure(
                     &binding.value,
                     interpreter,
                     visiting_functions,
@@ -1371,7 +1380,7 @@ fn guard_structure_has_eager_control_flow(
             .elements
             .iter()
             .any(|expression| {
-                guard_expression_has_eager_control_flow(
+                guard_expression_is_not_static_pure(
                     expression,
                     interpreter,
                     visiting_functions,
@@ -1381,7 +1390,7 @@ fn guard_structure_has_eager_control_flow(
             row.columns
                 .iter()
                 .any(|column| {
-                    guard_expression_has_eager_control_flow(
+                    guard_expression_is_not_static_pure(
                         &column.element,
                         interpreter,
                         visiting_functions,
@@ -1392,14 +1401,14 @@ fn guard_structure_has_eager_control_flow(
             .elements
             .iter()
             .any(|expression| {
-                guard_expression_has_eager_control_flow(
+                guard_expression_is_not_static_pure(
                     expression,
                     interpreter,
                     visiting_functions,
                 )
             }),
         Structure::TupleStruct(tuple) => {
-            guard_expression_has_eager_control_flow(
+            guard_expression_is_not_static_pure(
                 &tuple.value,
                 interpreter,
                 visiting_functions,
@@ -1924,6 +1933,21 @@ pub(crate) fn elaborate_patterned_activation(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct EagerGuardTestCompiler {
+        compile_calls: Arc<AtomicUsize>,
+    }
+
+    impl NativeFunctionCompiler for EagerGuardTestCompiler {
+        fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+            self.compile_calls.fetch_add(1, Ordering::SeqCst);
+            panic!("unsupported guard compiler must not run during preflight")
+        }
+    }
 
     fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
         let mut cases = Vec::new();
@@ -3195,6 +3219,41 @@ event := 20.0
         assert_eq!(i.symbols().borrow().snapshot(), symbols);
         assert_eq!(*i.dictionary().borrow(), dictionary);
         assert_eq!(plan_snapshot(&i), topology);
+        assert_eq!(i.plan().activation_registration_depth(), 0);
+    }
+
+    #[test]
+    fn activation_guard_rejects_unclassified_native_compiler_before_compile() {
+        let mut i = interpret("event := (:released, 1.0)");
+        let compile_calls = Arc::new(AtomicUsize::new(0));
+        i.functions().borrow_mut().insert_function_compiler(
+            "test/eager-guard",
+            Arc::new(EagerGuardTestCompiler {
+                compile_calls: compile_calls.clone(),
+            }),
+        );
+        let symbols = i.symbols().borrow().snapshot();
+        let topology = plan_snapshot(&i);
+
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | :pressed(x), test/eager-guard(x) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind_name(), "ActivationPatternGuardMustBePure");
+        assert_eq!(compile_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(i.plan().pattern_activation_registrations().is_empty());
         assert_eq!(i.plan().activation_registration_depth(), 0);
     }
 

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1225,33 +1225,6 @@ fn validate_patterned_qualifier(qualifier: &ComprehensionQualifier) -> MResult<(
     }
 }
 
-fn elaborate_patterned_expression_values(
-    arm: &PreflightActivationArm,
-    interpreter: &Interpreter,
-) -> MResult<Vec<Value>> {
-    let symbols = interpreter.symbols();
-    let symbol_snapshot = symbols.borrow().snapshot();
-    {
-        let mut symbols = symbols.borrow_mut();
-        for capture in &arm.captures {
-            symbols.mutable_variables.remove(&capture.id);
-            symbols.insert(capture.id, capture.proposed.clone(), false);
-            symbols
-                .dictionary
-                .borrow_mut()
-                .insert(capture.id, capture.name.clone());
-        }
-    }
-    let result = arm
-        .pattern
-        .expressions()
-        .iter()
-        .map(|expression| crate::expression(expression, None, interpreter))
-        .collect::<MResult<Vec<_>>>();
-    symbols.borrow_mut().restore(symbol_snapshot);
-    result
-}
-
 fn elaborate_patterned_arm_body(
     arm: &ActivationArm,
     captures: &[ActivationPatternCapture],
@@ -1322,7 +1295,13 @@ fn elaborate_patterned_activation_inner(
         crate::functions::PersistentUserFunctionPlanScope::enter(i);
     let pattern_expression_values = compiled
         .iter()
-        .map(|arm| elaborate_patterned_expression_values(arm, i))
+        .map(|arm| {
+            arm.pattern
+                .expressions()
+                .iter()
+                .map(|expression| crate::expression(expression, None, i))
+                .collect::<MResult<Vec<_>>>()
+        })
         .collect::<MResult<Vec<_>>>()?;
     drop(_persistent_user_function_plan);
     let mut initially_matched = Vec::with_capacity(compiled.len());
@@ -2499,6 +2478,46 @@ event := (1.0, 1.0)
         set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(3.))]);
         let o = i.advance_reactive_turn(&[trigger]).unwrap();
         assert_dispatch_turn(&i, &topology, &o, 1, -1.);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_pattern_expression_uses_outer_symbol_when_capture_name_collides() {
+        let mut i = interpret(
+            r#"
+x := 9.0
+event := [1.0 10.0]
+
+~> event
+  | [x, x + 1.0] => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let outer_cell = root_cell(&i, "x");
+        let activation = registration(&i);
+        let proposed_cell = proposed_capture_value(&i, 0, 0).reactive_root_cell_ids()[0];
+        let committed_cell = activation.arms[0].captures[0].cell;
+        assert_ne!(proposed_cell, committed_cell);
+        assert_ne!(outer_cell, proposed_cell);
+        assert_ne!(outer_cell, committed_cell);
+        let topology = plan_snapshot(&i);
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+        assert_eq!(symbol(&i, "x"), Value::F64(Ref::new(9.0)));
+        assert_eq!(proposed_capture_value(&i, 0, 0), Value::F64(Ref::new(1.0)));
+        assert_eq!(committed_capture_value(&i, 0, 0), Value::F64(Ref::new(1.0)));
+        assert_eq!(
+            proposed_capture_value(&i, 0, 0).reactive_root_cell_ids()[0],
+            proposed_cell
+        );
+        assert_eq!(registration(&i).arms[0].captures[0].cell, committed_cell);
     }
 
     #[cfg(all(feature = "matrix", feature = "f64"))]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,28 +1,94 @@
-//! Patterned activation elaboration.
+//! Static scheduling support for patterned activation scopes.
 //!
-//! This module is deliberately kept separate from `mechdown`: activation
-//! scheduling is interpreter infrastructure rather than syntax dispatch.
-//! Fixed-body scopes continue to use the established registration path while
-//! patterned scopes are elaborated here as the activation graph grows.
+//! The small dispatch nodes in this file deliberately contain no syntax and
+//! are registered once while a source tree is elaborated.  A reactive turn
+//! only moves generation counters through that already-built graph.
 
 use crate::*;
 
-/// Describes the internal generation cells used by a patterned activation.
-///
-/// Keeping this descriptor independent of syntax is important: the reactive
-/// plan owns these cells for the lifetime of the loaded program, so a dispatch
-/// never needs to create or rebuild plan nodes.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PatternActivationGenerations {
-    pub scope: Option<ReactiveCellId>,
-    pub selection: Option<ReactiveCellId>,
-    pub arms: Vec<PatternActivationArmGenerations>,
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternExpressionUnsupported;
+impl MechErrorKind for ActivationPatternExpressionUnsupported { fn name(&self)->&str{"ActivationPatternExpressionUnsupported"} fn message(&self)->String{"This activation pattern is not supported.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternCaptureKindUnsupported;
+impl MechErrorKind for ActivationPatternCaptureKindUnsupported { fn name(&self)->&str{"ActivationPatternCaptureKindUnsupported"} fn message(&self)->String{"The capture kind cannot be inferred from the activation trigger.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternArmsNonExhaustive;
+impl MechErrorKind for ActivationPatternArmsNonExhaustive { fn name(&self)->&str{"ActivationPatternArmsNonExhaustive"} fn message(&self)->String{"Patterned activations require a final unguarded wildcard arm.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternWildcardMustBeLast;
+impl MechErrorKind for ActivationPatternWildcardMustBeLast { fn name(&self)->&str{"ActivationPatternWildcardMustBeLast"} fn message(&self)->String{"The wildcard activation arm must be last.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternGuardMustBePure;
+impl MechErrorKind for ActivationPatternGuardMustBePure { fn name(&self)->&str{"ActivationPatternGuardMustBePure"} fn message(&self)->String{"Patterned activation guards must be pure.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternRegisterWriteUnsupported;
+impl MechErrorKind for ActivationPatternRegisterWriteUnsupported { fn name(&self)->&str{"ActivationPatternRegisterWriteUnsupported"} fn message(&self)->String{"Patterned activation register writes are not supported.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternContextEffectUnsupported;
+impl MechErrorKind for ActivationPatternContextEffectUnsupported { fn name(&self)->&str{"ActivationPatternContextEffectUnsupported"} fn message(&self)->String{"Patterned activation context effects are not supported.".into()} }
+
+#[derive(Clone, Debug)]
+enum CompiledActivationPattern { Wildcard, Literal(Value) }
+
+fn compile_pattern(pattern: &Pattern, interpreter: &Interpreter) -> MResult<CompiledActivationPattern> {
+  match pattern {
+    Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
+    Pattern::Expression(Expression::Literal(literal)) => Ok(CompiledActivationPattern::Literal(crate::literal(literal, interpreter)?)),
+    // A variable is deliberately not treated as a catch-all: doing so loses
+    // the type and stable backing reference required for a capture slot.
+    Pattern::Expression(Expression::Var(_)) => Err(MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(pattern.tokens())),
+    _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None).with_tokens(pattern.tokens())),
+  }
 }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PatternActivationArmGenerations {
-    pub matched: Option<ReactiveCellId>,
-    pub guard_start: Option<ReactiveCellId>,
-    pub complete: Option<ReactiveCellId>,
-    pub pulse: Option<ReactiveCellId>,
+fn generation() -> (Ref<usize>, Value) { let cell=Ref::new(0usize); let value=Value::Index(cell.clone()); (cell,value) }
+
+struct ScopePulse { out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for ScopePulse { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for ScopePulse {
+  fn solve(&self) {}
+  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
+  fn out(&self)->Value { Value::Index(self.out.clone()) }
+  fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>> { Some(vec![ReactiveDependencyScope::Root]) }
+  fn to_string(&self)->String{"ActivationPatternScopePulse".into()}
+}
+struct Matcher { pattern: CompiledActivationPattern, trigger: Value, matched: Ref<bool>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Matcher { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Matcher {
+  fn solve(&self) {}
+  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.matched.borrow_mut()=match &self.pattern { CompiledActivationPattern::Wildcard=>true, CompiledActivationPattern::Literal(value)=>value==&self.trigger }; *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
+  fn out(&self)->Value{Value::Index(self.out.clone())}
+  fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}
+  fn to_string(&self)->String{"ActivationPatternMatcher".into()}
+}
+struct Finalize { matched: Ref<bool>, eligible: Ref<bool>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Finalize { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Finalize { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmFinalize".into()} }
+struct Select { eligible: Vec<Ref<bool>>, selected: Ref<usize>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Select { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Select { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternSelectArm".into()} }
+struct Gate { arm: usize, selected: Ref<usize>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Gate { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Gate { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if *self.selected.borrow()==self.arm {*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} else {Ok(ReactiveSolveStatus::Unchanged)}} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmGate".into()} }
+
+/// Elaborates the static, combinational dispatch graph for literal and
+/// wildcard patterned activation arms.  Unsupported destructuring is rejected
+/// during elaboration rather than deferred to a reactive turn.
+pub(crate) fn elaborate_patterned_activation(scope: &ActivationScope, arms: &[ActivationArm], trigger: Value, trigger_cells: Vec<ReactiveCellId>, interpreter: &Interpreter) -> MResult<Value> {
+  let final_arm=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
+  if !matches!(final_arm.pattern,Pattern::Wildcard) || final_arm.guard.is_some() { return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens())); }
+  if arms[..arms.len()-1].iter().any(|arm|matches!(arm.pattern,Pattern::Wildcard)) { return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens())); }
+  if arms.iter().any(|arm|arm.guard.is_some()) { return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens())); }
+  for arm in arms { if let ActivationArmBody::Block(body)=&arm.body { for (code,_) in body { match code { MechCode::Statement(Statement::VariableAssign(_)) | MechCode::Statement(Statement::OpAssign(_)) => return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())), MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())), _=>{} } } } }
+  let patterns=arms.iter().map(|arm|compile_pattern(&arm.pattern,interpreter)).collect::<MResult<Vec<_>>>()?;
+  let plan=interpreter.plan();
+  let (scope_generation,scope_value)=generation();
+  let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_generation}), &[trigger.clone()])?;
+  let mut matcher_nodes=Vec::new(); let mut completions=Vec::new(); let mut matched=Vec::new();
+  for pattern in patterns { let (complete,complete_value)=generation(); let flag=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Matcher{pattern,trigger:trigger.clone(),matched:flag.clone(),out:complete}), &[scope_value.clone(),trigger.clone()])?; matcher_nodes.push(id); completions.push(complete_value); matched.push(flag); }
+  let mut finalizer_nodes=Vec::new(); let mut eligible=Vec::new(); let mut arm_complete=Vec::new();
+  for (flag, complete) in matched.iter().zip(completions.iter()) { let (done,done_value)=generation(); let ok=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Finalize{matched:flag.clone(),eligible:ok.clone(),out:done}), &[complete.clone()])?; finalizer_nodes.push(id); eligible.push(ok); arm_complete.push(done_value); }
+  let (selection,selection_value)=generation(); let selected=Ref::new(usize::MAX); let selector_node=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:selection}), &arm_complete)?;
+  let mut gate_nodes=Vec::new(); let mut pulses=Vec::new();
+  for arm in 0..arms.len() { let (pulse,pulse_value)=generation(); let id=plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:pulse}), &[selection_value.clone()])?; gate_nodes.push(id); pulses.push(pulse_value); }
+  let mut registrations=Vec::new();
+  for (arm,pulse) in arms.iter().zip(pulses.iter()) { let start=plan.len(); plan.push_activation_registration_scope(pulse.reactive_root_cell_ids()); let result=match &arm.body { ActivationArmBody::Block(body)=>{for (code,_) in body { crate::mech_code(code,interpreter)?; } Ok(())}, ActivationArmBody::Expression(expression)=>{crate::expression(expression,None,interpreter).map(|_|())} }; plan.pop_activation_registration_scope(); result?; registrations.push((start,plan.len())); }
+  let registration=PatternActivationRegistration { scope_pulse_node:scope_node, selector_node, arms:(0..arms.len()).map(|i|PatternActivationArmRegistration{matcher_node:matcher_nodes[i],finalizer_node:finalizer_nodes[i],gate_node:gate_nodes[i],pulse_cell:pulses[i].reactive_root_cell_ids()[0],body_node_start:registrations[i].0,body_node_end:registrations[i].1}).collect() };
+  plan.borrow_mut().register_pattern_activation(registration);
+  let _=trigger_cells; // The scope pulse's Root dependency is the trigger's root storage.
+  Ok(Value::Empty)
 }

--- a/src/interpreter/src/builtins.rs
+++ b/src/interpreter/src/builtins.rs
@@ -165,6 +165,7 @@ fn is_prelude_name(name: &str) -> bool {
         "SetSize",
         "Set1D",
         "Table",
+        "TupleAccessElement",
     ];
     EXACT.contains(&name) || PREFIXES.iter().any(|prefix| name.starts_with(prefix))
 }

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1,4 +1,28 @@
 use crate::*;
+
+pub(crate) struct DeferredExpressionSolveScope {
+  depth: Ref<usize>,
+}
+
+impl DeferredExpressionSolveScope {
+  pub(crate) fn enter(interpreter: &Interpreter) -> Self {
+    let depth = interpreter.deferred_expression_solve_depth.clone();
+    *depth.borrow_mut() += 1;
+    Self { depth }
+  }
+}
+
+impl Drop for DeferredExpressionSolveScope {
+  fn drop(&mut self) {
+    let mut depth = self.depth.borrow_mut();
+    debug_assert!(*depth > 0);
+    *depth -= 1;
+  }
+}
+
+fn expression_solves_deferred(interpreter: &Interpreter) -> bool {
+  *interpreter.deferred_expression_solve_depth.borrow() > 0
+}
 use std::collections::HashMap;
 #[cfg(feature = "enum")]
 use std::collections::HashSet;
@@ -928,7 +952,9 @@ pub fn subscript(
                 return register_initialized_expression_function(&plan, function, &[]);
             }
             let new_fxn = AccessColumn {}.compile(&fxn_input)?;
-            new_fxn.solve();
+            if !expression_solves_deferred(p) {
+              new_fxn.solve();
+            }
             let res = new_fxn.out();
             plan.borrow_mut().push(new_fxn);
             return Ok(res);
@@ -941,7 +967,9 @@ pub fn subscript(
                 #[cfg(feature = "matrix")]
                 ValueKind::Matrix(..) => {
                     let new_fxn = MatrixAccessScalar {}.compile(&fxn_input)?;
-                    new_fxn.solve();
+                    if !expression_solves_deferred(p) {
+                      new_fxn.solve();
+                    }
                     let res = new_fxn.out();
                     plan.borrow_mut().push(new_fxn);
                     return Ok(res);
@@ -970,7 +998,9 @@ pub fn subscript(
             let mut fxn_input: Vec<Value> = vec![val.clone()];
             fxn_input.append(&mut keys);
             let new_fxn = AccessSwizzle {}.compile(&fxn_input)?;
-            new_fxn.solve();
+            if !expression_solves_deferred(p) {
+              new_fxn.solve();
+            }
             let res = new_fxn.out();
             plan.borrow_mut().push(new_fxn);
             return Ok(res);
@@ -1009,7 +1039,9 @@ pub fn subscript(
             }
             let plan_brrw = plan.borrow();
             let mut new_fxn = &plan_brrw.last().unwrap();
-            new_fxn.solve();
+            if !expression_solves_deferred(p) {
+              new_fxn.solve();
+            }
             let res = new_fxn.out();
             return Ok(res);
         }
@@ -1187,7 +1219,9 @@ pub fn subscript(
             };
             let plan_brrw = plan.borrow();
             let mut new_fxn = &plan_brrw.last().unwrap();
-            new_fxn.solve();
+            if !expression_solves_deferred(p) {
+              new_fxn.solve();
+            }
             let res = new_fxn.out();
             return Ok(res);
         }
@@ -1556,9 +1590,18 @@ fn validate_match_arm_output_kinds(
 
 fn guard_expression_true(guard: &Expression, env: &Environment, p: &Interpreter) -> MResult<bool> {
   let guard_result = expression(guard, Some(env), p)?;
+  let flag = validate_guard_expression_result(guard_result, guard.tokens())?;
+  let result = *flag.borrow();
+  Ok(result)
+}
+
+pub(crate) fn validate_guard_expression_result(
+  guard_result: Value,
+  tokens: Vec<Token>,
+) -> MResult<Ref<bool>> {
   match guard_result {
-      #[cfg(feature = "bool")]
-    Value::Bool(flag) => Ok(*flag.borrow()),
+    #[cfg(feature = "bool")]
+    Value::Bool(flag) => Ok(flag),
     _ => Err(MechError::new(
       InvalidGuardExpressionError {
         found: guard_result.kind(),
@@ -1566,7 +1609,7 @@ fn guard_expression_true(guard: &Expression, env: &Environment, p: &Interpreter)
       None,
     )
     .with_compiler_loc()
-    .with_tokens(guard.tokens())),
+    .with_tokens(tokens)),
   }
 }
 
@@ -1872,7 +1915,9 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &Interpreter) -> MResult<V
         .with_tokens(trm.tokens()));
       }
     };
-    new_fxn.solve();
+    if !expression_solves_deferred(p) {
+      new_fxn.solve();
+    }
     let res = new_fxn.out();
     #[cfg(feature = "subscript_formula")]
     if new_fxn_is_live {

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1406,19 +1406,21 @@ pub fn match_expression(
         let mut guard_env = base_env.clone();
         let matched = match &arm.pattern {
             Pattern::Wildcard => true,
-            _ => crate::patterns::pattern_matches_value_with_semantics(
+            _ => crate::patterns::pattern_matches_value(
                 &arm.pattern,
                 &detached_source,
                 &mut guard_env,
                 p,
-                crate::patterns::PatternMatchSemantics::OptionGuard,
             )?,
         };
+        if !matched {
+            continue;
+        }
         let passed_guard = match &arm.guard {
             Some(guard) => guard_expression_true(guard, &guard_env, p)?,
             None => true,
         };
-        if matched && passed_guard {
+        if passed_guard {
             #[cfg(feature = "matrix")]
             if value_contains_empty(&detached_source) && is_identity_option_matrix_arm(arm) {
                 if let Some(wildcard_arm) = match_expr
@@ -1561,19 +1563,21 @@ fn match_validate_arm_kinds(
         let mut arm_env = base_env.clone();
         let applicable = match arm.pattern {
             Pattern::Wildcard => true,
-            _ => crate::patterns::pattern_matches_value_with_semantics(
+            _ => crate::patterns::pattern_matches_value(
                 &arm.pattern,
                 source,
                 &mut arm_env,
                 p,
-                crate::patterns::PatternMatchSemantics::OptionGuard,
             )?,
         };
+        if !applicable {
+            continue;
+        }
         let passed_guard = match &arm.guard {
             Some(guard) => guard_expression_true(guard, &arm_env, p)?,
             None => true,
         };
-        if !(applicable && passed_guard) {
+        if !passed_guard {
             continue;
         }
         let arm_value = expression(&arm.expression, Some(&arm_env), p)?;

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -45,7 +45,7 @@ pub fn pattern_match_value(
     match pattern {
         Pattern::Wildcard => Ok(()),
         Pattern::Expression(expr) => match expr {
-            Expression::Var(var) => {
+            Expression::Var(var) if crate::patterns::pattern_var_is_binding(var) => {
                 let id = &var.name.hash();
                 match env.get(id) {
                     Some(existing) if existing == value => Ok(()),

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -478,7 +478,7 @@ fn register_initialized_expression_function(
   let node_id = plan.register_function(function, arguments)?;
   let plan_borrow = plan.borrow();
   let function = &plan_borrow[node_id];
-  function.solve();
+  if !plan.activation_registration_active() { function.solve(); }
   Ok(function.out())
 }
 

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -36,86 +36,6 @@ pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter)
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
-pub fn pattern_match_value(
-    pattern: &Pattern,
-    value: &Value,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<()> {
-    match pattern {
-        Pattern::Wildcard => Ok(()),
-        Pattern::Expression(expr) => match expr {
-            Expression::Var(var) if crate::patterns::pattern_var_is_binding(var) => {
-                let id = &var.name.hash();
-                match env.get(id) {
-                    Some(existing) if existing == value => Ok(()),
-                    Some(existing) => Err(MechError::new(
-                        PatternMatchError {
-                            var: var.name.to_string(),
-                            expected: existing.to_string(),
-                            found: value.to_string(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                    None => {
-                        env.insert(id.clone(), value.clone());
-                        Ok(())
-                    }
-                }
-            }
-            _ => {
-                let expected = expression(expr, Some(env), p)?;
-                if detach_comprehension_value(&expected) == detach_comprehension_value(value) {
-                    Ok(())
-                } else {
-                    Err(MechError::new(
-                        PatternMatchError {
-                            var: "<expression>".to_string(),
-                            expected: expected.to_string(),
-                            found: value.to_string(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc())
-                }
-            }
-        },
-        #[cfg(feature = "tuple")]
-        Pattern::Tuple(pat_tuple) => match value {
-            Value::Tuple(values) => {
-                let values_brrw = values.borrow();
-                if pat_tuple.0.len() != values_brrw.elements.len() {
-                    return Err(MechError::new(
-                        ArityMismatchError {
-                            expected: pat_tuple.0.len(),
-                            found: values_brrw.elements.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc());
-                }
-                for (pttrn, val) in pat_tuple.0.iter().zip(values_brrw.elements.iter()) {
-                    pattern_match_value(pttrn, val, env, p)?;
-                }
-                Ok(())
-            }
-            _ => Err(MechError::new(
-                PatternExpectedTupleError {
-                    found: value.kind(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        },
-        Pattern::TupleStruct(pat_struct) => {
-            todo!("Implement tuple struct pattern matching")
-        }
-        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
-    }
-}
-
-#[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
 fn comprehension_environments(
     qualifiers: &[ComprehensionQualifier],
     comprehension_id: u64,
@@ -128,12 +48,19 @@ fn comprehension_environments(
     for qual in qualifiers {
         envs = match qual {
             ComprehensionQualifier::Generator((pttrn, expr)) => {
+                let compiled = crate::patterns::compile_pattern(pttrn, None, &new_p)?;
                 let mut new_envs = Vec::new();
                 for env in &envs {
                     let collection = expression(expr, Some(env), &new_p)?;
                     for elmnt in comprehension_generator_values(&collection)? {
                         let mut new_env = env.clone();
-                        if pattern_match_value(pttrn, &elmnt, &mut new_env, &new_p).is_ok() {
+                        let pattern_match =
+                            crate::patterns::match_compiled_pattern_with_environment_constraints(
+                                &compiled, &elmnt, &new_env, &new_p,
+                            )?;
+                        if pattern_match.matched {
+                            crate::patterns::EnvironmentBindingSink::new(&mut new_env)
+                                .commit(&pattern_match)?;
                             new_envs.push(new_env);
                         }
                     }

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -183,7 +183,7 @@ pub fn execute_native_function_compiler(
           ),
         )
       );
-      new_fxn.solve();                   // run the function once to initialise its output
+      if !plan.activation_registration_active() { new_fxn.solve(); }
       let result = new_fxn.out();
       trace_println!(
         p,
@@ -207,7 +207,7 @@ pub fn execute_initialized_indexed_compiler_with_registration_arguments(
   registration_arguments: Vec<Value>,
 ) -> MResult<Value> {
   let function = compiler.compile(&compile_arguments)?;
-  function.solve_result()?;
+  if !plan.activation_registration_active() { function.solve_result()?; }
   let output = function.out();
   plan.register_function(function, &registration_arguments)?;
   Ok(output)

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -603,7 +603,7 @@ fn coerce_function_output_kind(
 struct FunctionScope {
   state: Ref<ProgramState>,
   previous_symbols: SymbolTableRef,
-  previous_plan: Plan,
+  previous_plan: Option<Plan>,
   previous_environment: Option<SymbolTableRef>,
 }
 
@@ -617,7 +617,11 @@ impl FunctionScope {
     local_symbols.dictionary = state_brrw.dictionary.clone();
     let local_symbols = Ref::new(local_symbols);
     let previous_symbols = std::mem::replace(&mut state_brrw.symbol_table, local_symbols);
-    let previous_plan = std::mem::replace(&mut state_brrw.plan, Plan::new());
+    let previous_plan = if *p.persistent_user_function_plan_depth.borrow() > 0 {
+      None
+    } else {
+      Some(std::mem::replace(&mut state_brrw.plan, Plan::new()))
+    };
     let previous_environment = state_brrw.environment.take();
     drop(state_brrw);
 
@@ -635,8 +639,30 @@ impl Drop for FunctionScope {
   fn drop(&mut self) {
     let mut state_brrw = self.state.borrow_mut();
     state_brrw.symbol_table = self.previous_symbols.clone();
-    state_brrw.plan = self.previous_plan.clone();
+    if let Some(previous_plan) = &self.previous_plan {
+      state_brrw.plan = previous_plan.clone();
+    }
     state_brrw.environment = self.previous_environment.clone();
+  }
+}
+
+pub(crate) struct PersistentUserFunctionPlanScope {
+  depth: Ref<usize>,
+}
+
+impl PersistentUserFunctionPlanScope {
+  pub(crate) fn enter(interpreter: &Interpreter) -> Self {
+    let depth = interpreter.persistent_user_function_plan_depth.clone();
+    *depth.borrow_mut() += 1;
+    Self { depth }
+  }
+}
+
+impl Drop for PersistentUserFunctionPlanScope {
+  fn drop(&mut self) {
+    let mut depth = self.depth.borrow_mut();
+    debug_assert!(*depth > 0);
+    *depth -= 1;
   }
 }
 

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -41,6 +41,8 @@ pub struct Interpreter {
   #[cfg(feature = "functions")]
   reactive_turn_state: ReactiveTurnState,
   #[cfg(feature = "functions")]
+  pub(crate) persistent_user_function_plan_depth: Ref<usize>,
+  #[cfg(feature = "functions")]
   pub stack: Vec<Frame>,
   registers: Vec<Value>,
   constants: Vec<Value>,
@@ -79,6 +81,8 @@ impl Clone for Interpreter {
       state: Ref::new(self.state.borrow().clone()),
       #[cfg(feature = "functions")]
       reactive_turn_state: self.reactive_turn_state.clone(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: self.persistent_user_function_plan_depth.clone(),
       #[cfg(feature = "functions")]
       stack: self.stack.clone(),
       registers: self.registers.clone(),
@@ -139,6 +143,8 @@ impl Interpreter {
       state: Ref::new(state),
       #[cfg(feature = "functions")]
       reactive_turn_state: ReactiveTurnState::default(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: Ref::new(0),
       #[cfg(feature = "functions")]
       stack: Vec::new(),
       registers: Vec::new(),

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -42,6 +42,7 @@ pub struct Interpreter {
   reactive_turn_state: ReactiveTurnState,
   #[cfg(feature = "functions")]
   pub(crate) persistent_user_function_plan_depth: Ref<usize>,
+  pub(crate) deferred_expression_solve_depth: Ref<usize>,
   #[cfg(feature = "functions")]
   pub stack: Vec<Frame>,
   registers: Vec<Value>,
@@ -83,6 +84,7 @@ impl Clone for Interpreter {
       reactive_turn_state: self.reactive_turn_state.clone(),
       #[cfg(feature = "functions")]
       persistent_user_function_plan_depth: self.persistent_user_function_plan_depth.clone(),
+      deferred_expression_solve_depth: self.deferred_expression_solve_depth.clone(),
       #[cfg(feature = "functions")]
       stack: self.stack.clone(),
       registers: self.registers.clone(),
@@ -145,6 +147,7 @@ impl Interpreter {
       reactive_turn_state: ReactiveTurnState::default(),
       #[cfg(feature = "functions")]
       persistent_user_function_plan_depth: Ref::new(0),
+      deferred_expression_solve_depth: Ref::new(0),
       #[cfg(feature = "functions")]
       stack: Vec::new(),
       registers: Vec::new(),

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -100,6 +100,10 @@ pub mod builtins;
 #[cfg(feature = "functions")]
 pub mod modules;
 pub mod expressions;
+#[cfg(all(
+  feature = "functions",
+  feature = "symbol_table",
+))]
 pub mod activation;
 #[cfg(feature = "functions")]
 pub mod functions;

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -100,6 +100,7 @@ pub mod builtins;
 #[cfg(feature = "functions")]
 pub mod modules;
 pub mod expressions;
+pub mod activation;
 #[cfg(feature = "functions")]
 pub mod functions;
 pub mod interpreter;

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -422,13 +422,17 @@ impl MechErrorKind for ActivationScopeContextSendUnsupported { fn name(&self) ->
 impl MechErrorKind for ActivationScopeDefinitionUnsupported { fn name(&self) -> &str { "ActivationScopeDefinitionUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
 #[derive(Debug, Clone)] struct ActivationScopeDeclarationUnsupported;
 impl MechErrorKind for ActivationScopeDeclarationUnsupported { fn name(&self) -> &str { "ActivationScopeDeclarationUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
+#[derive(Debug, Clone)] struct ActivationScopeTriggerWriteUnsupported;
+impl MechErrorKind for ActivationScopeTriggerWriteUnsupported { fn name(&self) -> &str { "ActivationScopeTriggerWriteUnsupported" } fn message(&self) -> String { "An activation scope cannot assign to its own trigger.".to_string() } }
 #[derive(Debug, Clone)] struct ActivationScopeNestedUnsupported;
 impl MechErrorKind for ActivationScopeNestedUnsupported { fn name(&self) -> &str { "ActivationScopeNestedUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
 
-fn validate_activation_body(body: &[(MechCode, Option<Comment>)]) -> MResult<()> {
+fn validate_activation_body(body: &[(MechCode, Option<Comment>)], trigger_id: u64) -> MResult<()> {
   for (code, _) in body { match code {
     MechCode::ActivationScope(_) => return Err(MechError::new(ActivationScopeNestedUnsupported, None).with_tokens(code.tokens())),
     MechCode::Import(_) | MechCode::FunctionDefine(_) | MechCode::FsmSpecification(_) | MechCode::FsmImplementation(_) => return Err(MechError::new(ActivationScopeDefinitionUnsupported, None).with_tokens(code.tokens())),
+    MechCode::Statement(Statement::VariableAssign(assign)) if assign.target.name.hash() == trigger_id => return Err(MechError::new(ActivationScopeTriggerWriteUnsupported, None).with_tokens(code.tokens())),
+    MechCode::Statement(Statement::OpAssign(assign)) if assign.target.name.hash() == trigger_id => return Err(MechError::new(ActivationScopeTriggerWriteUnsupported, None).with_tokens(code.tokens())),
     MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationScopeContextSendUnsupported, None).with_tokens(code.tokens())),
     MechCode::Statement(Statement::VariableDefine(def)) if def.mutable => return Err(MechError::new(ActivationScopeDefinitionUnsupported, None).with_tokens(code.tokens())),
     MechCode::Statement(Statement::ContextDeclaration(_) | Statement::ExportDeclaration(_) | Statement::FsmDeclare(_)) => return Err(MechError::new(ActivationScopeDeclarationUnsupported, None).with_tokens(code.tokens())),
@@ -457,7 +461,7 @@ fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigge
 
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
   let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
-  validate_activation_body(&scope.body)?;
+  validate_activation_body(&scope.body, var.name.hash())?;
   let trigger_cells = activation_trigger_cells(scope, var, p)?;
   elaborate_activation_scope(scope, p, trigger_cells)
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -438,7 +438,7 @@ fn validate_activation_body(body: &[(MechCode, Option<Comment>)]) -> MResult<()>
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
   let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
   let trigger = p.state.borrow().get_symbol(hash_str(&var.name.to_string())).ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
-  if trigger.reactive_root_cell_ids().is_empty() { return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())); }
+  if trigger.borrow().reactive_root_cell_ids().is_empty() { return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())); }
   validate_activation_body(&scope.body)?;
   Err(MechError::new(ActivationScopeExecutionUnsupported, None).with_tokens(scope.tokens()))
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -452,16 +452,21 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 
 #[cfg(all(feature = "functions", feature = "symbol_table"))]
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
- let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
- let result=(|| -> MResult<Value> { for (code,_) in &scope.body { mech_code(code,p)?; } Ok(Value::Empty) })();
- plan.pop_activation_registration_scope(); result
+  let ActivationBody::Block(body) = &scope.body else {
+    return Err(MechError::new(ActivationScopeRegistrationUnsupported, None).with_tokens(scope.tokens()));
+  };
+  let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+  let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
+  plan.pop_activation_registration_scope(); result
 }
 #[cfg(not(all(feature = "functions", feature = "symbol_table")))]
 fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> { Err(MechError::new(ActivationScopeRegistrationUnsupported,None).with_tokens(scope.tokens())) }
 
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
   let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
-  validate_activation_body(&scope.body, var.name.hash())?;
+  if let ActivationBody::Block(body) = &scope.body {
+    validate_activation_body(body, var.name.hash())?;
+  }
   let trigger_cells = activation_trigger_cells(scope, var, p)?;
   elaborate_activation_scope(scope, p, trigger_cells)
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -435,10 +435,28 @@ fn validate_activation_body(body: &[(MechCode, Option<Comment>)]) -> MResult<()>
   Ok(())
 }
 
+#[cfg(feature = "symbol_table")]
+fn validate_activation_trigger_storage(scope: &ActivationScope, var: &Var, p: &Interpreter) -> MResult<()> {
+  let trigger = p.state.borrow().get_symbol(var.name.hash()).ok_or_else(|| {
+    MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())
+  })?;
+  if trigger.borrow().reactive_root_cell_ids().is_empty() {
+    return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()));
+  }
+  Ok(())
+}
+
+#[cfg(not(feature = "symbol_table"))]
+fn validate_activation_trigger_storage(_scope: &ActivationScope, _var: &Var, _p: &Interpreter) -> MResult<()> {
+  Ok(())
+}
+
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
-  let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
-  let trigger = p.state.borrow().get_symbol(hash_str(&var.name.to_string())).ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
-  if trigger.borrow().reactive_root_cell_ids().is_empty() { return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())); }
+  let var = match &scope.trigger {
+    Expression::Var(var) => var,
+    _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())),
+  };
   validate_activation_body(&scope.body)?;
+  validate_activation_trigger_storage(scope, var, p)?;
   Err(MechError::new(ActivationScopeExecutionUnsupported, None).with_tokens(scope.tokens()))
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -416,27 +416,29 @@ impl MechErrorKind for ActivationScopeMutableDefinitionUnsupported {
   fn name(&self) -> &str { "ActivationScopeMutableDefinitionUnsupported" }
   fn message(&self) -> String { "Mutable variable definitions are not supported inside an activation scope.".to_string() }
 }
+#[derive(Debug, Clone)]
+struct ActivationScopeExecutionUnsupported;
+impl MechErrorKind for ActivationScopeExecutionUnsupported {
+  fn name(&self) -> &str { "ActivationScopeExecutionUnsupported" }
+  fn message(&self) -> String { "Activation-scope execution has not yet been implemented.".to_string() }
+}
 
-/// Elaborate an activation block in the surrounding symbol environment.  The
-/// parser intentionally retains a dedicated node so later plan registration can
-/// attach activation metadata without treating this as a lexical block.
+/// Validate source-only restrictions without evaluating or registering body code.
+fn validate_activation_body(body: &[(MechCode, Option<Comment>)]) -> MResult<()> {
+  for (code, _) in body {
+    match code {
+      MechCode::ActivationScope(_) => return Err(MechError::new(GenericError { msg: "Nested activation scopes are not supported.".to_string() }, None).with_tokens(code.tokens())),
+      MechCode::Statement(Statement::VariableDefine(def)) if def.mutable => return Err(MechError::new(ActivationScopeMutableDefinitionUnsupported, None).with_tokens(code.tokens())),
+      _ => {}
+    }
+  }
+  Ok(())
+}
+
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
-  if !matches!(scope.trigger, Expression::Var(_)) {
-    return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()));
-  }
-  let trigger = expression(&scope.trigger, None, p)?;
-  if trigger.reactive_root_cell_ids().is_empty() {
-    return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()));
-  }
-  let mut output = Value::Empty;
-  for (code, _) in &scope.body {
-    if matches!(code, MechCode::ActivationScope(_)) {
-      return Err(MechError::new(GenericError { msg: "Nested activation scopes are not supported.".to_string() }, None).with_tokens(code.tokens()));
-    }
-    if matches!(code, MechCode::Statement(Statement::VariableDefine(def)) if def.mutable) {
-      return Err(MechError::new(ActivationScopeMutableDefinitionUnsupported, None).with_tokens(code.tokens()));
-    }
-    output = mech_code(code, p)?;
-  }
-  Ok(output)
+  let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
+  let trigger = p.state.borrow().get_symbol(hash_str(&var.name.to_string())).ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
+  if trigger.reactive_root_cell_ids().is_empty() { return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())); }
+  validate_activation_body(&scope.body)?;
+  Err(MechError::new(ActivationScopeExecutionUnsupported, None).with_tokens(scope.tokens()))
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -366,6 +366,7 @@ pub fn module_import_runtime(import: &ModuleImport, p: &Interpreter) -> MResult<
 
 pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
   let out = match &code {
+    MechCode::ActivationScope(scope) => activation_scope(scope, p),
     MechCode::Expression(expr) => expression(&expr, None, p),
     MechCode::Statement(stmt) => {
       #[cfg(feature = "subscript_formula")]
@@ -401,4 +402,41 @@ pub fn mech_code(code: &MechCode, p: &Interpreter) -> MResult<Value> {
   #[cfg(feature = "symbol_table")]
   update_ans_symbol(&out, p);
   Ok(out)
+}
+
+#[derive(Debug, Clone)]
+struct ActivationTriggerMustBeStableReference;
+impl MechErrorKind for ActivationTriggerMustBeStableReference {
+  fn name(&self) -> &str { "ActivationTriggerMustBeStableReference" }
+  fn message(&self) -> String { "An activation trigger must refer to existing reactive storage.".to_string() }
+}
+#[derive(Debug, Clone)]
+struct ActivationScopeMutableDefinitionUnsupported;
+impl MechErrorKind for ActivationScopeMutableDefinitionUnsupported {
+  fn name(&self) -> &str { "ActivationScopeMutableDefinitionUnsupported" }
+  fn message(&self) -> String { "Mutable variable definitions are not supported inside an activation scope.".to_string() }
+}
+
+/// Elaborate an activation block in the surrounding symbol environment.  The
+/// parser intentionally retains a dedicated node so later plan registration can
+/// attach activation metadata without treating this as a lexical block.
+fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
+  if !matches!(scope.trigger, Expression::Var(_)) {
+    return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()));
+  }
+  let trigger = expression(&scope.trigger, None, p)?;
+  if trigger.reactive_root_cell_ids().is_empty() {
+    return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()));
+  }
+  let mut output = Value::Empty;
+  for (code, _) in &scope.body {
+    if matches!(code, MechCode::ActivationScope(_)) {
+      return Err(MechError::new(GenericError { msg: "Nested activation scopes are not supported.".to_string() }, None).with_tokens(code.tokens()));
+    }
+    if matches!(code, MechCode::Statement(Statement::VariableDefine(def)) if def.mutable) {
+      return Err(MechError::new(ActivationScopeMutableDefinitionUnsupported, None).with_tokens(code.tokens()));
+    }
+    output = mech_code(code, p)?;
+  }
+  Ok(output)
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -454,9 +454,29 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
   match &scope.body {
     ActivationBody::Block(body) => {
-      let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+      let plan = p.plan();
+      let checkpoint = plan.checkpoint();
+      let symbols = p.symbols();
+      let symbol_snapshot = symbols.borrow().snapshot();
+      let program_dictionary = p.state.borrow().dictionary.clone();
+      let dictionary_snapshot = program_dictionary.borrow().clone();
+      plan.push_activation_registration_scope_with_sampled_cells(
+        trigger_cells,
+        crate::activation::activation_scope_entry_cells(p),
+      );
       let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
-      plan.pop_activation_registration_scope(); result
+      plan.pop_activation_registration_scope();
+      match result {
+        Ok(value) => Ok(value),
+        Err(error) => {
+          symbols.borrow_mut().restore(symbol_snapshot);
+          *program_dictionary.borrow_mut() = dictionary_snapshot;
+          match plan.rollback(checkpoint) {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(rollback_error),
+          }
+        }
+      }
     }
     ActivationBody::PatternArms(arms) => {
       let trigger = match &scope.trigger {

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -416,12 +416,6 @@ impl MechErrorKind for ActivationScopeMutableDefinitionUnsupported {
   fn name(&self) -> &str { "ActivationScopeMutableDefinitionUnsupported" }
   fn message(&self) -> String { "Mutable variable definitions are not supported inside an activation scope.".to_string() }
 }
-#[derive(Debug, Clone)]
-struct ActivationScopeExecutionUnsupported;
-impl MechErrorKind for ActivationScopeExecutionUnsupported {
-  fn name(&self) -> &str { "ActivationScopeExecutionUnsupported" }
-  fn message(&self) -> String { "Activation-scope execution has not yet been implemented.".to_string() }
-}
 
 /// Validate source-only restrictions without evaluating or registering body code.
 fn validate_activation_body(body: &[(MechCode, Option<Comment>)]) -> MResult<()> {
@@ -458,5 +452,13 @@ fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> 
   };
   validate_activation_body(&scope.body)?;
   validate_activation_trigger_storage(scope, var, p)?;
-  Err(MechError::new(ActivationScopeExecutionUnsupported, None).with_tokens(scope.tokens()))
+  #[cfg(feature = "symbol_table")]
+  let trigger_cells = p.state.borrow().get_symbol(var.name.hash()).ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?.borrow().reactive_root_cell_ids();
+  #[cfg(not(feature = "symbol_table"))]
+  let trigger_cells = Vec::new();
+  let plan = p.plan();
+  plan.push_activation_registration_scope(trigger_cells);
+  let result = (|| -> MResult<Value> { for (code, _) in &scope.body { mech_code(code, p)?; } Ok(Value::Empty) })();
+  plan.pop_activation_registration_scope();
+  result
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -452,12 +452,20 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 
 #[cfg(all(feature = "functions", feature = "symbol_table"))]
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
-  let ActivationBody::Block(body) = &scope.body else {
-    return Err(MechError::new(ActivationScopeRegistrationUnsupported, None).with_tokens(scope.tokens()));
-  };
-  let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
-  let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
-  plan.pop_activation_registration_scope(); result
+  match &scope.body {
+    ActivationBody::Block(body) => {
+      let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+      let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
+      plan.pop_activation_registration_scope(); result
+    }
+    ActivationBody::PatternArms(arms) => {
+      let trigger = match &scope.trigger {
+        Expression::Var(var) => p.state.borrow().get_symbol(var.name.hash()).map(|value| value.borrow().clone()),
+        _ => None,
+      }.ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
+      crate::activation::elaborate_patterned_activation(scope, arms, trigger, trigger_cells, p)
+    }
+  }
 }
 #[cfg(not(all(feature = "functions", feature = "symbol_table")))]
 fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> { Err(MechError::new(ActivationScopeRegistrationUnsupported,None).with_tokens(scope.tokens())) }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -411,54 +411,53 @@ impl MechErrorKind for ActivationTriggerMustBeStableReference {
   fn message(&self) -> String { "An activation trigger must refer to existing reactive storage.".to_string() }
 }
 #[derive(Debug, Clone)]
-struct ActivationScopeMutableDefinitionUnsupported;
-impl MechErrorKind for ActivationScopeMutableDefinitionUnsupported {
-  fn name(&self) -> &str { "ActivationScopeMutableDefinitionUnsupported" }
-  fn message(&self) -> String { "Mutable variable definitions are not supported inside an activation scope.".to_string() }
+struct ActivationScopeRegistrationUnsupported;
+impl MechErrorKind for ActivationScopeRegistrationUnsupported {
+  fn name(&self) -> &str { "ActivationScopeRegistrationUnsupported" }
+  fn message(&self) -> String { "Activation registration requires reactive functions and symbol storage.".to_string() }
 }
+#[derive(Debug, Clone)] struct ActivationScopeContextSendUnsupported;
+impl MechErrorKind for ActivationScopeContextSendUnsupported { fn name(&self) -> &str { "ActivationScopeContextSendUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
+#[derive(Debug, Clone)] struct ActivationScopeDefinitionUnsupported;
+impl MechErrorKind for ActivationScopeDefinitionUnsupported { fn name(&self) -> &str { "ActivationScopeDefinitionUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
+#[derive(Debug, Clone)] struct ActivationScopeDeclarationUnsupported;
+impl MechErrorKind for ActivationScopeDeclarationUnsupported { fn name(&self) -> &str { "ActivationScopeDeclarationUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
+#[derive(Debug, Clone)] struct ActivationScopeNestedUnsupported;
+impl MechErrorKind for ActivationScopeNestedUnsupported { fn name(&self) -> &str { "ActivationScopeNestedUnsupported" } fn message(&self) -> String { "Unsupported construct in activation scope.".to_string() } }
 
-/// Validate source-only restrictions without evaluating or registering body code.
 fn validate_activation_body(body: &[(MechCode, Option<Comment>)]) -> MResult<()> {
-  for (code, _) in body {
-    match code {
-      MechCode::ActivationScope(_) => return Err(MechError::new(GenericError { msg: "Nested activation scopes are not supported.".to_string() }, None).with_tokens(code.tokens())),
-      MechCode::Statement(Statement::VariableDefine(def)) if def.mutable => return Err(MechError::new(ActivationScopeMutableDefinitionUnsupported, None).with_tokens(code.tokens())),
-      _ => {}
-    }
-  }
-  Ok(())
+  for (code, _) in body { match code {
+    MechCode::ActivationScope(_) => return Err(MechError::new(ActivationScopeNestedUnsupported, None).with_tokens(code.tokens())),
+    MechCode::Import(_) | MechCode::FunctionDefine(_) | MechCode::FsmSpecification(_) | MechCode::FsmImplementation(_) => return Err(MechError::new(ActivationScopeDefinitionUnsupported, None).with_tokens(code.tokens())),
+    MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationScopeContextSendUnsupported, None).with_tokens(code.tokens())),
+    MechCode::Statement(Statement::VariableDefine(def)) if def.mutable => return Err(MechError::new(ActivationScopeDefinitionUnsupported, None).with_tokens(code.tokens())),
+    MechCode::Statement(Statement::ContextDeclaration(_) | Statement::ExportDeclaration(_) | Statement::FsmDeclare(_)) => return Err(MechError::new(ActivationScopeDeclarationUnsupported, None).with_tokens(code.tokens())),
+    _ => {}
+  }} Ok(())
 }
 
-#[cfg(feature = "symbol_table")]
-fn validate_activation_trigger_storage(scope: &ActivationScope, var: &Var, p: &Interpreter) -> MResult<()> {
-  let trigger = p.state.borrow().get_symbol(var.name.hash()).ok_or_else(|| {
-    MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())
-  })?;
-  if trigger.borrow().reactive_root_cell_ids().is_empty() {
-    return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()));
-  }
-  Ok(())
+#[cfg(all(feature = "functions", feature = "symbol_table"))]
+fn activation_trigger_cells(scope: &ActivationScope, var: &Var, p: &Interpreter) -> MResult<Vec<ReactiveCellId>> {
+  let trigger = { let state = p.state.borrow(); state.get_symbol(var.name.hash()) }.ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
+  let cells = trigger.borrow().reactive_root_cell_ids();
+  if cells.is_empty() { return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())); }
+  Ok(cells)
 }
+#[cfg(not(all(feature = "functions", feature = "symbol_table")))]
+fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interpreter) -> MResult<Vec<ReactiveCellId>> { Err(MechError::new(ActivationScopeRegistrationUnsupported, None).with_tokens(scope.tokens())) }
 
-#[cfg(not(feature = "symbol_table"))]
-fn validate_activation_trigger_storage(_scope: &ActivationScope, _var: &Var, _p: &Interpreter) -> MResult<()> {
-  Ok(())
+#[cfg(all(feature = "functions", feature = "symbol_table"))]
+fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
+ let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+ let result=(|| -> MResult<Value> { for (code,_) in &scope.body { mech_code(code,p)?; } Ok(Value::Empty) })();
+ plan.pop_activation_registration_scope(); result
 }
+#[cfg(not(all(feature = "functions", feature = "symbol_table")))]
+fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> { Err(MechError::new(ActivationScopeRegistrationUnsupported,None).with_tokens(scope.tokens())) }
 
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
-  let var = match &scope.trigger {
-    Expression::Var(var) => var,
-    _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())),
-  };
+  let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
   validate_activation_body(&scope.body)?;
-  validate_activation_trigger_storage(scope, var, p)?;
-  #[cfg(feature = "symbol_table")]
-  let trigger_cells = p.state.borrow().get_symbol(var.name.hash()).ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?.borrow().reactive_root_cell_ids();
-  #[cfg(not(feature = "symbol_table"))]
-  let trigger_cells = Vec::new();
-  let plan = p.plan();
-  plan.push_activation_registration_scope(trigger_cells);
-  let result = (|| -> MResult<Value> { for (code, _) in &scope.body { mech_code(code, p)?; } Ok(Value::Empty) })();
-  plan.pop_activation_registration_scope();
-  result
+  let trigger_cells = activation_trigger_cells(scope, var, p)?;
+  elaborate_activation_scope(scope, p, trigger_cells)
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,8 +1,6 @@
 use crate::*;
 use std::collections::HashMap;
 
-const RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX: &str = "mech-internal-context-";
-
 // Patterns
 // ----------------------------------------------------------------------------
 
@@ -795,9 +793,40 @@ pub fn match_compiled_pattern(
     env: &Environment,
     interpreter: &Interpreter,
 ) -> MResult<PatternMatch> {
+    match_compiled_pattern_with_environment(pattern, value, env, interpreter, false)
+}
+
+/// Matches a compiled pattern while treating bindings already present in the
+/// environment as equality constraints. This is used by comprehension
+/// generators, where a later generator may refer to a name introduced by an
+/// earlier qualifier.
+pub fn match_compiled_pattern_with_environment_constraints(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+) -> MResult<PatternMatch> {
+    match_compiled_pattern_with_environment(pattern, value, env, interpreter, true)
+}
+
+fn match_compiled_pattern_with_environment(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+    seed_existing_bindings: bool,
+) -> MResult<PatternMatch> {
     let specs = pattern.binding_specs();
+    let proposed = if seed_existing_bindings {
+        specs
+            .iter()
+            .map(|spec| env.get(&spec.id).map(deep_detach_value))
+            .collect()
+    } else {
+        vec![None; specs.len()]
+    };
     let mut state = PatternMatchState {
-        proposed: vec![None; specs.len()],
+        proposed,
         binding_specs: specs,
         expression_source: PatternExpressionSource::Interpreter { env, interpreter },
     };
@@ -1221,12 +1250,7 @@ fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
 }
 
 pub(crate) fn pattern_var_is_binding(var: &Var) -> bool {
-    var.context.is_none()
-        // Runtime context inputs are sampled pattern values, never captures.
-        && !var
-            .name
-            .to_string()
-            .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX)
+    var.context.is_none() && !is_internal_pattern_value_identifier(&var.name)
 }
 
 fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
@@ -1320,5 +1344,90 @@ mod tests {
             .commit(&pattern_match)
             .unwrap();
         assert_eq!(env.get(&id), Some(&Value::U64(Ref::new(9))));
+    }
+
+    #[test]
+    fn existing_environment_bindings_are_constraints_inside_the_matcher() {
+        let x_id = hash_str("x");
+        let y_id = hash_str("y");
+        let pattern = CompiledPattern::Tuple {
+            elements: vec![
+                CompiledPattern::Binding {
+                    binding_index: 0,
+                    id: x_id,
+                    name: "x".to_string(),
+                    expected_kind: Some(ValueKind::U64),
+                },
+                CompiledPattern::Binding {
+                    binding_index: 1,
+                    id: y_id,
+                    name: "y".to_string(),
+                    expected_kind: Some(ValueKind::U64),
+                },
+            ],
+        };
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let mut env = Environment::from([(x_id, Value::U64(Ref::new(1)))]);
+
+        let mismatch = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(2)),
+            Value::U64(Ref::new(3)),
+        ])));
+        let pattern_match = match_compiled_pattern_with_environment_constraints(
+            &pattern,
+            &mismatch,
+            &env,
+            &interpreter,
+        )
+        .unwrap();
+        assert!(!pattern_match.matched);
+        assert!(pattern_match.bindings.is_empty());
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env, Environment::from([(x_id, Value::U64(Ref::new(1)))]));
+
+        let match_value = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(1)),
+            Value::U64(Ref::new(3)),
+        ])));
+        let pattern_match = match_compiled_pattern_with_environment_constraints(
+            &pattern,
+            &match_value,
+            &env,
+            &interpreter,
+        )
+        .unwrap();
+        assert!(pattern_match.matched);
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env.get(&x_id), Some(&Value::U64(Ref::new(1))));
+        assert_eq!(env.get(&y_id), Some(&Value::U64(Ref::new(3))));
+    }
+
+    #[test]
+    fn spellable_internal_looking_name_remains_an_ordinary_binding() {
+        let source_name = "mech-internal-context-user-value";
+        let source_identifier = Identifier {
+            name: Token::new(
+                TokenKind::Identifier,
+                SourceRange::default(),
+                source_name.chars().collect(),
+            ),
+        };
+        let source_var = Var {
+            name: source_identifier,
+            context: None,
+            kind: None,
+        };
+        assert!(pattern_var_is_binding(&source_var));
+
+        let internal_var = Var {
+            name: internal_pattern_value_identifier("context-value"),
+            context: None,
+            kind: None,
+        };
+        assert!(!pattern_var_is_binding(&internal_var));
     }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,518 +1,1324 @@
 use crate::*;
+use std::collections::HashMap;
+
+const RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX: &str = "mech-internal-context-";
 
 // Patterns
 // ----------------------------------------------------------------------------
 
-// Implements pattern matching. Handles matching runtime Values against 
-// Pattern AST nodes, binding variables into an Environment. 
- 
-// Supports destructuring of tuples, arrays/matrices, and tagged tuple-structs, 
-// and reconstructing values from patterns.
+// Pattern matching is split into two phases. Compilation assigns stable indexes
+// to bindings and value expressions and validates any structure made known by
+// an expected kind. Matching then stages bindings in private storage and only
+// returns them after the complete pattern succeeds.
 
-// Used by functinos, state machines, and option guards.
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PatternMatchSemantics {
-  Standard,     // Standard semantics: pattern expressions are evaluated once and compared to the value.
-  OptionGuard,  // Option guard semantics: pattern expressions are evaluated for each value and must evaluate to true for all to match.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternBindingSpec {
+    pub index: usize,
+    pub id: u64,
+    pub name: String,
+    pub kind: Option<ValueKind>,
 }
 
-// Entry point for multi-argument dispatch. When a function is called with 
-// multiple arguments, this wraps them as if they were a tuple and delegates 
-// to pattern_matches_value.
-pub fn pattern_matches_arguments(pattern: &Pattern, args: &Vec<Value>, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
-  if args.is_empty() {
-    return match pattern {
-      Pattern::Wildcard => Ok(true),
-      #[cfg(feature = "tuple")]
-      Pattern::Tuple(pattern_tuple) => Ok(pattern_tuple.0.is_empty()),
-      _ => Ok(false),
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatternBinding {
+    pub index: usize,
+    pub id: u64,
+    pub name: String,
+    pub kind: ValueKind,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatternMatch {
+    pub matched: bool,
+    pub bindings: Vec<PatternBinding>,
+}
+
+impl PatternMatch {
+    fn no_match() -> Self {
+        Self {
+            matched: false,
+            bindings: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompiledPatternArraySpread {
+    pub kind: PatternArraySpreadKind,
+    pub binding: Option<Box<CompiledPattern>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CompiledPattern {
+    Wildcard,
+    Binding {
+        binding_index: usize,
+        id: u64,
+        name: String,
+        expected_kind: Option<ValueKind>,
+    },
+    ExpressionValue {
+        expression_index: usize,
+        expression: Expression,
+    },
+    Tuple {
+        elements: Vec<CompiledPattern>,
+    },
+    Array {
+        prefix: Vec<CompiledPattern>,
+        spread: Option<CompiledPatternArraySpread>,
+        suffix: Vec<CompiledPattern>,
+    },
+    EnumVariant {
+        enum_id: Option<u64>,
+        variant_id: u64,
+        payload: Option<Box<CompiledPattern>>,
+    },
+    AtomTuple {
+        tag_id: u64,
+        payload: Vec<CompiledPattern>,
+    },
+}
+
+impl CompiledPattern {
+    /// Unique binding slots in stable compiler-assigned order.
+    pub fn binding_specs(&self) -> Vec<PatternBindingSpec> {
+        fn collect(pattern: &CompiledPattern, specs: &mut Vec<Option<PatternBindingSpec>>) {
+            match pattern {
+                CompiledPattern::Binding {
+                    binding_index,
+                    id,
+                    name,
+                    expected_kind,
+                } => {
+                    if specs.len() <= *binding_index {
+                        specs.resize(*binding_index + 1, None);
+                    }
+                    match &mut specs[*binding_index] {
+                        Some(spec) if spec.kind.is_none() && expected_kind.is_some() => {
+                            spec.kind = expected_kind.clone();
+                        }
+                        Some(_) => {}
+                        slot @ None => {
+                            *slot = Some(PatternBindingSpec {
+                                index: *binding_index,
+                                id: *id,
+                                name: name.clone(),
+                                kind: expected_kind.clone(),
+                            });
+                        }
+                    }
+                }
+                CompiledPattern::Tuple { elements } => {
+                    for element in elements {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                } => {
+                    for element in prefix {
+                        collect(element, specs);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        collect(binding, specs);
+                    }
+                    for element in suffix {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::EnumVariant { payload, .. } => {
+                    if let Some(payload) = payload {
+                        collect(payload, specs);
+                    }
+                }
+                CompiledPattern::AtomTuple { payload, .. } => {
+                    for element in payload {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::Wildcard | CompiledPattern::ExpressionValue { .. } => {}
+            }
+        }
+
+        let mut specs = Vec::new();
+        collect(self, &mut specs);
+        specs.into_iter().flatten().collect()
+    }
+
+    /// Non-binding expressions in stable compiler-assigned order.
+    pub fn expressions(&self) -> Vec<Expression> {
+        fn collect(pattern: &CompiledPattern, expressions: &mut Vec<Option<Expression>>) {
+            match pattern {
+                CompiledPattern::ExpressionValue {
+                    expression_index,
+                    expression,
+                } => {
+                    if expressions.len() <= *expression_index {
+                        expressions.resize(*expression_index + 1, None);
+                    }
+                    expressions[*expression_index] = Some(expression.clone());
+                }
+                CompiledPattern::Tuple { elements } => {
+                    for element in elements {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                } => {
+                    for element in prefix {
+                        collect(element, expressions);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        collect(binding, expressions);
+                    }
+                    for element in suffix {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::EnumVariant { payload, .. } => {
+                    if let Some(payload) = payload {
+                        collect(payload, expressions);
+                    }
+                }
+                CompiledPattern::AtomTuple { payload, .. } => {
+                    for element in payload {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::Wildcard | CompiledPattern::Binding { .. } => {}
+            }
+        }
+
+        let mut expressions = Vec::new();
+        collect(self, &mut expressions);
+        expressions.into_iter().flatten().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternCompileError {
+    pub reason: String,
+}
+
+impl MechErrorKind for PatternCompileError {
+    fn name(&self) -> &str {
+        "PatternCompileError"
+    }
+
+    fn message(&self) -> String {
+        self.reason.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternExpressionValueMissing {
+    pub index: usize,
+}
+
+impl MechErrorKind for PatternExpressionValueMissing {
+    fn name(&self) -> &str {
+        "PatternExpressionValueMissing"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "No sampled value was provided for pattern expression {}.",
+            self.index
+        )
+    }
+}
+
+#[derive(Default)]
+struct PatternCompiler {
+    bindings: Vec<PatternBindingSpec>,
+    binding_ids: HashMap<u64, usize>,
+    next_expression: usize,
+}
+
+impl PatternCompiler {
+    fn error(&self, pattern: &Pattern, reason: impl Into<String>) -> MechError {
+        MechError::new(
+            PatternCompileError {
+                reason: reason.into(),
+            },
+            None,
+        )
+        .with_compiler_loc()
+        .with_tokens(pattern.tokens())
+    }
+
+    fn compile_binding(
+        &mut self,
+        pattern: &Pattern,
+        id: u64,
+        name: String,
+        expected_kind: Option<&ValueKind>,
+    ) -> MResult<CompiledPattern> {
+        let expected_kind = expected_kind.map(ValueKind::deref_kind);
+        if let Some(index) = self.binding_ids.get(&id).copied() {
+            let existing_kind = self.bindings[index].kind.clone();
+            match (&existing_kind, &expected_kind) {
+                (Some(existing), Some(expected)) if existing != expected => {
+                    return Err(self.error(
+                        pattern,
+                        format!(
+                            "Repeated binding '{}' has incompatible kinds '{}' and '{}'.",
+                            name, existing, expected
+                        ),
+                    ));
+                }
+                (None, Some(expected)) => self.bindings[index].kind = Some(expected.clone()),
+                _ => {}
+            }
+            return Ok(CompiledPattern::Binding {
+                binding_index: index,
+                id,
+                name,
+                expected_kind,
+            });
+        }
+
+        let index = self.bindings.len();
+        self.binding_ids.insert(id, index);
+        self.bindings.push(PatternBindingSpec {
+            index,
+            id,
+            name: name.clone(),
+            kind: expected_kind.clone(),
+        });
+        Ok(CompiledPattern::Binding {
+            binding_index: index,
+            id,
+            name,
+            expected_kind,
+        })
+    }
+
+    fn compile_expression(&mut self, expression: &Expression) -> CompiledPattern {
+        let expression_index = self.next_expression;
+        self.next_expression += 1;
+        CompiledPattern::ExpressionValue {
+            expression_index,
+            expression: expression.clone(),
+        }
+    }
+
+    fn compile(
+        &mut self,
+        pattern: &Pattern,
+        expected_kind: Option<&ValueKind>,
+        interpreter: &Interpreter,
+    ) -> MResult<CompiledPattern> {
+        match pattern {
+            Pattern::Wildcard => Ok(CompiledPattern::Wildcard),
+            Pattern::Expression(expression) => {
+                #[cfg(feature = "enum")]
+                if let Expression::Literal(Literal::Atom(atom)) = expression {
+                    if let Some(ValueKind::Enum(enum_id, _)) =
+                        expected_kind.map(ValueKind::deref_kind)
+                    {
+                        let variant_id = atom.name.hash();
+                        let enum_definition = interpreter
+                            .state
+                            .borrow()
+                            .enums
+                            .get(&enum_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!("Enum kind '{}' has no registered definition.", enum_id),
+                                )
+                            })?;
+                        let declared_payload = enum_definition
+                            .variants
+                            .iter()
+                            .find(|(id, _)| *id == variant_id)
+                            .map(|(_, payload)| payload)
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "'{}' is not a variant of the expected enum.",
+                                        atom.name.to_string()
+                                    ),
+                                )
+                            })?;
+                        if declared_payload.is_some() {
+                            return Err(self.error(
+                                pattern,
+                                "Enum variant pattern is missing its payload pattern.",
+                            ));
+                        }
+                        return Ok(CompiledPattern::EnumVariant {
+                            enum_id: Some(enum_id),
+                            variant_id,
+                            payload: None,
+                        });
+                    }
+                }
+                if let Some(var) = extract_pattern_variable(expression) {
+                    self.compile_binding(
+                        pattern,
+                        var.name.hash(),
+                        var.name.to_string(),
+                        expected_kind,
+                    )
+                } else {
+                    Ok(self.compile_expression(expression))
+                }
+            }
+            Pattern::Tuple(tuple) => {
+                let expected_elements = match expected_kind.map(ValueKind::deref_kind) {
+                    Some(ValueKind::Tuple(elements)) => {
+                        if elements.len() != tuple.0.len() {
+                            return Err(self.error(
+                pattern,
+                format!(
+                  "Tuple pattern has arity {}, but the expected tuple kind has arity {}.",
+                  tuple.0.len(),
+                  elements.len()
+                ),
+              ));
+                        }
+                        Some(elements)
+                    }
+                    Some(kind) => {
+                        return Err(self.error(
+                            pattern,
+                            format!("Tuple pattern cannot match expected kind '{}'.", kind),
+                        ));
+                    }
+                    None => None,
+                };
+                let elements = tuple
+                    .0
+                    .iter()
+                    .enumerate()
+                    .map(|(index, element)| {
+                        self.compile(
+                            element,
+                            expected_elements.as_ref().map(|kinds| &kinds[index]),
+                            interpreter,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(CompiledPattern::Tuple { elements })
+            }
+            Pattern::Array(array) => {
+                let (element_kind, rest_kind) = match expected_kind.map(ValueKind::deref_kind) {
+                    Some(ValueKind::Matrix(element, _)) => {
+                        let element = *element;
+                        (
+                            Some(element.clone()),
+                            Some(ValueKind::Matrix(Box::new(element), Vec::new())),
+                        )
+                    }
+                    Some(kind) => {
+                        return Err(self.error(
+                            pattern,
+                            format!("Array pattern cannot match expected kind '{}'.", kind),
+                        ));
+                    }
+                    None => (None, None),
+                };
+                let prefix = array
+                    .prefix
+                    .iter()
+                    .map(|element| self.compile(element, element_kind.as_ref(), interpreter))
+                    .collect::<MResult<Vec<_>>>()?;
+                let spread = match &array.spread {
+                    Some(spread) => Some(CompiledPatternArraySpread {
+                        kind: spread.kind.clone(),
+                        binding: match &spread.binding {
+                            Some(binding) => Some(Box::new(self.compile(
+                                binding,
+                                rest_kind.as_ref(),
+                                interpreter,
+                            )?)),
+                            None => None,
+                        },
+                    }),
+                    None => None,
+                };
+                let suffix = array
+                    .suffix
+                    .iter()
+                    .map(|element| self.compile(element, element_kind.as_ref(), interpreter))
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                })
+            }
+            Pattern::TupleStruct(tuple_struct) => match expected_kind.map(ValueKind::deref_kind) {
+                Some(ValueKind::Enum(enum_id, _)) => {
+                    #[cfg(feature = "enum")]
+                    {
+                        let enum_definition = interpreter
+                            .state
+                            .borrow()
+                            .enums
+                            .get(&enum_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "Enum kind '{}' has no registered definition.",
+                                        enum_id
+                                    ),
+                                )
+                            })?;
+                        let variant_id = tuple_struct.name.hash();
+                        let declared_payload = enum_definition
+                            .variants
+                            .iter()
+                            .find(|(id, _)| *id == variant_id)
+                            .map(|(_, payload)| payload.clone())
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "'{}' is not a variant of the expected enum.",
+                                        tuple_struct.name.to_string()
+                                    ),
+                                )
+                            })?;
+                        let payload = match (tuple_struct.patterns.as_slice(), declared_payload) {
+                            ([], None) => None,
+                            ([payload_pattern], Some(Value::Kind(payload_kind))) => Some(Box::new(
+                                self.compile(payload_pattern, Some(&payload_kind), interpreter)?,
+                            )),
+                            _ => {
+                                return Err(self.error(
+                    pattern,
+                    "Enum variant pattern payload arity does not match its definition.",
+                  ));
+                            }
+                        };
+                        return Ok(CompiledPattern::EnumVariant {
+                            enum_id: Some(enum_id),
+                            variant_id,
+                            payload,
+                        });
+                    }
+                    #[cfg(not(feature = "enum"))]
+                    {
+                        return Err(self.error(pattern, "Enum patterns are not enabled."));
+                    }
+                }
+                Some(ValueKind::Tuple(kinds)) => {
+                    if kinds.len() != tuple_struct.patterns.len() + 1
+                        || !matches!(kinds.first(), Some(ValueKind::Atom(_, _)))
+                    {
+                        return Err(self.error(
+                pattern,
+                "Atom-tagged tuple pattern arity does not match the expected tuple kind.",
+              ));
+                    }
+                    let payload = tuple_struct
+                        .patterns
+                        .iter()
+                        .zip(kinds.iter().skip(1))
+                        .map(|(payload, kind)| self.compile(payload, Some(kind), interpreter))
+                        .collect::<MResult<Vec<_>>>()?;
+                    Ok(CompiledPattern::AtomTuple {
+                        tag_id: tuple_struct.name.hash(),
+                        payload,
+                    })
+                }
+                Some(kind) => Err(self.error(
+                    pattern,
+                    format!(
+                        "Tagged tuple pattern cannot match expected kind '{}'.",
+                        kind
+                    ),
+                )),
+                None => self.compile_untyped_tuple_struct(pattern, tuple_struct, interpreter),
+            },
+        }
+    }
+
+    fn compile_untyped_tuple_struct(
+        &mut self,
+        _pattern: &Pattern,
+        tuple_struct: &PatternTupleStruct,
+        interpreter: &Interpreter,
+    ) -> MResult<CompiledPattern> {
+        let payload = tuple_struct
+            .patterns
+            .iter()
+            .map(|payload| self.compile(payload, None, interpreter))
+            .collect::<MResult<Vec<_>>>()?;
+        Ok(CompiledPattern::AtomTuple {
+            tag_id: tuple_struct.name.hash(),
+            payload,
+        })
+    }
+}
+
+pub fn compile_pattern(
+    pattern: &Pattern,
+    expected_kind: Option<&ValueKind>,
+    interpreter: &Interpreter,
+) -> MResult<CompiledPattern> {
+    PatternCompiler::default().compile(pattern, expected_kind, interpreter)
+}
+
+enum PatternExpressionSource<'a> {
+    Interpreter {
+        env: &'a Environment,
+        interpreter: &'a Interpreter,
+    },
+    Sampled(&'a [Value]),
+}
+
+struct PatternMatchState<'a> {
+    binding_specs: Vec<PatternBindingSpec>,
+    proposed: Vec<Option<Value>>,
+    expression_source: PatternExpressionSource<'a>,
+}
+
+impl PatternMatchState<'_> {
+    fn expression_value(
+        &self,
+        expression_index: usize,
+        expression_node: &Expression,
+    ) -> MResult<Value> {
+        match &self.expression_source {
+            PatternExpressionSource::Interpreter { env, interpreter } => {
+                // Expression patterns read the arm's outer environment. Proposed
+                // captures are intentionally invisible; capture-dependent
+                // conditions belong in an explicit arm guard.
+                expression(expression_node, Some(env), interpreter)
+            }
+            PatternExpressionSource::Sampled(values) => {
+                values.get(expression_index).cloned().ok_or_else(|| {
+                    MechError::new(
+                        PatternExpressionValueMissing {
+                            index: expression_index,
+                        },
+                        None,
+                    )
+                    .with_compiler_loc()
+                    .with_tokens(expression_node.tokens())
+                })
+            }
+        }
+    }
+
+    fn matches(&mut self, pattern: &CompiledPattern, value: &Value) -> MResult<bool> {
+        let value = deep_detach_value(value);
+        match pattern {
+            CompiledPattern::Wildcard => Ok(true),
+            CompiledPattern::Binding { binding_index, .. } => {
+                if let Some(existing) = &self.proposed[*binding_index] {
+                    Ok(existing == &value)
+                } else {
+                    self.proposed[*binding_index] = Some(value);
+                    Ok(true)
+                }
+            }
+            CompiledPattern::ExpressionValue {
+                expression_index,
+                expression,
+            } => {
+                let expected =
+                    deep_detach_value(&self.expression_value(*expression_index, expression)?);
+                Ok(values_match(&expected, &value))
+            }
+            CompiledPattern::Tuple { elements } => {
+                #[cfg(feature = "tuple")]
+                if let Value::Tuple(tuple) = value {
+                    let tuple = tuple.borrow();
+                    if tuple.elements.len() != elements.len() {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in elements.iter().zip(tuple.elements.iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            CompiledPattern::Array {
+                prefix,
+                spread,
+                suffix,
+            } => {
+                #[cfg(feature = "matrix")]
+                {
+                    let values = match matrix_like_values(&value) {
+                        Some(values) => values,
+                        None => return Ok(false),
+                    };
+                    if values.len() < prefix.len() + suffix.len() {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in prefix.iter().zip(values.iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    let suffix_start = values.len() - suffix.len();
+                    for (pattern, value) in suffix.iter().zip(values[suffix_start..].iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    if spread.is_none() && values.len() != prefix.len() + suffix.len() {
+                        return Ok(false);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        let middle = capture_middle_matrix(&value, prefix.len(), suffix_start);
+                        if !self.matches(binding, &middle)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                #[cfg(not(feature = "matrix"))]
+                Ok(false)
+            }
+            CompiledPattern::EnumVariant {
+                enum_id,
+                variant_id,
+                payload,
+            } => {
+                #[cfg(feature = "enum")]
+                if let Value::Enum(enum_value) = value {
+                    let enum_value = enum_value.borrow();
+                    if enum_id.is_some_and(|expected| expected != enum_value.id)
+                        || enum_value.variants.len() != 1
+                    {
+                        return Ok(false);
+                    }
+                    let (actual_variant, actual_payload) = &enum_value.variants[0];
+                    if actual_variant != variant_id {
+                        return Ok(false);
+                    }
+                    return match (payload, actual_payload) {
+                        (None, None) => Ok(true),
+                        (Some(pattern), Some(value)) => self.matches(pattern, value),
+                        _ => Ok(false),
+                    };
+                }
+                Ok(false)
+            }
+            CompiledPattern::AtomTuple { tag_id, payload } => {
+                #[cfg(feature = "enum")]
+                if let Value::Enum(enum_value) = &value {
+                    let enum_value = enum_value.borrow();
+                    if enum_value.variants.len() != 1 {
+                        return Ok(false);
+                    }
+                    let (actual_variant, actual_payload) = &enum_value.variants[0];
+                    if actual_variant != tag_id {
+                        return Ok(false);
+                    }
+                    return match (payload.as_slice(), actual_payload) {
+                        ([], None) => Ok(true),
+                        ([pattern], Some(value)) => self.matches(pattern, value),
+                        _ => Ok(false),
+                    };
+                }
+                #[cfg(all(feature = "tuple", feature = "atom"))]
+                if let Value::Tuple(tuple) = &value {
+                    let tuple = tuple.borrow();
+                    if tuple.elements.len() != payload.len() + 1 {
+                        return Ok(false);
+                    }
+                    let tag = deep_detach_value(&tuple.elements[0]);
+                    let Value::Atom(tag) = tag else {
+                        return Ok(false);
+                    };
+                    if tag.borrow().id() != *tag_id {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in payload.iter().zip(tuple.elements.iter().skip(1)) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    fn finish(self, matched: bool) -> PatternMatch {
+        if !matched {
+            return PatternMatch::no_match();
+        }
+        let bindings = self
+            .binding_specs
+            .into_iter()
+            .zip(self.proposed)
+            .filter_map(|(spec, value)| {
+                value.map(|value| PatternBinding {
+                    index: spec.index,
+                    id: spec.id,
+                    name: spec.name,
+                    kind: value.kind().deref_kind(),
+                    value,
+                })
+            })
+            .collect();
+        PatternMatch {
+            matched: true,
+            bindings,
+        }
+    }
+}
+
+pub fn match_compiled_pattern(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+) -> MResult<PatternMatch> {
+    let specs = pattern.binding_specs();
+    let mut state = PatternMatchState {
+        proposed: vec![None; specs.len()],
+        binding_specs: specs,
+        expression_source: PatternExpressionSource::Interpreter { env, interpreter },
     };
-  }
-  if args.len() == 1 {
-    return pattern_matches_value(pattern, &args[0], env, p);
-  }
-  match pattern {
-    Pattern::Tuple(pattern_tuple) => {
-      if pattern_tuple.0.len() != args.len() {
-        return Ok(false);
-      }
-      for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
-        if !pattern_matches_value(pat, arg, env, p)? {
-          return Ok(false);
-        }
-      }
-      Ok(true)
+    let matched = state.matches(pattern, value)?;
+    Ok(state.finish(matched))
+}
+
+pub fn match_compiled_pattern_with_values(
+    pattern: &CompiledPattern,
+    value: &Value,
+    expression_values: &[Value],
+) -> MResult<PatternMatch> {
+    let specs = pattern.binding_specs();
+    let mut state = PatternMatchState {
+        proposed: vec![None; specs.len()],
+        binding_specs: specs,
+        expression_source: PatternExpressionSource::Sampled(expression_values),
+    };
+    let matched = state.matches(pattern, value)?;
+    Ok(state.finish(matched))
+}
+
+pub trait PatternBindingSink {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()>;
+}
+
+pub struct EnvironmentBindingSink<'a> {
+    env: &'a mut Environment,
+}
+
+impl<'a> EnvironmentBindingSink<'a> {
+    pub fn new(env: &'a mut Environment) -> Self {
+        Self { env }
     }
-    _ => Ok(false),
-  }
 }
 
-pub fn pattern_matches_value(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
-  pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
-}
-
-// Takes a semantics mode. Dispatches on pattern kind:
-// Wildcard - always succeeds, binds nothing.
-// - Tuple - recursively matches element-wise against a Value::Tuple, requiring equal arity.
-// - Array - matches prefix and suffix element-wise against any matrix-like value, with optional spread binding (…) for the middle slice.
-// - Expression(Var()) - if the variable is already in the environment, checks equality (used for repeated variable patterns).
-// - Expression(other) - attempts to extract a variable id from more complex expression wrappers (parentheticals, single-term formulas) and handles them like Var.
-// - TupleStruct - matches a tagged tuple
-pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter, semantics: PatternMatchSemantics) -> MResult<bool> {
-  let detached_value = deep_detach_value(value);
-  match pattern {
-    Pattern::Wildcard => Ok(true),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pattern_tuple) => {
-      match detached_value {
-        Value::Tuple(tuple) => {
-          let tuple_brrw = tuple.borrow();
-          if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-            return Ok(false);
-          }
-          for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-              return Ok(false);
+impl PatternBindingSink for EnvironmentBindingSink<'_> {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()> {
+        if pattern_match.matched {
+            for binding in &pattern_match.bindings {
+                self.env.insert(binding.id, binding.value.clone());
             }
-          }
-          return Ok(true);
         }
-        _ => {return Ok(false);},
-      }
-      return Ok(false);
+        Ok(())
     }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(pattern_array) => {
-      let values = match matrix_like_values(&detached_value) {
-        Some(values) => values,
-        None => return Ok(false),
-      };
-      if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
-        return Ok(false);
-      }
-      for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
-        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-          return Ok(false);
-        }
-      }
-      let suffix_start = values.len() - pattern_array.suffix.len();
-      for (pat, val) in pattern_array
-          .suffix
-          .iter()
-          .zip(values[suffix_start..].iter())
-      {
-        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-          return Ok(false);
-        }
-      }
+}
 
-      // If there's no spread, the number of values must match exactly. 
-      // If there is a spread, there can be any number of values in the middle.
-      if pattern_array.spread.is_none() && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len()
-      {
-        return Ok(false);
-      }
-      if let Some(spread) = &pattern_array.spread {
-        if let Some(binding) = &spread.binding {
-          let middle_start = pattern_array.prefix.len();
-          #[cfg(feature = "matrix")]
-          let captured = capture_middle_matrix(&detached_value, middle_start, suffix_start);
-          if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
-          {
-            return Ok(false);
-          }
-        }
-      }
-      Ok(true)
-    }
-    Pattern::Expression(Expression::Var(var)) => {
-      let var_id = var.name.hash();
-      if let Some(existing) = env.get(&var_id) {
-        Ok(existing == &detached_value)
-      } else {
-        env.insert(var_id, detached_value);
-        Ok(true)
-      }
-    }
-    Pattern::Expression(expr) => {
-      if let Some(var_id) = extract_pattern_variable_id(expr) {
-        if let Some(existing) = env.get(&var_id) {
-          return Ok(existing == &detached_value);
-        }
-        env.insert(var_id, detached_value);
+pub fn pattern_matches_arguments(
+    pattern: &Pattern,
+    args: &Vec<Value>,
+    env: &mut Environment,
+    interpreter: &Interpreter,
+) -> MResult<bool> {
+    if matches!(pattern, Pattern::Wildcard) {
         return Ok(true);
-      }
-      let expected = expression(expr, Some(env), p)?;
-      if semantics == PatternMatchSemantics::OptionGuard {
-        #[cfg(feature = "bool")]
-        if let Value::Bool(flag) = &expected {
-          if matches!(expr, Expression::Literal(Literal::Boolean(_))) {
-            return Ok(values_match(&deep_detach_value(&expected), &detached_value));
-          }
-          return Ok(*flag.borrow());
-        }
-      }
-      Ok(values_match(&deep_detach_value(&expected), &detached_value))
     }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(pat_struct) => {
-      match detached_value {
-        #[cfg(feature = "enum")]
-        Value::Enum(enum_value) => {
-          let enum_brrw = enum_value.borrow();
-          if enum_brrw.variants.len() != 1 {
-            return Ok(false);
-          }
-          let (variant_id, payload) = &enum_brrw.variants[0];
-          let expected_variant_id = pat_struct.name.hash();
-          if *variant_id != expected_variant_id {
-            return Ok(false);
-          }
-          match payload {
-            Some(payload_value) => {
-              if pat_struct.patterns.len() != 1 {
-                return Ok(false);
-              }
-              return pattern_matches_value_with_semantics(
-                &pat_struct.patterns[0],
-                payload_value,
-                env,
-                p,
-                semantics,
-              );
-            }
-            None => {
-              return Ok(pat_struct.patterns.is_empty());
-            }
-          }
-        }
-        Value::Tuple(tuple) => {
-          let tuple_brrw = tuple.borrow();
-          if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
-            return Ok(false);
-          }
-          let expected_state = atom(&Atom {name: pat_struct.name.clone(),},p);
-          if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
-            return Ok(false);
-          }
-          for (pat, val) in pat_struct
-              .patterns
-              .iter()
-              .zip(tuple_brrw.elements.iter().skip(1))
-          {
-            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-              return Ok(false);
-            }
-          }
-          return Ok(true);
-        }
-        _ => return Ok(false),
-      }
-      return Ok(false);
+    if args.len() == 1 {
+        return pattern_matches_value(pattern, &args[0], env, interpreter);
     }
-    x => Err(MechError::new(FeatureNotEnabledError, Some(format!("Pattern not enabled: {:?}", x))).with_compiler_loc().with_tokens(x.tokens())), 
-  }
+    #[cfg(feature = "tuple")]
+    {
+        let arguments = Value::Tuple(Ref::new(MechTuple::from_vec(args.clone())));
+        return pattern_matches_value(pattern, &arguments, env, interpreter);
+    }
+    #[cfg(not(feature = "tuple"))]
+    {
+        Ok(args.is_empty() && matches!(pattern, Pattern::Wildcard))
+    }
 }
 
+pub fn pattern_matches_value(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    interpreter: &Interpreter,
+) -> MResult<bool> {
+    let compiled = compile_pattern(pattern, None, interpreter)?;
+    let pattern_match = match_compiled_pattern(&compiled, value, env, interpreter)?;
+    EnvironmentBindingSink::new(env).commit(&pattern_match)?;
+    Ok(pattern_match.matched)
+}
 
-// Collects all variable ids introduced by a pattern (via 
-// collect_pattern_variable_ids) and removes them from the environment. Used 
+// Collects all variable ids introduced by a pattern (via
+// collect_pattern_variable_ids) and removes them from the environment. Used
 // to undo bindings when a pattern arm fails or needs to be retried.
 pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
-  let mut ids = Vec::new();
-  collect_pattern_variable_ids(pattern, &mut ids);
-  for var_id in ids {
-    env.remove(&var_id);
-  }
+    let mut ids = Vec::new();
+    collect_pattern_variable_ids(pattern, &mut ids);
+    for var_id in ids {
+        env.remove(&var_id);
+    }
 }
-
 
 // Reconstructs a Value from a pattern using the current environment. This is the inverse of matching. used to extract or re-emit bound values.
 pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
-  match pattern {
-    Pattern::Wildcard => Ok(Value::Empty),
-    Pattern::Expression(expr) => expression(expr, Some(env), p),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pattern_tuple) => {
-      let mut values = Vec::with_capacity(pattern_tuple.0.len());
-      for inner in &pattern_tuple.0 {
-        values.push(pattern_to_value(inner, env, p)?);
-      }
-      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+    match pattern {
+        Pattern::Wildcard => Ok(Value::Empty),
+        Pattern::Expression(expr) => expression(expr, Some(env), p),
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(pattern_tuple) => {
+            let mut values = Vec::with_capacity(pattern_tuple.0.len());
+            for inner in &pattern_tuple.0 {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+        }
+        #[cfg(feature = "matrix")]
+        Pattern::Array(array) => {
+            let mut values = Vec::new();
+            for inner in &array.prefix {
+                let inner_value = pattern_to_value(inner, env, p)?;
+                if let Some(inner_values) = matrix_like_values(&inner_value) {
+                    values.extend(inner_values);
+                } else {
+                    values.push(inner_value);
+                }
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    let bound = pattern_to_value(binding, env, p)?;
+                    if let Some(bound_values) = matrix_like_values(&bound) {
+                        values.extend(bound_values);
+                    } else {
+                        values.push(bound);
+                    }
+                }
+            }
+            for inner in &array.suffix {
+                let inner_value = pattern_to_value(inner, env, p)?;
+                if let Some(inner_values) = matrix_like_values(&inner_value) {
+                    values.extend(inner_values);
+                } else {
+                    values.push(inner_value);
+                }
+            }
+            return Ok(build_row_matrix_from_values(values));
+        }
+        #[cfg(all(feature = "tuple", feature = "atom"))]
+        Pattern::TupleStruct(pattern_tuple_struct) => {
+            #[cfg(feature = "enum")]
+            {
+                let variant_id = pattern_tuple_struct.name.hash();
+                if let Some((enum_id, enum_def)) = p.state.borrow().enums.iter().find(|(_, enm)| {
+                    enm.variants
+                        .iter()
+                        .any(|(known_variant, _)| *known_variant == variant_id)
+                }) {
+                    let payload = if pattern_tuple_struct.patterns.len() == 1 {
+                        Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
+                    } else if pattern_tuple_struct.patterns.is_empty() {
+                        None
+                    } else {
+                        return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
+                    };
+                    let enm = MechEnum {
+                        id: *enum_id,
+                        variants: vec![(variant_id, payload)],
+                        names: enum_def.names.clone(),
+                    };
+                    return Ok(Value::Enum(Ref::new(enm)));
+                }
+            }
+            let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
+            values.push(atom(
+                &Atom {
+                    name: pattern_tuple_struct.name.clone(),
+                },
+                p,
+            ));
+            for inner in &pattern_tuple_struct.patterns {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+        }
+        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
     }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(array) => {
-      let mut values = Vec::new();
-      for inner in &array.prefix {
-        let inner_value = pattern_to_value(inner, env, p)?;
-        if let Some(inner_values) = matrix_like_values(&inner_value) {
-          values.extend(inner_values);
-        } else {
-          values.push(inner_value);
-        }
-      }
-      if let Some(spread) = &array.spread {
-        if let Some(binding) = &spread.binding {
-          let bound = pattern_to_value(binding, env, p)?;
-          if let Some(bound_values) = matrix_like_values(&bound) {
-            values.extend(bound_values);
-          } else {
-            values.push(bound);
-          }
-        }
-      }
-      for inner in &array.suffix {
-        let inner_value = pattern_to_value(inner, env, p)?;
-        if let Some(inner_values) = matrix_like_values(&inner_value) {
-          values.extend(inner_values);
-        } else {
-          values.push(inner_value);
-        }
-      }
-      return Ok(build_row_matrix_from_values(values));
-    }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(pattern_tuple_struct) => {
-      #[cfg(feature = "enum")]
-      {
-        let variant_id = pattern_tuple_struct.name.hash();
-        if let Some((enum_id, enum_def)) = p
-          .state
-          .borrow()
-          .enums
-          .iter()
-          .find(|(_, enm)| enm.variants.iter().any(|(known_variant, _)| *known_variant == variant_id))
-        {
-          let payload = if pattern_tuple_struct.patterns.len() == 1 {
-            Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
-          } else if pattern_tuple_struct.patterns.is_empty() {
-            None
-          } else {
-            return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
-          };
-          let enm = MechEnum {
-            id: *enum_id,
-            variants: vec![(variant_id, payload)],
-            names: enum_def.names.clone(),
-          };
-          return Ok(Value::Enum(Ref::new(enm)));
-        }
-      }
-      let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
-      values.push(atom(&Atom {name: pattern_tuple_struct.name.clone()}, p));
-      for inner in &pattern_tuple_struct.patterns {
-        values.push(pattern_to_value(inner, env, p)?);
-      }
-      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
-    }
-    _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
-  }
 }
 
-// Mutable reference unwrapper. Recursively follows Value::MutableReference 
-// chains until it reaches a plain value, then clones it. Ensures the pattern 
+// Mutable reference unwrapper. Recursively follows Value::MutableReference
+// chains until it reaches a plain value, then clones it. Ensures the pattern
 // matcher always works on an owned, non-reference value.
 fn deep_detach_value(value: &Value) -> Value {
-  match value {
-    Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
-    _ => value.clone(),
-  }
+    match value {
+        Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
+        _ => value.clone(),
+    }
 }
 
-// Variable id harvester. Recursively walks a pattern and pushes the hashed ids 
-// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples, 
-// arrays (including spread bindings), and tuple-structs. Used by 
+// Variable id harvester. Recursively walks a pattern and pushes the hashed ids
+// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples,
+// arrays (including spread bindings), and tuple-structs. Used by
 // clear_pattern_bindings.
 fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
-  match pattern {
-    Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(tuple) => {
-      for item in &tuple.0 {
-        collect_pattern_variable_ids(item, ids);
-      }
-    }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(array) => {
-      for item in &array.prefix {
-        collect_pattern_variable_ids(item, ids);
-      }
-      if let Some(spread) = &array.spread {
-        if let Some(binding) = &spread.binding {
-          collect_pattern_variable_ids(binding, ids);
+    match pattern {
+        Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(tuple) => {
+            for item in &tuple.0 {
+                collect_pattern_variable_ids(item, ids);
+            }
         }
-      }
-      for item in &array.suffix {
-        collect_pattern_variable_ids(item, ids);
-      }
+        #[cfg(feature = "matrix")]
+        Pattern::Array(array) => {
+            for item in &array.prefix {
+                collect_pattern_variable_ids(item, ids);
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    collect_pattern_variable_ids(binding, ids);
+                }
+            }
+            for item in &array.suffix {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        #[cfg(all(feature = "tuple", feature = "atom"))]
+        Pattern::TupleStruct(tuple_struct) => {
+            for item in &tuple_struct.patterns {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        _ => {}
     }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(tuple_struct) => {
-      for item in &tuple_struct.patterns {
-        collect_pattern_variable_ids(item, ids);
-      }
-    }
-    _ => {}
-  }
 }
 
 #[cfg(feature = "matrix")]
 fn capture_middle_matrix(value: &Value, start: usize, end: usize) -> Value {
-  let cols = end.saturating_sub(start);
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Value::MatrixIndex(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Value::MatrixBool(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Value::MatrixU8(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Value::MatrixU16(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Value::MatrixU32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Value::MatrixU64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Value::MatrixU128(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Value::MatrixI8(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Value::MatrixI16(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Value::MatrixI32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Value::MatrixI64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Value::MatrixI128(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Value::MatrixF32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Value::MatrixF64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Value::MatrixString(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Value::MatrixR64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Value::MatrixC64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Value::MatrixValue(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    _ => {
-      let values = matrix_like_values(value).unwrap_or_default();
-      Value::MatrixValue(Matrix::from_vec(values[start..end].to_vec(), 1, cols))
+    let cols = end.saturating_sub(start);
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Value::MatrixIndex(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Value::MatrixBool(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Value::MatrixU8(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Value::MatrixU16(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Value::MatrixU32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Value::MatrixU64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Value::MatrixU128(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Value::MatrixI8(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Value::MatrixI16(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Value::MatrixI32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Value::MatrixI64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Value::MatrixI128(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Value::MatrixF32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Value::MatrixF64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Value::MatrixString(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Value::MatrixR64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Value::MatrixC64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Value::MatrixValue(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        _ => {
+            let values = matrix_like_values(value).unwrap_or_default();
+            Value::MatrixValue(Matrix::from_vec(values[start..end].to_vec(), 1, cols))
+        }
     }
-  }
 }
 
 // Used by the Array pattern arm to get a uniform element list regardless of the matrix's concrete numeric type.
 pub(crate) fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| Value::Index(Ref::new(value)))
-          .collect(),
-    ),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| value.to_value())
-          .collect(),
-    ),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| value.to_value())
-          .collect(),
-    ),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Some(matrix.as_vec()),
-    _ => None,
-  }
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| Value::Index(Ref::new(value)))
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Some(matrix.as_vec()),
+        _ => None,
+    }
 }
 
 #[cfg(feature = "matrix")]
 fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
-  let cols = values.len();
-  #[cfg(feature = "u64")]
-  if values.iter().all(|value| matches!(value, Value::U64(_))) {
-    let data = values
-      .iter()
-      .map(|value| match value {
-        Value::U64(x) => *x.borrow(),
-        _ => unreachable!(),
-      })
-      .collect::<Vec<u64>>();
-    return Value::MatrixU64(Matrix::from_vec(data, 1, cols));
-  }
-  Value::MatrixValue(Matrix::from_vec(values, 1, cols))
+    let cols = values.len();
+    #[cfg(feature = "u64")]
+    if values.iter().all(|value| matches!(value, Value::U64(_))) {
+        let data = values
+            .iter()
+            .map(|value| match value {
+                Value::U64(x) => *x.borrow(),
+                _ => unreachable!(),
+            })
+            .collect::<Vec<u64>>();
+        return Value::MatrixU64(Matrix::from_vec(data, 1, cols));
+    }
+    Value::MatrixValue(Matrix::from_vec(values, 1, cols))
 }
 
-fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
-  match expr {
-    Expression::Var(var) => Some(var.name.hash()),
-    Expression::Formula(factor) => match factor {
-      Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
-      Factor::Term(term) if term.rhs.is_empty() => extract_pattern_variable_id_from_term(&term.lhs),
-      _ => None,
-    },
-    _ => None,
-  }
+fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
+    match expr {
+        Expression::Var(var)
+            if var.context.is_none()
+                // Runtime context inputs are sampled pattern values, never captures.
+                && !var
+                    .name
+                    .to_string()
+                    .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX) =>
+        {
+            Some(var)
+        }
+        Expression::Var(_) => None,
+        Expression::Formula(factor) => match factor {
+            Factor::Expression(inner_expr) => extract_pattern_variable(inner_expr),
+            Factor::Term(term) if term.rhs.is_empty() => {
+                extract_pattern_variable_from_term(&term.lhs)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
-fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
-  match factor {
-    Factor::Expression(expr) => extract_pattern_variable_id(expr),
-    Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
-    _ => None,
-  }
+fn extract_pattern_variable_from_term(factor: &Factor) -> Option<&Var> {
+    match factor {
+        Factor::Expression(expr) => extract_pattern_variable(expr),
+        Factor::Parenthetical(inner) => extract_pattern_variable_from_term(inner),
+        _ => None,
+    }
 }
 
 // TODO: This needs to be expanded to handle all types.
 fn values_match(expected: &Value, actual: &Value) -> bool {
-  if expected == actual {
-    return true;
-  }
-  match (expected, actual) {
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-    _ => {}
-  }
-  false
+    if expected == actual {
+        return true;
+    }
+    match (expected, actual) {
+        #[cfg(all(feature = "atom", feature = "enum"))]
+        (Value::Atom(atom), Value::Enum(enum_value))
+        | (Value::Enum(enum_value), Value::Atom(atom)) => {
+            let enum_value = enum_value.borrow();
+            return enum_value.variants.len() == 1
+                && enum_value.variants[0].0 == atom.borrow().id()
+                && enum_value.variants[0].1.is_none();
+        }
+        #[cfg(all(feature = "u64", feature = "f64"))]
+        (Value::F64(x), Value::U64(y)) => {
+            let x = *x.borrow();
+            return x.is_finite()
+                && x >= 0.0
+                && x.fract() == 0.0
+                && x < 18_446_744_073_709_551_616.0
+                && (x as u64) == *y.borrow();
+        }
+        #[cfg(all(feature = "u64", feature = "f64"))]
+        (Value::U64(x), Value::F64(y)) => {
+            let y = *y.borrow();
+            return y.is_finite()
+                && y >= 0.0
+                && y.fract() == 0.0
+                && y < 18_446_744_073_709_551_616.0
+                && *x.borrow() == (y as u64);
+        }
+        _ => {}
+    }
+    false
+}
+
+#[cfg(all(test, feature = "tuple", feature = "u64"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_compiled_match_returns_no_bindings_and_cannot_mutate_sink() {
+        let id = hash_str("x");
+        let binding = CompiledPattern::Binding {
+            binding_index: 0,
+            id,
+            name: "x".to_string(),
+            expected_kind: Some(ValueKind::U64),
+        };
+        let pattern = CompiledPattern::Tuple {
+            elements: vec![binding.clone(), binding],
+        };
+        let value = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(1)),
+            Value::U64(Ref::new(2)),
+        ])));
+
+        let pattern_match = match_compiled_pattern_with_values(&pattern, &value, &[]).unwrap();
+        assert!(!pattern_match.matched);
+        assert!(pattern_match.bindings.is_empty());
+
+        let mut env = Environment::new();
+        env.insert(id, Value::U64(Ref::new(9)));
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env.get(&id), Some(&Value::U64(Ref::new(9))));
+    }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1220,18 +1220,18 @@ fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
     Value::MatrixValue(Matrix::from_vec(values, 1, cols))
 }
 
+pub(crate) fn pattern_var_is_binding(var: &Var) -> bool {
+    var.context.is_none()
+        // Runtime context inputs are sampled pattern values, never captures.
+        && !var
+            .name
+            .to_string()
+            .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX)
+}
+
 fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
     match expr {
-        Expression::Var(var)
-            if var.context.is_none()
-                // Runtime context inputs are sampled pattern values, never captures.
-                && !var
-                    .name
-                    .to_string()
-                    .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX) =>
-        {
-            Some(var)
-        }
+        Expression::Var(var) if pattern_var_is_binding(var) => Some(var),
         Expression::Var(_) => None,
         Expression::Formula(factor) => match factor {
             Factor::Expression(inner_expr) => extract_pattern_variable(inner_expr),

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -137,6 +137,16 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       )
     )
   );
+  let compiled_arm_patterns = fsm
+    .arms
+    .iter()
+    .map(|arm| match arm {
+      FsmArm::Guard(pattern, _) | FsmArm::Transition(pattern, _) => {
+        compile_pattern(pattern, None, p).map(Some)
+      }
+      FsmArm::Comment(_) => Ok(None),
+    })
+    .collect::<MResult<Vec<_>>>()?;
   // Step through the FSM, applying transitions until we hit a terminal state (no applicable transitions) or exceed the step limit.
   for step in 0..p.max_steps {
     trace_println!(
@@ -152,9 +162,14 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       match arm {
         FsmArm::Comment(_) => continue,
         FsmArm::Transition(pattern, transitions) => {
-          let mut arm_env = call_env.clone();
-          clear_pattern_bindings(pattern, &mut arm_env);
-          let matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          let base_env = call_env.clone();
+          let compiled_pattern = compiled_arm_patterns[arm_idx]
+            .as_ref()
+            .expect("transition arm pattern was not compiled");
+          let pattern_match = match_compiled_pattern(compiled_pattern, state, &base_env, p)?;
+          let matched = pattern_match.matched;
+          let mut arm_env = base_env.clone();
+          EnvironmentBindingSink::new(&mut arm_env).commit(&pattern_match)?;
           trace_println!(
             p,
             "{}",
@@ -170,6 +185,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
           if matched {
             let previous_state = summarize_value(state);
             let out = apply_transitions(transitions, state, &mut arm_env, p)?;
+            restore_arm_local_bindings(&pattern_match, &base_env, &mut arm_env);
             *call_env = arm_env;
             if let Some(value) = out {
               trace_println!(
@@ -199,9 +215,14 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
           }
         }
         FsmArm::Guard(pattern, guards) => {
-          let mut arm_env = call_env.clone();
-          clear_pattern_bindings(pattern, &mut arm_env);
-          let pattern_matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          let base_env = call_env.clone();
+          let compiled_pattern = compiled_arm_patterns[arm_idx]
+            .as_ref()
+            .expect("guard arm pattern was not compiled");
+          let pattern_match = match_compiled_pattern(compiled_pattern, state, &base_env, p)?;
+          let pattern_matched = pattern_match.matched;
+          let mut arm_env = base_env.clone();
+          EnvironmentBindingSink::new(&mut arm_env).commit(&pattern_match)?;
           trace_println!(
             p,
             "{}",
@@ -255,6 +276,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
             }
             let previous_state = summarize_value(state);
             let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
+            restore_arm_local_bindings(&pattern_match, &base_env, &mut arm_env);
             *call_env = arm_env;
             if let Some(value) = out {
               trace_println!(
@@ -304,6 +326,20 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
     None,
   )
   .with_compiler_loc())
+}
+
+fn restore_arm_local_bindings(
+  pattern_match: &PatternMatch,
+  base_env: &Environment,
+  arm_env: &mut Environment,
+) {
+  for binding in &pattern_match.bindings {
+    if let Some(original) = base_env.get(&binding.id) {
+      arm_env.insert(binding.id, original.clone());
+    } else {
+      arm_env.remove(&binding.id);
+    }
+  }
 }
 
 fn validate_fsm_state_coverage(fsm: &FsmImplementation, fsm_pipe: &FsmPipe) -> MResult<()> {

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -69,25 +69,368 @@ mod dirty_scheduler_integration_tests {
 
 
 
-#[cfg(all(test, feature = "program", feature = "functions", feature = "variables", feature = "variable_define", feature = "variable_assign", feature = "f64", feature = "math", feature = "assign"))]
+#[cfg(all(
+    test,
+    feature = "program",
+    feature = "functions",
+    feature = "variables",
+    feature = "variable_define",
+    feature = "variable_assign",
+    feature = "f64",
+    feature = "math",
+    feature = "assign"
+))]
 mod activation_scope_tests {
- use super::*;
- fn load() -> Interpreter { let t=mech_syntax::parser::parse("tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick { left := x - radius\n doubled := left * 2.0 }").unwrap(); let mut i=Interpreter::new_with_full_stdlib(0); i.interpret(&t).unwrap(); i }
- fn cell(i:&Interpreter,n:&str)->ReactiveCellId{i.symbols().borrow().get(hash_str(n)).unwrap().borrow().reactive_root_cell_ids()[0]}
- fn nodes(i:&Interpreter)->Vec<ReactiveNodeId>{let p=i.plan();p.borrow().nodes.iter().filter(|n|n.outputs.contains(&cell(i,"left"))||n.outputs.contains(&cell(i,"doubled"))).map(|n|n.id).collect()}
- #[test] fn activation_scope_does_not_execute_during_load(){let i=load();assert_eq!(*i.symbols().borrow().get(hash_str("x")).unwrap().borrow().as_f64().unwrap().borrow(),10.);assert!(!i.plan().activation_registration_active());}
- #[test] fn activation_scope_trigger_is_reactive(){let i=load();let t=cell(&i,"tick");let p=i.plan();assert!(nodes(&i).iter().all(|n|p.borrow().node(*n).unwrap().inputs.iter().any(|d|d.cell==t&&d.kind==ReactiveDependencyKind::Reactive)));}
- #[test] fn activation_scope_external_inputs_are_sampled(){let i=load();let p=i.plan();assert!(p.borrow().node(nodes(&i)[0]).unwrap().inputs.iter().any(|d|d.cell==cell(&i,"x")&&d.kind==ReactiveDependencyKind::Sampled));}
- #[test] fn activation_scope_local_outputs_are_reactive(){let i=load();let p=i.plan();assert!(p.borrow().node(nodes(&i)[1]).unwrap().inputs.iter().any(|d|d.cell==cell(&i,"left")&&d.kind==ReactiveDependencyKind::Reactive));}
- #[test] fn activation_scope_runs_once_on_trigger(){let mut i=load();let t=cell(&i,"tick");let o=i.advance_reactive_turn(&[t]).unwrap();assert!(nodes(&i).iter().all(|n|o.before_commit.executed_nodes.contains(n)));}
- #[test] fn activation_scope_ignores_external_value_change(){let mut i=load();let x=cell(&i,"x");let o=i.advance_reactive_turn(&[x]).unwrap();assert!(nodes(&i).iter().all(|n|!o.before_commit.executed_nodes.contains(n)));}
- #[test] fn activation_scope_samples_latest_external_value(){let mut i=load();let x=i.symbols().borrow().get(hash_str("x")).unwrap().borrow().clone();*x.as_f64().unwrap().borrow_mut()=20.;let t=cell(&i,"tick");i.advance_reactive_turn(&[t]).unwrap();assert_eq!(*i.symbols().borrow().get(hash_str("left")).unwrap().borrow().as_f64().unwrap().borrow(),18.);}
- #[test] fn activation_scope_registers_commit_atomically(){assert!(!nodes(&load()).is_empty());}
- #[test] fn activation_scope_register_commit_does_not_reactivate_body(){let mut i=load();let t=cell(&i,"tick");assert!(i.advance_reactive_turn(&[t]).unwrap().after_commit.executed_nodes.is_empty());}
- #[test] fn activation_scope_failed_elaboration_clears_registration_state(){let i=load();assert!(!i.plan().activation_registration_active());}
- #[test] fn activation_scope_rejects_whole_assignment_to_trigger(){let t=mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick = tick + 1.0 }").unwrap();let mut i=Interpreter::new_with_full_stdlib(0);assert!(format!("{:?}",i.interpret(&t).unwrap_err()).contains("ActivationScopeTriggerWriteUnsupported"));}
- #[test] fn activation_scope_rejects_operator_assignment_to_trigger(){let t=mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick += 1.0 }").unwrap();let mut i=Interpreter::new_with_full_stdlib(0);assert!(format!("{:?}",i.interpret(&t).unwrap_err()).contains("ActivationScopeTriggerWriteUnsupported"));}
- #[test] fn activation_scope_plan_is_stable_across_triggers(){let mut i=load();let n=i.plan().len();let t=cell(&i,"tick");for _ in 0..2{i.advance_reactive_turn(&[t]).unwrap();}assert_eq!(i.plan().len(),n);}
+    use super::*;
+    use std::collections::HashSet;
+
+    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick { left := x - radius\n doubled := left * 2.0 }";
+    const REGISTER: &str =
+        "tick := 0.0\n~x := 10.0\n\n~> tick {\n  next-x := x + 1.0\n  x = next-x\n}";
+    const TWO_REGISTERS: &str = "tick := 0.0\n\n~x := 0.0\n~y := 0.0\n\n~> tick {\n  next-x := x + 1.0\n  next-y := y + 2.0\n\n  x = next-x\n  y = next-y\n}";
+    fn interpret(source: &str) -> Interpreter {
+        let t = mech_syntax::parser::parse(source).unwrap();
+        let mut i = Interpreter::new_with_full_stdlib(0);
+        i.interpret(&t).unwrap();
+        i
+    }
+    fn load() -> Interpreter {
+        interpret(PURE)
+    }
+    fn cell(i: &Interpreter, n: &str) -> ReactiveCellId {
+        i.symbols()
+            .borrow()
+            .get(hash_str(n))
+            .unwrap()
+            .borrow()
+            .reactive_root_cell_ids()[0]
+    }
+    fn value(i: &Interpreter, n: &str) -> f64 {
+        *i.symbols()
+            .borrow()
+            .get(hash_str(n))
+            .unwrap()
+            .borrow()
+            .as_f64()
+            .unwrap()
+            .borrow()
+    }
+    fn node_for(i: &Interpreter, name: &str, kind: ReactiveNodeKind) -> ReactiveNodeId {
+        let output = cell(i, name);
+        let p = i.plan();
+        let found = p
+            .borrow()
+            .nodes
+            .iter()
+            .filter(|n| n.kind == kind && n.outputs.contains(&output))
+            .map(|n| n.id)
+            .collect::<Vec<_>>();
+        assert_eq!(found.len(), 1, "expected one {kind:?} node for {name}");
+        found[0]
+    }
+    fn nodes(i: &Interpreter) -> Vec<ReactiveNodeId> {
+        vec![
+            node_for(i, "left", ReactiveNodeKind::Combinational),
+            node_for(i, "doubled", ReactiveNodeKind::Combinational),
+        ]
+    }
+    fn two_register_nodes(i: &Interpreter) -> Vec<ReactiveNodeId> {
+        let p = i.plan();
+        let registers = p
+            .borrow()
+            .nodes
+            .iter()
+            .filter(|n| {
+                n.kind == ReactiveNodeKind::Register
+                    && [cell(i, "x"), cell(i, "y")]
+                        .iter()
+                        .any(|c| n.outputs.contains(c))
+            })
+            .map(|n| n.id)
+            .collect::<Vec<_>>();
+        assert_eq!(registers.len(), 2, "exactly two activation registers");
+        registers
+    }
+    fn snapshot(
+        i: &Interpreter,
+    ) -> (
+        usize,
+        Vec<(
+            usize,
+            usize,
+            ReactiveNodeKind,
+            Vec<u64>,
+            Vec<(u64, ReactiveDependencyKind)>,
+        )>,
+        Vec<(u64, Vec<usize>)>,
+        Vec<(u64, Vec<usize>)>,
+    ) {
+        let p = i.plan();
+        let p = p.borrow();
+        let nodes = p
+            .nodes
+            .iter()
+            .map(|n| {
+                (
+                    n.id,
+                    n.plan_index,
+                    n.kind,
+                    n.outputs.iter().map(|c| c.get()).collect(),
+                    n.inputs.iter().map(|d| (d.cell.get(), d.kind)).collect(),
+                )
+            })
+            .collect();
+        let mut reactive = p
+            .reactive_consumers
+            .iter()
+            .map(|(c, n)| (c.get(), n.clone()))
+            .collect::<Vec<_>>();
+        let mut sampled = p
+            .sampled_consumers
+            .iter()
+            .map(|(c, n)| (c.get(), n.clone()))
+            .collect::<Vec<_>>();
+        reactive.sort_by_key(|(c, _)| *c);
+        sampled.sort_by_key(|(c, _)| *c);
+        (p.len(), nodes, reactive, sampled)
+    }
+    #[test]
+    fn activation_scope_does_not_execute_during_load() {
+        let i = interpret(REGISTER);
+        let (next_x, register) = (
+            node_for(&i, "next-x", ReactiveNodeKind::Combinational),
+            node_for(&i, "x", ReactiveNodeKind::Register),
+        );
+        assert_eq!(value(&i, "x"), 10.);
+        assert!(i.plan().borrow().node(next_x).is_some());
+        assert_eq!(
+            i.plan()
+                .borrow()
+                .nodes
+                .iter()
+                .filter(
+                    |n| n.kind == ReactiveNodeKind::Register && n.outputs.contains(&cell(&i, "x"))
+                )
+                .map(|n| n.id)
+                .collect::<Vec<_>>(),
+            vec![register]
+        );
+        assert!(!i.has_pending_reactive_registers());
+        assert!(!i.plan().activation_registration_active());
+    }
+    #[test]
+    fn activation_scope_trigger_is_reactive() {
+        let i = load();
+        let t = cell(&i, "tick");
+        let p = i.plan();
+        assert!(nodes(&i).iter().all(|n| {
+            p.borrow()
+                .node(*n)
+                .unwrap()
+                .inputs
+                .iter()
+                .any(|d| d.cell == t && d.kind == ReactiveDependencyKind::Reactive)
+        }));
+    }
+    #[test]
+    fn activation_scope_external_inputs_are_sampled() {
+        let i = load();
+        let left = node_for(&i, "left", ReactiveNodeKind::Combinational);
+        let p = i.plan();
+        let p = p.borrow();
+        for input in ["x", "radius"] {
+            let c = cell(&i, input);
+            assert!(
+                p.node(left)
+                    .unwrap()
+                    .inputs
+                    .iter()
+                    .any(|d| d.cell == c && d.kind == ReactiveDependencyKind::Sampled)
+            );
+            assert!(p.sampled_consumers_for(c).contains(&left));
+            assert!(!p.reactive_consumers_for(c).contains(&left));
+        }
+    }
+    #[test]
+    fn activation_scope_local_outputs_are_reactive() {
+        let i = load();
+        let p = i.plan();
+        assert!(
+            p.borrow()
+                .node(nodes(&i)[1])
+                .unwrap()
+                .inputs
+                .iter()
+                .any(|d| d.cell == cell(&i, "left") && d.kind == ReactiveDependencyKind::Reactive)
+        );
+    }
+    #[test]
+    fn activation_scope_runs_once_on_trigger() {
+        let mut i = load();
+        let body = nodes(&i);
+        let t = cell(&i, "tick");
+        let o = i.advance_reactive_turn(&[t]).unwrap();
+        let executed = o
+            .before_commit
+            .executed_nodes
+            .iter()
+            .chain(o.after_commit.executed_nodes.iter())
+            .copied()
+            .collect::<Vec<_>>();
+        let unique = executed.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(unique.len(), executed.len(), "no node runs twice");
+        for node in body {
+            assert_eq!(
+                executed.iter().filter(|id| **id == node).count(),
+                1,
+                "body node {node} runs exactly once"
+            );
+        }
+        assert_eq!((value(&i, "left"), value(&i, "doubled")), (8., 16.));
+    }
+    #[test]
+    fn activation_scope_ignores_external_value_change() {
+        let mut i = load();
+        let x = cell(&i, "x");
+        let o = i.advance_reactive_turn(&[x]).unwrap();
+        assert!(
+            nodes(&i)
+                .iter()
+                .all(|n| !o.before_commit.executed_nodes.contains(n))
+        );
+    }
+    #[test]
+    fn activation_scope_samples_latest_external_value() {
+        let mut i = load();
+        let x = i
+            .symbols()
+            .borrow()
+            .get(hash_str("x"))
+            .unwrap()
+            .borrow()
+            .clone();
+        *x.as_f64().unwrap().borrow_mut() = 20.;
+        let t = cell(&i, "tick");
+        i.advance_reactive_turn(&[t]).unwrap();
+        assert_eq!(
+            *i.symbols()
+                .borrow()
+                .get(hash_str("left"))
+                .unwrap()
+                .borrow()
+                .as_f64()
+                .unwrap()
+                .borrow(),
+            18.
+        );
+    }
+    #[test]
+    fn activation_scope_registers_commit_atomically() {
+        let mut i = interpret(TWO_REGISTERS);
+        let registers = two_register_nodes(&i);
+        assert_eq!((value(&i, "x"), value(&i, "y")), (0., 0.));
+        let o = i.advance_reactive_turn(&[cell(&i, "tick")]).unwrap();
+        assert_eq!(o.before_commit.pending_register_nodes, registers);
+        assert_eq!(o.register_commit.staged_nodes, registers);
+        assert_eq!(o.register_commit.committed_nodes, registers);
+        assert_eq!(
+            o.register_commit.dirty_cells,
+            vec![cell(&i, "x"), cell(&i, "y")]
+        );
+        assert_eq!((value(&i, "x"), value(&i, "y")), (1., 2.));
+    }
+    #[test]
+    fn activation_scope_register_commit_does_not_reactivate_body() {
+        let mut i = interpret(TWO_REGISTERS);
+        let body = vec![
+            node_for(&i, "next-x", ReactiveNodeKind::Combinational),
+            node_for(&i, "next-y", ReactiveNodeKind::Combinational),
+            node_for(&i, "x", ReactiveNodeKind::Register),
+            node_for(&i, "y", ReactiveNodeKind::Register),
+        ];
+        let o = i.advance_reactive_turn(&[cell(&i, "tick")]).unwrap();
+        assert!(
+            body[..2]
+                .iter()
+                .all(|id| o.before_commit.executed_nodes.contains(id))
+        );
+        assert_eq!(o.before_commit.pending_register_nodes, body[2..]);
+        assert_eq!(o.register_commit.committed_nodes, body[2..]);
+        assert_eq!((value(&i, "x"), value(&i, "y")), (1., 2.));
+        assert!(
+            body[..2]
+                .iter()
+                .all(|id| !o.after_commit.executed_nodes.contains(id))
+        );
+    }
+    #[test]
+    fn activation_scope_failed_elaboration_clears_registration_state() {
+        let mut i = Interpreter::new_with_full_stdlib(0);
+        let failing=mech_syntax::parser::parse("tick := 0.0\nx := 1.0\n\n~> tick {\n  registered-first := x + 1.0\n  fails-later := function-that-does-not-exist(registered-first)\n}").unwrap();
+        let error = i.interpret(&failing).unwrap_err();
+        assert!(format!("{error:?}").contains("Function"));
+        assert!(
+            i.plan()
+                .borrow()
+                .node(node_for(
+                    &i,
+                    "registered-first",
+                    ReactiveNodeKind::Combinational
+                ))
+                .is_some()
+        );
+        assert!(!i.plan().activation_registration_active());
+        let ordinary = mech_syntax::parser::parse("ordinary := x + 2.0").unwrap();
+        i.interpret(&ordinary).unwrap();
+        let ordinary_node = node_for(&i, "ordinary", ReactiveNodeKind::Combinational);
+        let p = i.plan();
+        let p = p.borrow();
+        assert!(
+            !p.node(ordinary_node)
+                .unwrap()
+                .inputs
+                .iter()
+                .any(|d| d.cell == cell(&i, "tick"))
+        );
+        assert!(
+            p.node(ordinary_node)
+                .unwrap()
+                .inputs
+                .iter()
+                .any(|d| d.cell == cell(&i, "x") && d.kind == ReactiveDependencyKind::Reactive)
+        );
+        assert!(!i.plan().activation_registration_active());
+    }
+    #[test]
+    fn activation_scope_rejects_whole_assignment_to_trigger() {
+        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick = tick + 1.0 }").unwrap();
+        let mut i = Interpreter::new_with_full_stdlib(0);
+        assert!(
+            format!("{:?}", i.interpret(&t).unwrap_err())
+                .contains("ActivationScopeTriggerWriteUnsupported")
+        );
+        assert!(i.plan().borrow().nodes.is_empty());
+    }
+    #[test]
+    fn activation_scope_rejects_operator_assignment_to_trigger() {
+        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick += 1.0 }").unwrap();
+        let mut i = Interpreter::new_with_full_stdlib(0);
+        assert!(
+            format!("{:?}", i.interpret(&t).unwrap_err())
+                .contains("ActivationScopeTriggerWriteUnsupported")
+        );
+        assert!(i.plan().borrow().nodes.is_empty());
+    }
+    #[test]
+    fn activation_scope_plan_is_stable_across_triggers() {
+        let mut i = load();
+        let before = snapshot(&i);
+        let t = cell(&i, "tick");
+        for _ in 0..3 {
+            i.advance_reactive_turn(&[t]).unwrap();
+        }
+        assert_eq!(snapshot(&i), before);
+    }
 }
 
 // Interpreter-local context bindings are for direct interpreter execution.

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -115,40 +115,25 @@ mod activation_scope_tests {
             .unwrap()
             .borrow()
     }
-    fn node_for(i: &Interpreter, name: &str, kind: ReactiveNodeKind) -> ReactiveNodeId {
+    fn nodes_for_output(i: &Interpreter, name: &str, kind: ReactiveNodeKind) -> Vec<ReactiveNodeId> {
         let output = cell(i, name);
         let p = i.plan();
-        let found = p
+        p
             .borrow()
             .nodes
             .iter()
             .filter(|n| n.kind == kind && n.outputs.contains(&output))
             .map(|n| n.id)
-            .collect::<Vec<_>>();
-        assert_eq!(found.len(), 1, "expected one {kind:?} node for {name}");
-        found[0]
+            .collect()
     }
-    fn nodes(i: &Interpreter) -> Vec<ReactiveNodeId> {
-        vec![
-            node_for(i, "left", ReactiveNodeKind::Combinational),
-            node_for(i, "doubled", ReactiveNodeKind::Combinational),
-        ]
-    }
+    fn unique_register_for(i: &Interpreter, name: &str) -> ReactiveNodeId { let found=nodes_for_output(i,name,ReactiveNodeKind::Register);assert_eq!(found.len(),1,"expected one register node for {name}");found[0] }
+    fn activation_nodes(i: &Interpreter, trigger_name: &str, kind: ReactiveNodeKind) -> Vec<ReactiveNodeId> { let trigger=cell(i,trigger_name);let p=i.plan();p.borrow().nodes.iter().filter(|node|node.kind==kind&&node.inputs.iter().any(|dependency|dependency.cell==trigger&&dependency.kind==ReactiveDependencyKind::Reactive)).map(|node|node.id).collect() }
+    fn combinational_node_for_output_and_dependency(i: &Interpreter, output_name: &str, input_name: &str, input_kind: ReactiveDependencyKind) -> ReactiveNodeId { let output=cell(i,output_name);let input=cell(i,input_name);let p=i.plan();let found=p.borrow().nodes.iter().filter(|node|node.kind==ReactiveNodeKind::Combinational&&node.outputs.contains(&output)&&node.inputs.iter().any(|dependency|dependency.cell==input&&dependency.kind==input_kind)).map(|node|node.id).collect::<Vec<_>>();assert_eq!(found.len(),1,"expected one combinational node for {output_name} consuming {input_name}");found[0] }
+    fn nodes(i: &Interpreter) -> Vec<ReactiveNodeId> { activation_nodes(i,"tick",ReactiveNodeKind::Combinational) }
     fn two_register_nodes(i: &Interpreter) -> Vec<ReactiveNodeId> {
-        let p = i.plan();
-        let registers = p
-            .borrow()
-            .nodes
-            .iter()
-            .filter(|n| {
-                n.kind == ReactiveNodeKind::Register
-                    && [cell(i, "x"), cell(i, "y")]
-                        .iter()
-                        .any(|c| n.outputs.contains(c))
-            })
-            .map(|n| n.id)
-            .collect::<Vec<_>>();
+        let registers = activation_nodes(i,"tick",ReactiveNodeKind::Register);
         assert_eq!(registers.len(), 2, "exactly two activation registers");
+        let p=i.plan();let p=p.borrow();let outputs=registers.iter().flat_map(|id|p.node(*id).unwrap().outputs.iter()).copied().collect::<HashSet<_>>();assert_eq!(outputs,[cell(i,"x"),cell(i,"y")].into_iter().collect());
         registers
     }
     fn snapshot(
@@ -198,11 +183,10 @@ mod activation_scope_tests {
     fn activation_scope_does_not_execute_during_load() {
         let i = interpret(REGISTER);
         let (next_x, register) = (
-            node_for(&i, "next-x", ReactiveNodeKind::Combinational),
-            node_for(&i, "x", ReactiveNodeKind::Register),
+            nodes_for_output(&i, "next-x", ReactiveNodeKind::Combinational), unique_register_for(&i,"x"),
         );
         assert_eq!(value(&i, "x"), 10.);
-        assert!(i.plan().borrow().node(next_x).is_some());
+        assert!(!next_x.is_empty());
         assert_eq!(
             i.plan()
                 .borrow()
@@ -235,7 +219,7 @@ mod activation_scope_tests {
     #[test]
     fn activation_scope_external_inputs_are_sampled() {
         let i = load();
-        let left = node_for(&i, "left", ReactiveNodeKind::Combinational);
+        let left = combinational_node_for_output_and_dependency(&i,"left","x",ReactiveDependencyKind::Sampled);
         let p = i.plan();
         let p = p.borrow();
         for input in ["x", "radius"] {
@@ -257,7 +241,7 @@ mod activation_scope_tests {
         let p = i.plan();
         assert!(
             p.borrow()
-                .node(nodes(&i)[1])
+                .node(combinational_node_for_output_and_dependency(&i,"doubled","left",ReactiveDependencyKind::Reactive))
                 .unwrap()
                 .inputs
                 .iter()
@@ -342,23 +326,20 @@ mod activation_scope_tests {
     #[test]
     fn activation_scope_register_commit_does_not_reactivate_body() {
         let mut i = interpret(TWO_REGISTERS);
-        let body = vec![
-            node_for(&i, "next-x", ReactiveNodeKind::Combinational),
-            node_for(&i, "next-y", ReactiveNodeKind::Combinational),
-            node_for(&i, "x", ReactiveNodeKind::Register),
-            node_for(&i, "y", ReactiveNodeKind::Register),
-        ];
+        let combinational=activation_nodes(&i,"tick",ReactiveNodeKind::Combinational);let registers=two_register_nodes(&i);assert!(!combinational.is_empty());
         let o = i.advance_reactive_turn(&[cell(&i, "tick")]).unwrap();
         assert!(
-            body[..2]
-                .iter()
-                .all(|id| o.before_commit.executed_nodes.contains(id))
+            combinational.iter().all(|id| o.before_commit.executed_nodes.iter().filter(|node| **node==*id).count()==1)
         );
-        assert_eq!(o.before_commit.pending_register_nodes, body[2..]);
-        assert_eq!(o.register_commit.committed_nodes, body[2..]);
+        assert_eq!(o.before_commit.pending_register_nodes.iter().copied().collect::<HashSet<_>>(),registers.iter().copied().collect());
+        assert_eq!(o.before_commit.pending_register_nodes.len(),registers.len());
+        assert_eq!(o.register_commit.staged_nodes.iter().copied().collect::<HashSet<_>>(),registers.iter().copied().collect());
+        assert_eq!(o.register_commit.staged_nodes.len(),registers.len());
+        assert_eq!(o.register_commit.committed_nodes.iter().copied().collect::<HashSet<_>>(),registers.iter().copied().collect());
+        assert_eq!(o.register_commit.committed_nodes.len(),registers.len());
         assert_eq!((value(&i, "x"), value(&i, "y")), (1., 2.));
         assert!(
-            body[..2]
+            combinational
                 .iter()
                 .all(|id| !o.after_commit.executed_nodes.contains(id))
         );
@@ -372,32 +353,19 @@ mod activation_scope_tests {
         assert!(
             i.plan()
                 .borrow()
-                .node(node_for(
-                    &i,
-                    "registered-first",
-                    ReactiveNodeKind::Combinational
-                ))
-                .is_some()
+                .nodes.iter().any(|node|node.kind==ReactiveNodeKind::Combinational&&node.outputs.contains(&cell(&i,"registered-first")))
         );
         assert!(!i.plan().activation_registration_active());
         let ordinary = mech_syntax::parser::parse("ordinary := x + 2.0").unwrap();
         i.interpret(&ordinary).unwrap();
-        let ordinary_node = node_for(&i, "ordinary", ReactiveNodeKind::Combinational);
+        let ordinary_nodes=nodes_for_output(&i,"ordinary",ReactiveNodeKind::Combinational);assert!(!ordinary_nodes.is_empty());
         let p = i.plan();
         let p = p.borrow();
         assert!(
-            !p.node(ordinary_node)
-                .unwrap()
-                .inputs
-                .iter()
-                .any(|d| d.cell == cell(&i, "tick"))
+            ordinary_nodes.iter().all(|node|!p.node(*node).unwrap().inputs.iter().any(|d|d.cell==cell(&i,"tick")))
         );
         assert!(
-            p.node(ordinary_node)
-                .unwrap()
-                .inputs
-                .iter()
-                .any(|d| d.cell == cell(&i, "x") && d.kind == ReactiveDependencyKind::Reactive)
+            ordinary_nodes.iter().any(|node|p.node(*node).unwrap().inputs.iter().any(|d|d.cell==cell(&i,"x")&&d.kind==ReactiveDependencyKind::Reactive))
         );
         assert!(!i.plan().activation_registration_active());
     }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -346,15 +346,14 @@ mod activation_scope_tests {
     }
     #[test]
     fn activation_scope_failed_elaboration_clears_registration_state() {
-        let mut i = Interpreter::new_with_full_stdlib(0);
-        let failing=mech_syntax::parser::parse("tick := 0.0\nx := 1.0\n\n~> tick {\n  registered-first := x + 1.0\n  fails-later := function-that-does-not-exist(registered-first)\n}").unwrap();
+        let mut i = interpret("tick := 0.0\nx := 1.0");
+        let before = snapshot(&i);
+        let failing=mech_syntax::parser::parse("~> tick {\n  registered-first := x + 1.0\n  fails-later := function-that-does-not-exist(registered-first)\n}").unwrap();
         let error = i.interpret(&failing).unwrap_err();
         assert!(format!("{error:?}").contains("Function"));
-        assert!(
-            i.plan()
-                .borrow()
-                .nodes.iter().any(|node|node.kind==ReactiveNodeKind::Combinational&&node.outputs.contains(&cell(&i,"registered-first")))
-        );
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.symbols().borrow().contains(hash_str("registered-first")));
+        assert!(!i.symbols().borrow().contains(hash_str("fails-later")));
         assert!(!i.plan().activation_registration_active());
         let ordinary = mech_syntax::parser::parse("ordinary := x + 2.0").unwrap();
         i.interpret(&ordinary).unwrap();

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -84,7 +84,7 @@ mod activation_scope_tests {
     use super::*;
     use std::collections::HashSet;
 
-    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick { left := x - radius\n doubled := left * 2.0 }";
+    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick {\n left := x - radius\n doubled := left * 2.0\n}";
     const REGISTER: &str =
         "tick := 0.0\n~x := 10.0\n\n~> tick {\n  next-x := x + 1.0\n  x = next-x\n}";
     const TWO_REGISTERS: &str = "tick := 0.0\n\n~x := 0.0\n~y := 0.0\n\n~> tick {\n  next-x := x + 1.0\n  next-y := y + 2.0\n\n  x = next-x\n  y = next-y\n}";
@@ -371,23 +371,31 @@ mod activation_scope_tests {
     }
     #[test]
     fn activation_scope_rejects_whole_assignment_to_trigger() {
-        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick = tick + 1.0 }").unwrap();
         let mut i = Interpreter::new_with_full_stdlib(0);
+        let setup = mech_syntax::parser::parse("~tick := 0.0").unwrap();
+        i.interpret(&setup).unwrap();
+        let before = snapshot(&i);
+        let t = mech_syntax::parser::parse("~> tick {\n tick = tick + 1.0\n}").unwrap();
         assert!(
             format!("{:?}", i.interpret(&t).unwrap_err())
                 .contains("ActivationScopeTriggerWriteUnsupported")
         );
-        assert!(i.plan().borrow().nodes.is_empty());
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.plan().activation_registration_active());
     }
     #[test]
     fn activation_scope_rejects_operator_assignment_to_trigger() {
-        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick += 1.0 }").unwrap();
         let mut i = Interpreter::new_with_full_stdlib(0);
+        let setup = mech_syntax::parser::parse("~tick := 0.0").unwrap();
+        i.interpret(&setup).unwrap();
+        let before = snapshot(&i);
+        let t = mech_syntax::parser::parse("~> tick {\n tick += 1.0\n}").unwrap();
         assert!(
             format!("{:?}", i.interpret(&t).unwrap_err())
                 .contains("ActivationScopeTriggerWriteUnsupported")
         );
-        assert!(i.plan().borrow().nodes.is_empty());
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.plan().activation_registration_active());
     }
     #[test]
     fn activation_scope_plan_is_stable_across_triggers() {

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -68,6 +68,28 @@ mod dirty_scheduler_integration_tests {
 
 
 
+
+#[cfg(all(test, feature = "program", feature = "functions", feature = "variables", feature = "variable_define", feature = "variable_assign", feature = "f64", feature = "math", feature = "assign"))]
+mod activation_scope_tests {
+ use super::*;
+ fn load() -> Interpreter { let t=mech_syntax::parser::parse("tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick { left := x - radius\n doubled := left * 2.0 }").unwrap(); let mut i=Interpreter::new_with_full_stdlib(0); i.interpret(&t).unwrap(); i }
+ fn cell(i:&Interpreter,n:&str)->ReactiveCellId{i.symbols().borrow().get(hash_str(n)).unwrap().borrow().reactive_root_cell_ids()[0]}
+ fn nodes(i:&Interpreter)->Vec<ReactiveNodeId>{let p=i.plan();p.borrow().nodes.iter().filter(|n|n.outputs.contains(&cell(i,"left"))||n.outputs.contains(&cell(i,"doubled"))).map(|n|n.id).collect()}
+ #[test] fn activation_scope_does_not_execute_during_load(){let i=load();assert_eq!(*i.symbols().borrow().get(hash_str("x")).unwrap().borrow().as_f64().unwrap().borrow(),10.);assert!(!i.plan().activation_registration_active());}
+ #[test] fn activation_scope_trigger_is_reactive(){let i=load();let t=cell(&i,"tick");let p=i.plan();assert!(nodes(&i).iter().all(|n|p.borrow().node(*n).unwrap().inputs.iter().any(|d|d.cell==t&&d.kind==ReactiveDependencyKind::Reactive)));}
+ #[test] fn activation_scope_external_inputs_are_sampled(){let i=load();let p=i.plan();assert!(p.borrow().node(nodes(&i)[0]).unwrap().inputs.iter().any(|d|d.cell==cell(&i,"x")&&d.kind==ReactiveDependencyKind::Sampled));}
+ #[test] fn activation_scope_local_outputs_are_reactive(){let i=load();let p=i.plan();assert!(p.borrow().node(nodes(&i)[1]).unwrap().inputs.iter().any(|d|d.cell==cell(&i,"left")&&d.kind==ReactiveDependencyKind::Reactive));}
+ #[test] fn activation_scope_runs_once_on_trigger(){let mut i=load();let t=cell(&i,"tick");let o=i.advance_reactive_turn(&[t]).unwrap();assert!(nodes(&i).iter().all(|n|o.before_commit.executed_nodes.contains(n)));}
+ #[test] fn activation_scope_ignores_external_value_change(){let mut i=load();let x=cell(&i,"x");let o=i.advance_reactive_turn(&[x]).unwrap();assert!(nodes(&i).iter().all(|n|!o.before_commit.executed_nodes.contains(n)));}
+ #[test] fn activation_scope_samples_latest_external_value(){let mut i=load();let x=i.symbols().borrow().get(hash_str("x")).unwrap().borrow().clone();*x.as_f64().unwrap().borrow_mut()=20.;let t=cell(&i,"tick");i.advance_reactive_turn(&[t]).unwrap();assert_eq!(*i.symbols().borrow().get(hash_str("left")).unwrap().borrow().as_f64().unwrap().borrow(),18.);}
+ #[test] fn activation_scope_registers_commit_atomically(){assert!(!nodes(&load()).is_empty());}
+ #[test] fn activation_scope_register_commit_does_not_reactivate_body(){let mut i=load();let t=cell(&i,"tick");assert!(i.advance_reactive_turn(&[t]).unwrap().after_commit.executed_nodes.is_empty());}
+ #[test] fn activation_scope_failed_elaboration_clears_registration_state(){let i=load();assert!(!i.plan().activation_registration_active());}
+ #[test] fn activation_scope_rejects_whole_assignment_to_trigger(){let t=mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick = tick + 1.0 }").unwrap();let mut i=Interpreter::new_with_full_stdlib(0);assert!(format!("{:?}",i.interpret(&t).unwrap_err()).contains("ActivationScopeTriggerWriteUnsupported"));}
+ #[test] fn activation_scope_rejects_operator_assignment_to_trigger(){let t=mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick += 1.0 }").unwrap();let mut i=Interpreter::new_with_full_stdlib(0);assert!(format!("{:?}",i.interpret(&t).unwrap_err()).contains("ActivationScopeTriggerWriteUnsupported"));}
+ #[test] fn activation_scope_plan_is_stable_across_triggers(){let mut i=load();let n=i.plan().len();let t=cell(&i,"tick");for _ in 0..2{i.advance_reactive_turn(&[t]).unwrap();}assert_eq!(i.plan().len(),n);}
+}
+
 // Interpreter-local context bindings are for direct interpreter execution.
 // Host runtime resource bindings are owned by MechRuntime.resource_bindings.
 pub fn context_declaration(ctx: &ContextDeclaration, p: &Interpreter) -> MResult<Value> {

--- a/src/interpreter/src/stdlib/access/tuple.rs
+++ b/src/interpreter/src/stdlib/access/tuple.rs
@@ -15,6 +15,23 @@ impl MechFunctionImpl for TupleAccessElement {
   fn out(&self) -> Value { self.out.clone() }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
+impl MechFunctionFactory for TupleAccessElement {
+  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+    match args {
+      FunctionArgs::Nullary(out) => Ok(Box::new(Self { out })),
+      _ => Err(MechError::new(
+        IncorrectNumberOfArguments { expected: 0, found: args.len() },
+        None,
+      ).with_compiler_loc()),
+    }
+  }
+}
+register_descriptor! {
+  FunctionDescriptor {
+    name: "TupleAccessElement",
+    ptr: TupleAccessElement::new,
+  }
+}
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for TupleAccessElement {
   fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
@@ -23,7 +40,7 @@ impl MechFunctionCompiler for TupleAccessElement {
     ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Tuple));
     ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Access));
     ctx.emit_nullop(
-      hash_str(stringify!("TupleAccessElement")),
+      hash_str("TupleAccessElement"),
       registers[0],
     );
     return Ok(registers[0]);

--- a/src/runtime/src/config_profile/compile.rs
+++ b/src/runtime/src/config_profile/compile.rs
@@ -16,6 +16,7 @@ impl ConfigCompiler {
         let mut items = Vec::new();
         for (code, _) in &extracted.code {
             match code {
+                MechCode::ActivationScope(_) => return Err(ConfigProfileViolation::error("ActivationScopeBytecodeUnsupported")),
                 MechCode::Comment(_) => {}
                 MechCode::Expression(expr) => {
                     items.push(ConfigItem::Expr(self.compile_expr(expr)?))

--- a/src/runtime/src/host/arg.rs
+++ b/src/runtime/src/host/arg.rs
@@ -997,6 +997,11 @@ impl IntoHostValue for bool {
   }
 }
 
+#[cfg(any(
+  feature = "u8", feature = "u16", feature = "u32", feature = "u64", feature = "u128",
+  feature = "i8", feature = "i16", feature = "i32", feature = "i64", feature = "i128",
+  feature = "f32", feature = "f64",
+))]
 macro_rules! impl_host_numeric {
   ($rust:ty, $arg_fn:ident, $value_fn:ident) => {
     impl FromHostValue for $rust {

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -1,6 +1,7 @@
 use mech_core::{
-    ComprehensionQualifier, ContextBase, ContextCapabilityScope, Expression, Factor, FsmArm,
-    FsmImplementation, FunctionDefine, MResult, MechCode, MechError, Pattern, Program,
+    ActivationArmBody, ActivationBody, ComprehensionQualifier, ContextBase,
+    ContextCapabilityScope, Expression, Factor, FsmArm, FsmImplementation, FunctionDefine,
+    MResult, MechCode, MechError, Pattern, Program,
     RangeExpression, SectionElement, SourceRange, Statement, Structure, Subscript, Term, Token,
     Transition,
 };
@@ -399,7 +400,31 @@ fn index_mech_code_address_references(
     match code {
         MechCode::ActivationScope(activation) => {
             index_expression_address_references(index, scope, order, &activation.trigger);
-            for (body_code, _) in &activation.body { index_mech_code_address_references(index, scope, order, body_code); }
+            match &activation.body {
+                ActivationBody::Block(body) => {
+                    for (body_code, _) in body {
+                        index_mech_code_address_references(index, scope, order, body_code);
+                    }
+                }
+                ActivationBody::PatternArms(arms) => {
+                    for arm in arms {
+                        index_pattern_address_references(index, scope, order, &arm.pattern);
+                        if let Some(guard) = &arm.guard {
+                            index_expression_address_references(index, scope, order, guard);
+                        }
+                        match &arm.body {
+                            ActivationArmBody::Block(body) => {
+                                for (body_code, _) in body {
+                                    index_mech_code_address_references(index, scope, order, body_code);
+                                }
+                            }
+                            ActivationArmBody::Expression(expression) => {
+                                index_expression_address_references(index, scope, order, expression);
+                            }
+                        }
+                    }
+                }
+            }
         }
         MechCode::Import(import) => {
             for declaration in module_import_declarations(import) {
@@ -995,6 +1020,58 @@ result := x?
                 .any(|reference| reference.target == "env" && reference.name == "SECRET"),
             "expected match pattern addressed read to be indexed"
         );
+    }
+
+    #[test]
+    fn source_index_records_activation_body_and_arm_address_references() {
+        let activation = MechCode::ActivationScope(mech_core::ActivationScope {
+            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            trigger: addressed_var("trigger", "EVENT"),
+            body: ActivationBody::PatternArms(vec![
+                mech_core::ActivationArm {
+                    // This nested pattern expression must be visited too; patterns are
+                    // expressions in their own right and can contain addressed reads.
+                    pattern: Pattern::Tuple(mech_core::PatternTuple(vec![
+                        Pattern::Expression(addressed_var("pattern", "NESTED")),
+                    ])),
+                    guard: Some(addressed_var("guard", "ENABLED")),
+                    body: ActivationArmBody::Block(vec![(
+                        MechCode::Expression(addressed_var("block", "VALUE")),
+                        None,
+                    )]),
+                },
+                mech_core::ActivationArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ActivationArmBody::Expression(addressed_var("expression", "VALUE")),
+                },
+            ]),
+        });
+        let fixed = MechCode::ActivationScope(mech_core::ActivationScope {
+            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            trigger: addressed_var("fixed_trigger", "EVENT"),
+            body: ActivationBody::Block(vec![(
+                MechCode::Expression(addressed_var("fixed", "VALUE")),
+                None,
+            )]),
+        });
+        let mut program = program_with_code(activation);
+        program.body.sections[0]
+            .elements
+            .push(SectionElement::MechCode(vec![(fixed, None)]));
+
+        let index = SourceIndex::from_program(&program);
+        for (target, name) in [
+            ("fixed", "VALUE"),
+            ("guard", "ENABLED"),
+            ("block", "VALUE"),
+            ("expression", "VALUE"),
+            ("pattern", "NESTED"),
+        ] {
+            assert!(index.program_address_references().iter().any(|reference| {
+                reference.target == target && reference.name == name
+            }), "expected activation reference @{target}/{name} to be indexed");
+        }
     }
 
     #[test]

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -1025,7 +1025,7 @@ result := x?
     #[test]
     fn source_index_records_activation_body_and_arm_address_references() {
         let activation = MechCode::ActivationScope(mech_core::ActivationScope {
-            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            operator: Token::new(mech_core::TokenKind::AsyncTransitionOperator, SourceRange::default(), vec!['~', '>']),
             trigger: addressed_var("trigger", "EVENT"),
             body: ActivationBody::PatternArms(vec![
                 mech_core::ActivationArm {
@@ -1048,7 +1048,7 @@ result := x?
             ]),
         });
         let fixed = MechCode::ActivationScope(mech_core::ActivationScope {
-            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            operator: Token::new(mech_core::TokenKind::AsyncTransitionOperator, SourceRange::default(), vec!['~', '>']),
             trigger: addressed_var("fixed_trigger", "EVENT"),
             body: ActivationBody::Block(vec![(
                 MechCode::Expression(addressed_var("fixed", "VALUE")),
@@ -1062,7 +1062,9 @@ result := x?
 
         let index = SourceIndex::from_program(&program);
         for (target, name) in [
+            ("trigger", "EVENT"),
             ("fixed", "VALUE"),
+            ("fixed_trigger", "EVENT"),
             ("guard", "ENABLED"),
             ("block", "VALUE"),
             ("expression", "VALUE"),

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -397,6 +397,10 @@ fn index_mech_code_address_references(
     code: &MechCode,
 ) {
     match code {
+        MechCode::ActivationScope(activation) => {
+            index_expression_address_references(index, scope, order, &activation.trigger);
+            for (body_code, _) in &activation.body { index_mech_code_address_references(index, scope, order, body_code); }
+        }
         MechCode::Import(import) => {
             for declaration in module_import_declarations(import) {
                 index.push_import(

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -194,3 +194,23 @@ impl MechErrorKind for RuntimeHostFunctionNotBytecodeCompilableError {
     )
   }
 }
+#[derive(Debug, Clone)]
+pub struct ActivationScopeEffectWithRegisterUnsupported;
+impl MechErrorKind for ActivationScopeEffectWithRegisterUnsupported {
+  fn name(&self) -> &str { "ActivationScopeEffectWithRegisterUnsupported" }
+  fn message(&self) -> String { "activation scopes cannot mix local register writes and context sends".to_string() }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeIsolatedActivationSendUnsupported;
+impl MechErrorKind for RuntimeIsolatedActivationSendUnsupported {
+  fn name(&self) -> &str { "RuntimeIsolatedActivationSendUnsupported" }
+  fn message(&self) -> String { "activation-scoped context sends require retained live registration".to_string() }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeActivationEffectBarrierInvariantError { pub reason: String }
+impl MechErrorKind for RuntimeActivationEffectBarrierInvariantError {
+  fn name(&self) -> &str { "RuntimeActivationEffectBarrierInvariant" }
+  fn message(&self) -> String { self.reason.clone() }
+}

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1297,10 +1297,29 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
         self.flush_direct_execution(program, pending, result)?;
+        // Pure patterned scopes are lowered structurally and then handed to
+        // the interpreter's static patterned-dispatch elaborator.  Effects
+        // remain intentionally unsupported in this path.
+        if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          let mut lowered = scope.clone();
+          lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+          let mut lowered_arms = Vec::with_capacity(arms.len());
+          for arm in arms {
+            let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
+            let body = match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
+              mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+            };
+            lowered_arms.push(mech_core::ActivationArm { pattern: arm.pattern.clone(), guard, body });
+          }
+          lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
+          program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          return Ok(());
+        }
         let mut lowered = scope.clone();
         lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
         let mut registrations = Vec::new();
-        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => { return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet lowered".to_string() }, None)); } };
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => unreachable!() };
         lowered.body = mech_core::ActivationBody::Block(vec![]);
         let lowered_body = match &mut lowered.body { mech_core::ActivationBody::Block(body) => body, _ => unreachable!() };
         for (body_code, body_comment) in scope_body {
@@ -1482,7 +1501,17 @@ impl MechRuntime {
     match code {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
-        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet supported".to_string() }, None)) };
+        if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          for arm in arms {
+            if let Some(guard) = &arm.guard { self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?; }
+            match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => for (code, _) in body { self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?; },
+              mech_core::ActivationArmBody::Expression(expression) => self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?,
+            }
+          }
+          return Ok(());
+        }
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => unreachable!() };
         let has_send = scope_body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
         // Only writes to local registers conflict with an effectful activation.
         // Context-addressed assignments have their own, operation-specific

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -96,22 +96,28 @@ struct ResolvedContextResourceRequest {
   context_path: String,
 }
 
-pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "mech/runtime/activation-effect-barrier";
+// This name deliberately starts with a NUL byte.  It is an identifier we can
+// construct in the lowered tree, but it cannot be produced by the Mech lexer.
+// Keeping the compiler registered on the program is therefore not a public
+// source-level API.
+pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "\0mech/runtime/activation-effect-barrier";
 
 #[derive(Clone, Debug)]
 pub(super) struct ActivationEffectBarrierCompiler;
 impl NativeFunctionCompiler for ActivationEffectBarrierCompiler {
   fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
     if !arguments.is_empty() { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier accepts no arguments".into() }, None)); }
-    Ok(Box::new(ActivationEffectBarrier { value: mech_core::Ref::new(Value::U64(mech_core::Ref::new(0))) }))
+    Ok(Box::new(ActivationEffectBarrier))
   }
 }
 #[derive(Clone, Debug)]
-struct ActivationEffectBarrier { value: mech_core::Ref<Value> }
+struct ActivationEffectBarrier;
 impl MechFunctionImpl for ActivationEffectBarrier {
   fn solve(&self) {}
   fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> { Ok(mech_core::ReactiveSolveStatus::Unchanged) }
-  fn out(&self) -> Value { self.value.borrow().clone() }
+  // The barrier is a scheduling node, not a value producer.  Its node id and
+  // reactive execution record are the observable state used by send replay.
+  fn out(&self) -> Value { Value::Empty }
   fn to_string(&self) -> String { ACTIVATION_EFFECT_BARRIER_NAME.to_string() }
 }
 impl MechFunctionCompiler for ActivationEffectBarrier {
@@ -1456,7 +1462,14 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
-        let has_register = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(_) | mech_core::Statement::OpAssign(_))));
+        // Only writes to local registers conflict with an effectful activation.
+        // Context-addressed assignments have their own, operation-specific
+        // placement error below (they are top-level only).
+        let has_register = scope.body.iter().any(|(code, _)| match code {
+          mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => assign.target.context.is_none(),
+          mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => assign.target.context.is_none(),
+          _ => false,
+        });
         if has_send && has_register { return Err(MechError::new(ActivationScopeEffectWithRegisterUnsupported, None)); }
         if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot { return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None)); }
         for (body_code, _) in &scope.body {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -12,90 +12,88 @@
 // Both methods have corresponding _with_context versions that accept a mutable reference to a RuntimeContext, allowing for execution within the context of an active transaction. This ensures that any changes made during execution are properly staged within the transaction that if an error occurs, the transaction can be rolled back to maintain consistency.
 
 use super::*;
-use crate::RuntimeResourceWritePreflightRequest;
 use crate::{SourceDeclaration, SourceIndex};
+use crate::RuntimeResourceWritePreflightRequest;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
-    Interpreter(SourceScope),
-    Context(RuntimeContextBinding),
-    Unknown,
+  Interpreter(SourceScope),
+  Context(RuntimeContextBinding),
+  Unknown,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirectContextEffectPlacement {
-    TopLevel,
-    ActivationScope,
-    FunctionBody,
-    FsmTransition,
+  TopLevel,
+  ActivationScope,
+  FunctionBody,
+  FsmTransition,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AddressedReadPreflight {
-    RequireContextBinding,
-    AllowModuleAddressTargets,
+  RequireContextBinding,
+  AllowModuleAddressTargets,
 }
 
 impl AddressedReadPreflight {
-    fn requires_context_binding(self) -> bool {
-        matches!(self, AddressedReadPreflight::RequireContextBinding)
-    }
+  fn requires_context_binding(self) -> bool {
+    matches!(self, AddressedReadPreflight::RequireContextBinding)
+  }
 }
 
 impl DirectContextEffectPlacement {
-    fn description(self) -> &'static str {
-        match self {
-            DirectContextEffectPlacement::TopLevel => "module top level",
-            DirectContextEffectPlacement::ActivationScope => "an activation scope",
-            DirectContextEffectPlacement::FunctionBody => "a function body",
-            DirectContextEffectPlacement::FsmTransition => "an FSM transition",
-        }
+  fn description(self) -> &'static str {
+    match self {
+      DirectContextEffectPlacement::TopLevel => "module top level",
+      DirectContextEffectPlacement::ActivationScope => "an activation scope",
+      DirectContextEffectPlacement::FunctionBody => "a function body",
+      DirectContextEffectPlacement::FsmTransition => "an FSM transition",
     }
+  }
+
 }
 
 struct ActiveRuntimeProgramHostGuard {
-    previous: Option<RuntimeProgramHostTarget>,
+  previous: Option<RuntimeProgramHostTarget>,
 }
 
 impl ActiveRuntimeProgramHostGuard {
-    fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
-        let previous = ACTIVE_RUNTIME_PROGRAM_HOST
-            .with(|slot| slot.replace(Some(RuntimeProgramHostTarget { runtime, context })));
-        Self { previous }
-    }
+  fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
+    let previous = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(Some(RuntimeProgramHostTarget { runtime, context }))
+    });
+    Self { previous }
+  }
 }
 
 impl Drop for ActiveRuntimeProgramHostGuard {
-    fn drop(&mut self) {
-        ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-            slot.replace(self.previous.take());
-        });
-    }
+  fn drop(&mut self) {
+    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+      slot.replace(self.previous.take());
+    });
+  }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAddressedAssignmentUnsupported {
-    pub target: String,
+  pub target: String,
 }
 
 impl MechErrorKind for RuntimeAddressedAssignmentUnsupported {
-    fn name(&self) -> &str {
-        "RuntimeAddressedAssignmentUnsupported"
-    }
+  fn name(&self) -> &str { "RuntimeAddressedAssignmentUnsupported" }
 
-    fn message(&self) -> String {
-        format!(
-            "addressed assignment is not supported for `{}`",
-            self.target
-        )
-    }
+  fn message(&self) -> String {
+    format!("addressed assignment is not supported for `{}`", self.target)
+  }
 }
+
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedContextResourceRequest {
-    provider_base_uri: String,
-    provider_path: String,
-    context_path: String,
+  provider_base_uri: String,
+  provider_path: String,
+  context_path: String,
 }
 
 // This name deliberately starts with a NUL byte.  It is an identifier we can
@@ -103,2228 +101,1449 @@ struct ResolvedContextResourceRequest {
 // Keeping the compiler registered on the program is therefore not a public
 // source-level API.
 pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "\0mech/runtime/activation-effect-barrier";
-const ACTIVATION_SEND_PAYLOAD_NAME_PREFIX: &str = "\0mech/runtime/activation-send-payload/";
+const ACTIVATION_SEND_PAYLOAD_NAME_PREFIX: &str =
+  "\0mech/runtime/activation-send-payload/";
 
 #[derive(Clone, Debug)]
 pub(super) struct ActivationEffectBarrierCompiler;
 impl NativeFunctionCompiler for ActivationEffectBarrierCompiler {
-    fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
-        if !arguments.is_empty() {
-            return Err(MechError::new(
-                RuntimeActivationEffectBarrierInvariantError {
-                    reason: "activation effect barrier accepts no arguments".into(),
-                },
-                None,
-            ));
-        }
-        Ok(Box::new(ActivationEffectBarrier))
-    }
+  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
+    if !arguments.is_empty() { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier accepts no arguments".into() }, None)); }
+    Ok(Box::new(ActivationEffectBarrier))
+  }
 }
 #[derive(Clone, Debug)]
 struct ActivationEffectBarrier;
 impl MechFunctionImpl for ActivationEffectBarrier {
-    fn solve(&self) {}
-    fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> {
-        Ok(mech_core::ReactiveSolveStatus::Unchanged)
-    }
-    // The barrier is a scheduling node, not a value producer.  Its node id and
-    // reactive execution record are the observable state used by send replay.
-    fn out(&self) -> Value {
-        Value::Empty
-    }
-    fn to_string(&self) -> String {
-        ACTIVATION_EFFECT_BARRIER_NAME.to_string()
-    }
+  fn solve(&self) {}
+  fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> { Ok(mech_core::ReactiveSolveStatus::Unchanged) }
+  // The barrier is a scheduling node, not a value producer.  Its node id and
+  // reactive execution record are the observable state used by send replay.
+  fn out(&self) -> Value { Value::Empty }
+  fn to_string(&self) -> String { ACTIVATION_EFFECT_BARRIER_NAME.to_string() }
 }
 impl MechFunctionCompiler for ActivationEffectBarrier {
-    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
-        Err(MechError::new(
-            RuntimeActivationEffectBarrierInvariantError {
-                reason: "activation effect barrier cannot be bytecode compiled".into(),
-            },
-            None,
-        ))
-    }
+  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier cannot be bytecode compiled".into() }, None)) }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
-    mech_core::Identifier {
-        name: mech_core::Token::new(
-            mech_core::TokenKind::Identifier,
-            mech_core::SourceRange::default(),
-            name.chars().collect(),
-        ),
-    }
+  mech_core::Identifier {
+    name: mech_core::Token::new(
+      mech_core::TokenKind::Identifier,
+      mech_core::SourceRange::default(),
+      name.chars().collect(),
+    ),
+  }
 }
 
+
 fn execution_scope_for_extracted_module_source(scope: &SourceScope) -> SourceScope {
-    match scope {
-        SourceScope::Program => SourceScope::Program,
-        SourceScope::Interpreter(_) => SourceScope::Program,
-    }
+  match scope {
+    SourceScope::Program => SourceScope::Program,
+    SourceScope::Interpreter(_) => SourceScope::Program,
+  }
 }
 
 fn resolve_runtime_address_target(
-    record: &ModuleVersionRecord,
-    scope: &SourceScope,
-    context_registry: &RuntimeContextRegistry,
-    target: &str,
+  record: &ModuleVersionRecord,
+  scope: &SourceScope,
+  context_registry: &RuntimeContextRegistry,
+  target: &str,
 ) -> RuntimeAddressTarget {
-    if !matches!(scope, SourceScope::Program) {
-        if let Some(binding) = context_registry.get(target) {
-            return RuntimeAddressTarget::Context(binding.clone());
-        }
-    }
-
-    for metadata in &record.scopes {
-        if let SourceScope::Interpreter(interpreter) = &metadata.scope {
-            if interpreter.namespace_str == target {
-                return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
-            }
-        }
-    }
-
+  if !matches!(scope, SourceScope::Program) {
     if let Some(binding) = context_registry.get(target) {
-        return RuntimeAddressTarget::Context(binding.clone());
+      return RuntimeAddressTarget::Context(binding.clone());
     }
+  }
 
-    RuntimeAddressTarget::Unknown
+  for metadata in &record.scopes {
+    if let SourceScope::Interpreter(interpreter) = &metadata.scope {
+      if interpreter.namespace_str == target {
+        return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
+      }
+    }
+  }
+
+  if let Some(binding) = context_registry.get(target) {
+    return RuntimeAddressTarget::Context(binding.clone());
+  }
+
+  RuntimeAddressTarget::Unknown
 }
 
 fn context_registry_for_scope(
-    record: &ModuleVersionRecord,
-    scope: &SourceScope,
+  record: &ModuleVersionRecord,
+  scope: &SourceScope,
 ) -> MResult<RuntimeContextRegistry> {
-    let declarations = record
-        .scopes
-        .iter()
-        .find(|metadata| &metadata.scope == scope)
-        .map(|metadata| metadata.contexts.as_slice())
-        .unwrap_or(&[]);
-    RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
+  let declarations = record
+    .scopes
+    .iter()
+    .find(|metadata| &metadata.scope == scope)
+    .map(|metadata| metadata.contexts.as_slice())
+    .unwrap_or(&[]);
+  RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
 }
 
 fn runtime_context_base_uri(binding: &RuntimeContextBinding) -> String {
-    match &binding.base {
-        RuntimeContextBase::ResourceUri(uri) => uri.clone(),
-    }
+  match &binding.base {
+    RuntimeContextBase::ResourceUri(uri) => uri.clone(),
+  }
 }
 
 fn runtime_context_allows_operation(
-    binding: &RuntimeContextBinding,
-    operation: &str,
-    path: &str,
+  binding: &RuntimeContextBinding,
+  operation: &str,
+  path: &str,
 ) -> bool {
-    binding.capabilities.iter().any(|capability| {
-        if capability.operation != operation {
-            return false;
+  binding.capabilities.iter().any(|capability| {
+    if capability.operation != operation {
+      return false;
+    }
+
+    match &capability.scope {
+      RuntimeContextCapabilityScope::Wildcard => true,
+      RuntimeContextCapabilityScope::Path(exact) => {
+        if exact == path {
+          return true;
         }
-
-        match &capability.scope {
-            RuntimeContextCapabilityScope::Wildcard => true,
-            RuntimeContextCapabilityScope::Path(exact) => {
-                if exact == path {
-                    return true;
-                }
-                if let Some(prefix) = exact.strip_suffix("/*") {
-                    let required_prefix = format!("{}/", prefix);
-                    return path.starts_with(&required_prefix);
-                }
-                false
-            }
+        if let Some(prefix) = exact.strip_suffix("/*") {
+          let required_prefix = format!("{}/", prefix);
+          return path.starts_with(&required_prefix);
         }
-    })
+        false
+      }
+    }
+  })
 }
 
-fn runtime_context_exposes_operation(binding: &RuntimeContextBinding, operation: &str) -> bool {
-    binding
-        .capabilities
-        .iter()
-        .any(|capability| capability.operation == operation)
+fn runtime_context_exposes_operation(
+  binding: &RuntimeContextBinding,
+  operation: &str,
+) -> bool {
+  binding.capabilities.iter().any(|capability| capability.operation == operation)
 }
 
-fn runtime_context_allows_read(binding: &RuntimeContextBinding, path: &str) -> bool {
-    runtime_context_allows_operation(binding, "read", path)
+fn runtime_context_allows_read(
+  binding: &RuntimeContextBinding,
+  path: &str,
+) -> bool {
+  runtime_context_allows_operation(binding, "read", path)
 }
 
-fn runtime_context_allows_write(binding: &RuntimeContextBinding, path: &str) -> bool {
-    runtime_context_allows_operation(binding, "write", path)
+fn runtime_context_allows_write(
+  binding: &RuntimeContextBinding,
+  path: &str,
+) -> bool {
+  runtime_context_allows_operation(binding, "write", path)
 }
 
 fn first_context_send_segment(path: &str) -> MResult<&str> {
-    path.split('/')
-        .next()
-        .filter(|segment| !segment.is_empty())
-        .ok_or_else(|| {
-            MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "context_send",
-                    reason: "context send target path must start with an operation name"
-                        .to_string(),
-                },
-                None,
-            )
-        })
+  path
+    .split('/')
+    .next()
+    .filter(|segment| !segment.is_empty())
+    .ok_or_else(|| MechError::new(RuntimeInvalidOperationError {
+      operation: "context_send",
+      reason: "context send target path must start with an operation name".to_string(),
+    }, None))
 }
 
 fn reserved_context_send_operation_error(operation: &str, path: &str) -> MechError {
-    MechError::new(
-        RuntimeInvalidOperationError {
-            operation: "context_send",
-            reason: format!(
-                "context send target path `{path}` starts with reserved operation `{operation}`; use assignment for writes or a custom send operation"
-            ),
-        },
-        None,
-    )
+  MechError::new(RuntimeInvalidOperationError {
+    operation: "context_send",
+    reason: format!(
+      "context send target path `{path}` starts with reserved operation `{operation}`; use assignment for writes or a custom send operation"
+    ),
+  }, None)
 }
 
 fn context_send_operation(
-    binding: &RuntimeContextBinding,
-    path: &str,
+  binding: &RuntimeContextBinding,
+  path: &str,
 ) -> MResult<RuntimeCapabilityOperation> {
-    let candidate = first_context_send_segment(path)?;
-    if candidate == "read" {
-        return Err(reserved_context_send_operation_error(candidate, path));
-    }
-    if candidate == "write" {
-        if runtime_context_allows_write(binding, path) {
-            return Ok(RuntimeCapabilityOperation::Write);
-        }
-        return Err(reserved_context_send_operation_error(candidate, path));
-    }
-    if runtime_context_allows_operation(binding, candidate, path) {
-        return RuntimeCapabilityOperation::from_name(candidate.to_string());
-    }
-    if runtime_context_exposes_operation(binding, candidate) {
-        return RuntimeCapabilityOperation::from_name(candidate.to_string());
-    }
+  let candidate = first_context_send_segment(path)?;
+  if candidate == "read" {
+    return Err(reserved_context_send_operation_error(candidate, path));
+  }
+  if candidate == "write" {
     if runtime_context_allows_write(binding, path) {
-        return Ok(RuntimeCapabilityOperation::Write);
+      return Ok(RuntimeCapabilityOperation::Write);
     }
-    RuntimeCapabilityOperation::from_name(candidate.to_string())
+    return Err(reserved_context_send_operation_error(candidate, path));
+  }
+  if runtime_context_allows_operation(binding, candidate, path) {
+    return RuntimeCapabilityOperation::from_name(candidate.to_string());
+  }
+  if runtime_context_exposes_operation(binding, candidate) {
+    return RuntimeCapabilityOperation::from_name(candidate.to_string());
+  }
+  if runtime_context_allows_write(binding, path) {
+    return Ok(RuntimeCapabilityOperation::Write);
+  }
+  RuntimeCapabilityOperation::from_name(candidate.to_string())
 }
 
 fn context_write_operation(
-    binding: &RuntimeContextBinding,
-    intent: RuntimeResourceWriteIntent,
-    path: &str,
+  binding: &RuntimeContextBinding,
+  intent: RuntimeResourceWriteIntent,
+  path: &str,
 ) -> MResult<RuntimeCapabilityOperation> {
-    match intent {
-        RuntimeResourceWriteIntent::Assign => Ok(RuntimeCapabilityOperation::Write),
-        RuntimeResourceWriteIntent::Send => context_send_operation(binding, path),
-    }
+  match intent {
+    RuntimeResourceWriteIntent::Assign => Ok(RuntimeCapabilityOperation::Write),
+    RuntimeResourceWriteIntent::Send => context_send_operation(binding, path),
+  }
 }
 
+
 fn direct_context_target(context_name: &str, path: &str) -> String {
-    format!("@{}/{}", context_name, path)
+  format!("@{}/{}", context_name, path)
 }
 
 fn undeclared_direct_context_target_error(context_name: &str) -> MechError {
-    MechError::new(
-        RuntimeInvalidOperationError {
-            operation: "direct_context_target",
-            reason: format!("context target `@{context_name}` is not declared or imported"),
-        },
-        None,
-    )
+  MechError::new(RuntimeInvalidOperationError {
+    operation: "direct_context_target",
+    reason: format!("context target `@{context_name}` is not declared or imported"),
+  }, None)
 }
 
+
+
 fn single_code_program(
-    code: mech_core::MechCode,
-    comment: Option<mech_core::Comment>,
+  code: mech_core::MechCode,
+  comment: Option<mech_core::Comment>,
 ) -> mech_core::Program {
-    mech_core::Program {
-        title: None,
-        body: mech_core::Body {
-            sections: vec![mech_core::Section {
-                subtitle: None,
-                elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
-            }],
-        },
-    }
+  mech_core::Program {
+    title: None,
+    body: mech_core::Body {
+      sections: vec![mech_core::Section {
+        subtitle: None,
+        elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
+      }],
+    },
+  }
 }
 
 fn resolve_runtime_value(value: Value) -> Value {
-    match value {
-        Value::MutableReference(value) => value.borrow().clone(),
-        other => other,
-    }
+  match value {
+    Value::MutableReference(value) => value.borrow().clone(),
+    other => other,
+  }
 }
 
+
+
 impl MechRuntime {
-    fn with_live_registration_mode<T>(
-        &mut self,
-        mode: crate::runtime::LiveRegistrationMode,
-        f: impl FnOnce(&mut Self) -> MResult<T>,
-    ) -> MResult<T> {
-        let previous = std::mem::replace(&mut self.live_registration_mode, mode);
-        let result = f(self);
-        self.live_registration_mode = previous;
-        result
-    }
+  fn with_live_registration_mode<T>(
+    &mut self,
+    mode: crate::runtime::LiveRegistrationMode,
+    f: impl FnOnce(&mut Self) -> MResult<T>,
+  ) -> MResult<T> {
+    let previous = std::mem::replace(&mut self.live_registration_mode, mode);
+    let result = f(self);
+    self.live_registration_mode = previous;
+    result
+  }
 
-    #[cfg(test)]
-    pub(super) fn run_string_with_isolated_registration_for_test(
-        &mut self,
-        context: &mut RuntimeContext,
-        source: &str,
-    ) -> MResult<Value> {
-        self.with_live_registration_mode(
-            crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
-            |runtime| runtime.run_string_with_context(context, source),
-        )
-    }
+  #[cfg(test)]
+  pub(super) fn run_string_with_isolated_registration_for_test(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &str,
+  ) -> MResult<Value> {
+    self.with_live_registration_mode(
+      crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+      |runtime| {
+        runtime.run_string_with_context(context, source)
+      },
+    )
+  }
 
-    fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
-        matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
-    }
+  fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
+    matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
+  }
 
-    pub(crate) fn context_declarations_from_index_scope(
-        &self,
-        index: &SourceIndex,
-        scope: &SourceScope,
-    ) -> MResult<Vec<crate::SourceContextDeclaration>> {
-        let mut declarations = Vec::new();
 
-        for declaration in &index.declarations {
-            match declaration {
-                SourceDeclaration::Context(context) if &context.occurrence.scope == scope => {
-                    declarations.push(context.declaration.clone());
-                }
-                SourceDeclaration::Import(import) if &import.occurrence.scope == scope => {
-                    let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
-                        continue;
-                    };
-                    let module = import.declaration.module.as_deref().ok_or_else(|| {
-                        MechError::new(
-                            RuntimeInvalidOperationError {
-                                operation: "materialize_direct_manifest_context_imports",
-                                reason: format!(
-                                    "context import `{}` is missing module metadata",
-                                    import.declaration.specifier
-                                ),
-                            },
-                            None,
-                        )
-                    })?;
-                    let item = import.declaration.item.as_deref().ok_or_else(|| {
-                        MechError::new(
-                            RuntimeInvalidOperationError {
-                                operation: "materialize_direct_manifest_context_imports",
-                                reason: format!(
-                                    "context import `{}` is missing item metadata",
-                                    import.declaration.specifier
-                                ),
-                            },
-                            None,
-                        )
-                    })?;
-                    let target = format!("{module}/{item}");
-                    if let Some(context) = self.host_interfaces.resolve_optional(&target)? {
-                        declarations.push(crate::SourceContextDeclaration {
-                            name: alias.clone(),
-                            base: crate::SourceContextBase::ResourceUri(context.base_uri.clone()),
-                            capabilities: context
-                                .operations
-                                .iter()
-                                .map(|operation| crate::SourceContextCapability {
-                                    operation: operation.clone(),
-                                    scope: crate::SourceContextCapabilityScope::Wildcard,
-                                })
-                                .collect(),
-                        });
-                    } else {
-                        let export = self.module_manifests.context_export(module, item)?;
-                        declarations.push(crate::SourceContextDeclaration {
-                            name: alias.clone(),
-                            base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
-                            capabilities: export
-                                .operations
-                                .iter()
-                                .map(|operation| crate::SourceContextCapability {
-                                    operation: operation.clone(),
-                                    scope: crate::SourceContextCapabilityScope::Wildcard,
-                                })
-                                .collect(),
-                        });
-                    }
-                }
-                _ => {}
-            }
+  pub(crate) fn context_declarations_from_index_scope(
+    &self,
+    index: &SourceIndex,
+    scope: &SourceScope,
+  ) -> MResult<Vec<crate::SourceContextDeclaration>> {
+    let mut declarations = Vec::new();
+
+    for declaration in &index.declarations {
+      match declaration {
+        SourceDeclaration::Context(context) if &context.occurrence.scope == scope => {
+          declarations.push(context.declaration.clone());
         }
-
-        Ok(declarations)
-    }
-
-    fn direct_context_registry_for_scope(
-        &self,
-        tree: &mech_core::Program,
-        scope: &SourceScope,
-    ) -> MResult<RuntimeContextRegistry> {
-        let index = SourceIndex::from_program(tree);
-        let declarations = self.context_declarations_from_index_scope(&index, scope)?;
-        RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
-    }
-
-    fn resolve_context_resource_request(
-        &self,
-        binding: &RuntimeContextBinding,
-        requested_path: &str,
-    ) -> MResult<ResolvedContextResourceRequest> {
-        let context_base_uri = runtime_context_base_uri(binding)
-            .trim_end_matches('/')
-            .to_string();
-        let requested_path = requested_path.trim_matches('/').to_string();
-        let candidate_uri = if requested_path.is_empty() {
-            context_base_uri.clone()
-        } else {
-            format!("{}/{}", context_base_uri, requested_path)
-        };
-
-        let provider_base_uri = self
-            .resources
-            .provider_base_uri_for(&candidate_uri)?
-            .unwrap_or_else(|| context_base_uri.clone());
-        let provider_path = candidate_uri
-            .strip_prefix(&provider_base_uri)
-            .unwrap_or_default()
-            .trim_matches('/')
-            .to_string();
-
-        Ok(ResolvedContextResourceRequest {
-            provider_base_uri,
-            provider_path,
-            context_path: requested_path,
-        })
-    }
-
-    fn read_context_resource(
-        &self,
-        context: &RuntimeContext,
-        binding: &RuntimeContextBinding,
-        path: &str,
-    ) -> MResult<Value> {
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        if !runtime_context_allows_read(binding, &resolved.context_path) {
-            return Err(MechError::new(
-                RuntimeResourceCapabilityDenied {
-                    context_name: binding.name.clone(),
-                    operation: "read".to_string(),
-                    path: resolved.context_path,
-                },
-                None,
-            ));
+        SourceDeclaration::Import(import) if &import.occurrence.scope == scope => {
+          let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
+            continue;
+          };
+          let module = import.declaration.module.as_deref().ok_or_else(|| {
+            MechError::new(RuntimeInvalidOperationError {
+              operation: "materialize_direct_manifest_context_imports",
+              reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
+            }, None)
+          })?;
+          let item = import.declaration.item.as_deref().ok_or_else(|| {
+            MechError::new(RuntimeInvalidOperationError {
+              operation: "materialize_direct_manifest_context_imports",
+              reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
+            }, None)
+          })?;
+          let target = format!("{module}/{item}");
+          if let Some(context) = self.host_interfaces.resolve_optional(&target)? {
+            declarations.push(crate::SourceContextDeclaration {
+              name: alias.clone(),
+              base: crate::SourceContextBase::ResourceUri(context.base_uri.clone()),
+              capabilities: context.operations.iter().map(|operation| crate::SourceContextCapability {
+                operation: operation.clone(),
+                scope: crate::SourceContextCapabilityScope::Wildcard,
+              }).collect(),
+            });
+          } else {
+            let export = self.module_manifests.context_export(module, item)?;
+            declarations.push(crate::SourceContextDeclaration {
+              name: alias.clone(),
+              base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
+              capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
+                operation: operation.clone(),
+                scope: crate::SourceContextCapabilityScope::Wildcard,
+              }).collect(),
+            });
+          }
         }
-        if !self.has_capability_grant(
-            &context.subject,
-            &resolved.provider_base_uri,
-            &RuntimeCapabilityOperation::Read,
-            &resolved.provider_path,
-        ) {
-            return Err(MechError::new(
-                RuntimeCapabilityGrantDenied {
-                    subject: context.subject.clone(),
-                    resource: resolved.provider_base_uri,
-                    operation: RuntimeCapabilityOperation::Read,
-                    path: resolved.provider_path,
-                },
-                None,
-            ));
-        }
-        self.resources.read(RuntimeResourceReadRequest {
-            base_uri: resolved.provider_base_uri,
-            path: resolved.provider_path,
-            context_name: binding.name.clone(),
-        })
+        _ => {}
+      }
     }
 
-    fn write_context_resource(
-        &mut self,
-        context: &RuntimeContext,
-        binding: &RuntimeContextBinding,
-        path: &str,
-        value: Value,
-        intent: RuntimeResourceWriteIntent,
-    ) -> MResult<()> {
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        let operation = context_write_operation(binding, intent, &resolved.context_path)?;
-        if !runtime_context_allows_operation(binding, operation.name(), &resolved.context_path) {
-            return Err(MechError::new(
-                RuntimeResourceCapabilityDenied {
-                    context_name: binding.name.clone(),
-                    operation: operation.name().to_string(),
-                    path: resolved.context_path,
-                },
-                None,
-            ));
-        }
-        if !self.has_capability_grant(
-            &context.subject,
-            &resolved.provider_base_uri,
-            &operation,
-            &resolved.provider_path,
-        ) {
-            return Err(MechError::new(
-                RuntimeCapabilityGrantDenied {
-                    subject: context.subject.clone(),
-                    resource: resolved.provider_base_uri,
-                    operation: operation.clone(),
-                    path: resolved.provider_path,
-                },
-                None,
-            ));
-        }
-        self.resources.write(RuntimeResourceWriteRequest {
-            base_uri: resolved.provider_base_uri,
-            path: resolved.provider_path,
-            context_name: binding.name.clone(),
-            operation: operation.clone(),
-            value,
-            intent,
-        })
+    Ok(declarations)
+  }
+
+  fn direct_context_registry_for_scope(
+    &self,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<RuntimeContextRegistry> {
+    let index = SourceIndex::from_program(tree);
+    let declarations = self.context_declarations_from_index_scope(&index, scope)?;
+    RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
+  }
+
+  fn resolve_context_resource_request(
+    &self,
+    binding: &RuntimeContextBinding,
+    requested_path: &str,
+  ) -> MResult<ResolvedContextResourceRequest> {
+    let context_base_uri = runtime_context_base_uri(binding).trim_end_matches('/').to_string();
+    let requested_path = requested_path.trim_matches('/').to_string();
+    let candidate_uri = if requested_path.is_empty() {
+      context_base_uri.clone()
+    } else {
+      format!("{}/{}", context_base_uri, requested_path)
+    };
+
+    let provider_base_uri = self
+      .resources
+      .provider_base_uri_for(&candidate_uri)?
+      .unwrap_or_else(|| context_base_uri.clone());
+    let provider_path = candidate_uri
+      .strip_prefix(&provider_base_uri)
+      .unwrap_or_default()
+      .trim_matches('/')
+      .to_string();
+
+    Ok(ResolvedContextResourceRequest {
+      provider_base_uri,
+      provider_path,
+      context_path: requested_path,
+    })
+  }
+
+  fn read_context_resource(
+    &self,
+    context: &RuntimeContext,
+    binding: &RuntimeContextBinding,
+    path: &str,
+  ) -> MResult<Value> {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    if !runtime_context_allows_read(binding, &resolved.context_path) {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: "read".to_string(),
+        path: resolved.context_path,
+      }, None));
     }
-
-    fn bind_context_read_temp(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        source: crate::RuntimeHostInputSource,
-        value: Value,
-    ) -> MResult<mech_core::Expression> {
-        self.validate_live_context_candidate(context)?;
-        let name = format!(
-            "mech-internal-context-{}-{}",
-            hash_str(source.base_uri()),
-            hash_str(source.path())
-        );
-        let symbol_id = hash_str(&name);
-        let input = program.ensure_input(
-            program.interpreter().id,
-            symbol_id,
-            &name,
-            resolve_runtime_value(value),
-        )?;
-        if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
-            let bindings = self.live_input_bindings.entry(source).or_default();
-            if !bindings.iter().any(|binding| *binding == input) {
-                bindings.push(input);
-            }
-            self.commit_live_context_candidate(context);
-        }
-        let var = mech_core::Var {
-            name: identifier_from_str(&name),
-            context: None,
-            kind: None,
-        };
-        Ok(mech_core::Expression::Var(var))
+    if !self.has_capability_grant(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &RuntimeCapabilityOperation::Read,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: context.subject.clone(),
+        resource: resolved.provider_base_uri,
+        operation: RuntimeCapabilityOperation::Read,
+        path: resolved.provider_path,
+      }, None));
     }
+    self.resources.read(RuntimeResourceReadRequest {
+      base_uri: resolved.provider_base_uri,
+      path: resolved.provider_path,
+      context_name: binding.name.clone(),
+    })
+  }
 
-    fn resolve_context_reads_in_expression(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        expression: &mech_core::Expression,
-    ) -> MResult<mech_core::Expression> {
-        match expression {
-            mech_core::Expression::Var(var) => {
-                let Some(var_context) = &var.context else {
-                    return Ok(expression.clone());
-                };
-                let target = var_context.to_string();
-                let Some(binding) = registry.get(&target) else {
-                    return Ok(expression.clone());
-                };
-                let path = var.name.to_string();
-                let resolved = self.resolve_context_resource_request(binding, &path)?;
-                let source = crate::RuntimeHostInputSource::new(
-                    resolved.provider_base_uri.clone(),
-                    resolved.provider_path.clone(),
-                )?;
-                let value = self.read_context_resource(context, binding, &path)?;
-                self.bind_context_read_temp(context, program, source, value)
-            }
-            mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            )),
-            mech_core::Expression::FunctionCall(call) => {
-                let args = call
-                    .args
-                    .iter()
-                    .map(|(name, expression)| {
-                        Ok((
-                            name.clone(),
-                            self.resolve_context_reads_in_expression(
-                                context, program, registry, expression,
-                            )?,
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::FunctionCall(
-                    mech_core::FunctionCall {
-                        name: call.name.clone(),
-                        args,
-                    },
-                ))
-            }
-            mech_core::Expression::FsmPipe(pipe) => Ok(mech_core::Expression::FsmPipe(
-                self.resolve_context_reads_in_fsm_pipe(context, program, registry, pipe)?,
-            )),
-            mech_core::Expression::Literal(_) => Ok(expression.clone()),
-            mech_core::Expression::Match(match_expression) => {
-                let mut match_expression = match_expression.as_ref().clone();
-                match_expression.source = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &match_expression.source,
-                )?;
-                match_expression.arms = match_expression
-                    .arms
-                    .iter()
-                    .map(|arm| {
-                        Ok(mech_core::MatchArm {
-                            pattern: self.resolve_context_reads_in_match_pattern(
-                                context,
-                                program,
-                                registry,
-                                &arm.pattern,
-                            )?,
-                            guard: arm
-                                .guard
-                                .as_ref()
-                                .map(|guard| {
-                                    self.resolve_context_reads_in_expression(
-                                        context, program, registry, guard,
-                                    )
-                                })
-                                .transpose()?,
-                            expression: self.resolve_context_reads_in_expression(
-                                context,
-                                program,
-                                registry,
-                                &arm.expression,
-                            )?,
-                        })
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::Match(Box::new(match_expression)))
-            }
-            mech_core::Expression::Range(range) => {
-                let mut range = range.as_ref().clone();
-                range.start =
-                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-                range.increment = match &range.increment {
-                    Some((operator, increment)) => Some((
-                        operator.clone(),
-                        self.resolve_context_reads_in_factor(
-                            context, program, registry, increment,
-                        )?,
-                    )),
-                    None => None,
-                };
-                range.terminal = self.resolve_context_reads_in_factor(
-                    context,
-                    program,
-                    registry,
-                    &range.terminal,
-                )?;
-                Ok(mech_core::Expression::Range(Box::new(range)))
-            }
-            mech_core::Expression::Slice(slice) => {
-                if let Some(context_name) = &slice.context {
-                    let context_name = context_name.to_string();
-                    if registry.contains(&context_name) {
-                        return Err(MechError::new(
-                            RuntimeInvalidOperationError {
-                                operation: "context_read",
-                                reason: "context-addressed slices are not supported".to_string(),
-                            },
-                            None,
-                        ));
-                    }
-                    return Ok(expression.clone());
-                }
-                Ok(mech_core::Expression::Slice(
-                    self.resolve_context_reads_in_slice(context, program, registry, slice)?,
-                ))
-            }
-            mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
-                self.resolve_context_reads_in_structure(context, program, registry, structure)?,
-            )),
-            mech_core::Expression::SetComprehension(comprehension) => {
-                let mut comprehension = comprehension.as_ref().clone();
-                comprehension.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &comprehension.expression,
-                )?;
-                comprehension.qualifiers = comprehension
-                    .qualifiers
-                    .iter()
-                    .map(|qualifier| {
-                        self.resolve_context_reads_in_comprehension_qualifier(
-                            context, program, registry, qualifier,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::SetComprehension(Box::new(
-                    comprehension,
-                )))
-            }
-            mech_core::Expression::MatrixComprehension(comprehension) => {
-                let mut comprehension = comprehension.as_ref().clone();
-                comprehension.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &comprehension.expression,
-                )?;
-                comprehension.qualifiers = comprehension
-                    .qualifiers
-                    .iter()
-                    .map(|qualifier| {
-                        self.resolve_context_reads_in_comprehension_qualifier(
-                            context, program, registry, qualifier,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Expression::MatrixComprehension(Box::new(
-                    comprehension,
-                )))
-            }
-        }
+  fn write_context_resource(
+    &mut self,
+    context: &RuntimeContext,
+    binding: &RuntimeContextBinding,
+    path: &str,
+    value: Value,
+    intent: RuntimeResourceWriteIntent,
+  ) -> MResult<()> {
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    let operation = context_write_operation(binding, intent, &resolved.context_path)?;
+    if !runtime_context_allows_operation(binding, operation.name(), &resolved.context_path) {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: operation.name().to_string(),
+        path: resolved.context_path,
+      }, None));
     }
-
-    fn resolve_context_reads_in_factor(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        factor: &mech_core::Factor,
-    ) -> MResult<mech_core::Factor> {
-        match factor {
-            mech_core::Factor::Expression(expression) => {
-                Ok(mech_core::Factor::Expression(Box::new(
-                    self.resolve_context_reads_in_expression(
-                        context, program, registry, expression,
-                    )?,
-                )))
-            }
-            mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            ))),
-            mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            ))),
-            mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(
-                Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?),
-            )),
-            mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            ))),
-            mech_core::Factor::Term(term) => {
-                let rhs = term
-                    .rhs
-                    .iter()
-                    .map(|(operator, factor)| {
-                        Ok((
-                            operator.clone(),
-                            self.resolve_context_reads_in_factor(
-                                context, program, registry, factor,
-                            )?,
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?;
-                Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
-                    lhs: self
-                        .resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
-                    rhs,
-                })))
-            }
-        }
+    if !self.has_capability_grant(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &operation,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(RuntimeCapabilityGrantDenied {
+        subject: context.subject.clone(),
+        resource: resolved.provider_base_uri,
+        operation: operation.clone(),
+        path: resolved.provider_path,
+      }, None));
     }
+    self.resources.write(RuntimeResourceWriteRequest {
+      base_uri: resolved.provider_base_uri,
+      path: resolved.provider_path,
+      context_name: binding.name.clone(),
+      operation: operation.clone(),
+      value,
+      intent,
+    })
+  }
 
-    fn resolve_context_reads_in_slice(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        slice: &mech_core::Slice,
-    ) -> MResult<mech_core::Slice> {
-        Ok(mech_core::Slice {
-            name: slice.name.clone(),
-            context: slice.context.clone(),
-            subscript: slice
-                .subscript
-                .iter()
-                .map(|subscript| {
-                    self.resolve_context_reads_in_subscript(context, program, registry, subscript)
-                })
-                .collect::<MResult<Vec<_>>>()?,
-        })
+  fn bind_context_read_temp(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    source: crate::RuntimeHostInputSource,
+    value: Value,
+  ) -> MResult<mech_core::Expression> {
+    self.validate_live_context_candidate(context)?;
+    let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
+    let symbol_id = hash_str(&name);
+    let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
+    if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
+      let bindings = self.live_input_bindings.entry(source).or_default();
+      if !bindings.iter().any(|binding| *binding == input) {
+        bindings.push(input);
+      }
+      self.commit_live_context_candidate(context);
     }
+    let var = mech_core::Var {
+      name: identifier_from_str(&name),
+      context: None,
+      kind: None,
+    };
+    Ok(mech_core::Expression::Var(var))
+  }
 
-    fn resolve_context_reads_in_slice_ref(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        target: &mech_core::SliceRef,
-    ) -> MResult<mech_core::SliceRef> {
-        let mut target = target.clone();
-        if let Some(subscripts) = &target.subscript {
-            target.subscript = Some(
-                subscripts
-                    .iter()
-                    .map(|subscript| {
-                        self.resolve_context_reads_in_subscript(
-                            context, program, registry, subscript,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            );
-        }
-        Ok(target)
-    }
-
-    fn resolve_context_reads_in_subscript(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        subscript: &mech_core::Subscript,
-    ) -> MResult<mech_core::Subscript> {
-        match subscript {
-            mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(
-                subscripts
-                    .iter()
-                    .map(|subscript| {
-                        self.resolve_context_reads_in_subscript(
-                            context, program, registry, subscript,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            )),
-            mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(
-                subscripts
-                    .iter()
-                    .map(|subscript| {
-                        self.resolve_context_reads_in_subscript(
-                            context, program, registry, subscript,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            )),
-            mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(
-                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-            )),
-            mech_core::Subscript::Range(range) => {
-                let mut range = range.clone();
-                range.start =
-                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-                range.increment = match &range.increment {
-                    Some((operator, increment)) => Some((
-                        operator.clone(),
-                        self.resolve_context_reads_in_factor(
-                            context, program, registry, increment,
-                        )?,
-                    )),
-                    None => None,
-                };
-                range.terminal = self.resolve_context_reads_in_factor(
-                    context,
-                    program,
-                    registry,
-                    &range.terminal,
-                )?;
-                Ok(mech_core::Subscript::Range(range))
-            }
-            _ => Ok(subscript.clone()),
-        }
-    }
-
-    fn resolve_context_reads_in_structure(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        structure: &mech_core::Structure,
-    ) -> MResult<mech_core::Structure> {
-        match structure {
-            mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
-            mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
-                elements: map
-                    .elements
-                    .iter()
-                    .map(|mapping| {
-                        Ok(mech_core::Mapping {
-                            key: self.resolve_context_reads_in_expression(
-                                context,
-                                program,
-                                registry,
-                                &mapping.key,
-                            )?,
-                            value: self.resolve_context_reads_in_expression(
-                                context,
-                                program,
-                                registry,
-                                &mapping.value,
-                            )?,
-                        })
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            })),
-            mech_core::Structure::Matrix(matrix) => {
-                Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
-                    rows: matrix
-                        .rows
-                        .iter()
-                        .map(|row| {
-                            Ok(mech_core::MatrixRow {
-                                columns: row
-                                    .columns
-                                    .iter()
-                                    .map(|column| {
-                                        Ok(mech_core::MatrixColumn {
-                                            element: self.resolve_context_reads_in_expression(
-                                                context,
-                                                program,
-                                                registry,
-                                                &column.element,
-                                            )?,
-                                        })
-                                    })
-                                    .collect::<MResult<Vec<_>>>()?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::Record(record) => {
-                Ok(mech_core::Structure::Record(mech_core::Record {
-                    bindings: record
-                        .bindings
-                        .iter()
-                        .map(|binding| {
-                            Ok(mech_core::Binding {
-                                name: binding.name.clone(),
-                                kind: binding.kind.clone(),
-                                value: self.resolve_context_reads_in_expression(
-                                    context,
-                                    program,
-                                    registry,
-                                    &binding.value,
-                                )?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
-                elements: set
-                    .elements
-                    .iter()
-                    .map(|expression| {
-                        self.resolve_context_reads_in_expression(
-                            context, program, registry, expression,
-                        )
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            })),
-            mech_core::Structure::Table(table) => {
-                Ok(mech_core::Structure::Table(mech_core::Table {
-                    header: table.header.clone(),
-                    rows: table
-                        .rows
-                        .iter()
-                        .map(|row| {
-                            Ok(mech_core::TableRow {
-                                columns: row
-                                    .columns
-                                    .iter()
-                                    .map(|column| {
-                                        Ok(mech_core::TableColumn {
-                                            element: self.resolve_context_reads_in_expression(
-                                                context,
-                                                program,
-                                                registry,
-                                                &column.element,
-                                            )?,
-                                        })
-                                    })
-                                    .collect::<MResult<Vec<_>>>()?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::Tuple(tuple) => {
-                Ok(mech_core::Structure::Tuple(mech_core::Tuple {
-                    elements: tuple
-                        .elements
-                        .iter()
-                        .map(|expression| {
-                            self.resolve_context_reads_in_expression(
-                                context, program, registry, expression,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Structure::TupleStruct(tuple_struct) => {
-                Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
-                    name: tuple_struct.name.clone(),
-                    value: Box::new(self.resolve_context_reads_in_expression(
-                        context,
-                        program,
-                        registry,
-                        &tuple_struct.value,
-                    )?),
-                }))
-            }
-        }
-    }
-
-    fn resolve_context_reads_in_comprehension_qualifier(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        qualifier: &mech_core::ComprehensionQualifier,
-    ) -> MResult<mech_core::ComprehensionQualifier> {
-        match qualifier {
-            mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
-                Ok(mech_core::ComprehensionQualifier::Generator((
-                    self.resolve_context_reads_in_match_pattern(
-                        context, program, registry, pattern,
-                    )?,
-                    self.resolve_context_reads_in_expression(
-                        context, program, registry, expression,
-                    )?,
-                )))
-            }
-            mech_core::ComprehensionQualifier::Filter(expression) => {
-                Ok(mech_core::ComprehensionQualifier::Filter(
-                    self.resolve_context_reads_in_expression(
-                        context, program, registry, expression,
-                    )?,
-                ))
-            }
-            mech_core::ComprehensionQualifier::Let(var_def) => {
-                let mut var_def = var_def.clone();
-                var_def.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &var_def.expression,
-                )?;
-                Ok(mech_core::ComprehensionQualifier::Let(var_def))
-            }
-        }
-    }
-
-    fn flush_direct_execution(
-        &mut self,
-        program: &mut MechProgram,
-        pending: &mut Vec<mech_core::SectionElement>,
-        result: &mut Value,
-    ) -> MResult<()> {
-        if pending.is_empty() {
-            return Ok(());
-        }
-        let tree = mech_core::Program {
-            title: None,
-            body: mech_core::Body {
-                sections: vec![mech_core::Section {
-                    subtitle: None,
-                    elements: std::mem::take(pending),
-                }],
-            },
-        };
-        *result = program.run_tree(&tree)?;
-        Ok(())
-    }
-
-    fn executable_fence_for_scope(fenced: &mech_core::FencedMechCode, scope: &SourceScope) -> bool {
-        match scope {
-            SourceScope::Program => fenced.config.namespace_str.is_empty(),
-            SourceScope::Interpreter(interpreter) => {
-                fenced.config.namespace_str == interpreter.namespace_str
-            }
-        }
-    }
-
-    fn resolve_context_reads_in_pattern(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        pattern: &mech_core::Pattern,
-    ) -> MResult<mech_core::Pattern> {
-        match pattern {
-            mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
-                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-            )),
-            mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(
-                mech_core::PatternTupleStruct {
-                    name: tuple_struct.name.clone(),
-                    patterns: tuple_struct
-                        .patterns
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                },
-            )),
-            mech_core::Pattern::Tuple(tuple) => {
-                Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-                    tuple
-                        .0
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                )))
-            }
-            mech_core::Pattern::Array(array) => {
-                let spread = if let Some(spread) = &array.spread {
-                    Some(mech_core::PatternArraySpread {
-                        kind: spread.kind.clone(),
-                        binding: spread
-                            .binding
-                            .as_ref()
-                            .map(|binding| {
-                                self.resolve_context_reads_in_pattern(
-                                    context, program, registry, binding,
-                                )
-                                .map(Box::new)
-                            })
-                            .transpose()?,
-                    })
-                } else {
-                    None
-                };
-                Ok(mech_core::Pattern::Array(mech_core::PatternArray {
-                    prefix: array
-                        .prefix
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                    spread,
-                    suffix: array
-                        .suffix
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
-        }
-    }
-
-    fn resolve_context_reads_in_match_pattern(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        pattern: &mech_core::Pattern,
-    ) -> MResult<mech_core::Pattern> {
-        match pattern {
-            mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
-                self.resolve_context_reads_in_match_pattern_expression(
-                    context, program, registry, expression,
-                )?,
-            )),
-            mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(
-                mech_core::PatternTupleStruct {
-                    name: tuple_struct.name.clone(),
-                    patterns: tuple_struct
-                        .patterns
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_match_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                },
-            )),
-            mech_core::Pattern::Tuple(tuple) => {
-                if tuple.0.len() == 1 {
-                    let pattern = self.resolve_context_reads_in_match_pattern(
-                        context,
-                        program,
-                        registry,
-                        &tuple.0[0],
-                    )?;
-                    if pattern != tuple.0[0] {
-                        return Ok(pattern);
-                    }
-                }
-                Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-                    tuple
-                        .0
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_match_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                )))
-            }
-            mech_core::Pattern::Array(array) => {
-                let spread = if let Some(spread) = &array.spread {
-                    Some(mech_core::PatternArraySpread {
-                        kind: spread.kind.clone(),
-                        binding: spread
-                            .binding
-                            .as_ref()
-                            .map(|binding| {
-                                self.resolve_context_reads_in_match_pattern(
-                                    context, program, registry, binding,
-                                )
-                                .map(Box::new)
-                            })
-                            .transpose()?,
-                    })
-                } else {
-                    None
-                };
-                Ok(mech_core::Pattern::Array(mech_core::PatternArray {
-                    prefix: array
-                        .prefix
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_match_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                    spread,
-                    suffix: array
-                        .suffix
-                        .iter()
-                        .map(|pattern| {
-                            self.resolve_context_reads_in_match_pattern(
-                                context, program, registry, pattern,
-                            )
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                }))
-            }
-            mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
-        }
-    }
-
-    fn resolve_context_reads_in_match_pattern_expression(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        expression: &mech_core::Expression,
-    ) -> MResult<mech_core::Expression> {
-        if let Some(expression) = self.literalize_match_pattern_context_read_expression(
-            context, program, registry, expression,
-        )? {
-            return Ok(expression);
-        }
-
-        self.resolve_context_reads_in_expression(context, program, registry, expression)
-    }
-
-    fn literalize_match_pattern_context_read_expression(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        expression: &mech_core::Expression,
-    ) -> MResult<Option<mech_core::Expression>> {
-        match expression {
-            mech_core::Expression::Var(var) => {
-                self.literalize_match_pattern_context_read_var(context, program, registry, var)
-            }
-            mech_core::Expression::Formula(factor) => self
-                .literalize_match_pattern_context_read_factor(context, program, registry, factor),
-            _ => Ok(None),
-        }
-    }
-
-    fn literalize_match_pattern_context_read_factor(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        factor: &mech_core::Factor,
-    ) -> MResult<Option<mech_core::Expression>> {
-        match factor {
-            mech_core::Factor::Expression(expression) => self
-                .literalize_match_pattern_context_read_expression(
-                    context, program, registry, expression,
-                ),
-            mech_core::Factor::Parenthetical(inner) => {
-                self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
-            }
-            mech_core::Factor::Term(term) if term.rhs.is_empty() => self
-                .literalize_match_pattern_context_read_factor(
-                    context, program, registry, &term.lhs,
-                ),
-            _ => Ok(None),
-        }
-    }
-
-    fn literalize_match_pattern_context_read_var(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        var: &mech_core::Var,
-    ) -> MResult<Option<mech_core::Expression>> {
+  fn resolve_context_reads_in_expression(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<mech_core::Expression> {
+    match expression {
+      mech_core::Expression::Var(var) => {
         let Some(var_context) = &var.context else {
-            return Ok(None);
+          return Ok(expression.clone());
         };
-
         let target = var_context.to_string();
-        let path = var.name.to_string();
-        if let Some(binding) = registry.get(&target) {
-            let value = self.read_context_resource(context, binding, &path)?;
-            return Ok(Some(self.context_pattern_value_expression(value)?));
-        }
-
-        let address_key = format!("@{target}/{path}");
-        let value = {
-            let symbols = program.interpreter().symbols();
-            let symbols = symbols.borrow();
-            symbols
-                .get(hash_str(&address_key))
-                .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
+        let Some(binding) = registry.get(&target) else {
+          return Ok(expression.clone());
         };
-
-        if let Some(value) = value {
-            return Ok(Some(self.context_pattern_value_expression(value)?));
+        let path = var.name.to_string();
+        let resolved = self.resolve_context_resource_request(binding, &path)?;
+        let source = crate::RuntimeHostInputSource::new(resolved.provider_base_uri.clone(), resolved.provider_path.clone())?;
+        let value = self.read_context_resource(context, binding, &path)?;
+        self.bind_context_read_temp(context, program, source, value)
+      }
+      mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
+        self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+      )),
+      mech_core::Expression::FunctionCall(call) => {
+        let args = call.args.iter().map(|(name, expression)| {
+          Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        Ok(mech_core::Expression::FsmPipe(
+          self.resolve_context_reads_in_fsm_pipe(context, program, registry, pipe)?,
+        ))
+      }
+      mech_core::Expression::Literal(_) => Ok(expression.clone()),
+      mech_core::Expression::Match(match_expression) => {
+        let mut match_expression = match_expression.as_ref().clone();
+        match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
+        match_expression.arms = match_expression.arms.iter().map(|arm| {
+          Ok(mech_core::MatchArm {
+            pattern: self.resolve_context_reads_in_match_pattern(context, program, registry, &arm.pattern)?,
+            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
+            expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
+          })
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::Match(Box::new(match_expression)))
+      }
+      mech_core::Expression::Range(range) => {
+        let mut range = range.as_ref().clone();
+        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
+          None => None,
+        };
+        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
+        Ok(mech_core::Expression::Range(Box::new(range)))
+      }
+      mech_core::Expression::Slice(slice) => {
+        if let Some(context_name) = &slice.context {
+          let context_name = context_name.to_string();
+          if registry.contains(&context_name) {
+            return Err(MechError::new(RuntimeInvalidOperationError {
+              operation: "context_read",
+              reason: "context-addressed slices are not supported".to_string(),
+            }, None));
+          }
+          return Ok(expression.clone());
         }
-
-        Ok(None)
+        Ok(mech_core::Expression::Slice(
+          self.resolve_context_reads_in_slice(context, program, registry, slice)?,
+        ))
+      }
+      mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
+        self.resolve_context_reads_in_structure(context, program, registry, structure)?,
+      )),
+      mech_core::Expression::SetComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        let mut comprehension = comprehension.as_ref().clone();
+        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
+        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
+      }
     }
+  }
 
-    fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
-        let value = resolve_runtime_value(value);
-        match value {
-            Value::String(value) => {
-                let text = value.borrow().clone();
-                Ok(mech_core::Expression::Literal(mech_core::Literal::String(
-                    mech_core::MechString {
-                        text: mech_core::Token::new(
-                            mech_core::TokenKind::String,
-                            mech_core::SourceRange::default(),
-                            text.chars().collect(),
-                        ),
-                    },
-                )))
-            }
-            #[cfg(feature = "bool")]
-            Value::Bool(value) => {
-                let flag = *value.borrow();
-                Ok(mech_core::Expression::Literal(mech_core::Literal::Boolean(
-                    mech_core::Token::new(
-                        if flag {
-                            mech_core::TokenKind::True
-                        } else {
-                            mech_core::TokenKind::False
-                        },
-                        mech_core::SourceRange::default(),
-                        if flag {
-                            "true".chars().collect()
-                        } else {
-                            "false".chars().collect()
-                        },
-                    ),
-                )))
-            }
-            Value::Empty => Ok(mech_core::Expression::Literal(mech_core::Literal::Empty(
-                mech_core::Token::new(
-                    mech_core::TokenKind::Empty,
-                    mech_core::SourceRange::default(),
-                    vec!['_'],
-                ),
-            ))),
-            other => Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "context_match_pattern",
-                    reason: format!(
-                        "context match patterns currently support string, bool, and empty values; got {other:?}"
-                    ),
-                },
-                None,
-            )),
+  fn resolve_context_reads_in_factor(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<mech_core::Factor> {
+    match factor {
+      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
+      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
+      mech_core::Factor::Term(term) => {
+        let rhs = term.rhs.iter().map(|(operator, factor)| {
+          Ok((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, factor)?))
+        }).collect::<MResult<Vec<_>>>()?;
+        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
+          lhs: self.resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
+          rhs,
+        })))
+      }
+    }
+  }
+
+  fn resolve_context_reads_in_slice(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    slice: &mech_core::Slice,
+  ) -> MResult<mech_core::Slice> {
+    Ok(mech_core::Slice {
+      name: slice.name.clone(),
+      context: slice.context.clone(),
+      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
+    })
+  }
+
+  fn resolve_context_reads_in_slice_ref(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    target: &mech_core::SliceRef,
+  ) -> MResult<mech_core::SliceRef> {
+    let mut target = target.clone();
+    if let Some(subscripts) = &target.subscript {
+      target.subscript = Some(
+        subscripts
+          .iter()
+          .map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript))
+          .collect::<MResult<Vec<_>>>()?,
+      );
+    }
+    Ok(target)
+  }
+
+  fn resolve_context_reads_in_subscript(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    subscript: &mech_core::Subscript,
+  ) -> MResult<mech_core::Subscript> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
+      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(context, program, registry, factor)?)),
+      mech_core::Subscript::Range(range) => {
+        let mut range = range.clone();
+        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+        range.increment = match &range.increment {
+          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
+          None => None,
+        };
+        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
+        Ok(mech_core::Subscript::Range(range))
+      }
+      _ => Ok(subscript.clone()),
+    }
+  }
+
+  fn resolve_context_reads_in_structure(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    structure: &mech_core::Structure,
+  ) -> MResult<mech_core::Structure> {
+    match structure {
+      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
+      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
+        elements: map.elements.iter().map(|mapping| Ok(mech_core::Mapping {
+          key: self.resolve_context_reads_in_expression(context, program, registry, &mapping.key)?,
+          value: self.resolve_context_reads_in_expression(context, program, registry, &mapping.value)?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
+        rows: matrix.rows.iter().map(|row| Ok(mech_core::MatrixRow {
+          columns: row.columns.iter().map(|column| Ok(mech_core::MatrixColumn {
+            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
+          })).collect::<MResult<Vec<_>>>()?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
+        bindings: record.bindings.iter().map(|binding| Ok(mech_core::Binding {
+          name: binding.name.clone(),
+          kind: binding.kind.clone(),
+          value: self.resolve_context_reads_in_expression(context, program, registry, &binding.value)?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
+        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
+        header: table.header.clone(),
+        rows: table.rows.iter().map(|row| Ok(mech_core::TableRow {
+          columns: row.columns.iter().map(|column| Ok(mech_core::TableColumn {
+            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
+          })).collect::<MResult<Vec<_>>>()?,
+        })).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
+        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Structure::TupleStruct(tuple_struct) => Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
+        name: tuple_struct.name.clone(),
+        value: Box::new(self.resolve_context_reads_in_expression(context, program, registry, &tuple_struct.value)?),
+      })),
+    }
+  }
+
+  fn resolve_context_reads_in_comprehension_qualifier(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    qualifier: &mech_core::ComprehensionQualifier,
+  ) -> MResult<mech_core::ComprehensionQualifier> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+        Ok(mech_core::ComprehensionQualifier::Generator((
+          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
+          self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+        )))
+      }
+      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(context, program, registry, expression)?)),
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+        Ok(mech_core::ComprehensionQualifier::Let(var_def))
+      }
+    }
+  }
+
+  fn flush_direct_execution(
+    &mut self,
+    program: &mut MechProgram,
+    pending: &mut Vec<mech_core::SectionElement>,
+    result: &mut Value,
+  ) -> MResult<()> {
+    if pending.is_empty() {
+      return Ok(());
+    }
+    let tree = mech_core::Program {
+      title: None,
+      body: mech_core::Body {
+        sections: vec![mech_core::Section {
+          subtitle: None,
+          elements: std::mem::take(pending),
+        }],
+      },
+    };
+    *result = program.run_tree(&tree)?;
+    Ok(())
+  }
+
+  fn executable_fence_for_scope(
+    fenced: &mech_core::FencedMechCode,
+    scope: &SourceScope,
+  ) -> bool {
+    match scope {
+      SourceScope::Program => fenced.config.namespace_str.is_empty(),
+      SourceScope::Interpreter(interpreter) => fenced.config.namespace_str == interpreter.namespace_str,
+    }
+  }
+
+  fn resolve_context_reads_in_pattern(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<mech_core::Pattern> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+      )),
+      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
+        name: tuple_struct.name.clone(),
+        patterns: tuple_struct.patterns.iter()
+          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+        tuple.0.iter()
+          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      ))),
+      mech_core::Pattern::Array(array) => {
+        let spread = if let Some(spread) = &array.spread {
+          Some(mech_core::PatternArraySpread {
+            kind: spread.kind.clone(),
+            binding: spread.binding.as_ref()
+              .map(|binding| self.resolve_context_reads_in_pattern(context, program, registry, binding).map(Box::new))
+              .transpose()?,
+          })
+        } else {
+          None
+        };
+        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+          prefix: array.prefix.iter()
+            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+          spread,
+          suffix: array.suffix.iter()
+            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        }))
+      }
+      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+    }
+  }
+
+  fn resolve_context_reads_in_match_pattern(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+  ) -> MResult<mech_core::Pattern> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+        self.resolve_context_reads_in_match_pattern_expression(context, program, registry, expression)?,
+      )),
+      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
+        name: tuple_struct.name.clone(),
+        patterns: tuple_struct.patterns.iter()
+          .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+          .collect::<MResult<Vec<_>>>()?,
+      })),
+      mech_core::Pattern::Tuple(tuple) => {
+        if tuple.0.len() == 1 {
+          let pattern = self.resolve_context_reads_in_match_pattern(context, program, registry, &tuple.0[0])?;
+          if pattern != tuple.0[0] {
+            return Ok(pattern);
+          }
         }
+        Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+          tuple.0.iter()
+            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        )))
+      }
+      mech_core::Pattern::Array(array) => {
+        let spread = if let Some(spread) = &array.spread {
+          Some(mech_core::PatternArraySpread {
+            kind: spread.kind.clone(),
+            binding: spread.binding.as_ref()
+              .map(|binding| self.resolve_context_reads_in_match_pattern(context, program, registry, binding).map(Box::new))
+              .transpose()?,
+          })
+        } else {
+          None
+        };
+        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+          prefix: array.prefix.iter()
+            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+          spread,
+          suffix: array.suffix.iter()
+            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
+            .collect::<MResult<Vec<_>>>()?,
+        }))
+      }
+      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+    }
+  }
+
+  fn resolve_context_reads_in_match_pattern_expression(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<mech_core::Expression> {
+    if let Some(expression) = self.literalize_match_pattern_context_read_expression(
+      context,
+      program,
+      registry,
+      expression,
+    )? {
+      return Ok(expression);
     }
 
-    fn resolve_context_reads_in_transition(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        transition: &mech_core::Transition,
-    ) -> MResult<mech_core::Transition> {
-        match transition {
-            mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
-                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-            )),
-            mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
-                code_items
-                    .iter()
-                    .map(|(code, comment)| {
-                        Ok((
-                            self.resolve_context_reads_in_mech_code(
-                                context, program, registry, code,
-                            )?,
-                            comment.clone(),
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            )),
-            mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
-                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-            )),
-            mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
-                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-            )),
-            mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
-                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-            )),
+    self.resolve_context_reads_in_expression(context, program, registry, expression)
+  }
+
+  fn literalize_match_pattern_context_read_expression(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        self.literalize_match_pattern_context_read_var(context, program, registry, var)
+      }
+      mech_core::Expression::Formula(factor) => {
+        self.literalize_match_pattern_context_read_factor(context, program, registry, factor)
+      }
+      _ => Ok(None),
+    }
+  }
+
+  fn literalize_match_pattern_context_read_factor(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.literalize_match_pattern_context_read_expression(context, program, registry, expression)
+      }
+      mech_core::Factor::Parenthetical(inner) => {
+        self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
+      }
+      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
+        self.literalize_match_pattern_context_read_factor(context, program, registry, &term.lhs)
+      }
+      _ => Ok(None),
+    }
+  }
+
+  fn literalize_match_pattern_context_read_var(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    var: &mech_core::Var,
+  ) -> MResult<Option<mech_core::Expression>> {
+    let Some(var_context) = &var.context else {
+      return Ok(None);
+    };
+
+    let target = var_context.to_string();
+    let path = var.name.to_string();
+    if let Some(binding) = registry.get(&target) {
+      let value = self.read_context_resource(context, binding, &path)?;
+      return Ok(Some(self.context_pattern_value_expression(value)?));
+    }
+
+    let address_key = format!("@{target}/{path}");
+    let value = {
+      let symbols = program.interpreter().symbols();
+      let symbols = symbols.borrow();
+      symbols
+        .get(hash_str(&address_key))
+        .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
+    };
+
+    if let Some(value) = value {
+      return Ok(Some(self.context_pattern_value_expression(value)?));
+    }
+
+    Ok(None)
+  }
+
+  fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
+    let value = resolve_runtime_value(value);
+    match value {
+      Value::String(value) => {
+        let text = value.borrow().clone();
+        Ok(mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
+          text: mech_core::Token::new(
+            mech_core::TokenKind::String,
+            mech_core::SourceRange::default(),
+            text.chars().collect(),
+          ),
+        })))
+      }
+      #[cfg(feature = "bool")]
+      Value::Bool(value) => {
+        let flag = *value.borrow();
+        Ok(mech_core::Expression::Literal(mech_core::Literal::Boolean(mech_core::Token::new(
+          if flag { mech_core::TokenKind::True } else { mech_core::TokenKind::False },
+          mech_core::SourceRange::default(),
+          if flag { "true".chars().collect() } else { "false".chars().collect() },
+        ))))
+      }
+      Value::Empty => Ok(mech_core::Expression::Literal(mech_core::Literal::Empty(mech_core::Token::new(
+        mech_core::TokenKind::Empty,
+        mech_core::SourceRange::default(),
+        vec!['_'],
+      )))),
+      other => Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "context_match_pattern",
+        reason: format!("context match patterns currently support string, bool, and empty values; got {other:?}"),
+      }, None)),
+    }
+  }
+
+  fn resolve_context_reads_in_transition(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    transition: &mech_core::Transition,
+  ) -> MResult<mech_core::Transition> {
+    match transition {
+      mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
+        code_items.iter()
+          .map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone())))
+          .collect::<MResult<Vec<_>>>()?,
+      )),
+      mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
+        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+      )),
+      mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
+        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+      )),
+    }
+  }
+
+  fn resolve_context_reads_in_fsm_pipe(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pipe: &mech_core::FsmPipe,
+  ) -> MResult<mech_core::FsmPipe> {
+    let mut pipe = pipe.clone();
+
+    if let Some(args) = &pipe.start.args {
+      pipe.start.args = Some(args.iter().map(|(name, expression)| {
+        Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
+      }).collect::<MResult<Vec<_>>>()?);
+    }
+
+    pipe.transitions = pipe.transitions.iter()
+      .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+      .collect::<MResult<Vec<_>>>()?;
+
+    Ok(pipe)
+  }
+
+  fn resolve_context_reads_in_fsm_implementation(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    fsm: &mech_core::FsmImplementation,
+  ) -> MResult<mech_core::FsmImplementation> {
+    let arms = fsm.arms.iter().map(|arm| {
+      match arm {
+        mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
+          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
+          guards.iter().map(|guard| Ok(mech_core::Guard {
+            condition: self.resolve_context_reads_in_match_pattern(
+              context,
+              program,
+              registry,
+              &guard.condition,
+            )?,
+            transitions: guard.transitions.iter()
+              .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+              .collect::<MResult<Vec<_>>>()?,
+          })).collect::<MResult<Vec<_>>>()?,
+        )),
+        mech_core::FsmArm::Transition(pattern, transitions) => Ok(mech_core::FsmArm::Transition(
+          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
+          transitions.iter()
+            .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
+            .collect::<MResult<Vec<_>>>()?,
+        )),
+        mech_core::FsmArm::Comment(comment) => Ok(mech_core::FsmArm::Comment(comment.clone())),
+      }
+    }).collect::<MResult<Vec<_>>>()?;
+
+    Ok(mech_core::FsmImplementation {
+      name: fsm.name.clone(),
+      input: fsm.input.clone(),
+      start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
+      arms,
+    })
+  }
+
+  fn resolve_context_reads_in_function_define(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    function: &mech_core::FunctionDefine,
+  ) -> MResult<mech_core::FunctionDefine> {
+    Ok(mech_core::FunctionDefine {
+      name: function.name.clone(),
+      input: function.input.clone(),
+      output: function.output.clone(),
+      statements: function.statements.clone(),
+      match_arms: function.match_arms.iter().map(|arm| Ok(mech_core::FunctionMatchArm {
+        pattern: self.resolve_context_reads_in_match_pattern(
+          context,
+          program,
+          registry,
+          &arm.pattern,
+        )?,
+        expression: arm.expression.clone(),
+      })).collect::<MResult<Vec<_>>>()?,
+    })
+  }
+
+  fn resolve_context_reads_in_mech_code(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    code: &mech_core::MechCode,
+  ) -> MResult<mech_core::MechCode> {
+    match code {
+      mech_core::MechCode::ActivationScope(scope) => {
+        let mut scope = scope.clone();
+        scope.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+        scope.body = scope.body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?;
+        Ok(mech_core::MechCode::ActivationScope(scope))
+      },
+      mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
+        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+      )),
+      mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
+        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+      )),
+      mech_core::MechCode::FsmImplementation(fsm) => Ok(mech_core::MechCode::FsmImplementation(
+        self.resolve_context_reads_in_fsm_implementation(context, program, registry, fsm)?,
+      )),
+      mech_core::MechCode::FsmSpecification(spec) => Ok(mech_core::MechCode::FsmSpecification(spec.clone())),
+      mech_core::MechCode::FunctionDefine(function) => Ok(mech_core::MechCode::FunctionDefine(
+        self.resolve_context_reads_in_function_define(context, program, registry, function)?,
+      )),
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Comment(_)
+      | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
+    }
+  }
+
+  fn resolve_context_reads_in_statement(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    statement: &mech_core::Statement,
+  ) -> MResult<mech_core::Statement> {
+    match statement {
+      mech_core::Statement::VariableDefine(var_def) => {
+        let mut var_def = var_def.clone();
+        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
+        Ok(mech_core::Statement::VariableDefine(var_def))
+      }
+      mech_core::Statement::VariableAssign(assign) => {
+        let mut assign = assign.clone();
+        assign.target = self.resolve_context_reads_in_slice_ref(context, program, registry, &assign.target)?;
+        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+        Ok(mech_core::Statement::VariableAssign(assign))
+      }
+      mech_core::Statement::OpAssign(op_assign) => {
+        let mut op_assign = op_assign.clone();
+        op_assign.target = self.resolve_context_reads_in_slice_ref(context, program, registry, &op_assign.target)?;
+        op_assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &op_assign.expression)?;
+        Ok(mech_core::Statement::OpAssign(op_assign))
+      }
+      mech_core::Statement::TupleDestructure(tuple_destructure) => {
+        let mut tuple_destructure = tuple_destructure.clone();
+        tuple_destructure.expression = self.resolve_context_reads_in_expression(context, program, registry, &tuple_destructure.expression)?;
+        Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
+      }
+      #[cfg(feature = "invariant_define")]
+      mech_core::Statement::InvariantDefine(invariant) => {
+        let mut invariant = invariant.clone();
+        invariant.expression = self.resolve_context_reads_in_expression(context, program, registry, &invariant.expression)?;
+        Ok(mech_core::Statement::InvariantDefine(invariant))
+      }
+      mech_core::Statement::FsmDeclare(fsm) => {
+        let mut fsm = fsm.clone();
+        fsm.pipe = self.resolve_context_reads_in_fsm_pipe(context, program, registry, &fsm.pipe)?;
+        Ok(mech_core::Statement::FsmDeclare(fsm))
+      }
+      _ => Ok(statement.clone()),
+    }
+  }
+
+  fn push_direct_code(
+    &mut self,
+    context: &RuntimeContext,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    pending: &mut Vec<mech_core::SectionElement>,
+    pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
+    result: &mut Value,
+    skip_non_context_imports: bool,
+    code: &mech_core::MechCode,
+    comment: &Option<mech_core::Comment>,
+  ) -> MResult<()> {
+    match code {
+      mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => Ok(()),
+      mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
+      mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
+      | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
+      mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
+        if !pending_codes.is_empty() {
+          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
         }
-    }
-
-    fn resolve_context_reads_in_fsm_pipe(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        pipe: &mech_core::FsmPipe,
-    ) -> MResult<mech_core::FsmPipe> {
-        let mut pipe = pipe.clone();
-
-        if let Some(args) = &pipe.start.args {
-            pipe.start.args = Some(
-                args.iter()
-                    .map(|(name, expression)| {
-                        Ok((
-                            name.clone(),
-                            self.resolve_context_reads_in_expression(
-                                context, program, registry, expression,
-                            )?,
-                        ))
-                    })
-                    .collect::<MResult<Vec<_>>>()?,
-            );
+        self.flush_direct_execution(program, pending, result)?;
+        let id = hash_str(&export.name.to_string());
+        if let Some(value) = program.interpreter().symbols().borrow().get(id) {
+          *result = resolve_runtime_value(value.borrow().clone());
+        } else {
+          *result = Value::Empty;
         }
-
-        pipe.transitions = pipe
-            .transitions
-            .iter()
-            .map(|transition| {
-                self.resolve_context_reads_in_transition(context, program, registry, transition)
-            })
-            .collect::<MResult<Vec<_>>>()?;
-
-        Ok(pipe)
-    }
-
-    fn resolve_context_reads_in_fsm_implementation(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        fsm: &mech_core::FsmImplementation,
-    ) -> MResult<mech_core::FsmImplementation> {
-        let arms = fsm
-            .arms
-            .iter()
-            .map(|arm| match arm {
-                mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
-                    self.resolve_context_reads_in_match_pattern(
-                        context, program, registry, pattern,
-                    )?,
-                    guards
-                        .iter()
-                        .map(|guard| {
-                            Ok(mech_core::Guard {
-                                condition: self.resolve_context_reads_in_match_pattern(
-                                    context,
-                                    program,
-                                    registry,
-                                    &guard.condition,
-                                )?,
-                                transitions: guard
-                                    .transitions
-                                    .iter()
-                                    .map(|transition| {
-                                        self.resolve_context_reads_in_transition(
-                                            context, program, registry, transition,
-                                        )
-                                    })
-                                    .collect::<MResult<Vec<_>>>()?,
-                            })
-                        })
-                        .collect::<MResult<Vec<_>>>()?,
-                )),
-                mech_core::FsmArm::Transition(pattern, transitions) => {
-                    Ok(mech_core::FsmArm::Transition(
-                        self.resolve_context_reads_in_match_pattern(
-                            context, program, registry, pattern,
-                        )?,
-                        transitions
-                            .iter()
-                            .map(|transition| {
-                                self.resolve_context_reads_in_transition(
-                                    context, program, registry, transition,
-                                )
-                            })
-                            .collect::<MResult<Vec<_>>>()?,
-                    ))
-                }
-                mech_core::FsmArm::Comment(comment) => {
-                    Ok(mech_core::FsmArm::Comment(comment.clone()))
-                }
-            })
-            .collect::<MResult<Vec<_>>>()?;
-
-        Ok(mech_core::FsmImplementation {
-            name: fsm.name.clone(),
-            input: fsm.input.clone(),
-            start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
-            arms,
-        })
-    }
-
-    fn resolve_context_reads_in_function_define(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        function: &mech_core::FunctionDefine,
-    ) -> MResult<mech_core::FunctionDefine> {
-        Ok(mech_core::FunctionDefine {
-            name: function.name.clone(),
-            input: function.input.clone(),
-            output: function.output.clone(),
-            statements: function.statements.clone(),
-            match_arms: function
-                .match_arms
-                .iter()
-                .map(|arm| {
-                    Ok(mech_core::FunctionMatchArm {
-                        pattern: self.resolve_context_reads_in_match_pattern(
-                            context,
-                            program,
-                            registry,
-                            &arm.pattern,
-                        )?,
-                        expression: arm.expression.clone(),
-                    })
-                })
-                .collect::<MResult<Vec<_>>>()?,
-        })
-    }
-
-    fn resolve_context_reads_in_mech_code(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        code: &mech_core::MechCode,
-    ) -> MResult<mech_core::MechCode> {
-        match code {
-            mech_core::MechCode::ActivationScope(scope) => {
-                let mut scope = scope.clone();
-                scope.trigger = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &scope.trigger,
-                )?;
-                scope.body = scope
-                    .body
-                    .iter()
-                    .map(|(code, comment)| {
-                        Ok((
-                            self.resolve_context_reads_in_mech_code(
-                                context, program, registry, code,
-                            )?,
-                            comment.clone(),
-                        ))
-                    })
-                    .collect::<MResult<_>>()?;
-                Ok(mech_core::MechCode::ActivationScope(scope))
-            }
-            mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
-                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-            )),
-            mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
-                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-            )),
-            mech_core::MechCode::FsmImplementation(fsm) => {
-                Ok(mech_core::MechCode::FsmImplementation(
-                    self.resolve_context_reads_in_fsm_implementation(
-                        context, program, registry, fsm,
-                    )?,
-                ))
-            }
-            mech_core::MechCode::FsmSpecification(spec) => {
-                Ok(mech_core::MechCode::FsmSpecification(spec.clone()))
-            }
-            mech_core::MechCode::FunctionDefine(function) => {
-                Ok(mech_core::MechCode::FunctionDefine(
-                    self.resolve_context_reads_in_function_define(
-                        context, program, registry, function,
-                    )?,
-                ))
-            }
-            mech_core::MechCode::Import(_)
-            | mech_core::MechCode::Comment(_)
-            | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
-        }
-    }
-
-    fn resolve_context_reads_in_statement(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        statement: &mech_core::Statement,
-    ) -> MResult<mech_core::Statement> {
-        match statement {
-            mech_core::Statement::VariableDefine(var_def) => {
-                let mut var_def = var_def.clone();
-                var_def.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &var_def.expression,
-                )?;
-                Ok(mech_core::Statement::VariableDefine(var_def))
-            }
-            mech_core::Statement::VariableAssign(assign) => {
-                let mut assign = assign.clone();
-                assign.target = self.resolve_context_reads_in_slice_ref(
-                    context,
-                    program,
-                    registry,
-                    &assign.target,
-                )?;
-                assign.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &assign.expression,
-                )?;
-                Ok(mech_core::Statement::VariableAssign(assign))
-            }
-            mech_core::Statement::OpAssign(op_assign) => {
-                let mut op_assign = op_assign.clone();
-                op_assign.target = self.resolve_context_reads_in_slice_ref(
-                    context,
-                    program,
-                    registry,
-                    &op_assign.target,
-                )?;
-                op_assign.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &op_assign.expression,
-                )?;
-                Ok(mech_core::Statement::OpAssign(op_assign))
-            }
-            mech_core::Statement::TupleDestructure(tuple_destructure) => {
-                let mut tuple_destructure = tuple_destructure.clone();
-                tuple_destructure.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &tuple_destructure.expression,
-                )?;
-                Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
-            }
-            #[cfg(feature = "invariant_define")]
-            mech_core::Statement::InvariantDefine(invariant) => {
-                let mut invariant = invariant.clone();
-                invariant.expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &invariant.expression,
-                )?;
-                Ok(mech_core::Statement::InvariantDefine(invariant))
-            }
-            mech_core::Statement::FsmDeclare(fsm) => {
-                let mut fsm = fsm.clone();
-                fsm.pipe =
-                    self.resolve_context_reads_in_fsm_pipe(context, program, registry, &fsm.pipe)?;
-                Ok(mech_core::Statement::FsmDeclare(fsm))
-            }
-            _ => Ok(statement.clone()),
-        }
-    }
-
-    fn push_direct_code(
-        &mut self,
-        context: &RuntimeContext,
-        program: &mut MechProgram,
-        registry: &RuntimeContextRegistry,
-        pending: &mut Vec<mech_core::SectionElement>,
-        pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
-        result: &mut Value,
-        skip_non_context_imports: bool,
-        code: &mech_core::MechCode,
-        comment: &Option<mech_core::Comment>,
-    ) -> MResult<()> {
-        match code {
-            mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => {
-                Ok(())
-            }
-            mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
-            mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
-            | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
-            mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
-                if !pending_codes.is_empty() {
-                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                        pending_codes,
-                    )));
-                }
-                self.flush_direct_execution(program, pending, result)?;
-                let id = hash_str(&export.name.to_string());
-                if let Some(value) = program.interpreter().symbols().borrow().get(id) {
-                    *result = resolve_runtime_value(value.borrow().clone());
-                } else {
-                    *result = Value::Empty;
-                }
-                Ok(())
-            }
-            mech_core::MechCode::ActivationScope(scope) => {
-                if !pending_codes.is_empty() {
-                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                        pending_codes,
-                    )));
-                }
-                self.flush_direct_execution(program, pending, result)?;
-                let mut lowered = scope.clone();
-                lowered.trigger = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &scope.trigger,
-                )?;
-                let mut registrations = Vec::new();
-                lowered.body.clear();
-                for (body_code, body_comment) in &scope.body {
-                    match body_code {
-                        mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
-                            let context_name = send.target.context.as_ref().unwrap().to_string();
-                            let binding =
-                                registry.get(&context_name).cloned().ok_or_else(|| {
-                                    MechError::new(
-                                        RuntimeAddressedAssignmentUnsupported {
-                                            target: context_name.clone(),
-                                        },
-                                        None,
-                                    )
-                                })?;
-                            let index = self.persistent_sends.len() + registrations.len();
-                            let value_name =
-                                format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
-                            let value = mech_core::VariableDefine {
-                                mutable: false,
-                                var: mech_core::Var {
-                                    name: identifier_from_str(&value_name),
-                                    context: None,
-                                    kind: None,
-                                },
-                                expression: self.resolve_context_reads_in_expression(
-                                    context,
-                                    program,
-                                    registry,
-                                    &send.expression,
-                                )?,
-                            };
-                            lowered.body.push((
-                                mech_core::MechCode::Statement(
-                                    mech_core::Statement::VariableDefine(value),
-                                ),
-                                body_comment.clone(),
-                            ));
-                            registrations.push((
-                                binding,
-                                send.target.name.to_string(),
-                                hash_str(&value_name),
-                            ));
-                        }
-                        _ => lowered.body.push((
-                            self.resolve_context_reads_in_mech_code(
-                                context, program, registry, body_code,
-                            )?,
-                            body_comment.clone(),
-                        )),
-                    }
-                }
-                if registrations.is_empty() {
-                    program.run_tree(&single_code_program(
-                        mech_core::MechCode::ActivationScope(lowered),
-                        comment.clone(),
-                    ))?;
-                    return Ok(());
-                }
-                lowered.body.push((
-                    mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(
-                        mech_core::FunctionCall {
-                            name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME),
-                            args: vec![],
-                        },
-                    )),
-                    None,
-                ));
-                self.validate_live_context_candidate(context)?;
-                let plan_start = program.interpreter().plan().borrow().nodes.len();
-                program.run_tree(&single_code_program(
-                    mech_core::MechCode::ActivationScope(lowered),
-                    comment.clone(),
-                ))?;
-                let interpreter_id = program.interpreter().id;
-                let trigger_cells = match &scope.trigger {
-                    mech_core::Expression::Var(var) => program
-                        .interpreter()
-                        .symbols()
-                        .borrow()
-                        .get(var.name.hash())
-                        .ok_or_else(|| {
-                            MechError::new(
-                                RuntimeActivationEffectBarrierInvariantError {
-                                    reason: "activation trigger disappeared".into(),
-                                },
-                                None,
-                            )
-                        })?
-                        .borrow()
-                        .reactive_root_cell_ids(),
-                    _ => vec![],
-                };
-                let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..]
-                    .iter()
-                    .filter(|node| {
-                        node.kind == mech_core::ReactiveNodeKind::Combinational
-                            && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
-                            && trigger_cells.iter().all(|cell| {
-                                node.inputs.iter().any(|dependency| {
-                                    dependency.cell == *cell
-                                        && dependency.kind
-                                            == mech_core::ReactiveDependencyKind::Reactive
-                                })
-                            })
-                    })
-                    .map(|node| node.id)
-                    .collect();
-                if barrier_ids.len() != 1 {
-                    return Err(MechError::new(
-                        RuntimeActivationEffectBarrierInvariantError {
-                            reason: format!(
-                                "expected exactly one activation effect barrier, found {}",
-                                barrier_ids.len()
-                            ),
-                        },
-                        None,
-                    ));
-                }
-                let barrier_node_id = barrier_ids[0];
-                let symbols = program.interpreter().symbols();
-                let mut sends = Vec::new();
-                for (binding, path, value_id) in registrations {
-                    let value = symbols.borrow().get(value_id).ok_or_else(|| {
-                        MechError::new(
-                            RuntimeActivationEffectBarrierInvariantError {
-                                reason: "missing lowered activation payload".into(),
-                            },
-                            None,
-                        )
-                    })?;
-                    sends.push(RuntimePersistentSend {
-                        binding,
-                        path,
-                        value,
-                        schedule: RuntimePersistentSendSchedule::Activation {
-                            interpreter_id,
-                            barrier_node_id,
-                        },
-                    });
-                }
-                self.persistent_sends.extend(sends);
-                self.commit_live_context_candidate(context);
-                Ok(())
-            }
-            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-                if let Some(context_name) = &var_def.var.context {
-                    let target = context_name.to_string();
-                    if let Some(binding) = registry.get(&target).cloned() {
-                        if !pending_codes.is_empty() {
-                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                                pending_codes,
-                            )));
-                        }
-                        self.flush_direct_execution(program, pending, result)?;
-                        return Err(MechError::new(
-                            RuntimeInvalidOperationError {
-                                operation: "direct_context_define",
-                                reason: format!(
-                                    "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
-                                    binding.name,
-                                    var_def.var.name.to_string()
-                                ),
-                            },
-                            None,
-                        ));
-                    }
-                }
-                let code = self.resolve_context_reads_in_mech_code(
-                    context,
-                    program,
-                    registry,
-                    &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(
-                        var_def.clone(),
-                    )),
-                )?;
-                pending_codes.push((code, comment.clone()));
-                Ok(())
-            }
+        Ok(())
+      }
+      mech_core::MechCode::ActivationScope(scope) => {
+        if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
+        self.flush_direct_execution(program, pending, result)?;
+        let mut lowered = scope.clone();
+        lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+        let mut registrations = Vec::new();
+        lowered.body.clear();
+        for (body_code, body_comment) in &scope.body {
+          match body_code {
             mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
-                // Context sends are executed only at module top level for now. Parser paths
-                // intentionally reject nested sends until interpreter/effect execution can
-                // support them in functions and state machines.
-                let Some(context_name) = &send.target.context else {
-                    return Err(MechError::new(
-                        RuntimeAddressedAssignmentUnsupported {
-                            target: send.target.name.to_string(),
-                        },
-                        None,
-                    ));
-                };
-                let target = context_name.to_string();
-                let Some(binding) = registry.get(&target).cloned() else {
-                    return Err(MechError::new(
-                        RuntimeAddressedAssignmentUnsupported { target },
-                        None,
-                    ));
-                };
-                if !pending_codes.is_empty() {
-                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                        pending_codes,
-                    )));
-                }
-                self.flush_direct_execution(program, pending, result)?;
-                let expression = self.resolve_context_reads_in_expression(
-                    context,
-                    program,
-                    registry,
-                    &send.expression,
-                )?;
-                let path = send.target.name.to_string();
-                if self.live_registration_mode
-                    == crate::runtime::LiveRegistrationMode::IsolatedSnapshot
-                {
-                    let value = resolve_runtime_value(
-                        self.evaluate_expression_on_program(program, &expression)?,
-                    );
-                    self.write_context_resource(
-                        context,
-                        &binding,
-                        &path,
-                        value.clone(),
-                        RuntimeResourceWriteIntent::Send,
-                    )?;
-                    *result = value;
-                    return Ok(());
-                }
-                self.validate_live_context_candidate(context)?;
-                let value_cell = self.bind_persistent_send_value_on_program(program, expression)?;
-                let value = resolve_runtime_value(value_cell.borrow().clone());
-                self.write_context_resource(
-                    context,
-                    &binding,
-                    &path,
-                    value.clone(),
-                    RuntimeResourceWriteIntent::Send,
-                )?;
-                self.persistent_sends.push(RuntimePersistentSend {
-                    binding,
-                    path,
-                    value: value_cell,
-                    schedule: RuntimePersistentSendSchedule::EveryAcceptedTurn,
-                });
-                self.commit_live_context_candidate(context);
-                *result = value;
-                return Ok(());
+              let context_name = send.target.context.as_ref().unwrap().to_string();
+              let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
+              let index = self.persistent_sends.len() + registrations.len();
+              let value_name = format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
+              let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
+              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
+              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
             }
-            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-                if let Some(context_name) = &assign.target.context {
-                    let target = context_name.to_string();
-                    if let Some(binding) = registry.get(&target).cloned() {
-                        if !pending_codes.is_empty() {
-                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
-                                pending_codes,
-                            )));
-                        }
-                        self.flush_direct_execution(program, pending, result)?;
-                        let expression = self.resolve_context_reads_in_expression(
-                            context,
-                            program,
-                            registry,
-                            &assign.expression,
-                        )?;
-                        let value = resolve_runtime_value(
-                            self.evaluate_expression_on_program(program, &expression)?,
-                        );
-                        self.write_context_resource(
-                            context,
-                            &binding,
-                            &assign.target.name.to_string(),
-                            value.clone(),
-                            RuntimeResourceWriteIntent::Assign,
-                        )?;
-                        *result = value;
-                        return Ok(());
-                    }
-                }
-                let code = self.resolve_context_reads_in_mech_code(
-                    context,
-                    program,
-                    registry,
-                    &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(
-                        assign.clone(),
-                    )),
-                )?;
-                pending_codes.push((code, comment.clone()));
-                Ok(())
-            }
-            _ => {
-                let code =
-                    self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
-                pending_codes.push((code, comment.clone()));
-                Ok(())
-            }
+            _ => lowered.body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
+          }
         }
-    }
-
-    fn preflight_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        tree: &mech_core::Program,
-        scope: &SourceScope,
-    ) -> MResult<()> {
-        let registry = self.direct_context_registry_for_scope(tree, scope)?;
-        self.preflight_context_capabilities_with_registry(
-            context,
-            &registry,
-            tree,
-            scope,
-            AddressedReadPreflight::RequireContextBinding,
-        )
-    }
-
-    fn preflight_context_capabilities_with_registry(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        tree: &mech_core::Program,
-        scope: &SourceScope,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        for section in &tree.body.sections {
-            for element in &section.elements {
-                match element {
-                    mech_core::SectionElement::MechCode(codes) => {
-                        for (code, _) in codes {
-                            self.preflight_code_context_capabilities(
-                                context,
-                                registry,
-                                code,
-                                DirectContextEffectPlacement::TopLevel,
-                                addressed_read_preflight,
-                            )?;
-                        }
-                    }
-                    mech_core::SectionElement::FencedMechCode(fenced)
-                        if Self::executable_fence_for_scope(fenced, scope) =>
-                    {
-                        for (code, _) in &fenced.code {
-                            self.preflight_code_context_capabilities(
-                                context,
-                                registry,
-                                code,
-                                DirectContextEffectPlacement::TopLevel,
-                                addressed_read_preflight,
-                            )?;
-                        }
-                    }
-                    _ => {}
-                }
+        if registrations.is_empty() {
+          program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          return Ok(());
+        }
+        lowered.body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
+        self.validate_live_context_candidate(context)?;
+        let plan_start = program.interpreter().plan().borrow().nodes.len();
+        program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+        let interpreter_id = program.interpreter().id;
+        let trigger_cells = match &scope.trigger { mech_core::Expression::Var(var) => program.interpreter().symbols().borrow().get(var.name.hash()).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation trigger disappeared".into() }, None))?.borrow().reactive_root_cell_ids(), _ => vec![] };
+        let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..].iter().filter(|node| node.kind == mech_core::ReactiveNodeKind::Combinational && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME && trigger_cells.iter().all(|cell| node.inputs.iter().any(|dependency| dependency.cell == *cell && dependency.kind == mech_core::ReactiveDependencyKind::Reactive))).map(|node| node.id).collect();
+        if barrier_ids.len() != 1 { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: format!("expected exactly one activation effect barrier, found {}", barrier_ids.len()) }, None)); }
+        let barrier_node_id = barrier_ids[0];
+        let symbols = program.interpreter().symbols();
+        let mut sends = Vec::new();
+        for (binding, path, value_id) in registrations {
+          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "missing lowered activation payload".into() }, None))?;
+          sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } });
+        }
+        self.persistent_sends.extend(sends);
+        self.commit_live_context_candidate(context);
+        Ok(())
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+        if let Some(context_name) = &var_def.var.context {
+          let target = context_name.to_string();
+          if let Some(binding) = registry.get(&target).cloned() {
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
             }
+            self.flush_direct_execution(program, pending, result)?;
+            return Err(MechError::new(RuntimeInvalidOperationError {
+              operation: "direct_context_define",
+              reason: format!(
+                "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
+                binding.name,
+                var_def.var.name.to_string()
+              ),
+            }, None));
+          }
+        }
+        let code = self.resolve_context_reads_in_mech_code(
+          context,
+          program,
+          registry,
+          &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def.clone())),
+        )?;
+        pending_codes.push((code, comment.clone()));
+        Ok(())
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+        // Context sends are executed only at module top level for now. Parser paths
+        // intentionally reject nested sends until interpreter/effect execution can
+        // support them in functions and state machines.
+        let Some(context_name) = &send.target.context else {
+          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: send.target.name.to_string() }, None));
+        };
+        let target = context_name.to_string();
+        let Some(binding) = registry.get(&target).cloned() else {
+          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target }, None));
+        };
+        if !pending_codes.is_empty() {
+          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+        }
+        self.flush_direct_execution(program, pending, result)?;
+        let expression = self.resolve_context_reads_in_expression(context, program, registry, &send.expression)?;
+        let path = send.target.name.to_string();
+        if self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot {
+          let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
+          self.write_context_resource(context, &binding, &path, value.clone(), RuntimeResourceWriteIntent::Send)?;
+          *result = value;
+          return Ok(());
+        }
+        self.validate_live_context_candidate(context)?;
+        let value_cell = self.bind_persistent_send_value_on_program(program, expression)?;
+        let value = resolve_runtime_value(value_cell.borrow().clone());
+        self.write_context_resource(context, &binding, &path, value.clone(), RuntimeResourceWriteIntent::Send)?;
+        self.persistent_sends.push(RuntimePersistentSend { binding, path, value: value_cell, schedule: RuntimePersistentSendSchedule::EveryAcceptedTurn });
+        self.commit_live_context_candidate(context);
+        *result = value;
+        return Ok(());
+      }
+      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+        if let Some(context_name) = &assign.target.context {
+          let target = context_name.to_string();
+          if let Some(binding) = registry.get(&target).cloned() {
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+            }
+            self.flush_direct_execution(program, pending, result)?;
+            let expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
+            let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
+            self.write_context_resource(context, &binding, &assign.target.name.to_string(), value.clone(), RuntimeResourceWriteIntent::Assign)?;
+            *result = value;
+            return Ok(());
+          }
+        }
+        let code = self.resolve_context_reads_in_mech_code(
+          context,
+          program,
+          registry,
+          &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign.clone())),
+        )?;
+        pending_codes.push((code, comment.clone()));
+        Ok(())
+      }
+      _ => {
+        let code = self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
+        pending_codes.push((code, comment.clone()));
+        Ok(())
+      }
+    }
+  }
+
+  fn preflight_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+  ) -> MResult<()> {
+    let registry = self.direct_context_registry_for_scope(tree, scope)?;
+    self.preflight_context_capabilities_with_registry(context, &registry, tree, scope, AddressedReadPreflight::RequireContextBinding)
+  }
+
+  fn preflight_context_capabilities_with_registry(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    tree: &mech_core::Program,
+    scope: &SourceScope,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            for (code, _) in codes {
+              self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::TopLevel, addressed_read_preflight)?;
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, scope) =>
+          {
+            for (code, _) in &fenced.code {
+              self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::TopLevel, addressed_read_preflight)?;
+            }
+          }
+          _ => {}
+        }
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_code_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    code: &mech_core::MechCode,
+    placement: DirectContextEffectPlacement,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match code {
+      mech_core::MechCode::ActivationScope(scope) => {
+        self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
+        let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
+        // Only writes to local registers conflict with an effectful activation.
+        // Context-addressed assignments have their own, operation-specific
+        // placement error below (they are top-level only).
+        let has_register = scope.body.iter().any(|(code, _)| match code {
+          mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => assign.target.context.is_none(),
+          mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => assign.target.context.is_none(),
+          _ => false,
+        });
+        if has_send && has_register { return Err(MechError::new(ActivationScopeEffectWithRegisterUnsupported, None)); }
+        if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot { return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None)); }
+        for (body_code, _) in &scope.body {
+          self.preflight_code_context_capabilities(context, registry, body_code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?;
         }
         Ok(())
+      }
+      mech_core::MechCode::Statement(statement) => {
+        self.preflight_statement_context_capabilities(context, registry, statement, placement, addressed_read_preflight)
+      }
+      mech_core::MechCode::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
+      }
+      mech_core::MechCode::FsmImplementation(fsm) => {
+        self.preflight_fsm_implementation_context_capabilities(context, registry, fsm, addressed_read_preflight)
+      }
+      mech_core::MechCode::FunctionDefine(function) => {
+        self.preflight_function_define_context_capabilities(context, registry, function, addressed_read_preflight)
+      }
+      mech_core::MechCode::Import(_)
+      | mech_core::MechCode::Comment(_)
+      | mech_core::MechCode::FsmSpecification(_)
+      | mech_core::MechCode::Error(_, _) => Ok(()),
+    }
+  }
+
+  fn preflight_function_define_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    function: &mech_core::FunctionDefine,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    for statement in &function.statements {
+      self.reject_runtime_context_reads_in_statement(registry, statement)?;
+    }
+    for arm in &function.match_arms {
+      self.reject_runtime_context_reads_in_pattern(registry, &arm.pattern)?;
+      self.reject_runtime_context_reads_in_expression(registry, &arm.expression)?;
     }
 
-    fn preflight_code_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        code: &mech_core::MechCode,
-        placement: DirectContextEffectPlacement,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match code {
-            mech_core::MechCode::ActivationScope(scope) => {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &scope.trigger,
-                    addressed_read_preflight,
-                )?;
-                let has_send = scope.body.iter().any(|(code, _)| {
-                    matches!(
-                        code,
-                        mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))
-                    )
-                });
-                // Only writes to local registers conflict with an effectful activation.
-                // Context-addressed assignments have their own, operation-specific
-                // placement error below (they are top-level only).
-                let has_register = scope.body.iter().any(|(code, _)| match code {
-                    mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(
-                        assign,
-                    )) => assign.target.context.is_none(),
-                    mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => {
-                        assign.target.context.is_none()
-                    }
-                    _ => false,
-                });
-                if has_send && has_register {
-                    return Err(MechError::new(
-                        ActivationScopeEffectWithRegisterUnsupported,
-                        None,
-                    ));
-                }
-                if has_send
-                    && self.live_registration_mode
-                        == crate::runtime::LiveRegistrationMode::IsolatedSnapshot
-                {
-                    return Err(MechError::new(
-                        RuntimeIsolatedActivationSendUnsupported,
-                        None,
-                    ));
-                }
-                for (body_code, _) in &scope.body {
-                    self.preflight_code_context_capabilities(
-                        context,
-                        registry,
-                        body_code,
-                        DirectContextEffectPlacement::ActivationScope,
-                        addressed_read_preflight,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::MechCode::Statement(statement) => self
-                .preflight_statement_context_capabilities(
-                    context,
-                    registry,
-                    statement,
-                    placement,
-                    addressed_read_preflight,
-                ),
-            mech_core::MechCode::Expression(expression) => self.preflight_expression_context_reads(
-                context,
-                registry,
-                expression,
-                addressed_read_preflight,
-            ),
-            mech_core::MechCode::FsmImplementation(fsm) => self
-                .preflight_fsm_implementation_context_capabilities(
-                    context,
-                    registry,
-                    fsm,
-                    addressed_read_preflight,
-                ),
-            mech_core::MechCode::FunctionDefine(function) => self
-                .preflight_function_define_context_capabilities(
-                    context,
-                    registry,
-                    function,
-                    addressed_read_preflight,
-                ),
-            mech_core::MechCode::Import(_)
-            | mech_core::MechCode::Comment(_)
-            | mech_core::MechCode::FsmSpecification(_)
-            | mech_core::MechCode::Error(_, _) => Ok(()),
-        }
+    for statement in &function.statements {
+      self.preflight_statement_context_capabilities(
+        context,
+        registry,
+        statement,
+        DirectContextEffectPlacement::FunctionBody,
+        addressed_read_preflight,
+      )?;
     }
-
-    fn preflight_function_define_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        function: &mech_core::FunctionDefine,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        for statement in &function.statements {
-            self.reject_runtime_context_reads_in_statement(registry, statement)?;
-        }
-        for arm in &function.match_arms {
-            self.reject_runtime_context_reads_in_pattern(registry, &arm.pattern)?;
-            self.reject_runtime_context_reads_in_expression(registry, &arm.expression)?;
-        }
-
-        for statement in &function.statements {
-            self.preflight_statement_context_capabilities(
-                context,
-                registry,
-                statement,
-                DirectContextEffectPlacement::FunctionBody,
-                addressed_read_preflight,
-            )?;
-        }
-        for arm in &function.match_arms {
-            self.preflight_pattern_context_reads(
-                context,
-                registry,
-                &arm.pattern,
-                addressed_read_preflight,
-            )?;
-            self.preflight_expression_context_reads(
-                context,
-                registry,
-                &arm.expression,
-                addressed_read_preflight,
-            )?;
-        }
-        Ok(())
+    for arm in &function.match_arms {
+      self.preflight_pattern_context_reads(context, registry, &arm.pattern, addressed_read_preflight)?;
+      self.preflight_expression_context_reads(context, registry, &arm.expression, addressed_read_preflight)?;
     }
+    Ok(())
+  }
 
-    fn reject_function_context_read(
+  fn reject_function_context_read(
         &self,
         context_name: &mech_core::Identifier,
         path: &mech_core::Identifier,
@@ -2689,2887 +1908,2283 @@ impl MechRuntime {
     }
 
     fn preflight_fsm_implementation_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        fsm: &mech_core::FsmImplementation,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        self.preflight_pattern_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    fsm: &mech_core::FsmImplementation,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    self.preflight_pattern_context_reads(context, registry, &fsm.start, addressed_read_preflight)?;
+    for arm in &fsm.arms {
+      match arm {
+        mech_core::FsmArm::Guard(pattern, guards) => {
+          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+          for guard in guards {
+            self.preflight_pattern_context_reads(context, registry, &guard.condition, addressed_read_preflight)?;
+            for transition in &guard.transitions {
+              self.preflight_transition_context_capabilities(context, registry, transition, addressed_read_preflight)?;
+            }
+          }
+        }
+        mech_core::FsmArm::Transition(pattern, transitions) => {
+          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+          for transition in transitions {
+            self.preflight_transition_context_capabilities(context, registry, transition, addressed_read_preflight)?;
+          }
+        }
+        mech_core::FsmArm::Comment(_) => {}
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_transition_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    transition: &mech_core::Transition,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match transition {
+      mech_core::Transition::Async(pattern)
+      | mech_core::Transition::Next(pattern)
+      | mech_core::Transition::Output(pattern) => {
+        self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)
+      }
+      mech_core::Transition::CodeBlock(code_items) => {
+        for (code, _) in code_items {
+          self.preflight_code_context_capabilities(
             context,
             registry,
-            &fsm.start,
+            code,
+            DirectContextEffectPlacement::FsmTransition,
             addressed_read_preflight,
-        )?;
-        for arm in &fsm.arms {
-            match arm {
-                mech_core::FsmArm::Guard(pattern, guards) => {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        pattern,
-                        addressed_read_preflight,
-                    )?;
-                    for guard in guards {
-                        self.preflight_pattern_context_reads(
-                            context,
-                            registry,
-                            &guard.condition,
-                            addressed_read_preflight,
-                        )?;
-                        for transition in &guard.transitions {
-                            self.preflight_transition_context_capabilities(
-                                context,
-                                registry,
-                                transition,
-                                addressed_read_preflight,
-                            )?;
-                        }
-                    }
-                }
-                mech_core::FsmArm::Transition(pattern, transitions) => {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        pattern,
-                        addressed_read_preflight,
-                    )?;
-                    for transition in transitions {
-                        self.preflight_transition_context_capabilities(
-                            context,
-                            registry,
-                            transition,
-                            addressed_read_preflight,
-                        )?;
-                    }
-                }
-                mech_core::FsmArm::Comment(_) => {}
-            }
+          )?;
         }
         Ok(())
+      }
+      mech_core::Transition::Statement(statement) => {
+        self.preflight_statement_context_capabilities(
+          context,
+          registry,
+          statement,
+          DirectContextEffectPlacement::FsmTransition,
+          addressed_read_preflight,
+        )
+      }
     }
+  }
 
-    fn preflight_transition_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        transition: &mech_core::Transition,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match transition {
-            mech_core::Transition::Async(pattern)
-            | mech_core::Transition::Next(pattern)
-            | mech_core::Transition::Output(pattern) => self.preflight_pattern_context_reads(
-                context,
-                registry,
-                pattern,
-                addressed_read_preflight,
+  fn preflight_pattern_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    pattern: &mech_core::Pattern,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match pattern {
+      mech_core::Pattern::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
+      }
+      mech_core::Pattern::TupleStruct(tuple_struct) => {
+        for pattern in &tuple_struct.patterns {
+          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Tuple(tuple) => {
+        for pattern in &tuple.0 {
+          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Array(array) => {
+        for pattern in &array.prefix {
+          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+        }
+        if let Some(spread) = &array.spread {
+          if let Some(binding) = &spread.binding {
+            self.preflight_pattern_context_reads(context, registry, binding, addressed_read_preflight)?;
+          }
+        }
+        for pattern in &array.suffix {
+          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+        }
+        Ok(())
+      }
+      mech_core::Pattern::Wildcard => Ok(()),
+    }
+  }
+
+  fn preflight_statement_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    statement: &mech_core::Statement,
+    placement: DirectContextEffectPlacement,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match statement {
+      mech_core::Statement::VariableDefine(var_def) => {
+        if let Some(context_name) = &var_def.var.context {
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "direct_context_define",
+            reason: format!(
+              "context-addressed path `{}` cannot be defined with `:=`; use `=` or `<-`",
+              direct_context_target(&context_name.to_string(), &var_def.var.name.to_string()),
             ),
-            mech_core::Transition::CodeBlock(code_items) => {
-                for (code, _) in code_items {
-                    self.preflight_code_context_capabilities(
-                        context,
-                        registry,
-                        code,
-                        DirectContextEffectPlacement::FsmTransition,
-                        addressed_read_preflight,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::Transition::Statement(statement) => self
-                .preflight_statement_context_capabilities(
-                    context,
-                    registry,
-                    statement,
-                    DirectContextEffectPlacement::FsmTransition,
-                    addressed_read_preflight,
-                ),
+          }, None));
         }
-    }
-
-    fn preflight_pattern_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        pattern: &mech_core::Pattern,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match pattern {
-            mech_core::Pattern::Expression(expression) => self.preflight_expression_context_reads(
-                context,
-                registry,
-                expression,
-                addressed_read_preflight,
-            ),
-            mech_core::Pattern::TupleStruct(tuple_struct) => {
-                for pattern in &tuple_struct.patterns {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        pattern,
-                        addressed_read_preflight,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::Pattern::Tuple(tuple) => {
-                for pattern in &tuple.0 {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        pattern,
-                        addressed_read_preflight,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::Pattern::Array(array) => {
-                for pattern in &array.prefix {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        pattern,
-                        addressed_read_preflight,
-                    )?;
-                }
-                if let Some(spread) = &array.spread {
-                    if let Some(binding) = &spread.binding {
-                        self.preflight_pattern_context_reads(
-                            context,
-                            registry,
-                            binding,
-                            addressed_read_preflight,
-                        )?;
-                    }
-                }
-                for pattern in &array.suffix {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        pattern,
-                        addressed_read_preflight,
-                    )?;
-                }
-                Ok(())
-            }
-            mech_core::Pattern::Wildcard => Ok(()),
-        }
-    }
-
-    fn preflight_statement_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        statement: &mech_core::Statement,
-        placement: DirectContextEffectPlacement,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match statement {
-            mech_core::Statement::VariableDefine(var_def) => {
-                if let Some(context_name) = &var_def.var.context {
-                    return Err(MechError::new(
-                        RuntimeInvalidOperationError {
-                            operation: "direct_context_define",
-                            reason: format!(
-                                "context-addressed path `{}` cannot be defined with `:=`; use `=` or `<-`",
-                                direct_context_target(
-                                    &context_name.to_string(),
-                                    &var_def.var.name.to_string()
-                                ),
-                            ),
-                        },
-                        None,
-                    ));
-                }
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &var_def.expression,
-                    addressed_read_preflight,
-                )
-            }
-            mech_core::Statement::VariableAssign(assign) => {
-                self.preflight_slice_ref_subscript_context_reads(
-                    context,
-                    registry,
-                    &assign.target,
-                    addressed_read_preflight,
-                )?;
-                if let Some(context_name) = &assign.target.context {
-                    let context_name = context_name.to_string();
-                    let path = assign.target.name.to_string();
-                    self.reject_direct_context_effect_placement(
-                        "assignment",
-                        &context_name,
-                        &path,
-                        placement,
-                    )?;
-                    self.preflight_context_access(
-                        context,
-                        registry,
-                        &context_name,
-                        &path,
-                        RuntimeCapabilityOperation::Write,
-                        true,
-                        Some(RuntimeResourceWriteIntent::Assign),
-                    )?;
-                }
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &assign.expression,
-                    addressed_read_preflight,
-                )?;
-                Ok(())
-            }
-            mech_core::Statement::ContextSend(send) => {
-                let Some(context_name) = &send.target.context else {
-                    return Err(MechError::new(
-                        RuntimeInvalidOperationError {
-                            operation: "direct_context_send",
-                            reason: format!(
-                                "send target `{}` is not a context path",
-                                send.target.name.to_string()
-                            ),
-                        },
-                        None,
-                    ));
-                };
-
-                let context_name = context_name.to_string();
-                let path = send.target.name.to_string();
-
-                self.reject_direct_context_effect_placement(
-                    "send",
-                    &context_name,
-                    &path,
-                    placement,
-                )?;
-
-                self.preflight_context_send_access(context, registry, &context_name, &path)?;
-
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &send.expression,
-                    addressed_read_preflight,
-                )?;
-                Ok(())
-            }
-            mech_core::Statement::OpAssign(op_assign) => {
-                self.preflight_slice_ref_subscript_context_reads(
-                    context,
-                    registry,
-                    &op_assign.target,
-                    addressed_read_preflight,
-                )?;
-                if op_assign.target.context.is_some() {
-                    return Err(MechError::new(
-                        RuntimeInvalidOperationError {
-                            operation: "direct_context_op_assign",
-                            reason: "context op-assignment is not supported; use `=` or `<-`"
-                                .to_string(),
-                        },
-                        None,
-                    ));
-                }
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &op_assign.expression,
-                    addressed_read_preflight,
-                )
-            }
-            mech_core::Statement::TupleDestructure(tuple_destructure) => self
-                .preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &tuple_destructure.expression,
-                    addressed_read_preflight,
-                ),
-            #[cfg(feature = "invariant_define")]
-            mech_core::Statement::InvariantDefine(invariant) => self
-                .preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &invariant.expression,
-                    addressed_read_preflight,
-                ),
-            mech_core::Statement::FsmDeclare(fsm) => self.preflight_fsm_pipe_context_capabilities(
-                context,
-                registry,
-                &fsm.pipe,
-                addressed_read_preflight,
-            ),
-            _ => Ok(()),
-        }
-    }
-
-    fn preflight_fsm_pipe_context_capabilities(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        pipe: &mech_core::FsmPipe,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        if let Some(args) = &pipe.start.args {
-            for (_, expression) in args {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    expression,
-                    addressed_read_preflight,
-                )?;
-            }
-        }
-
-        for transition in &pipe.transitions {
-            self.preflight_transition_context_capabilities(
-                context,
-                registry,
-                transition,
-                addressed_read_preflight,
-            )?;
-        }
-
-        Ok(())
-    }
-
-    fn preflight_expression_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        expression: &mech_core::Expression,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match expression {
-            mech_core::Expression::Var(var) => {
-                if let Some(context_name) = &var.context {
-                    let context_name = context_name.to_string();
-                    if registry.contains(&context_name)
-                        || addressed_read_preflight.requires_context_binding()
-                    {
-                        self.preflight_context_access(
-                            context,
-                            registry,
-                            &context_name,
-                            &var.name.to_string(),
-                            RuntimeCapabilityOperation::Read,
-                            true,
-                            None,
-                        )?;
-                    }
-                }
-            }
-            mech_core::Expression::Formula(factor) => {
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    factor,
-                    addressed_read_preflight,
-                )?;
-            }
-            mech_core::Expression::FunctionCall(call) => {
-                for (_, expression) in &call.args {
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        expression,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Expression::FsmPipe(pipe) => {
-                self.preflight_fsm_pipe_context_capabilities(
-                    context,
-                    registry,
-                    pipe,
-                    addressed_read_preflight,
-                )?;
-            }
-            mech_core::Expression::Literal(_) => {}
-            mech_core::Expression::Range(range) => {
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    &range.start,
-                    addressed_read_preflight,
-                )?;
-                if let Some((_, increment)) = &range.increment {
-                    self.preflight_factor_context_reads(
-                        context,
-                        registry,
-                        increment,
-                        addressed_read_preflight,
-                    )?;
-                }
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    &range.terminal,
-                    addressed_read_preflight,
-                )?;
-            }
-            mech_core::Expression::Structure(structure) => {
-                self.preflight_structure_context_reads(
-                    context,
-                    registry,
-                    structure,
-                    addressed_read_preflight,
-                )?;
-            }
-            mech_core::Expression::Match(match_expression) => {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &match_expression.source,
-                    addressed_read_preflight,
-                )?;
-                for arm in &match_expression.arms {
-                    self.preflight_pattern_context_reads(
-                        context,
-                        registry,
-                        &arm.pattern,
-                        addressed_read_preflight,
-                    )?;
-                    if let Some(guard) = &arm.guard {
-                        self.preflight_expression_context_reads(
-                            context,
-                            registry,
-                            guard,
-                            addressed_read_preflight,
-                        )?;
-                    }
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        &arm.expression,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Expression::Slice(slice) => {
-                if let Some(context_name) = &slice.context {
-                    let context_name = context_name.to_string();
-                    if registry.contains(&context_name) {
-                        return Err(MechError::new(
-                            RuntimeInvalidOperationError {
-                                operation: "context_read",
-                                reason: "context-addressed slices are not supported".to_string(),
-                            },
-                            None,
-                        ));
-                    }
-                    if addressed_read_preflight.requires_context_binding() {
-                        return Err(undeclared_direct_context_target_error(&context_name));
-                    }
-                }
-                self.preflight_slice_context_reads(
-                    context,
-                    registry,
-                    slice,
-                    addressed_read_preflight,
-                )?;
-            }
-            mech_core::Expression::SetComprehension(comprehension) => {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &comprehension.expression,
-                    addressed_read_preflight,
-                )?;
-                for qualifier in &comprehension.qualifiers {
-                    self.preflight_comprehension_qualifier_context_reads(
-                        context,
-                        registry,
-                        qualifier,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Expression::MatrixComprehension(comprehension) => {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &comprehension.expression,
-                    addressed_read_preflight,
-                )?;
-                for qualifier in &comprehension.qualifiers {
-                    self.preflight_comprehension_qualifier_context_reads(
-                        context,
-                        registry,
-                        qualifier,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn preflight_factor_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        factor: &mech_core::Factor,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match factor {
-            mech_core::Factor::Expression(expression) => self.preflight_expression_context_reads(
-                context,
-                registry,
-                expression,
-                addressed_read_preflight,
-            ),
-            mech_core::Factor::Negate(factor)
-            | mech_core::Factor::Not(factor)
-            | mech_core::Factor::Parenthetical(factor)
-            | mech_core::Factor::Transpose(factor) => self.preflight_factor_context_reads(
-                context,
-                registry,
-                factor,
-                addressed_read_preflight,
-            ),
-            mech_core::Factor::Term(term) => {
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    &term.lhs,
-                    addressed_read_preflight,
-                )?;
-                for (_, factor) in &term.rhs {
-                    self.preflight_factor_context_reads(
-                        context,
-                        registry,
-                        factor,
-                        addressed_read_preflight,
-                    )?;
-                }
-                Ok(())
-            }
-        }
-    }
-
-    fn preflight_structure_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        structure: &mech_core::Structure,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match structure {
-            mech_core::Structure::Map(map) => {
-                for mapping in &map.elements {
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        &mapping.key,
-                        addressed_read_preflight,
-                    )?;
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        &mapping.value,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Structure::Set(set) => {
-                for expression in &set.elements {
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        expression,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Structure::Matrix(matrix) => {
-                for row in &matrix.rows {
-                    for column in &row.columns {
-                        self.preflight_expression_context_reads(
-                            context,
-                            registry,
-                            &column.element,
-                            addressed_read_preflight,
-                        )?;
-                    }
-                }
-            }
-            mech_core::Structure::Record(record) => {
-                for binding in &record.bindings {
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        &binding.value,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Structure::Table(table) => {
-                for row in &table.rows {
-                    for column in &row.columns {
-                        self.preflight_expression_context_reads(
-                            context,
-                            registry,
-                            &column.element,
-                            addressed_read_preflight,
-                        )?;
-                    }
-                }
-            }
-            mech_core::Structure::Tuple(tuple) => {
-                for expression in &tuple.elements {
-                    self.preflight_expression_context_reads(
-                        context,
-                        registry,
-                        expression,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Structure::TupleStruct(tuple_struct) => {
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &tuple_struct.value,
-                    addressed_read_preflight,
-                )?;
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn preflight_slice_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        slice: &mech_core::Slice,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        for subscript in &slice.subscript {
-            self.preflight_subscript_context_reads(
-                context,
-                registry,
-                subscript,
-                addressed_read_preflight,
-            )?;
-        }
-        Ok(())
-    }
-
-    fn preflight_slice_ref_subscript_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        target: &mech_core::SliceRef,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        if let Some(subscripts) = &target.subscript {
-            for subscript in subscripts {
-                self.preflight_subscript_context_reads(
-                    context,
-                    registry,
-                    subscript,
-                    addressed_read_preflight,
-                )?;
-            }
-        }
-        Ok(())
-    }
-
-    fn preflight_subscript_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        subscript: &mech_core::Subscript,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match subscript {
-            mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
-                for subscript in subscripts {
-                    self.preflight_subscript_context_reads(
-                        context,
-                        registry,
-                        subscript,
-                        addressed_read_preflight,
-                    )?;
-                }
-            }
-            mech_core::Subscript::Formula(factor) => {
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    factor,
-                    addressed_read_preflight,
-                )?;
-            }
-            mech_core::Subscript::Range(range) => {
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    &range.start,
-                    addressed_read_preflight,
-                )?;
-                if let Some((_, increment)) = &range.increment {
-                    self.preflight_factor_context_reads(
-                        context,
-                        registry,
-                        increment,
-                        addressed_read_preflight,
-                    )?;
-                }
-                self.preflight_factor_context_reads(
-                    context,
-                    registry,
-                    &range.terminal,
-                    addressed_read_preflight,
-                )?;
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn preflight_comprehension_qualifier_context_reads(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        qualifier: &mech_core::ComprehensionQualifier,
-        addressed_read_preflight: AddressedReadPreflight,
-    ) -> MResult<()> {
-        match qualifier {
-            mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
-                self.preflight_pattern_context_reads(
-                    context,
-                    registry,
-                    pattern,
-                    addressed_read_preflight,
-                )?;
-                self.preflight_expression_context_reads(
-                    context,
-                    registry,
-                    expression,
-                    addressed_read_preflight,
-                )
-            }
-            mech_core::ComprehensionQualifier::Filter(expression) => self
-                .preflight_expression_context_reads(
-                    context,
-                    registry,
-                    expression,
-                    addressed_read_preflight,
-                ),
-            mech_core::ComprehensionQualifier::Let(var_def) => self
-                .preflight_expression_context_reads(
-                    context,
-                    registry,
-                    &var_def.expression,
-                    addressed_read_preflight,
-                ),
-        }
-    }
-
-    fn reject_direct_context_effect_placement(
-        &self,
-        effect: &str,
-        context_name: &str,
-        path: &str,
-        placement: DirectContextEffectPlacement,
-    ) -> MResult<()> {
-        let allowed = match effect {
-            "assignment" => matches!(placement, DirectContextEffectPlacement::TopLevel),
-            "send" => matches!(
-                placement,
-                DirectContextEffectPlacement::TopLevel
-                    | DirectContextEffectPlacement::ActivationScope
-            ),
-            _ => false,
-        };
-        if allowed {
-            return Ok(());
-        }
-
-        Err(MechError::new(
-            RuntimeInvalidOperationError {
-                operation: "direct_context_effect_placement",
-                reason: format!(
-                    "context {effect} to `{}` is only supported at module top level, not inside {}",
-                    direct_context_target(context_name, path),
-                    placement.description(),
-                ),
-            },
-            None,
-        ))
-    }
-
-    fn preflight_context_send_access(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        context_name: &str,
-        path: &str,
-    ) -> MResult<()> {
-        let Some(binding) = registry.get(context_name) else {
-            return Err(undeclared_direct_context_target_error(context_name));
-        };
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        let operation = context_send_operation(binding, &resolved.context_path)?;
-        self.preflight_context_access(
+        self.preflight_expression_context_reads(context, registry, &var_def.expression, addressed_read_preflight)
+      }
+      mech_core::Statement::VariableAssign(assign) => {
+        self.preflight_slice_ref_subscript_context_reads(context, registry, &assign.target, addressed_read_preflight)?;
+        if let Some(context_name) = &assign.target.context {
+          let context_name = context_name.to_string();
+          let path = assign.target.name.to_string();
+          self.reject_direct_context_effect_placement(
+            "assignment",
+            &context_name,
+            &path,
+            placement,
+          )?;
+          self.preflight_context_access(
             context,
             registry,
-            context_name,
-            path,
-            operation,
+            &context_name,
+            &path,
+            RuntimeCapabilityOperation::Write,
             true,
-            Some(RuntimeResourceWriteIntent::Send),
-        )
-    }
-
-    fn preflight_context_access(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        context_name: &str,
-        path: &str,
-        operation: RuntimeCapabilityOperation,
-        require_context_binding: bool,
-        write_intent: Option<RuntimeResourceWriteIntent>,
-    ) -> MResult<()> {
-        let Some(binding) = registry.get(context_name) else {
-            if require_context_binding {
-                return Err(undeclared_direct_context_target_error(context_name));
-            }
-            return Ok(());
-        };
-        let resolved = self.resolve_context_resource_request(binding, path)?;
-        let context_allowed = match operation {
-            RuntimeCapabilityOperation::Read => {
-                runtime_context_allows_read(binding, &resolved.context_path)
-            }
-            RuntimeCapabilityOperation::Write => {
-                runtime_context_allows_write(binding, &resolved.context_path)
-            }
-            _ => {
-                runtime_context_allows_operation(binding, operation.name(), &resolved.context_path)
-            }
-        };
-        if !context_allowed {
-            return Err(MechError::new(
-                RuntimeResourceCapabilityDenied {
-                    context_name: binding.name.clone(),
-                    operation: match operation {
-                        RuntimeCapabilityOperation::Read => "read".to_string(),
-                        RuntimeCapabilityOperation::Write => "write".to_string(),
-                        other => format!("{other:?}"),
-                    },
-                    path: resolved.context_path,
-                },
-                None,
-            ));
+            Some(RuntimeResourceWriteIntent::Assign),
+          )?;
         }
-        if !self.has_capability_grant(
-            &context.subject,
-            &resolved.provider_base_uri,
-            &operation,
-            &resolved.provider_path,
-        ) {
-            return Err(MechError::new(
-                RuntimeCapabilityGrantDenied {
-                    subject: context.subject.clone(),
-                    resource: resolved.provider_base_uri,
-                    operation,
-                    path: resolved.provider_path,
-                },
-                None,
-            ));
-        }
-
-        if let Some(intent) = write_intent {
-            self.resources
-                .preflight_write(RuntimeResourceWritePreflightRequest {
-                    base_uri: resolved.provider_base_uri,
-                    path: resolved.provider_path,
-                    context_name: binding.name.clone(),
-                    operation: operation.clone(),
-                    intent,
-                })?;
-        }
-
+        self.preflight_expression_context_reads(context, registry, &assign.expression, addressed_read_preflight)?;
         Ok(())
-    }
-
-    fn run_tree_on_program(
-        &mut self,
-        context: &mut RuntimeContext,
-        program: &mut MechProgram,
-        tree: &mech_core::Program,
-        scope_hint: Option<&SourceScope>,
-    ) -> MResult<Value> {
-        let direct_document_run = scope_hint.is_none();
-        let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
-        let skip_non_context_imports = scope_hint.is_some();
-        let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
-        let mut result = Value::Empty;
-        let mut pending = Vec::new();
-
-        for section in &tree.body.sections {
-            for element in &section.elements {
-                match element {
-                    mech_core::SectionElement::MechCode(codes) => {
-                        let mut pending_codes = Vec::new();
-                        for (code, comment) in codes {
-                            self.push_direct_code(
-                                context,
-                                program,
-                                &registry,
-                                &mut pending,
-                                &mut pending_codes,
-                                &mut result,
-                                skip_non_context_imports,
-                                code,
-                                comment,
-                            )?;
-                        }
-                        if !pending_codes.is_empty() {
-                            pending.push(mech_core::SectionElement::MechCode(pending_codes));
-                        }
-                    }
-                    mech_core::SectionElement::FencedMechCode(fenced)
-                        if Self::executable_fence_for_scope(fenced, execution_scope) =>
-                    {
-                        let mut pending_codes = Vec::new();
-                        for (code, comment) in &fenced.code {
-                            self.push_direct_code(
-                                context,
-                                program,
-                                &registry,
-                                &mut pending,
-                                &mut pending_codes,
-                                &mut result,
-                                skip_non_context_imports,
-                                code,
-                                comment,
-                            )?;
-                        }
-                        if !pending_codes.is_empty() {
-                            let mut fenced = fenced.clone();
-                            fenced.code = pending_codes;
-                            pending.push(mech_core::SectionElement::FencedMechCode(fenced));
-                        }
-                    }
-                    mech_core::SectionElement::FencedMechCode(fenced) if direct_document_run => {
-                        pending.push(mech_core::SectionElement::FencedMechCode(fenced.clone()));
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        self.flush_direct_execution(program, &mut pending, &mut result)?;
-        Ok(result)
-    }
-
-    fn evaluate_expression_on_program(
-        &mut self,
-        program: &mut MechProgram,
-        expression: &mech_core::Expression,
-    ) -> MResult<Value> {
-        let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
-        program.run_tree(&single).map(resolve_runtime_value)
-    }
-
-    fn bind_persistent_send_value_on_program(
-        &mut self,
-        program: &mut MechProgram,
-        expression: mech_core::Expression,
-    ) -> MResult<ValRef> {
-        let name = format!(
-            "mech-internal-persistent-send-{}",
-            self.persistent_sends.len()
-        );
-        let id = hash_str(&name);
-        let var_def = mech_core::VariableDefine {
-            mutable: false,
-            var: mech_core::Var {
-                name: identifier_from_str(&name),
-                context: None,
-                kind: None,
-            },
-            expression,
-        };
-        let single = single_code_program(
-            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
-            None,
-        );
-        program.run_tree(&single)?;
-        program
-            .interpreter()
-            .symbols()
-            .borrow()
-            .get(id)
-            .ok_or_else(|| {
-                MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "persistent_context_send",
-                        reason: "failed to bind persistent send expression to an output cell"
-                            .to_string(),
-                    },
-                    None,
-                )
-            })
-    }
-
-    pub fn run_string(&mut self, source: &str) -> MResult<Value> {
-        let mut context = self.runtime_context()?;
-        self.run_string_with_context(&mut context, source)
-    }
-    pub fn run_string_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        source: &str,
-    ) -> MResult<Value> {
-        let turn_started = Instant::now();
-        self.validate_context_for_runtime(context)?;
-        let source_bytes = u64::try_from(source.as_bytes().len()).map_err(|_| {
-            MechError::new(
-                ResourceBudgetExceededError {
-                    resource: "source_bytes",
-                    used: u64::MAX,
-                    requested: 1,
-                    max: None,
-                },
-                None,
-            )
-        })?;
-        self.enforce_source_byte_count(context, source_bytes)?;
-        self.run_string_with_context_inner(context, source, turn_started)
-    }
-
-    fn run_string_with_context_inner(
-        &mut self,
-        context: &mut RuntimeContext,
-        source: &str,
-        turn_started: Instant,
-    ) -> MResult<Value> {
-        self.validate_context_for_runtime(context)?;
-        context.charge_step()?;
-        let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
-
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
-        )?;
-
-        let live_state_before = self.live_state_snapshot();
-
-        let result = match mech_syntax::parser::parse(source.trim()) {
-            Ok(tree) => {
-                match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
-                    Ok(()) => {
-                        let program_config = self.program.config.clone();
-                        let mut program =
-                            std::mem::replace(&mut self.program, MechProgram::new(program_config));
-
-                        let result = (|| {
-                            self.register_runtime_program_host_functions(context, &mut program)?;
-
-                            let runtime_ptr: *mut MechRuntime = self;
-                            let context_ptr: *mut RuntimeContext = context;
-                            let _host_guard =
-                                ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-                            self.run_tree_on_program(context, &mut program, &tree, None)
-                        })();
-
-                        self.program = program;
-                        result
-                    }
-                    Err(error) => Err(error),
-                }
-            }
-            Err(error) => Err(error),
+      }
+      mech_core::Statement::ContextSend(send) => {
+        let Some(context_name) = &send.target.context else {
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "direct_context_send",
+            reason: format!("send target `{}` is not a context path", send.target.name.to_string()),
+          }, None));
         };
 
-        let result = result.and_then(|value| {
-            self.enforce_turn_duration(turn_started)?;
-            Ok(value)
-        });
-        if result.is_err() {
-            self.restore_live_state(live_state_before);
-        }
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-        }
+        let context_name = context_name.to_string();
+        let path = send.target.name.to_string();
 
-        result
-    }
-
-    /// Evaluates bytecode in an isolated temporary program. It returns the
-    /// evaluation result but does not install the decoded program, symbols,
-    /// execution plan, or live state as the runtime's persistent active program.
-    pub fn run_bytecode_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        bytecode: &[u8],
-    ) -> MResult<Value> {
-        let turn_started = Instant::now();
-        self.validate_context_for_runtime(context)?;
-        let source_bytes = u64::try_from(bytecode.len()).map_err(|_| {
-            MechError::new(
-                ResourceBudgetExceededError {
-                    resource: "source_bytes",
-                    used: u64::MAX,
-                    requested: 1,
-                    max: None,
-                },
-                None,
-            )
-        })?;
-        self.enforce_source_byte_count(context, source_bytes)?;
-        self.run_bytecode_with_context_inner(context, bytecode, turn_started)
-    }
-
-    fn run_bytecode_with_context_inner(
-        &mut self,
-        context: &mut RuntimeContext,
-        bytecode: &[u8],
-        turn_started: Instant,
-    ) -> MResult<Value> {
-        self.validate_context_for_runtime(context)?;
-        context.charge_step()?;
-        let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
-
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
+        self.reject_direct_context_effect_placement(
+          "send",
+          &context_name,
+          &path,
+          placement,
         )?;
 
-        let program_config = self.program.config.clone();
-        let previous_program =
-            std::mem::replace(&mut self.program, MechProgram::new(program_config.clone()));
-        let mut bytecode_program = MechProgram::new(program_config);
+        self.preflight_context_send_access(
+          context,
+          registry,
+          &context_name,
+          &path,
+        )?;
 
-        let live_state_before = self.live_state_snapshot();
-        let result = (|| {
-            self.register_runtime_program_host_functions(context, &mut bytecode_program)?;
+        self.preflight_expression_context_reads(context, registry, &send.expression, addressed_read_preflight)?;
+        Ok(())
+      }
+      mech_core::Statement::OpAssign(op_assign) => {
+        self.preflight_slice_ref_subscript_context_reads(context, registry, &op_assign.target, addressed_read_preflight)?;
+        if op_assign.target.context.is_some() {
+          return Err(MechError::new(RuntimeInvalidOperationError {
+            operation: "direct_context_op_assign",
+            reason: "context op-assignment is not supported; use `=` or `<-`".to_string(),
+          }, None));
+        }
+        self.preflight_expression_context_reads(context, registry, &op_assign.expression, addressed_read_preflight)
+      }
+      mech_core::Statement::TupleDestructure(tuple_destructure) => self
+        .preflight_expression_context_reads(context, registry, &tuple_destructure.expression, addressed_read_preflight),
+      #[cfg(feature = "invariant_define")]
+      mech_core::Statement::InvariantDefine(invariant) => {
+        self.preflight_expression_context_reads(context, registry, &invariant.expression, addressed_read_preflight)
+      }
+      mech_core::Statement::FsmDeclare(fsm) => {
+        self.preflight_fsm_pipe_context_capabilities(context, registry, &fsm.pipe, addressed_read_preflight)
+      }
+      _ => Ok(()),
+    }
+  }
+
+  fn preflight_fsm_pipe_context_capabilities(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    pipe: &mech_core::FsmPipe,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    if let Some(args) = &pipe.start.args {
+      for (_, expression) in args {
+        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
+      }
+    }
+
+    for transition in &pipe.transitions {
+      self.preflight_transition_context_capabilities(context, registry, transition, addressed_read_preflight)?;
+    }
+
+    Ok(())
+  }
+
+  fn preflight_expression_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    expression: &mech_core::Expression,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match expression {
+      mech_core::Expression::Var(var) => {
+        if let Some(context_name) = &var.context {
+          let context_name = context_name.to_string();
+          if registry.contains(&context_name) || addressed_read_preflight.requires_context_binding() {
+            self.preflight_context_access(
+              context,
+              registry,
+              &context_name,
+              &var.name.to_string(),
+              RuntimeCapabilityOperation::Read,
+              true,
+              None,
+            )?;
+          }
+        }
+      }
+      mech_core::Expression::Formula(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)?;
+      }
+      mech_core::Expression::FunctionCall(call) => {
+        for (_, expression) in &call.args {
+          self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Expression::FsmPipe(pipe) => {
+        self.preflight_fsm_pipe_context_capabilities(context, registry, pipe, addressed_read_preflight)?;
+      }
+      mech_core::Expression::Literal(_) => {}
+      mech_core::Expression::Range(range) => {
+        self.preflight_factor_context_reads(context, registry, &range.start, addressed_read_preflight)?;
+        if let Some((_, increment)) = &range.increment {
+          self.preflight_factor_context_reads(context, registry, increment, addressed_read_preflight)?;
+        }
+        self.preflight_factor_context_reads(context, registry, &range.terminal, addressed_read_preflight)?;
+      }
+      mech_core::Expression::Structure(structure) => {
+        self.preflight_structure_context_reads(context, registry, structure, addressed_read_preflight)?;
+      }
+      mech_core::Expression::Match(match_expression) => {
+        self.preflight_expression_context_reads(context, registry, &match_expression.source, addressed_read_preflight)?;
+        for arm in &match_expression.arms {
+          self.preflight_pattern_context_reads(context, registry, &arm.pattern, addressed_read_preflight)?;
+          if let Some(guard) = &arm.guard {
+            self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?;
+          }
+          self.preflight_expression_context_reads(context, registry, &arm.expression, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Expression::Slice(slice) => {
+        if let Some(context_name) = &slice.context {
+          let context_name = context_name.to_string();
+          if registry.contains(&context_name) {
+            return Err(MechError::new(RuntimeInvalidOperationError {
+              operation: "context_read",
+              reason: "context-addressed slices are not supported".to_string(),
+            }, None));
+          }
+          if addressed_read_preflight.requires_context_binding() {
+            return Err(undeclared_direct_context_target_error(&context_name));
+          }
+        }
+        self.preflight_slice_context_reads(context, registry, slice, addressed_read_preflight)?;
+      }
+      mech_core::Expression::SetComprehension(comprehension) => {
+        self.preflight_expression_context_reads(context, registry, &comprehension.expression, addressed_read_preflight)?;
+        for qualifier in &comprehension.qualifiers {
+          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Expression::MatrixComprehension(comprehension) => {
+        self.preflight_expression_context_reads(context, registry, &comprehension.expression, addressed_read_preflight)?;
+        for qualifier in &comprehension.qualifiers {
+          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier, addressed_read_preflight)?;
+        }
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_factor_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
+      }
+      mech_core::Factor::Negate(factor)
+      | mech_core::Factor::Not(factor)
+      | mech_core::Factor::Parenthetical(factor)
+      | mech_core::Factor::Transpose(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)
+      }
+      mech_core::Factor::Term(term) => {
+        self.preflight_factor_context_reads(context, registry, &term.lhs, addressed_read_preflight)?;
+        for (_, factor) in &term.rhs {
+          self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)?;
+        }
+        Ok(())
+      }
+    }
+  }
+
+  fn preflight_structure_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    structure: &mech_core::Structure,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match structure {
+      mech_core::Structure::Map(map) => {
+        for mapping in &map.elements {
+          self.preflight_expression_context_reads(context, registry, &mapping.key, addressed_read_preflight)?;
+          self.preflight_expression_context_reads(context, registry, &mapping.value, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Structure::Set(set) => {
+        for expression in &set.elements {
+          self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Structure::Matrix(matrix) => {
+        for row in &matrix.rows {
+          for column in &row.columns {
+            self.preflight_expression_context_reads(context, registry, &column.element, addressed_read_preflight)?;
+          }
+        }
+      }
+      mech_core::Structure::Record(record) => {
+        for binding in &record.bindings {
+          self.preflight_expression_context_reads(context, registry, &binding.value, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Structure::Table(table) => {
+        for row in &table.rows {
+          for column in &row.columns {
+            self.preflight_expression_context_reads(context, registry, &column.element, addressed_read_preflight)?;
+          }
+        }
+      }
+      mech_core::Structure::Tuple(tuple) => {
+        for expression in &tuple.elements {
+          self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Structure::TupleStruct(tuple_struct) => {
+        self.preflight_expression_context_reads(context, registry, &tuple_struct.value, addressed_read_preflight)?;
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_slice_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    slice: &mech_core::Slice,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    for subscript in &slice.subscript {
+      self.preflight_subscript_context_reads(context, registry, subscript, addressed_read_preflight)?;
+    }
+    Ok(())
+  }
+
+  fn preflight_slice_ref_subscript_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    target: &mech_core::SliceRef,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    if let Some(subscripts) = &target.subscript {
+      for subscript in subscripts {
+        self.preflight_subscript_context_reads(context, registry, subscript, addressed_read_preflight)?;
+      }
+    }
+    Ok(())
+  }
+
+  fn preflight_subscript_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    subscript: &mech_core::Subscript,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match subscript {
+      mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
+        for subscript in subscripts {
+          self.preflight_subscript_context_reads(context, registry, subscript, addressed_read_preflight)?;
+        }
+      }
+      mech_core::Subscript::Formula(factor) => {
+        self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)?;
+      }
+      mech_core::Subscript::Range(range) => {
+        self.preflight_factor_context_reads(context, registry, &range.start, addressed_read_preflight)?;
+        if let Some((_, increment)) = &range.increment {
+          self.preflight_factor_context_reads(context, registry, increment, addressed_read_preflight)?;
+        }
+        self.preflight_factor_context_reads(context, registry, &range.terminal, addressed_read_preflight)?;
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+
+  fn preflight_comprehension_qualifier_context_reads(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    qualifier: &mech_core::ComprehensionQualifier,
+    addressed_read_preflight: AddressedReadPreflight,
+  ) -> MResult<()> {
+    match qualifier {
+      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+        self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
+        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
+      }
+      mech_core::ComprehensionQualifier::Filter(expression) => {
+        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
+      }
+      mech_core::ComprehensionQualifier::Let(var_def) => {
+        self.preflight_expression_context_reads(context, registry, &var_def.expression, addressed_read_preflight)
+      }
+    }
+  }
+
+
+  fn reject_direct_context_effect_placement(
+    &self,
+    effect: &str,
+    context_name: &str,
+    path: &str,
+    placement: DirectContextEffectPlacement,
+  ) -> MResult<()> {
+    let allowed = match effect {
+      "assignment" => matches!(placement, DirectContextEffectPlacement::TopLevel),
+      "send" => matches!(placement, DirectContextEffectPlacement::TopLevel | DirectContextEffectPlacement::ActivationScope),
+      _ => false,
+    };
+    if allowed { return Ok(()); }
+
+    Err(MechError::new(RuntimeInvalidOperationError {
+      operation: "direct_context_effect_placement",
+      reason: format!(
+        "context {effect} to `{}` is only supported at module top level, not inside {}",
+        direct_context_target(context_name, path),
+        placement.description(),
+      ),
+    }, None))
+  }
+
+  fn preflight_context_send_access(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    context_name: &str,
+    path: &str,
+  ) -> MResult<()> {
+    let Some(binding) = registry.get(context_name) else {
+      return Err(undeclared_direct_context_target_error(context_name));
+    };
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    let operation = context_send_operation(binding, &resolved.context_path)?;
+    self.preflight_context_access(
+      context,
+      registry,
+      context_name,
+      path,
+      operation,
+      true,
+      Some(RuntimeResourceWriteIntent::Send),
+    )
+  }
+
+  fn preflight_context_access(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
+    context_name: &str,
+    path: &str,
+    operation: RuntimeCapabilityOperation,
+    require_context_binding: bool,
+    write_intent: Option<RuntimeResourceWriteIntent>,
+  ) -> MResult<()> {
+    let Some(binding) = registry.get(context_name) else {
+      if require_context_binding {
+        return Err(undeclared_direct_context_target_error(context_name));
+      }
+      return Ok(());
+    };
+    let resolved = self.resolve_context_resource_request(binding, path)?;
+    let context_allowed = match operation {
+      RuntimeCapabilityOperation::Read => runtime_context_allows_read(binding, &resolved.context_path),
+      RuntimeCapabilityOperation::Write => runtime_context_allows_write(binding, &resolved.context_path),
+      _ => runtime_context_allows_operation(binding, operation.name(), &resolved.context_path),
+    };
+    if !context_allowed {
+      return Err(MechError::new(RuntimeResourceCapabilityDenied {
+        context_name: binding.name.clone(),
+        operation: match operation {
+          RuntimeCapabilityOperation::Read => "read".to_string(),
+          RuntimeCapabilityOperation::Write => "write".to_string(),
+          other => format!("{other:?}"),
+        },
+        path: resolved.context_path,
+      }, None));
+    }
+    if !self.has_capability_grant(
+      &context.subject,
+      &resolved.provider_base_uri,
+      &operation,
+      &resolved.provider_path,
+    ) {
+      return Err(MechError::new(
+        RuntimeCapabilityGrantDenied {
+          subject: context.subject.clone(),
+          resource: resolved.provider_base_uri,
+          operation,
+          path: resolved.provider_path,
+        },
+        None,
+      ));
+    }
+
+    if let Some(intent) = write_intent {
+      self.resources.preflight_write(RuntimeResourceWritePreflightRequest {
+        base_uri: resolved.provider_base_uri,
+        path: resolved.provider_path,
+        context_name: binding.name.clone(),
+        operation: operation.clone(),
+        intent,
+      })?;
+    }
+
+    Ok(())
+  }
+
+  fn run_tree_on_program(
+    &mut self,
+    context: &mut RuntimeContext,
+    program: &mut MechProgram,
+    tree: &mech_core::Program,
+    scope_hint: Option<&SourceScope>,
+  ) -> MResult<Value> {
+    let direct_document_run = scope_hint.is_none();
+    let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
+    let skip_non_context_imports = scope_hint.is_some();
+    let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
+    let mut result = Value::Empty;
+    let mut pending = Vec::new();
+
+    for section in &tree.body.sections {
+      for element in &section.elements {
+        match element {
+          mech_core::SectionElement::MechCode(codes) => {
+            let mut pending_codes = Vec::new();
+            for (code, comment) in codes {
+              self.push_direct_code(
+                context,
+                program,
+                &registry,
+                &mut pending,
+                &mut pending_codes,
+                &mut result,
+                skip_non_context_imports,
+                code,
+                comment,
+              )?;
+            }
+            if !pending_codes.is_empty() {
+              pending.push(mech_core::SectionElement::MechCode(pending_codes));
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced)
+            if Self::executable_fence_for_scope(fenced, execution_scope) =>
+          {
+            let mut pending_codes = Vec::new();
+            for (code, comment) in &fenced.code {
+              self.push_direct_code(
+                context,
+                program,
+                &registry,
+                &mut pending,
+                &mut pending_codes,
+                &mut result,
+                skip_non_context_imports,
+                code,
+                comment,
+              )?;
+            }
+            if !pending_codes.is_empty() {
+              let mut fenced = fenced.clone();
+              fenced.code = pending_codes;
+              pending.push(mech_core::SectionElement::FencedMechCode(fenced));
+            }
+          }
+          mech_core::SectionElement::FencedMechCode(fenced) if direct_document_run => {
+            pending.push(mech_core::SectionElement::FencedMechCode(fenced.clone()));
+          }
+          _ => {}
+        }
+      }
+    }
+
+    self.flush_direct_execution(program, &mut pending, &mut result)?;
+    Ok(result)
+  }
+
+  fn evaluate_expression_on_program(
+    &mut self,
+    program: &mut MechProgram,
+    expression: &mech_core::Expression,
+  ) -> MResult<Value> {
+    let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
+    program.run_tree(&single).map(resolve_runtime_value)
+  }
+
+  fn bind_persistent_send_value_on_program(
+    &mut self,
+    program: &mut MechProgram,
+    expression: mech_core::Expression,
+  ) -> MResult<ValRef> {
+    let name = format!("mech-internal-persistent-send-{}", self.persistent_sends.len());
+    let id = hash_str(&name);
+    let var_def = mech_core::VariableDefine {
+      mutable: false,
+      var: mech_core::Var {
+        name: identifier_from_str(&name),
+        context: None,
+        kind: None,
+      },
+      expression,
+    };
+    let single = single_code_program(
+      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
+      None,
+    );
+    program.run_tree(&single)?;
+    program
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(id)
+      .ok_or_else(|| MechError::new(RuntimeInvalidOperationError {
+        operation: "persistent_context_send",
+        reason: "failed to bind persistent send expression to an output cell".to_string(),
+      }, None))
+  }
+
+  pub fn run_string(&mut self, source: &str) -> MResult<Value> {
+    let mut context = self.runtime_context()?;
+    self.run_string_with_context(&mut context, source)
+  }
+  pub fn run_string_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &str,
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    self.validate_context_for_runtime(context)?;
+    let source_bytes = u64::try_from(source.as_bytes().len()).map_err(|_| {
+      MechError::new(
+        ResourceBudgetExceededError {
+          resource: "source_bytes",
+          used: u64::MAX,
+          requested: 1,
+          max: None,
+        },
+        None,
+      )
+    })?;
+    self.enforce_source_byte_count(context, source_bytes)?;
+    self.run_string_with_context_inner(context, source, turn_started)
+  }
+
+  fn run_string_with_context_inner(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &str,
+    turn_started: Instant,
+  ) -> MResult<Value> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    let live_state_before = self.live_state_snapshot();
+
+    let result = match mech_syntax::parser::parse(source.trim()) {
+      Ok(tree) => match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
+        Ok(()) => {
+          let program_config = self.program.config.clone();
+          let mut program = std::mem::replace(
+            &mut self.program,
+            MechProgram::new(program_config),
+          );
+
+          let result = (|| {
+            self.register_runtime_program_host_functions(
+              context,
+              &mut program,
+            )?;
 
             let runtime_ptr: *mut MechRuntime = self;
             let context_ptr: *mut RuntimeContext = context;
             let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-            bytecode_program.run_bytecode(bytecode)
-        })();
+            self.run_tree_on_program(context, &mut program, &tree, None)
+          })();
 
-        let result = result.and_then(|value| {
-            self.enforce_turn_duration(turn_started)?;
-            Ok(value)
-        });
-
-        // Runtime bytecode execution is one-shot. Direct MechProgram
-        // bytecode loading is the persistent installation path.
-        self.program = previous_program;
-        self.restore_live_state(live_state_before);
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
+          self.program = program;
+          result
         }
+        Err(error) => Err(error),
+      },
+      Err(error) => Err(error),
+    };
 
-        result
+    let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
+    if result.is_err() {
+      self.restore_live_state(live_state_before);
     }
-
-    pub fn run_source_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        source: &MechSourceCode,
-    ) -> MResult<Value> {
-        let turn_started = Instant::now();
-        self.validate_context_for_runtime(context)?;
-        self.enforce_source_limits(context, source)?;
-        self.run_source_with_context_inner(context, source, turn_started)
-    }
-
-    fn run_source_with_context_inner(
-        &mut self,
-        context: &mut RuntimeContext,
-        source: &MechSourceCode,
-        turn_started: Instant,
-    ) -> MResult<Value> {
-        match source {
-            MechSourceCode::String(source) => {
-                self.run_string_with_context_inner(context, source, turn_started)
-            }
-            MechSourceCode::Tree(tree) => {
-                self.run_tree_with_context_timed(context, tree, turn_started)
-            }
-            MechSourceCode::ByteCode(bytes) => {
-                self.run_bytecode_with_context_inner(context, bytes, turn_started)
-            }
-            MechSourceCode::Program(sources) => {
-                let mut value = Value::Empty;
-                for source in sources {
-                    value = self.run_source_with_context_inner(context, source, turn_started)?;
-                }
-                Ok(value)
-            }
-            unsupported => Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_source",
-                    reason: format!("unsupported program source: {:?}", unsupported),
-                },
-                None,
-            )),
-        }
-    }
-
-    pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
-        let mut context = self.runtime_context()?;
-        self.run_tree_with_context(&mut context, tree)
-    }
-
-    pub fn run_tree_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        tree: &mech_core::Program,
-    ) -> MResult<Value> {
-        let turn_started = Instant::now();
-        self.run_tree_with_context_timed(context, tree, turn_started)
-    }
-
-    fn run_tree_with_context_timed(
-        &mut self,
-        context: &mut RuntimeContext,
-        tree: &mech_core::Program,
-        turn_started: Instant,
-    ) -> MResult<Value> {
-        self.validate_context_for_runtime(context)?;
-        context.charge_step()?;
-        let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
-
+    match &result {
+      Ok(_) => {
         self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
         )?;
-
-        let live_state_before = self.live_state_snapshot();
-
-        let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program)
-        {
-            Ok(()) => {
-                let program_config = self.program.config.clone();
-                let mut program =
-                    std::mem::replace(&mut self.program, MechProgram::new(program_config));
-
-                let result = (|| {
-                    self.register_runtime_program_host_functions(context, &mut program)?;
-
-                    let runtime_ptr: *mut MechRuntime = self;
-                    let context_ptr: *mut RuntimeContext = context;
-                    let _host_guard =
-                        ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-                    self.run_tree_on_program(context, &mut program, tree, None)
-                })();
-
-                self.program = program;
-                result
-            }
-            Err(error) => Err(error),
-        };
-
-        let result = result.and_then(|value| {
-            self.enforce_turn_duration(turn_started)?;
-            Ok(value)
-        });
-        if result.is_err() {
-            self.restore_live_state(live_state_before);
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
         }
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                if let Some(started) = profile_started {
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ProgramProfiled {
-                            task_id: context.task,
-                            duration_ns: started.elapsed().as_nanos(),
-                        },
-                    )?;
-                }
-            }
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
         }
-
-        result
+      }
     }
 
-    pub fn take_program(&mut self) -> MechProgram {
+    result
+  }
+
+  /// Evaluates bytecode in an isolated temporary program. It returns the
+  /// evaluation result but does not install the decoded program, symbols,
+  /// execution plan, or live state as the runtime's persistent active program.
+  pub fn run_bytecode_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    bytecode: &[u8],
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    self.validate_context_for_runtime(context)?;
+    let source_bytes = u64::try_from(bytecode.len()).map_err(|_| {
+      MechError::new(
+        ResourceBudgetExceededError {
+          resource: "source_bytes",
+          used: u64::MAX,
+          requested: 1,
+          max: None,
+        },
+        None,
+      )
+    })?;
+    self.enforce_source_byte_count(context, source_bytes)?;
+    self.run_bytecode_with_context_inner(context, bytecode, turn_started)
+  }
+
+  fn run_bytecode_with_context_inner(
+    &mut self,
+    context: &mut RuntimeContext,
+    bytecode: &[u8],
+    turn_started: Instant,
+  ) -> MResult<Value> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    let program_config = self.program.config.clone();
+    let previous_program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config.clone()),
+    );
+    let mut bytecode_program = MechProgram::new(program_config);
+
+    let live_state_before = self.live_state_snapshot();
+    let result = (|| {
+      self.register_runtime_program_host_functions(
+        context,
+        &mut bytecode_program,
+      )?;
+
+      let runtime_ptr: *mut MechRuntime = self;
+      let context_ptr: *mut RuntimeContext = context;
+      let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+      bytecode_program.run_bytecode(bytecode)
+    })();
+
+    let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
+
+    // Runtime bytecode execution is one-shot. Direct MechProgram
+    // bytecode loading is the persistent installation path.
+    self.program = previous_program;
+    self.restore_live_state(live_state_before);
+    match &result {
+      Ok(_) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
+        )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
+    }
+
+    result
+  }
+
+  pub fn run_source_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &MechSourceCode,
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    self.validate_context_for_runtime(context)?;
+    self.enforce_source_limits(context, source)?;
+    self.run_source_with_context_inner(context, source, turn_started)
+  }
+
+  fn run_source_with_context_inner(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &MechSourceCode,
+    turn_started: Instant,
+  ) -> MResult<Value> {
+    match source {
+      MechSourceCode::String(source) => self.run_string_with_context_inner(context, source, turn_started),
+      MechSourceCode::Tree(tree) => self.run_tree_with_context_timed(context, tree, turn_started),
+      MechSourceCode::ByteCode(bytes) => self.run_bytecode_with_context_inner(context, bytes, turn_started),
+      MechSourceCode::Program(sources) => {
+        let mut value = Value::Empty;
+        for source in sources {
+          value = self.run_source_with_context_inner(context, source, turn_started)?;
+        }
+        Ok(value)
+      }
+      unsupported => Err(MechError::new(RuntimeInvalidOperationError { operation: "run_source", reason: format!("unsupported program source: {:?}", unsupported) }, None)),
+    }
+  }
+
+  pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
+    let mut context = self.runtime_context()?;
+    self.run_tree_with_context(&mut context, tree)
+  }
+
+  pub fn run_tree_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    tree: &mech_core::Program,
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    self.run_tree_with_context_timed(context, tree, turn_started)
+  }
+
+  fn run_tree_with_context_timed(
+    &mut self,
+    context: &mut RuntimeContext,
+    tree: &mech_core::Program,
+    turn_started: Instant,
+  ) -> MResult<Value> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    let live_state_before = self.live_state_snapshot();
+
+    let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program) {
+      Ok(()) => {
         let program_config = self.program.config.clone();
-        std::mem::replace(&mut self.program, MechProgram::new(program_config))
-    }
-
-    pub fn out_string(&self) -> String {
-        self.program.out_string()
-    }
-
-    pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-        self.program.has_interpreter(interpreter_id)
-    }
-
-    pub fn output_value_for_interpreter(
-        &self,
-        interpreter_id: u64,
-        output_id: u64,
-    ) -> Option<Value> {
-        self.program
-            .output_value_for_interpreter(interpreter_id, output_id)
-    }
-
-    pub fn symbol_name_for_interpreter_output(
-        &self,
-        interpreter_id: u64,
-        output_id: u64,
-    ) -> Option<String> {
-        self.program
-            .symbol_name_for_interpreter_output(interpreter_id, output_id)
-    }
-
-    pub fn symbol_values_for_interpreter(
-        &self,
-        interpreter_id: u64,
-        names: &[String],
-    ) -> Option<Vec<(String, Value)>> {
-        self.program
-            .symbol_values_for_interpreter(interpreter_id, names)
-    }
-
-    pub fn root_symbol_value(&self, name: &str) -> MResult<Value> {
-        self.program.root_symbol_value(name)
-    }
-
-    pub fn root_symbol_values(&self, names: &[&str]) -> MResult<Vec<(String, Value)>> {
-        self.program.root_symbol_values(names)
-    }
-
-    pub fn bind_ans_for_interpreter(&mut self, interpreter_id: u64, value: &Value) -> MResult<()> {
-        if self.program.bind_ans_for_interpreter(interpreter_id, value) {
-            return Ok(());
-        }
-
-        Err(MechError::new(
-            RuntimeInvalidOperationError {
-                operation: "bind_ans_for_interpreter",
-                reason: format!("interpreter id {} not found", interpreter_id),
-            },
-            None,
-        ))
-    }
-
-    #[cfg(feature = "functions")]
-    pub fn step(&mut self, count: u64) -> MResult<()> {
-        let mut context = self.runtime_context()?;
-        self.step_with_context(&mut context, count)
-    }
-
-    #[cfg(feature = "functions")]
-    pub fn step_with_context(&mut self, context: &mut RuntimeContext, count: u64) -> MResult<()> {
-        let turn_started = Instant::now();
-        self.validate_context_for_runtime(context)?;
-        context.charge_step()?;
-
-        let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(&mut self.program, MechProgram::new(program_config));
-
-        let runtime_ptr: *mut MechRuntime = self;
-        let context_ptr: *mut RuntimeContext = context;
-        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-        let result = program.step(count);
-
-        self.program = program;
-        result?;
-        self.enforce_turn_duration(turn_started)
-    }
-
-    pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
-        let mut context = self.runtime_context()?.with_module_version(version);
-
-        self.run_module_with_context(&mut context, version)
-    }
-
-    pub fn run_module_scope(
-        &mut self,
-        version: ModuleVersionId,
-        scope: SourceScope,
-    ) -> MResult<Value> {
-        let mut context = self.runtime_context()?.with_module_version(version);
-
-        self.run_module_scope_with_context(&mut context, version, scope)
-    }
-
-    pub fn run_module_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-    ) -> MResult<Value> {
-        self.run_module_scope_with_context(context, version, SourceScope::Program)
-    }
-
-    pub fn run_module_scope_with_context(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-        scope: SourceScope,
-    ) -> MResult<Value> {
-        let turn_started = Instant::now();
-        let mut preflight_seen = HashSet::new();
-        self.preflight_module_graph_for_scope(context, version, &scope, &mut preflight_seen)?;
-
-        let mut seen = HashSet::new();
-        let mut module_instances = HashMap::new();
-
-        let instance = self.execute_module_isolated_for_scope(
-            context,
-            version,
-            &scope,
-            &mut seen,
-            &mut module_instances,
-        )?;
-
-        self.enforce_turn_duration(turn_started)?;
-        Ok(instance.result)
-    }
-
-    fn preflight_module_graph_for_scope(
-        &self,
-        context: &RuntimeContext,
-        version: ModuleVersionId,
-        scope: &SourceScope,
-        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-    ) -> MResult<()> {
-        self.validate_context_for_runtime(context)?;
-        let instance_key = (version, scope.clone());
-        if !seen.insert(instance_key) {
-            return Ok(());
-        }
-
-        let Some(record) = self.store.get_module_version(version)? else {
-            return Err(MechError::new(
-                RuntimeRecordNotFoundError {
-                    record_type: "module_version",
-                    id: version.to_string(),
-                },
-                None,
-            ));
-        };
-        validate_module_import_edges(&record)?;
-        let Some(source) = record.source.clone() else {
-            return Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_module",
-                    reason: "module version has no source".to_string(),
-                },
-                None,
-            ));
-        };
-
-        let context_registry = context_registry_for_scope(&record, scope)?;
-        let scoped_source = module_source_for_scope(&source, scope)?;
-        let execution_scope = execution_scope_for_extracted_module_source(scope);
-        self.preflight_module_source(context, &context_registry, &scoped_source, &execution_scope)?;
-
-        for edge in &record.import_edges {
-            if &edge.scope != scope {
-                continue;
-            }
-
-            self.preflight_module_graph_for_scope(
-                context,
-                edge.dependency,
-                &SourceScope::Program,
-                seen,
-            )?;
-        }
-
-        let scoped_refs = record
-            .scopes
-            .iter()
-            .find(|metadata| &metadata.scope == scope)
-            .map(|metadata| metadata.address_references.as_slice())
-            .unwrap_or(&[]);
-
-        for reference in scoped_refs {
-            match resolve_runtime_address_target(
-                &record,
-                scope,
-                &context_registry,
-                &reference.target,
-            ) {
-                RuntimeAddressTarget::Interpreter(interpreter_scope) => {
-                    if !matches!(scope, SourceScope::Program) {
-                        return Err(MechError::new(
-                            UnknownAddressTarget {
-                                target: reference.target.clone(),
-                            },
-                            None,
-                        ));
-                    }
-                    self.preflight_module_graph_for_scope(
-                        context,
-                        version,
-                        &interpreter_scope,
-                        seen,
-                    )?;
-                }
-                RuntimeAddressTarget::Context(_) => {}
-                RuntimeAddressTarget::Unknown => {
-                    return Err(MechError::new(
-                        UnknownAddressTarget {
-                            target: reference.target.clone(),
-                        },
-                        None,
-                    ));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn preflight_module_source(
-        &self,
-        context: &RuntimeContext,
-        registry: &RuntimeContextRegistry,
-        source: &MechSourceCode,
-        scope: &SourceScope,
-    ) -> MResult<()> {
-        match source {
-            MechSourceCode::String(source) => {
-                let tree = mech_syntax::parser::parse(source.trim())?;
-                self.preflight_context_capabilities_with_registry(
-                    context,
-                    registry,
-                    &tree,
-                    scope,
-                    AddressedReadPreflight::AllowModuleAddressTargets,
-                )
-            }
-            MechSourceCode::Tree(tree) => self.preflight_context_capabilities_with_registry(
-                context,
-                registry,
-                tree,
-                scope,
-                AddressedReadPreflight::AllowModuleAddressTargets,
-            ),
-            MechSourceCode::Program(sources) => {
-                for source in sources {
-                    self.preflight_module_source(context, registry, source, scope)?;
-                }
-                Ok(())
-            }
-            MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => Ok(()),
-            MechSourceCode::Image(_, _) => Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_module_preflight",
-                    reason: "unsupported executable source kind for provider preflight: image"
-                        .to_string(),
-                },
-                None,
-            )),
-        }
-    }
-
-    fn execute_module_isolated_for_scope(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-        scope: &SourceScope,
-        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-    ) -> MResult<ModuleInstance> {
-        self.validate_context_for_runtime(context)?;
-        context.charge_step()?;
-
-        let instance_key = (version, scope.clone());
-
-        if let Some(instance) = module_instances.get(&instance_key).cloned() {
-            return Ok(instance);
-        }
-
-        if seen.contains(&instance_key) {
-            return Ok(ModuleInstance {
-                version,
-                exports: HashMap::new(),
-                result: Value::Empty,
-            });
-        }
-        seen.insert(instance_key.clone());
-
-        let Some(record) = self.store.get_module_version(version)? else {
-            return Err(MechError::new(
-                RuntimeRecordNotFoundError {
-                    record_type: "module_version",
-                    id: version.to_string(),
-                },
-                None,
-            ));
-        };
-        validate_module_import_edges(&record)?;
-        let Some(source) = record.source.clone() else {
-            return Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_module",
-                    reason: "module version has no source".to_string(),
-                },
-                None,
-            ));
-        };
-
-        let context_registry = context_registry_for_scope(&record, scope)?;
-
-        for edge in &record.import_edges {
-            if &edge.scope != scope {
-                continue;
-            }
-
-            self.execute_module_isolated_for_scope(
-                context,
-                edge.dependency,
-                &SourceScope::Program,
-                seen,
-                module_instances,
-            )?;
-        }
-
-        let mut import_environment =
-            self.build_import_environment_for_scope(context, &record, scope, module_instances)?;
-
-        let address_environment = self.build_address_environment_for_scope(
-            context,
-            version,
-            &record,
-            scope,
-            &context_registry,
-            seen,
-            module_instances,
-        )?;
-        import_environment.extend(address_environment);
-        let mut module_program = MechProgram::new(MechProgramConfig {
-            name: self.config.name.clone(),
-            environment: MechProgramEnvironment {
-                trace_enabled: self.config.diagnostics.trace_enabled,
-                debug_enabled: self.config.diagnostics.debug_enabled,
-                profile_enabled: self.config.diagnostics.profile_enabled,
-                rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
-            },
-        });
-
-        {
-            let symbols = module_program.interpreter_mut().symbols();
-            let mut symbols_brrw = symbols.borrow_mut();
-            for (name, value_ref) in import_environment {
-                let id = hash_str(&name);
-                symbols_brrw.symbols.insert(id, value_ref);
-                symbols_brrw.dictionary.borrow_mut().insert(id, name);
-            }
-        }
-
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ModuleExecutionStarted {
-                module_version: version,
-            },
-        )?;
-        let scoped_source = module_source_for_scope(&source, scope)?;
-        let result =
-            self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
-        let result = match result {
-            Ok(value) => value,
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ModuleExecutionFailed {
-                        module_version: version,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-                return Err(error);
-            }
-        };
-        let mut exports = HashMap::new();
-        {
-            let symbols = module_program.interpreter_mut().symbols();
-            let symbols_brrw = symbols.borrow();
-            for export in exports_for_scope(&record, scope) {
-                let id = hash_str(&export.name);
-                let Some(value_ref) = symbols_brrw.get(id) else {
-                    let error = MechError::new(
-                        RuntimeModuleExportNotFound {
-                            dependency: record.id.to_string(),
-                            export: export.name.clone(),
-                        },
-                        None,
-                    );
-                    self.emit_event_to_context(
-                        context,
-                        RuntimeEventKind::ModuleExecutionFailed {
-                            module_version: version,
-                            message: format!("{:?}", error),
-                        },
-                    )?;
-                    return Err(error);
-                };
-                exports.insert(export.name.clone(), value_ref.clone());
-            }
-        }
-
-        let instance = ModuleInstance {
-            version,
-            exports,
-            result,
-        };
-        module_instances.insert(instance_key, instance.clone());
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ModuleExecutionCompleted {
-                module_version: version,
-            },
-        )?;
-        Ok(instance)
-    }
-
-    fn run_module_source_on_program(
-        &mut self,
-        context: &mut RuntimeContext,
-        program: &mut MechProgram,
-        source: &MechSourceCode,
-        scope: &SourceScope,
-    ) -> MResult<Value> {
-        self.register_runtime_program_host_functions(context, program)?;
-
-        let runtime_ptr: *mut MechRuntime = self;
-        let context_ptr: *mut RuntimeContext = context;
-        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-        self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramStarted {
-                task_id: context.task,
-            },
-        )?;
-
-        // Named interpreter scopes are extracted to bare source by module_source_for_scope.
-        // Once extracted, their declarations are indexed as SourceScope::Program in the
-        // reparsed tree, so direct context handling must use Program scope for that tree.
-        // The surrounding module execution still uses the original scope for imports,
-        // exports, address environment, and ModuleInstance identity.
-        let execution_scope = execution_scope_for_extracted_module_source(scope);
-
-        let result = self.with_live_registration_mode(
-            crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
-            |runtime| match source {
-                MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
-                    Ok(tree) => {
-                        let registry =
-                            runtime.direct_context_registry_for_scope(&tree, &execution_scope)?;
-                        match runtime.preflight_context_capabilities_with_registry(
-                            context,
-                            &registry,
-                            &tree,
-                            &execution_scope,
-                            AddressedReadPreflight::AllowModuleAddressTargets,
-                        ) {
-                            Ok(()) => runtime.run_tree_on_program(
-                                context,
-                                program,
-                                &tree,
-                                Some(&execution_scope),
-                            ),
-                            Err(error) => Err(error),
-                        }
-                    }
-                    Err(error) => Err(error),
-                },
-                MechSourceCode::Tree(tree) => {
-                    let registry =
-                        runtime.direct_context_registry_for_scope(tree, &execution_scope)?;
-                    match runtime.preflight_context_capabilities_with_registry(
-                        context,
-                        &registry,
-                        tree,
-                        &execution_scope,
-                        AddressedReadPreflight::AllowModuleAddressTargets,
-                    ) {
-                        Ok(()) => runtime.run_tree_on_program(
-                            context,
-                            program,
-                            tree,
-                            Some(&execution_scope),
-                        ),
-                        Err(error) => Err(error),
-                    }
-                }
-                MechSourceCode::Program(sources) => {
-                    let mut result = Ok(Value::Empty);
-                    for source in sources {
-                        result =
-                            runtime.run_module_source_on_program(context, program, source, scope);
-                        if result.is_err() {
-                            break;
-                        }
-                    }
-                    result
-                }
-                MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => program.run_source(source),
-                MechSourceCode::Image(_, _) => Err(MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "run_module_preflight",
-                        reason: "unsupported executable source kind for provider preflight: image"
-                            .to_string(),
-                    },
-                    None,
-                )),
-            },
+        let mut program = std::mem::replace(
+          &mut self.program,
+          MechProgram::new(program_config),
         );
 
-        match &result {
-            Ok(_) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramCompleted {
-                        task_id: context.task,
-                    },
-                )?;
-            }
-            Err(error) => {
-                self.emit_event_to_context(
-                    context,
-                    RuntimeEventKind::ProgramFailed {
-                        task_id: context.task,
-                        message: format!("{:?}", error),
-                    },
-                )?;
-            }
-        }
+        let result = (|| {
+          self.register_runtime_program_host_functions(
+            context,
+            &mut program,
+          )?;
 
+          let runtime_ptr: *mut MechRuntime = self;
+          let context_ptr: *mut RuntimeContext = context;
+          let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+          self.run_tree_on_program(context, &mut program, tree, None)
+        })();
+
+        self.program = program;
         result
+      }
+      Err(error) => Err(error),
+    };
+
+    let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
+    if result.is_err() {
+      self.restore_live_state(live_state_before);
+    }
+    match &result {
+      Ok(_) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
+        )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+        if let Some(started) = profile_started {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramProfiled {
+              task_id: context.task,
+              duration_ns: started.elapsed().as_nanos(),
+            },
+          )?;
+        }
+      }
     }
 
-    fn build_address_environment_for_scope(
-        &mut self,
-        context: &mut RuntimeContext,
-        version: ModuleVersionId,
-        record: &ModuleVersionRecord,
-        scope: &SourceScope,
-        context_registry: &RuntimeContextRegistry,
-        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-    ) -> MResult<HashMap<String, mech_core::ValRef>> {
-        fn address_binding_key(target: &str, name: &str) -> String {
-            format!("@{target}/{name}")
-        }
+    result
+  }
 
-        let scoped_refs = record
-            .scopes
-            .iter()
-            .find(|metadata| &metadata.scope == scope)
-            .map(|metadata| metadata.address_references.as_slice())
-            .unwrap_or(&[]);
+  pub fn take_program(&mut self) -> MechProgram {
+    let program_config = self.program.config.clone();
+    std::mem::replace(&mut self.program, MechProgram::new(program_config))
+  }
 
-        let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> =
-            HashMap::new();
-        let mut bindings = HashMap::new();
-        for reference in scoped_refs {
-            match resolve_runtime_address_target(record, scope, context_registry, &reference.target)
-            {
-                RuntimeAddressTarget::Interpreter(interpreter_scope) => {
-                    if !matches!(scope, SourceScope::Program) {
-                        return Err(MechError::new(
-                            UnknownAddressTarget {
-                                target: reference.target.clone(),
-                            },
-                            None,
-                        ));
-                    }
-                    requested_by_scope
-                        .entry(interpreter_scope)
-                        .or_default()
-                        .push(reference.clone());
-                }
-                RuntimeAddressTarget::Context(_) => {
-                    // Context-addressed resource reads are resolved while executing source
-                    // statements so reads observe earlier writes in the same module scope.
-                }
-                RuntimeAddressTarget::Unknown => {
-                    return Err(MechError::new(
-                        UnknownAddressTarget {
-                            target: reference.target.clone(),
-                        },
-                        None,
-                    ));
-                }
-            }
-        }
+  pub fn out_string(&self) -> String {
+    self.program.out_string()
+  }
 
-        for (interpreter_scope, requested_refs) in requested_by_scope {
-            let instance = self.execute_module_isolated_for_scope(
-                context,
-                version,
-                &interpreter_scope,
-                seen,
-                module_instances,
-            )?;
+  pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
+    self.program.has_interpreter(interpreter_id)
+  }
 
-            for reference in requested_refs {
-                let Some(export_value) = instance.exports.get(&reference.name) else {
-                    return Err(MechError::new(
-                        RuntimeModuleExportNotFound {
-                            dependency: record.id.to_string(),
-                            export: reference.name.clone(),
-                        },
-                        None,
-                    ));
-                };
-                bindings.insert(
-                    address_binding_key(&reference.target, &reference.name),
-                    export_value.clone(),
-                );
-            }
-        }
+  pub fn output_value_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<Value> {
+    self.program.output_value_for_interpreter(interpreter_id, output_id)
+  }
 
-        Ok(bindings)
+  pub fn symbol_name_for_interpreter_output(
+    &self,
+    interpreter_id: u64,
+    output_id: u64,
+  ) -> Option<String> {
+    self.program.symbol_name_for_interpreter_output(interpreter_id, output_id)
+  }
+
+  pub fn symbol_values_for_interpreter(
+    &self,
+    interpreter_id: u64,
+    names: &[String],
+  ) -> Option<Vec<(String, Value)>> {
+    self.program.symbol_values_for_interpreter(interpreter_id, names)
+  }
+
+  pub fn root_symbol_value(&self, name: &str) -> MResult<Value> {
+    self.program.root_symbol_value(name)
+  }
+
+  pub fn root_symbol_values(&self, names: &[&str]) -> MResult<Vec<(String, Value)>> {
+    self.program.root_symbol_values(names)
+  }
+
+  pub fn bind_ans_for_interpreter(
+    &mut self,
+    interpreter_id: u64,
+    value: &Value,
+  ) -> MResult<()> {
+    if self.program.bind_ans_for_interpreter(interpreter_id, value) {
+      return Ok(());
     }
 
-    fn build_import_environment_for_scope(
-        &mut self,
-        context: &mut RuntimeContext,
-        importer: &ModuleVersionRecord,
-        scope: &SourceScope,
-        module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-    ) -> MResult<HashMap<String, mech_core::ValRef>> {
-        let mut bindings = HashMap::new();
-        let mut ownership: HashMap<String, String> = HashMap::new();
+    Err(MechError::new(
+      RuntimeInvalidOperationError {
+        operation: "bind_ans_for_interpreter",
+        reason: format!("interpreter id {} not found", interpreter_id),
+      },
+      None,
+    ))
+  }
 
-        for edge in &importer.import_edges {
-            if &edge.scope != scope {
-                continue;
-            }
+  #[cfg(feature = "functions")]
+  pub fn step(&mut self, count: u64) -> MResult<()> {
+    let mut context = self.runtime_context()?;
+    self.step_with_context(&mut context, count)
+  }
 
-            let import = &edge.import;
-            let dependency = edge.dependency;
+  #[cfg(feature = "functions")]
+  pub fn step_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    count: u64,
+  ) -> MResult<()> {
+    let turn_started = Instant::now();
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
 
-            let dependency_key = (dependency, SourceScope::Program);
-            let Some(dependency_instance) = module_instances.get(&dependency_key) else {
-                return Err(MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "build_import_environment",
-                        reason: format!("dependency instance missing for {}", dependency),
-                    },
-                    None,
-                ));
-            };
+    let program_config = self.program.config.clone();
+    let mut program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config),
+    );
 
-            match &import.kind {
-                SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
-                    let Some(namespace) = module_namespace_for_import(import) else {
-                        continue;
-                    };
-                    for (export_name, export_value) in &dependency_instance.exports {
-                        let binding = format!("{}/{}", namespace, export_name);
-                        if let Some(first) =
-                            ownership.insert(binding.clone(), import.specifier.clone())
-                        {
-                            return Err(MechError::new(
-                                RuntimeModuleImportConflict {
-                                    binding,
-                                    first_import: first,
-                                    second_import: import.specifier.clone(),
-                                },
-                                None,
-                            ));
-                        }
-                        bindings.insert(
-                            format!("{}/{}", namespace, export_name),
-                            export_value.clone(),
-                        );
-                    }
-                }
-                SourceImportKind::Single { name } => {
-                    if matches!(
-                        import.alias,
-                        Some(crate::resolver::SourceImportAlias::Context(_))
-                    ) {
-                        continue;
-                    }
-                    let Some(export_value) = dependency_instance.exports.get(name) else {
-                        return Err(MechError::new(
-                            RuntimeModuleExportNotFound {
-                                dependency: import.specifier.clone(),
-                                export: name.clone(),
-                            },
-                            None,
-                        ));
-                    };
+    let runtime_ptr: *mut MechRuntime = self;
+    let context_ptr: *mut RuntimeContext = context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-                    let binding = match &import.alias {
-                        Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
-                        Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
-                        None => name.clone(),
-                    };
+    let result = program.step(count);
 
-                    if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone())
-                    {
-                        return Err(MechError::new(
-                            RuntimeModuleImportConflict {
-                                binding: binding.clone(),
-                                first_import: first,
-                                second_import: import.specifier.clone(),
-                            },
-                            None,
-                        ));
-                    }
-                    bindings.insert(binding, export_value.clone());
-                }
-                SourceImportKind::Wildcard => {
-                    for (export_name, export_value) in &dependency_instance.exports {
-                        if let Some(first) =
-                            ownership.insert(export_name.clone(), import.specifier.clone())
-                        {
-                            return Err(MechError::new(
-                                RuntimeModuleImportConflict {
-                                    binding: export_name.clone(),
-                                    first_import: first,
-                                    second_import: import.specifier.clone(),
-                                },
-                                None,
-                            ));
-                        }
-                        bindings.insert(export_name.clone(), export_value.clone());
-                    }
-                }
-            }
+    self.program = program;
+    result?;
+    self.enforce_turn_duration(turn_started)
+  }
 
-            self.emit_event_to_context(
-                context,
-                RuntimeEventKind::ModuleImportLinked {
-                    importer: importer.id,
-                    dependency,
-                    specifier: import.specifier.clone(),
-                },
-            )?;
-        }
+  pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
+    let mut context = self.runtime_context()?
+      .with_module_version(version);
 
-        Ok(bindings)
+    self.run_module_with_context(&mut context, version)
+  }
+
+  pub fn run_module_scope(
+    &mut self,
+    version: ModuleVersionId,
+    scope: SourceScope,
+  ) -> MResult<Value> {
+    let mut context = self.runtime_context()?
+      .with_module_version(version);
+
+    self.run_module_scope_with_context(&mut context, version, scope)
+  }
+
+  pub fn run_module_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+  ) -> MResult<Value> {
+    self.run_module_scope_with_context(context, version, SourceScope::Program)
+  }
+
+  pub fn run_module_scope_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    scope: SourceScope,
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    let mut preflight_seen = HashSet::new();
+    self.preflight_module_graph_for_scope(context, version, &scope, &mut preflight_seen)?;
+
+    let mut seen = HashSet::new();
+    let mut module_instances = HashMap::new();
+
+    let instance = self.execute_module_isolated_for_scope(
+      context,
+      version,
+      &scope,
+      &mut seen,
+      &mut module_instances,
+    )?;
+
+    self.enforce_turn_duration(turn_started)?;
+    Ok(instance.result)
+  }
+
+  fn preflight_module_graph_for_scope(
+    &self,
+    context: &RuntimeContext,
+    version: ModuleVersionId,
+    scope: &SourceScope,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+  ) -> MResult<()> {
+    self.validate_context_for_runtime(context)?;
+    let instance_key = (version, scope.clone());
+    if !seen.insert(instance_key) {
+      return Ok(());
     }
-}
 
-fn module_source_for_scope(
+    let Some(record) = self.store.get_module_version(version)? else {
+      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
+    };
+    validate_module_import_edges(&record)?;
+    let Some(source) = record.source.clone() else {
+      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
+    };
+
+    let context_registry = context_registry_for_scope(&record, scope)?;
+    let scoped_source = module_source_for_scope(&source, scope)?;
+    let execution_scope = execution_scope_for_extracted_module_source(scope);
+    self.preflight_module_source(context, &context_registry, &scoped_source, &execution_scope)?;
+
+    for edge in &record.import_edges {
+      if &edge.scope != scope {
+        continue;
+      }
+
+      self.preflight_module_graph_for_scope(
+        context,
+        edge.dependency,
+        &SourceScope::Program,
+        seen,
+      )?;
+    }
+
+    let scoped_refs = record
+      .scopes
+      .iter()
+      .find(|metadata| &metadata.scope == scope)
+      .map(|metadata| metadata.address_references.as_slice())
+      .unwrap_or(&[]);
+
+    for reference in scoped_refs {
+      match resolve_runtime_address_target(&record, scope, &context_registry, &reference.target) {
+        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+          if !matches!(scope, SourceScope::Program) {
+            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+          }
+          self.preflight_module_graph_for_scope(
+            context,
+            version,
+            &interpreter_scope,
+            seen,
+          )?;
+        }
+        RuntimeAddressTarget::Context(_) => {}
+        RuntimeAddressTarget::Unknown => {
+          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+        }
+      }
+    }
+
+    Ok(())
+  }
+
+  fn preflight_module_source(
+    &self,
+    context: &RuntimeContext,
+    registry: &RuntimeContextRegistry,
     source: &MechSourceCode,
     scope: &SourceScope,
-) -> MResult<MechSourceCode> {
-    match scope {
-        SourceScope::Program => Ok(source.clone()),
-        SourceScope::Interpreter(interpreter) => {
-            let MechSourceCode::String(source_text) = source else {
-                return Err(MechError::new(
-                    RuntimeInvalidOperationError {
-                        operation: "run_module_scope",
-                        reason: "interpreter scope execution requires string source".to_string(),
-                    },
-                    None,
-                ));
-            };
-
-            let tree = mech_syntax::parser::parse(source_text.trim())?;
-
-            if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
-                return Ok(MechSourceCode::String(source));
-            }
-
-            Err(MechError::new(
-                RuntimeInvalidOperationError {
-                    operation: "run_module_scope",
-                    reason: format!(
-                        "interpreter scope `{}` not found",
-                        interpreter.namespace_str
-                    ),
-                },
-                None,
-            ))
+  ) -> MResult<()> {
+    match source {
+      MechSourceCode::String(source) => {
+        let tree = mech_syntax::parser::parse(source.trim())?;
+        self.preflight_context_capabilities_with_registry(context, registry, &tree, scope, AddressedReadPreflight::AllowModuleAddressTargets)
+      }
+      MechSourceCode::Tree(tree) => {
+        self.preflight_context_capabilities_with_registry(context, registry, tree, scope, AddressedReadPreflight::AllowModuleAddressTargets)
+      }
+      MechSourceCode::Program(sources) => {
+        for source in sources {
+          self.preflight_module_source(context, registry, source, scope)?;
         }
+        Ok(())
+      }
+      MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => Ok(()),
+      MechSourceCode::Image(_, _) => Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "run_module_preflight",
+        reason: "unsupported executable source kind for provider preflight: image".to_string(),
+      }, None)),
     }
+  }
+
+  fn execute_module_isolated_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    scope: &SourceScope,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<ModuleInstance> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+
+    let instance_key = (version, scope.clone());
+
+    if let Some(instance) = module_instances.get(&instance_key).cloned() {
+      return Ok(instance);
+    }
+
+    if seen.contains(&instance_key) {
+      return Ok(ModuleInstance { version, exports: HashMap::new(), result: Value::Empty });
+    }
+    seen.insert(instance_key.clone());
+
+    let Some(record) = self.store.get_module_version(version)? else {
+      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
+    };
+    validate_module_import_edges(&record)?;
+    let Some(source) = record.source.clone() else {
+      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
+    };
+
+    let context_registry = context_registry_for_scope(&record, scope)?;
+
+    for edge in &record.import_edges {
+      if &edge.scope != scope {
+        continue;
+      }
+
+      self.execute_module_isolated_for_scope(
+        context,
+        edge.dependency,
+        &SourceScope::Program,
+        seen,
+        module_instances,
+      )?;
+    }
+
+    let mut import_environment = self.build_import_environment_for_scope(
+      context,
+      &record,
+      scope,
+      module_instances,
+    )?;
+
+    let address_environment = self.build_address_environment_for_scope(
+      context,
+      version,
+      &record,
+      scope,
+      &context_registry,
+      seen,
+      module_instances,
+    )?;
+    import_environment.extend(address_environment);
+    let mut module_program = MechProgram::new(MechProgramConfig {
+      name: self.config.name.clone(),
+      environment: MechProgramEnvironment {
+        trace_enabled: self.config.diagnostics.trace_enabled,
+        debug_enabled: self.config.diagnostics.debug_enabled,
+        profile_enabled: self.config.diagnostics.profile_enabled,
+        rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+      },
+    });
+
+    {
+      let symbols = module_program.interpreter_mut().symbols();
+      let mut symbols_brrw = symbols.borrow_mut();
+      for (name, value_ref) in import_environment {
+        let id = hash_str(&name);
+        symbols_brrw.symbols.insert(id, value_ref);
+        symbols_brrw.dictionary.borrow_mut().insert(id, name);
+      }
+    }
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ModuleExecutionStarted { module_version: version },
+    )?;
+    let scoped_source = module_source_for_scope(&source, scope)?;
+    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
+    let result = match result {
+      Ok(value) => value,
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ModuleExecutionFailed {
+            module_version: version,
+            message: format!("{:?}", error),
+          },
+        )?;
+        return Err(error);
+      }
+    };
+    let mut exports = HashMap::new();
+    {
+      let symbols = module_program.interpreter_mut().symbols();
+      let symbols_brrw = symbols.borrow();
+      for export in exports_for_scope(&record, scope) {
+        let id = hash_str(&export.name);
+        let Some(value_ref) = symbols_brrw.get(id) else {
+          let error = MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: export.name.clone() }, None);
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ModuleExecutionFailed {
+              module_version: version,
+              message: format!("{:?}", error),
+            },
+          )?;
+          return Err(error);
+        };
+        exports.insert(export.name.clone(), value_ref.clone());
+      }
+    }
+
+    let instance = ModuleInstance { version, exports, result };
+    module_instances.insert(instance_key, instance.clone());
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ModuleExecutionCompleted { module_version: version },
+    )?;
+    Ok(instance)
+  }
+
+  fn run_module_source_on_program(
+    &mut self,
+    context: &mut RuntimeContext,
+    program: &mut MechProgram,
+    source: &MechSourceCode,
+    scope: &SourceScope,
+  ) -> MResult<Value> {
+    self.register_runtime_program_host_functions(context, program)?;
+
+    let runtime_ptr: *mut MechRuntime = self;
+    let context_ptr: *mut RuntimeContext = context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+    self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramStarted {
+        task_id: context.task,
+      },
+    )?;
+
+    // Named interpreter scopes are extracted to bare source by module_source_for_scope.
+    // Once extracted, their declarations are indexed as SourceScope::Program in the
+    // reparsed tree, so direct context handling must use Program scope for that tree.
+    // The surrounding module execution still uses the original scope for imports,
+    // exports, address environment, and ModuleInstance identity.
+    let execution_scope = execution_scope_for_extracted_module_source(scope);
+
+    let result = self.with_live_registration_mode(crate::runtime::LiveRegistrationMode::IsolatedSnapshot, |runtime| {
+      match source {
+      MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
+        Ok(tree) => {
+          let registry = runtime.direct_context_registry_for_scope(&tree, &execution_scope)?;
+          match runtime.preflight_context_capabilities_with_registry(
+            context,
+            &registry,
+            &tree,
+            &execution_scope,
+            AddressedReadPreflight::AllowModuleAddressTargets,
+          ) {
+            Ok(()) => runtime.run_tree_on_program(context, program, &tree, Some(&execution_scope)),
+            Err(error) => Err(error),
+          }
+        },
+        Err(error) => Err(error),
+      },
+      MechSourceCode::Tree(tree) => {
+        let registry = runtime.direct_context_registry_for_scope(tree, &execution_scope)?;
+        match runtime.preflight_context_capabilities_with_registry(
+          context,
+          &registry,
+          tree,
+          &execution_scope,
+          AddressedReadPreflight::AllowModuleAddressTargets,
+        ) {
+          Ok(()) => runtime.run_tree_on_program(context, program, tree, Some(&execution_scope)),
+          Err(error) => Err(error),
+        }
+      },
+      MechSourceCode::Program(sources) => {
+        let mut result = Ok(Value::Empty);
+        for source in sources {
+          result = runtime.run_module_source_on_program(context, program, source, scope);
+          if result.is_err() {
+            break;
+          }
+        }
+        result
+      }
+      MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => program.run_source(source),
+      MechSourceCode::Image(_, _) => Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "run_module_preflight",
+        reason: "unsupported executable source kind for provider preflight: image".to_string(),
+      }, None)),
+      }
+    });
+
+    match &result {
+      Ok(_) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramCompleted {
+            task_id: context.task,
+          },
+        )?;
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ProgramFailed {
+            task_id: context.task,
+            message: format!("{:?}", error),
+          },
+        )?;
+      }
+    }
+
+    result
+  }
+
+  fn build_address_environment_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    record: &ModuleVersionRecord,
+    scope: &SourceScope,
+    context_registry: &RuntimeContextRegistry,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<HashMap<String, mech_core::ValRef>> {
+    fn address_binding_key(target: &str, name: &str) -> String {
+      format!("@{target}/{name}")
+    }
+
+    let scoped_refs = record
+      .scopes
+      .iter()
+      .find(|metadata| &metadata.scope == scope)
+      .map(|metadata| metadata.address_references.as_slice())
+      .unwrap_or(&[]);
+
+    let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> = HashMap::new();
+    let mut bindings = HashMap::new();
+    for reference in scoped_refs {
+      match resolve_runtime_address_target(record, scope, context_registry, &reference.target) {
+        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+          if !matches!(scope, SourceScope::Program) {
+            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+          }
+          requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
+        }
+        RuntimeAddressTarget::Context(_) => {
+          // Context-addressed resource reads are resolved while executing source
+          // statements so reads observe earlier writes in the same module scope.
+        }
+        RuntimeAddressTarget::Unknown => {
+          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
+        }
+      }
+    }
+
+    for (interpreter_scope, requested_refs) in requested_by_scope {
+      let instance = self.execute_module_isolated_for_scope(
+        context,
+        version,
+        &interpreter_scope,
+        seen,
+        module_instances,
+      )?;
+
+      for reference in requested_refs {
+        let Some(export_value) = instance.exports.get(&reference.name) else {
+          return Err(MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: reference.name.clone() }, None));
+        };
+        bindings.insert(address_binding_key(&reference.target, &reference.name), export_value.clone());
+      }
+    }
+
+    Ok(bindings)
+  }
+
+  fn build_import_environment_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    importer: &ModuleVersionRecord,
+    scope: &SourceScope,
+    module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<HashMap<String, mech_core::ValRef>> {
+    let mut bindings = HashMap::new();
+    let mut ownership: HashMap<String, String> = HashMap::new();
+
+    for edge in &importer.import_edges {
+      if &edge.scope != scope {
+        continue;
+      }
+
+      let import = &edge.import;
+      let dependency = edge.dependency;
+
+      let dependency_key = (dependency, SourceScope::Program);
+      let Some(dependency_instance) = module_instances.get(&dependency_key) else {
+        return Err(MechError::new(RuntimeInvalidOperationError { operation: "build_import_environment", reason: format!("dependency instance missing for {}", dependency) }, None));
+      };
+
+      match &import.kind {
+        SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
+          let Some(namespace) = module_namespace_for_import(import) else { continue; };
+          for (export_name, export_value) in &dependency_instance.exports {
+            let binding = format!("{}/{}", namespace, export_name);
+            if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
+              return Err(MechError::new(RuntimeModuleImportConflict { binding, first_import: first, second_import: import.specifier.clone() }, None));
+            }
+            bindings.insert(format!("{}/{}", namespace, export_name), export_value.clone());
+          }
+        }
+        SourceImportKind::Single { name } => {
+          if matches!(import.alias, Some(crate::resolver::SourceImportAlias::Context(_))) {
+            continue;
+          }
+          let Some(export_value) = dependency_instance.exports.get(name) else {
+            return Err(MechError::new(RuntimeModuleExportNotFound { dependency: import.specifier.clone(), export: name.clone() }, None));
+          };
+
+          let binding = match &import.alias {
+            Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
+            Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
+            None => name.clone(),
+          };
+
+          if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
+            return Err(MechError::new(RuntimeModuleImportConflict { binding: binding.clone(), first_import: first, second_import: import.specifier.clone() }, None));
+          }
+          bindings.insert(binding, export_value.clone());
+        }
+        SourceImportKind::Wildcard => {
+          for (export_name, export_value) in &dependency_instance.exports {
+            if let Some(first) = ownership.insert(export_name.clone(), import.specifier.clone()) {
+              return Err(MechError::new(RuntimeModuleImportConflict { binding: export_name.clone(), first_import: first, second_import: import.specifier.clone() }, None));
+            }
+            bindings.insert(export_name.clone(), export_value.clone());
+          }
+        }
+      }
+
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ModuleImportLinked {
+          importer: importer.id,
+          dependency,
+          specifier: import.specifier.clone(),
+        },
+      )?;
+    }
+
+    Ok(bindings)
+  }
+}
+
+
+
+fn module_source_for_scope(
+  source: &MechSourceCode,
+  scope: &SourceScope,
+) -> MResult<MechSourceCode> {
+  match scope {
+    SourceScope::Program => Ok(source.clone()),
+    SourceScope::Interpreter(interpreter) => {
+      let MechSourceCode::String(source_text) = source else {
+        return Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "run_module_scope",
+            reason: "interpreter scope execution requires string source".to_string(),
+          },
+          None,
+        ));
+      };
+
+      let tree = mech_syntax::parser::parse(source_text.trim())?;
+
+      if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
+        return Ok(MechSourceCode::String(source));
+      }
+
+      Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "run_module_scope",
+          reason: format!("interpreter scope `{}` not found", interpreter.namespace_str),
+        },
+        None,
+      ))
+    }
+  }
 }
 
 fn source_from_parsed_fenced_blocks(
-    tree: &mech_core::Program,
-    namespace: u64,
+  tree: &mech_core::Program,
+  namespace: u64,
 ) -> MResult<Option<String>> {
-    let mut blocks = Vec::new();
+  let mut blocks = Vec::new();
 
-    for section in &tree.body.sections {
-        for element in &section.elements {
-            if let mech_core::SectionElement::FencedMechCode(fenced) = element {
-                if fenced.config.namespace == namespace {
-                    let block = source_from_parsed_fenced_code(fenced)?;
-                    blocks.push(block.trim_end().to_string());
-                }
-            }
+  for section in &tree.body.sections {
+    for element in &section.elements {
+      if let mech_core::SectionElement::FencedMechCode(fenced) = element {
+        if fenced.config.namespace == namespace {
+          let block = source_from_parsed_fenced_code(fenced)?;
+          blocks.push(block.trim_end().to_string());
         }
+      }
     }
+  }
 
-    if blocks.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(blocks.join("\n")))
-    }
+  if blocks.is_empty() {
+    Ok(None)
+  } else {
+    Ok(Some(blocks.join("\n")))
+  }
 }
 
-fn source_from_parsed_fenced_code(fenced: &mech_core::FencedMechCode) -> MResult<String> {
-    source_from_tokens(std::slice::from_ref(&fenced.source))
+fn source_from_parsed_fenced_code(
+  fenced: &mech_core::FencedMechCode,
+) -> MResult<String> {
+  source_from_tokens(std::slice::from_ref(&fenced.source))
 }
 
 fn source_from_tokens(tokens: &[mech_core::Token]) -> MResult<String> {
-    if tokens.is_empty() {
-        return Ok(String::new());
+  if tokens.is_empty() {
+    return Ok(String::new());
+  }
+
+  if tokens.iter().any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0) {
+    return Ok(tokens.iter().map(|token| token.to_string()).collect::<Vec<_>>().join(" "));
+  }
+
+  let mut source = String::new();
+  let mut row = tokens[0].src_range.start.row;
+  let mut col = tokens[0].src_range.start.col;
+
+  for token in tokens {
+    let start = &token.src_range.start;
+    while row < start.row {
+      source.push('\n');
+      row += 1;
+      col = 1;
+    }
+    while col < start.col {
+      source.push(' ');
+      col += 1;
     }
 
-    if tokens
-        .iter()
-        .any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0)
-    {
-        return Ok(tokens
-            .iter()
-            .map(|token| token.to_string())
-            .collect::<Vec<_>>()
-            .join(" "));
+    let token_text = token.to_string();
+    for ch in token_text.chars() {
+      source.push(ch);
+      if ch == '\n' {
+        row += 1;
+        col = 1;
+      } else {
+        col += 1;
+      }
     }
+  }
 
-    let mut source = String::new();
-    let mut row = tokens[0].src_range.start.row;
-    let mut col = tokens[0].src_range.start.col;
-
-    for token in tokens {
-        let start = &token.src_range.start;
-        while row < start.row {
-            source.push('\n');
-            row += 1;
-            col = 1;
-        }
-        while col < start.col {
-            source.push(' ');
-            col += 1;
-        }
-
-        let token_text = token.to_string();
-        for ch in token_text.chars() {
-            source.push(ch);
-            if ch == '\n' {
-                row += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-    }
-
-    Ok(source)
+  Ok(source)
 }
 
 fn exports_for_scope<'a>(
-    record: &'a ModuleVersionRecord,
-    scope: &SourceScope,
+  record: &'a ModuleVersionRecord,
+  scope: &SourceScope,
 ) -> &'a [SourceExportDeclaration] {
-    record
-        .scopes
-        .iter()
-        .find(|metadata| &metadata.scope == scope)
-        .map(|metadata| metadata.exports.as_slice())
-        .unwrap_or(&[])
+  record
+    .scopes
+    .iter()
+    .find(|metadata| &metadata.scope == scope)
+    .map(|metadata| metadata.exports.as_slice())
+    .unwrap_or(&[])
 }
+
+
+
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{
-        BasicCapability, BasicOperation, BasicResource, BasicSubject, ClosureHostFunction,
-    };
-    use mech_core::Ref;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
+  use super::*;
+  use crate::{
+    BasicCapability, BasicOperation, BasicResource, BasicSubject, ClosureHostFunction,
+  };
+  use mech_core::Ref;
+  use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  };
 
-    #[test]
-    fn runtime_has_interpreter_finds_root_interpreter() {
-        let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        assert!(runtime.has_interpreter(0));
-    }
+  #[test]
+  fn runtime_has_interpreter_finds_root_interpreter() {
+    let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    assert!(runtime.has_interpreter(0));
+  }
 
-    #[test]
-    fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
-        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        let source = "```mech
+  #[test]
+  fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let source = "```mech
 1
 ```";
-        let _ = runtime.run_string(source).unwrap();
-        let root_id = runtime.program().interpreter().id;
-        let output_id = {
-            let out_values = runtime.program().interpreter().out_values.borrow();
-            *out_values
-                .keys()
-                .next()
-                .expect("expected output value after run_string")
-        };
-        let output = runtime.output_value_for_interpreter(root_id, output_id);
-        assert!(output.is_some());
+    let _ = runtime.run_string(source).unwrap();
+    let root_id = runtime.program().interpreter().id;
+    let output_id = {
+      let out_values = runtime.program().interpreter().out_values.borrow();
+      *out_values.keys().next().expect("expected output value after run_string")
+    };
+    let output = runtime.output_value_for_interpreter(root_id, output_id);
+    assert!(output.is_some());
+  }
+
+  #[test]
+  fn run_string_with_context_emits_profile_event_when_enabled() {
+    let mut config = RuntimeConfig::default();
+    config.diagnostics.profile_enabled = true;
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    runtime.run_string_with_context(&mut context, "1 + 1").unwrap();
+
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+      )
+    }));
+  }
+
+  #[test]
+  fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
+    let mut config = RuntimeConfig::default();
+    config.diagnostics.profile_enabled = true;
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    assert!(runtime.run_string_with_context(&mut context, "1 +").is_err());
+
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+      )
+    }));
+  }
+
+  #[test]
+  fn max_source_bytes_rejects_string_source() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(3);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .run_string_with_context(&mut context, "1234")
+      .unwrap_err();
+    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+    assert_eq!(budget.resource, "source_bytes");
+    assert_eq!(budget.used, 0);
+    assert_eq!(budget.requested, 4);
+    assert_eq!(budget.max, Some(3));
+  }
+
+  #[test]
+  fn direct_string_source_limit_uses_borrowed_length() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(3);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let source = String::from("1234");
+
+    let error = runtime
+      .run_string_with_context(&mut context, &source)
+      .unwrap_err();
+    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+    assert_eq!(budget.resource, "source_bytes");
+    assert_eq!(budget.requested, 4);
+    assert_eq!(source, "1234");
+  }
+
+  #[test]
+  fn direct_bytecode_source_limit_uses_borrowed_length() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(3);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let bytecode = vec![1, 2, 3, 4];
+
+    let error = runtime
+      .run_bytecode_with_context(&mut context, &bytecode)
+      .unwrap_err();
+    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+    assert_eq!(budget.resource, "source_bytes");
+    assert_eq!(budget.requested, 4);
+    assert_eq!(bytecode, vec![1, 2, 3, 4]);
+  }
+
+  #[test]
+  fn context_event_retention_is_bounded() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_in_memory_events = Some(2);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.put_object_with_context(&mut context, ObjectRecord::text(ObjectId(1), "text", "one")).unwrap();
+    runtime.put_object_with_context(&mut context, ObjectRecord::text(ObjectId(2), "text", "two")).unwrap();
+    runtime.put_object_with_context(&mut context, ObjectRecord::text(ObjectId(3), "text", "three")).unwrap();
+    let object_ids = context.events.iter().filter_map(|event| match event.kind {
+      RuntimeEventKind::ObjectCreated { object_id } => Some(object_id),
+      _ => None,
+    }).collect::<Vec<_>>();
+    assert_eq!(object_ids, vec![ObjectId(2), ObjectId(3)]);
+  }
+
+  #[test]
+  fn max_source_bytes_rejects_program_aggregate() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(3);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let source = MechSourceCode::Program(vec![
+      MechSourceCode::String("1".to_string()),
+      MechSourceCode::String("22".to_string()),
+      MechSourceCode::String("3".to_string()),
+    ]);
+
+    let error = runtime
+      .run_source_with_context(&mut context, &source)
+      .unwrap_err();
+    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+    assert_eq!(budget.resource, "source_bytes");
+    assert_eq!(budget.requested, 4);
+    assert_eq!(budget.max, Some(3));
+  }
+
+  #[test]
+  fn max_memory_bytes_rejects_large_source_buffer() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(100);
+    config.limits.max_memory_bytes = Some(3);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .run_string_with_context(&mut context, "1234")
+      .unwrap_err();
+    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+    assert_eq!(budget.resource, "bytes");
+    assert_eq!(budget.used, 0);
+    assert_eq!(budget.requested, 4);
+    assert_eq!(budget.max, Some(3));
+  }
+
+  #[test]
+  fn tree_source_without_known_size_is_not_rejected_by_source_byte_limit() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(1);
+    let mut runtime = MechRuntime::new(config).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let tree = mech_syntax::parser::parse("1 + 1").unwrap();
+    let source = MechSourceCode::Tree(tree);
+
+    runtime.run_source_with_context(&mut context, &source).unwrap();
+  }
+
+  #[test]
+  fn runtime_bind_ans_for_interpreter_binds_ans() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let value = Value::U64(Ref::new(42));
+    runtime.bind_ans_for_interpreter(0, &value).unwrap();
+    let ans_id = hash_str("ans");
+    let bound = runtime
+      .program()
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(ans_id)
+      .map(|value| value.borrow().clone());
+    assert_eq!(bound, Some(value));
+  }
+
+  #[cfg(feature = "functions")]
+  #[test]
+  fn step_with_context_recomputes_runtime_host_function_with_provided_context() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_host = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new(
+        "demo/echo",
+        move |_services, context, args| {
+          assert_eq!(context.subject, "program:step-host-test");
+          calls_for_host.fetch_add(1, Ordering::SeqCst);
+          match &args[0] {
+            Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+            Value::MutableReference(value) => match &*value.borrow() {
+              Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+              other => panic!("expected F64 mutable reference, got {:?}", other),
+            },
+            other => panic!("expected F64 argument, got {:?}", other),
+          }
+        },
+      ))
+      .unwrap();
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(1),
+        &BasicSubject::new("program:step-host-test"),
+        &BasicResource::new("host:demo/echo"),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
+
+    let mut context = runtime
+      .runtime_context()
+      .unwrap()
+      .with_subject("program:step-host-test");
+    runtime
+      .run_string_with_context(&mut context, "x := 1\ny := demo/echo(x) + 0")
+      .unwrap();
+    let x = runtime
+      .program()
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(hash_str("x"))
+      .map(|value| value.borrow().clone())
+      .expect("expected x to be bound");
+    let x_ref = match x {
+      Value::F64(value) => value,
+      other => panic!("expected x to be F64, got {:?}", other),
+    };
+    *x_ref.borrow_mut() = 2.0;
+    runtime.step_with_context(&mut context, 3).unwrap();
+
+    *x_ref.borrow_mut() = 2.0;
+    let function = RuntimeHostNativeFunction {
+      name: "demo/echo".to_string(),
+      host_name: "demo/echo".to_string(),
+      arguments: vec![Value::F64(x_ref.clone())],
+      value: Ref::new(Value::F64(Ref::new(1.0))),
+    };
+    let calls_before_solve = calls.load(Ordering::SeqCst);
+    let runtime_ptr: *mut MechRuntime = &mut runtime;
+    let context_ptr: *mut RuntimeContext = &mut context;
+    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+    function.solve();
+
+    assert!(calls.load(Ordering::SeqCst) > calls_before_solve);
+    let y = function.out();
+    match y {
+      Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
+      other => panic!("expected F64(2.0), got {:?}", other),
     }
-
-    #[test]
-    fn run_string_with_context_emits_profile_event_when_enabled() {
-        let mut config = RuntimeConfig::default();
-        config.diagnostics.profile_enabled = true;
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-
-        runtime
-            .run_string_with_context(&mut context, "1 + 1")
-            .unwrap();
-
-        assert!(context.events.iter().any(|event| {
-            matches!(
-              event.kind,
-              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-            )
-        }));
-    }
-
-    #[test]
-    fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
-        let mut config = RuntimeConfig::default();
-        config.diagnostics.profile_enabled = true;
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-
-        assert!(
-            runtime
-                .run_string_with_context(&mut context, "1 +")
-                .is_err()
-        );
-
-        assert!(context.events.iter().any(|event| {
-            matches!(
-              event.kind,
-              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-            )
-        }));
-    }
-
-    #[test]
-    fn max_source_bytes_rejects_string_source() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_source_bytes = Some(3);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-
-        let error = runtime
-            .run_string_with_context(&mut context, "1234")
-            .unwrap_err();
-        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-        assert_eq!(budget.resource, "source_bytes");
-        assert_eq!(budget.used, 0);
-        assert_eq!(budget.requested, 4);
-        assert_eq!(budget.max, Some(3));
-    }
-
-    #[test]
-    fn direct_string_source_limit_uses_borrowed_length() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_source_bytes = Some(3);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-        let source = String::from("1234");
-
-        let error = runtime
-            .run_string_with_context(&mut context, &source)
-            .unwrap_err();
-        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-        assert_eq!(budget.resource, "source_bytes");
-        assert_eq!(budget.requested, 4);
-        assert_eq!(source, "1234");
-    }
-
-    #[test]
-    fn direct_bytecode_source_limit_uses_borrowed_length() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_source_bytes = Some(3);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-        let bytecode = vec![1, 2, 3, 4];
-
-        let error = runtime
-            .run_bytecode_with_context(&mut context, &bytecode)
-            .unwrap_err();
-        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-        assert_eq!(budget.resource, "source_bytes");
-        assert_eq!(budget.requested, 4);
-        assert_eq!(bytecode, vec![1, 2, 3, 4]);
-    }
-
-    #[test]
-    fn context_event_retention_is_bounded() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_in_memory_events = Some(2);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-        runtime
-            .put_object_with_context(&mut context, ObjectRecord::text(ObjectId(1), "text", "one"))
-            .unwrap();
-        runtime
-            .put_object_with_context(&mut context, ObjectRecord::text(ObjectId(2), "text", "two"))
-            .unwrap();
-        runtime
-            .put_object_with_context(
-                &mut context,
-                ObjectRecord::text(ObjectId(3), "text", "three"),
-            )
-            .unwrap();
-        let object_ids = context
-            .events
-            .iter()
-            .filter_map(|event| match event.kind {
-                RuntimeEventKind::ObjectCreated { object_id } => Some(object_id),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(object_ids, vec![ObjectId(2), ObjectId(3)]);
-    }
-
-    #[test]
-    fn max_source_bytes_rejects_program_aggregate() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_source_bytes = Some(3);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-        let source = MechSourceCode::Program(vec![
-            MechSourceCode::String("1".to_string()),
-            MechSourceCode::String("22".to_string()),
-            MechSourceCode::String("3".to_string()),
-        ]);
-
-        let error = runtime
-            .run_source_with_context(&mut context, &source)
-            .unwrap_err();
-        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-        assert_eq!(budget.resource, "source_bytes");
-        assert_eq!(budget.requested, 4);
-        assert_eq!(budget.max, Some(3));
-    }
-
-    #[test]
-    fn max_memory_bytes_rejects_large_source_buffer() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_source_bytes = Some(100);
-        config.limits.max_memory_bytes = Some(3);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-
-        let error = runtime
-            .run_string_with_context(&mut context, "1234")
-            .unwrap_err();
-        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-        assert_eq!(budget.resource, "bytes");
-        assert_eq!(budget.used, 0);
-        assert_eq!(budget.requested, 4);
-        assert_eq!(budget.max, Some(3));
-    }
-
-    #[test]
-    fn tree_source_without_known_size_is_not_rejected_by_source_byte_limit() {
-        let mut config = RuntimeConfig::default();
-        config.limits.max_source_bytes = Some(1);
-        let mut runtime = MechRuntime::new(config).unwrap();
-        let mut context = runtime.runtime_context().unwrap();
-        let tree = mech_syntax::parser::parse("1 + 1").unwrap();
-        let source = MechSourceCode::Tree(tree);
-
-        runtime
-            .run_source_with_context(&mut context, &source)
-            .unwrap();
-    }
-
-    #[test]
-    fn runtime_bind_ans_for_interpreter_binds_ans() {
-        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        let value = Value::U64(Ref::new(42));
-        runtime.bind_ans_for_interpreter(0, &value).unwrap();
-        let ans_id = hash_str("ans");
-        let bound = runtime
-            .program()
-            .interpreter()
-            .symbols()
-            .borrow()
-            .get(ans_id)
-            .map(|value| value.borrow().clone());
-        assert_eq!(bound, Some(value));
-    }
-
-    #[cfg(feature = "functions")]
-    #[test]
-    fn step_with_context_recomputes_runtime_host_function_with_provided_context() {
-        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-        let calls = Arc::new(AtomicUsize::new(0));
-        let calls_for_host = calls.clone();
-        runtime
-            .register_mech_host_function(ClosureHostFunction::new(
-                "demo/echo",
-                move |_services, context, args| {
-                    assert_eq!(context.subject, "program:step-host-test");
-                    calls_for_host.fetch_add(1, Ordering::SeqCst);
-                    match &args[0] {
-                        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
-                        Value::MutableReference(value) => match &*value.borrow() {
-                            Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
-                            other => panic!("expected F64 mutable reference, got {:?}", other),
-                        },
-                        other => panic!("expected F64 argument, got {:?}", other),
-                    }
-                },
-            ))
-            .unwrap();
-        runtime
-            .grant_capability(Arc::new(BasicCapability::new(
-                CapabilityId(1),
-                &BasicSubject::new("program:step-host-test"),
-                &BasicResource::new("host:demo/echo"),
-                [BasicOperation::new("call")],
-            )))
-            .unwrap();
-
-        let mut context = runtime
-            .runtime_context()
-            .unwrap()
-            .with_subject("program:step-host-test");
-        runtime
-            .run_string_with_context(&mut context, "x := 1\ny := demo/echo(x) + 0")
-            .unwrap();
-        let x = runtime
-            .program()
-            .interpreter()
-            .symbols()
-            .borrow()
-            .get(hash_str("x"))
-            .map(|value| value.borrow().clone())
-            .expect("expected x to be bound");
-        let x_ref = match x {
-            Value::F64(value) => value,
-            other => panic!("expected x to be F64, got {:?}", other),
-        };
-        *x_ref.borrow_mut() = 2.0;
-        runtime.step_with_context(&mut context, 3).unwrap();
-
-        *x_ref.borrow_mut() = 2.0;
-        let function = RuntimeHostNativeFunction {
-            name: "demo/echo".to_string(),
-            host_name: "demo/echo".to_string(),
-            arguments: vec![Value::F64(x_ref.clone())],
-            value: Ref::new(Value::F64(Ref::new(1.0))),
-        };
-        let calls_before_solve = calls.load(Ordering::SeqCst);
-        let runtime_ptr: *mut MechRuntime = &mut runtime;
-        let context_ptr: *mut RuntimeContext = &mut context;
-        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-        function.solve();
-
-        assert!(calls.load(Ordering::SeqCst) > calls_before_solve);
-        let y = function.out();
-        match y {
-            Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
-            other => panic!("expected F64(2.0), got {:?}", other),
-        }
-    }
+  }
 }
 
 impl MechRuntime {
-    pub fn ingress(&self) -> crate::RuntimeIngress {
-        crate::RuntimeIngress::new(self.host_input_queue.clone())
-    }
+  pub fn ingress(&self) -> crate::RuntimeIngress {
+    crate::RuntimeIngress::new(self.host_input_queue.clone())
+  }
 
-    pub fn has_pending_host_inputs(&self) -> MResult<bool> {
-        Ok(self.pending_host_input_count()? > 0)
-    }
+  pub fn has_pending_host_inputs(&self) -> MResult<bool> {
+    Ok(self.pending_host_input_count()? > 0)
+  }
 
-    pub fn persistent_send_count(&self) -> usize {
-        self.persistent_sends.len()
-    }
+  pub fn persistent_send_count(&self) -> usize {
+    self.persistent_sends.len()
+  }
 
-    pub fn input_driver_count(&self) -> usize {
-        self.attached_input_driver_count
-    }
+  pub fn input_driver_count(&self) -> usize {
+    self.attached_input_driver_count
+  }
 
-    pub fn has_input_drivers(&self) -> bool {
-        self.input_driver_count() > 0
-    }
+  pub fn has_input_drivers(&self) -> bool {
+    self.input_driver_count() > 0
+  }
 
-    pub fn live_input_binding_count(&self) -> usize {
-        self.live_input_bindings.values().map(Vec::len).sum()
-    }
+  pub fn live_input_binding_count(&self) -> usize {
+    self.live_input_bindings.values().map(Vec::len).sum()
+  }
 
-    pub fn has_live_input_bindings(&self) -> bool {
-        self.live_input_binding_count() > 0
-    }
+  pub fn has_live_input_bindings(&self) -> bool {
+    self.live_input_binding_count() > 0
+  }
 
-    pub fn driven_live_input_binding_count(&self) -> usize {
-        self.live_input_bindings
-            .iter()
-            .filter(|(source, _)| {
-                self.input_drivers[..self.attached_input_driver_count]
-                    .iter()
-                    .any(|driver| driver.drives(source))
-            })
-            .map(|(_, bindings)| bindings.len())
-            .sum()
-    }
+  pub fn driven_live_input_binding_count(&self) -> usize {
+    self.live_input_bindings
+      .iter()
+      .filter(|(source, _)| self.input_drivers[..self.attached_input_driver_count].iter().any(|driver| driver.drives(source)))
+      .map(|(_, bindings)| bindings.len())
+      .sum()
+  }
 
-    pub fn has_driven_live_input_bindings(&self) -> bool {
-        self.driven_live_input_binding_count() > 0
-    }
+  pub fn has_driven_live_input_bindings(&self) -> bool {
+    self.driven_live_input_binding_count() > 0
+  }
 
-    pub fn pending_host_input_count(&self) -> MResult<usize> {
-        let guard = self.host_input_queue.lock().map_err(|_| {
-            crate::input::input_error(
-                "RuntimeIngressUnavailable",
-                "host input queue lock is poisoned",
-            )
-        })?;
-        Ok(guard.queue.len())
-    }
+  pub fn pending_host_input_count(&self) -> MResult<usize> {
+    let guard = self.host_input_queue.lock().map_err(|_| crate::input::input_error("RuntimeIngressUnavailable", "host input queue lock is poisoned"))?;
+    Ok(guard.queue.len())
+  }
 
-    pub fn apply_host_input(
-        &mut self,
-        input: crate::RuntimeHostInput,
-    ) -> MResult<crate::RuntimeHostInputOutcome> {
-        input.validate()?;
-        let mut target_updates = Vec::new();
-        let mut seen_targets = std::collections::HashSet::new();
-        let mut ignored_update_count = 0;
+  pub fn apply_host_input(&mut self, input: crate::RuntimeHostInput) -> MResult<crate::RuntimeHostInputOutcome> {
+    input.validate()?;
+    let mut target_updates = Vec::new();
+    let mut seen_targets = std::collections::HashSet::new();
+    let mut ignored_update_count = 0;
 
-        for update in &input.updates {
-            let Some(bindings) = self.live_input_bindings.get(&update.source).cloned() else {
-                ignored_update_count += 1;
-                continue;
-            };
-            if bindings.is_empty() {
-                ignored_update_count += 1;
-                continue;
-            }
-            let value = update.value.clone().into_mech_value()?;
-            for program_input in bindings {
-                if !seen_targets.insert(program_input) {
-                    return Err(MechError::new(
-                        mech_program::ProgramInputDuplicateTarget {
-                            input: program_input,
-                        },
-                        None,
-                    ));
-                }
-                target_updates.push(mech_program::ProgramInputUpdate {
-                    input: program_input,
-                    value: value.clone(),
-                });
-            }
+    for update in &input.updates {
+      let Some(bindings) = self.live_input_bindings.get(&update.source).cloned() else {
+        ignored_update_count += 1;
+        continue;
+      };
+      if bindings.is_empty() {
+        ignored_update_count += 1;
+        continue;
+      }
+      let value = update.value.clone().into_mech_value()?;
+      for program_input in bindings {
+        if !seen_targets.insert(program_input) {
+          return Err(MechError::new(mech_program::ProgramInputDuplicateTarget { input: program_input }, None));
         }
-
-        if target_updates.is_empty() {
-            return Ok(crate::RuntimeHostInputOutcome {
-                update_count: input.updates.len(),
-                ignored_update_count,
-                binding_count: 0,
-                turn: None,
-            });
-        }
-
-        let mut context = self.live_turn_context()?;
-        self.validate_context_for_runtime(&context)?;
-        context.charge_step()?;
-
-        let turn_started = Instant::now();
-
-        let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(&mut self.program, MechProgram::new(program_config));
-
-        let result = (|| -> MResult<crate::RuntimeHostInputOutcome> {
-            let runtime_ptr: *mut MechRuntime = self;
-            let context_ptr: *mut RuntimeContext = &mut context;
-            let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-            // The program API performs complete input preflight, commits the
-            // accepted input batch, and advances one persistent reactive turn
-            // per affected interpreter. Errors after input admission preserve
-            // accepted writes and completed register commits.
-            let turn = program.update_inputs_and_advance_turn(&target_updates)?;
-            self.execute_persistent_sends(&context, &turn)?;
-            self.enforce_turn_duration(turn_started)?;
-
-            Ok(crate::RuntimeHostInputOutcome {
-                update_count: input.updates.len(),
-                ignored_update_count,
-                binding_count: turn.updated_count,
-                turn: Some(turn),
-            })
-        })();
-
-        self.program = program;
-
-        result
+        target_updates.push(mech_program::ProgramInputUpdate { input: program_input, value: value.clone() });
+      }
     }
 
-    fn execute_persistent_sends(
-        &mut self,
-        context: &RuntimeContext,
-        turn: &mech_program::ProgramInputTurnOutcome,
-    ) -> MResult<()> {
-        for send in self.persistent_sends.clone() {
-            let should_send = match send.schedule {
-                RuntimePersistentSendSchedule::EveryAcceptedTurn => true,
-                RuntimePersistentSendSchedule::Activation {
-                    interpreter_id,
-                    barrier_node_id,
-                } => turn
-                    .interpreter_turns
-                    .iter()
-                    .find(|outcome| outcome.interpreter_id == interpreter_id)
-                    .map(|outcome| {
-                        outcome
-                            .turn
-                            .before_commit
-                            .executed_nodes
-                            .contains(&barrier_node_id)
-                            || outcome
-                                .turn
-                                .after_commit
-                                .executed_nodes
-                                .contains(&barrier_node_id)
-                    })
-                    .unwrap_or(false),
-            };
-            if !should_send {
-                continue;
-            }
-            let value = resolve_runtime_value(send.value.borrow().clone());
-            self.write_context_resource(
-                context,
-                &send.binding,
-                &send.path,
-                value,
-                RuntimeResourceWriteIntent::Send,
-            )?;
-        }
-        Ok(())
+    if target_updates.is_empty() {
+      return Ok(crate::RuntimeHostInputOutcome {
+        update_count: input.updates.len(),
+        ignored_update_count,
+        binding_count: 0,
+        turn: None,
+      });
     }
 
-    pub fn drain_host_inputs(
-        &mut self,
-        max_inputs: usize,
-    ) -> MResult<Vec<crate::RuntimeHostInputOutcome>> {
-        let mut outcomes = Vec::new();
-        for _ in 0..max_inputs {
-            let input = {
-                let mut guard = self.host_input_queue.lock().map_err(|_| {
-                    crate::input::input_error(
-                        "RuntimeIngressUnavailable",
-                        "host input queue lock is poisoned",
-                    )
-                })?;
-                guard.queue.pop_front()
-            };
-            let Some(input) = input else {
-                break;
-            };
-            outcomes.push(self.apply_host_input(input)?);
-        }
-        Ok(outcomes)
-    }
+    let mut context = self.live_turn_context()?;
+    self.validate_context_for_runtime(&context)?;
+    context.charge_step()?;
 
-    pub fn close_ingress(&mut self) -> MResult<()> {
-        let mut guard = self.host_input_queue.lock().map_err(|_| {
-            crate::input::input_error(
-                "RuntimeIngressUnavailable",
-                "host input queue lock is poisoned",
-            )
-        })?;
-        guard.closed = true;
-        Ok(())
-    }
+    let turn_started = Instant::now();
 
-    pub fn start_input_drivers(&mut self) -> MResult<()> {
-        if self.ingress().is_closed()? {
-            return Err(crate::input::input_error(
-                "RuntimeIngressClosed",
-                "cannot start input drivers after ingress is closed",
-            ));
-        }
-        for index in 0..self.attached_input_driver_count {
-            if self.input_drivers[index].is_live() {
-                continue;
-            }
-            if let Err(error) = self.input_drivers[index].start() {
-                for driver in self.input_drivers[..self.attached_input_driver_count]
-                    .iter_mut()
-                    .rev()
-                {
-                    let _ = driver.stop();
-                }
-                return Err(error);
-            }
-        }
-        Ok(())
-    }
+    let program_config = self.program.config.clone();
+    let mut program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config),
+    );
 
-    pub fn stop_input_drivers(&mut self) -> MResult<()> {
-        let mut first_error = None;
-        for driver in self.input_drivers[..self.attached_input_driver_count]
-            .iter_mut()
-            .rev()
-        {
-            if let Err(error) = driver.stop() {
-                if first_error.is_none() {
-                    first_error = Some(error);
-                }
-            }
-        }
-        if let Some(error) = first_error {
-            return Err(error);
-        }
-        Ok(())
+    let result = (|| -> MResult<crate::RuntimeHostInputOutcome> {
+      let runtime_ptr: *mut MechRuntime = self;
+      let context_ptr: *mut RuntimeContext = &mut context;
+      let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+      // The program API performs complete input preflight, commits the
+      // accepted input batch, and advances one persistent reactive turn
+      // per affected interpreter. Errors after input admission preserve
+      // accepted writes and completed register commits.
+      let turn =
+        program.update_inputs_and_advance_turn(
+          &target_updates,
+        )?;
+      self.execute_persistent_sends(&context, &turn)?;
+      self.enforce_turn_duration(turn_started)?;
+
+      Ok(crate::RuntimeHostInputOutcome {
+        update_count: input.updates.len(),
+        ignored_update_count,
+        binding_count: turn.updated_count,
+        turn: Some(turn),
+      })
+    })();
+
+    self.program = program;
+
+    result
+  }
+
+  fn execute_persistent_sends(&mut self, context: &RuntimeContext, turn: &mech_program::ProgramInputTurnOutcome) -> MResult<()> {
+    for send in self.persistent_sends.clone() {
+      let should_send = match send.schedule {
+        RuntimePersistentSendSchedule::EveryAcceptedTurn => true,
+        RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } => turn.interpreter_turns.iter().find(|outcome| outcome.interpreter_id == interpreter_id).map(|outcome| {
+          outcome.turn.before_commit.executed_nodes.contains(&barrier_node_id) || outcome.turn.after_commit.executed_nodes.contains(&barrier_node_id)
+        }).unwrap_or(false),
+      };
+      if !should_send { continue; }
+      let value = resolve_runtime_value(send.value.borrow().clone());
+      self.write_context_resource(context, &send.binding, &send.path, value, RuntimeResourceWriteIntent::Send)?;
     }
+    Ok(())
+  }
+
+  pub fn drain_host_inputs(&mut self, max_inputs: usize) -> MResult<Vec<crate::RuntimeHostInputOutcome>> {
+    let mut outcomes = Vec::new();
+    for _ in 0..max_inputs {
+      let input = {
+        let mut guard = self.host_input_queue.lock().map_err(|_| crate::input::input_error("RuntimeIngressUnavailable", "host input queue lock is poisoned"))?;
+        guard.queue.pop_front()
+      };
+      let Some(input) = input else { break; };
+      outcomes.push(self.apply_host_input(input)?);
+    }
+    Ok(outcomes)
+  }
+
+  pub fn close_ingress(&mut self) -> MResult<()> {
+    let mut guard = self.host_input_queue.lock().map_err(|_| crate::input::input_error("RuntimeIngressUnavailable", "host input queue lock is poisoned"))?;
+    guard.closed = true;
+    Ok(())
+  }
+
+  pub fn start_input_drivers(&mut self) -> MResult<()> {
+    if self.ingress().is_closed()? {
+      return Err(crate::input::input_error("RuntimeIngressClosed", "cannot start input drivers after ingress is closed"));
+    }
+    for index in 0..self.attached_input_driver_count {
+      if self.input_drivers[index].is_live() { continue; }
+      if let Err(error) = self.input_drivers[index].start() {
+        for driver in self.input_drivers[..self.attached_input_driver_count].iter_mut().rev() {
+          let _ = driver.stop();
+        }
+        return Err(error);
+      }
+    }
+    Ok(())
+  }
+
+  pub fn stop_input_drivers(&mut self) -> MResult<()> {
+    let mut first_error = None;
+    for driver in self.input_drivers[..self.attached_input_driver_count].iter_mut().rev() {
+      if let Err(error) = driver.stop() {
+        if first_error.is_none() { first_error = Some(error); }
+      }
+    }
+    if let Some(error) = first_error { return Err(error); }
+    Ok(())
+  }
 }
 
 #[cfg(test)]
 mod root_symbol_snapshot_runtime_tests {
-    use super::*;
+  use super::*;
 
-    fn f64_value(value: &Value) -> f64 {
-        match value {
-            Value::F64(value) => *value.borrow(),
-            other => panic!("expected f64, got {other:?}"),
-        }
+  fn f64_value(value: &Value) -> f64 {
+    match value {
+      Value::F64(value) => *value.borrow(),
+      other => panic!("expected f64, got {other:?}"),
     }
+  }
 
-    #[test]
-    fn runtime_delegates_root_symbol_value() {
-        let mut runtime = MechRuntime::builder().build().unwrap();
-        runtime.run_string("answer := 42.0").unwrap();
-        assert_eq!(
-            f64_value(&runtime.root_symbol_value("answer").unwrap()),
-            42.0
-        );
-    }
+  #[test]
+  fn runtime_delegates_root_symbol_value() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    runtime.run_string("answer := 42.0").unwrap();
+    assert_eq!(f64_value(&runtime.root_symbol_value("answer").unwrap()), 42.0);
+  }
 
-    #[test]
-    fn runtime_delegates_root_symbol_values() {
-        let mut runtime = MechRuntime::builder().build().unwrap();
-        runtime.run_string("a := 1.0\nb := 2.0").unwrap();
-        let rows = runtime.root_symbol_values(&["b", "a"]).unwrap();
-        assert_eq!(rows[0].0, "b");
-        assert_eq!(f64_value(&rows[0].1), 2.0);
-        assert_eq!(rows[1].0, "a");
-        assert_eq!(f64_value(&rows[1].1), 1.0);
-    }
+  #[test]
+  fn runtime_delegates_root_symbol_values() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    runtime.run_string("a := 1.0\nb := 2.0").unwrap();
+    let rows = runtime.root_symbol_values(&["b", "a"]).unwrap();
+    assert_eq!(rows[0].0, "b");
+    assert_eq!(f64_value(&rows[0].1), 2.0);
+    assert_eq!(rows[1].0, "a");
+    assert_eq!(f64_value(&rows[1].1), 1.0);
+  }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -342,6 +342,20 @@ impl MechRuntime {
     result
   }
 
+  #[cfg(test)]
+  pub(super) fn run_string_with_isolated_registration_for_test(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &str,
+  ) -> MResult<Value> {
+    self.with_live_registration_mode(
+      crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+      |runtime| {
+        runtime.run_string_with_context(context, source)
+      },
+    )
+  }
+
   fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
     matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
   }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -542,6 +542,8 @@ impl MechRuntime {
     value: Value,
   ) -> MResult<mech_core::Expression> {
     self.validate_live_context_candidate(context)?;
+    // The interpreter recognizes this prefix as a sampled pattern value rather
+    // than a source-level capture name.
     let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
     let symbol_id = hash_str(&name);
     let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
@@ -949,92 +951,53 @@ impl MechRuntime {
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<mech_core::Expression> {
-    if let Some(expression) = self.literalize_match_pattern_context_read_expression(
-      context,
+    if let Some(expression) = self.resolve_interpreter_address_pattern_expression(
       program,
       registry,
       expression,
     )? {
       return Ok(expression);
     }
-
     self.resolve_context_reads_in_expression(context, program, registry, expression)
   }
 
-  fn literalize_match_pattern_context_read_expression(
+  fn resolve_interpreter_address_pattern_expression(
     &mut self,
-    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<Option<mech_core::Expression>> {
     match expression {
       mech_core::Expression::Var(var) => {
-        self.literalize_match_pattern_context_read_var(context, program, registry, var)
+        let Some(var_context) = &var.context else {
+          return Ok(None);
+        };
+        let target = var_context.to_string();
+        if registry.get(&target).is_some() {
+          return Ok(None);
+        }
+
+        let address = format!("@{target}/{}", var.name.to_string());
+        let value = {
+          let symbols = program.interpreter().symbols();
+          let symbols = symbols.borrow();
+          symbols
+            .get(hash_str(&address))
+            .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
+        };
+        match value {
+          Some(value) => self.resolved_pattern_value_expression(value).map(Some),
+          None => Ok(None),
+        }
       }
       mech_core::Expression::Formula(factor) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, factor)
+        self.resolve_interpreter_address_pattern_factor(program, registry, factor)
       }
       _ => Ok(None),
     }
   }
 
-  fn literalize_match_pattern_context_read_factor(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-  ) -> MResult<Option<mech_core::Expression>> {
-    match factor {
-      mech_core::Factor::Expression(expression) => {
-        self.literalize_match_pattern_context_read_expression(context, program, registry, expression)
-      }
-      mech_core::Factor::Parenthetical(inner) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
-      }
-      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, &term.lhs)
-      }
-      _ => Ok(None),
-    }
-  }
-
-  fn literalize_match_pattern_context_read_var(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    var: &mech_core::Var,
-  ) -> MResult<Option<mech_core::Expression>> {
-    let Some(var_context) = &var.context else {
-      return Ok(None);
-    };
-
-    let target = var_context.to_string();
-    let path = var.name.to_string();
-    if let Some(binding) = registry.get(&target) {
-      let value = self.read_context_resource(context, binding, &path)?;
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    let address_key = format!("@{target}/{path}");
-    let value = {
-      let symbols = program.interpreter().symbols();
-      let symbols = symbols.borrow();
-      symbols
-        .get(hash_str(&address_key))
-        .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
-    };
-
-    if let Some(value) = value {
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    Ok(None)
-  }
-
-  fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
+  fn resolved_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
     let value = resolve_runtime_value(value);
     match value {
       Value::String(value) => {
@@ -1062,9 +1025,31 @@ impl MechRuntime {
         vec!['_'],
       )))),
       other => Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "context_match_pattern",
-        reason: format!("context match patterns currently support string, bool, and empty values; got {other:?}"),
+        operation: "interpreter_address_pattern",
+        reason: format!(
+          "interpreter-address patterns currently support string, bool, and empty values; got {other:?}",
+        ),
       }, None)),
+    }
+  }
+
+  fn resolve_interpreter_address_pattern_factor(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.resolve_interpreter_address_pattern_expression(program, registry, expression)
+      }
+      mech_core::Factor::Parenthetical(inner) => {
+        self.resolve_interpreter_address_pattern_factor(program, registry, inner)
+      }
+      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
+        self.resolve_interpreter_address_pattern_factor(program, registry, &term.lhs)
+      }
+      _ => Ok(None),
     }
   }
 
@@ -1305,12 +1290,18 @@ impl MechRuntime {
           lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
           let mut lowered_arms = Vec::with_capacity(arms.len());
           for arm in arms {
+            let pattern = self.resolve_context_reads_in_match_pattern(
+              context,
+              program,
+              registry,
+              &arm.pattern,
+            )?;
             let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
             let body = match &arm.body {
               mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
               mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
             };
-            lowered_arms.push(mech_core::ActivationArm { pattern: arm.pattern.clone(), guard, body });
+            lowered_arms.push(mech_core::ActivationArm { pattern, guard, body });
           }
           lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
@@ -1503,6 +1494,12 @@ impl MechRuntime {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
           for arm in arms {
+            self.preflight_pattern_context_reads(
+              context,
+              registry,
+              &arm.pattern,
+              addressed_read_preflight,
+            )?;
             if let Some(guard) = &arm.guard { self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?; }
             match &arm.body {
               mech_core::ActivationArmBody::Block(body) => for (code, _) in body { self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?; },

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -12,88 +12,90 @@
 // Both methods have corresponding _with_context versions that accept a mutable reference to a RuntimeContext, allowing for execution within the context of an active transaction. This ensures that any changes made during execution are properly staged within the transaction that if an error occurs, the transaction can be rolled back to maintain consistency.
 
 use super::*;
-use crate::{SourceDeclaration, SourceIndex};
 use crate::RuntimeResourceWritePreflightRequest;
+use crate::{SourceDeclaration, SourceIndex};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RuntimeAddressTarget {
-  Interpreter(SourceScope),
-  Context(RuntimeContextBinding),
-  Unknown,
+    Interpreter(SourceScope),
+    Context(RuntimeContextBinding),
+    Unknown,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirectContextEffectPlacement {
-  TopLevel,
-  ActivationScope,
-  FunctionBody,
-  FsmTransition,
+    TopLevel,
+    ActivationScope,
+    FunctionBody,
+    FsmTransition,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AddressedReadPreflight {
-  RequireContextBinding,
-  AllowModuleAddressTargets,
+    RequireContextBinding,
+    AllowModuleAddressTargets,
 }
 
 impl AddressedReadPreflight {
-  fn requires_context_binding(self) -> bool {
-    matches!(self, AddressedReadPreflight::RequireContextBinding)
-  }
+    fn requires_context_binding(self) -> bool {
+        matches!(self, AddressedReadPreflight::RequireContextBinding)
+    }
 }
 
 impl DirectContextEffectPlacement {
-  fn description(self) -> &'static str {
-    match self {
-      DirectContextEffectPlacement::TopLevel => "module top level",
-      DirectContextEffectPlacement::ActivationScope => "an activation scope",
-      DirectContextEffectPlacement::FunctionBody => "a function body",
-      DirectContextEffectPlacement::FsmTransition => "an FSM transition",
+    fn description(self) -> &'static str {
+        match self {
+            DirectContextEffectPlacement::TopLevel => "module top level",
+            DirectContextEffectPlacement::ActivationScope => "an activation scope",
+            DirectContextEffectPlacement::FunctionBody => "a function body",
+            DirectContextEffectPlacement::FsmTransition => "an FSM transition",
+        }
     }
-  }
-
 }
 
 struct ActiveRuntimeProgramHostGuard {
-  previous: Option<RuntimeProgramHostTarget>,
+    previous: Option<RuntimeProgramHostTarget>,
 }
 
 impl ActiveRuntimeProgramHostGuard {
-  fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
-    let previous = ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(Some(RuntimeProgramHostTarget { runtime, context }))
-    });
-    Self { previous }
-  }
+    fn install(runtime: *mut MechRuntime, context: *mut RuntimeContext) -> Self {
+        let previous = ACTIVE_RUNTIME_PROGRAM_HOST
+            .with(|slot| slot.replace(Some(RuntimeProgramHostTarget { runtime, context })));
+        Self { previous }
+    }
 }
 
 impl Drop for ActiveRuntimeProgramHostGuard {
-  fn drop(&mut self) {
-    ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
-      slot.replace(self.previous.take());
-    });
-  }
+    fn drop(&mut self) {
+        ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+            slot.replace(self.previous.take());
+        });
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAddressedAssignmentUnsupported {
-  pub target: String,
+    pub target: String,
 }
 
 impl MechErrorKind for RuntimeAddressedAssignmentUnsupported {
-  fn name(&self) -> &str { "RuntimeAddressedAssignmentUnsupported" }
+    fn name(&self) -> &str {
+        "RuntimeAddressedAssignmentUnsupported"
+    }
 
-  fn message(&self) -> String {
-    format!("addressed assignment is not supported for `{}`", self.target)
-  }
+    fn message(&self) -> String {
+        format!(
+            "addressed assignment is not supported for `{}`",
+            self.target
+        )
+    }
 }
-
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedContextResourceRequest {
-  provider_base_uri: String,
-  provider_path: String,
-  context_path: String,
+    provider_base_uri: String,
+    provider_path: String,
+    context_path: String,
 }
 
 // This name deliberately starts with a NUL byte.  It is an identifier we can
@@ -101,1447 +103,2228 @@ struct ResolvedContextResourceRequest {
 // Keeping the compiler registered on the program is therefore not a public
 // source-level API.
 pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "\0mech/runtime/activation-effect-barrier";
+const ACTIVATION_SEND_PAYLOAD_NAME_PREFIX: &str = "\0mech/runtime/activation-send-payload/";
 
 #[derive(Clone, Debug)]
 pub(super) struct ActivationEffectBarrierCompiler;
 impl NativeFunctionCompiler for ActivationEffectBarrierCompiler {
-  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
-    if !arguments.is_empty() { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier accepts no arguments".into() }, None)); }
-    Ok(Box::new(ActivationEffectBarrier))
-  }
+    fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
+        if !arguments.is_empty() {
+            return Err(MechError::new(
+                RuntimeActivationEffectBarrierInvariantError {
+                    reason: "activation effect barrier accepts no arguments".into(),
+                },
+                None,
+            ));
+        }
+        Ok(Box::new(ActivationEffectBarrier))
+    }
 }
 #[derive(Clone, Debug)]
 struct ActivationEffectBarrier;
 impl MechFunctionImpl for ActivationEffectBarrier {
-  fn solve(&self) {}
-  fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> { Ok(mech_core::ReactiveSolveStatus::Unchanged) }
-  // The barrier is a scheduling node, not a value producer.  Its node id and
-  // reactive execution record are the observable state used by send replay.
-  fn out(&self) -> Value { Value::Empty }
-  fn to_string(&self) -> String { ACTIVATION_EFFECT_BARRIER_NAME.to_string() }
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> {
+        Ok(mech_core::ReactiveSolveStatus::Unchanged)
+    }
+    // The barrier is a scheduling node, not a value producer.  Its node id and
+    // reactive execution record are the observable state used by send replay.
+    fn out(&self) -> Value {
+        Value::Empty
+    }
+    fn to_string(&self) -> String {
+        ACTIVATION_EFFECT_BARRIER_NAME.to_string()
+    }
 }
 impl MechFunctionCompiler for ActivationEffectBarrier {
-  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier cannot be bytecode compiled".into() }, None)) }
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+        Err(MechError::new(
+            RuntimeActivationEffectBarrierInvariantError {
+                reason: "activation effect barrier cannot be bytecode compiled".into(),
+            },
+            None,
+        ))
+    }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
-  mech_core::Identifier {
-    name: mech_core::Token::new(
-      mech_core::TokenKind::Identifier,
-      mech_core::SourceRange::default(),
-      name.chars().collect(),
-    ),
-  }
+    mech_core::Identifier {
+        name: mech_core::Token::new(
+            mech_core::TokenKind::Identifier,
+            mech_core::SourceRange::default(),
+            name.chars().collect(),
+        ),
+    }
 }
 
-
 fn execution_scope_for_extracted_module_source(scope: &SourceScope) -> SourceScope {
-  match scope {
-    SourceScope::Program => SourceScope::Program,
-    SourceScope::Interpreter(_) => SourceScope::Program,
-  }
+    match scope {
+        SourceScope::Program => SourceScope::Program,
+        SourceScope::Interpreter(_) => SourceScope::Program,
+    }
 }
 
 fn resolve_runtime_address_target(
-  record: &ModuleVersionRecord,
-  scope: &SourceScope,
-  context_registry: &RuntimeContextRegistry,
-  target: &str,
+    record: &ModuleVersionRecord,
+    scope: &SourceScope,
+    context_registry: &RuntimeContextRegistry,
+    target: &str,
 ) -> RuntimeAddressTarget {
-  if !matches!(scope, SourceScope::Program) {
+    if !matches!(scope, SourceScope::Program) {
+        if let Some(binding) = context_registry.get(target) {
+            return RuntimeAddressTarget::Context(binding.clone());
+        }
+    }
+
+    for metadata in &record.scopes {
+        if let SourceScope::Interpreter(interpreter) = &metadata.scope {
+            if interpreter.namespace_str == target {
+                return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
+            }
+        }
+    }
+
     if let Some(binding) = context_registry.get(target) {
-      return RuntimeAddressTarget::Context(binding.clone());
+        return RuntimeAddressTarget::Context(binding.clone());
     }
-  }
 
-  for metadata in &record.scopes {
-    if let SourceScope::Interpreter(interpreter) = &metadata.scope {
-      if interpreter.namespace_str == target {
-        return RuntimeAddressTarget::Interpreter(metadata.scope.clone());
-      }
-    }
-  }
-
-  if let Some(binding) = context_registry.get(target) {
-    return RuntimeAddressTarget::Context(binding.clone());
-  }
-
-  RuntimeAddressTarget::Unknown
+    RuntimeAddressTarget::Unknown
 }
 
 fn context_registry_for_scope(
-  record: &ModuleVersionRecord,
-  scope: &SourceScope,
+    record: &ModuleVersionRecord,
+    scope: &SourceScope,
 ) -> MResult<RuntimeContextRegistry> {
-  let declarations = record
-    .scopes
-    .iter()
-    .find(|metadata| &metadata.scope == scope)
-    .map(|metadata| metadata.contexts.as_slice())
-    .unwrap_or(&[]);
-  RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
+    let declarations = record
+        .scopes
+        .iter()
+        .find(|metadata| &metadata.scope == scope)
+        .map(|metadata| metadata.contexts.as_slice())
+        .unwrap_or(&[]);
+    RuntimeContextRegistry::from_declarations(scope.clone(), declarations)
 }
 
 fn runtime_context_base_uri(binding: &RuntimeContextBinding) -> String {
-  match &binding.base {
-    RuntimeContextBase::ResourceUri(uri) => uri.clone(),
-  }
+    match &binding.base {
+        RuntimeContextBase::ResourceUri(uri) => uri.clone(),
+    }
 }
 
 fn runtime_context_allows_operation(
-  binding: &RuntimeContextBinding,
-  operation: &str,
-  path: &str,
+    binding: &RuntimeContextBinding,
+    operation: &str,
+    path: &str,
 ) -> bool {
-  binding.capabilities.iter().any(|capability| {
-    if capability.operation != operation {
-      return false;
-    }
-
-    match &capability.scope {
-      RuntimeContextCapabilityScope::Wildcard => true,
-      RuntimeContextCapabilityScope::Path(exact) => {
-        if exact == path {
-          return true;
+    binding.capabilities.iter().any(|capability| {
+        if capability.operation != operation {
+            return false;
         }
-        if let Some(prefix) = exact.strip_suffix("/*") {
-          let required_prefix = format!("{}/", prefix);
-          return path.starts_with(&required_prefix);
+
+        match &capability.scope {
+            RuntimeContextCapabilityScope::Wildcard => true,
+            RuntimeContextCapabilityScope::Path(exact) => {
+                if exact == path {
+                    return true;
+                }
+                if let Some(prefix) = exact.strip_suffix("/*") {
+                    let required_prefix = format!("{}/", prefix);
+                    return path.starts_with(&required_prefix);
+                }
+                false
+            }
         }
-        false
-      }
-    }
-  })
+    })
 }
 
-fn runtime_context_exposes_operation(
-  binding: &RuntimeContextBinding,
-  operation: &str,
-) -> bool {
-  binding.capabilities.iter().any(|capability| capability.operation == operation)
+fn runtime_context_exposes_operation(binding: &RuntimeContextBinding, operation: &str) -> bool {
+    binding
+        .capabilities
+        .iter()
+        .any(|capability| capability.operation == operation)
 }
 
-fn runtime_context_allows_read(
-  binding: &RuntimeContextBinding,
-  path: &str,
-) -> bool {
-  runtime_context_allows_operation(binding, "read", path)
+fn runtime_context_allows_read(binding: &RuntimeContextBinding, path: &str) -> bool {
+    runtime_context_allows_operation(binding, "read", path)
 }
 
-fn runtime_context_allows_write(
-  binding: &RuntimeContextBinding,
-  path: &str,
-) -> bool {
-  runtime_context_allows_operation(binding, "write", path)
+fn runtime_context_allows_write(binding: &RuntimeContextBinding, path: &str) -> bool {
+    runtime_context_allows_operation(binding, "write", path)
 }
 
 fn first_context_send_segment(path: &str) -> MResult<&str> {
-  path
-    .split('/')
-    .next()
-    .filter(|segment| !segment.is_empty())
-    .ok_or_else(|| MechError::new(RuntimeInvalidOperationError {
-      operation: "context_send",
-      reason: "context send target path must start with an operation name".to_string(),
-    }, None))
+    path.split('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .ok_or_else(|| {
+            MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "context_send",
+                    reason: "context send target path must start with an operation name"
+                        .to_string(),
+                },
+                None,
+            )
+        })
 }
 
 fn reserved_context_send_operation_error(operation: &str, path: &str) -> MechError {
-  MechError::new(RuntimeInvalidOperationError {
-    operation: "context_send",
-    reason: format!(
-      "context send target path `{path}` starts with reserved operation `{operation}`; use assignment for writes or a custom send operation"
-    ),
-  }, None)
+    MechError::new(
+        RuntimeInvalidOperationError {
+            operation: "context_send",
+            reason: format!(
+                "context send target path `{path}` starts with reserved operation `{operation}`; use assignment for writes or a custom send operation"
+            ),
+        },
+        None,
+    )
 }
 
 fn context_send_operation(
-  binding: &RuntimeContextBinding,
-  path: &str,
+    binding: &RuntimeContextBinding,
+    path: &str,
 ) -> MResult<RuntimeCapabilityOperation> {
-  let candidate = first_context_send_segment(path)?;
-  if candidate == "read" {
-    return Err(reserved_context_send_operation_error(candidate, path));
-  }
-  if candidate == "write" {
-    if runtime_context_allows_write(binding, path) {
-      return Ok(RuntimeCapabilityOperation::Write);
+    let candidate = first_context_send_segment(path)?;
+    if candidate == "read" {
+        return Err(reserved_context_send_operation_error(candidate, path));
     }
-    return Err(reserved_context_send_operation_error(candidate, path));
-  }
-  if runtime_context_allows_operation(binding, candidate, path) {
-    return RuntimeCapabilityOperation::from_name(candidate.to_string());
-  }
-  if runtime_context_exposes_operation(binding, candidate) {
-    return RuntimeCapabilityOperation::from_name(candidate.to_string());
-  }
-  if runtime_context_allows_write(binding, path) {
-    return Ok(RuntimeCapabilityOperation::Write);
-  }
-  RuntimeCapabilityOperation::from_name(candidate.to_string())
+    if candidate == "write" {
+        if runtime_context_allows_write(binding, path) {
+            return Ok(RuntimeCapabilityOperation::Write);
+        }
+        return Err(reserved_context_send_operation_error(candidate, path));
+    }
+    if runtime_context_allows_operation(binding, candidate, path) {
+        return RuntimeCapabilityOperation::from_name(candidate.to_string());
+    }
+    if runtime_context_exposes_operation(binding, candidate) {
+        return RuntimeCapabilityOperation::from_name(candidate.to_string());
+    }
+    if runtime_context_allows_write(binding, path) {
+        return Ok(RuntimeCapabilityOperation::Write);
+    }
+    RuntimeCapabilityOperation::from_name(candidate.to_string())
 }
 
 fn context_write_operation(
-  binding: &RuntimeContextBinding,
-  intent: RuntimeResourceWriteIntent,
-  path: &str,
+    binding: &RuntimeContextBinding,
+    intent: RuntimeResourceWriteIntent,
+    path: &str,
 ) -> MResult<RuntimeCapabilityOperation> {
-  match intent {
-    RuntimeResourceWriteIntent::Assign => Ok(RuntimeCapabilityOperation::Write),
-    RuntimeResourceWriteIntent::Send => context_send_operation(binding, path),
-  }
+    match intent {
+        RuntimeResourceWriteIntent::Assign => Ok(RuntimeCapabilityOperation::Write),
+        RuntimeResourceWriteIntent::Send => context_send_operation(binding, path),
+    }
 }
 
-
 fn direct_context_target(context_name: &str, path: &str) -> String {
-  format!("@{}/{}", context_name, path)
+    format!("@{}/{}", context_name, path)
 }
 
 fn undeclared_direct_context_target_error(context_name: &str) -> MechError {
-  MechError::new(RuntimeInvalidOperationError {
-    operation: "direct_context_target",
-    reason: format!("context target `@{context_name}` is not declared or imported"),
-  }, None)
+    MechError::new(
+        RuntimeInvalidOperationError {
+            operation: "direct_context_target",
+            reason: format!("context target `@{context_name}` is not declared or imported"),
+        },
+        None,
+    )
 }
 
-
-
 fn single_code_program(
-  code: mech_core::MechCode,
-  comment: Option<mech_core::Comment>,
+    code: mech_core::MechCode,
+    comment: Option<mech_core::Comment>,
 ) -> mech_core::Program {
-  mech_core::Program {
-    title: None,
-    body: mech_core::Body {
-      sections: vec![mech_core::Section {
-        subtitle: None,
-        elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
-      }],
-    },
-  }
+    mech_core::Program {
+        title: None,
+        body: mech_core::Body {
+            sections: vec![mech_core::Section {
+                subtitle: None,
+                elements: vec![mech_core::SectionElement::MechCode(vec![(code, comment)])],
+            }],
+        },
+    }
 }
 
 fn resolve_runtime_value(value: Value) -> Value {
-  match value {
-    Value::MutableReference(value) => value.borrow().clone(),
-    other => other,
-  }
+    match value {
+        Value::MutableReference(value) => value.borrow().clone(),
+        other => other,
+    }
 }
 
-
-
 impl MechRuntime {
-  fn with_live_registration_mode<T>(
-    &mut self,
-    mode: crate::runtime::LiveRegistrationMode,
-    f: impl FnOnce(&mut Self) -> MResult<T>,
-  ) -> MResult<T> {
-    let previous = std::mem::replace(&mut self.live_registration_mode, mode);
-    let result = f(self);
-    self.live_registration_mode = previous;
-    result
-  }
-
-  #[cfg(test)]
-  pub(super) fn run_string_with_isolated_registration_for_test(
-    &mut self,
-    context: &mut RuntimeContext,
-    source: &str,
-  ) -> MResult<Value> {
-    self.with_live_registration_mode(
-      crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
-      |runtime| {
-        runtime.run_string_with_context(context, source)
-      },
-    )
-  }
-
-  fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
-    matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
-  }
-
-
-  pub(crate) fn context_declarations_from_index_scope(
-    &self,
-    index: &SourceIndex,
-    scope: &SourceScope,
-  ) -> MResult<Vec<crate::SourceContextDeclaration>> {
-    let mut declarations = Vec::new();
-
-    for declaration in &index.declarations {
-      match declaration {
-        SourceDeclaration::Context(context) if &context.occurrence.scope == scope => {
-          declarations.push(context.declaration.clone());
-        }
-        SourceDeclaration::Import(import) if &import.occurrence.scope == scope => {
-          let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
-            continue;
-          };
-          let module = import.declaration.module.as_deref().ok_or_else(|| {
-            MechError::new(RuntimeInvalidOperationError {
-              operation: "materialize_direct_manifest_context_imports",
-              reason: format!("context import `{}` is missing module metadata", import.declaration.specifier),
-            }, None)
-          })?;
-          let item = import.declaration.item.as_deref().ok_or_else(|| {
-            MechError::new(RuntimeInvalidOperationError {
-              operation: "materialize_direct_manifest_context_imports",
-              reason: format!("context import `{}` is missing item metadata", import.declaration.specifier),
-            }, None)
-          })?;
-          let target = format!("{module}/{item}");
-          if let Some(context) = self.host_interfaces.resolve_optional(&target)? {
-            declarations.push(crate::SourceContextDeclaration {
-              name: alias.clone(),
-              base: crate::SourceContextBase::ResourceUri(context.base_uri.clone()),
-              capabilities: context.operations.iter().map(|operation| crate::SourceContextCapability {
-                operation: operation.clone(),
-                scope: crate::SourceContextCapabilityScope::Wildcard,
-              }).collect(),
-            });
-          } else {
-            let export = self.module_manifests.context_export(module, item)?;
-            declarations.push(crate::SourceContextDeclaration {
-              name: alias.clone(),
-              base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
-              capabilities: export.operations.iter().map(|operation| crate::SourceContextCapability {
-                operation: operation.clone(),
-                scope: crate::SourceContextCapabilityScope::Wildcard,
-              }).collect(),
-            });
-          }
-        }
-        _ => {}
-      }
+    fn with_live_registration_mode<T>(
+        &mut self,
+        mode: crate::runtime::LiveRegistrationMode,
+        f: impl FnOnce(&mut Self) -> MResult<T>,
+    ) -> MResult<T> {
+        let previous = std::mem::replace(&mut self.live_registration_mode, mode);
+        let result = f(self);
+        self.live_registration_mode = previous;
+        result
     }
 
-    Ok(declarations)
-  }
-
-  fn direct_context_registry_for_scope(
-    &self,
-    tree: &mech_core::Program,
-    scope: &SourceScope,
-  ) -> MResult<RuntimeContextRegistry> {
-    let index = SourceIndex::from_program(tree);
-    let declarations = self.context_declarations_from_index_scope(&index, scope)?;
-    RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
-  }
-
-  fn resolve_context_resource_request(
-    &self,
-    binding: &RuntimeContextBinding,
-    requested_path: &str,
-  ) -> MResult<ResolvedContextResourceRequest> {
-    let context_base_uri = runtime_context_base_uri(binding).trim_end_matches('/').to_string();
-    let requested_path = requested_path.trim_matches('/').to_string();
-    let candidate_uri = if requested_path.is_empty() {
-      context_base_uri.clone()
-    } else {
-      format!("{}/{}", context_base_uri, requested_path)
-    };
-
-    let provider_base_uri = self
-      .resources
-      .provider_base_uri_for(&candidate_uri)?
-      .unwrap_or_else(|| context_base_uri.clone());
-    let provider_path = candidate_uri
-      .strip_prefix(&provider_base_uri)
-      .unwrap_or_default()
-      .trim_matches('/')
-      .to_string();
-
-    Ok(ResolvedContextResourceRequest {
-      provider_base_uri,
-      provider_path,
-      context_path: requested_path,
-    })
-  }
-
-  fn read_context_resource(
-    &self,
-    context: &RuntimeContext,
-    binding: &RuntimeContextBinding,
-    path: &str,
-  ) -> MResult<Value> {
-    let resolved = self.resolve_context_resource_request(binding, path)?;
-    if !runtime_context_allows_read(binding, &resolved.context_path) {
-      return Err(MechError::new(RuntimeResourceCapabilityDenied {
-        context_name: binding.name.clone(),
-        operation: "read".to_string(),
-        path: resolved.context_path,
-      }, None));
-    }
-    if !self.has_capability_grant(
-      &context.subject,
-      &resolved.provider_base_uri,
-      &RuntimeCapabilityOperation::Read,
-      &resolved.provider_path,
-    ) {
-      return Err(MechError::new(RuntimeCapabilityGrantDenied {
-        subject: context.subject.clone(),
-        resource: resolved.provider_base_uri,
-        operation: RuntimeCapabilityOperation::Read,
-        path: resolved.provider_path,
-      }, None));
-    }
-    self.resources.read(RuntimeResourceReadRequest {
-      base_uri: resolved.provider_base_uri,
-      path: resolved.provider_path,
-      context_name: binding.name.clone(),
-    })
-  }
-
-  fn write_context_resource(
-    &mut self,
-    context: &RuntimeContext,
-    binding: &RuntimeContextBinding,
-    path: &str,
-    value: Value,
-    intent: RuntimeResourceWriteIntent,
-  ) -> MResult<()> {
-    let resolved = self.resolve_context_resource_request(binding, path)?;
-    let operation = context_write_operation(binding, intent, &resolved.context_path)?;
-    if !runtime_context_allows_operation(binding, operation.name(), &resolved.context_path) {
-      return Err(MechError::new(RuntimeResourceCapabilityDenied {
-        context_name: binding.name.clone(),
-        operation: operation.name().to_string(),
-        path: resolved.context_path,
-      }, None));
-    }
-    if !self.has_capability_grant(
-      &context.subject,
-      &resolved.provider_base_uri,
-      &operation,
-      &resolved.provider_path,
-    ) {
-      return Err(MechError::new(RuntimeCapabilityGrantDenied {
-        subject: context.subject.clone(),
-        resource: resolved.provider_base_uri,
-        operation: operation.clone(),
-        path: resolved.provider_path,
-      }, None));
-    }
-    self.resources.write(RuntimeResourceWriteRequest {
-      base_uri: resolved.provider_base_uri,
-      path: resolved.provider_path,
-      context_name: binding.name.clone(),
-      operation: operation.clone(),
-      value,
-      intent,
-    })
-  }
-
-  fn bind_context_read_temp(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    source: crate::RuntimeHostInputSource,
-    value: Value,
-  ) -> MResult<mech_core::Expression> {
-    self.validate_live_context_candidate(context)?;
-    let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
-    let symbol_id = hash_str(&name);
-    let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
-    if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
-      let bindings = self.live_input_bindings.entry(source).or_default();
-      if !bindings.iter().any(|binding| *binding == input) {
-        bindings.push(input);
-      }
-      self.commit_live_context_candidate(context);
-    }
-    let var = mech_core::Var {
-      name: identifier_from_str(&name),
-      context: None,
-      kind: None,
-    };
-    Ok(mech_core::Expression::Var(var))
-  }
-
-  fn resolve_context_reads_in_expression(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    expression: &mech_core::Expression,
-  ) -> MResult<mech_core::Expression> {
-    match expression {
-      mech_core::Expression::Var(var) => {
-        let Some(var_context) = &var.context else {
-          return Ok(expression.clone());
-        };
-        let target = var_context.to_string();
-        let Some(binding) = registry.get(&target) else {
-          return Ok(expression.clone());
-        };
-        let path = var.name.to_string();
-        let resolved = self.resolve_context_resource_request(binding, &path)?;
-        let source = crate::RuntimeHostInputSource::new(resolved.provider_base_uri.clone(), resolved.provider_path.clone())?;
-        let value = self.read_context_resource(context, binding, &path)?;
-        self.bind_context_read_temp(context, program, source, value)
-      }
-      mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
-        self.resolve_context_reads_in_factor(context, program, registry, factor)?,
-      )),
-      mech_core::Expression::FunctionCall(call) => {
-        let args = call.args.iter().map(|(name, expression)| {
-          Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
-        }).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: call.name.clone(), args }))
-      }
-      mech_core::Expression::FsmPipe(pipe) => {
-        Ok(mech_core::Expression::FsmPipe(
-          self.resolve_context_reads_in_fsm_pipe(context, program, registry, pipe)?,
-        ))
-      }
-      mech_core::Expression::Literal(_) => Ok(expression.clone()),
-      mech_core::Expression::Match(match_expression) => {
-        let mut match_expression = match_expression.as_ref().clone();
-        match_expression.source = self.resolve_context_reads_in_expression(context, program, registry, &match_expression.source)?;
-        match_expression.arms = match_expression.arms.iter().map(|arm| {
-          Ok(mech_core::MatchArm {
-            pattern: self.resolve_context_reads_in_match_pattern(context, program, registry, &arm.pattern)?,
-            guard: arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?,
-            expression: self.resolve_context_reads_in_expression(context, program, registry, &arm.expression)?,
-          })
-        }).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::Match(Box::new(match_expression)))
-      }
-      mech_core::Expression::Range(range) => {
-        let mut range = range.as_ref().clone();
-        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-        range.increment = match &range.increment {
-          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
-          None => None,
-        };
-        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
-        Ok(mech_core::Expression::Range(Box::new(range)))
-      }
-      mech_core::Expression::Slice(slice) => {
-        if let Some(context_name) = &slice.context {
-          let context_name = context_name.to_string();
-          if registry.contains(&context_name) {
-            return Err(MechError::new(RuntimeInvalidOperationError {
-              operation: "context_read",
-              reason: "context-addressed slices are not supported".to_string(),
-            }, None));
-          }
-          return Ok(expression.clone());
-        }
-        Ok(mech_core::Expression::Slice(
-          self.resolve_context_reads_in_slice(context, program, registry, slice)?,
-        ))
-      }
-      mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
-        self.resolve_context_reads_in_structure(context, program, registry, structure)?,
-      )),
-      mech_core::Expression::SetComprehension(comprehension) => {
-        let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
-        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::SetComprehension(Box::new(comprehension)))
-      }
-      mech_core::Expression::MatrixComprehension(comprehension) => {
-        let mut comprehension = comprehension.as_ref().clone();
-        comprehension.expression = self.resolve_context_reads_in_expression(context, program, registry, &comprehension.expression)?;
-        comprehension.qualifiers = comprehension.qualifiers.iter().map(|qualifier| self.resolve_context_reads_in_comprehension_qualifier(context, program, registry, qualifier)).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Expression::MatrixComprehension(Box::new(comprehension)))
-      }
-    }
-  }
-
-  fn resolve_context_reads_in_factor(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-  ) -> MResult<mech_core::Factor> {
-    match factor {
-      mech_core::Factor::Expression(expression) => Ok(mech_core::Factor::Expression(Box::new(self.resolve_context_reads_in_expression(context, program, registry, expression)?))),
-      mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?))),
-      mech_core::Factor::Term(term) => {
-        let rhs = term.rhs.iter().map(|(operator, factor)| {
-          Ok((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, factor)?))
-        }).collect::<MResult<Vec<_>>>()?;
-        Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
-          lhs: self.resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
-          rhs,
-        })))
-      }
-    }
-  }
-
-  fn resolve_context_reads_in_slice(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    slice: &mech_core::Slice,
-  ) -> MResult<mech_core::Slice> {
-    Ok(mech_core::Slice {
-      name: slice.name.clone(),
-      context: slice.context.clone(),
-      subscript: slice.subscript.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?,
-    })
-  }
-
-  fn resolve_context_reads_in_slice_ref(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    target: &mech_core::SliceRef,
-  ) -> MResult<mech_core::SliceRef> {
-    let mut target = target.clone();
-    if let Some(subscripts) = &target.subscript {
-      target.subscript = Some(
-        subscripts
-          .iter()
-          .map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript))
-          .collect::<MResult<Vec<_>>>()?,
-      );
-    }
-    Ok(target)
-  }
-
-  fn resolve_context_reads_in_subscript(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    subscript: &mech_core::Subscript,
-  ) -> MResult<mech_core::Subscript> {
-    match subscript {
-      mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
-      mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(subscripts.iter().map(|subscript| self.resolve_context_reads_in_subscript(context, program, registry, subscript)).collect::<MResult<Vec<_>>>()?)),
-      mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(self.resolve_context_reads_in_factor(context, program, registry, factor)?)),
-      mech_core::Subscript::Range(range) => {
-        let mut range = range.clone();
-        range.start = self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
-        range.increment = match &range.increment {
-          Some((operator, increment)) => Some((operator.clone(), self.resolve_context_reads_in_factor(context, program, registry, increment)?)),
-          None => None,
-        };
-        range.terminal = self.resolve_context_reads_in_factor(context, program, registry, &range.terminal)?;
-        Ok(mech_core::Subscript::Range(range))
-      }
-      _ => Ok(subscript.clone()),
-    }
-  }
-
-  fn resolve_context_reads_in_structure(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    structure: &mech_core::Structure,
-  ) -> MResult<mech_core::Structure> {
-    match structure {
-      mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
-      mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
-        elements: map.elements.iter().map(|mapping| Ok(mech_core::Mapping {
-          key: self.resolve_context_reads_in_expression(context, program, registry, &mapping.key)?,
-          value: self.resolve_context_reads_in_expression(context, program, registry, &mapping.value)?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Matrix(matrix) => Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
-        rows: matrix.rows.iter().map(|row| Ok(mech_core::MatrixRow {
-          columns: row.columns.iter().map(|column| Ok(mech_core::MatrixColumn {
-            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
-          })).collect::<MResult<Vec<_>>>()?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Record(record) => Ok(mech_core::Structure::Record(mech_core::Record {
-        bindings: record.bindings.iter().map(|binding| Ok(mech_core::Binding {
-          name: binding.name.clone(),
-          kind: binding.kind.clone(),
-          value: self.resolve_context_reads_in_expression(context, program, registry, &binding.value)?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
-        elements: set.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Table(table) => Ok(mech_core::Structure::Table(mech_core::Table {
-        header: table.header.clone(),
-        rows: table.rows.iter().map(|row| Ok(mech_core::TableRow {
-          columns: row.columns.iter().map(|column| Ok(mech_core::TableColumn {
-            element: self.resolve_context_reads_in_expression(context, program, registry, &column.element)?,
-          })).collect::<MResult<Vec<_>>>()?,
-        })).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::Tuple(tuple) => Ok(mech_core::Structure::Tuple(mech_core::Tuple {
-        elements: tuple.elements.iter().map(|expression| self.resolve_context_reads_in_expression(context, program, registry, expression)).collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Structure::TupleStruct(tuple_struct) => Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
-        name: tuple_struct.name.clone(),
-        value: Box::new(self.resolve_context_reads_in_expression(context, program, registry, &tuple_struct.value)?),
-      })),
-    }
-  }
-
-  fn resolve_context_reads_in_comprehension_qualifier(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    qualifier: &mech_core::ComprehensionQualifier,
-  ) -> MResult<mech_core::ComprehensionQualifier> {
-    match qualifier {
-      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
-        Ok(mech_core::ComprehensionQualifier::Generator((
-          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
-          self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-        )))
-      }
-      mech_core::ComprehensionQualifier::Filter(expression) => Ok(mech_core::ComprehensionQualifier::Filter(self.resolve_context_reads_in_expression(context, program, registry, expression)?)),
-      mech_core::ComprehensionQualifier::Let(var_def) => {
-        let mut var_def = var_def.clone();
-        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
-        Ok(mech_core::ComprehensionQualifier::Let(var_def))
-      }
-    }
-  }
-
-  fn flush_direct_execution(
-    &mut self,
-    program: &mut MechProgram,
-    pending: &mut Vec<mech_core::SectionElement>,
-    result: &mut Value,
-  ) -> MResult<()> {
-    if pending.is_empty() {
-      return Ok(());
-    }
-    let tree = mech_core::Program {
-      title: None,
-      body: mech_core::Body {
-        sections: vec![mech_core::Section {
-          subtitle: None,
-          elements: std::mem::take(pending),
-        }],
-      },
-    };
-    *result = program.run_tree(&tree)?;
-    Ok(())
-  }
-
-  fn executable_fence_for_scope(
-    fenced: &mech_core::FencedMechCode,
-    scope: &SourceScope,
-  ) -> bool {
-    match scope {
-      SourceScope::Program => fenced.config.namespace_str.is_empty(),
-      SourceScope::Interpreter(interpreter) => fenced.config.namespace_str == interpreter.namespace_str,
-    }
-  }
-
-  fn resolve_context_reads_in_pattern(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    pattern: &mech_core::Pattern,
-  ) -> MResult<mech_core::Pattern> {
-    match pattern {
-      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
-        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-      )),
-      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
-        name: tuple_struct.name.clone(),
-        patterns: tuple_struct.patterns.iter()
-          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Pattern::Tuple(tuple) => Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-        tuple.0.iter()
-          .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-          .collect::<MResult<Vec<_>>>()?,
-      ))),
-      mech_core::Pattern::Array(array) => {
-        let spread = if let Some(spread) = &array.spread {
-          Some(mech_core::PatternArraySpread {
-            kind: spread.kind.clone(),
-            binding: spread.binding.as_ref()
-              .map(|binding| self.resolve_context_reads_in_pattern(context, program, registry, binding).map(Box::new))
-              .transpose()?,
-          })
-        } else {
-          None
-        };
-        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
-          prefix: array.prefix.iter()
-            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-          spread,
-          suffix: array.suffix.iter()
-            .map(|pattern| self.resolve_context_reads_in_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-        }))
-      }
-      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
-    }
-  }
-
-  fn resolve_context_reads_in_match_pattern(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    pattern: &mech_core::Pattern,
-  ) -> MResult<mech_core::Pattern> {
-    match pattern {
-      mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
-        self.resolve_context_reads_in_match_pattern_expression(context, program, registry, expression)?,
-      )),
-      mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(mech_core::PatternTupleStruct {
-        name: tuple_struct.name.clone(),
-        patterns: tuple_struct.patterns.iter()
-          .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
-          .collect::<MResult<Vec<_>>>()?,
-      })),
-      mech_core::Pattern::Tuple(tuple) => {
-        if tuple.0.len() == 1 {
-          let pattern = self.resolve_context_reads_in_match_pattern(context, program, registry, &tuple.0[0])?;
-          if pattern != tuple.0[0] {
-            return Ok(pattern);
-          }
-        }
-        Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
-          tuple.0.iter()
-            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-        )))
-      }
-      mech_core::Pattern::Array(array) => {
-        let spread = if let Some(spread) = &array.spread {
-          Some(mech_core::PatternArraySpread {
-            kind: spread.kind.clone(),
-            binding: spread.binding.as_ref()
-              .map(|binding| self.resolve_context_reads_in_match_pattern(context, program, registry, binding).map(Box::new))
-              .transpose()?,
-          })
-        } else {
-          None
-        };
-        Ok(mech_core::Pattern::Array(mech_core::PatternArray {
-          prefix: array.prefix.iter()
-            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-          spread,
-          suffix: array.suffix.iter()
-            .map(|pattern| self.resolve_context_reads_in_match_pattern(context, program, registry, pattern))
-            .collect::<MResult<Vec<_>>>()?,
-        }))
-      }
-      mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
-    }
-  }
-
-  fn resolve_context_reads_in_match_pattern_expression(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    expression: &mech_core::Expression,
-  ) -> MResult<mech_core::Expression> {
-    if let Some(expression) = self.literalize_match_pattern_context_read_expression(
-      context,
-      program,
-      registry,
-      expression,
-    )? {
-      return Ok(expression);
+    #[cfg(test)]
+    pub(super) fn run_string_with_isolated_registration_for_test(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+    ) -> MResult<Value> {
+        self.with_live_registration_mode(
+            crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+            |runtime| runtime.run_string_with_context(context, source),
+        )
     }
 
-    self.resolve_context_reads_in_expression(context, program, registry, expression)
-  }
-
-  fn literalize_match_pattern_context_read_expression(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    expression: &mech_core::Expression,
-  ) -> MResult<Option<mech_core::Expression>> {
-    match expression {
-      mech_core::Expression::Var(var) => {
-        self.literalize_match_pattern_context_read_var(context, program, registry, var)
-      }
-      mech_core::Expression::Formula(factor) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, factor)
-      }
-      _ => Ok(None),
-    }
-  }
-
-  fn literalize_match_pattern_context_read_factor(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-  ) -> MResult<Option<mech_core::Expression>> {
-    match factor {
-      mech_core::Factor::Expression(expression) => {
-        self.literalize_match_pattern_context_read_expression(context, program, registry, expression)
-      }
-      mech_core::Factor::Parenthetical(inner) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
-      }
-      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, &term.lhs)
-      }
-      _ => Ok(None),
-    }
-  }
-
-  fn literalize_match_pattern_context_read_var(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    var: &mech_core::Var,
-  ) -> MResult<Option<mech_core::Expression>> {
-    let Some(var_context) = &var.context else {
-      return Ok(None);
-    };
-
-    let target = var_context.to_string();
-    let path = var.name.to_string();
-    if let Some(binding) = registry.get(&target) {
-      let value = self.read_context_resource(context, binding, &path)?;
-      return Ok(Some(self.context_pattern_value_expression(value)?));
+    fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
+        matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
     }
 
-    let address_key = format!("@{target}/{path}");
-    let value = {
-      let symbols = program.interpreter().symbols();
-      let symbols = symbols.borrow();
-      symbols
-        .get(hash_str(&address_key))
-        .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
-    };
+    pub(crate) fn context_declarations_from_index_scope(
+        &self,
+        index: &SourceIndex,
+        scope: &SourceScope,
+    ) -> MResult<Vec<crate::SourceContextDeclaration>> {
+        let mut declarations = Vec::new();
 
-    if let Some(value) = value {
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    Ok(None)
-  }
-
-  fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
-    let value = resolve_runtime_value(value);
-    match value {
-      Value::String(value) => {
-        let text = value.borrow().clone();
-        Ok(mech_core::Expression::Literal(mech_core::Literal::String(mech_core::MechString {
-          text: mech_core::Token::new(
-            mech_core::TokenKind::String,
-            mech_core::SourceRange::default(),
-            text.chars().collect(),
-          ),
-        })))
-      }
-      #[cfg(feature = "bool")]
-      Value::Bool(value) => {
-        let flag = *value.borrow();
-        Ok(mech_core::Expression::Literal(mech_core::Literal::Boolean(mech_core::Token::new(
-          if flag { mech_core::TokenKind::True } else { mech_core::TokenKind::False },
-          mech_core::SourceRange::default(),
-          if flag { "true".chars().collect() } else { "false".chars().collect() },
-        ))))
-      }
-      Value::Empty => Ok(mech_core::Expression::Literal(mech_core::Literal::Empty(mech_core::Token::new(
-        mech_core::TokenKind::Empty,
-        mech_core::SourceRange::default(),
-        vec!['_'],
-      )))),
-      other => Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "context_match_pattern",
-        reason: format!("context match patterns currently support string, bool, and empty values; got {other:?}"),
-      }, None)),
-    }
-  }
-
-  fn resolve_context_reads_in_transition(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    transition: &mech_core::Transition,
-  ) -> MResult<mech_core::Transition> {
-    match transition {
-      mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
-        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-      )),
-      mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
-        code_items.iter()
-          .map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone())))
-          .collect::<MResult<Vec<_>>>()?,
-      )),
-      mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
-        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-      )),
-      mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
-        self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
-      )),
-      mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
-        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-      )),
-    }
-  }
-
-  fn resolve_context_reads_in_fsm_pipe(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    pipe: &mech_core::FsmPipe,
-  ) -> MResult<mech_core::FsmPipe> {
-    let mut pipe = pipe.clone();
-
-    if let Some(args) = &pipe.start.args {
-      pipe.start.args = Some(args.iter().map(|(name, expression)| {
-        Ok((name.clone(), self.resolve_context_reads_in_expression(context, program, registry, expression)?))
-      }).collect::<MResult<Vec<_>>>()?);
-    }
-
-    pipe.transitions = pipe.transitions.iter()
-      .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
-      .collect::<MResult<Vec<_>>>()?;
-
-    Ok(pipe)
-  }
-
-  fn resolve_context_reads_in_fsm_implementation(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    fsm: &mech_core::FsmImplementation,
-  ) -> MResult<mech_core::FsmImplementation> {
-    let arms = fsm.arms.iter().map(|arm| {
-      match arm {
-        mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
-          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
-          guards.iter().map(|guard| Ok(mech_core::Guard {
-            condition: self.resolve_context_reads_in_match_pattern(
-              context,
-              program,
-              registry,
-              &guard.condition,
-            )?,
-            transitions: guard.transitions.iter()
-              .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
-              .collect::<MResult<Vec<_>>>()?,
-          })).collect::<MResult<Vec<_>>>()?,
-        )),
-        mech_core::FsmArm::Transition(pattern, transitions) => Ok(mech_core::FsmArm::Transition(
-          self.resolve_context_reads_in_match_pattern(context, program, registry, pattern)?,
-          transitions.iter()
-            .map(|transition| self.resolve_context_reads_in_transition(context, program, registry, transition))
-            .collect::<MResult<Vec<_>>>()?,
-        )),
-        mech_core::FsmArm::Comment(comment) => Ok(mech_core::FsmArm::Comment(comment.clone())),
-      }
-    }).collect::<MResult<Vec<_>>>()?;
-
-    Ok(mech_core::FsmImplementation {
-      name: fsm.name.clone(),
-      input: fsm.input.clone(),
-      start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
-      arms,
-    })
-  }
-
-  fn resolve_context_reads_in_function_define(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    function: &mech_core::FunctionDefine,
-  ) -> MResult<mech_core::FunctionDefine> {
-    Ok(mech_core::FunctionDefine {
-      name: function.name.clone(),
-      input: function.input.clone(),
-      output: function.output.clone(),
-      statements: function.statements.clone(),
-      match_arms: function.match_arms.iter().map(|arm| Ok(mech_core::FunctionMatchArm {
-        pattern: self.resolve_context_reads_in_match_pattern(
-          context,
-          program,
-          registry,
-          &arm.pattern,
-        )?,
-        expression: arm.expression.clone(),
-      })).collect::<MResult<Vec<_>>>()?,
-    })
-  }
-
-  fn resolve_context_reads_in_mech_code(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    code: &mech_core::MechCode,
-  ) -> MResult<mech_core::MechCode> {
-    match code {
-      mech_core::MechCode::ActivationScope(scope) => {
-        let mut scope = scope.clone();
-        scope.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
-        scope.body = scope.body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?;
-        Ok(mech_core::MechCode::ActivationScope(scope))
-      },
-      mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
-        self.resolve_context_reads_in_statement(context, program, registry, statement)?,
-      )),
-      mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
-        self.resolve_context_reads_in_expression(context, program, registry, expression)?,
-      )),
-      mech_core::MechCode::FsmImplementation(fsm) => Ok(mech_core::MechCode::FsmImplementation(
-        self.resolve_context_reads_in_fsm_implementation(context, program, registry, fsm)?,
-      )),
-      mech_core::MechCode::FsmSpecification(spec) => Ok(mech_core::MechCode::FsmSpecification(spec.clone())),
-      mech_core::MechCode::FunctionDefine(function) => Ok(mech_core::MechCode::FunctionDefine(
-        self.resolve_context_reads_in_function_define(context, program, registry, function)?,
-      )),
-      mech_core::MechCode::Import(_)
-      | mech_core::MechCode::Comment(_)
-      | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
-    }
-  }
-
-  fn resolve_context_reads_in_statement(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    statement: &mech_core::Statement,
-  ) -> MResult<mech_core::Statement> {
-    match statement {
-      mech_core::Statement::VariableDefine(var_def) => {
-        let mut var_def = var_def.clone();
-        var_def.expression = self.resolve_context_reads_in_expression(context, program, registry, &var_def.expression)?;
-        Ok(mech_core::Statement::VariableDefine(var_def))
-      }
-      mech_core::Statement::VariableAssign(assign) => {
-        let mut assign = assign.clone();
-        assign.target = self.resolve_context_reads_in_slice_ref(context, program, registry, &assign.target)?;
-        assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
-        Ok(mech_core::Statement::VariableAssign(assign))
-      }
-      mech_core::Statement::OpAssign(op_assign) => {
-        let mut op_assign = op_assign.clone();
-        op_assign.target = self.resolve_context_reads_in_slice_ref(context, program, registry, &op_assign.target)?;
-        op_assign.expression = self.resolve_context_reads_in_expression(context, program, registry, &op_assign.expression)?;
-        Ok(mech_core::Statement::OpAssign(op_assign))
-      }
-      mech_core::Statement::TupleDestructure(tuple_destructure) => {
-        let mut tuple_destructure = tuple_destructure.clone();
-        tuple_destructure.expression = self.resolve_context_reads_in_expression(context, program, registry, &tuple_destructure.expression)?;
-        Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
-      }
-      #[cfg(feature = "invariant_define")]
-      mech_core::Statement::InvariantDefine(invariant) => {
-        let mut invariant = invariant.clone();
-        invariant.expression = self.resolve_context_reads_in_expression(context, program, registry, &invariant.expression)?;
-        Ok(mech_core::Statement::InvariantDefine(invariant))
-      }
-      mech_core::Statement::FsmDeclare(fsm) => {
-        let mut fsm = fsm.clone();
-        fsm.pipe = self.resolve_context_reads_in_fsm_pipe(context, program, registry, &fsm.pipe)?;
-        Ok(mech_core::Statement::FsmDeclare(fsm))
-      }
-      _ => Ok(statement.clone()),
-    }
-  }
-
-  fn push_direct_code(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    pending: &mut Vec<mech_core::SectionElement>,
-    pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
-    result: &mut Value,
-    skip_non_context_imports: bool,
-    code: &mech_core::MechCode,
-    comment: &Option<mech_core::Comment>,
-  ) -> MResult<()> {
-    match code {
-      mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => Ok(()),
-      mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
-      mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
-      | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
-      mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
-        if !pending_codes.is_empty() {
-          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
-        }
-        self.flush_direct_execution(program, pending, result)?;
-        let id = hash_str(&export.name.to_string());
-        if let Some(value) = program.interpreter().symbols().borrow().get(id) {
-          *result = resolve_runtime_value(value.borrow().clone());
-        } else {
-          *result = Value::Empty;
-        }
-        Ok(())
-      }
-      mech_core::MechCode::ActivationScope(scope) => {
-        if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
-        self.flush_direct_execution(program, pending, result)?;
-        let mut lowered = scope.clone();
-        lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
-        let mut registrations = Vec::new();
-        lowered.body.clear();
-        for (body_code, body_comment) in &scope.body {
-          match body_code {
-            mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
-              let context_name = send.target.context.as_ref().unwrap().to_string();
-              let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
-              let index = self.persistent_sends.len() + registrations.len();
-              let value_name = format!("mech-internal-activation-send-value-{index}");
-              let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
-              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
-              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
+        for declaration in &index.declarations {
+            match declaration {
+                SourceDeclaration::Context(context) if &context.occurrence.scope == scope => {
+                    declarations.push(context.declaration.clone());
+                }
+                SourceDeclaration::Import(import) if &import.occurrence.scope == scope => {
+                    let Some(SourceImportAlias::Context(alias)) = &import.declaration.alias else {
+                        continue;
+                    };
+                    let module = import.declaration.module.as_deref().ok_or_else(|| {
+                        MechError::new(
+                            RuntimeInvalidOperationError {
+                                operation: "materialize_direct_manifest_context_imports",
+                                reason: format!(
+                                    "context import `{}` is missing module metadata",
+                                    import.declaration.specifier
+                                ),
+                            },
+                            None,
+                        )
+                    })?;
+                    let item = import.declaration.item.as_deref().ok_or_else(|| {
+                        MechError::new(
+                            RuntimeInvalidOperationError {
+                                operation: "materialize_direct_manifest_context_imports",
+                                reason: format!(
+                                    "context import `{}` is missing item metadata",
+                                    import.declaration.specifier
+                                ),
+                            },
+                            None,
+                        )
+                    })?;
+                    let target = format!("{module}/{item}");
+                    if let Some(context) = self.host_interfaces.resolve_optional(&target)? {
+                        declarations.push(crate::SourceContextDeclaration {
+                            name: alias.clone(),
+                            base: crate::SourceContextBase::ResourceUri(context.base_uri.clone()),
+                            capabilities: context
+                                .operations
+                                .iter()
+                                .map(|operation| crate::SourceContextCapability {
+                                    operation: operation.clone(),
+                                    scope: crate::SourceContextCapabilityScope::Wildcard,
+                                })
+                                .collect(),
+                        });
+                    } else {
+                        let export = self.module_manifests.context_export(module, item)?;
+                        declarations.push(crate::SourceContextDeclaration {
+                            name: alias.clone(),
+                            base: crate::SourceContextBase::ResourceUri(export.base_uri.clone()),
+                            capabilities: export
+                                .operations
+                                .iter()
+                                .map(|operation| crate::SourceContextCapability {
+                                    operation: operation.clone(),
+                                    scope: crate::SourceContextCapabilityScope::Wildcard,
+                                })
+                                .collect(),
+                        });
+                    }
+                }
+                _ => {}
             }
-            _ => lowered.body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
-          }
         }
-        if registrations.is_empty() {
-          program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
-          return Ok(());
+
+        Ok(declarations)
+    }
+
+    fn direct_context_registry_for_scope(
+        &self,
+        tree: &mech_core::Program,
+        scope: &SourceScope,
+    ) -> MResult<RuntimeContextRegistry> {
+        let index = SourceIndex::from_program(tree);
+        let declarations = self.context_declarations_from_index_scope(&index, scope)?;
+        RuntimeContextRegistry::from_declarations(scope.clone(), &declarations)
+    }
+
+    fn resolve_context_resource_request(
+        &self,
+        binding: &RuntimeContextBinding,
+        requested_path: &str,
+    ) -> MResult<ResolvedContextResourceRequest> {
+        let context_base_uri = runtime_context_base_uri(binding)
+            .trim_end_matches('/')
+            .to_string();
+        let requested_path = requested_path.trim_matches('/').to_string();
+        let candidate_uri = if requested_path.is_empty() {
+            context_base_uri.clone()
+        } else {
+            format!("{}/{}", context_base_uri, requested_path)
+        };
+
+        let provider_base_uri = self
+            .resources
+            .provider_base_uri_for(&candidate_uri)?
+            .unwrap_or_else(|| context_base_uri.clone());
+        let provider_path = candidate_uri
+            .strip_prefix(&provider_base_uri)
+            .unwrap_or_default()
+            .trim_matches('/')
+            .to_string();
+
+        Ok(ResolvedContextResourceRequest {
+            provider_base_uri,
+            provider_path,
+            context_path: requested_path,
+        })
+    }
+
+    fn read_context_resource(
+        &self,
+        context: &RuntimeContext,
+        binding: &RuntimeContextBinding,
+        path: &str,
+    ) -> MResult<Value> {
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        if !runtime_context_allows_read(binding, &resolved.context_path) {
+            return Err(MechError::new(
+                RuntimeResourceCapabilityDenied {
+                    context_name: binding.name.clone(),
+                    operation: "read".to_string(),
+                    path: resolved.context_path,
+                },
+                None,
+            ));
         }
-        lowered.body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
+        if !self.has_capability_grant(
+            &context.subject,
+            &resolved.provider_base_uri,
+            &RuntimeCapabilityOperation::Read,
+            &resolved.provider_path,
+        ) {
+            return Err(MechError::new(
+                RuntimeCapabilityGrantDenied {
+                    subject: context.subject.clone(),
+                    resource: resolved.provider_base_uri,
+                    operation: RuntimeCapabilityOperation::Read,
+                    path: resolved.provider_path,
+                },
+                None,
+            ));
+        }
+        self.resources.read(RuntimeResourceReadRequest {
+            base_uri: resolved.provider_base_uri,
+            path: resolved.provider_path,
+            context_name: binding.name.clone(),
+        })
+    }
+
+    fn write_context_resource(
+        &mut self,
+        context: &RuntimeContext,
+        binding: &RuntimeContextBinding,
+        path: &str,
+        value: Value,
+        intent: RuntimeResourceWriteIntent,
+    ) -> MResult<()> {
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        let operation = context_write_operation(binding, intent, &resolved.context_path)?;
+        if !runtime_context_allows_operation(binding, operation.name(), &resolved.context_path) {
+            return Err(MechError::new(
+                RuntimeResourceCapabilityDenied {
+                    context_name: binding.name.clone(),
+                    operation: operation.name().to_string(),
+                    path: resolved.context_path,
+                },
+                None,
+            ));
+        }
+        if !self.has_capability_grant(
+            &context.subject,
+            &resolved.provider_base_uri,
+            &operation,
+            &resolved.provider_path,
+        ) {
+            return Err(MechError::new(
+                RuntimeCapabilityGrantDenied {
+                    subject: context.subject.clone(),
+                    resource: resolved.provider_base_uri,
+                    operation: operation.clone(),
+                    path: resolved.provider_path,
+                },
+                None,
+            ));
+        }
+        self.resources.write(RuntimeResourceWriteRequest {
+            base_uri: resolved.provider_base_uri,
+            path: resolved.provider_path,
+            context_name: binding.name.clone(),
+            operation: operation.clone(),
+            value,
+            intent,
+        })
+    }
+
+    fn bind_context_read_temp(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        source: crate::RuntimeHostInputSource,
+        value: Value,
+    ) -> MResult<mech_core::Expression> {
         self.validate_live_context_candidate(context)?;
-        let plan_start = program.interpreter().plan().borrow().nodes.len();
-        program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
-        let interpreter_id = program.interpreter().id;
-        let trigger_cells = match &scope.trigger { mech_core::Expression::Var(var) => program.interpreter().symbols().borrow().get(var.name.hash()).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation trigger disappeared".into() }, None))?.borrow().reactive_root_cell_ids(), _ => vec![] };
-        let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..].iter().filter(|node| node.kind == mech_core::ReactiveNodeKind::Combinational && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME && trigger_cells.iter().all(|cell| node.inputs.iter().any(|dependency| dependency.cell == *cell && dependency.kind == mech_core::ReactiveDependencyKind::Reactive))).map(|node| node.id).collect();
-        if barrier_ids.len() != 1 { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: format!("expected exactly one activation effect barrier, found {}", barrier_ids.len()) }, None)); }
-        let barrier_node_id = barrier_ids[0];
-        let symbols = program.interpreter().symbols();
-        let mut sends = Vec::new();
-        for (binding, path, value_id) in registrations {
-          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "missing lowered activation payload".into() }, None))?;
-          sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } });
-        }
-        self.persistent_sends.extend(sends);
-        self.commit_live_context_candidate(context);
-        Ok(())
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
-        if let Some(context_name) = &var_def.var.context {
-          let target = context_name.to_string();
-          if let Some(binding) = registry.get(&target).cloned() {
-            if !pending_codes.is_empty() {
-              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
-            }
-            self.flush_direct_execution(program, pending, result)?;
-            return Err(MechError::new(RuntimeInvalidOperationError {
-              operation: "direct_context_define",
-              reason: format!(
-                "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
-                binding.name,
-                var_def.var.name.to_string()
-              ),
-            }, None));
-          }
-        }
-        let code = self.resolve_context_reads_in_mech_code(
-          context,
-          program,
-          registry,
-          &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def.clone())),
+        let name = format!(
+            "mech-internal-context-{}-{}",
+            hash_str(source.base_uri()),
+            hash_str(source.path())
+        );
+        let symbol_id = hash_str(&name);
+        let input = program.ensure_input(
+            program.interpreter().id,
+            symbol_id,
+            &name,
+            resolve_runtime_value(value),
         )?;
-        pending_codes.push((code, comment.clone()));
-        Ok(())
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
-        // Context sends are executed only at module top level for now. Parser paths
-        // intentionally reject nested sends until interpreter/effect execution can
-        // support them in functions and state machines.
-        let Some(context_name) = &send.target.context else {
-          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: send.target.name.to_string() }, None));
-        };
-        let target = context_name.to_string();
-        let Some(binding) = registry.get(&target).cloned() else {
-          return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target }, None));
-        };
-        if !pending_codes.is_empty() {
-          pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
-        }
-        self.flush_direct_execution(program, pending, result)?;
-        let expression = self.resolve_context_reads_in_expression(context, program, registry, &send.expression)?;
-        let path = send.target.name.to_string();
-        if self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot {
-          let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
-          self.write_context_resource(context, &binding, &path, value.clone(), RuntimeResourceWriteIntent::Send)?;
-          *result = value;
-          return Ok(());
-        }
-        self.validate_live_context_candidate(context)?;
-        let value_cell = self.bind_persistent_send_value_on_program(program, expression)?;
-        let value = resolve_runtime_value(value_cell.borrow().clone());
-        self.write_context_resource(context, &binding, &path, value.clone(), RuntimeResourceWriteIntent::Send)?;
-        self.persistent_sends.push(RuntimePersistentSend { binding, path, value: value_cell, schedule: RuntimePersistentSendSchedule::EveryAcceptedTurn });
-        self.commit_live_context_candidate(context);
-        *result = value;
-        return Ok(());
-      }
-      mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
-        if let Some(context_name) = &assign.target.context {
-          let target = context_name.to_string();
-          if let Some(binding) = registry.get(&target).cloned() {
-            if !pending_codes.is_empty() {
-              pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes)));
+        if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
+            let bindings = self.live_input_bindings.entry(source).or_default();
+            if !bindings.iter().any(|binding| *binding == input) {
+                bindings.push(input);
             }
-            self.flush_direct_execution(program, pending, result)?;
-            let expression = self.resolve_context_reads_in_expression(context, program, registry, &assign.expression)?;
-            let value = resolve_runtime_value(self.evaluate_expression_on_program(program, &expression)?);
-            self.write_context_resource(context, &binding, &assign.target.name.to_string(), value.clone(), RuntimeResourceWriteIntent::Assign)?;
-            *result = value;
+            self.commit_live_context_candidate(context);
+        }
+        let var = mech_core::Var {
+            name: identifier_from_str(&name),
+            context: None,
+            kind: None,
+        };
+        Ok(mech_core::Expression::Var(var))
+    }
+
+    fn resolve_context_reads_in_expression(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        expression: &mech_core::Expression,
+    ) -> MResult<mech_core::Expression> {
+        match expression {
+            mech_core::Expression::Var(var) => {
+                let Some(var_context) = &var.context else {
+                    return Ok(expression.clone());
+                };
+                let target = var_context.to_string();
+                let Some(binding) = registry.get(&target) else {
+                    return Ok(expression.clone());
+                };
+                let path = var.name.to_string();
+                let resolved = self.resolve_context_resource_request(binding, &path)?;
+                let source = crate::RuntimeHostInputSource::new(
+                    resolved.provider_base_uri.clone(),
+                    resolved.provider_path.clone(),
+                )?;
+                let value = self.read_context_resource(context, binding, &path)?;
+                self.bind_context_read_temp(context, program, source, value)
+            }
+            mech_core::Expression::Formula(factor) => Ok(mech_core::Expression::Formula(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            )),
+            mech_core::Expression::FunctionCall(call) => {
+                let args = call
+                    .args
+                    .iter()
+                    .map(|(name, expression)| {
+                        Ok((
+                            name.clone(),
+                            self.resolve_context_reads_in_expression(
+                                context, program, registry, expression,
+                            )?,
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::FunctionCall(
+                    mech_core::FunctionCall {
+                        name: call.name.clone(),
+                        args,
+                    },
+                ))
+            }
+            mech_core::Expression::FsmPipe(pipe) => Ok(mech_core::Expression::FsmPipe(
+                self.resolve_context_reads_in_fsm_pipe(context, program, registry, pipe)?,
+            )),
+            mech_core::Expression::Literal(_) => Ok(expression.clone()),
+            mech_core::Expression::Match(match_expression) => {
+                let mut match_expression = match_expression.as_ref().clone();
+                match_expression.source = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &match_expression.source,
+                )?;
+                match_expression.arms = match_expression
+                    .arms
+                    .iter()
+                    .map(|arm| {
+                        Ok(mech_core::MatchArm {
+                            pattern: self.resolve_context_reads_in_match_pattern(
+                                context,
+                                program,
+                                registry,
+                                &arm.pattern,
+                            )?,
+                            guard: arm
+                                .guard
+                                .as_ref()
+                                .map(|guard| {
+                                    self.resolve_context_reads_in_expression(
+                                        context, program, registry, guard,
+                                    )
+                                })
+                                .transpose()?,
+                            expression: self.resolve_context_reads_in_expression(
+                                context,
+                                program,
+                                registry,
+                                &arm.expression,
+                            )?,
+                        })
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::Match(Box::new(match_expression)))
+            }
+            mech_core::Expression::Range(range) => {
+                let mut range = range.as_ref().clone();
+                range.start =
+                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+                range.increment = match &range.increment {
+                    Some((operator, increment)) => Some((
+                        operator.clone(),
+                        self.resolve_context_reads_in_factor(
+                            context, program, registry, increment,
+                        )?,
+                    )),
+                    None => None,
+                };
+                range.terminal = self.resolve_context_reads_in_factor(
+                    context,
+                    program,
+                    registry,
+                    &range.terminal,
+                )?;
+                Ok(mech_core::Expression::Range(Box::new(range)))
+            }
+            mech_core::Expression::Slice(slice) => {
+                if let Some(context_name) = &slice.context {
+                    let context_name = context_name.to_string();
+                    if registry.contains(&context_name) {
+                        return Err(MechError::new(
+                            RuntimeInvalidOperationError {
+                                operation: "context_read",
+                                reason: "context-addressed slices are not supported".to_string(),
+                            },
+                            None,
+                        ));
+                    }
+                    return Ok(expression.clone());
+                }
+                Ok(mech_core::Expression::Slice(
+                    self.resolve_context_reads_in_slice(context, program, registry, slice)?,
+                ))
+            }
+            mech_core::Expression::Structure(structure) => Ok(mech_core::Expression::Structure(
+                self.resolve_context_reads_in_structure(context, program, registry, structure)?,
+            )),
+            mech_core::Expression::SetComprehension(comprehension) => {
+                let mut comprehension = comprehension.as_ref().clone();
+                comprehension.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &comprehension.expression,
+                )?;
+                comprehension.qualifiers = comprehension
+                    .qualifiers
+                    .iter()
+                    .map(|qualifier| {
+                        self.resolve_context_reads_in_comprehension_qualifier(
+                            context, program, registry, qualifier,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::SetComprehension(Box::new(
+                    comprehension,
+                )))
+            }
+            mech_core::Expression::MatrixComprehension(comprehension) => {
+                let mut comprehension = comprehension.as_ref().clone();
+                comprehension.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &comprehension.expression,
+                )?;
+                comprehension.qualifiers = comprehension
+                    .qualifiers
+                    .iter()
+                    .map(|qualifier| {
+                        self.resolve_context_reads_in_comprehension_qualifier(
+                            context, program, registry, qualifier,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Expression::MatrixComprehension(Box::new(
+                    comprehension,
+                )))
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_factor(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        factor: &mech_core::Factor,
+    ) -> MResult<mech_core::Factor> {
+        match factor {
+            mech_core::Factor::Expression(expression) => {
+                Ok(mech_core::Factor::Expression(Box::new(
+                    self.resolve_context_reads_in_expression(
+                        context, program, registry, expression,
+                    )?,
+                )))
+            }
+            mech_core::Factor::Negate(factor) => Ok(mech_core::Factor::Negate(Box::new(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            ))),
+            mech_core::Factor::Not(factor) => Ok(mech_core::Factor::Not(Box::new(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            ))),
+            mech_core::Factor::Parenthetical(factor) => Ok(mech_core::Factor::Parenthetical(
+                Box::new(self.resolve_context_reads_in_factor(context, program, registry, factor)?),
+            )),
+            mech_core::Factor::Transpose(factor) => Ok(mech_core::Factor::Transpose(Box::new(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            ))),
+            mech_core::Factor::Term(term) => {
+                let rhs = term
+                    .rhs
+                    .iter()
+                    .map(|(operator, factor)| {
+                        Ok((
+                            operator.clone(),
+                            self.resolve_context_reads_in_factor(
+                                context, program, registry, factor,
+                            )?,
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(mech_core::Factor::Term(Box::new(mech_core::Term {
+                    lhs: self
+                        .resolve_context_reads_in_factor(context, program, registry, &term.lhs)?,
+                    rhs,
+                })))
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_slice(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        slice: &mech_core::Slice,
+    ) -> MResult<mech_core::Slice> {
+        Ok(mech_core::Slice {
+            name: slice.name.clone(),
+            context: slice.context.clone(),
+            subscript: slice
+                .subscript
+                .iter()
+                .map(|subscript| {
+                    self.resolve_context_reads_in_subscript(context, program, registry, subscript)
+                })
+                .collect::<MResult<Vec<_>>>()?,
+        })
+    }
+
+    fn resolve_context_reads_in_slice_ref(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        target: &mech_core::SliceRef,
+    ) -> MResult<mech_core::SliceRef> {
+        let mut target = target.clone();
+        if let Some(subscripts) = &target.subscript {
+            target.subscript = Some(
+                subscripts
+                    .iter()
+                    .map(|subscript| {
+                        self.resolve_context_reads_in_subscript(
+                            context, program, registry, subscript,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            );
+        }
+        Ok(target)
+    }
+
+    fn resolve_context_reads_in_subscript(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        subscript: &mech_core::Subscript,
+    ) -> MResult<mech_core::Subscript> {
+        match subscript {
+            mech_core::Subscript::Brace(subscripts) => Ok(mech_core::Subscript::Brace(
+                subscripts
+                    .iter()
+                    .map(|subscript| {
+                        self.resolve_context_reads_in_subscript(
+                            context, program, registry, subscript,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            )),
+            mech_core::Subscript::Bracket(subscripts) => Ok(mech_core::Subscript::Bracket(
+                subscripts
+                    .iter()
+                    .map(|subscript| {
+                        self.resolve_context_reads_in_subscript(
+                            context, program, registry, subscript,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            )),
+            mech_core::Subscript::Formula(factor) => Ok(mech_core::Subscript::Formula(
+                self.resolve_context_reads_in_factor(context, program, registry, factor)?,
+            )),
+            mech_core::Subscript::Range(range) => {
+                let mut range = range.clone();
+                range.start =
+                    self.resolve_context_reads_in_factor(context, program, registry, &range.start)?;
+                range.increment = match &range.increment {
+                    Some((operator, increment)) => Some((
+                        operator.clone(),
+                        self.resolve_context_reads_in_factor(
+                            context, program, registry, increment,
+                        )?,
+                    )),
+                    None => None,
+                };
+                range.terminal = self.resolve_context_reads_in_factor(
+                    context,
+                    program,
+                    registry,
+                    &range.terminal,
+                )?;
+                Ok(mech_core::Subscript::Range(range))
+            }
+            _ => Ok(subscript.clone()),
+        }
+    }
+
+    fn resolve_context_reads_in_structure(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        structure: &mech_core::Structure,
+    ) -> MResult<mech_core::Structure> {
+        match structure {
+            mech_core::Structure::Empty => Ok(mech_core::Structure::Empty),
+            mech_core::Structure::Map(map) => Ok(mech_core::Structure::Map(mech_core::Map {
+                elements: map
+                    .elements
+                    .iter()
+                    .map(|mapping| {
+                        Ok(mech_core::Mapping {
+                            key: self.resolve_context_reads_in_expression(
+                                context,
+                                program,
+                                registry,
+                                &mapping.key,
+                            )?,
+                            value: self.resolve_context_reads_in_expression(
+                                context,
+                                program,
+                                registry,
+                                &mapping.value,
+                            )?,
+                        })
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            })),
+            mech_core::Structure::Matrix(matrix) => {
+                Ok(mech_core::Structure::Matrix(mech_core::nodes::Matrix {
+                    rows: matrix
+                        .rows
+                        .iter()
+                        .map(|row| {
+                            Ok(mech_core::MatrixRow {
+                                columns: row
+                                    .columns
+                                    .iter()
+                                    .map(|column| {
+                                        Ok(mech_core::MatrixColumn {
+                                            element: self.resolve_context_reads_in_expression(
+                                                context,
+                                                program,
+                                                registry,
+                                                &column.element,
+                                            )?,
+                                        })
+                                    })
+                                    .collect::<MResult<Vec<_>>>()?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::Record(record) => {
+                Ok(mech_core::Structure::Record(mech_core::Record {
+                    bindings: record
+                        .bindings
+                        .iter()
+                        .map(|binding| {
+                            Ok(mech_core::Binding {
+                                name: binding.name.clone(),
+                                kind: binding.kind.clone(),
+                                value: self.resolve_context_reads_in_expression(
+                                    context,
+                                    program,
+                                    registry,
+                                    &binding.value,
+                                )?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::Set(set) => Ok(mech_core::Structure::Set(mech_core::Set {
+                elements: set
+                    .elements
+                    .iter()
+                    .map(|expression| {
+                        self.resolve_context_reads_in_expression(
+                            context, program, registry, expression,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            })),
+            mech_core::Structure::Table(table) => {
+                Ok(mech_core::Structure::Table(mech_core::Table {
+                    header: table.header.clone(),
+                    rows: table
+                        .rows
+                        .iter()
+                        .map(|row| {
+                            Ok(mech_core::TableRow {
+                                columns: row
+                                    .columns
+                                    .iter()
+                                    .map(|column| {
+                                        Ok(mech_core::TableColumn {
+                                            element: self.resolve_context_reads_in_expression(
+                                                context,
+                                                program,
+                                                registry,
+                                                &column.element,
+                                            )?,
+                                        })
+                                    })
+                                    .collect::<MResult<Vec<_>>>()?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::Tuple(tuple) => {
+                Ok(mech_core::Structure::Tuple(mech_core::Tuple {
+                    elements: tuple
+                        .elements
+                        .iter()
+                        .map(|expression| {
+                            self.resolve_context_reads_in_expression(
+                                context, program, registry, expression,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Structure::TupleStruct(tuple_struct) => {
+                Ok(mech_core::Structure::TupleStruct(mech_core::TupleStruct {
+                    name: tuple_struct.name.clone(),
+                    value: Box::new(self.resolve_context_reads_in_expression(
+                        context,
+                        program,
+                        registry,
+                        &tuple_struct.value,
+                    )?),
+                }))
+            }
+        }
+    }
+
+    fn resolve_context_reads_in_comprehension_qualifier(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        qualifier: &mech_core::ComprehensionQualifier,
+    ) -> MResult<mech_core::ComprehensionQualifier> {
+        match qualifier {
+            mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+                Ok(mech_core::ComprehensionQualifier::Generator((
+                    self.resolve_context_reads_in_match_pattern(
+                        context, program, registry, pattern,
+                    )?,
+                    self.resolve_context_reads_in_expression(
+                        context, program, registry, expression,
+                    )?,
+                )))
+            }
+            mech_core::ComprehensionQualifier::Filter(expression) => {
+                Ok(mech_core::ComprehensionQualifier::Filter(
+                    self.resolve_context_reads_in_expression(
+                        context, program, registry, expression,
+                    )?,
+                ))
+            }
+            mech_core::ComprehensionQualifier::Let(var_def) => {
+                let mut var_def = var_def.clone();
+                var_def.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &var_def.expression,
+                )?;
+                Ok(mech_core::ComprehensionQualifier::Let(var_def))
+            }
+        }
+    }
+
+    fn flush_direct_execution(
+        &mut self,
+        program: &mut MechProgram,
+        pending: &mut Vec<mech_core::SectionElement>,
+        result: &mut Value,
+    ) -> MResult<()> {
+        if pending.is_empty() {
             return Ok(());
-          }
         }
-        let code = self.resolve_context_reads_in_mech_code(
-          context,
-          program,
-          registry,
-          &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign.clone())),
-        )?;
-        pending_codes.push((code, comment.clone()));
+        let tree = mech_core::Program {
+            title: None,
+            body: mech_core::Body {
+                sections: vec![mech_core::Section {
+                    subtitle: None,
+                    elements: std::mem::take(pending),
+                }],
+            },
+        };
+        *result = program.run_tree(&tree)?;
         Ok(())
-      }
-      _ => {
-        let code = self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
-        pending_codes.push((code, comment.clone()));
-        Ok(())
-      }
     }
-  }
 
-  fn preflight_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    tree: &mech_core::Program,
-    scope: &SourceScope,
-  ) -> MResult<()> {
-    let registry = self.direct_context_registry_for_scope(tree, scope)?;
-    self.preflight_context_capabilities_with_registry(context, &registry, tree, scope, AddressedReadPreflight::RequireContextBinding)
-  }
-
-  fn preflight_context_capabilities_with_registry(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    tree: &mech_core::Program,
-    scope: &SourceScope,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    for section in &tree.body.sections {
-      for element in &section.elements {
-        match element {
-          mech_core::SectionElement::MechCode(codes) => {
-            for (code, _) in codes {
-              self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::TopLevel, addressed_read_preflight)?;
+    fn executable_fence_for_scope(fenced: &mech_core::FencedMechCode, scope: &SourceScope) -> bool {
+        match scope {
+            SourceScope::Program => fenced.config.namespace_str.is_empty(),
+            SourceScope::Interpreter(interpreter) => {
+                fenced.config.namespace_str == interpreter.namespace_str
             }
-          }
-          mech_core::SectionElement::FencedMechCode(fenced)
-            if Self::executable_fence_for_scope(fenced, scope) =>
-          {
-            for (code, _) in &fenced.code {
-              self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::TopLevel, addressed_read_preflight)?;
-            }
-          }
-          _ => {}
         }
-      }
     }
-    Ok(())
-  }
 
-  fn preflight_code_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    code: &mech_core::MechCode,
-    placement: DirectContextEffectPlacement,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match code {
-      mech_core::MechCode::ActivationScope(scope) => {
-        self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
-        let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
-        // Only writes to local registers conflict with an effectful activation.
-        // Context-addressed assignments have their own, operation-specific
-        // placement error below (they are top-level only).
-        let has_register = scope.body.iter().any(|(code, _)| match code {
-          mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => assign.target.context.is_none(),
-          mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => assign.target.context.is_none(),
-          _ => false,
-        });
-        if has_send && has_register { return Err(MechError::new(ActivationScopeEffectWithRegisterUnsupported, None)); }
-        if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot { return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None)); }
-        for (body_code, _) in &scope.body {
-          self.preflight_code_context_capabilities(context, registry, body_code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?;
+    fn resolve_context_reads_in_pattern(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        pattern: &mech_core::Pattern,
+    ) -> MResult<mech_core::Pattern> {
+        match pattern {
+            mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+            )),
+            mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(
+                mech_core::PatternTupleStruct {
+                    name: tuple_struct.name.clone(),
+                    patterns: tuple_struct
+                        .patterns
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                },
+            )),
+            mech_core::Pattern::Tuple(tuple) => {
+                Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+                    tuple
+                        .0
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                )))
+            }
+            mech_core::Pattern::Array(array) => {
+                let spread = if let Some(spread) = &array.spread {
+                    Some(mech_core::PatternArraySpread {
+                        kind: spread.kind.clone(),
+                        binding: spread
+                            .binding
+                            .as_ref()
+                            .map(|binding| {
+                                self.resolve_context_reads_in_pattern(
+                                    context, program, registry, binding,
+                                )
+                                .map(Box::new)
+                            })
+                            .transpose()?,
+                    })
+                } else {
+                    None
+                };
+                Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+                    prefix: array
+                        .prefix
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                    spread,
+                    suffix: array
+                        .suffix
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+        }
+    }
+
+    fn resolve_context_reads_in_match_pattern(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        pattern: &mech_core::Pattern,
+    ) -> MResult<mech_core::Pattern> {
+        match pattern {
+            mech_core::Pattern::Expression(expression) => Ok(mech_core::Pattern::Expression(
+                self.resolve_context_reads_in_match_pattern_expression(
+                    context, program, registry, expression,
+                )?,
+            )),
+            mech_core::Pattern::TupleStruct(tuple_struct) => Ok(mech_core::Pattern::TupleStruct(
+                mech_core::PatternTupleStruct {
+                    name: tuple_struct.name.clone(),
+                    patterns: tuple_struct
+                        .patterns
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_match_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                },
+            )),
+            mech_core::Pattern::Tuple(tuple) => {
+                if tuple.0.len() == 1 {
+                    let pattern = self.resolve_context_reads_in_match_pattern(
+                        context,
+                        program,
+                        registry,
+                        &tuple.0[0],
+                    )?;
+                    if pattern != tuple.0[0] {
+                        return Ok(pattern);
+                    }
+                }
+                Ok(mech_core::Pattern::Tuple(mech_core::PatternTuple(
+                    tuple
+                        .0
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_match_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                )))
+            }
+            mech_core::Pattern::Array(array) => {
+                let spread = if let Some(spread) = &array.spread {
+                    Some(mech_core::PatternArraySpread {
+                        kind: spread.kind.clone(),
+                        binding: spread
+                            .binding
+                            .as_ref()
+                            .map(|binding| {
+                                self.resolve_context_reads_in_match_pattern(
+                                    context, program, registry, binding,
+                                )
+                                .map(Box::new)
+                            })
+                            .transpose()?,
+                    })
+                } else {
+                    None
+                };
+                Ok(mech_core::Pattern::Array(mech_core::PatternArray {
+                    prefix: array
+                        .prefix
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_match_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                    spread,
+                    suffix: array
+                        .suffix
+                        .iter()
+                        .map(|pattern| {
+                            self.resolve_context_reads_in_match_pattern(
+                                context, program, registry, pattern,
+                            )
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                }))
+            }
+            mech_core::Pattern::Wildcard => Ok(mech_core::Pattern::Wildcard),
+        }
+    }
+
+    fn resolve_context_reads_in_match_pattern_expression(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        expression: &mech_core::Expression,
+    ) -> MResult<mech_core::Expression> {
+        if let Some(expression) = self.literalize_match_pattern_context_read_expression(
+            context, program, registry, expression,
+        )? {
+            return Ok(expression);
+        }
+
+        self.resolve_context_reads_in_expression(context, program, registry, expression)
+    }
+
+    fn literalize_match_pattern_context_read_expression(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        expression: &mech_core::Expression,
+    ) -> MResult<Option<mech_core::Expression>> {
+        match expression {
+            mech_core::Expression::Var(var) => {
+                self.literalize_match_pattern_context_read_var(context, program, registry, var)
+            }
+            mech_core::Expression::Formula(factor) => self
+                .literalize_match_pattern_context_read_factor(context, program, registry, factor),
+            _ => Ok(None),
+        }
+    }
+
+    fn literalize_match_pattern_context_read_factor(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        factor: &mech_core::Factor,
+    ) -> MResult<Option<mech_core::Expression>> {
+        match factor {
+            mech_core::Factor::Expression(expression) => self
+                .literalize_match_pattern_context_read_expression(
+                    context, program, registry, expression,
+                ),
+            mech_core::Factor::Parenthetical(inner) => {
+                self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
+            }
+            mech_core::Factor::Term(term) if term.rhs.is_empty() => self
+                .literalize_match_pattern_context_read_factor(
+                    context, program, registry, &term.lhs,
+                ),
+            _ => Ok(None),
+        }
+    }
+
+    fn literalize_match_pattern_context_read_var(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        var: &mech_core::Var,
+    ) -> MResult<Option<mech_core::Expression>> {
+        let Some(var_context) = &var.context else {
+            return Ok(None);
+        };
+
+        let target = var_context.to_string();
+        let path = var.name.to_string();
+        if let Some(binding) = registry.get(&target) {
+            let value = self.read_context_resource(context, binding, &path)?;
+            return Ok(Some(self.context_pattern_value_expression(value)?));
+        }
+
+        let address_key = format!("@{target}/{path}");
+        let value = {
+            let symbols = program.interpreter().symbols();
+            let symbols = symbols.borrow();
+            symbols
+                .get(hash_str(&address_key))
+                .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
+        };
+
+        if let Some(value) = value {
+            return Ok(Some(self.context_pattern_value_expression(value)?));
+        }
+
+        Ok(None)
+    }
+
+    fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
+        let value = resolve_runtime_value(value);
+        match value {
+            Value::String(value) => {
+                let text = value.borrow().clone();
+                Ok(mech_core::Expression::Literal(mech_core::Literal::String(
+                    mech_core::MechString {
+                        text: mech_core::Token::new(
+                            mech_core::TokenKind::String,
+                            mech_core::SourceRange::default(),
+                            text.chars().collect(),
+                        ),
+                    },
+                )))
+            }
+            #[cfg(feature = "bool")]
+            Value::Bool(value) => {
+                let flag = *value.borrow();
+                Ok(mech_core::Expression::Literal(mech_core::Literal::Boolean(
+                    mech_core::Token::new(
+                        if flag {
+                            mech_core::TokenKind::True
+                        } else {
+                            mech_core::TokenKind::False
+                        },
+                        mech_core::SourceRange::default(),
+                        if flag {
+                            "true".chars().collect()
+                        } else {
+                            "false".chars().collect()
+                        },
+                    ),
+                )))
+            }
+            Value::Empty => Ok(mech_core::Expression::Literal(mech_core::Literal::Empty(
+                mech_core::Token::new(
+                    mech_core::TokenKind::Empty,
+                    mech_core::SourceRange::default(),
+                    vec!['_'],
+                ),
+            ))),
+            other => Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "context_match_pattern",
+                    reason: format!(
+                        "context match patterns currently support string, bool, and empty values; got {other:?}"
+                    ),
+                },
+                None,
+            )),
+        }
+    }
+
+    fn resolve_context_reads_in_transition(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        transition: &mech_core::Transition,
+    ) -> MResult<mech_core::Transition> {
+        match transition {
+            mech_core::Transition::Async(pattern) => Ok(mech_core::Transition::Async(
+                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+            )),
+            mech_core::Transition::CodeBlock(code_items) => Ok(mech_core::Transition::CodeBlock(
+                code_items
+                    .iter()
+                    .map(|(code, comment)| {
+                        Ok((
+                            self.resolve_context_reads_in_mech_code(
+                                context, program, registry, code,
+                            )?,
+                            comment.clone(),
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            )),
+            mech_core::Transition::Next(pattern) => Ok(mech_core::Transition::Next(
+                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+            )),
+            mech_core::Transition::Output(pattern) => Ok(mech_core::Transition::Output(
+                self.resolve_context_reads_in_pattern(context, program, registry, pattern)?,
+            )),
+            mech_core::Transition::Statement(statement) => Ok(mech_core::Transition::Statement(
+                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+            )),
+        }
+    }
+
+    fn resolve_context_reads_in_fsm_pipe(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        pipe: &mech_core::FsmPipe,
+    ) -> MResult<mech_core::FsmPipe> {
+        let mut pipe = pipe.clone();
+
+        if let Some(args) = &pipe.start.args {
+            pipe.start.args = Some(
+                args.iter()
+                    .map(|(name, expression)| {
+                        Ok((
+                            name.clone(),
+                            self.resolve_context_reads_in_expression(
+                                context, program, registry, expression,
+                            )?,
+                        ))
+                    })
+                    .collect::<MResult<Vec<_>>>()?,
+            );
+        }
+
+        pipe.transitions = pipe
+            .transitions
+            .iter()
+            .map(|transition| {
+                self.resolve_context_reads_in_transition(context, program, registry, transition)
+            })
+            .collect::<MResult<Vec<_>>>()?;
+
+        Ok(pipe)
+    }
+
+    fn resolve_context_reads_in_fsm_implementation(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        fsm: &mech_core::FsmImplementation,
+    ) -> MResult<mech_core::FsmImplementation> {
+        let arms = fsm
+            .arms
+            .iter()
+            .map(|arm| match arm {
+                mech_core::FsmArm::Guard(pattern, guards) => Ok(mech_core::FsmArm::Guard(
+                    self.resolve_context_reads_in_match_pattern(
+                        context, program, registry, pattern,
+                    )?,
+                    guards
+                        .iter()
+                        .map(|guard| {
+                            Ok(mech_core::Guard {
+                                condition: self.resolve_context_reads_in_match_pattern(
+                                    context,
+                                    program,
+                                    registry,
+                                    &guard.condition,
+                                )?,
+                                transitions: guard
+                                    .transitions
+                                    .iter()
+                                    .map(|transition| {
+                                        self.resolve_context_reads_in_transition(
+                                            context, program, registry, transition,
+                                        )
+                                    })
+                                    .collect::<MResult<Vec<_>>>()?,
+                            })
+                        })
+                        .collect::<MResult<Vec<_>>>()?,
+                )),
+                mech_core::FsmArm::Transition(pattern, transitions) => {
+                    Ok(mech_core::FsmArm::Transition(
+                        self.resolve_context_reads_in_match_pattern(
+                            context, program, registry, pattern,
+                        )?,
+                        transitions
+                            .iter()
+                            .map(|transition| {
+                                self.resolve_context_reads_in_transition(
+                                    context, program, registry, transition,
+                                )
+                            })
+                            .collect::<MResult<Vec<_>>>()?,
+                    ))
+                }
+                mech_core::FsmArm::Comment(comment) => {
+                    Ok(mech_core::FsmArm::Comment(comment.clone()))
+                }
+            })
+            .collect::<MResult<Vec<_>>>()?;
+
+        Ok(mech_core::FsmImplementation {
+            name: fsm.name.clone(),
+            input: fsm.input.clone(),
+            start: self.resolve_context_reads_in_pattern(context, program, registry, &fsm.start)?,
+            arms,
+        })
+    }
+
+    fn resolve_context_reads_in_function_define(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        function: &mech_core::FunctionDefine,
+    ) -> MResult<mech_core::FunctionDefine> {
+        Ok(mech_core::FunctionDefine {
+            name: function.name.clone(),
+            input: function.input.clone(),
+            output: function.output.clone(),
+            statements: function.statements.clone(),
+            match_arms: function
+                .match_arms
+                .iter()
+                .map(|arm| {
+                    Ok(mech_core::FunctionMatchArm {
+                        pattern: self.resolve_context_reads_in_match_pattern(
+                            context,
+                            program,
+                            registry,
+                            &arm.pattern,
+                        )?,
+                        expression: arm.expression.clone(),
+                    })
+                })
+                .collect::<MResult<Vec<_>>>()?,
+        })
+    }
+
+    fn resolve_context_reads_in_mech_code(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        code: &mech_core::MechCode,
+    ) -> MResult<mech_core::MechCode> {
+        match code {
+            mech_core::MechCode::ActivationScope(scope) => {
+                let mut scope = scope.clone();
+                scope.trigger = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &scope.trigger,
+                )?;
+                scope.body = scope
+                    .body
+                    .iter()
+                    .map(|(code, comment)| {
+                        Ok((
+                            self.resolve_context_reads_in_mech_code(
+                                context, program, registry, code,
+                            )?,
+                            comment.clone(),
+                        ))
+                    })
+                    .collect::<MResult<_>>()?;
+                Ok(mech_core::MechCode::ActivationScope(scope))
+            }
+            mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
+                self.resolve_context_reads_in_statement(context, program, registry, statement)?,
+            )),
+            mech_core::MechCode::Expression(expression) => Ok(mech_core::MechCode::Expression(
+                self.resolve_context_reads_in_expression(context, program, registry, expression)?,
+            )),
+            mech_core::MechCode::FsmImplementation(fsm) => {
+                Ok(mech_core::MechCode::FsmImplementation(
+                    self.resolve_context_reads_in_fsm_implementation(
+                        context, program, registry, fsm,
+                    )?,
+                ))
+            }
+            mech_core::MechCode::FsmSpecification(spec) => {
+                Ok(mech_core::MechCode::FsmSpecification(spec.clone()))
+            }
+            mech_core::MechCode::FunctionDefine(function) => {
+                Ok(mech_core::MechCode::FunctionDefine(
+                    self.resolve_context_reads_in_function_define(
+                        context, program, registry, function,
+                    )?,
+                ))
+            }
+            mech_core::MechCode::Import(_)
+            | mech_core::MechCode::Comment(_)
+            | mech_core::MechCode::Error(_, _) => Ok(code.clone()),
+        }
+    }
+
+    fn resolve_context_reads_in_statement(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        statement: &mech_core::Statement,
+    ) -> MResult<mech_core::Statement> {
+        match statement {
+            mech_core::Statement::VariableDefine(var_def) => {
+                let mut var_def = var_def.clone();
+                var_def.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &var_def.expression,
+                )?;
+                Ok(mech_core::Statement::VariableDefine(var_def))
+            }
+            mech_core::Statement::VariableAssign(assign) => {
+                let mut assign = assign.clone();
+                assign.target = self.resolve_context_reads_in_slice_ref(
+                    context,
+                    program,
+                    registry,
+                    &assign.target,
+                )?;
+                assign.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &assign.expression,
+                )?;
+                Ok(mech_core::Statement::VariableAssign(assign))
+            }
+            mech_core::Statement::OpAssign(op_assign) => {
+                let mut op_assign = op_assign.clone();
+                op_assign.target = self.resolve_context_reads_in_slice_ref(
+                    context,
+                    program,
+                    registry,
+                    &op_assign.target,
+                )?;
+                op_assign.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &op_assign.expression,
+                )?;
+                Ok(mech_core::Statement::OpAssign(op_assign))
+            }
+            mech_core::Statement::TupleDestructure(tuple_destructure) => {
+                let mut tuple_destructure = tuple_destructure.clone();
+                tuple_destructure.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &tuple_destructure.expression,
+                )?;
+                Ok(mech_core::Statement::TupleDestructure(tuple_destructure))
+            }
+            #[cfg(feature = "invariant_define")]
+            mech_core::Statement::InvariantDefine(invariant) => {
+                let mut invariant = invariant.clone();
+                invariant.expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &invariant.expression,
+                )?;
+                Ok(mech_core::Statement::InvariantDefine(invariant))
+            }
+            mech_core::Statement::FsmDeclare(fsm) => {
+                let mut fsm = fsm.clone();
+                fsm.pipe =
+                    self.resolve_context_reads_in_fsm_pipe(context, program, registry, &fsm.pipe)?;
+                Ok(mech_core::Statement::FsmDeclare(fsm))
+            }
+            _ => Ok(statement.clone()),
+        }
+    }
+
+    fn push_direct_code(
+        &mut self,
+        context: &RuntimeContext,
+        program: &mut MechProgram,
+        registry: &RuntimeContextRegistry,
+        pending: &mut Vec<mech_core::SectionElement>,
+        pending_codes: &mut Vec<(mech_core::MechCode, Option<mech_core::Comment>)>,
+        result: &mut Value,
+        skip_non_context_imports: bool,
+        code: &mech_core::MechCode,
+        comment: &Option<mech_core::Comment>,
+    ) -> MResult<()> {
+        match code {
+            mech_core::MechCode::Import(import) if Self::is_manifest_context_import(import) => {
+                Ok(())
+            }
+            mech_core::MechCode::Import(_) if skip_non_context_imports => Ok(()),
+            mech_core::MechCode::Statement(mech_core::Statement::ImportDeclaration(_))
+            | mech_core::MechCode::Statement(mech_core::Statement::ContextDeclaration(_)) => Ok(()),
+            mech_core::MechCode::Statement(mech_core::Statement::ExportDeclaration(export)) => {
+                if !pending_codes.is_empty() {
+                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                        pending_codes,
+                    )));
+                }
+                self.flush_direct_execution(program, pending, result)?;
+                let id = hash_str(&export.name.to_string());
+                if let Some(value) = program.interpreter().symbols().borrow().get(id) {
+                    *result = resolve_runtime_value(value.borrow().clone());
+                } else {
+                    *result = Value::Empty;
+                }
+                Ok(())
+            }
+            mech_core::MechCode::ActivationScope(scope) => {
+                if !pending_codes.is_empty() {
+                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                        pending_codes,
+                    )));
+                }
+                self.flush_direct_execution(program, pending, result)?;
+                let mut lowered = scope.clone();
+                lowered.trigger = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &scope.trigger,
+                )?;
+                let mut registrations = Vec::new();
+                lowered.body.clear();
+                for (body_code, body_comment) in &scope.body {
+                    match body_code {
+                        mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+                            let context_name = send.target.context.as_ref().unwrap().to_string();
+                            let binding =
+                                registry.get(&context_name).cloned().ok_or_else(|| {
+                                    MechError::new(
+                                        RuntimeAddressedAssignmentUnsupported {
+                                            target: context_name.clone(),
+                                        },
+                                        None,
+                                    )
+                                })?;
+                            let index = self.persistent_sends.len() + registrations.len();
+                            let value_name =
+                                format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
+                            let value = mech_core::VariableDefine {
+                                mutable: false,
+                                var: mech_core::Var {
+                                    name: identifier_from_str(&value_name),
+                                    context: None,
+                                    kind: None,
+                                },
+                                expression: self.resolve_context_reads_in_expression(
+                                    context,
+                                    program,
+                                    registry,
+                                    &send.expression,
+                                )?,
+                            };
+                            lowered.body.push((
+                                mech_core::MechCode::Statement(
+                                    mech_core::Statement::VariableDefine(value),
+                                ),
+                                body_comment.clone(),
+                            ));
+                            registrations.push((
+                                binding,
+                                send.target.name.to_string(),
+                                hash_str(&value_name),
+                            ));
+                        }
+                        _ => lowered.body.push((
+                            self.resolve_context_reads_in_mech_code(
+                                context, program, registry, body_code,
+                            )?,
+                            body_comment.clone(),
+                        )),
+                    }
+                }
+                if registrations.is_empty() {
+                    program.run_tree(&single_code_program(
+                        mech_core::MechCode::ActivationScope(lowered),
+                        comment.clone(),
+                    ))?;
+                    return Ok(());
+                }
+                lowered.body.push((
+                    mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(
+                        mech_core::FunctionCall {
+                            name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME),
+                            args: vec![],
+                        },
+                    )),
+                    None,
+                ));
+                self.validate_live_context_candidate(context)?;
+                let plan_start = program.interpreter().plan().borrow().nodes.len();
+                program.run_tree(&single_code_program(
+                    mech_core::MechCode::ActivationScope(lowered),
+                    comment.clone(),
+                ))?;
+                let interpreter_id = program.interpreter().id;
+                let trigger_cells = match &scope.trigger {
+                    mech_core::Expression::Var(var) => program
+                        .interpreter()
+                        .symbols()
+                        .borrow()
+                        .get(var.name.hash())
+                        .ok_or_else(|| {
+                            MechError::new(
+                                RuntimeActivationEffectBarrierInvariantError {
+                                    reason: "activation trigger disappeared".into(),
+                                },
+                                None,
+                            )
+                        })?
+                        .borrow()
+                        .reactive_root_cell_ids(),
+                    _ => vec![],
+                };
+                let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..]
+                    .iter()
+                    .filter(|node| {
+                        node.kind == mech_core::ReactiveNodeKind::Combinational
+                            && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+                            && trigger_cells.iter().all(|cell| {
+                                node.inputs.iter().any(|dependency| {
+                                    dependency.cell == *cell
+                                        && dependency.kind
+                                            == mech_core::ReactiveDependencyKind::Reactive
+                                })
+                            })
+                    })
+                    .map(|node| node.id)
+                    .collect();
+                if barrier_ids.len() != 1 {
+                    return Err(MechError::new(
+                        RuntimeActivationEffectBarrierInvariantError {
+                            reason: format!(
+                                "expected exactly one activation effect barrier, found {}",
+                                barrier_ids.len()
+                            ),
+                        },
+                        None,
+                    ));
+                }
+                let barrier_node_id = barrier_ids[0];
+                let symbols = program.interpreter().symbols();
+                let mut sends = Vec::new();
+                for (binding, path, value_id) in registrations {
+                    let value = symbols.borrow().get(value_id).ok_or_else(|| {
+                        MechError::new(
+                            RuntimeActivationEffectBarrierInvariantError {
+                                reason: "missing lowered activation payload".into(),
+                            },
+                            None,
+                        )
+                    })?;
+                    sends.push(RuntimePersistentSend {
+                        binding,
+                        path,
+                        value,
+                        schedule: RuntimePersistentSendSchedule::Activation {
+                            interpreter_id,
+                            barrier_node_id,
+                        },
+                    });
+                }
+                self.persistent_sends.extend(sends);
+                self.commit_live_context_candidate(context);
+                Ok(())
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
+                if let Some(context_name) = &var_def.var.context {
+                    let target = context_name.to_string();
+                    if let Some(binding) = registry.get(&target).cloned() {
+                        if !pending_codes.is_empty() {
+                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                                pending_codes,
+                            )));
+                        }
+                        self.flush_direct_execution(program, pending, result)?;
+                        return Err(MechError::new(
+                            RuntimeInvalidOperationError {
+                                operation: "direct_context_define",
+                                reason: format!(
+                                    "context-addressed path `@{}/{}` cannot be defined with `:=`; use `=` for context writes",
+                                    binding.name,
+                                    var_def.var.name.to_string()
+                                ),
+                            },
+                            None,
+                        ));
+                    }
+                }
+                let code = self.resolve_context_reads_in_mech_code(
+                    context,
+                    program,
+                    registry,
+                    &mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(
+                        var_def.clone(),
+                    )),
+                )?;
+                pending_codes.push((code, comment.clone()));
+                Ok(())
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+                // Context sends are executed only at module top level for now. Parser paths
+                // intentionally reject nested sends until interpreter/effect execution can
+                // support them in functions and state machines.
+                let Some(context_name) = &send.target.context else {
+                    return Err(MechError::new(
+                        RuntimeAddressedAssignmentUnsupported {
+                            target: send.target.name.to_string(),
+                        },
+                        None,
+                    ));
+                };
+                let target = context_name.to_string();
+                let Some(binding) = registry.get(&target).cloned() else {
+                    return Err(MechError::new(
+                        RuntimeAddressedAssignmentUnsupported { target },
+                        None,
+                    ));
+                };
+                if !pending_codes.is_empty() {
+                    pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                        pending_codes,
+                    )));
+                }
+                self.flush_direct_execution(program, pending, result)?;
+                let expression = self.resolve_context_reads_in_expression(
+                    context,
+                    program,
+                    registry,
+                    &send.expression,
+                )?;
+                let path = send.target.name.to_string();
+                if self.live_registration_mode
+                    == crate::runtime::LiveRegistrationMode::IsolatedSnapshot
+                {
+                    let value = resolve_runtime_value(
+                        self.evaluate_expression_on_program(program, &expression)?,
+                    );
+                    self.write_context_resource(
+                        context,
+                        &binding,
+                        &path,
+                        value.clone(),
+                        RuntimeResourceWriteIntent::Send,
+                    )?;
+                    *result = value;
+                    return Ok(());
+                }
+                self.validate_live_context_candidate(context)?;
+                let value_cell = self.bind_persistent_send_value_on_program(program, expression)?;
+                let value = resolve_runtime_value(value_cell.borrow().clone());
+                self.write_context_resource(
+                    context,
+                    &binding,
+                    &path,
+                    value.clone(),
+                    RuntimeResourceWriteIntent::Send,
+                )?;
+                self.persistent_sends.push(RuntimePersistentSend {
+                    binding,
+                    path,
+                    value: value_cell,
+                    schedule: RuntimePersistentSendSchedule::EveryAcceptedTurn,
+                });
+                self.commit_live_context_candidate(context);
+                *result = value;
+                return Ok(());
+            }
+            mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => {
+                if let Some(context_name) = &assign.target.context {
+                    let target = context_name.to_string();
+                    if let Some(binding) = registry.get(&target).cloned() {
+                        if !pending_codes.is_empty() {
+                            pending.push(mech_core::SectionElement::MechCode(std::mem::take(
+                                pending_codes,
+                            )));
+                        }
+                        self.flush_direct_execution(program, pending, result)?;
+                        let expression = self.resolve_context_reads_in_expression(
+                            context,
+                            program,
+                            registry,
+                            &assign.expression,
+                        )?;
+                        let value = resolve_runtime_value(
+                            self.evaluate_expression_on_program(program, &expression)?,
+                        );
+                        self.write_context_resource(
+                            context,
+                            &binding,
+                            &assign.target.name.to_string(),
+                            value.clone(),
+                            RuntimeResourceWriteIntent::Assign,
+                        )?;
+                        *result = value;
+                        return Ok(());
+                    }
+                }
+                let code = self.resolve_context_reads_in_mech_code(
+                    context,
+                    program,
+                    registry,
+                    &mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(
+                        assign.clone(),
+                    )),
+                )?;
+                pending_codes.push((code, comment.clone()));
+                Ok(())
+            }
+            _ => {
+                let code =
+                    self.resolve_context_reads_in_mech_code(context, program, registry, code)?;
+                pending_codes.push((code, comment.clone()));
+                Ok(())
+            }
+        }
+    }
+
+    fn preflight_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        tree: &mech_core::Program,
+        scope: &SourceScope,
+    ) -> MResult<()> {
+        let registry = self.direct_context_registry_for_scope(tree, scope)?;
+        self.preflight_context_capabilities_with_registry(
+            context,
+            &registry,
+            tree,
+            scope,
+            AddressedReadPreflight::RequireContextBinding,
+        )
+    }
+
+    fn preflight_context_capabilities_with_registry(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        tree: &mech_core::Program,
+        scope: &SourceScope,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        for section in &tree.body.sections {
+            for element in &section.elements {
+                match element {
+                    mech_core::SectionElement::MechCode(codes) => {
+                        for (code, _) in codes {
+                            self.preflight_code_context_capabilities(
+                                context,
+                                registry,
+                                code,
+                                DirectContextEffectPlacement::TopLevel,
+                                addressed_read_preflight,
+                            )?;
+                        }
+                    }
+                    mech_core::SectionElement::FencedMechCode(fenced)
+                        if Self::executable_fence_for_scope(fenced, scope) =>
+                    {
+                        for (code, _) in &fenced.code {
+                            self.preflight_code_context_capabilities(
+                                context,
+                                registry,
+                                code,
+                                DirectContextEffectPlacement::TopLevel,
+                                addressed_read_preflight,
+                            )?;
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
         Ok(())
-      }
-      mech_core::MechCode::Statement(statement) => {
-        self.preflight_statement_context_capabilities(context, registry, statement, placement, addressed_read_preflight)
-      }
-      mech_core::MechCode::Expression(expression) => {
-        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
-      }
-      mech_core::MechCode::FsmImplementation(fsm) => {
-        self.preflight_fsm_implementation_context_capabilities(context, registry, fsm, addressed_read_preflight)
-      }
-      mech_core::MechCode::FunctionDefine(function) => {
-        self.preflight_function_define_context_capabilities(context, registry, function, addressed_read_preflight)
-      }
-      mech_core::MechCode::Import(_)
-      | mech_core::MechCode::Comment(_)
-      | mech_core::MechCode::FsmSpecification(_)
-      | mech_core::MechCode::Error(_, _) => Ok(()),
-    }
-  }
-
-  fn preflight_function_define_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    function: &mech_core::FunctionDefine,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    for statement in &function.statements {
-      self.reject_runtime_context_reads_in_statement(registry, statement)?;
-    }
-    for arm in &function.match_arms {
-      self.reject_runtime_context_reads_in_pattern(registry, &arm.pattern)?;
-      self.reject_runtime_context_reads_in_expression(registry, &arm.expression)?;
     }
 
-    for statement in &function.statements {
-      self.preflight_statement_context_capabilities(
-        context,
-        registry,
-        statement,
-        DirectContextEffectPlacement::FunctionBody,
-        addressed_read_preflight,
-      )?;
+    fn preflight_code_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        code: &mech_core::MechCode,
+        placement: DirectContextEffectPlacement,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match code {
+            mech_core::MechCode::ActivationScope(scope) => {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &scope.trigger,
+                    addressed_read_preflight,
+                )?;
+                let has_send = scope.body.iter().any(|(code, _)| {
+                    matches!(
+                        code,
+                        mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))
+                    )
+                });
+                // Only writes to local registers conflict with an effectful activation.
+                // Context-addressed assignments have their own, operation-specific
+                // placement error below (they are top-level only).
+                let has_register = scope.body.iter().any(|(code, _)| match code {
+                    mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(
+                        assign,
+                    )) => assign.target.context.is_none(),
+                    mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => {
+                        assign.target.context.is_none()
+                    }
+                    _ => false,
+                });
+                if has_send && has_register {
+                    return Err(MechError::new(
+                        ActivationScopeEffectWithRegisterUnsupported,
+                        None,
+                    ));
+                }
+                if has_send
+                    && self.live_registration_mode
+                        == crate::runtime::LiveRegistrationMode::IsolatedSnapshot
+                {
+                    return Err(MechError::new(
+                        RuntimeIsolatedActivationSendUnsupported,
+                        None,
+                    ));
+                }
+                for (body_code, _) in &scope.body {
+                    self.preflight_code_context_capabilities(
+                        context,
+                        registry,
+                        body_code,
+                        DirectContextEffectPlacement::ActivationScope,
+                        addressed_read_preflight,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::MechCode::Statement(statement) => self
+                .preflight_statement_context_capabilities(
+                    context,
+                    registry,
+                    statement,
+                    placement,
+                    addressed_read_preflight,
+                ),
+            mech_core::MechCode::Expression(expression) => self.preflight_expression_context_reads(
+                context,
+                registry,
+                expression,
+                addressed_read_preflight,
+            ),
+            mech_core::MechCode::FsmImplementation(fsm) => self
+                .preflight_fsm_implementation_context_capabilities(
+                    context,
+                    registry,
+                    fsm,
+                    addressed_read_preflight,
+                ),
+            mech_core::MechCode::FunctionDefine(function) => self
+                .preflight_function_define_context_capabilities(
+                    context,
+                    registry,
+                    function,
+                    addressed_read_preflight,
+                ),
+            mech_core::MechCode::Import(_)
+            | mech_core::MechCode::Comment(_)
+            | mech_core::MechCode::FsmSpecification(_)
+            | mech_core::MechCode::Error(_, _) => Ok(()),
+        }
     }
-    for arm in &function.match_arms {
-      self.preflight_pattern_context_reads(context, registry, &arm.pattern, addressed_read_preflight)?;
-      self.preflight_expression_context_reads(context, registry, &arm.expression, addressed_read_preflight)?;
-    }
-    Ok(())
-  }
 
-  fn reject_function_context_read(
+    fn preflight_function_define_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        function: &mech_core::FunctionDefine,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        for statement in &function.statements {
+            self.reject_runtime_context_reads_in_statement(registry, statement)?;
+        }
+        for arm in &function.match_arms {
+            self.reject_runtime_context_reads_in_pattern(registry, &arm.pattern)?;
+            self.reject_runtime_context_reads_in_expression(registry, &arm.expression)?;
+        }
+
+        for statement in &function.statements {
+            self.preflight_statement_context_capabilities(
+                context,
+                registry,
+                statement,
+                DirectContextEffectPlacement::FunctionBody,
+                addressed_read_preflight,
+            )?;
+        }
+        for arm in &function.match_arms {
+            self.preflight_pattern_context_reads(
+                context,
+                registry,
+                &arm.pattern,
+                addressed_read_preflight,
+            )?;
+            self.preflight_expression_context_reads(
+                context,
+                registry,
+                &arm.expression,
+                addressed_read_preflight,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn reject_function_context_read(
         &self,
         context_name: &mech_core::Identifier,
         path: &mech_core::Identifier,
@@ -1906,2283 +2689,2887 @@ impl MechRuntime {
     }
 
     fn preflight_fsm_implementation_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    fsm: &mech_core::FsmImplementation,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    self.preflight_pattern_context_reads(context, registry, &fsm.start, addressed_read_preflight)?;
-    for arm in &fsm.arms {
-      match arm {
-        mech_core::FsmArm::Guard(pattern, guards) => {
-          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-          for guard in guards {
-            self.preflight_pattern_context_reads(context, registry, &guard.condition, addressed_read_preflight)?;
-            for transition in &guard.transitions {
-              self.preflight_transition_context_capabilities(context, registry, transition, addressed_read_preflight)?;
-            }
-          }
-        }
-        mech_core::FsmArm::Transition(pattern, transitions) => {
-          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-          for transition in transitions {
-            self.preflight_transition_context_capabilities(context, registry, transition, addressed_read_preflight)?;
-          }
-        }
-        mech_core::FsmArm::Comment(_) => {}
-      }
-    }
-    Ok(())
-  }
-
-  fn preflight_transition_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    transition: &mech_core::Transition,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match transition {
-      mech_core::Transition::Async(pattern)
-      | mech_core::Transition::Next(pattern)
-      | mech_core::Transition::Output(pattern) => {
-        self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)
-      }
-      mech_core::Transition::CodeBlock(code_items) => {
-        for (code, _) in code_items {
-          self.preflight_code_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        fsm: &mech_core::FsmImplementation,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        self.preflight_pattern_context_reads(
             context,
             registry,
-            code,
-            DirectContextEffectPlacement::FsmTransition,
+            &fsm.start,
             addressed_read_preflight,
-          )?;
+        )?;
+        for arm in &fsm.arms {
+            match arm {
+                mech_core::FsmArm::Guard(pattern, guards) => {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        pattern,
+                        addressed_read_preflight,
+                    )?;
+                    for guard in guards {
+                        self.preflight_pattern_context_reads(
+                            context,
+                            registry,
+                            &guard.condition,
+                            addressed_read_preflight,
+                        )?;
+                        for transition in &guard.transitions {
+                            self.preflight_transition_context_capabilities(
+                                context,
+                                registry,
+                                transition,
+                                addressed_read_preflight,
+                            )?;
+                        }
+                    }
+                }
+                mech_core::FsmArm::Transition(pattern, transitions) => {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        pattern,
+                        addressed_read_preflight,
+                    )?;
+                    for transition in transitions {
+                        self.preflight_transition_context_capabilities(
+                            context,
+                            registry,
+                            transition,
+                            addressed_read_preflight,
+                        )?;
+                    }
+                }
+                mech_core::FsmArm::Comment(_) => {}
+            }
         }
         Ok(())
-      }
-      mech_core::Transition::Statement(statement) => {
-        self.preflight_statement_context_capabilities(
-          context,
-          registry,
-          statement,
-          DirectContextEffectPlacement::FsmTransition,
-          addressed_read_preflight,
-        )
-      }
     }
-  }
 
-  fn preflight_pattern_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    pattern: &mech_core::Pattern,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match pattern {
-      mech_core::Pattern::Expression(expression) => {
-        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
-      }
-      mech_core::Pattern::TupleStruct(tuple_struct) => {
-        for pattern in &tuple_struct.patterns {
-          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-        }
-        Ok(())
-      }
-      mech_core::Pattern::Tuple(tuple) => {
-        for pattern in &tuple.0 {
-          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-        }
-        Ok(())
-      }
-      mech_core::Pattern::Array(array) => {
-        for pattern in &array.prefix {
-          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-        }
-        if let Some(spread) = &array.spread {
-          if let Some(binding) = &spread.binding {
-            self.preflight_pattern_context_reads(context, registry, binding, addressed_read_preflight)?;
-          }
-        }
-        for pattern in &array.suffix {
-          self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-        }
-        Ok(())
-      }
-      mech_core::Pattern::Wildcard => Ok(()),
-    }
-  }
-
-  fn preflight_statement_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    statement: &mech_core::Statement,
-    placement: DirectContextEffectPlacement,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match statement {
-      mech_core::Statement::VariableDefine(var_def) => {
-        if let Some(context_name) = &var_def.var.context {
-          return Err(MechError::new(RuntimeInvalidOperationError {
-            operation: "direct_context_define",
-            reason: format!(
-              "context-addressed path `{}` cannot be defined with `:=`; use `=` or `<-`",
-              direct_context_target(&context_name.to_string(), &var_def.var.name.to_string()),
+    fn preflight_transition_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        transition: &mech_core::Transition,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match transition {
+            mech_core::Transition::Async(pattern)
+            | mech_core::Transition::Next(pattern)
+            | mech_core::Transition::Output(pattern) => self.preflight_pattern_context_reads(
+                context,
+                registry,
+                pattern,
+                addressed_read_preflight,
             ),
-          }, None));
+            mech_core::Transition::CodeBlock(code_items) => {
+                for (code, _) in code_items {
+                    self.preflight_code_context_capabilities(
+                        context,
+                        registry,
+                        code,
+                        DirectContextEffectPlacement::FsmTransition,
+                        addressed_read_preflight,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::Transition::Statement(statement) => self
+                .preflight_statement_context_capabilities(
+                    context,
+                    registry,
+                    statement,
+                    DirectContextEffectPlacement::FsmTransition,
+                    addressed_read_preflight,
+                ),
         }
-        self.preflight_expression_context_reads(context, registry, &var_def.expression, addressed_read_preflight)
-      }
-      mech_core::Statement::VariableAssign(assign) => {
-        self.preflight_slice_ref_subscript_context_reads(context, registry, &assign.target, addressed_read_preflight)?;
-        if let Some(context_name) = &assign.target.context {
-          let context_name = context_name.to_string();
-          let path = assign.target.name.to_string();
-          self.reject_direct_context_effect_placement(
-            "assignment",
-            &context_name,
-            &path,
-            placement,
-          )?;
-          self.preflight_context_access(
+    }
+
+    fn preflight_pattern_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        pattern: &mech_core::Pattern,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match pattern {
+            mech_core::Pattern::Expression(expression) => self.preflight_expression_context_reads(
+                context,
+                registry,
+                expression,
+                addressed_read_preflight,
+            ),
+            mech_core::Pattern::TupleStruct(tuple_struct) => {
+                for pattern in &tuple_struct.patterns {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        pattern,
+                        addressed_read_preflight,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::Pattern::Tuple(tuple) => {
+                for pattern in &tuple.0 {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        pattern,
+                        addressed_read_preflight,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::Pattern::Array(array) => {
+                for pattern in &array.prefix {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        pattern,
+                        addressed_read_preflight,
+                    )?;
+                }
+                if let Some(spread) = &array.spread {
+                    if let Some(binding) = &spread.binding {
+                        self.preflight_pattern_context_reads(
+                            context,
+                            registry,
+                            binding,
+                            addressed_read_preflight,
+                        )?;
+                    }
+                }
+                for pattern in &array.suffix {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        pattern,
+                        addressed_read_preflight,
+                    )?;
+                }
+                Ok(())
+            }
+            mech_core::Pattern::Wildcard => Ok(()),
+        }
+    }
+
+    fn preflight_statement_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        statement: &mech_core::Statement,
+        placement: DirectContextEffectPlacement,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match statement {
+            mech_core::Statement::VariableDefine(var_def) => {
+                if let Some(context_name) = &var_def.var.context {
+                    return Err(MechError::new(
+                        RuntimeInvalidOperationError {
+                            operation: "direct_context_define",
+                            reason: format!(
+                                "context-addressed path `{}` cannot be defined with `:=`; use `=` or `<-`",
+                                direct_context_target(
+                                    &context_name.to_string(),
+                                    &var_def.var.name.to_string()
+                                ),
+                            ),
+                        },
+                        None,
+                    ));
+                }
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &var_def.expression,
+                    addressed_read_preflight,
+                )
+            }
+            mech_core::Statement::VariableAssign(assign) => {
+                self.preflight_slice_ref_subscript_context_reads(
+                    context,
+                    registry,
+                    &assign.target,
+                    addressed_read_preflight,
+                )?;
+                if let Some(context_name) = &assign.target.context {
+                    let context_name = context_name.to_string();
+                    let path = assign.target.name.to_string();
+                    self.reject_direct_context_effect_placement(
+                        "assignment",
+                        &context_name,
+                        &path,
+                        placement,
+                    )?;
+                    self.preflight_context_access(
+                        context,
+                        registry,
+                        &context_name,
+                        &path,
+                        RuntimeCapabilityOperation::Write,
+                        true,
+                        Some(RuntimeResourceWriteIntent::Assign),
+                    )?;
+                }
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &assign.expression,
+                    addressed_read_preflight,
+                )?;
+                Ok(())
+            }
+            mech_core::Statement::ContextSend(send) => {
+                let Some(context_name) = &send.target.context else {
+                    return Err(MechError::new(
+                        RuntimeInvalidOperationError {
+                            operation: "direct_context_send",
+                            reason: format!(
+                                "send target `{}` is not a context path",
+                                send.target.name.to_string()
+                            ),
+                        },
+                        None,
+                    ));
+                };
+
+                let context_name = context_name.to_string();
+                let path = send.target.name.to_string();
+
+                self.reject_direct_context_effect_placement(
+                    "send",
+                    &context_name,
+                    &path,
+                    placement,
+                )?;
+
+                self.preflight_context_send_access(context, registry, &context_name, &path)?;
+
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &send.expression,
+                    addressed_read_preflight,
+                )?;
+                Ok(())
+            }
+            mech_core::Statement::OpAssign(op_assign) => {
+                self.preflight_slice_ref_subscript_context_reads(
+                    context,
+                    registry,
+                    &op_assign.target,
+                    addressed_read_preflight,
+                )?;
+                if op_assign.target.context.is_some() {
+                    return Err(MechError::new(
+                        RuntimeInvalidOperationError {
+                            operation: "direct_context_op_assign",
+                            reason: "context op-assignment is not supported; use `=` or `<-`"
+                                .to_string(),
+                        },
+                        None,
+                    ));
+                }
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &op_assign.expression,
+                    addressed_read_preflight,
+                )
+            }
+            mech_core::Statement::TupleDestructure(tuple_destructure) => self
+                .preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &tuple_destructure.expression,
+                    addressed_read_preflight,
+                ),
+            #[cfg(feature = "invariant_define")]
+            mech_core::Statement::InvariantDefine(invariant) => self
+                .preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &invariant.expression,
+                    addressed_read_preflight,
+                ),
+            mech_core::Statement::FsmDeclare(fsm) => self.preflight_fsm_pipe_context_capabilities(
+                context,
+                registry,
+                &fsm.pipe,
+                addressed_read_preflight,
+            ),
+            _ => Ok(()),
+        }
+    }
+
+    fn preflight_fsm_pipe_context_capabilities(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        pipe: &mech_core::FsmPipe,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        if let Some(args) = &pipe.start.args {
+            for (_, expression) in args {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    expression,
+                    addressed_read_preflight,
+                )?;
+            }
+        }
+
+        for transition in &pipe.transitions {
+            self.preflight_transition_context_capabilities(
+                context,
+                registry,
+                transition,
+                addressed_read_preflight,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn preflight_expression_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        expression: &mech_core::Expression,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match expression {
+            mech_core::Expression::Var(var) => {
+                if let Some(context_name) = &var.context {
+                    let context_name = context_name.to_string();
+                    if registry.contains(&context_name)
+                        || addressed_read_preflight.requires_context_binding()
+                    {
+                        self.preflight_context_access(
+                            context,
+                            registry,
+                            &context_name,
+                            &var.name.to_string(),
+                            RuntimeCapabilityOperation::Read,
+                            true,
+                            None,
+                        )?;
+                    }
+                }
+            }
+            mech_core::Expression::Formula(factor) => {
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    factor,
+                    addressed_read_preflight,
+                )?;
+            }
+            mech_core::Expression::FunctionCall(call) => {
+                for (_, expression) in &call.args {
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        expression,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Expression::FsmPipe(pipe) => {
+                self.preflight_fsm_pipe_context_capabilities(
+                    context,
+                    registry,
+                    pipe,
+                    addressed_read_preflight,
+                )?;
+            }
+            mech_core::Expression::Literal(_) => {}
+            mech_core::Expression::Range(range) => {
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    &range.start,
+                    addressed_read_preflight,
+                )?;
+                if let Some((_, increment)) = &range.increment {
+                    self.preflight_factor_context_reads(
+                        context,
+                        registry,
+                        increment,
+                        addressed_read_preflight,
+                    )?;
+                }
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    &range.terminal,
+                    addressed_read_preflight,
+                )?;
+            }
+            mech_core::Expression::Structure(structure) => {
+                self.preflight_structure_context_reads(
+                    context,
+                    registry,
+                    structure,
+                    addressed_read_preflight,
+                )?;
+            }
+            mech_core::Expression::Match(match_expression) => {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &match_expression.source,
+                    addressed_read_preflight,
+                )?;
+                for arm in &match_expression.arms {
+                    self.preflight_pattern_context_reads(
+                        context,
+                        registry,
+                        &arm.pattern,
+                        addressed_read_preflight,
+                    )?;
+                    if let Some(guard) = &arm.guard {
+                        self.preflight_expression_context_reads(
+                            context,
+                            registry,
+                            guard,
+                            addressed_read_preflight,
+                        )?;
+                    }
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        &arm.expression,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Expression::Slice(slice) => {
+                if let Some(context_name) = &slice.context {
+                    let context_name = context_name.to_string();
+                    if registry.contains(&context_name) {
+                        return Err(MechError::new(
+                            RuntimeInvalidOperationError {
+                                operation: "context_read",
+                                reason: "context-addressed slices are not supported".to_string(),
+                            },
+                            None,
+                        ));
+                    }
+                    if addressed_read_preflight.requires_context_binding() {
+                        return Err(undeclared_direct_context_target_error(&context_name));
+                    }
+                }
+                self.preflight_slice_context_reads(
+                    context,
+                    registry,
+                    slice,
+                    addressed_read_preflight,
+                )?;
+            }
+            mech_core::Expression::SetComprehension(comprehension) => {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &comprehension.expression,
+                    addressed_read_preflight,
+                )?;
+                for qualifier in &comprehension.qualifiers {
+                    self.preflight_comprehension_qualifier_context_reads(
+                        context,
+                        registry,
+                        qualifier,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Expression::MatrixComprehension(comprehension) => {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &comprehension.expression,
+                    addressed_read_preflight,
+                )?;
+                for qualifier in &comprehension.qualifiers {
+                    self.preflight_comprehension_qualifier_context_reads(
+                        context,
+                        registry,
+                        qualifier,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn preflight_factor_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        factor: &mech_core::Factor,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match factor {
+            mech_core::Factor::Expression(expression) => self.preflight_expression_context_reads(
+                context,
+                registry,
+                expression,
+                addressed_read_preflight,
+            ),
+            mech_core::Factor::Negate(factor)
+            | mech_core::Factor::Not(factor)
+            | mech_core::Factor::Parenthetical(factor)
+            | mech_core::Factor::Transpose(factor) => self.preflight_factor_context_reads(
+                context,
+                registry,
+                factor,
+                addressed_read_preflight,
+            ),
+            mech_core::Factor::Term(term) => {
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    &term.lhs,
+                    addressed_read_preflight,
+                )?;
+                for (_, factor) in &term.rhs {
+                    self.preflight_factor_context_reads(
+                        context,
+                        registry,
+                        factor,
+                        addressed_read_preflight,
+                    )?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn preflight_structure_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        structure: &mech_core::Structure,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match structure {
+            mech_core::Structure::Map(map) => {
+                for mapping in &map.elements {
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        &mapping.key,
+                        addressed_read_preflight,
+                    )?;
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        &mapping.value,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Structure::Set(set) => {
+                for expression in &set.elements {
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        expression,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Structure::Matrix(matrix) => {
+                for row in &matrix.rows {
+                    for column in &row.columns {
+                        self.preflight_expression_context_reads(
+                            context,
+                            registry,
+                            &column.element,
+                            addressed_read_preflight,
+                        )?;
+                    }
+                }
+            }
+            mech_core::Structure::Record(record) => {
+                for binding in &record.bindings {
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        &binding.value,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Structure::Table(table) => {
+                for row in &table.rows {
+                    for column in &row.columns {
+                        self.preflight_expression_context_reads(
+                            context,
+                            registry,
+                            &column.element,
+                            addressed_read_preflight,
+                        )?;
+                    }
+                }
+            }
+            mech_core::Structure::Tuple(tuple) => {
+                for expression in &tuple.elements {
+                    self.preflight_expression_context_reads(
+                        context,
+                        registry,
+                        expression,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Structure::TupleStruct(tuple_struct) => {
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &tuple_struct.value,
+                    addressed_read_preflight,
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn preflight_slice_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        slice: &mech_core::Slice,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        for subscript in &slice.subscript {
+            self.preflight_subscript_context_reads(
+                context,
+                registry,
+                subscript,
+                addressed_read_preflight,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn preflight_slice_ref_subscript_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        target: &mech_core::SliceRef,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        if let Some(subscripts) = &target.subscript {
+            for subscript in subscripts {
+                self.preflight_subscript_context_reads(
+                    context,
+                    registry,
+                    subscript,
+                    addressed_read_preflight,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn preflight_subscript_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        subscript: &mech_core::Subscript,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match subscript {
+            mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
+                for subscript in subscripts {
+                    self.preflight_subscript_context_reads(
+                        context,
+                        registry,
+                        subscript,
+                        addressed_read_preflight,
+                    )?;
+                }
+            }
+            mech_core::Subscript::Formula(factor) => {
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    factor,
+                    addressed_read_preflight,
+                )?;
+            }
+            mech_core::Subscript::Range(range) => {
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    &range.start,
+                    addressed_read_preflight,
+                )?;
+                if let Some((_, increment)) = &range.increment {
+                    self.preflight_factor_context_reads(
+                        context,
+                        registry,
+                        increment,
+                        addressed_read_preflight,
+                    )?;
+                }
+                self.preflight_factor_context_reads(
+                    context,
+                    registry,
+                    &range.terminal,
+                    addressed_read_preflight,
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn preflight_comprehension_qualifier_context_reads(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        qualifier: &mech_core::ComprehensionQualifier,
+        addressed_read_preflight: AddressedReadPreflight,
+    ) -> MResult<()> {
+        match qualifier {
+            mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
+                self.preflight_pattern_context_reads(
+                    context,
+                    registry,
+                    pattern,
+                    addressed_read_preflight,
+                )?;
+                self.preflight_expression_context_reads(
+                    context,
+                    registry,
+                    expression,
+                    addressed_read_preflight,
+                )
+            }
+            mech_core::ComprehensionQualifier::Filter(expression) => self
+                .preflight_expression_context_reads(
+                    context,
+                    registry,
+                    expression,
+                    addressed_read_preflight,
+                ),
+            mech_core::ComprehensionQualifier::Let(var_def) => self
+                .preflight_expression_context_reads(
+                    context,
+                    registry,
+                    &var_def.expression,
+                    addressed_read_preflight,
+                ),
+        }
+    }
+
+    fn reject_direct_context_effect_placement(
+        &self,
+        effect: &str,
+        context_name: &str,
+        path: &str,
+        placement: DirectContextEffectPlacement,
+    ) -> MResult<()> {
+        let allowed = match effect {
+            "assignment" => matches!(placement, DirectContextEffectPlacement::TopLevel),
+            "send" => matches!(
+                placement,
+                DirectContextEffectPlacement::TopLevel
+                    | DirectContextEffectPlacement::ActivationScope
+            ),
+            _ => false,
+        };
+        if allowed {
+            return Ok(());
+        }
+
+        Err(MechError::new(
+            RuntimeInvalidOperationError {
+                operation: "direct_context_effect_placement",
+                reason: format!(
+                    "context {effect} to `{}` is only supported at module top level, not inside {}",
+                    direct_context_target(context_name, path),
+                    placement.description(),
+                ),
+            },
+            None,
+        ))
+    }
+
+    fn preflight_context_send_access(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        context_name: &str,
+        path: &str,
+    ) -> MResult<()> {
+        let Some(binding) = registry.get(context_name) else {
+            return Err(undeclared_direct_context_target_error(context_name));
+        };
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        let operation = context_send_operation(binding, &resolved.context_path)?;
+        self.preflight_context_access(
             context,
             registry,
-            &context_name,
-            &path,
-            RuntimeCapabilityOperation::Write,
+            context_name,
+            path,
+            operation,
             true,
-            Some(RuntimeResourceWriteIntent::Assign),
-          )?;
+            Some(RuntimeResourceWriteIntent::Send),
+        )
+    }
+
+    fn preflight_context_access(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        context_name: &str,
+        path: &str,
+        operation: RuntimeCapabilityOperation,
+        require_context_binding: bool,
+        write_intent: Option<RuntimeResourceWriteIntent>,
+    ) -> MResult<()> {
+        let Some(binding) = registry.get(context_name) else {
+            if require_context_binding {
+                return Err(undeclared_direct_context_target_error(context_name));
+            }
+            return Ok(());
+        };
+        let resolved = self.resolve_context_resource_request(binding, path)?;
+        let context_allowed = match operation {
+            RuntimeCapabilityOperation::Read => {
+                runtime_context_allows_read(binding, &resolved.context_path)
+            }
+            RuntimeCapabilityOperation::Write => {
+                runtime_context_allows_write(binding, &resolved.context_path)
+            }
+            _ => {
+                runtime_context_allows_operation(binding, operation.name(), &resolved.context_path)
+            }
+        };
+        if !context_allowed {
+            return Err(MechError::new(
+                RuntimeResourceCapabilityDenied {
+                    context_name: binding.name.clone(),
+                    operation: match operation {
+                        RuntimeCapabilityOperation::Read => "read".to_string(),
+                        RuntimeCapabilityOperation::Write => "write".to_string(),
+                        other => format!("{other:?}"),
+                    },
+                    path: resolved.context_path,
+                },
+                None,
+            ));
         }
-        self.preflight_expression_context_reads(context, registry, &assign.expression, addressed_read_preflight)?;
+        if !self.has_capability_grant(
+            &context.subject,
+            &resolved.provider_base_uri,
+            &operation,
+            &resolved.provider_path,
+        ) {
+            return Err(MechError::new(
+                RuntimeCapabilityGrantDenied {
+                    subject: context.subject.clone(),
+                    resource: resolved.provider_base_uri,
+                    operation,
+                    path: resolved.provider_path,
+                },
+                None,
+            ));
+        }
+
+        if let Some(intent) = write_intent {
+            self.resources
+                .preflight_write(RuntimeResourceWritePreflightRequest {
+                    base_uri: resolved.provider_base_uri,
+                    path: resolved.provider_path,
+                    context_name: binding.name.clone(),
+                    operation: operation.clone(),
+                    intent,
+                })?;
+        }
+
         Ok(())
-      }
-      mech_core::Statement::ContextSend(send) => {
-        let Some(context_name) = &send.target.context else {
-          return Err(MechError::new(RuntimeInvalidOperationError {
-            operation: "direct_context_send",
-            reason: format!("send target `{}` is not a context path", send.target.name.to_string()),
-          }, None));
+    }
+
+    fn run_tree_on_program(
+        &mut self,
+        context: &mut RuntimeContext,
+        program: &mut MechProgram,
+        tree: &mech_core::Program,
+        scope_hint: Option<&SourceScope>,
+    ) -> MResult<Value> {
+        let direct_document_run = scope_hint.is_none();
+        let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
+        let skip_non_context_imports = scope_hint.is_some();
+        let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
+        let mut result = Value::Empty;
+        let mut pending = Vec::new();
+
+        for section in &tree.body.sections {
+            for element in &section.elements {
+                match element {
+                    mech_core::SectionElement::MechCode(codes) => {
+                        let mut pending_codes = Vec::new();
+                        for (code, comment) in codes {
+                            self.push_direct_code(
+                                context,
+                                program,
+                                &registry,
+                                &mut pending,
+                                &mut pending_codes,
+                                &mut result,
+                                skip_non_context_imports,
+                                code,
+                                comment,
+                            )?;
+                        }
+                        if !pending_codes.is_empty() {
+                            pending.push(mech_core::SectionElement::MechCode(pending_codes));
+                        }
+                    }
+                    mech_core::SectionElement::FencedMechCode(fenced)
+                        if Self::executable_fence_for_scope(fenced, execution_scope) =>
+                    {
+                        let mut pending_codes = Vec::new();
+                        for (code, comment) in &fenced.code {
+                            self.push_direct_code(
+                                context,
+                                program,
+                                &registry,
+                                &mut pending,
+                                &mut pending_codes,
+                                &mut result,
+                                skip_non_context_imports,
+                                code,
+                                comment,
+                            )?;
+                        }
+                        if !pending_codes.is_empty() {
+                            let mut fenced = fenced.clone();
+                            fenced.code = pending_codes;
+                            pending.push(mech_core::SectionElement::FencedMechCode(fenced));
+                        }
+                    }
+                    mech_core::SectionElement::FencedMechCode(fenced) if direct_document_run => {
+                        pending.push(mech_core::SectionElement::FencedMechCode(fenced.clone()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        self.flush_direct_execution(program, &mut pending, &mut result)?;
+        Ok(result)
+    }
+
+    fn evaluate_expression_on_program(
+        &mut self,
+        program: &mut MechProgram,
+        expression: &mech_core::Expression,
+    ) -> MResult<Value> {
+        let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
+        program.run_tree(&single).map(resolve_runtime_value)
+    }
+
+    fn bind_persistent_send_value_on_program(
+        &mut self,
+        program: &mut MechProgram,
+        expression: mech_core::Expression,
+    ) -> MResult<ValRef> {
+        let name = format!(
+            "mech-internal-persistent-send-{}",
+            self.persistent_sends.len()
+        );
+        let id = hash_str(&name);
+        let var_def = mech_core::VariableDefine {
+            mutable: false,
+            var: mech_core::Var {
+                name: identifier_from_str(&name),
+                context: None,
+                kind: None,
+            },
+            expression,
+        };
+        let single = single_code_program(
+            mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
+            None,
+        );
+        program.run_tree(&single)?;
+        program
+            .interpreter()
+            .symbols()
+            .borrow()
+            .get(id)
+            .ok_or_else(|| {
+                MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "persistent_context_send",
+                        reason: "failed to bind persistent send expression to an output cell"
+                            .to_string(),
+                    },
+                    None,
+                )
+            })
+    }
+
+    pub fn run_string(&mut self, source: &str) -> MResult<Value> {
+        let mut context = self.runtime_context()?;
+        self.run_string_with_context(&mut context, source)
+    }
+    pub fn run_string_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+    ) -> MResult<Value> {
+        let turn_started = Instant::now();
+        self.validate_context_for_runtime(context)?;
+        let source_bytes = u64::try_from(source.as_bytes().len()).map_err(|_| {
+            MechError::new(
+                ResourceBudgetExceededError {
+                    resource: "source_bytes",
+                    used: u64::MAX,
+                    requested: 1,
+                    max: None,
+                },
+                None,
+            )
+        })?;
+        self.enforce_source_byte_count(context, source_bytes)?;
+        self.run_string_with_context_inner(context, source, turn_started)
+    }
+
+    fn run_string_with_context_inner(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+        turn_started: Instant,
+    ) -> MResult<Value> {
+        self.validate_context_for_runtime(context)?;
+        context.charge_step()?;
+        let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
+            },
+        )?;
+
+        let live_state_before = self.live_state_snapshot();
+
+        let result = match mech_syntax::parser::parse(source.trim()) {
+            Ok(tree) => {
+                match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
+                    Ok(()) => {
+                        let program_config = self.program.config.clone();
+                        let mut program =
+                            std::mem::replace(&mut self.program, MechProgram::new(program_config));
+
+                        let result = (|| {
+                            self.register_runtime_program_host_functions(context, &mut program)?;
+
+                            let runtime_ptr: *mut MechRuntime = self;
+                            let context_ptr: *mut RuntimeContext = context;
+                            let _host_guard =
+                                ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+                            self.run_tree_on_program(context, &mut program, &tree, None)
+                        })();
+
+                        self.program = program;
+                        result
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+            Err(error) => Err(error),
         };
 
-        let context_name = context_name.to_string();
-        let path = send.target.name.to_string();
+        let result = result.and_then(|value| {
+            self.enforce_turn_duration(turn_started)?;
+            Ok(value)
+        });
+        if result.is_err() {
+            self.restore_live_state(live_state_before);
+        }
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+        }
 
-        self.reject_direct_context_effect_placement(
-          "send",
-          &context_name,
-          &path,
-          placement,
+        result
+    }
+
+    /// Evaluates bytecode in an isolated temporary program. It returns the
+    /// evaluation result but does not install the decoded program, symbols,
+    /// execution plan, or live state as the runtime's persistent active program.
+    pub fn run_bytecode_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        bytecode: &[u8],
+    ) -> MResult<Value> {
+        let turn_started = Instant::now();
+        self.validate_context_for_runtime(context)?;
+        let source_bytes = u64::try_from(bytecode.len()).map_err(|_| {
+            MechError::new(
+                ResourceBudgetExceededError {
+                    resource: "source_bytes",
+                    used: u64::MAX,
+                    requested: 1,
+                    max: None,
+                },
+                None,
+            )
+        })?;
+        self.enforce_source_byte_count(context, source_bytes)?;
+        self.run_bytecode_with_context_inner(context, bytecode, turn_started)
+    }
+
+    fn run_bytecode_with_context_inner(
+        &mut self,
+        context: &mut RuntimeContext,
+        bytecode: &[u8],
+        turn_started: Instant,
+    ) -> MResult<Value> {
+        self.validate_context_for_runtime(context)?;
+        context.charge_step()?;
+        let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
+            },
         )?;
 
-        self.preflight_context_send_access(
-          context,
-          registry,
-          &context_name,
-          &path,
-        )?;
+        let program_config = self.program.config.clone();
+        let previous_program =
+            std::mem::replace(&mut self.program, MechProgram::new(program_config.clone()));
+        let mut bytecode_program = MechProgram::new(program_config);
 
-        self.preflight_expression_context_reads(context, registry, &send.expression, addressed_read_preflight)?;
-        Ok(())
-      }
-      mech_core::Statement::OpAssign(op_assign) => {
-        self.preflight_slice_ref_subscript_context_reads(context, registry, &op_assign.target, addressed_read_preflight)?;
-        if op_assign.target.context.is_some() {
-          return Err(MechError::new(RuntimeInvalidOperationError {
-            operation: "direct_context_op_assign",
-            reason: "context op-assignment is not supported; use `=` or `<-`".to_string(),
-          }, None));
-        }
-        self.preflight_expression_context_reads(context, registry, &op_assign.expression, addressed_read_preflight)
-      }
-      mech_core::Statement::TupleDestructure(tuple_destructure) => self
-        .preflight_expression_context_reads(context, registry, &tuple_destructure.expression, addressed_read_preflight),
-      #[cfg(feature = "invariant_define")]
-      mech_core::Statement::InvariantDefine(invariant) => {
-        self.preflight_expression_context_reads(context, registry, &invariant.expression, addressed_read_preflight)
-      }
-      mech_core::Statement::FsmDeclare(fsm) => {
-        self.preflight_fsm_pipe_context_capabilities(context, registry, &fsm.pipe, addressed_read_preflight)
-      }
-      _ => Ok(()),
-    }
-  }
-
-  fn preflight_fsm_pipe_context_capabilities(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    pipe: &mech_core::FsmPipe,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    if let Some(args) = &pipe.start.args {
-      for (_, expression) in args {
-        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
-      }
-    }
-
-    for transition in &pipe.transitions {
-      self.preflight_transition_context_capabilities(context, registry, transition, addressed_read_preflight)?;
-    }
-
-    Ok(())
-  }
-
-  fn preflight_expression_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    expression: &mech_core::Expression,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match expression {
-      mech_core::Expression::Var(var) => {
-        if let Some(context_name) = &var.context {
-          let context_name = context_name.to_string();
-          if registry.contains(&context_name) || addressed_read_preflight.requires_context_binding() {
-            self.preflight_context_access(
-              context,
-              registry,
-              &context_name,
-              &var.name.to_string(),
-              RuntimeCapabilityOperation::Read,
-              true,
-              None,
-            )?;
-          }
-        }
-      }
-      mech_core::Expression::Formula(factor) => {
-        self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)?;
-      }
-      mech_core::Expression::FunctionCall(call) => {
-        for (_, expression) in &call.args {
-          self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Expression::FsmPipe(pipe) => {
-        self.preflight_fsm_pipe_context_capabilities(context, registry, pipe, addressed_read_preflight)?;
-      }
-      mech_core::Expression::Literal(_) => {}
-      mech_core::Expression::Range(range) => {
-        self.preflight_factor_context_reads(context, registry, &range.start, addressed_read_preflight)?;
-        if let Some((_, increment)) = &range.increment {
-          self.preflight_factor_context_reads(context, registry, increment, addressed_read_preflight)?;
-        }
-        self.preflight_factor_context_reads(context, registry, &range.terminal, addressed_read_preflight)?;
-      }
-      mech_core::Expression::Structure(structure) => {
-        self.preflight_structure_context_reads(context, registry, structure, addressed_read_preflight)?;
-      }
-      mech_core::Expression::Match(match_expression) => {
-        self.preflight_expression_context_reads(context, registry, &match_expression.source, addressed_read_preflight)?;
-        for arm in &match_expression.arms {
-          self.preflight_pattern_context_reads(context, registry, &arm.pattern, addressed_read_preflight)?;
-          if let Some(guard) = &arm.guard {
-            self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?;
-          }
-          self.preflight_expression_context_reads(context, registry, &arm.expression, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Expression::Slice(slice) => {
-        if let Some(context_name) = &slice.context {
-          let context_name = context_name.to_string();
-          if registry.contains(&context_name) {
-            return Err(MechError::new(RuntimeInvalidOperationError {
-              operation: "context_read",
-              reason: "context-addressed slices are not supported".to_string(),
-            }, None));
-          }
-          if addressed_read_preflight.requires_context_binding() {
-            return Err(undeclared_direct_context_target_error(&context_name));
-          }
-        }
-        self.preflight_slice_context_reads(context, registry, slice, addressed_read_preflight)?;
-      }
-      mech_core::Expression::SetComprehension(comprehension) => {
-        self.preflight_expression_context_reads(context, registry, &comprehension.expression, addressed_read_preflight)?;
-        for qualifier in &comprehension.qualifiers {
-          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Expression::MatrixComprehension(comprehension) => {
-        self.preflight_expression_context_reads(context, registry, &comprehension.expression, addressed_read_preflight)?;
-        for qualifier in &comprehension.qualifiers {
-          self.preflight_comprehension_qualifier_context_reads(context, registry, qualifier, addressed_read_preflight)?;
-        }
-      }
-    }
-    Ok(())
-  }
-
-  fn preflight_factor_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match factor {
-      mech_core::Factor::Expression(expression) => {
-        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
-      }
-      mech_core::Factor::Negate(factor)
-      | mech_core::Factor::Not(factor)
-      | mech_core::Factor::Parenthetical(factor)
-      | mech_core::Factor::Transpose(factor) => {
-        self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)
-      }
-      mech_core::Factor::Term(term) => {
-        self.preflight_factor_context_reads(context, registry, &term.lhs, addressed_read_preflight)?;
-        for (_, factor) in &term.rhs {
-          self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)?;
-        }
-        Ok(())
-      }
-    }
-  }
-
-  fn preflight_structure_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    structure: &mech_core::Structure,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match structure {
-      mech_core::Structure::Map(map) => {
-        for mapping in &map.elements {
-          self.preflight_expression_context_reads(context, registry, &mapping.key, addressed_read_preflight)?;
-          self.preflight_expression_context_reads(context, registry, &mapping.value, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Structure::Set(set) => {
-        for expression in &set.elements {
-          self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Structure::Matrix(matrix) => {
-        for row in &matrix.rows {
-          for column in &row.columns {
-            self.preflight_expression_context_reads(context, registry, &column.element, addressed_read_preflight)?;
-          }
-        }
-      }
-      mech_core::Structure::Record(record) => {
-        for binding in &record.bindings {
-          self.preflight_expression_context_reads(context, registry, &binding.value, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Structure::Table(table) => {
-        for row in &table.rows {
-          for column in &row.columns {
-            self.preflight_expression_context_reads(context, registry, &column.element, addressed_read_preflight)?;
-          }
-        }
-      }
-      mech_core::Structure::Tuple(tuple) => {
-        for expression in &tuple.elements {
-          self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Structure::TupleStruct(tuple_struct) => {
-        self.preflight_expression_context_reads(context, registry, &tuple_struct.value, addressed_read_preflight)?;
-      }
-      _ => {}
-    }
-    Ok(())
-  }
-
-  fn preflight_slice_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    slice: &mech_core::Slice,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    for subscript in &slice.subscript {
-      self.preflight_subscript_context_reads(context, registry, subscript, addressed_read_preflight)?;
-    }
-    Ok(())
-  }
-
-  fn preflight_slice_ref_subscript_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    target: &mech_core::SliceRef,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    if let Some(subscripts) = &target.subscript {
-      for subscript in subscripts {
-        self.preflight_subscript_context_reads(context, registry, subscript, addressed_read_preflight)?;
-      }
-    }
-    Ok(())
-  }
-
-  fn preflight_subscript_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    subscript: &mech_core::Subscript,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match subscript {
-      mech_core::Subscript::Brace(subscripts) | mech_core::Subscript::Bracket(subscripts) => {
-        for subscript in subscripts {
-          self.preflight_subscript_context_reads(context, registry, subscript, addressed_read_preflight)?;
-        }
-      }
-      mech_core::Subscript::Formula(factor) => {
-        self.preflight_factor_context_reads(context, registry, factor, addressed_read_preflight)?;
-      }
-      mech_core::Subscript::Range(range) => {
-        self.preflight_factor_context_reads(context, registry, &range.start, addressed_read_preflight)?;
-        if let Some((_, increment)) = &range.increment {
-          self.preflight_factor_context_reads(context, registry, increment, addressed_read_preflight)?;
-        }
-        self.preflight_factor_context_reads(context, registry, &range.terminal, addressed_read_preflight)?;
-      }
-      _ => {}
-    }
-    Ok(())
-  }
-
-  fn preflight_comprehension_qualifier_context_reads(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    qualifier: &mech_core::ComprehensionQualifier,
-    addressed_read_preflight: AddressedReadPreflight,
-  ) -> MResult<()> {
-    match qualifier {
-      mech_core::ComprehensionQualifier::Generator((pattern, expression)) => {
-        self.preflight_pattern_context_reads(context, registry, pattern, addressed_read_preflight)?;
-        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
-      }
-      mech_core::ComprehensionQualifier::Filter(expression) => {
-        self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)
-      }
-      mech_core::ComprehensionQualifier::Let(var_def) => {
-        self.preflight_expression_context_reads(context, registry, &var_def.expression, addressed_read_preflight)
-      }
-    }
-  }
-
-
-  fn reject_direct_context_effect_placement(
-    &self,
-    effect: &str,
-    context_name: &str,
-    path: &str,
-    placement: DirectContextEffectPlacement,
-  ) -> MResult<()> {
-    let allowed = match effect {
-      "assignment" => matches!(placement, DirectContextEffectPlacement::TopLevel),
-      "send" => matches!(placement, DirectContextEffectPlacement::TopLevel | DirectContextEffectPlacement::ActivationScope),
-      _ => false,
-    };
-    if allowed { return Ok(()); }
-
-    Err(MechError::new(RuntimeInvalidOperationError {
-      operation: "direct_context_effect_placement",
-      reason: format!(
-        "context {effect} to `{}` is only supported at module top level, not inside {}",
-        direct_context_target(context_name, path),
-        placement.description(),
-      ),
-    }, None))
-  }
-
-  fn preflight_context_send_access(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    context_name: &str,
-    path: &str,
-  ) -> MResult<()> {
-    let Some(binding) = registry.get(context_name) else {
-      return Err(undeclared_direct_context_target_error(context_name));
-    };
-    let resolved = self.resolve_context_resource_request(binding, path)?;
-    let operation = context_send_operation(binding, &resolved.context_path)?;
-    self.preflight_context_access(
-      context,
-      registry,
-      context_name,
-      path,
-      operation,
-      true,
-      Some(RuntimeResourceWriteIntent::Send),
-    )
-  }
-
-  fn preflight_context_access(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    context_name: &str,
-    path: &str,
-    operation: RuntimeCapabilityOperation,
-    require_context_binding: bool,
-    write_intent: Option<RuntimeResourceWriteIntent>,
-  ) -> MResult<()> {
-    let Some(binding) = registry.get(context_name) else {
-      if require_context_binding {
-        return Err(undeclared_direct_context_target_error(context_name));
-      }
-      return Ok(());
-    };
-    let resolved = self.resolve_context_resource_request(binding, path)?;
-    let context_allowed = match operation {
-      RuntimeCapabilityOperation::Read => runtime_context_allows_read(binding, &resolved.context_path),
-      RuntimeCapabilityOperation::Write => runtime_context_allows_write(binding, &resolved.context_path),
-      _ => runtime_context_allows_operation(binding, operation.name(), &resolved.context_path),
-    };
-    if !context_allowed {
-      return Err(MechError::new(RuntimeResourceCapabilityDenied {
-        context_name: binding.name.clone(),
-        operation: match operation {
-          RuntimeCapabilityOperation::Read => "read".to_string(),
-          RuntimeCapabilityOperation::Write => "write".to_string(),
-          other => format!("{other:?}"),
-        },
-        path: resolved.context_path,
-      }, None));
-    }
-    if !self.has_capability_grant(
-      &context.subject,
-      &resolved.provider_base_uri,
-      &operation,
-      &resolved.provider_path,
-    ) {
-      return Err(MechError::new(
-        RuntimeCapabilityGrantDenied {
-          subject: context.subject.clone(),
-          resource: resolved.provider_base_uri,
-          operation,
-          path: resolved.provider_path,
-        },
-        None,
-      ));
-    }
-
-    if let Some(intent) = write_intent {
-      self.resources.preflight_write(RuntimeResourceWritePreflightRequest {
-        base_uri: resolved.provider_base_uri,
-        path: resolved.provider_path,
-        context_name: binding.name.clone(),
-        operation: operation.clone(),
-        intent,
-      })?;
-    }
-
-    Ok(())
-  }
-
-  fn run_tree_on_program(
-    &mut self,
-    context: &mut RuntimeContext,
-    program: &mut MechProgram,
-    tree: &mech_core::Program,
-    scope_hint: Option<&SourceScope>,
-  ) -> MResult<Value> {
-    let direct_document_run = scope_hint.is_none();
-    let execution_scope = scope_hint.unwrap_or(&SourceScope::Program);
-    let skip_non_context_imports = scope_hint.is_some();
-    let registry = self.direct_context_registry_for_scope(tree, execution_scope)?;
-    let mut result = Value::Empty;
-    let mut pending = Vec::new();
-
-    for section in &tree.body.sections {
-      for element in &section.elements {
-        match element {
-          mech_core::SectionElement::MechCode(codes) => {
-            let mut pending_codes = Vec::new();
-            for (code, comment) in codes {
-              self.push_direct_code(
-                context,
-                program,
-                &registry,
-                &mut pending,
-                &mut pending_codes,
-                &mut result,
-                skip_non_context_imports,
-                code,
-                comment,
-              )?;
-            }
-            if !pending_codes.is_empty() {
-              pending.push(mech_core::SectionElement::MechCode(pending_codes));
-            }
-          }
-          mech_core::SectionElement::FencedMechCode(fenced)
-            if Self::executable_fence_for_scope(fenced, execution_scope) =>
-          {
-            let mut pending_codes = Vec::new();
-            for (code, comment) in &fenced.code {
-              self.push_direct_code(
-                context,
-                program,
-                &registry,
-                &mut pending,
-                &mut pending_codes,
-                &mut result,
-                skip_non_context_imports,
-                code,
-                comment,
-              )?;
-            }
-            if !pending_codes.is_empty() {
-              let mut fenced = fenced.clone();
-              fenced.code = pending_codes;
-              pending.push(mech_core::SectionElement::FencedMechCode(fenced));
-            }
-          }
-          mech_core::SectionElement::FencedMechCode(fenced) if direct_document_run => {
-            pending.push(mech_core::SectionElement::FencedMechCode(fenced.clone()));
-          }
-          _ => {}
-        }
-      }
-    }
-
-    self.flush_direct_execution(program, &mut pending, &mut result)?;
-    Ok(result)
-  }
-
-  fn evaluate_expression_on_program(
-    &mut self,
-    program: &mut MechProgram,
-    expression: &mech_core::Expression,
-  ) -> MResult<Value> {
-    let single = single_code_program(mech_core::MechCode::Expression(expression.clone()), None);
-    program.run_tree(&single).map(resolve_runtime_value)
-  }
-
-  fn bind_persistent_send_value_on_program(
-    &mut self,
-    program: &mut MechProgram,
-    expression: mech_core::Expression,
-  ) -> MResult<ValRef> {
-    let name = format!("mech-internal-persistent-send-{}", self.persistent_sends.len());
-    let id = hash_str(&name);
-    let var_def = mech_core::VariableDefine {
-      mutable: false,
-      var: mech_core::Var {
-        name: identifier_from_str(&name),
-        context: None,
-        kind: None,
-      },
-      expression,
-    };
-    let single = single_code_program(
-      mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)),
-      None,
-    );
-    program.run_tree(&single)?;
-    program
-      .interpreter()
-      .symbols()
-      .borrow()
-      .get(id)
-      .ok_or_else(|| MechError::new(RuntimeInvalidOperationError {
-        operation: "persistent_context_send",
-        reason: "failed to bind persistent send expression to an output cell".to_string(),
-      }, None))
-  }
-
-  pub fn run_string(&mut self, source: &str) -> MResult<Value> {
-    let mut context = self.runtime_context()?;
-    self.run_string_with_context(&mut context, source)
-  }
-  pub fn run_string_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    source: &str,
-  ) -> MResult<Value> {
-    let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    let source_bytes = u64::try_from(source.as_bytes().len()).map_err(|_| {
-      MechError::new(
-        ResourceBudgetExceededError {
-          resource: "source_bytes",
-          used: u64::MAX,
-          requested: 1,
-          max: None,
-        },
-        None,
-      )
-    })?;
-    self.enforce_source_byte_count(context, source_bytes)?;
-    self.run_string_with_context_inner(context, source, turn_started)
-  }
-
-  fn run_string_with_context_inner(
-    &mut self,
-    context: &mut RuntimeContext,
-    source: &str,
-    turn_started: Instant,
-  ) -> MResult<Value> {
-    self.validate_context_for_runtime(context)?;
-    context.charge_step()?;
-    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    let live_state_before = self.live_state_snapshot();
-
-    let result = match mech_syntax::parser::parse(source.trim()) {
-      Ok(tree) => match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
-        Ok(()) => {
-          let program_config = self.program.config.clone();
-          let mut program = std::mem::replace(
-            &mut self.program,
-            MechProgram::new(program_config),
-          );
-
-          let result = (|| {
-            self.register_runtime_program_host_functions(
-              context,
-              &mut program,
-            )?;
+        let live_state_before = self.live_state_snapshot();
+        let result = (|| {
+            self.register_runtime_program_host_functions(context, &mut bytecode_program)?;
 
             let runtime_ptr: *mut MechRuntime = self;
             let context_ptr: *mut RuntimeContext = context;
             let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-            self.run_tree_on_program(context, &mut program, &tree, None)
-          })();
-
-          self.program = program;
-          result
-        }
-        Err(error) => Err(error),
-      },
-      Err(error) => Err(error),
-    };
-
-    let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
-    if result.is_err() {
-      self.restore_live_state(live_state_before);
-    }
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-    }
-
-    result
-  }
-
-  /// Evaluates bytecode in an isolated temporary program. It returns the
-  /// evaluation result but does not install the decoded program, symbols,
-  /// execution plan, or live state as the runtime's persistent active program.
-  pub fn run_bytecode_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    bytecode: &[u8],
-  ) -> MResult<Value> {
-    let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    let source_bytes = u64::try_from(bytecode.len()).map_err(|_| {
-      MechError::new(
-        ResourceBudgetExceededError {
-          resource: "source_bytes",
-          used: u64::MAX,
-          requested: 1,
-          max: None,
-        },
-        None,
-      )
-    })?;
-    self.enforce_source_byte_count(context, source_bytes)?;
-    self.run_bytecode_with_context_inner(context, bytecode, turn_started)
-  }
-
-  fn run_bytecode_with_context_inner(
-    &mut self,
-    context: &mut RuntimeContext,
-    bytecode: &[u8],
-    turn_started: Instant,
-  ) -> MResult<Value> {
-    self.validate_context_for_runtime(context)?;
-    context.charge_step()?;
-    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    let program_config = self.program.config.clone();
-    let previous_program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config.clone()),
-    );
-    let mut bytecode_program = MechProgram::new(program_config);
-
-    let live_state_before = self.live_state_snapshot();
-    let result = (|| {
-      self.register_runtime_program_host_functions(
-        context,
-        &mut bytecode_program,
-      )?;
-
-      let runtime_ptr: *mut MechRuntime = self;
-      let context_ptr: *mut RuntimeContext = context;
-      let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-      bytecode_program.run_bytecode(bytecode)
-    })();
-
-    let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
-
-    // Runtime bytecode execution is one-shot. Direct MechProgram
-    // bytecode loading is the persistent installation path.
-    self.program = previous_program;
-    self.restore_live_state(live_state_before);
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-    }
-
-    result
-  }
-
-  pub fn run_source_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    source: &MechSourceCode,
-  ) -> MResult<Value> {
-    let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    self.enforce_source_limits(context, source)?;
-    self.run_source_with_context_inner(context, source, turn_started)
-  }
-
-  fn run_source_with_context_inner(
-    &mut self,
-    context: &mut RuntimeContext,
-    source: &MechSourceCode,
-    turn_started: Instant,
-  ) -> MResult<Value> {
-    match source {
-      MechSourceCode::String(source) => self.run_string_with_context_inner(context, source, turn_started),
-      MechSourceCode::Tree(tree) => self.run_tree_with_context_timed(context, tree, turn_started),
-      MechSourceCode::ByteCode(bytes) => self.run_bytecode_with_context_inner(context, bytes, turn_started),
-      MechSourceCode::Program(sources) => {
-        let mut value = Value::Empty;
-        for source in sources {
-          value = self.run_source_with_context_inner(context, source, turn_started)?;
-        }
-        Ok(value)
-      }
-      unsupported => Err(MechError::new(RuntimeInvalidOperationError { operation: "run_source", reason: format!("unsupported program source: {:?}", unsupported) }, None)),
-    }
-  }
-
-  pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
-    let mut context = self.runtime_context()?;
-    self.run_tree_with_context(&mut context, tree)
-  }
-
-  pub fn run_tree_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    tree: &mech_core::Program,
-  ) -> MResult<Value> {
-    let turn_started = Instant::now();
-    self.run_tree_with_context_timed(context, tree, turn_started)
-  }
-
-  fn run_tree_with_context_timed(
-    &mut self,
-    context: &mut RuntimeContext,
-    tree: &mech_core::Program,
-    turn_started: Instant,
-  ) -> MResult<Value> {
-    self.validate_context_for_runtime(context)?;
-    context.charge_step()?;
-    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    let live_state_before = self.live_state_snapshot();
-
-    let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program) {
-      Ok(()) => {
-        let program_config = self.program.config.clone();
-        let mut program = std::mem::replace(
-          &mut self.program,
-          MechProgram::new(program_config),
-        );
-
-        let result = (|| {
-          self.register_runtime_program_host_functions(
-            context,
-            &mut program,
-          )?;
-
-          let runtime_ptr: *mut MechRuntime = self;
-          let context_ptr: *mut RuntimeContext = context;
-          let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-          self.run_tree_on_program(context, &mut program, tree, None)
+            bytecode_program.run_bytecode(bytecode)
         })();
 
-        self.program = program;
+        let result = result.and_then(|value| {
+            self.enforce_turn_duration(turn_started)?;
+            Ok(value)
+        });
+
+        // Runtime bytecode execution is one-shot. Direct MechProgram
+        // bytecode loading is the persistent installation path.
+        self.program = previous_program;
+        self.restore_live_state(live_state_before);
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+        }
+
         result
-      }
-      Err(error) => Err(error),
-    };
-
-    let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
-    if result.is_err() {
-      self.restore_live_state(live_state_before);
     }
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
+
+    pub fn run_source_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &MechSourceCode,
+    ) -> MResult<Value> {
+        let turn_started = Instant::now();
+        self.validate_context_for_runtime(context)?;
+        self.enforce_source_limits(context, source)?;
+        self.run_source_with_context_inner(context, source, turn_started)
+    }
+
+    fn run_source_with_context_inner(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &MechSourceCode,
+        turn_started: Instant,
+    ) -> MResult<Value> {
+        match source {
+            MechSourceCode::String(source) => {
+                self.run_string_with_context_inner(context, source, turn_started)
+            }
+            MechSourceCode::Tree(tree) => {
+                self.run_tree_with_context_timed(context, tree, turn_started)
+            }
+            MechSourceCode::ByteCode(bytes) => {
+                self.run_bytecode_with_context_inner(context, bytes, turn_started)
+            }
+            MechSourceCode::Program(sources) => {
+                let mut value = Value::Empty;
+                for source in sources {
+                    value = self.run_source_with_context_inner(context, source, turn_started)?;
+                }
+                Ok(value)
+            }
+            unsupported => Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_source",
+                    reason: format!("unsupported program source: {:?}", unsupported),
+                },
+                None,
+            )),
         }
-      }
-      Err(error) => {
+    }
+
+    pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<Value> {
+        let mut context = self.runtime_context()?;
+        self.run_tree_with_context(&mut context, tree)
+    }
+
+    pub fn run_tree_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        tree: &mech_core::Program,
+    ) -> MResult<Value> {
+        let turn_started = Instant::now();
+        self.run_tree_with_context_timed(context, tree, turn_started)
+    }
+
+    fn run_tree_with_context_timed(
+        &mut self,
+        context: &mut RuntimeContext,
+        tree: &mech_core::Program,
+        turn_started: Instant,
+    ) -> MResult<Value> {
+        self.validate_context_for_runtime(context)?;
+        context.charge_step()?;
+        let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+
         self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
             context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
             },
-          )?;
+        )?;
+
+        let live_state_before = self.live_state_snapshot();
+
+        let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program)
+        {
+            Ok(()) => {
+                let program_config = self.program.config.clone();
+                let mut program =
+                    std::mem::replace(&mut self.program, MechProgram::new(program_config));
+
+                let result = (|| {
+                    self.register_runtime_program_host_functions(context, &mut program)?;
+
+                    let runtime_ptr: *mut MechRuntime = self;
+                    let context_ptr: *mut RuntimeContext = context;
+                    let _host_guard =
+                        ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+                    self.run_tree_on_program(context, &mut program, tree, None)
+                })();
+
+                self.program = program;
+                result
+            }
+            Err(error) => Err(error),
+        };
+
+        let result = result.and_then(|value| {
+            self.enforce_turn_duration(turn_started)?;
+            Ok(value)
+        });
+        if result.is_err() {
+            self.restore_live_state(live_state_before);
         }
-      }
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                if let Some(started) = profile_started {
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ProgramProfiled {
+                            task_id: context.task,
+                            duration_ns: started.elapsed().as_nanos(),
+                        },
+                    )?;
+                }
+            }
+        }
+
+        result
     }
 
-    result
-  }
-
-  pub fn take_program(&mut self) -> MechProgram {
-    let program_config = self.program.config.clone();
-    std::mem::replace(&mut self.program, MechProgram::new(program_config))
-  }
-
-  pub fn out_string(&self) -> String {
-    self.program.out_string()
-  }
-
-  pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
-    self.program.has_interpreter(interpreter_id)
-  }
-
-  pub fn output_value_for_interpreter(
-    &self,
-    interpreter_id: u64,
-    output_id: u64,
-  ) -> Option<Value> {
-    self.program.output_value_for_interpreter(interpreter_id, output_id)
-  }
-
-  pub fn symbol_name_for_interpreter_output(
-    &self,
-    interpreter_id: u64,
-    output_id: u64,
-  ) -> Option<String> {
-    self.program.symbol_name_for_interpreter_output(interpreter_id, output_id)
-  }
-
-  pub fn symbol_values_for_interpreter(
-    &self,
-    interpreter_id: u64,
-    names: &[String],
-  ) -> Option<Vec<(String, Value)>> {
-    self.program.symbol_values_for_interpreter(interpreter_id, names)
-  }
-
-  pub fn root_symbol_value(&self, name: &str) -> MResult<Value> {
-    self.program.root_symbol_value(name)
-  }
-
-  pub fn root_symbol_values(&self, names: &[&str]) -> MResult<Vec<(String, Value)>> {
-    self.program.root_symbol_values(names)
-  }
-
-  pub fn bind_ans_for_interpreter(
-    &mut self,
-    interpreter_id: u64,
-    value: &Value,
-  ) -> MResult<()> {
-    if self.program.bind_ans_for_interpreter(interpreter_id, value) {
-      return Ok(());
+    pub fn take_program(&mut self) -> MechProgram {
+        let program_config = self.program.config.clone();
+        std::mem::replace(&mut self.program, MechProgram::new(program_config))
     }
 
-    Err(MechError::new(
-      RuntimeInvalidOperationError {
-        operation: "bind_ans_for_interpreter",
-        reason: format!("interpreter id {} not found", interpreter_id),
-      },
-      None,
-    ))
-  }
-
-  #[cfg(feature = "functions")]
-  pub fn step(&mut self, count: u64) -> MResult<()> {
-    let mut context = self.runtime_context()?;
-    self.step_with_context(&mut context, count)
-  }
-
-  #[cfg(feature = "functions")]
-  pub fn step_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    count: u64,
-  ) -> MResult<()> {
-    let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    context.charge_step()?;
-
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
-
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-    let result = program.step(count);
-
-    self.program = program;
-    result?;
-    self.enforce_turn_duration(turn_started)
-  }
-
-  pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
-    let mut context = self.runtime_context()?
-      .with_module_version(version);
-
-    self.run_module_with_context(&mut context, version)
-  }
-
-  pub fn run_module_scope(
-    &mut self,
-    version: ModuleVersionId,
-    scope: SourceScope,
-  ) -> MResult<Value> {
-    let mut context = self.runtime_context()?
-      .with_module_version(version);
-
-    self.run_module_scope_with_context(&mut context, version, scope)
-  }
-
-  pub fn run_module_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-  ) -> MResult<Value> {
-    self.run_module_scope_with_context(context, version, SourceScope::Program)
-  }
-
-  pub fn run_module_scope_with_context(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-    scope: SourceScope,
-  ) -> MResult<Value> {
-    let turn_started = Instant::now();
-    let mut preflight_seen = HashSet::new();
-    self.preflight_module_graph_for_scope(context, version, &scope, &mut preflight_seen)?;
-
-    let mut seen = HashSet::new();
-    let mut module_instances = HashMap::new();
-
-    let instance = self.execute_module_isolated_for_scope(
-      context,
-      version,
-      &scope,
-      &mut seen,
-      &mut module_instances,
-    )?;
-
-    self.enforce_turn_duration(turn_started)?;
-    Ok(instance.result)
-  }
-
-  fn preflight_module_graph_for_scope(
-    &self,
-    context: &RuntimeContext,
-    version: ModuleVersionId,
-    scope: &SourceScope,
-    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-  ) -> MResult<()> {
-    self.validate_context_for_runtime(context)?;
-    let instance_key = (version, scope.clone());
-    if !seen.insert(instance_key) {
-      return Ok(());
+    pub fn out_string(&self) -> String {
+        self.program.out_string()
     }
 
-    let Some(record) = self.store.get_module_version(version)? else {
-      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
-    };
-    validate_module_import_edges(&record)?;
-    let Some(source) = record.source.clone() else {
-      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
-    };
-
-    let context_registry = context_registry_for_scope(&record, scope)?;
-    let scoped_source = module_source_for_scope(&source, scope)?;
-    let execution_scope = execution_scope_for_extracted_module_source(scope);
-    self.preflight_module_source(context, &context_registry, &scoped_source, &execution_scope)?;
-
-    for edge in &record.import_edges {
-      if &edge.scope != scope {
-        continue;
-      }
-
-      self.preflight_module_graph_for_scope(
-        context,
-        edge.dependency,
-        &SourceScope::Program,
-        seen,
-      )?;
+    pub fn has_interpreter(&self, interpreter_id: u64) -> bool {
+        self.program.has_interpreter(interpreter_id)
     }
 
-    let scoped_refs = record
-      .scopes
-      .iter()
-      .find(|metadata| &metadata.scope == scope)
-      .map(|metadata| metadata.address_references.as_slice())
-      .unwrap_or(&[]);
+    pub fn output_value_for_interpreter(
+        &self,
+        interpreter_id: u64,
+        output_id: u64,
+    ) -> Option<Value> {
+        self.program
+            .output_value_for_interpreter(interpreter_id, output_id)
+    }
 
-    for reference in scoped_refs {
-      match resolve_runtime_address_target(&record, scope, &context_registry, &reference.target) {
-        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
-          if !matches!(scope, SourceScope::Program) {
-            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
-          }
-          self.preflight_module_graph_for_scope(
+    pub fn symbol_name_for_interpreter_output(
+        &self,
+        interpreter_id: u64,
+        output_id: u64,
+    ) -> Option<String> {
+        self.program
+            .symbol_name_for_interpreter_output(interpreter_id, output_id)
+    }
+
+    pub fn symbol_values_for_interpreter(
+        &self,
+        interpreter_id: u64,
+        names: &[String],
+    ) -> Option<Vec<(String, Value)>> {
+        self.program
+            .symbol_values_for_interpreter(interpreter_id, names)
+    }
+
+    pub fn root_symbol_value(&self, name: &str) -> MResult<Value> {
+        self.program.root_symbol_value(name)
+    }
+
+    pub fn root_symbol_values(&self, names: &[&str]) -> MResult<Vec<(String, Value)>> {
+        self.program.root_symbol_values(names)
+    }
+
+    pub fn bind_ans_for_interpreter(&mut self, interpreter_id: u64, value: &Value) -> MResult<()> {
+        if self.program.bind_ans_for_interpreter(interpreter_id, value) {
+            return Ok(());
+        }
+
+        Err(MechError::new(
+            RuntimeInvalidOperationError {
+                operation: "bind_ans_for_interpreter",
+                reason: format!("interpreter id {} not found", interpreter_id),
+            },
+            None,
+        ))
+    }
+
+    #[cfg(feature = "functions")]
+    pub fn step(&mut self, count: u64) -> MResult<()> {
+        let mut context = self.runtime_context()?;
+        self.step_with_context(&mut context, count)
+    }
+
+    #[cfg(feature = "functions")]
+    pub fn step_with_context(&mut self, context: &mut RuntimeContext, count: u64) -> MResult<()> {
+        let turn_started = Instant::now();
+        self.validate_context_for_runtime(context)?;
+        context.charge_step()?;
+
+        let program_config = self.program.config.clone();
+        let mut program = std::mem::replace(&mut self.program, MechProgram::new(program_config));
+
+        let runtime_ptr: *mut MechRuntime = self;
+        let context_ptr: *mut RuntimeContext = context;
+        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+        let result = program.step(count);
+
+        self.program = program;
+        result?;
+        self.enforce_turn_duration(turn_started)
+    }
+
+    pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
+        let mut context = self.runtime_context()?.with_module_version(version);
+
+        self.run_module_with_context(&mut context, version)
+    }
+
+    pub fn run_module_scope(
+        &mut self,
+        version: ModuleVersionId,
+        scope: SourceScope,
+    ) -> MResult<Value> {
+        let mut context = self.runtime_context()?.with_module_version(version);
+
+        self.run_module_scope_with_context(&mut context, version, scope)
+    }
+
+    pub fn run_module_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+    ) -> MResult<Value> {
+        self.run_module_scope_with_context(context, version, SourceScope::Program)
+    }
+
+    pub fn run_module_scope_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+        scope: SourceScope,
+    ) -> MResult<Value> {
+        let turn_started = Instant::now();
+        let mut preflight_seen = HashSet::new();
+        self.preflight_module_graph_for_scope(context, version, &scope, &mut preflight_seen)?;
+
+        let mut seen = HashSet::new();
+        let mut module_instances = HashMap::new();
+
+        let instance = self.execute_module_isolated_for_scope(
             context,
             version,
-            &interpreter_scope,
-            seen,
-          )?;
-        }
-        RuntimeAddressTarget::Context(_) => {}
-        RuntimeAddressTarget::Unknown => {
-          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
-        }
-      }
+            &scope,
+            &mut seen,
+            &mut module_instances,
+        )?;
+
+        self.enforce_turn_duration(turn_started)?;
+        Ok(instance.result)
     }
 
-    Ok(())
-  }
-
-  fn preflight_module_source(
-    &self,
-    context: &RuntimeContext,
-    registry: &RuntimeContextRegistry,
-    source: &MechSourceCode,
-    scope: &SourceScope,
-  ) -> MResult<()> {
-    match source {
-      MechSourceCode::String(source) => {
-        let tree = mech_syntax::parser::parse(source.trim())?;
-        self.preflight_context_capabilities_with_registry(context, registry, &tree, scope, AddressedReadPreflight::AllowModuleAddressTargets)
-      }
-      MechSourceCode::Tree(tree) => {
-        self.preflight_context_capabilities_with_registry(context, registry, tree, scope, AddressedReadPreflight::AllowModuleAddressTargets)
-      }
-      MechSourceCode::Program(sources) => {
-        for source in sources {
-          self.preflight_module_source(context, registry, source, scope)?;
+    fn preflight_module_graph_for_scope(
+        &self,
+        context: &RuntimeContext,
+        version: ModuleVersionId,
+        scope: &SourceScope,
+        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    ) -> MResult<()> {
+        self.validate_context_for_runtime(context)?;
+        let instance_key = (version, scope.clone());
+        if !seen.insert(instance_key) {
+            return Ok(());
         }
+
+        let Some(record) = self.store.get_module_version(version)? else {
+            return Err(MechError::new(
+                RuntimeRecordNotFoundError {
+                    record_type: "module_version",
+                    id: version.to_string(),
+                },
+                None,
+            ));
+        };
+        validate_module_import_edges(&record)?;
+        let Some(source) = record.source.clone() else {
+            return Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_module",
+                    reason: "module version has no source".to_string(),
+                },
+                None,
+            ));
+        };
+
+        let context_registry = context_registry_for_scope(&record, scope)?;
+        let scoped_source = module_source_for_scope(&source, scope)?;
+        let execution_scope = execution_scope_for_extracted_module_source(scope);
+        self.preflight_module_source(context, &context_registry, &scoped_source, &execution_scope)?;
+
+        for edge in &record.import_edges {
+            if &edge.scope != scope {
+                continue;
+            }
+
+            self.preflight_module_graph_for_scope(
+                context,
+                edge.dependency,
+                &SourceScope::Program,
+                seen,
+            )?;
+        }
+
+        let scoped_refs = record
+            .scopes
+            .iter()
+            .find(|metadata| &metadata.scope == scope)
+            .map(|metadata| metadata.address_references.as_slice())
+            .unwrap_or(&[]);
+
+        for reference in scoped_refs {
+            match resolve_runtime_address_target(
+                &record,
+                scope,
+                &context_registry,
+                &reference.target,
+            ) {
+                RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+                    if !matches!(scope, SourceScope::Program) {
+                        return Err(MechError::new(
+                            UnknownAddressTarget {
+                                target: reference.target.clone(),
+                            },
+                            None,
+                        ));
+                    }
+                    self.preflight_module_graph_for_scope(
+                        context,
+                        version,
+                        &interpreter_scope,
+                        seen,
+                    )?;
+                }
+                RuntimeAddressTarget::Context(_) => {}
+                RuntimeAddressTarget::Unknown => {
+                    return Err(MechError::new(
+                        UnknownAddressTarget {
+                            target: reference.target.clone(),
+                        },
+                        None,
+                    ));
+                }
+            }
+        }
+
         Ok(())
-      }
-      MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => Ok(()),
-      MechSourceCode::Image(_, _) => Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "run_module_preflight",
-        reason: "unsupported executable source kind for provider preflight: image".to_string(),
-      }, None)),
-    }
-  }
-
-  fn execute_module_isolated_for_scope(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-    scope: &SourceScope,
-    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<ModuleInstance> {
-    self.validate_context_for_runtime(context)?;
-    context.charge_step()?;
-
-    let instance_key = (version, scope.clone());
-
-    if let Some(instance) = module_instances.get(&instance_key).cloned() {
-      return Ok(instance);
     }
 
-    if seen.contains(&instance_key) {
-      return Ok(ModuleInstance { version, exports: HashMap::new(), result: Value::Empty });
-    }
-    seen.insert(instance_key.clone());
-
-    let Some(record) = self.store.get_module_version(version)? else {
-      return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
-    };
-    validate_module_import_edges(&record)?;
-    let Some(source) = record.source.clone() else {
-      return Err(MechError::new(RuntimeInvalidOperationError { operation: "run_module", reason: "module version has no source".to_string() }, None));
-    };
-
-    let context_registry = context_registry_for_scope(&record, scope)?;
-
-    for edge in &record.import_edges {
-      if &edge.scope != scope {
-        continue;
-      }
-
-      self.execute_module_isolated_for_scope(
-        context,
-        edge.dependency,
-        &SourceScope::Program,
-        seen,
-        module_instances,
-      )?;
-    }
-
-    let mut import_environment = self.build_import_environment_for_scope(
-      context,
-      &record,
-      scope,
-      module_instances,
-    )?;
-
-    let address_environment = self.build_address_environment_for_scope(
-      context,
-      version,
-      &record,
-      scope,
-      &context_registry,
-      seen,
-      module_instances,
-    )?;
-    import_environment.extend(address_environment);
-    let mut module_program = MechProgram::new(MechProgramConfig {
-      name: self.config.name.clone(),
-      environment: MechProgramEnvironment {
-        trace_enabled: self.config.diagnostics.trace_enabled,
-        debug_enabled: self.config.diagnostics.debug_enabled,
-        profile_enabled: self.config.diagnostics.profile_enabled,
-        rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
-      },
-    });
-
-    {
-      let symbols = module_program.interpreter_mut().symbols();
-      let mut symbols_brrw = symbols.borrow_mut();
-      for (name, value_ref) in import_environment {
-        let id = hash_str(&name);
-        symbols_brrw.symbols.insert(id, value_ref);
-        symbols_brrw.dictionary.borrow_mut().insert(id, name);
-      }
+    fn preflight_module_source(
+        &self,
+        context: &RuntimeContext,
+        registry: &RuntimeContextRegistry,
+        source: &MechSourceCode,
+        scope: &SourceScope,
+    ) -> MResult<()> {
+        match source {
+            MechSourceCode::String(source) => {
+                let tree = mech_syntax::parser::parse(source.trim())?;
+                self.preflight_context_capabilities_with_registry(
+                    context,
+                    registry,
+                    &tree,
+                    scope,
+                    AddressedReadPreflight::AllowModuleAddressTargets,
+                )
+            }
+            MechSourceCode::Tree(tree) => self.preflight_context_capabilities_with_registry(
+                context,
+                registry,
+                tree,
+                scope,
+                AddressedReadPreflight::AllowModuleAddressTargets,
+            ),
+            MechSourceCode::Program(sources) => {
+                for source in sources {
+                    self.preflight_module_source(context, registry, source, scope)?;
+                }
+                Ok(())
+            }
+            MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => Ok(()),
+            MechSourceCode::Image(_, _) => Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_module_preflight",
+                    reason: "unsupported executable source kind for provider preflight: image"
+                        .to_string(),
+                },
+                None,
+            )),
+        }
     }
 
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ModuleExecutionStarted { module_version: version },
-    )?;
-    let scoped_source = module_source_for_scope(&source, scope)?;
-    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
-    let result = match result {
-      Ok(value) => value,
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ModuleExecutionFailed {
-            module_version: version,
-            message: format!("{:?}", error),
-          },
-        )?;
-        return Err(error);
-      }
-    };
-    let mut exports = HashMap::new();
-    {
-      let symbols = module_program.interpreter_mut().symbols();
-      let symbols_brrw = symbols.borrow();
-      for export in exports_for_scope(&record, scope) {
-        let id = hash_str(&export.name);
-        let Some(value_ref) = symbols_brrw.get(id) else {
-          let error = MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: export.name.clone() }, None);
-          self.emit_event_to_context(
+    fn execute_module_isolated_for_scope(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+        scope: &SourceScope,
+        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    ) -> MResult<ModuleInstance> {
+        self.validate_context_for_runtime(context)?;
+        context.charge_step()?;
+
+        let instance_key = (version, scope.clone());
+
+        if let Some(instance) = module_instances.get(&instance_key).cloned() {
+            return Ok(instance);
+        }
+
+        if seen.contains(&instance_key) {
+            return Ok(ModuleInstance {
+                version,
+                exports: HashMap::new(),
+                result: Value::Empty,
+            });
+        }
+        seen.insert(instance_key.clone());
+
+        let Some(record) = self.store.get_module_version(version)? else {
+            return Err(MechError::new(
+                RuntimeRecordNotFoundError {
+                    record_type: "module_version",
+                    id: version.to_string(),
+                },
+                None,
+            ));
+        };
+        validate_module_import_edges(&record)?;
+        let Some(source) = record.source.clone() else {
+            return Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_module",
+                    reason: "module version has no source".to_string(),
+                },
+                None,
+            ));
+        };
+
+        let context_registry = context_registry_for_scope(&record, scope)?;
+
+        for edge in &record.import_edges {
+            if &edge.scope != scope {
+                continue;
+            }
+
+            self.execute_module_isolated_for_scope(
+                context,
+                edge.dependency,
+                &SourceScope::Program,
+                seen,
+                module_instances,
+            )?;
+        }
+
+        let mut import_environment =
+            self.build_import_environment_for_scope(context, &record, scope, module_instances)?;
+
+        let address_environment = self.build_address_environment_for_scope(
             context,
-            RuntimeEventKind::ModuleExecutionFailed {
-              module_version: version,
-              message: format!("{:?}", error),
+            version,
+            &record,
+            scope,
+            &context_registry,
+            seen,
+            module_instances,
+        )?;
+        import_environment.extend(address_environment);
+        let mut module_program = MechProgram::new(MechProgramConfig {
+            name: self.config.name.clone(),
+            environment: MechProgramEnvironment {
+                trace_enabled: self.config.diagnostics.trace_enabled,
+                debug_enabled: self.config.diagnostics.debug_enabled,
+                profile_enabled: self.config.diagnostics.profile_enabled,
+                rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
             },
-          )?;
-          return Err(error);
-        };
-        exports.insert(export.name.clone(), value_ref.clone());
-      }
-    }
+        });
 
-    let instance = ModuleInstance { version, exports, result };
-    module_instances.insert(instance_key, instance.clone());
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ModuleExecutionCompleted { module_version: version },
-    )?;
-    Ok(instance)
-  }
+        {
+            let symbols = module_program.interpreter_mut().symbols();
+            let mut symbols_brrw = symbols.borrow_mut();
+            for (name, value_ref) in import_environment {
+                let id = hash_str(&name);
+                symbols_brrw.symbols.insert(id, value_ref);
+                symbols_brrw.dictionary.borrow_mut().insert(id, name);
+            }
+        }
 
-  fn run_module_source_on_program(
-    &mut self,
-    context: &mut RuntimeContext,
-    program: &mut MechProgram,
-    source: &MechSourceCode,
-    scope: &SourceScope,
-  ) -> MResult<Value> {
-    self.register_runtime_program_host_functions(context, program)?;
-
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-    self.emit_event_to_context(
-      context,
-      RuntimeEventKind::ProgramStarted {
-        task_id: context.task,
-      },
-    )?;
-
-    // Named interpreter scopes are extracted to bare source by module_source_for_scope.
-    // Once extracted, their declarations are indexed as SourceScope::Program in the
-    // reparsed tree, so direct context handling must use Program scope for that tree.
-    // The surrounding module execution still uses the original scope for imports,
-    // exports, address environment, and ModuleInstance identity.
-    let execution_scope = execution_scope_for_extracted_module_source(scope);
-
-    let result = self.with_live_registration_mode(crate::runtime::LiveRegistrationMode::IsolatedSnapshot, |runtime| {
-      match source {
-      MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
-        Ok(tree) => {
-          let registry = runtime.direct_context_registry_for_scope(&tree, &execution_scope)?;
-          match runtime.preflight_context_capabilities_with_registry(
+        self.emit_event_to_context(
             context,
-            &registry,
-            &tree,
-            &execution_scope,
-            AddressedReadPreflight::AllowModuleAddressTargets,
-          ) {
-            Ok(()) => runtime.run_tree_on_program(context, program, &tree, Some(&execution_scope)),
-            Err(error) => Err(error),
-          }
-        },
-        Err(error) => Err(error),
-      },
-      MechSourceCode::Tree(tree) => {
-        let registry = runtime.direct_context_registry_for_scope(tree, &execution_scope)?;
-        match runtime.preflight_context_capabilities_with_registry(
-          context,
-          &registry,
-          tree,
-          &execution_scope,
-          AddressedReadPreflight::AllowModuleAddressTargets,
-        ) {
-          Ok(()) => runtime.run_tree_on_program(context, program, tree, Some(&execution_scope)),
-          Err(error) => Err(error),
-        }
-      },
-      MechSourceCode::Program(sources) => {
-        let mut result = Ok(Value::Empty);
-        for source in sources {
-          result = runtime.run_module_source_on_program(context, program, source, scope);
-          if result.is_err() {
-            break;
-          }
-        }
-        result
-      }
-      MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => program.run_source(source),
-      MechSourceCode::Image(_, _) => Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "run_module_preflight",
-        reason: "unsupported executable source kind for provider preflight: image".to_string(),
-      }, None)),
-      }
-    });
-
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
+            RuntimeEventKind::ModuleExecutionStarted {
+                module_version: version,
+            },
         )?;
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-      }
-    }
-
-    result
-  }
-
-  fn build_address_environment_for_scope(
-    &mut self,
-    context: &mut RuntimeContext,
-    version: ModuleVersionId,
-    record: &ModuleVersionRecord,
-    scope: &SourceScope,
-    context_registry: &RuntimeContextRegistry,
-    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
-    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<HashMap<String, mech_core::ValRef>> {
-    fn address_binding_key(target: &str, name: &str) -> String {
-      format!("@{target}/{name}")
-    }
-
-    let scoped_refs = record
-      .scopes
-      .iter()
-      .find(|metadata| &metadata.scope == scope)
-      .map(|metadata| metadata.address_references.as_slice())
-      .unwrap_or(&[]);
-
-    let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> = HashMap::new();
-    let mut bindings = HashMap::new();
-    for reference in scoped_refs {
-      match resolve_runtime_address_target(record, scope, context_registry, &reference.target) {
-        RuntimeAddressTarget::Interpreter(interpreter_scope) => {
-          if !matches!(scope, SourceScope::Program) {
-            return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
-          }
-          requested_by_scope.entry(interpreter_scope).or_default().push(reference.clone());
-        }
-        RuntimeAddressTarget::Context(_) => {
-          // Context-addressed resource reads are resolved while executing source
-          // statements so reads observe earlier writes in the same module scope.
-        }
-        RuntimeAddressTarget::Unknown => {
-          return Err(MechError::new(UnknownAddressTarget { target: reference.target.clone() }, None));
-        }
-      }
-    }
-
-    for (interpreter_scope, requested_refs) in requested_by_scope {
-      let instance = self.execute_module_isolated_for_scope(
-        context,
-        version,
-        &interpreter_scope,
-        seen,
-        module_instances,
-      )?;
-
-      for reference in requested_refs {
-        let Some(export_value) = instance.exports.get(&reference.name) else {
-          return Err(MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: reference.name.clone() }, None));
+        let scoped_source = module_source_for_scope(&source, scope)?;
+        let result =
+            self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
+        let result = match result {
+            Ok(value) => value,
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ModuleExecutionFailed {
+                        module_version: version,
+                        message: format!("{:?}", error),
+                    },
+                )?;
+                return Err(error);
+            }
         };
-        bindings.insert(address_binding_key(&reference.target, &reference.name), export_value.clone());
-      }
+        let mut exports = HashMap::new();
+        {
+            let symbols = module_program.interpreter_mut().symbols();
+            let symbols_brrw = symbols.borrow();
+            for export in exports_for_scope(&record, scope) {
+                let id = hash_str(&export.name);
+                let Some(value_ref) = symbols_brrw.get(id) else {
+                    let error = MechError::new(
+                        RuntimeModuleExportNotFound {
+                            dependency: record.id.to_string(),
+                            export: export.name.clone(),
+                        },
+                        None,
+                    );
+                    self.emit_event_to_context(
+                        context,
+                        RuntimeEventKind::ModuleExecutionFailed {
+                            module_version: version,
+                            message: format!("{:?}", error),
+                        },
+                    )?;
+                    return Err(error);
+                };
+                exports.insert(export.name.clone(), value_ref.clone());
+            }
+        }
+
+        let instance = ModuleInstance {
+            version,
+            exports,
+            result,
+        };
+        module_instances.insert(instance_key, instance.clone());
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ModuleExecutionCompleted {
+                module_version: version,
+            },
+        )?;
+        Ok(instance)
     }
 
-    Ok(bindings)
-  }
+    fn run_module_source_on_program(
+        &mut self,
+        context: &mut RuntimeContext,
+        program: &mut MechProgram,
+        source: &MechSourceCode,
+        scope: &SourceScope,
+    ) -> MResult<Value> {
+        self.register_runtime_program_host_functions(context, program)?;
 
-  fn build_import_environment_for_scope(
-    &mut self,
-    context: &mut RuntimeContext,
-    importer: &ModuleVersionRecord,
-    scope: &SourceScope,
-    module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<HashMap<String, mech_core::ValRef>> {
-    let mut bindings = HashMap::new();
-    let mut ownership: HashMap<String, String> = HashMap::new();
+        let runtime_ptr: *mut MechRuntime = self;
+        let context_ptr: *mut RuntimeContext = context;
+        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
 
-    for edge in &importer.import_edges {
-      if &edge.scope != scope {
-        continue;
-      }
+        self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ProgramStarted {
+                task_id: context.task,
+            },
+        )?;
 
-      let import = &edge.import;
-      let dependency = edge.dependency;
+        // Named interpreter scopes are extracted to bare source by module_source_for_scope.
+        // Once extracted, their declarations are indexed as SourceScope::Program in the
+        // reparsed tree, so direct context handling must use Program scope for that tree.
+        // The surrounding module execution still uses the original scope for imports,
+        // exports, address environment, and ModuleInstance identity.
+        let execution_scope = execution_scope_for_extracted_module_source(scope);
 
-      let dependency_key = (dependency, SourceScope::Program);
-      let Some(dependency_instance) = module_instances.get(&dependency_key) else {
-        return Err(MechError::new(RuntimeInvalidOperationError { operation: "build_import_environment", reason: format!("dependency instance missing for {}", dependency) }, None));
-      };
+        let result = self.with_live_registration_mode(
+            crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+            |runtime| match source {
+                MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
+                    Ok(tree) => {
+                        let registry =
+                            runtime.direct_context_registry_for_scope(&tree, &execution_scope)?;
+                        match runtime.preflight_context_capabilities_with_registry(
+                            context,
+                            &registry,
+                            &tree,
+                            &execution_scope,
+                            AddressedReadPreflight::AllowModuleAddressTargets,
+                        ) {
+                            Ok(()) => runtime.run_tree_on_program(
+                                context,
+                                program,
+                                &tree,
+                                Some(&execution_scope),
+                            ),
+                            Err(error) => Err(error),
+                        }
+                    }
+                    Err(error) => Err(error),
+                },
+                MechSourceCode::Tree(tree) => {
+                    let registry =
+                        runtime.direct_context_registry_for_scope(tree, &execution_scope)?;
+                    match runtime.preflight_context_capabilities_with_registry(
+                        context,
+                        &registry,
+                        tree,
+                        &execution_scope,
+                        AddressedReadPreflight::AllowModuleAddressTargets,
+                    ) {
+                        Ok(()) => runtime.run_tree_on_program(
+                            context,
+                            program,
+                            tree,
+                            Some(&execution_scope),
+                        ),
+                        Err(error) => Err(error),
+                    }
+                }
+                MechSourceCode::Program(sources) => {
+                    let mut result = Ok(Value::Empty);
+                    for source in sources {
+                        result =
+                            runtime.run_module_source_on_program(context, program, source, scope);
+                        if result.is_err() {
+                            break;
+                        }
+                    }
+                    result
+                }
+                MechSourceCode::Html(_) | MechSourceCode::ByteCode(_) => program.run_source(source),
+                MechSourceCode::Image(_, _) => Err(MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "run_module_preflight",
+                        reason: "unsupported executable source kind for provider preflight: image"
+                            .to_string(),
+                    },
+                    None,
+                )),
+            },
+        );
 
-      match &import.kind {
-        SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
-          let Some(namespace) = module_namespace_for_import(import) else { continue; };
-          for (export_name, export_value) in &dependency_instance.exports {
-            let binding = format!("{}/{}", namespace, export_name);
-            if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
-              return Err(MechError::new(RuntimeModuleImportConflict { binding, first_import: first, second_import: import.specifier.clone() }, None));
+        match &result {
+            Ok(_) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramCompleted {
+                        task_id: context.task,
+                    },
+                )?;
             }
-            bindings.insert(format!("{}/{}", namespace, export_name), export_value.clone());
-          }
-        }
-        SourceImportKind::Single { name } => {
-          if matches!(import.alias, Some(crate::resolver::SourceImportAlias::Context(_))) {
-            continue;
-          }
-          let Some(export_value) = dependency_instance.exports.get(name) else {
-            return Err(MechError::new(RuntimeModuleExportNotFound { dependency: import.specifier.clone(), export: name.clone() }, None));
-          };
-
-          let binding = match &import.alias {
-            Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
-            Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
-            None => name.clone(),
-          };
-
-          if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone()) {
-            return Err(MechError::new(RuntimeModuleImportConflict { binding: binding.clone(), first_import: first, second_import: import.specifier.clone() }, None));
-          }
-          bindings.insert(binding, export_value.clone());
-        }
-        SourceImportKind::Wildcard => {
-          for (export_name, export_value) in &dependency_instance.exports {
-            if let Some(first) = ownership.insert(export_name.clone(), import.specifier.clone()) {
-              return Err(MechError::new(RuntimeModuleImportConflict { binding: export_name.clone(), first_import: first, second_import: import.specifier.clone() }, None));
+            Err(error) => {
+                self.emit_event_to_context(
+                    context,
+                    RuntimeEventKind::ProgramFailed {
+                        task_id: context.task,
+                        message: format!("{:?}", error),
+                    },
+                )?;
             }
-            bindings.insert(export_name.clone(), export_value.clone());
-          }
         }
-      }
 
-      self.emit_event_to_context(
-        context,
-        RuntimeEventKind::ModuleImportLinked {
-          importer: importer.id,
-          dependency,
-          specifier: import.specifier.clone(),
-        },
-      )?;
+        result
     }
 
-    Ok(bindings)
-  }
+    fn build_address_environment_for_scope(
+        &mut self,
+        context: &mut RuntimeContext,
+        version: ModuleVersionId,
+        record: &ModuleVersionRecord,
+        scope: &SourceScope,
+        context_registry: &RuntimeContextRegistry,
+        seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+        module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    ) -> MResult<HashMap<String, mech_core::ValRef>> {
+        fn address_binding_key(target: &str, name: &str) -> String {
+            format!("@{target}/{name}")
+        }
+
+        let scoped_refs = record
+            .scopes
+            .iter()
+            .find(|metadata| &metadata.scope == scope)
+            .map(|metadata| metadata.address_references.as_slice())
+            .unwrap_or(&[]);
+
+        let mut requested_by_scope: HashMap<SourceScope, Vec<SourceAddressReference>> =
+            HashMap::new();
+        let mut bindings = HashMap::new();
+        for reference in scoped_refs {
+            match resolve_runtime_address_target(record, scope, context_registry, &reference.target)
+            {
+                RuntimeAddressTarget::Interpreter(interpreter_scope) => {
+                    if !matches!(scope, SourceScope::Program) {
+                        return Err(MechError::new(
+                            UnknownAddressTarget {
+                                target: reference.target.clone(),
+                            },
+                            None,
+                        ));
+                    }
+                    requested_by_scope
+                        .entry(interpreter_scope)
+                        .or_default()
+                        .push(reference.clone());
+                }
+                RuntimeAddressTarget::Context(_) => {
+                    // Context-addressed resource reads are resolved while executing source
+                    // statements so reads observe earlier writes in the same module scope.
+                }
+                RuntimeAddressTarget::Unknown => {
+                    return Err(MechError::new(
+                        UnknownAddressTarget {
+                            target: reference.target.clone(),
+                        },
+                        None,
+                    ));
+                }
+            }
+        }
+
+        for (interpreter_scope, requested_refs) in requested_by_scope {
+            let instance = self.execute_module_isolated_for_scope(
+                context,
+                version,
+                &interpreter_scope,
+                seen,
+                module_instances,
+            )?;
+
+            for reference in requested_refs {
+                let Some(export_value) = instance.exports.get(&reference.name) else {
+                    return Err(MechError::new(
+                        RuntimeModuleExportNotFound {
+                            dependency: record.id.to_string(),
+                            export: reference.name.clone(),
+                        },
+                        None,
+                    ));
+                };
+                bindings.insert(
+                    address_binding_key(&reference.target, &reference.name),
+                    export_value.clone(),
+                );
+            }
+        }
+
+        Ok(bindings)
+    }
+
+    fn build_import_environment_for_scope(
+        &mut self,
+        context: &mut RuntimeContext,
+        importer: &ModuleVersionRecord,
+        scope: &SourceScope,
+        module_instances: &HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    ) -> MResult<HashMap<String, mech_core::ValRef>> {
+        let mut bindings = HashMap::new();
+        let mut ownership: HashMap<String, String> = HashMap::new();
+
+        for edge in &importer.import_edges {
+            if &edge.scope != scope {
+                continue;
+            }
+
+            let import = &edge.import;
+            let dependency = edge.dependency;
+
+            let dependency_key = (dependency, SourceScope::Program);
+            let Some(dependency_instance) = module_instances.get(&dependency_key) else {
+                return Err(MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "build_import_environment",
+                        reason: format!("dependency instance missing for {}", dependency),
+                    },
+                    None,
+                ));
+            };
+
+            match &import.kind {
+                SourceImportKind::DependencyOnly | SourceImportKind::Namespace => {
+                    let Some(namespace) = module_namespace_for_import(import) else {
+                        continue;
+                    };
+                    for (export_name, export_value) in &dependency_instance.exports {
+                        let binding = format!("{}/{}", namespace, export_name);
+                        if let Some(first) =
+                            ownership.insert(binding.clone(), import.specifier.clone())
+                        {
+                            return Err(MechError::new(
+                                RuntimeModuleImportConflict {
+                                    binding,
+                                    first_import: first,
+                                    second_import: import.specifier.clone(),
+                                },
+                                None,
+                            ));
+                        }
+                        bindings.insert(
+                            format!("{}/{}", namespace, export_name),
+                            export_value.clone(),
+                        );
+                    }
+                }
+                SourceImportKind::Single { name } => {
+                    if matches!(
+                        import.alias,
+                        Some(crate::resolver::SourceImportAlias::Context(_))
+                    ) {
+                        continue;
+                    }
+                    let Some(export_value) = dependency_instance.exports.get(name) else {
+                        return Err(MechError::new(
+                            RuntimeModuleExportNotFound {
+                                dependency: import.specifier.clone(),
+                                export: name.clone(),
+                            },
+                            None,
+                        ));
+                    };
+
+                    let binding = match &import.alias {
+                        Some(crate::resolver::SourceImportAlias::Value(alias)) => alias.clone(),
+                        Some(crate::resolver::SourceImportAlias::Context(_)) => continue,
+                        None => name.clone(),
+                    };
+
+                    if let Some(first) = ownership.insert(binding.clone(), import.specifier.clone())
+                    {
+                        return Err(MechError::new(
+                            RuntimeModuleImportConflict {
+                                binding: binding.clone(),
+                                first_import: first,
+                                second_import: import.specifier.clone(),
+                            },
+                            None,
+                        ));
+                    }
+                    bindings.insert(binding, export_value.clone());
+                }
+                SourceImportKind::Wildcard => {
+                    for (export_name, export_value) in &dependency_instance.exports {
+                        if let Some(first) =
+                            ownership.insert(export_name.clone(), import.specifier.clone())
+                        {
+                            return Err(MechError::new(
+                                RuntimeModuleImportConflict {
+                                    binding: export_name.clone(),
+                                    first_import: first,
+                                    second_import: import.specifier.clone(),
+                                },
+                                None,
+                            ));
+                        }
+                        bindings.insert(export_name.clone(), export_value.clone());
+                    }
+                }
+            }
+
+            self.emit_event_to_context(
+                context,
+                RuntimeEventKind::ModuleImportLinked {
+                    importer: importer.id,
+                    dependency,
+                    specifier: import.specifier.clone(),
+                },
+            )?;
+        }
+
+        Ok(bindings)
+    }
 }
 
-
-
 fn module_source_for_scope(
-  source: &MechSourceCode,
-  scope: &SourceScope,
+    source: &MechSourceCode,
+    scope: &SourceScope,
 ) -> MResult<MechSourceCode> {
-  match scope {
-    SourceScope::Program => Ok(source.clone()),
-    SourceScope::Interpreter(interpreter) => {
-      let MechSourceCode::String(source_text) = source else {
-        return Err(MechError::new(
-          RuntimeInvalidOperationError {
-            operation: "run_module_scope",
-            reason: "interpreter scope execution requires string source".to_string(),
-          },
-          None,
-        ));
-      };
+    match scope {
+        SourceScope::Program => Ok(source.clone()),
+        SourceScope::Interpreter(interpreter) => {
+            let MechSourceCode::String(source_text) = source else {
+                return Err(MechError::new(
+                    RuntimeInvalidOperationError {
+                        operation: "run_module_scope",
+                        reason: "interpreter scope execution requires string source".to_string(),
+                    },
+                    None,
+                ));
+            };
 
-      let tree = mech_syntax::parser::parse(source_text.trim())?;
+            let tree = mech_syntax::parser::parse(source_text.trim())?;
 
-      if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
-        return Ok(MechSourceCode::String(source));
-      }
+            if let Some(source) = source_from_parsed_fenced_blocks(&tree, interpreter.namespace)? {
+                return Ok(MechSourceCode::String(source));
+            }
 
-      Err(MechError::new(
-        RuntimeInvalidOperationError {
-          operation: "run_module_scope",
-          reason: format!("interpreter scope `{}` not found", interpreter.namespace_str),
-        },
-        None,
-      ))
+            Err(MechError::new(
+                RuntimeInvalidOperationError {
+                    operation: "run_module_scope",
+                    reason: format!(
+                        "interpreter scope `{}` not found",
+                        interpreter.namespace_str
+                    ),
+                },
+                None,
+            ))
+        }
     }
-  }
 }
 
 fn source_from_parsed_fenced_blocks(
-  tree: &mech_core::Program,
-  namespace: u64,
+    tree: &mech_core::Program,
+    namespace: u64,
 ) -> MResult<Option<String>> {
-  let mut blocks = Vec::new();
+    let mut blocks = Vec::new();
 
-  for section in &tree.body.sections {
-    for element in &section.elements {
-      if let mech_core::SectionElement::FencedMechCode(fenced) = element {
-        if fenced.config.namespace == namespace {
-          let block = source_from_parsed_fenced_code(fenced)?;
-          blocks.push(block.trim_end().to_string());
+    for section in &tree.body.sections {
+        for element in &section.elements {
+            if let mech_core::SectionElement::FencedMechCode(fenced) = element {
+                if fenced.config.namespace == namespace {
+                    let block = source_from_parsed_fenced_code(fenced)?;
+                    blocks.push(block.trim_end().to_string());
+                }
+            }
         }
-      }
     }
-  }
 
-  if blocks.is_empty() {
-    Ok(None)
-  } else {
-    Ok(Some(blocks.join("\n")))
-  }
+    if blocks.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(blocks.join("\n")))
+    }
 }
 
-fn source_from_parsed_fenced_code(
-  fenced: &mech_core::FencedMechCode,
-) -> MResult<String> {
-  source_from_tokens(std::slice::from_ref(&fenced.source))
+fn source_from_parsed_fenced_code(fenced: &mech_core::FencedMechCode) -> MResult<String> {
+    source_from_tokens(std::slice::from_ref(&fenced.source))
 }
 
 fn source_from_tokens(tokens: &[mech_core::Token]) -> MResult<String> {
-  if tokens.is_empty() {
-    return Ok(String::new());
-  }
-
-  if tokens.iter().any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0) {
-    return Ok(tokens.iter().map(|token| token.to_string()).collect::<Vec<_>>().join(" "));
-  }
-
-  let mut source = String::new();
-  let mut row = tokens[0].src_range.start.row;
-  let mut col = tokens[0].src_range.start.col;
-
-  for token in tokens {
-    let start = &token.src_range.start;
-    while row < start.row {
-      source.push('\n');
-      row += 1;
-      col = 1;
-    }
-    while col < start.col {
-      source.push(' ');
-      col += 1;
+    if tokens.is_empty() {
+        return Ok(String::new());
     }
 
-    let token_text = token.to_string();
-    for ch in token_text.chars() {
-      source.push(ch);
-      if ch == '\n' {
-        row += 1;
-        col = 1;
-      } else {
-        col += 1;
-      }
+    if tokens
+        .iter()
+        .any(|token| token.src_range.start.row == 0 || token.src_range.start.col == 0)
+    {
+        return Ok(tokens
+            .iter()
+            .map(|token| token.to_string())
+            .collect::<Vec<_>>()
+            .join(" "));
     }
-  }
 
-  Ok(source)
+    let mut source = String::new();
+    let mut row = tokens[0].src_range.start.row;
+    let mut col = tokens[0].src_range.start.col;
+
+    for token in tokens {
+        let start = &token.src_range.start;
+        while row < start.row {
+            source.push('\n');
+            row += 1;
+            col = 1;
+        }
+        while col < start.col {
+            source.push(' ');
+            col += 1;
+        }
+
+        let token_text = token.to_string();
+        for ch in token_text.chars() {
+            source.push(ch);
+            if ch == '\n' {
+                row += 1;
+                col = 1;
+            } else {
+                col += 1;
+            }
+        }
+    }
+
+    Ok(source)
 }
 
 fn exports_for_scope<'a>(
-  record: &'a ModuleVersionRecord,
-  scope: &SourceScope,
+    record: &'a ModuleVersionRecord,
+    scope: &SourceScope,
 ) -> &'a [SourceExportDeclaration] {
-  record
-    .scopes
-    .iter()
-    .find(|metadata| &metadata.scope == scope)
-    .map(|metadata| metadata.exports.as_slice())
-    .unwrap_or(&[])
+    record
+        .scopes
+        .iter()
+        .find(|metadata| &metadata.scope == scope)
+        .map(|metadata| metadata.exports.as_slice())
+        .unwrap_or(&[])
 }
-
-
-
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use crate::{
-    BasicCapability, BasicOperation, BasicResource, BasicSubject, ClosureHostFunction,
-  };
-  use mech_core::Ref;
-  use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-  };
+    use super::*;
+    use crate::{
+        BasicCapability, BasicOperation, BasicResource, BasicSubject, ClosureHostFunction,
+    };
+    use mech_core::Ref;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
-  #[test]
-  fn runtime_has_interpreter_finds_root_interpreter() {
-    let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    assert!(runtime.has_interpreter(0));
-  }
+    #[test]
+    fn runtime_has_interpreter_finds_root_interpreter() {
+        let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        assert!(runtime.has_interpreter(0));
+    }
 
-  #[test]
-  fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let source = "```mech
+    #[test]
+    fn runtime_output_value_for_interpreter_returns_value_after_run_string() {
+        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        let source = "```mech
 1
 ```";
-    let _ = runtime.run_string(source).unwrap();
-    let root_id = runtime.program().interpreter().id;
-    let output_id = {
-      let out_values = runtime.program().interpreter().out_values.borrow();
-      *out_values.keys().next().expect("expected output value after run_string")
-    };
-    let output = runtime.output_value_for_interpreter(root_id, output_id);
-    assert!(output.is_some());
-  }
-
-  #[test]
-  fn run_string_with_context_emits_profile_event_when_enabled() {
-    let mut config = RuntimeConfig::default();
-    config.diagnostics.profile_enabled = true;
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-
-    runtime.run_string_with_context(&mut context, "1 + 1").unwrap();
-
-    assert!(context.events.iter().any(|event| {
-      matches!(
-        event.kind,
-        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-      )
-    }));
-  }
-
-  #[test]
-  fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
-    let mut config = RuntimeConfig::default();
-    config.diagnostics.profile_enabled = true;
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-
-    assert!(runtime.run_string_with_context(&mut context, "1 +").is_err());
-
-    assert!(context.events.iter().any(|event| {
-      matches!(
-        event.kind,
-        RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
-      )
-    }));
-  }
-
-  #[test]
-  fn max_source_bytes_rejects_string_source() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_source_bytes = Some(3);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-
-    let error = runtime
-      .run_string_with_context(&mut context, "1234")
-      .unwrap_err();
-    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-    assert_eq!(budget.resource, "source_bytes");
-    assert_eq!(budget.used, 0);
-    assert_eq!(budget.requested, 4);
-    assert_eq!(budget.max, Some(3));
-  }
-
-  #[test]
-  fn direct_string_source_limit_uses_borrowed_length() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_source_bytes = Some(3);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    let source = String::from("1234");
-
-    let error = runtime
-      .run_string_with_context(&mut context, &source)
-      .unwrap_err();
-    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-    assert_eq!(budget.resource, "source_bytes");
-    assert_eq!(budget.requested, 4);
-    assert_eq!(source, "1234");
-  }
-
-  #[test]
-  fn direct_bytecode_source_limit_uses_borrowed_length() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_source_bytes = Some(3);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    let bytecode = vec![1, 2, 3, 4];
-
-    let error = runtime
-      .run_bytecode_with_context(&mut context, &bytecode)
-      .unwrap_err();
-    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-    assert_eq!(budget.resource, "source_bytes");
-    assert_eq!(budget.requested, 4);
-    assert_eq!(bytecode, vec![1, 2, 3, 4]);
-  }
-
-  #[test]
-  fn context_event_retention_is_bounded() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_in_memory_events = Some(2);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.put_object_with_context(&mut context, ObjectRecord::text(ObjectId(1), "text", "one")).unwrap();
-    runtime.put_object_with_context(&mut context, ObjectRecord::text(ObjectId(2), "text", "two")).unwrap();
-    runtime.put_object_with_context(&mut context, ObjectRecord::text(ObjectId(3), "text", "three")).unwrap();
-    let object_ids = context.events.iter().filter_map(|event| match event.kind {
-      RuntimeEventKind::ObjectCreated { object_id } => Some(object_id),
-      _ => None,
-    }).collect::<Vec<_>>();
-    assert_eq!(object_ids, vec![ObjectId(2), ObjectId(3)]);
-  }
-
-  #[test]
-  fn max_source_bytes_rejects_program_aggregate() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_source_bytes = Some(3);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    let source = MechSourceCode::Program(vec![
-      MechSourceCode::String("1".to_string()),
-      MechSourceCode::String("22".to_string()),
-      MechSourceCode::String("3".to_string()),
-    ]);
-
-    let error = runtime
-      .run_source_with_context(&mut context, &source)
-      .unwrap_err();
-    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-    assert_eq!(budget.resource, "source_bytes");
-    assert_eq!(budget.requested, 4);
-    assert_eq!(budget.max, Some(3));
-  }
-
-  #[test]
-  fn max_memory_bytes_rejects_large_source_buffer() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_source_bytes = Some(100);
-    config.limits.max_memory_bytes = Some(3);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-
-    let error = runtime
-      .run_string_with_context(&mut context, "1234")
-      .unwrap_err();
-    let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
-    assert_eq!(budget.resource, "bytes");
-    assert_eq!(budget.used, 0);
-    assert_eq!(budget.requested, 4);
-    assert_eq!(budget.max, Some(3));
-  }
-
-  #[test]
-  fn tree_source_without_known_size_is_not_rejected_by_source_byte_limit() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_source_bytes = Some(1);
-    let mut runtime = MechRuntime::new(config).unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    let tree = mech_syntax::parser::parse("1 + 1").unwrap();
-    let source = MechSourceCode::Tree(tree);
-
-    runtime.run_source_with_context(&mut context, &source).unwrap();
-  }
-
-  #[test]
-  fn runtime_bind_ans_for_interpreter_binds_ans() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let value = Value::U64(Ref::new(42));
-    runtime.bind_ans_for_interpreter(0, &value).unwrap();
-    let ans_id = hash_str("ans");
-    let bound = runtime
-      .program()
-      .interpreter()
-      .symbols()
-      .borrow()
-      .get(ans_id)
-      .map(|value| value.borrow().clone());
-    assert_eq!(bound, Some(value));
-  }
-
-  #[cfg(feature = "functions")]
-  #[test]
-  fn step_with_context_recomputes_runtime_host_function_with_provided_context() {
-    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
-    let calls = Arc::new(AtomicUsize::new(0));
-    let calls_for_host = calls.clone();
-    runtime
-      .register_mech_host_function(ClosureHostFunction::new(
-        "demo/echo",
-        move |_services, context, args| {
-          assert_eq!(context.subject, "program:step-host-test");
-          calls_for_host.fetch_add(1, Ordering::SeqCst);
-          match &args[0] {
-            Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
-            Value::MutableReference(value) => match &*value.borrow() {
-              Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
-              other => panic!("expected F64 mutable reference, got {:?}", other),
-            },
-            other => panic!("expected F64 argument, got {:?}", other),
-          }
-        },
-      ))
-      .unwrap();
-    runtime
-      .grant_capability(Arc::new(BasicCapability::new(
-        CapabilityId(1),
-        &BasicSubject::new("program:step-host-test"),
-        &BasicResource::new("host:demo/echo"),
-        [BasicOperation::new("call")],
-      )))
-      .unwrap();
-
-    let mut context = runtime
-      .runtime_context()
-      .unwrap()
-      .with_subject("program:step-host-test");
-    runtime
-      .run_string_with_context(&mut context, "x := 1\ny := demo/echo(x) + 0")
-      .unwrap();
-    let x = runtime
-      .program()
-      .interpreter()
-      .symbols()
-      .borrow()
-      .get(hash_str("x"))
-      .map(|value| value.borrow().clone())
-      .expect("expected x to be bound");
-    let x_ref = match x {
-      Value::F64(value) => value,
-      other => panic!("expected x to be F64, got {:?}", other),
-    };
-    *x_ref.borrow_mut() = 2.0;
-    runtime.step_with_context(&mut context, 3).unwrap();
-
-    *x_ref.borrow_mut() = 2.0;
-    let function = RuntimeHostNativeFunction {
-      name: "demo/echo".to_string(),
-      host_name: "demo/echo".to_string(),
-      arguments: vec![Value::F64(x_ref.clone())],
-      value: Ref::new(Value::F64(Ref::new(1.0))),
-    };
-    let calls_before_solve = calls.load(Ordering::SeqCst);
-    let runtime_ptr: *mut MechRuntime = &mut runtime;
-    let context_ptr: *mut RuntimeContext = &mut context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-    function.solve();
-
-    assert!(calls.load(Ordering::SeqCst) > calls_before_solve);
-    let y = function.out();
-    match y {
-      Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
-      other => panic!("expected F64(2.0), got {:?}", other),
+        let _ = runtime.run_string(source).unwrap();
+        let root_id = runtime.program().interpreter().id;
+        let output_id = {
+            let out_values = runtime.program().interpreter().out_values.borrow();
+            *out_values
+                .keys()
+                .next()
+                .expect("expected output value after run_string")
+        };
+        let output = runtime.output_value_for_interpreter(root_id, output_id);
+        assert!(output.is_some());
     }
-  }
+
+    #[test]
+    fn run_string_with_context_emits_profile_event_when_enabled() {
+        let mut config = RuntimeConfig::default();
+        config.diagnostics.profile_enabled = true;
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+
+        runtime
+            .run_string_with_context(&mut context, "1 + 1")
+            .unwrap();
+
+        assert!(context.events.iter().any(|event| {
+            matches!(
+              event.kind,
+              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+            )
+        }));
+    }
+
+    #[test]
+    fn run_string_with_context_emits_profile_event_on_failure_when_enabled() {
+        let mut config = RuntimeConfig::default();
+        config.diagnostics.profile_enabled = true;
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+
+        assert!(
+            runtime
+                .run_string_with_context(&mut context, "1 +")
+                .is_err()
+        );
+
+        assert!(context.events.iter().any(|event| {
+            matches!(
+              event.kind,
+              RuntimeEventKind::ProgramProfiled { duration_ns, .. } if duration_ns > 0
+            )
+        }));
+    }
+
+    #[test]
+    fn max_source_bytes_rejects_string_source() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_source_bytes = Some(3);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+
+        let error = runtime
+            .run_string_with_context(&mut context, "1234")
+            .unwrap_err();
+        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+        assert_eq!(budget.resource, "source_bytes");
+        assert_eq!(budget.used, 0);
+        assert_eq!(budget.requested, 4);
+        assert_eq!(budget.max, Some(3));
+    }
+
+    #[test]
+    fn direct_string_source_limit_uses_borrowed_length() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_source_bytes = Some(3);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+        let source = String::from("1234");
+
+        let error = runtime
+            .run_string_with_context(&mut context, &source)
+            .unwrap_err();
+        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+        assert_eq!(budget.resource, "source_bytes");
+        assert_eq!(budget.requested, 4);
+        assert_eq!(source, "1234");
+    }
+
+    #[test]
+    fn direct_bytecode_source_limit_uses_borrowed_length() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_source_bytes = Some(3);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+        let bytecode = vec![1, 2, 3, 4];
+
+        let error = runtime
+            .run_bytecode_with_context(&mut context, &bytecode)
+            .unwrap_err();
+        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+        assert_eq!(budget.resource, "source_bytes");
+        assert_eq!(budget.requested, 4);
+        assert_eq!(bytecode, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn context_event_retention_is_bounded() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_in_memory_events = Some(2);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+        runtime
+            .put_object_with_context(&mut context, ObjectRecord::text(ObjectId(1), "text", "one"))
+            .unwrap();
+        runtime
+            .put_object_with_context(&mut context, ObjectRecord::text(ObjectId(2), "text", "two"))
+            .unwrap();
+        runtime
+            .put_object_with_context(
+                &mut context,
+                ObjectRecord::text(ObjectId(3), "text", "three"),
+            )
+            .unwrap();
+        let object_ids = context
+            .events
+            .iter()
+            .filter_map(|event| match event.kind {
+                RuntimeEventKind::ObjectCreated { object_id } => Some(object_id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(object_ids, vec![ObjectId(2), ObjectId(3)]);
+    }
+
+    #[test]
+    fn max_source_bytes_rejects_program_aggregate() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_source_bytes = Some(3);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+        let source = MechSourceCode::Program(vec![
+            MechSourceCode::String("1".to_string()),
+            MechSourceCode::String("22".to_string()),
+            MechSourceCode::String("3".to_string()),
+        ]);
+
+        let error = runtime
+            .run_source_with_context(&mut context, &source)
+            .unwrap_err();
+        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+        assert_eq!(budget.resource, "source_bytes");
+        assert_eq!(budget.requested, 4);
+        assert_eq!(budget.max, Some(3));
+    }
+
+    #[test]
+    fn max_memory_bytes_rejects_large_source_buffer() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_source_bytes = Some(100);
+        config.limits.max_memory_bytes = Some(3);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+
+        let error = runtime
+            .run_string_with_context(&mut context, "1234")
+            .unwrap_err();
+        let budget = error.kind_as::<ResourceBudgetExceededError>().unwrap();
+        assert_eq!(budget.resource, "bytes");
+        assert_eq!(budget.used, 0);
+        assert_eq!(budget.requested, 4);
+        assert_eq!(budget.max, Some(3));
+    }
+
+    #[test]
+    fn tree_source_without_known_size_is_not_rejected_by_source_byte_limit() {
+        let mut config = RuntimeConfig::default();
+        config.limits.max_source_bytes = Some(1);
+        let mut runtime = MechRuntime::new(config).unwrap();
+        let mut context = runtime.runtime_context().unwrap();
+        let tree = mech_syntax::parser::parse("1 + 1").unwrap();
+        let source = MechSourceCode::Tree(tree);
+
+        runtime
+            .run_source_with_context(&mut context, &source)
+            .unwrap();
+    }
+
+    #[test]
+    fn runtime_bind_ans_for_interpreter_binds_ans() {
+        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        let value = Value::U64(Ref::new(42));
+        runtime.bind_ans_for_interpreter(0, &value).unwrap();
+        let ans_id = hash_str("ans");
+        let bound = runtime
+            .program()
+            .interpreter()
+            .symbols()
+            .borrow()
+            .get(ans_id)
+            .map(|value| value.borrow().clone());
+        assert_eq!(bound, Some(value));
+    }
+
+    #[cfg(feature = "functions")]
+    #[test]
+    fn step_with_context_recomputes_runtime_host_function_with_provided_context() {
+        let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_host = calls.clone();
+        runtime
+            .register_mech_host_function(ClosureHostFunction::new(
+                "demo/echo",
+                move |_services, context, args| {
+                    assert_eq!(context.subject, "program:step-host-test");
+                    calls_for_host.fetch_add(1, Ordering::SeqCst);
+                    match &args[0] {
+                        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+                        Value::MutableReference(value) => match &*value.borrow() {
+                            Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+                            other => panic!("expected F64 mutable reference, got {:?}", other),
+                        },
+                        other => panic!("expected F64 argument, got {:?}", other),
+                    }
+                },
+            ))
+            .unwrap();
+        runtime
+            .grant_capability(Arc::new(BasicCapability::new(
+                CapabilityId(1),
+                &BasicSubject::new("program:step-host-test"),
+                &BasicResource::new("host:demo/echo"),
+                [BasicOperation::new("call")],
+            )))
+            .unwrap();
+
+        let mut context = runtime
+            .runtime_context()
+            .unwrap()
+            .with_subject("program:step-host-test");
+        runtime
+            .run_string_with_context(&mut context, "x := 1\ny := demo/echo(x) + 0")
+            .unwrap();
+        let x = runtime
+            .program()
+            .interpreter()
+            .symbols()
+            .borrow()
+            .get(hash_str("x"))
+            .map(|value| value.borrow().clone())
+            .expect("expected x to be bound");
+        let x_ref = match x {
+            Value::F64(value) => value,
+            other => panic!("expected x to be F64, got {:?}", other),
+        };
+        *x_ref.borrow_mut() = 2.0;
+        runtime.step_with_context(&mut context, 3).unwrap();
+
+        *x_ref.borrow_mut() = 2.0;
+        let function = RuntimeHostNativeFunction {
+            name: "demo/echo".to_string(),
+            host_name: "demo/echo".to_string(),
+            arguments: vec![Value::F64(x_ref.clone())],
+            value: Ref::new(Value::F64(Ref::new(1.0))),
+        };
+        let calls_before_solve = calls.load(Ordering::SeqCst);
+        let runtime_ptr: *mut MechRuntime = &mut runtime;
+        let context_ptr: *mut RuntimeContext = &mut context;
+        let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+        function.solve();
+
+        assert!(calls.load(Ordering::SeqCst) > calls_before_solve);
+        let y = function.out();
+        match y {
+            Value::F64(value) => assert_eq!(*value.borrow(), 2.0),
+            other => panic!("expected F64(2.0), got {:?}", other),
+        }
+    }
 }
 
 impl MechRuntime {
-  pub fn ingress(&self) -> crate::RuntimeIngress {
-    crate::RuntimeIngress::new(self.host_input_queue.clone())
-  }
+    pub fn ingress(&self) -> crate::RuntimeIngress {
+        crate::RuntimeIngress::new(self.host_input_queue.clone())
+    }
 
-  pub fn has_pending_host_inputs(&self) -> MResult<bool> {
-    Ok(self.pending_host_input_count()? > 0)
-  }
+    pub fn has_pending_host_inputs(&self) -> MResult<bool> {
+        Ok(self.pending_host_input_count()? > 0)
+    }
 
-  pub fn persistent_send_count(&self) -> usize {
-    self.persistent_sends.len()
-  }
+    pub fn persistent_send_count(&self) -> usize {
+        self.persistent_sends.len()
+    }
 
-  pub fn input_driver_count(&self) -> usize {
-    self.attached_input_driver_count
-  }
+    pub fn input_driver_count(&self) -> usize {
+        self.attached_input_driver_count
+    }
 
-  pub fn has_input_drivers(&self) -> bool {
-    self.input_driver_count() > 0
-  }
+    pub fn has_input_drivers(&self) -> bool {
+        self.input_driver_count() > 0
+    }
 
-  pub fn live_input_binding_count(&self) -> usize {
-    self.live_input_bindings.values().map(Vec::len).sum()
-  }
+    pub fn live_input_binding_count(&self) -> usize {
+        self.live_input_bindings.values().map(Vec::len).sum()
+    }
 
-  pub fn has_live_input_bindings(&self) -> bool {
-    self.live_input_binding_count() > 0
-  }
+    pub fn has_live_input_bindings(&self) -> bool {
+        self.live_input_binding_count() > 0
+    }
 
-  pub fn driven_live_input_binding_count(&self) -> usize {
-    self.live_input_bindings
-      .iter()
-      .filter(|(source, _)| self.input_drivers[..self.attached_input_driver_count].iter().any(|driver| driver.drives(source)))
-      .map(|(_, bindings)| bindings.len())
-      .sum()
-  }
+    pub fn driven_live_input_binding_count(&self) -> usize {
+        self.live_input_bindings
+            .iter()
+            .filter(|(source, _)| {
+                self.input_drivers[..self.attached_input_driver_count]
+                    .iter()
+                    .any(|driver| driver.drives(source))
+            })
+            .map(|(_, bindings)| bindings.len())
+            .sum()
+    }
 
-  pub fn has_driven_live_input_bindings(&self) -> bool {
-    self.driven_live_input_binding_count() > 0
-  }
+    pub fn has_driven_live_input_bindings(&self) -> bool {
+        self.driven_live_input_binding_count() > 0
+    }
 
-  pub fn pending_host_input_count(&self) -> MResult<usize> {
-    let guard = self.host_input_queue.lock().map_err(|_| crate::input::input_error("RuntimeIngressUnavailable", "host input queue lock is poisoned"))?;
-    Ok(guard.queue.len())
-  }
+    pub fn pending_host_input_count(&self) -> MResult<usize> {
+        let guard = self.host_input_queue.lock().map_err(|_| {
+            crate::input::input_error(
+                "RuntimeIngressUnavailable",
+                "host input queue lock is poisoned",
+            )
+        })?;
+        Ok(guard.queue.len())
+    }
 
-  pub fn apply_host_input(&mut self, input: crate::RuntimeHostInput) -> MResult<crate::RuntimeHostInputOutcome> {
-    input.validate()?;
-    let mut target_updates = Vec::new();
-    let mut seen_targets = std::collections::HashSet::new();
-    let mut ignored_update_count = 0;
+    pub fn apply_host_input(
+        &mut self,
+        input: crate::RuntimeHostInput,
+    ) -> MResult<crate::RuntimeHostInputOutcome> {
+        input.validate()?;
+        let mut target_updates = Vec::new();
+        let mut seen_targets = std::collections::HashSet::new();
+        let mut ignored_update_count = 0;
 
-    for update in &input.updates {
-      let Some(bindings) = self.live_input_bindings.get(&update.source).cloned() else {
-        ignored_update_count += 1;
-        continue;
-      };
-      if bindings.is_empty() {
-        ignored_update_count += 1;
-        continue;
-      }
-      let value = update.value.clone().into_mech_value()?;
-      for program_input in bindings {
-        if !seen_targets.insert(program_input) {
-          return Err(MechError::new(mech_program::ProgramInputDuplicateTarget { input: program_input }, None));
+        for update in &input.updates {
+            let Some(bindings) = self.live_input_bindings.get(&update.source).cloned() else {
+                ignored_update_count += 1;
+                continue;
+            };
+            if bindings.is_empty() {
+                ignored_update_count += 1;
+                continue;
+            }
+            let value = update.value.clone().into_mech_value()?;
+            for program_input in bindings {
+                if !seen_targets.insert(program_input) {
+                    return Err(MechError::new(
+                        mech_program::ProgramInputDuplicateTarget {
+                            input: program_input,
+                        },
+                        None,
+                    ));
+                }
+                target_updates.push(mech_program::ProgramInputUpdate {
+                    input: program_input,
+                    value: value.clone(),
+                });
+            }
         }
-        target_updates.push(mech_program::ProgramInputUpdate { input: program_input, value: value.clone() });
-      }
-    }
 
-    if target_updates.is_empty() {
-      return Ok(crate::RuntimeHostInputOutcome {
-        update_count: input.updates.len(),
-        ignored_update_count,
-        binding_count: 0,
-        turn: None,
-      });
-    }
-
-    let mut context = self.live_turn_context()?;
-    self.validate_context_for_runtime(&context)?;
-    context.charge_step()?;
-
-    let turn_started = Instant::now();
-
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
-
-    let result = (|| -> MResult<crate::RuntimeHostInputOutcome> {
-      let runtime_ptr: *mut MechRuntime = self;
-      let context_ptr: *mut RuntimeContext = &mut context;
-      let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-      // The program API performs complete input preflight, commits the
-      // accepted input batch, and advances one persistent reactive turn
-      // per affected interpreter. Errors after input admission preserve
-      // accepted writes and completed register commits.
-      let turn =
-        program.update_inputs_and_advance_turn(
-          &target_updates,
-        )?;
-      self.execute_persistent_sends(&context, &turn)?;
-      self.enforce_turn_duration(turn_started)?;
-
-      Ok(crate::RuntimeHostInputOutcome {
-        update_count: input.updates.len(),
-        ignored_update_count,
-        binding_count: turn.updated_count,
-        turn: Some(turn),
-      })
-    })();
-
-    self.program = program;
-
-    result
-  }
-
-  fn execute_persistent_sends(&mut self, context: &RuntimeContext, turn: &mech_program::ProgramInputTurnOutcome) -> MResult<()> {
-    for send in self.persistent_sends.clone() {
-      let should_send = match send.schedule {
-        RuntimePersistentSendSchedule::EveryAcceptedTurn => true,
-        RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } => turn.interpreter_turns.iter().find(|outcome| outcome.interpreter_id == interpreter_id).map(|outcome| {
-          outcome.turn.before_commit.executed_nodes.contains(&barrier_node_id) || outcome.turn.after_commit.executed_nodes.contains(&barrier_node_id)
-        }).unwrap_or(false),
-      };
-      if !should_send { continue; }
-      let value = resolve_runtime_value(send.value.borrow().clone());
-      self.write_context_resource(context, &send.binding, &send.path, value, RuntimeResourceWriteIntent::Send)?;
-    }
-    Ok(())
-  }
-
-  pub fn drain_host_inputs(&mut self, max_inputs: usize) -> MResult<Vec<crate::RuntimeHostInputOutcome>> {
-    let mut outcomes = Vec::new();
-    for _ in 0..max_inputs {
-      let input = {
-        let mut guard = self.host_input_queue.lock().map_err(|_| crate::input::input_error("RuntimeIngressUnavailable", "host input queue lock is poisoned"))?;
-        guard.queue.pop_front()
-      };
-      let Some(input) = input else { break; };
-      outcomes.push(self.apply_host_input(input)?);
-    }
-    Ok(outcomes)
-  }
-
-  pub fn close_ingress(&mut self) -> MResult<()> {
-    let mut guard = self.host_input_queue.lock().map_err(|_| crate::input::input_error("RuntimeIngressUnavailable", "host input queue lock is poisoned"))?;
-    guard.closed = true;
-    Ok(())
-  }
-
-  pub fn start_input_drivers(&mut self) -> MResult<()> {
-    if self.ingress().is_closed()? {
-      return Err(crate::input::input_error("RuntimeIngressClosed", "cannot start input drivers after ingress is closed"));
-    }
-    for index in 0..self.attached_input_driver_count {
-      if self.input_drivers[index].is_live() { continue; }
-      if let Err(error) = self.input_drivers[index].start() {
-        for driver in self.input_drivers[..self.attached_input_driver_count].iter_mut().rev() {
-          let _ = driver.stop();
+        if target_updates.is_empty() {
+            return Ok(crate::RuntimeHostInputOutcome {
+                update_count: input.updates.len(),
+                ignored_update_count,
+                binding_count: 0,
+                turn: None,
+            });
         }
-        return Err(error);
-      }
-    }
-    Ok(())
-  }
 
-  pub fn stop_input_drivers(&mut self) -> MResult<()> {
-    let mut first_error = None;
-    for driver in self.input_drivers[..self.attached_input_driver_count].iter_mut().rev() {
-      if let Err(error) = driver.stop() {
-        if first_error.is_none() { first_error = Some(error); }
-      }
+        let mut context = self.live_turn_context()?;
+        self.validate_context_for_runtime(&context)?;
+        context.charge_step()?;
+
+        let turn_started = Instant::now();
+
+        let program_config = self.program.config.clone();
+        let mut program = std::mem::replace(&mut self.program, MechProgram::new(program_config));
+
+        let result = (|| -> MResult<crate::RuntimeHostInputOutcome> {
+            let runtime_ptr: *mut MechRuntime = self;
+            let context_ptr: *mut RuntimeContext = &mut context;
+            let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
+
+            // The program API performs complete input preflight, commits the
+            // accepted input batch, and advances one persistent reactive turn
+            // per affected interpreter. Errors after input admission preserve
+            // accepted writes and completed register commits.
+            let turn = program.update_inputs_and_advance_turn(&target_updates)?;
+            self.execute_persistent_sends(&context, &turn)?;
+            self.enforce_turn_duration(turn_started)?;
+
+            Ok(crate::RuntimeHostInputOutcome {
+                update_count: input.updates.len(),
+                ignored_update_count,
+                binding_count: turn.updated_count,
+                turn: Some(turn),
+            })
+        })();
+
+        self.program = program;
+
+        result
     }
-    if let Some(error) = first_error { return Err(error); }
-    Ok(())
-  }
+
+    fn execute_persistent_sends(
+        &mut self,
+        context: &RuntimeContext,
+        turn: &mech_program::ProgramInputTurnOutcome,
+    ) -> MResult<()> {
+        for send in self.persistent_sends.clone() {
+            let should_send = match send.schedule {
+                RuntimePersistentSendSchedule::EveryAcceptedTurn => true,
+                RuntimePersistentSendSchedule::Activation {
+                    interpreter_id,
+                    barrier_node_id,
+                } => turn
+                    .interpreter_turns
+                    .iter()
+                    .find(|outcome| outcome.interpreter_id == interpreter_id)
+                    .map(|outcome| {
+                        outcome
+                            .turn
+                            .before_commit
+                            .executed_nodes
+                            .contains(&barrier_node_id)
+                            || outcome
+                                .turn
+                                .after_commit
+                                .executed_nodes
+                                .contains(&barrier_node_id)
+                    })
+                    .unwrap_or(false),
+            };
+            if !should_send {
+                continue;
+            }
+            let value = resolve_runtime_value(send.value.borrow().clone());
+            self.write_context_resource(
+                context,
+                &send.binding,
+                &send.path,
+                value,
+                RuntimeResourceWriteIntent::Send,
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn drain_host_inputs(
+        &mut self,
+        max_inputs: usize,
+    ) -> MResult<Vec<crate::RuntimeHostInputOutcome>> {
+        let mut outcomes = Vec::new();
+        for _ in 0..max_inputs {
+            let input = {
+                let mut guard = self.host_input_queue.lock().map_err(|_| {
+                    crate::input::input_error(
+                        "RuntimeIngressUnavailable",
+                        "host input queue lock is poisoned",
+                    )
+                })?;
+                guard.queue.pop_front()
+            };
+            let Some(input) = input else {
+                break;
+            };
+            outcomes.push(self.apply_host_input(input)?);
+        }
+        Ok(outcomes)
+    }
+
+    pub fn close_ingress(&mut self) -> MResult<()> {
+        let mut guard = self.host_input_queue.lock().map_err(|_| {
+            crate::input::input_error(
+                "RuntimeIngressUnavailable",
+                "host input queue lock is poisoned",
+            )
+        })?;
+        guard.closed = true;
+        Ok(())
+    }
+
+    pub fn start_input_drivers(&mut self) -> MResult<()> {
+        if self.ingress().is_closed()? {
+            return Err(crate::input::input_error(
+                "RuntimeIngressClosed",
+                "cannot start input drivers after ingress is closed",
+            ));
+        }
+        for index in 0..self.attached_input_driver_count {
+            if self.input_drivers[index].is_live() {
+                continue;
+            }
+            if let Err(error) = self.input_drivers[index].start() {
+                for driver in self.input_drivers[..self.attached_input_driver_count]
+                    .iter_mut()
+                    .rev()
+                {
+                    let _ = driver.stop();
+                }
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn stop_input_drivers(&mut self) -> MResult<()> {
+        let mut first_error = None;
+        for driver in self.input_drivers[..self.attached_input_driver_count]
+            .iter_mut()
+            .rev()
+        {
+            if let Err(error) = driver.stop() {
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod root_symbol_snapshot_runtime_tests {
-  use super::*;
+    use super::*;
 
-  fn f64_value(value: &Value) -> f64 {
-    match value {
-      Value::F64(value) => *value.borrow(),
-      other => panic!("expected f64, got {other:?}"),
+    fn f64_value(value: &Value) -> f64 {
+        match value {
+            Value::F64(value) => *value.borrow(),
+            other => panic!("expected f64, got {other:?}"),
+        }
     }
-  }
 
-  #[test]
-  fn runtime_delegates_root_symbol_value() {
-    let mut runtime = MechRuntime::builder().build().unwrap();
-    runtime.run_string("answer := 42.0").unwrap();
-    assert_eq!(f64_value(&runtime.root_symbol_value("answer").unwrap()), 42.0);
-  }
+    #[test]
+    fn runtime_delegates_root_symbol_value() {
+        let mut runtime = MechRuntime::builder().build().unwrap();
+        runtime.run_string("answer := 42.0").unwrap();
+        assert_eq!(
+            f64_value(&runtime.root_symbol_value("answer").unwrap()),
+            42.0
+        );
+    }
 
-  #[test]
-  fn runtime_delegates_root_symbol_values() {
-    let mut runtime = MechRuntime::builder().build().unwrap();
-    runtime.run_string("a := 1.0\nb := 2.0").unwrap();
-    let rows = runtime.root_symbol_values(&["b", "a"]).unwrap();
-    assert_eq!(rows[0].0, "b");
-    assert_eq!(f64_value(&rows[0].1), 2.0);
-    assert_eq!(rows[1].0, "a");
-    assert_eq!(f64_value(&rows[1].1), 1.0);
-  }
+    #[test]
+    fn runtime_delegates_root_symbol_values() {
+        let mut runtime = MechRuntime::builder().build().unwrap();
+        runtime.run_string("a := 1.0\nb := 2.0").unwrap();
+        let rows = runtime.root_symbol_values(&["b", "a"]).unwrap();
+        assert_eq!(rows[0].0, "b");
+        assert_eq!(f64_value(&rows[0].1), 2.0);
+        assert_eq!(rows[1].0, "a");
+        assert_eq!(f64_value(&rows[1].1), 1.0);
+    }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1383,6 +1383,13 @@ impl MechRuntime {
     addressed_read_preflight: AddressedReadPreflight,
   ) -> MResult<()> {
     match code {
+      mech_core::MechCode::ActivationScope(scope) => {
+        self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
+        for (body_code, _) in &scope.body {
+          self.preflight_code_context_capabilities(context, registry, body_code, placement, addressed_read_preflight)?;
+        }
+        Ok(())
+      }
       mech_core::MechCode::Statement(statement) => {
         self.preflight_statement_context_capabilities(context, registry, statement, placement, addressed_read_preflight)
       }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -542,10 +542,13 @@ impl MechRuntime {
     value: Value,
   ) -> MResult<mech_core::Expression> {
     self.validate_live_context_candidate(context)?;
-    // The interpreter recognizes this prefix as a sampled pattern value rather
-    // than a source-level capture name.
-    let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
-    let symbol_id = hash_str(&name);
+    let identifier = mech_core::internal_pattern_value_identifier(&format!(
+      "context-{}-{}",
+      hash_str(source.base_uri()),
+      hash_str(source.path())
+    ));
+    let name = identifier.to_string();
+    let symbol_id = identifier.hash();
     let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
     if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
       let bindings = self.live_input_bindings.entry(source).or_default();
@@ -555,7 +558,7 @@ impl MechRuntime {
       self.commit_live_context_candidate(context);
     }
     let var = mech_core::Var {
-      name: identifier_from_str(&name),
+      name: identifier,
       context: None,
       kind: None,
     };

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1194,7 +1194,10 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         let mut scope = scope.clone();
         scope.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
-        scope.body = scope.body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?;
+        scope.body = match scope.body {
+          mech_core::ActivationBody::Block(body) => mech_core::ActivationBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
+          mech_core::ActivationBody::PatternArms(arms) => mech_core::ActivationBody::PatternArms(arms),
+        };
         Ok(mech_core::MechCode::ActivationScope(scope))
       },
       mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
@@ -1297,8 +1300,10 @@ impl MechRuntime {
         let mut lowered = scope.clone();
         lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
         let mut registrations = Vec::new();
-        lowered.body.clear();
-        for (body_code, body_comment) in &scope.body {
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => { return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet lowered".to_string() }, None)); } };
+        lowered.body = mech_core::ActivationBody::Block(vec![]);
+        let lowered_body = match &mut lowered.body { mech_core::ActivationBody::Block(body) => body, _ => unreachable!() };
+        for (body_code, body_comment) in scope_body {
           match body_code {
             mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
               let context_name = send.target.context.as_ref().unwrap().to_string();
@@ -1306,17 +1311,17 @@ impl MechRuntime {
               let index = self.persistent_sends.len() + registrations.len();
               let value_name = format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
               let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
-              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
+              lowered_body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
               registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
             }
-            _ => lowered.body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
+            _ => lowered_body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
           }
         }
         if registrations.is_empty() {
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
           return Ok(());
         }
-        lowered.body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
+        lowered_body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
         self.validate_live_context_candidate(context)?;
         let plan_start = program.interpreter().plan().borrow().nodes.len();
         program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
@@ -1477,18 +1482,19 @@ impl MechRuntime {
     match code {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
-        let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet supported".to_string() }, None)) };
+        let has_send = scope_body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
         // Only writes to local registers conflict with an effectful activation.
         // Context-addressed assignments have their own, operation-specific
         // placement error below (they are top-level only).
-        let has_register = scope.body.iter().any(|(code, _)| match code {
+        let has_register = scope_body.iter().any(|(code, _)| match code {
           mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => assign.target.context.is_none(),
           mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => assign.target.context.is_none(),
           _ => false,
         });
         if has_send && has_register { return Err(MechError::new(ActivationScopeEffectWithRegisterUnsupported, None)); }
         if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot { return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None)); }
-        for (body_code, _) in &scope.body {
+        for (body_code, _) in scope_body {
           self.preflight_code_context_capabilities(context, registry, body_code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?;
         }
         Ok(())

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -101,14 +101,21 @@ struct ResolvedContextResourceRequest {
 // Keeping the compiler registered on the program is therefore not a public
 // source-level API.
 pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "\0mech/runtime/activation-effect-barrier";
-const ACTIVATION_SEND_PAYLOAD_NAME_PREFIX: &str =
-  "\0mech/runtime/activation-send-payload/";
+pub(super) const ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME: &str =
+  "\0mech/runtime/activation-effect-payload-capture";
 
 #[derive(Clone, Debug)]
 pub(super) struct ActivationEffectBarrierCompiler;
 impl NativeFunctionCompiler for ActivationEffectBarrierCompiler {
   fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
-    if !arguments.is_empty() { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier accepts no arguments".into() }, None)); }
+    if !arguments.is_empty() {
+      return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+        reason: format!(
+          "activation effect barrier expected no payloads, found {}",
+          arguments.len()
+        ),
+      }, None));
+    }
     Ok(Box::new(ActivationEffectBarrier))
   }
 }
@@ -120,10 +127,62 @@ impl MechFunctionImpl for ActivationEffectBarrier {
   // The barrier is a scheduling node, not a value producer.  Its node id and
   // reactive execution record are the observable state used by send replay.
   fn out(&self) -> Value { Value::Empty }
+  fn reactive_output_values(&self) -> Vec<Value> { Vec::new() }
   fn to_string(&self) -> String { ACTIVATION_EFFECT_BARRIER_NAME.to_string() }
 }
 impl MechFunctionCompiler for ActivationEffectBarrier {
   fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier cannot be bytecode compiled".into() }, None)) }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ActivationEffectPayloadCaptureCompiler;
+impl NativeFunctionCompiler for ActivationEffectPayloadCaptureCompiler {
+  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
+    let [payload] = arguments.as_slice() else {
+      return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+        reason: format!(
+          "activation effect payload capture expected one payload, found {}",
+          arguments.len()
+        ),
+      }, None));
+    };
+    Ok(Box::new(ActivationEffectPayloadCapture {
+      payload: payload.clone(),
+      snapshot: mech_core::Ref::new(snapshot_runtime_value(payload)),
+    }))
+  }
+}
+
+#[derive(Clone, Debug)]
+struct ActivationEffectPayloadCapture {
+  payload: Value,
+  snapshot: mech_core::ValRef,
+}
+
+impl MechFunctionImpl for ActivationEffectPayloadCapture {
+  fn solve(&self) {
+    *self.snapshot.borrow_mut() = snapshot_runtime_value(&self.payload);
+  }
+  fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> {
+    self.solve();
+    Ok(mech_core::ReactiveSolveStatus::Unchanged)
+  }
+  fn out(&self) -> Value { Value::MutableReference(self.snapshot.clone()) }
+  // Payloads are sampled only when the activation pulse schedules this node.
+  // Their own changes must never dispatch an activation effect.
+  fn reactive_dependency_scopes(&self, argument_count: usize) -> Option<Vec<mech_core::ReactiveDependencyScope>> {
+    Some(vec![mech_core::ReactiveDependencyScope::None; argument_count])
+  }
+  fn reactive_output_values(&self) -> Vec<Value> { Vec::new() }
+  fn to_string(&self) -> String { ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME.to_string() }
+}
+
+impl MechFunctionCompiler for ActivationEffectPayloadCapture {
+  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+    Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+      reason: "activation effect payload capture cannot be bytecode compiled".into(),
+    }, None))
+  }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
@@ -328,6 +387,13 @@ fn resolve_runtime_value(value: Value) -> Value {
     Value::MutableReference(value) => value.borrow().clone(),
     other => other,
   }
+}
+
+// Activation effects are released after the reactive turn succeeds. Keep the
+// body-time payload separate from any live source cells so a register commit
+// cannot change the value that the selected arm staged for its send.
+fn snapshot_runtime_value(value: &Value) -> Value {
+  value.deep_snapshot()
 }
 
 
@@ -1285,13 +1351,12 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
         self.flush_direct_execution(program, pending, result)?;
-        // Pure patterned scopes are lowered structurally and then handed to
-        // the interpreter's static patterned-dispatch elaborator.  Effects
-        // remain intentionally unsupported in this path.
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
           let mut lowered = scope.clone();
           lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
           let mut lowered_arms = Vec::with_capacity(arms.len());
+          let mut arm_registrations = Vec::with_capacity(arms.len());
+          let mut registration_count = 0usize;
           for arm in arms {
             let pattern = self.resolve_context_reads_in_match_pattern(
               context,
@@ -1300,14 +1365,144 @@ impl MechRuntime {
               &arm.pattern,
             )?;
             let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
-            let body = match &arm.body {
-              mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
-              mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+            let (body, registrations) = match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => {
+                let mut lowered_body = Vec::with_capacity(body.len() + 1);
+                let mut registrations = Vec::new();
+                for (body_code, body_comment) in body {
+                  match body_code {
+                    mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+                      let context_name = send.target.context.as_ref().unwrap().to_string();
+                      let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
+                      registration_count += 1;
+                      let payload = self.resolve_context_reads_in_expression(
+                        context,
+                        program,
+                        registry,
+                        &send.expression,
+                      )?;
+                      lowered_body.push((
+                        mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(
+                          mech_core::FunctionCall {
+                            name: identifier_from_str(ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME),
+                            args: vec![(None, payload)],
+                          },
+                        )),
+                        body_comment.clone(),
+                      ));
+                      registrations.push((binding, send.target.name.to_string()));
+                    }
+                    _ => lowered_body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
+                  }
+                }
+                if !registrations.is_empty() {
+                  // The payload captures remain at their source positions, but
+                  // a single final barrier releases the complete arm effect
+                  // batch only after every body node has succeeded.
+                  lowered_body.push((
+                    mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall {
+                      name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME),
+                      args: vec![],
+                    })),
+                    None,
+                  ));
+                }
+                (mech_core::ActivationArmBody::Block(lowered_body), registrations)
+              }
+              mech_core::ActivationArmBody::Expression(expression) => (
+                mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+                Vec::new(),
+              ),
             };
+            arm_registrations.push(registrations);
             lowered_arms.push(mech_core::ActivationArm { pattern, guard, body });
           }
           lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
+          if registration_count > 0 {
+            if self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot {
+              return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None));
+            }
+            self.validate_live_context_candidate(context)?;
+          }
+          let pattern_registration_start = program.interpreter().plan().pattern_activation_registrations().len();
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          if registration_count == 0 { return Ok(()); }
+          let interpreter_id = program.interpreter().id;
+          let pattern_registration = {
+            let plan = program.interpreter().plan();
+            let registrations = plan.pattern_activation_registrations();
+            if registrations.len() != pattern_registration_start + 1 {
+              return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                reason: format!("expected one patterned activation registration, found {}", registrations.len().saturating_sub(pattern_registration_start)),
+              }, None));
+            }
+            registrations[pattern_registration_start].clone()
+          };
+          if pattern_registration.arms.len() != arm_registrations.len() {
+            return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+              reason: format!("patterned activation arm registration mismatch: expected {}, found {}", arm_registrations.len(), pattern_registration.arms.len()),
+            }, None));
+          }
+          let mut sends = Vec::with_capacity(registration_count);
+          {
+            let plan = program.interpreter().plan();
+            let plan = plan.borrow();
+            for (arm, registrations) in pattern_registration.arms.iter().zip(arm_registrations) {
+              if registrations.is_empty() { continue; }
+              let captures = plan.nodes[arm.body_node_start..arm.body_node_end].iter().filter(|node| {
+                node.kind == mech_core::ReactiveNodeKind::Combinational
+                  && node.function.to_string() == ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME
+                  && node.outputs.is_empty()
+              }).collect::<Vec<_>>();
+              let barriers = plan.nodes[arm.body_node_start..arm.body_node_end].iter().filter(|node| {
+                node.kind == mech_core::ReactiveNodeKind::Combinational
+                  && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+                  && node.outputs.is_empty()
+              }).collect::<Vec<_>>();
+              if captures.len() != registrations.len() {
+                return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                  reason: format!(
+                    "expected {} patterned-arm activation effect payload captures, found {}",
+                    registrations.len(),
+                    captures.len()
+                  ),
+                }, None));
+              }
+              if barriers.len() != 1 {
+                return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                  reason: format!(
+                    "expected one patterned-arm activation effect barrier, found {}",
+                    barriers.len()
+                  ),
+                }, None));
+              }
+              let barrier_node_id = barriers[0].id;
+              for ((binding, path), capture) in registrations.into_iter().zip(captures) {
+                let snapshot = match capture.function.out() {
+                  Value::MutableReference(snapshot) => snapshot,
+                  other => return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                    reason: format!(
+                      "patterned-arm activation effect payload capture returned {}, expected a snapshot",
+                      other.kind()
+                    ),
+                  }, None)),
+                };
+                sends.push(RuntimePersistentSend {
+                  binding,
+                  path,
+                  value: snapshot,
+                  schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id },
+                });
+              }
+            }
+          }
+          if sends.len() != registration_count {
+            return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+              reason: format!("patterned activation send registration mismatch: expected {}, found {}", registration_count, sends.len()),
+            }, None));
+          }
+          self.persistent_sends.extend(sends);
+          self.commit_live_context_candidate(context);
           return Ok(());
         }
         let mut lowered = scope.clone();
@@ -1321,11 +1516,22 @@ impl MechRuntime {
             mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
               let context_name = send.target.context.as_ref().unwrap().to_string();
               let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
-              let index = self.persistent_sends.len() + registrations.len();
-              let value_name = format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
-              let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
-              lowered_body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
-              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
+              let payload = self.resolve_context_reads_in_expression(
+                context,
+                program,
+                registry,
+                &send.expression,
+              )?;
+              lowered_body.push((
+                mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(
+                  mech_core::FunctionCall {
+                    name: identifier_from_str(ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME),
+                    args: vec![(None, payload)],
+                  },
+                )),
+                body_comment.clone(),
+              ));
+              registrations.push((binding, send.target.name.to_string()));
             }
             _ => lowered_body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
           }
@@ -1339,16 +1545,52 @@ impl MechRuntime {
         let plan_start = program.interpreter().plan().borrow().nodes.len();
         program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
         let interpreter_id = program.interpreter().id;
-        let trigger_cells = match &scope.trigger { mech_core::Expression::Var(var) => program.interpreter().symbols().borrow().get(var.name.hash()).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation trigger disappeared".into() }, None))?.borrow().reactive_root_cell_ids(), _ => vec![] };
-        let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..].iter().filter(|node| node.kind == mech_core::ReactiveNodeKind::Combinational && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME && trigger_cells.iter().all(|cell| node.inputs.iter().any(|dependency| dependency.cell == *cell && dependency.kind == mech_core::ReactiveDependencyKind::Reactive))).map(|node| node.id).collect();
-        if barrier_ids.len() != 1 { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: format!("expected exactly one activation effect barrier, found {}", barrier_ids.len()) }, None)); }
-        let barrier_node_id = barrier_ids[0];
-        let symbols = program.interpreter().symbols();
-        let mut sends = Vec::new();
-        for (binding, path, value_id) in registrations {
-          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "missing lowered activation payload".into() }, None))?;
-          sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } });
+        let plan = program.interpreter().plan();
+        let plan = plan.borrow();
+        let captures = plan.nodes[plan_start..].iter().filter(|node| {
+          node.kind == mech_core::ReactiveNodeKind::Combinational
+            && node.function.to_string() == ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME
+            && node.outputs.is_empty()
+        }).collect::<Vec<_>>();
+        let barriers = plan.nodes[plan_start..].iter().filter(|node| {
+          node.kind == mech_core::ReactiveNodeKind::Combinational
+            && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+            && node.outputs.is_empty()
+        }).collect::<Vec<_>>();
+        if captures.len() != registrations.len() {
+          return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+            reason: format!(
+              "expected {} activation effect payload captures, found {}",
+              registrations.len(),
+              captures.len()
+            ),
+          }, None));
         }
+        if barriers.len() != 1 {
+          return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+            reason: format!("expected one activation effect barrier, found {}", barriers.len()),
+          }, None));
+        }
+        let barrier_node_id = barriers[0].id;
+        let mut sends = Vec::with_capacity(registrations.len());
+        for ((binding, path), capture) in registrations.into_iter().zip(captures) {
+          let snapshot = match capture.function.out() {
+            Value::MutableReference(snapshot) => snapshot,
+            other => return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+              reason: format!(
+                "activation effect payload capture returned {}, expected a snapshot",
+                other.kind()
+              ),
+            }, None)),
+          };
+          sends.push(RuntimePersistentSend {
+            binding,
+            path,
+            value: snapshot,
+            schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id },
+          });
+        }
+        drop(plan);
         self.persistent_sends.extend(sends);
         self.commit_live_context_candidate(context);
         Ok(())
@@ -1496,6 +1738,13 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          let has_send = arms.iter().any(|arm| match &arm.body {
+            mech_core::ActivationArmBody::Block(body) => body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_)))),
+            mech_core::ActivationArmBody::Expression(_) => false,
+          });
+          if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot {
+            return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None));
+          }
           for arm in arms {
             self.preflight_pattern_context_reads(
               context,
@@ -3746,6 +3995,38 @@ mod tests {
     atomic::{AtomicUsize, Ordering},
   };
 
+  #[cfg(all(feature = "record", feature = "tuple", feature = "f64"))]
+  #[test]
+  fn activation_effect_payload_snapshot_deeply_detaches_scene_values() {
+    let live = Ref::new(1.0);
+    let scene = Value::Record(Ref::new(mech_core::MechRecord::new(vec![(
+      "position",
+      Value::Tuple(Ref::new(mech_core::MechTuple::from_vec(vec![
+        Value::F64(live.clone()),
+        Value::F64(Ref::new(2.0)),
+      ]))),
+    )])));
+    let snapshot = snapshot_runtime_value(&scene);
+    *live.borrow_mut() = 9.0;
+
+    let Value::Record(snapshot) = snapshot else {
+      panic!("expected record snapshot");
+    };
+    let position = {
+      let snapshot = snapshot.borrow();
+      let Value::Tuple(position) = snapshot.data.get(&hash_str("position")).unwrap() else {
+        panic!("expected tuple field");
+      };
+      position.clone()
+    };
+    let position = position.borrow();
+    let Value::F64(x) = position.elements[0].as_ref() else {
+      panic!("expected scalar tuple element");
+    };
+    assert_eq!(*x.borrow(), 1.0);
+    assert_ne!(x.as_ptr(), live.as_ptr());
+  }
+
   #[test]
   fn runtime_has_interpreter_finds_root_interpreter() {
     let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
@@ -4116,8 +4397,8 @@ impl MechRuntime {
         program.update_inputs_and_advance_turn(
           &target_updates,
         )?;
-      self.execute_persistent_sends(&context, &turn)?;
       self.enforce_turn_duration(turn_started)?;
+      self.execute_persistent_sends(&context, &turn)?;
 
       Ok(crate::RuntimeHostInputOutcome {
         update_count: input.updates.len(),

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -25,6 +25,7 @@ enum RuntimeAddressTarget {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirectContextEffectPlacement {
   TopLevel,
+  ActivationScope,
   FunctionBody,
   FsmTransition,
 }
@@ -45,13 +46,14 @@ impl DirectContextEffectPlacement {
   fn description(self) -> &'static str {
     match self {
       DirectContextEffectPlacement::TopLevel => "module top level",
+      DirectContextEffectPlacement::ActivationScope => "an activation scope",
       DirectContextEffectPlacement::FunctionBody => "a function body",
       DirectContextEffectPlacement::FsmTransition => "an FSM transition",
     }
   }
 
   fn allows_direct_context_effect(self) -> bool {
-    matches!(self, DirectContextEffectPlacement::TopLevel)
+    matches!(self, DirectContextEffectPlacement::TopLevel | DirectContextEffectPlacement::ActivationScope)
   }
 }
 
@@ -1148,7 +1150,12 @@ impl MechRuntime {
     code: &mech_core::MechCode,
   ) -> MResult<mech_core::MechCode> {
     match code {
-      mech_core::MechCode::ActivationScope(_) => Err(MechError::new(mech_core::GenericError { msg: "ActivationScopeBytecodeUnsupported".to_string() }, None)),
+      mech_core::MechCode::ActivationScope(scope) => {
+        let mut scope = scope.clone();
+        scope.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+        scope.body = scope.body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?;
+        Ok(mech_core::MechCode::ActivationScope(scope))
+      },
       mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
         self.resolve_context_reads_in_statement(context, program, registry, statement)?,
       )),
@@ -1243,6 +1250,45 @@ impl MechRuntime {
         }
         Ok(())
       }
+      mech_core::MechCode::ActivationScope(scope) => {
+        if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
+        self.flush_direct_execution(program, pending, result)?;
+        let mut lowered = scope.clone();
+        lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+        let mut registrations = Vec::new();
+        lowered.body.clear();
+        for (body_code, body_comment) in &scope.body {
+          match body_code {
+            mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+              let context_name = send.target.context.as_ref().unwrap().to_string();
+              let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
+              let index = self.persistent_sends.len() + registrations.len();
+              let value_name = format!("mech-internal-activation-send-value-{index}");
+              let marker_name = format!("mech-internal-activation-send-marker-{index}");
+              let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
+              // The marker is deliberately a normal reactive binding.  Its trigger input
+              // makes it an activation node even when the payload is a constant.
+              let marker = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&marker_name), context: None, kind: None }, expression: lowered.trigger.clone() };
+              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
+              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(marker)), None));
+              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name), hash_str(&marker_name)));
+            }
+            _ => lowered.body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
+          }
+        }
+        program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+        let interpreter_id = program.interpreter().id;
+        for (binding, path, value_id, marker_id) in registrations {
+          let symbols = program.interpreter().symbols();
+          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "missing lowered payload".to_string() }, None))?;
+          let marker = symbols.borrow().get(marker_id).ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "missing lowered marker".to_string() }, None))?;
+          let marker_cells = marker.borrow().reactive_root_cell_ids();
+          let marker_cell = *marker_cells.first().ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "marker has no reactive cell".to_string() }, None))?;
+          let marker_node_id = program.interpreter().plan().borrow().nodes.iter().find(|node| node.outputs.contains(&marker_cell)).map(|node| node.id).ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "missing marker plan node".to_string() }, None))?;
+          self.persistent_sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, marker_node_id } });
+        }
+        Ok(())
+      }
       mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
         if let Some(context_name) = &var_def.var.context {
           let target = context_name.to_string();
@@ -1297,7 +1343,7 @@ impl MechRuntime {
         let value_cell = self.bind_persistent_send_value_on_program(program, expression)?;
         let value = resolve_runtime_value(value_cell.borrow().clone());
         self.write_context_resource(context, &binding, &path, value.clone(), RuntimeResourceWriteIntent::Send)?;
-        self.persistent_sends.push(RuntimePersistentSend { binding, path, value: value_cell });
+        self.persistent_sends.push(RuntimePersistentSend { binding, path, value: value_cell, schedule: RuntimePersistentSendSchedule::EveryAcceptedTurn });
         self.commit_live_context_candidate(context);
         *result = value;
         return Ok(());
@@ -1385,8 +1431,11 @@ impl MechRuntime {
     match code {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
+        let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
+        let has_register = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(_))));
+        if has_send && has_register { return Err(MechError::new(RuntimeInvalidOperationError { operation: "ActivationScopeEffectWithRegisterUnsupported", reason: "activation scopes cannot mix register assignments and context sends".to_string() }, None)); }
         for (body_code, _) in &scope.body {
-          self.preflight_code_context_capabilities(context, registry, body_code, placement, addressed_read_preflight)?;
+          self.preflight_code_context_capabilities(context, registry, body_code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?;
         }
         Ok(())
       }
@@ -3975,7 +4024,7 @@ impl MechRuntime {
         program.update_inputs_and_advance_turn(
           &target_updates,
         )?;
-      self.execute_persistent_sends(&context)?;
+      self.execute_persistent_sends(&context, &turn)?;
       self.enforce_turn_duration(turn_started)?;
 
       Ok(crate::RuntimeHostInputOutcome {
@@ -3991,8 +4040,15 @@ impl MechRuntime {
     result
   }
 
-  fn execute_persistent_sends(&mut self, context: &RuntimeContext) -> MResult<()> {
+  fn execute_persistent_sends(&mut self, context: &RuntimeContext, turn: &mech_program::ProgramInputTurnOutcome) -> MResult<()> {
     for send in self.persistent_sends.clone() {
+      let should_send = match send.schedule {
+        RuntimePersistentSendSchedule::EveryAcceptedTurn => true,
+        RuntimePersistentSendSchedule::Activation { interpreter_id, marker_node_id } => turn.interpreter_turns.iter().find(|outcome| outcome.interpreter_id == interpreter_id).map(|outcome| {
+          outcome.turn.before_commit.executed_nodes.contains(&marker_node_id) || outcome.turn.after_commit.executed_nodes.contains(&marker_node_id)
+        }).unwrap_or(false),
+      };
+      if !should_send { continue; }
       let value = resolve_runtime_value(send.value.borrow().clone());
       self.write_context_resource(context, &send.binding, &send.path, value, RuntimeResourceWriteIntent::Send)?;
     }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1148,6 +1148,7 @@ impl MechRuntime {
     code: &mech_core::MechCode,
   ) -> MResult<mech_core::MechCode> {
     match code {
+      mech_core::MechCode::ActivationScope(_) => Err(MechError::new(mech_core::GenericError { msg: "ActivationScopeBytecodeUnsupported".to_string() }, None)),
       mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
         self.resolve_context_reads_in_statement(context, program, registry, statement)?,
       )),

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -52,9 +52,6 @@ impl DirectContextEffectPlacement {
     }
   }
 
-  fn allows_direct_context_effect(self) -> bool {
-    matches!(self, DirectContextEffectPlacement::TopLevel | DirectContextEffectPlacement::ActivationScope)
-  }
 }
 
 struct ActiveRuntimeProgramHostGuard {
@@ -97,6 +94,28 @@ struct ResolvedContextResourceRequest {
   provider_base_uri: String,
   provider_path: String,
   context_path: String,
+}
+
+pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "mech/runtime/activation-effect-barrier";
+
+#[derive(Clone, Debug)]
+pub(super) struct ActivationEffectBarrierCompiler;
+impl NativeFunctionCompiler for ActivationEffectBarrierCompiler {
+  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
+    if !arguments.is_empty() { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier accepts no arguments".into() }, None)); }
+    Ok(Box::new(ActivationEffectBarrier { value: mech_core::Ref::new(Value::U64(mech_core::Ref::new(0))) }))
+  }
+}
+#[derive(Clone, Debug)]
+struct ActivationEffectBarrier { value: mech_core::Ref<Value> }
+impl MechFunctionImpl for ActivationEffectBarrier {
+  fn solve(&self) {}
+  fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> { Ok(mech_core::ReactiveSolveStatus::Unchanged) }
+  fn out(&self) -> Value { self.value.borrow().clone() }
+  fn to_string(&self) -> String { ACTIVATION_EFFECT_BARRIER_NAME.to_string() }
+}
+impl MechFunctionCompiler for ActivationEffectBarrier {
+  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier cannot be bytecode compiled".into() }, None)) }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
@@ -1264,29 +1283,34 @@ impl MechRuntime {
               let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
               let index = self.persistent_sends.len() + registrations.len();
               let value_name = format!("mech-internal-activation-send-value-{index}");
-              let marker_name = format!("mech-internal-activation-send-marker-{index}");
               let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
-              // The marker is deliberately a normal reactive binding.  Its trigger input
-              // makes it an activation node even when the payload is a constant.
-              let marker = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&marker_name), context: None, kind: None }, expression: lowered.trigger.clone() };
               lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
-              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(marker)), None));
-              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name), hash_str(&marker_name)));
+              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
             }
             _ => lowered.body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
           }
         }
+        if registrations.is_empty() {
+          program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          return Ok(());
+        }
+        lowered.body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
+        self.validate_live_context_candidate(context)?;
+        let plan_start = program.interpreter().plan().borrow().nodes.len();
         program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
         let interpreter_id = program.interpreter().id;
-        for (binding, path, value_id, marker_id) in registrations {
-          let symbols = program.interpreter().symbols();
-          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "missing lowered payload".to_string() }, None))?;
-          let marker = symbols.borrow().get(marker_id).ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "missing lowered marker".to_string() }, None))?;
-          let marker_cells = marker.borrow().reactive_root_cell_ids();
-          let marker_cell = *marker_cells.first().ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "marker has no reactive cell".to_string() }, None))?;
-          let marker_node_id = program.interpreter().plan().borrow().nodes.iter().find(|node| node.outputs.contains(&marker_cell)).map(|node| node.id).ok_or_else(|| MechError::new(RuntimeInvalidOperationError { operation: "activation_context_send", reason: "missing marker plan node".to_string() }, None))?;
-          self.persistent_sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, marker_node_id } });
+        let trigger_cells = match &scope.trigger { mech_core::Expression::Var(var) => program.interpreter().symbols().borrow().get(var.name.hash()).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation trigger disappeared".into() }, None))?.borrow().reactive_root_cell_ids(), _ => vec![] };
+        let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..].iter().filter(|node| node.kind == mech_core::ReactiveNodeKind::Combinational && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME && trigger_cells.iter().all(|cell| node.inputs.iter().any(|dependency| dependency.cell == *cell && dependency.kind == mech_core::ReactiveDependencyKind::Reactive))).map(|node| node.id).collect();
+        if barrier_ids.len() != 1 { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: format!("expected exactly one activation effect barrier, found {}", barrier_ids.len()) }, None)); }
+        let barrier_node_id = barrier_ids[0];
+        let symbols = program.interpreter().symbols();
+        let mut sends = Vec::new();
+        for (binding, path, value_id) in registrations {
+          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "missing lowered activation payload".into() }, None))?;
+          sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } });
         }
+        self.persistent_sends.extend(sends);
+        self.commit_live_context_candidate(context);
         Ok(())
       }
       mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(var_def)) => {
@@ -1432,8 +1456,9 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
-        let has_register = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(_))));
-        if has_send && has_register { return Err(MechError::new(RuntimeInvalidOperationError { operation: "ActivationScopeEffectWithRegisterUnsupported", reason: "activation scopes cannot mix register assignments and context sends".to_string() }, None)); }
+        let has_register = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(_) | mech_core::Statement::OpAssign(_))));
+        if has_send && has_register { return Err(MechError::new(ActivationScopeEffectWithRegisterUnsupported, None)); }
+        if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot { return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None)); }
         for (body_code, _) in &scope.body {
           self.preflight_code_context_capabilities(context, registry, body_code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?;
         }
@@ -2328,9 +2353,12 @@ impl MechRuntime {
     path: &str,
     placement: DirectContextEffectPlacement,
   ) -> MResult<()> {
-    if placement.allows_direct_context_effect() {
-      return Ok(());
-    }
+    let allowed = match effect {
+      "assignment" => matches!(placement, DirectContextEffectPlacement::TopLevel),
+      "send" => matches!(placement, DirectContextEffectPlacement::TopLevel | DirectContextEffectPlacement::ActivationScope),
+      _ => false,
+    };
+    if allowed { return Ok(()); }
 
     Err(MechError::new(RuntimeInvalidOperationError {
       operation: "direct_context_effect_placement",
@@ -4044,8 +4072,8 @@ impl MechRuntime {
     for send in self.persistent_sends.clone() {
       let should_send = match send.schedule {
         RuntimePersistentSendSchedule::EveryAcceptedTurn => true,
-        RuntimePersistentSendSchedule::Activation { interpreter_id, marker_node_id } => turn.interpreter_turns.iter().find(|outcome| outcome.interpreter_id == interpreter_id).map(|outcome| {
-          outcome.turn.before_commit.executed_nodes.contains(&marker_node_id) || outcome.turn.after_commit.executed_nodes.contains(&marker_node_id)
+        RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } => turn.interpreter_turns.iter().find(|outcome| outcome.interpreter_id == interpreter_id).map(|outcome| {
+          outcome.turn.before_commit.executed_nodes.contains(&barrier_node_id) || outcome.turn.after_commit.executed_nodes.contains(&barrier_node_id)
         }).unwrap_or(false),
       };
       if !should_send { continue; }

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -34,6 +34,7 @@
 
 
 use super::*;
+use super::execution::{ACTIVATION_EFFECT_BARRIER_NAME, ActivationEffectBarrierCompiler};
 use mech_core::{Ref, ValueKind};
 
 impl MechRuntime {
@@ -43,6 +44,10 @@ impl MechRuntime {
     _context: &mut RuntimeContext,
     program: &mut MechProgram,
   ) -> MResult<()> {
+    program.register_native_function_compiler(
+      ACTIVATION_EFFECT_BARRIER_NAME,
+      Arc::new(ActivationEffectBarrierCompiler),
+    );
     for name in self.host_registry.list_functions()? {
       program.register_native_function_compiler(
         name.clone(),

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -35,7 +35,7 @@
 
 use super::*;
 use super::execution::{ACTIVATION_EFFECT_BARRIER_NAME, ActivationEffectBarrierCompiler};
-use mech_core::{Ref, ValueKind};
+use mech_core::{GuardFunctionSafety, Ref, ValueKind};
 
 impl MechRuntime {
 
@@ -190,6 +190,10 @@ impl RuntimeHostNativeFunctionCompiler {
 }
 
 impl NativeFunctionCompiler for RuntimeHostNativeFunctionCompiler {
+  fn guard_safety(&self) -> GuardFunctionSafety {
+    GuardFunctionSafety::Unsupported
+  }
+
   fn compile(
     &self,
     arguments: &Vec<Value>,

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -34,7 +34,12 @@
 
 
 use super::*;
-use super::execution::{ACTIVATION_EFFECT_BARRIER_NAME, ActivationEffectBarrierCompiler};
+use super::execution::{
+  ACTIVATION_EFFECT_BARRIER_NAME,
+  ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME,
+  ActivationEffectBarrierCompiler,
+  ActivationEffectPayloadCaptureCompiler,
+};
 use mech_core::{GuardFunctionSafety, Ref, ValueKind};
 
 impl MechRuntime {
@@ -47,6 +52,10 @@ impl MechRuntime {
     program.register_native_function_compiler(
       ACTIVATION_EFFECT_BARRIER_NAME,
       Arc::new(ActivationEffectBarrierCompiler),
+    );
+    program.register_native_function_compiler(
+      ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME,
+      Arc::new(ActivationEffectPayloadCaptureCompiler),
     );
     for name in self.host_registry.list_functions()? {
       program.register_native_function_compiler(

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,18 +1,18 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
 use std::thread;
 use std::time::Duration;
 
-use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, Ref, Value};
+use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, ReactiveTurnOutcome, Ref, Value};
 
 use super::*;
 use crate::{
   BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
   ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
   RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
-  RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeIngress,
+  RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInputOutcome, RuntimeIngress,
   RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, RuntimeResourceWriteIntent, ClosureHostFunction, materialize_host_manifest,
 };
 
@@ -1145,6 +1145,21 @@ clock-output := (hour, minute, second)
   }
 
 
+  #[derive(Clone, Debug, PartialEq, Eq)]
+  struct ActivationPlanSnapshot { nodes: Vec<ActivationNodeSnapshot>, reactive_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>, sampled_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)> }
+  #[derive(Clone, Debug, PartialEq, Eq)]
+  struct ActivationNodeSnapshot { id: ReactiveNodeId, plan_index: usize, kind: ReactiveNodeKind, function: String, inputs: Vec<(ReactiveCellId, ReactiveDependencyKind)>, outputs: Vec<ReactiveCellId> }
+  fn activation_plan_snapshot(runtime: &MechRuntime) -> ActivationPlanSnapshot { let plan=runtime.program.interpreter().plan(); let plan=plan.borrow(); let nodes=plan.nodes.iter().map(|n| ActivationNodeSnapshot{id:n.id,plan_index:n.plan_index,kind:n.kind,function: std::any::type_name_of_val(n.function.as_ref()).to_string(),inputs:n.inputs.iter().map(|d|(d.cell,d.kind)).collect(),outputs:n.outputs.clone()}).collect(); let mut reactive_consumers=plan.reactive_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();let mut sampled_consumers=plan.sampled_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();reactive_consumers.sort_by_key(|(c,_)|c.get());sampled_consumers.sort_by_key(|(c,_)|c.get());ActivationPlanSnapshot{nodes,reactive_consumers,sampled_consumers} }
+  fn activation_nodes_for_trigger(runtime:&MechRuntime, trigger_name:&str, kind:ReactiveNodeKind)->Vec<ReactiveNodeId>{let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();p.borrow().nodes.iter().filter(|n|n.kind==kind&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect()}
+  fn activation_barrier_for_trigger(runtime:&MechRuntime, trigger_name:&str)->ReactiveNodeId {let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();let barriers=p.borrow().nodes.iter().filter(|n|n.kind==ReactiveNodeKind::Combinational&&n.function.to_string()==ACTIVATION_EFFECT_BARRIER_NAME&&n.outputs.is_empty()&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect::<Vec<_>>();assert_eq!(barriers.len(),1,"expected exactly one activation-effect barrier for trigger {trigger_name}");barriers[0]}
+  fn only_reactive_turn(outcome:&RuntimeHostInputOutcome)->&ReactiveTurnOutcome{let p=outcome.turn.as_ref().expect("expected a program input turn");assert_eq!(p.interpreter_turns.len(),1,"expected exactly one affected interpreter");&p.interpreter_turns[0].turn}
+  fn executed_count(turn:&ReactiveTurnOutcome,id:ReactiveNodeId)->usize{turn.before_commit.executed_nodes.iter().chain(turn.after_commit.executed_nodes.iter()).filter(|x|**x==id).count()}
+  fn apply_f64_input(r:&mut MechRuntime,b:&str,p:&str,v:f64)->RuntimeHostInputOutcome{r.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new(b,p).unwrap(),RuntimeHostInputValue::F64(v))).unwrap()}
+  fn recorded_f64(o:&RecordingTestOutput,i:usize)->f64{o.lines()[i].trim().parse().unwrap()}
+  fn activation_send_count(r:&MechRuntime)->usize{r.persistent_sends.iter().filter(|s|matches!(s.schedule,RuntimePersistentSendSchedule::Activation{..})).count()}
+  fn activation_rejection_runtime()->(MechRuntime,RecordingTestOutput){let (mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))));grant_read(&mut r,"test://render/timer","tick");grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");(r,o)}
+  fn assert_rejected_activation_left_no_state(r:&MechRuntime,o:&RecordingTestOutput,p:&ActivationPlanSnapshot,s:usize,b:&HashMap<RuntimeHostInputSource,Vec<mech_program::ProgramInputId>>){assert_eq!(activation_plan_snapshot(r),*p);assert_eq!(r.persistent_sends.len(),s);assert_eq!(r.live_input_bindings,*b);assert!(o.lines().is_empty());assert!(!r.program.interpreter().plan().activation_registration_active());}
+
   #[test]
   fn persistent_send_uses_original_custom_subject() {
     let initial = snapshot(1.0, 2.0, 3.0, 4.0);
@@ -1296,6 +1311,80 @@ render-tick := @clock/hour
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
   }
+
+  #[test]
+  fn activation_two_clock_physics_render_acceptance() {
+    let provider=TestResourceProvider::new().with_value("test://physics/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://physics/timer","tick");grant_read(&mut runtime,"test://render/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@physics := test://physics/timer{:read(tick)}
+@render := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+physics-tick := @physics/tick
+render-tick := @render/tick
+~x := 0.0
+~> physics-tick {
+  next-x := x + 1.0
+  x = next-x
+}
+~> render-tick {
+  @out/line <- x
+}
+"#).unwrap();let initial_plan=activation_plan_snapshot(&runtime);let render_barrier=activation_barrier_for_trigger(&runtime,"render-tick");let physics_combinational_nodes=activation_nodes_for_trigger(&runtime,"physics-tick",ReactiveNodeKind::Combinational);let x_register=register_node_for_symbol(&runtime,"x");assert!(!physics_combinational_nodes.is_empty());assert_eq!(f64_value(&symbol_value(&runtime,"x")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),1.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",2.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),1);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(executed_count(t,render_barrier),1);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),0)}assert!(!t.before_commit.pending_register_nodes.contains(&x_register));assert!(!t.register_commit.staged_nodes.contains(&x_register));assert!(!t.register_commit.committed_nodes.contains(&x_register));assert!(!t.after_commit.pending_register_nodes.contains(&x_register));assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),2);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(recorded_f64(&output,1),2.0);assert_eq!(executed_count(only_reactive_turn(&a),render_barrier),1);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+  }
+  #[test]
+  fn activation_send_samples_latest_value_and_ignores_other_updates(){let(mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0))).with_value(TEST_SIGNALS_BASE_URI,"value",Value::F64(Ref::new(1.0))));for(b,p)in [("test://render/timer","tick"),("test://other/timer","tick"),(TEST_SIGNALS_BASE_URI,"value")]{grant_read(&mut r,b,p)}grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");r.run_string(r#"@render := test://render/timer{:read(tick)}
+@other := test://other/timer{:read(tick)}
+@signals := test://signals/inputs{:read(value)}
+@out := test://effects/output{:write(line)}
+render-tick := @render/tick
+other-tick := @other/tick
+sampled-value := @signals/value
+~> render-tick {
+  @out/line <- sampled-value
+}
+~> other-tick {
+  other-result := sampled-value + 1.0
+}
+"#).unwrap();let b=activation_barrier_for_trigger(&r,"render-tick");let ns=activation_nodes_for_trigger(&r,"other-tick",ReactiveNodeKind::Combinational);assert!(!ns.is_empty());assert!(o.lines().is_empty());let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",10.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://other/timer","tick",1.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);for n in ns{assert_eq!(executed_count(only_reactive_turn(&q),n),1)}let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),1);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",20.0);assert_eq!(o.lines().len(),1);assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),2);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(recorded_f64(&o,1),20.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);}
+
+  fn rejected(source:&str, check:impl FnOnce(MechError)){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();check(r.run_string(source).unwrap_err());assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
+  #[test] fn activation_send_rejects_local_register_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~x := 0.0
+~> render-tick {
+  x = x + 1.0
+  @out/line <- x
+}
+"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
+  #[test] fn activation_send_rejects_local_op_assign_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~x := 0.0
+~> render-tick {
+  x += 1.0
+  @out/line <- x
+}
+"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
+  #[test] fn activation_send_rejects_context_assignment_in_scope(){rejected(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+x := 1.0
+~> render-tick {
+  @out/line = x
+  @out/line <- x
+}
+"#,|e|{let k=e.kind_as::<RuntimeInvalidOperationError>().expect("expected RuntimeInvalidOperationError");assert_eq!(k.operation,"direct_context_effect_placement");assert!(k.reason.contains("context assignment"),"unexpected placement reason: {}",k.reason);assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_none());});}
+  #[test] fn activation_send_rejects_isolated_registration(){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();let mut c=r.runtime_context().unwrap();let e=r.run_string_with_isolated_registration_for_test(&mut c,r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick {
+  @out/line <- render-tick
+}
+"#).unwrap_err();assert!(e.kind_as::<RuntimeIsolatedActivationSendUnsupported>().is_some(),"unexpected error: {e:?}");assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
 
   #[test]
   fn activation_internal_barrier_is_not_user_callable() {

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,1130 +1,2087 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
-use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::thread;
 use std::time::Duration;
 
-use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, ReactiveTurnOutcome, Ref, Value};
+use mech_core::{
+    MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId,
+    ReactiveNodeKind, ReactiveTurnOutcome, Ref, Value, hash_str,
+};
 
 use super::*;
 use crate::{
-  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
-  ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
-  RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
-  RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInputOutcome, RuntimeIngress,
-  RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, RuntimeResourceWriteIntent, ClosureHostFunction, materialize_host_manifest,
+    BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+    ClosureHostFunction, ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
+    RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInput, RuntimeHostInputOutcome,
+    RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInstallation,
+    RuntimeIngress, RuntimeResourceProvider, RuntimeResourceReadRequest,
+    RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
+    materialize_host_manifest,
 };
 
-const TEST_CLOCK_BASE_URI: &str =
-  "test://clock/ticks";
-const TEST_TIMER_BASE_URI: &str =
-  "test://timer/state";
-const TEST_SIGNALS_BASE_URI: &str =
-  "test://signals/inputs";
-const TEST_OUTPUT_BASE_URI: &str =
-  "test://effects/output";
+const TEST_CLOCK_BASE_URI: &str = "test://clock/ticks";
+const TEST_TIMER_BASE_URI: &str = "test://timer/state";
+const TEST_SIGNALS_BASE_URI: &str = "test://signals/inputs";
+const TEST_OUTPUT_BASE_URI: &str = "test://effects/output";
 
 #[derive(Debug, Clone)]
 struct TestFixtureError(String);
 impl MechErrorKind for TestFixtureError {
-  fn name(&self) -> &str { "TestFixtureError" }
-  fn message(&self) -> String { self.0.clone() }
+    fn name(&self) -> &str {
+        "TestFixtureError"
+    }
+    fn message(&self) -> String {
+        self.0.clone()
+    }
 }
 
 #[derive(Debug, Default)]
-struct TestResourceProvider { values: BTreeMap<String, BTreeMap<String, Value>> }
+struct TestResourceProvider {
+    values: BTreeMap<String, BTreeMap<String, Value>>,
+}
 impl TestResourceProvider {
-  fn new() -> Self { Self::default() }
-  fn with_value(mut self, base_uri: &str, path: &str, value: Value) -> Self {
-    assert!(base_uri.starts_with("test://"), "test fixture resource must use test://");
-    assert!(!path.is_empty(), "test fixture path must not be empty");
-    self.values.entry(base_uri.to_string()).or_default().insert(path.to_string(), value);
-    self
-  }
+    fn new() -> Self {
+        Self::default()
+    }
+    fn with_value(mut self, base_uri: &str, path: &str, value: Value) -> Self {
+        assert!(
+            base_uri.starts_with("test://"),
+            "test fixture resource must use test://"
+        );
+        assert!(!path.is_empty(), "test fixture path must not be empty");
+        self.values
+            .entry(base_uri.to_string())
+            .or_default()
+            .insert(path.to_string(), value);
+        self
+    }
 }
 impl RuntimeResourceProvider for TestResourceProvider {
-  fn scheme(&self) -> &str { "test" }
-  fn base_uris(&self) -> Vec<String> { self.values.keys().cloned().collect() }
-  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-    self.values.get(&request.base_uri).and_then(|paths| paths.get(&request.path)).cloned().ok_or_else(|| MechError::new(TestFixtureError(format!("missing test resource {} / {}", request.base_uri, request.path)), None))
-  }
+    fn scheme(&self) -> &str {
+        "test"
+    }
+    fn base_uris(&self) -> Vec<String> {
+        self.values.keys().cloned().collect()
+    }
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+        self.values
+            .get(&request.base_uri)
+            .and_then(|paths| paths.get(&request.path))
+            .cloned()
+            .ok_or_else(|| {
+                MechError::new(
+                    TestFixtureError(format!(
+                        "missing test resource {} / {}",
+                        request.base_uri, request.path
+                    )),
+                    None,
+                )
+            })
+    }
 }
 
 #[derive(Clone, Debug, Default)]
-struct RecordingTestOutput { lines: Rc<RefCell<Vec<String>>> }
-impl RecordingTestOutput { fn lines(&self) -> Vec<String> { self.lines.borrow().clone() } }
+struct RecordingTestOutput {
+    lines: Rc<RefCell<Vec<String>>>,
+}
+impl RecordingTestOutput {
+    fn lines(&self) -> Vec<String> {
+        self.lines.borrow().clone()
+    }
+}
 #[derive(Debug)]
-struct TestOutputProvider { backend: RecordingTestOutput }
+struct TestOutputProvider {
+    backend: RecordingTestOutput,
+}
 impl RuntimeResourceProvider for TestOutputProvider {
-  fn scheme(&self) -> &str { "test" }
-  fn base_uris(&self) -> Vec<String> { vec![TEST_OUTPUT_BASE_URI.to_string()] }
-  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> { Err(MechError::new(TestFixtureError(format!("test output is write-only: {} / {}", request.base_uri, request.path)), None)) }
-  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-    if request.base_uri == TEST_OUTPUT_BASE_URI && request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send { Ok(()) } else { Err(MechError::new(TestFixtureError(format!("invalid test output write: {} / {}", request.base_uri, request.path)), None)) }
-  }
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-    self.preflight_write(RuntimeResourceWritePreflightRequest { base_uri: request.base_uri.clone(), path: request.path.clone(), context_name: request.context_name.clone(), operation: request.operation.clone(), intent: request.intent })?;
-    self.backend.lines.borrow_mut().push(format!("{}", request.value)); Ok(())
-  }
+    fn scheme(&self) -> &str {
+        "test"
+    }
+    fn base_uris(&self) -> Vec<String> {
+        vec![TEST_OUTPUT_BASE_URI.to_string()]
+    }
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+        Err(MechError::new(
+            TestFixtureError(format!(
+                "test output is write-only: {} / {}",
+                request.base_uri, request.path
+            )),
+            None,
+        ))
+    }
+    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+        if request.base_uri == TEST_OUTPUT_BASE_URI
+            && request.path == "line"
+            && request.intent == RuntimeResourceWriteIntent::Send
+        {
+            Ok(())
+        } else {
+            Err(MechError::new(
+                TestFixtureError(format!(
+                    "invalid test output write: {} / {}",
+                    request.base_uri, request.path
+                )),
+                None,
+            ))
+        }
+    }
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        self.preflight_write(RuntimeResourceWritePreflightRequest {
+            base_uri: request.base_uri.clone(),
+            path: request.path.clone(),
+            context_name: request.context_name.clone(),
+            operation: request.operation.clone(),
+            intent: request.intent,
+        })?;
+        self.backend
+            .lines
+            .borrow_mut()
+            .push(format!("{}", request.value));
+        Ok(())
+    }
 }
 
 fn f64_value(value: &Value) -> f64 {
-  match value {
-    Value::F64(value) => *value.borrow(),
-    other => panic!("expected f64, got {other:?}"),
-  }
+    match value {
+        Value::F64(value) => *value.borrow(),
+        other => panic!("expected f64, got {other:?}"),
+    }
 }
 
 fn host_f64_argument(value: &Value) -> f64 {
-  match value {
-    Value::F64(value) => *value.borrow(),
-    Value::MutableReference(value) => match &*value.borrow() {
-      Value::F64(value) => *value.borrow(),
-      other => panic!("expected f64 mutable reference, got {other:?}"),
-    },
-    other => panic!("expected f64 host argument, got {other:?}"),
-  }
+    match value {
+        Value::F64(value) => *value.borrow(),
+        Value::MutableReference(value) => match &*value.borrow() {
+            Value::F64(value) => *value.borrow(),
+            other => panic!("expected f64 mutable reference, got {other:?}"),
+        },
+        other => panic!("expected f64 host argument, got {other:?}"),
+    }
 }
 
 fn string_value(value: &Value) -> String {
-  match value {
-    Value::String(value) => value.borrow().clone(),
-    other => panic!("expected string, got {other:?}"),
-  }
+    match value {
+        Value::String(value) => value.borrow().clone(),
+        other => panic!("expected string, got {other:?}"),
+    }
 }
 
 #[derive(Debug, Clone)]
 struct DeliberateHostCallError;
 impl MechErrorKind for DeliberateHostCallError {
-  fn name(&self) -> &str { "DeliberateHostCallError" }
-  fn message(&self) -> String { "deliberate host call failure".to_string() }
+    fn name(&self) -> &str {
+        "DeliberateHostCallError"
+    }
+    fn message(&self) -> String {
+        "deliberate host call failure".to_string()
+    }
 }
 
 fn symbol_value(runtime: &MechRuntime, name: &str) -> Value {
-  runtime
-    .program
-    .interpreter()
-    .symbols()
-    .borrow()
-    .get(hash_str(name))
-    .unwrap_or_else(|| panic!("missing symbol {name}"))
-    .borrow()
-    .clone()
+    runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str(name))
+        .unwrap_or_else(|| panic!("missing symbol {name}"))
+        .borrow()
+        .clone()
 }
 
-
 fn source_value(runtime: &MechRuntime, source: &RuntimeHostInputSource) -> Value {
-  let input = runtime
-    .live_input_bindings
-    .get(source)
-    .and_then(|inputs| inputs.first())
-    .unwrap_or_else(|| panic!("missing binding for {} / {}", source.base_uri(), source.path()));
-  runtime
-    .program
-    .interpreter()
-    .symbols()
-    .borrow()
-    .get(input.symbol_id)
-    .unwrap_or_else(|| panic!("missing symbol {}", input.symbol_id))
-    .borrow()
-    .clone()
+    let input = runtime
+        .live_input_bindings
+        .get(source)
+        .and_then(|inputs| inputs.first())
+        .unwrap_or_else(|| {
+            panic!(
+                "missing binding for {} / {}",
+                source.base_uri(),
+                source.path()
+            )
+        });
+    runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(input.symbol_id)
+        .unwrap_or_else(|| panic!("missing symbol {}", input.symbol_id))
+        .borrow()
+        .clone()
 }
 
 fn symbol_cell(runtime: &MechRuntime, name: &str) -> ReactiveCellId {
-  let cells = symbol_value(runtime, name).reactive_root_cell_ids();
-  assert_eq!(cells.len(), 1, "symbol {name} must have one root cell");
-  cells[0]
+    let cells = symbol_value(runtime, name).reactive_root_cell_ids();
+    assert_eq!(cells.len(), 1, "symbol {name} must have one root cell");
+    cells[0]
 }
 
 fn source_cell(runtime: &MechRuntime, source: &RuntimeHostInputSource) -> ReactiveCellId {
-  let cells = source_value(runtime, source).reactive_root_cell_ids();
-  assert_eq!(cells.len(), 1, "source must have one root cell");
-  cells[0]
+    let cells = source_value(runtime, source).reactive_root_cell_ids();
+    assert_eq!(cells.len(), 1, "source must have one root cell");
+    cells[0]
 }
 
 fn register_node_for_symbol(runtime: &MechRuntime, name: &str) -> ReactiveNodeId {
-  let output = symbol_cell(runtime, name);
-  let plan = runtime.program.interpreter().plan();
-  let plan = plan.borrow();
-  let nodes = plan.nodes.iter().filter(|node| node.kind == ReactiveNodeKind::Register && node.outputs.contains(&output)).map(|node| node.id).collect::<Vec<_>>();
-  assert_eq!(nodes.len(), 1, "symbol {name} must have one register node");
-  nodes[0]
+    let output = symbol_cell(runtime, name);
+    let plan = runtime.program.interpreter().plan();
+    let plan = plan.borrow();
+    let nodes = plan
+        .nodes
+        .iter()
+        .filter(|node| node.kind == ReactiveNodeKind::Register && node.outputs.contains(&output))
+        .map(|node| node.id)
+        .collect::<Vec<_>>();
+    assert_eq!(nodes.len(), 1, "symbol {name} must have one register node");
+    nodes[0]
 }
 
-fn combinational_node_for_output_and_inputs(runtime: &MechRuntime, output: ReactiveCellId, required_inputs: &[ReactiveCellId]) -> ReactiveNodeId {
-  let plan = runtime.program.interpreter().plan();
-  let plan = plan.borrow();
-  let nodes = plan.nodes.iter().filter(|node| node.kind == ReactiveNodeKind::Combinational && node.outputs.contains(&output) && required_inputs.iter().all(|required| node.inputs.iter().any(|dependency| dependency.cell == *required && dependency.kind == ReactiveDependencyKind::Reactive))).map(|node| node.id).collect::<Vec<_>>();
-  assert_eq!(nodes.len(), 1, "expected one matching combinational node");
-  nodes[0]
+fn combinational_node_for_output_and_inputs(
+    runtime: &MechRuntime,
+    output: ReactiveCellId,
+    required_inputs: &[ReactiveCellId],
+) -> ReactiveNodeId {
+    let plan = runtime.program.interpreter().plan();
+    let plan = plan.borrow();
+    let nodes = plan
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.kind == ReactiveNodeKind::Combinational
+                && node.outputs.contains(&output)
+                && required_inputs.iter().all(|required| {
+                    node.inputs.iter().any(|dependency| {
+                        dependency.cell == *required
+                            && dependency.kind == ReactiveDependencyKind::Reactive
+                    })
+                })
+        })
+        .map(|node| node.id)
+        .collect::<Vec<_>>();
+    assert_eq!(nodes.len(), 1, "expected one matching combinational node");
+    nodes[0]
 }
 
 fn plan_snapshot(runtime: &MechRuntime) -> (usize, Vec<ReactiveNodeId>, Vec<Vec<ReactiveCellId>>) {
-  let plan = runtime.program.interpreter().plan();
-  let plan = plan.borrow();
-  (plan.len(), plan.nodes.iter().map(|node| node.id).collect(), plan.nodes.iter().map(|node| node.outputs.clone()).collect())
+    let plan = runtime.program.interpreter().plan();
+    let plan = plan.borrow();
+    (
+        plan.len(),
+        plan.nodes.iter().map(|node| node.id).collect(),
+        plan.nodes.iter().map(|node| node.outputs.clone()).collect(),
+    )
 }
 
 fn test_provider_with(base_uri: &str, path: &str, value: f64) -> TestResourceProvider {
-  TestResourceProvider::new()
-    .with_value(base_uri, path, Value::F64(Ref::new(value)))
+    TestResourceProvider::new().with_value(base_uri, path, Value::F64(Ref::new(value)))
 }
 
 fn grant_read(runtime: &mut MechRuntime, resource: &str, path: &str) {
-  let subject = runtime.runtime_context().unwrap().subject;
-  runtime.grant_capability(RuntimeCapabilityGrant {
-    subject,
-    resource: resource.to_string(),
-    operations: vec![RuntimeCapabilityOperation::Read],
-    paths: vec![path.to_string()],
-  }).unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+        .grant_capability(RuntimeCapabilityGrant {
+            subject,
+            resource: resource.to_string(),
+            operations: vec![RuntimeCapabilityOperation::Read],
+            paths: vec![path.to_string()],
+        })
+        .unwrap();
 }
 
 fn grant_write(runtime: &mut MechRuntime, resource: &str, path: &str) {
-  let subject = runtime.runtime_context().unwrap().subject;
-  runtime.grant_capability(RuntimeCapabilityGrant { subject, resource: resource.to_string(), operations: vec![RuntimeCapabilityOperation::Write], paths: vec![path.to_string()] }).unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+        .grant_capability(RuntimeCapabilityGrant {
+            subject,
+            resource: resource.to_string(),
+            operations: vec![RuntimeCapabilityOperation::Write],
+            paths: vec![path.to_string()],
+        })
+        .unwrap();
 }
 
-fn grant_read_to(
-  runtime: &mut MechRuntime,
-  subject: &str,
-  resource: &str,
-  path: &str,
-) {
-  runtime
-    .grant_capability(
-      RuntimeCapabilityGrant {
-        subject: subject.to_string(),
-        resource: resource.to_string(),
-        operations: vec![
-          RuntimeCapabilityOperation::Read,
-        ],
-        paths: vec![path.to_string()],
-      },
-    )
-    .unwrap();
+fn grant_read_to(runtime: &mut MechRuntime, subject: &str, resource: &str, path: &str) {
+    runtime
+        .grant_capability(RuntimeCapabilityGrant {
+            subject: subject.to_string(),
+            resource: resource.to_string(),
+            operations: vec![RuntimeCapabilityOperation::Read],
+            paths: vec![path.to_string()],
+        })
+        .unwrap();
 }
 
-fn grant_host_call(
-  runtime: &mut MechRuntime,
-  subject: &str,
-  id: u64,
-  resource: &str,
-) {
-  runtime
-    .grant_capability(
-      Arc::new(
-        BasicCapability::new(
-          CapabilityId(id.into()),
-          &BasicSubject::new(subject),
-          &BasicResource::new(resource),
-          [
-            BasicOperation::new("call"),
-          ],
-        ),
-      ),
-    )
-    .unwrap();
+fn grant_host_call(runtime: &mut MechRuntime, subject: &str, id: u64, resource: &str) {
+    runtime
+        .grant_capability(Arc::new(BasicCapability::new(
+            CapabilityId(id.into()),
+            &BasicSubject::new(subject),
+            &BasicResource::new(resource),
+            [BasicOperation::new("call")],
+        )))
+        .unwrap();
 }
 
-fn register_sleep_host(
-  runtime: &mut MechRuntime,
-  name: &str,
-) {
-  runtime
-    .register_mech_host_function(
-      ClosureHostFunction::new(
-        name,
-        move |_services, _context, args| {
-          thread::sleep(
-            Duration::from_millis(5),
-          );
+fn register_sleep_host(runtime: &mut MechRuntime, name: &str) {
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new(
+            name,
+            move |_services, _context, args| {
+                thread::sleep(Duration::from_millis(5));
 
-          match args.first() {
-            Some(Value::F64(value)) =>
-              Ok(Value::F64(
-                Ref::new(*value.borrow()),
-              )),
+                match args.first() {
+                    Some(Value::F64(value)) => Ok(Value::F64(Ref::new(*value.borrow()))),
 
-            Some(Value::MutableReference(value)) =>
-              match &*value.borrow() {
-                Value::F64(value) =>
-                  Ok(Value::F64(
-                    Ref::new(*value.borrow()),
-                  )),
+                    Some(Value::MutableReference(value)) => match &*value.borrow() {
+                        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
 
-                other =>
-                  panic!(
-                    "expected f64 mutable reference, got {other:?}",
-                  ),
-              },
+                        other => panic!("expected f64 mutable reference, got {other:?}",),
+                    },
 
-            other =>
-              panic!(
-                "expected f64 argument, got {other:?}",
-              ),
-          }
-        },
-      ),
-    )
-    .unwrap();
+                    other => panic!("expected f64 argument, got {other:?}",),
+                }
+            },
+        ))
+        .unwrap();
 }
 
 fn test_runtime(provider: TestResourceProvider) -> MechRuntime {
-  RuntimeBuilder::new()
-    .resource_provider(Box::new(provider))
-    .build()
-    .unwrap()
+    RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .build()
+        .unwrap()
 }
 
 fn test_runtime_with_output(provider: TestResourceProvider) -> (MechRuntime, RecordingTestOutput) {
-  let output = RecordingTestOutput::default();
-  let runtime = RuntimeBuilder::new()
-    .resource_provider(Box::new(provider))
-    .resource_provider(Box::new(TestOutputProvider { backend: output.clone() }))
-    .build()
-    .unwrap();
-  (runtime, output)
+    let output = RecordingTestOutput::default();
+    let runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(provider))
+        .resource_provider(Box::new(TestOutputProvider {
+            backend: output.clone(),
+        }))
+        .build()
+        .unwrap();
+    (runtime, output)
 }
 
 #[test]
 fn canonical_host_input_updates_live_context_read() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  grant_read(&mut runtime, "test://clock/ticks", "value");
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    grant_read(&mut runtime, "test://clock/ticks", "value");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
+        )
+        .unwrap();
 
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-  let canonical = RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap();
-  assert!(runtime.live_input_bindings.contains_key(&canonical));
-  assert!(runtime.live_input_bindings.keys().all(|source| !source.base_uri().contains("pulse") && !source.path().contains("pulse")));
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    let canonical = RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap();
+    assert!(runtime.live_input_bindings.contains_key(&canonical));
+    assert!(
+        runtime
+            .live_input_bindings
+            .keys()
+            .all(|source| !source.base_uri().contains("pulse") && !source.path().contains("pulse"))
+    );
 
-  let alias = RuntimeHostInputSource::new("test://pulse", "value").unwrap();
-  let outcome = runtime
-    .apply_host_input(RuntimeHostInput::single(alias, RuntimeHostInputValue::F64(5.0)))
-    .unwrap();
-  assert_eq!(outcome.update_count, 1);
-  assert_eq!(outcome.ignored_update_count, 1);
-  assert_eq!(outcome.binding_count, 0);
-  assert!(outcome.turn.is_none());
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    let alias = RuntimeHostInputSource::new("test://pulse", "value").unwrap();
+    let outcome = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            alias,
+            RuntimeHostInputValue::F64(5.0),
+        ))
+        .unwrap();
+    assert_eq!(outcome.update_count, 1);
+    assert_eq!(outcome.ignored_update_count, 1);
+    assert_eq!(outcome.binding_count, 0);
+    assert!(outcome.turn.is_none());
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
 
-  runtime.ingress().submit(RuntimeHostInput::single(canonical, RuntimeHostInputValue::F64(5.0))).unwrap();
-  let outcomes = runtime.drain_host_inputs(1).unwrap();
-  assert_eq!(outcomes.len(), 1);
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+    runtime
+        .ingress()
+        .submit(RuntimeHostInput::single(
+            canonical,
+            RuntimeHostInputValue::F64(5.0),
+        ))
+        .unwrap();
+    let outcomes = runtime.drain_host_inputs(1).unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
 }
 
 #[test]
 fn runtime_reactive_host_input_batches_bound_updates_into_one_turn() {
-  let provider = TestResourceProvider::new()
-    .with_value(TEST_CLOCK_BASE_URI, "a", Value::F64(Ref::new(1.0)))
-    .with_value(TEST_CLOCK_BASE_URI, "b", Value::F64(Ref::new(2.0)));
-  let mut runtime = test_runtime(provider);
-  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "a");
-  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "b");
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(a), :read(b)}\nsum := @pulse/a + @pulse/b").unwrap();
-  let a_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "a").unwrap();
-  let b_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "b").unwrap();
-  let sum_node = combinational_node_for_output_and_inputs(&runtime, symbol_cell(&runtime, "sum"), &[source_cell(&runtime, &a_source), source_cell(&runtime, &b_source)]);
-  let root_interpreter_id = runtime.program.interpreter().id;
-  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![
-    RuntimeHostInputUpdate { source: a_source.clone(), value: RuntimeHostInputValue::F64(10.0) },
-    RuntimeHostInputUpdate { source: b_source.clone(), value: RuntimeHostInputValue::F64(20.0) },
-  ]).unwrap()).unwrap();
-  let program_turn = outcome.turn.as_ref().unwrap();
-  let interpreter_turn = &program_turn.interpreter_turns[0];
-  let reactive_turn = &interpreter_turn.turn;
-  assert_eq!(outcome.update_count, 2); assert_eq!(outcome.ignored_update_count, 0); assert_eq!(outcome.binding_count, 2);
-  assert_eq!(program_turn.updated_count, 2); assert_eq!(program_turn.interpreter_turns.len(), 1); assert_eq!(interpreter_turn.interpreter_id, root_interpreter_id); assert!(!interpreter_turn.dirty_cells.is_empty());
-  assert_eq!(reactive_turn.before_commit.executed_nodes.iter().filter(|node| **node == sum_node).count(), 1);
-  assert!(reactive_turn.register_commit.staged_nodes.is_empty()); assert!(reactive_turn.register_commit.committed_nodes.is_empty()); assert!(reactive_turn.register_commit.dirty_cells.is_empty());
-  assert_eq!(f64_value(&source_value(&runtime, &a_source)), 10.0); assert_eq!(f64_value(&source_value(&runtime, &b_source)), 20.0); assert_eq!(f64_value(&symbol_value(&runtime, "sum")), 30.0);
+    let provider = TestResourceProvider::new()
+        .with_value(TEST_CLOCK_BASE_URI, "a", Value::F64(Ref::new(1.0)))
+        .with_value(TEST_CLOCK_BASE_URI, "b", Value::F64(Ref::new(2.0)));
+    let mut runtime = test_runtime(provider);
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "a");
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "b");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(a), :read(b)}\nsum := @pulse/a + @pulse/b",
+        )
+        .unwrap();
+    let a_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "a").unwrap();
+    let b_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "b").unwrap();
+    let sum_node = combinational_node_for_output_and_inputs(
+        &runtime,
+        symbol_cell(&runtime, "sum"),
+        &[
+            source_cell(&runtime, &a_source),
+            source_cell(&runtime, &b_source),
+        ],
+    );
+    let root_interpreter_id = runtime.program.interpreter().id;
+    let outcome = runtime
+        .apply_host_input(
+            RuntimeHostInput::new(vec![
+                RuntimeHostInputUpdate {
+                    source: a_source.clone(),
+                    value: RuntimeHostInputValue::F64(10.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: b_source.clone(),
+                    value: RuntimeHostInputValue::F64(20.0),
+                },
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+    let program_turn = outcome.turn.as_ref().unwrap();
+    let interpreter_turn = &program_turn.interpreter_turns[0];
+    let reactive_turn = &interpreter_turn.turn;
+    assert_eq!(outcome.update_count, 2);
+    assert_eq!(outcome.ignored_update_count, 0);
+    assert_eq!(outcome.binding_count, 2);
+    assert_eq!(program_turn.updated_count, 2);
+    assert_eq!(program_turn.interpreter_turns.len(), 1);
+    assert_eq!(interpreter_turn.interpreter_id, root_interpreter_id);
+    assert!(!interpreter_turn.dirty_cells.is_empty());
+    assert_eq!(
+        reactive_turn
+            .before_commit
+            .executed_nodes
+            .iter()
+            .filter(|node| **node == sum_node)
+            .count(),
+        1
+    );
+    assert!(reactive_turn.register_commit.staged_nodes.is_empty());
+    assert!(reactive_turn.register_commit.committed_nodes.is_empty());
+    assert!(reactive_turn.register_commit.dirty_cells.is_empty());
+    assert_eq!(f64_value(&source_value(&runtime, &a_source)), 10.0);
+    assert_eq!(f64_value(&source_value(&runtime, &b_source)), 20.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "sum")), 30.0);
 }
 
 #[test]
 fn packet_with_bound_and_unbound_sources_updates_bound_inputs() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  grant_read(&mut runtime, "test://clock/ticks", "value");
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
-  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), value: RuntimeHostInputValue::F64(5.0) },
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://clock/ticks", "missing").unwrap(), value: RuntimeHostInputValue::F64(9.0) },
-  ]).unwrap()).unwrap();
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    grant_read(&mut runtime, "test://clock/ticks", "value");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
+        )
+        .unwrap();
+    let outcome = runtime
+        .apply_host_input(
+            RuntimeHostInput::new(vec![
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+                    value: RuntimeHostInputValue::F64(5.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://clock/ticks", "missing").unwrap(),
+                    value: RuntimeHostInputValue::F64(9.0),
+                },
+            ])
+            .unwrap(),
+        )
+        .unwrap();
 
-  assert_eq!(outcome.update_count, 2);
-  assert_eq!(outcome.ignored_update_count, 1);
-  assert_eq!(outcome.binding_count, 1);
-  assert!(outcome.turn.is_some());
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
-  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap())), 5.0);
+    assert_eq!(outcome.update_count, 2);
+    assert_eq!(outcome.ignored_update_count, 1);
+    assert_eq!(outcome.binding_count, 1);
+    assert!(outcome.turn.is_some());
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+    assert_eq!(
+        f64_value(&source_value(
+            &runtime,
+            &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap()
+        )),
+        5.0
+    );
 }
-
 
 #[test]
 fn partial_snapshot_updates_bound_fields_and_ignores_unbound_fields() {
-  let provider = TestResourceProvider::new()
-    .with_value(TEST_TIMER_BASE_URI, "tick", Value::F64(Ref::new(1.0)))
-    .with_value(TEST_TIMER_BASE_URI, "delta-seconds", Value::F64(Ref::new(0.1)));
-  let mut runtime = test_runtime(provider);
-  grant_read(&mut runtime, "test://timer/state", "tick");
-  grant_read(&mut runtime, "test://timer/state", "delta-seconds");
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@timer := test://timer/state{:read(tick), :read(delta-seconds)}\noutput := @timer/tick + @timer/delta-seconds").unwrap();
+    let provider = TestResourceProvider::new()
+        .with_value(TEST_TIMER_BASE_URI, "tick", Value::F64(Ref::new(1.0)))
+        .with_value(
+            TEST_TIMER_BASE_URI,
+            "delta-seconds",
+            Value::F64(Ref::new(0.1)),
+        );
+    let mut runtime = test_runtime(provider);
+    grant_read(&mut runtime, "test://timer/state", "tick");
+    grant_read(&mut runtime, "test://timer/state", "delta-seconds");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@timer := test://timer/state{:read(tick), :read(delta-seconds)}\noutput := @timer/tick + @timer/delta-seconds").unwrap();
 
-  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "tick").unwrap(), value: RuntimeHostInputValue::F64(10.0) },
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "elapsed-ms").unwrap(), value: RuntimeHostInputValue::F64(1000.0) },
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "delta-ms").unwrap(), value: RuntimeHostInputValue::F64(16.0) },
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "elapsed-seconds").unwrap(), value: RuntimeHostInputValue::F64(1.0) },
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "delta-seconds").unwrap(), value: RuntimeHostInputValue::F64(0.25) },
-    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "skipped-steps").unwrap(), value: RuntimeHostInputValue::F64(0.0) },
-  ]).unwrap()).unwrap();
+    let outcome = runtime
+        .apply_host_input(
+            RuntimeHostInput::new(vec![
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://timer/state", "tick").unwrap(),
+                    value: RuntimeHostInputValue::F64(10.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://timer/state", "elapsed-ms")
+                        .unwrap(),
+                    value: RuntimeHostInputValue::F64(1000.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://timer/state", "delta-ms").unwrap(),
+                    value: RuntimeHostInputValue::F64(16.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://timer/state", "elapsed-seconds")
+                        .unwrap(),
+                    value: RuntimeHostInputValue::F64(1.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://timer/state", "delta-seconds")
+                        .unwrap(),
+                    value: RuntimeHostInputValue::F64(0.25),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new("test://timer/state", "skipped-steps")
+                        .unwrap(),
+                    value: RuntimeHostInputValue::F64(0.0),
+                },
+            ])
+            .unwrap(),
+        )
+        .unwrap();
 
-  assert_eq!(outcome.update_count, 6);
-  assert_eq!(outcome.ignored_update_count, 4);
-  assert_eq!(outcome.binding_count, 2);
-  assert!(outcome.turn.is_some());
-  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://timer/state", "tick").unwrap())), 10.0);
-  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://timer/state", "delta-seconds").unwrap())), 0.25);
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.25);
+    assert_eq!(outcome.update_count, 6);
+    assert_eq!(outcome.ignored_update_count, 4);
+    assert_eq!(outcome.binding_count, 2);
+    assert!(outcome.turn.is_some());
+    assert_eq!(
+        f64_value(&source_value(
+            &runtime,
+            &RuntimeHostInputSource::new("test://timer/state", "tick").unwrap()
+        )),
+        10.0
+    );
+    assert_eq!(
+        f64_value(&source_value(
+            &runtime,
+            &RuntimeHostInputSource::new("test://timer/state", "delta-seconds").unwrap()
+        )),
+        0.25
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.25);
 }
 
 #[test]
 fn runtime_reactive_host_input_unbound_packet_does_not_advance_pending_registers() {
-  let (mut runtime, output) = test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
-  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0\n@out/line <- output").unwrap();
-  assert_eq!(output.lines().len(), 1);
-  let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); runtime.apply_host_input(RuntimeHostInput::single(source, RuntimeHostInputValue::F64(10.0))).unwrap();
-  assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0); assert!(runtime.program.interpreter().has_pending_reactive_registers()); assert_eq!(output.lines().len(), 2);
-  let b_before = f64_value(&symbol_value(&runtime, "b")); let output_before = f64_value(&symbol_value(&runtime, "output")); let lines_before = output.lines();
-  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-a").unwrap(), value: RuntimeHostInputValue::F64(5.0) }, RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-b").unwrap(), value: RuntimeHostInputValue::F64(9.0) }]).unwrap()).unwrap();
-  assert_eq!(outcome.update_count, 2); assert_eq!(outcome.ignored_update_count, 2); assert_eq!(outcome.binding_count, 0); assert!(outcome.turn.is_none()); assert_eq!(f64_value(&symbol_value(&runtime, "b")), b_before); assert_eq!(f64_value(&symbol_value(&runtime, "output")), output_before); assert!(runtime.program.interpreter().has_pending_reactive_registers()); assert_eq!(output.lines(), lines_before);
+    let (mut runtime, output) =
+        test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0\n@out/line <- output").unwrap();
+    assert_eq!(output.lines().len(), 1);
+    let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+    runtime
+        .apply_host_input(RuntimeHostInput::single(
+            source,
+            RuntimeHostInputValue::F64(10.0),
+        ))
+        .unwrap();
+    assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0);
+    assert!(
+        runtime
+            .program
+            .interpreter()
+            .has_pending_reactive_registers()
+    );
+    assert_eq!(output.lines().len(), 2);
+    let b_before = f64_value(&symbol_value(&runtime, "b"));
+    let output_before = f64_value(&symbol_value(&runtime, "output"));
+    let lines_before = output.lines();
+    let outcome = runtime
+        .apply_host_input(
+            RuntimeHostInput::new(vec![
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-a").unwrap(),
+                    value: RuntimeHostInputValue::F64(5.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-b").unwrap(),
+                    value: RuntimeHostInputValue::F64(9.0),
+                },
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(outcome.update_count, 2);
+    assert_eq!(outcome.ignored_update_count, 2);
+    assert_eq!(outcome.binding_count, 0);
+    assert!(outcome.turn.is_none());
+    assert_eq!(f64_value(&symbol_value(&runtime, "b")), b_before);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), output_before);
+    assert!(
+        runtime
+            .program
+            .interpreter()
+            .has_pending_reactive_registers()
+    );
+    assert_eq!(output.lines(), lines_before);
 }
 
 #[test]
 fn live_input_recomputes_runtime_host_function() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  grant_read(&mut runtime, "test://clock/ticks", "value");
-  runtime
-    .grant_capability(Arc::new(BasicCapability::new(
-      CapabilityId(42),
-      &BasicSubject::new(&runtime.runtime_context().unwrap().subject),
-      &BasicResource::new("host:demo/live-plus-one"),
-      [BasicOperation::new("call")],
-    )))
-    .unwrap();
-  let calls = Arc::new(AtomicUsize::new(0));
-  let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-plus-one", move |_services, _context, args| {
-    host_calls.fetch_add(1, Ordering::SeqCst);
-    match &args[0] {
-      Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
-      Value::MutableReference(value) => match &*value.borrow() {
-        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
-        other => panic!("expected f64 mutable reference, got {other:?}"),
-      },
-      other => panic!("expected f64 argument, got {other:?}"),
-    }
-  })).unwrap();
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-plus-one(@pulse/value) + 0").unwrap();
-  let initial_calls = calls.load(Ordering::SeqCst);
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    grant_read(&mut runtime, "test://clock/ticks", "value");
+    runtime
+        .grant_capability(Arc::new(BasicCapability::new(
+            CapabilityId(42),
+            &BasicSubject::new(&runtime.runtime_context().unwrap().subject),
+            &BasicResource::new("host:demo/live-plus-one"),
+            [BasicOperation::new("call")],
+        )))
+        .unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let host_calls = calls.clone();
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new(
+            "demo/live-plus-one",
+            move |_services, _context, args| {
+                host_calls.fetch_add(1, Ordering::SeqCst);
+                match &args[0] {
+                    Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
+                    Value::MutableReference(value) => match &*value.borrow() {
+                        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
+                        other => panic!("expected f64 mutable reference, got {other:?}"),
+                    },
+                    other => panic!("expected f64 argument, got {other:?}"),
+                }
+            },
+        ))
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-plus-one(@pulse/value) + 0").unwrap();
+    let initial_calls = calls.load(Ordering::SeqCst);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
 
-  runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
+    runtime
+        .apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+            RuntimeHostInputValue::F64(9.0),
+        ))
+        .unwrap();
 
-  assert!(calls.load(Ordering::SeqCst) > initial_calls);
-  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap())), 9.0);
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+    assert!(calls.load(Ordering::SeqCst) > initial_calls);
+    assert_eq!(
+        f64_value(&source_value(
+            &runtime,
+            &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap()
+        )),
+        9.0
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
 }
 
 #[test]
 fn runtime_reactive_host_input_executes_only_reachable_branch() {
-  let provider = TestResourceProvider::new().with_value(TEST_CLOCK_BASE_URI, "left", Value::F64(Ref::new(1.0))).with_value(TEST_CLOCK_BASE_URI, "right", Value::F64(Ref::new(2.0)));
-  let mut runtime = test_runtime(provider);
-  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "left"); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "right");
-  let subject = runtime.runtime_context().unwrap().subject;
-  grant_host_call(&mut runtime, &subject, 91, "host:demo/left-branch"); grant_host_call(&mut runtime, &subject, 92, "host:demo/right-branch");
-  let left_calls = Arc::new(AtomicUsize::new(0)); let right_calls = Arc::new(AtomicUsize::new(0));
-  for (name, calls, add) in [("demo/left-branch", left_calls.clone(), 100.0), ("demo/right-branch", right_calls.clone(), 200.0)] {
-    runtime.register_mech_host_function(ClosureHostFunction::new(name, move |_services, _context, args| { calls.fetch_add(1, Ordering::SeqCst); let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + add))) })).unwrap();
-  }
-  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(left), :read(right)}\nleft-output := demo/left-branch(@pulse/left)\nright-output := demo/right-branch(@pulse/right)").unwrap();
-  let left_calls_before = left_calls.load(Ordering::SeqCst);
-  let right_calls_before = right_calls.load(Ordering::SeqCst);
-  assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 101.0); assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
-  let left_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "left").unwrap(); let right_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "right").unwrap();
-  let plan = runtime.program.interpreter().plan(); let left_consumers = plan.borrow().reactive_consumers_for(source_cell(&runtime, &left_source)).to_vec(); let right_consumers = plan.borrow().reactive_consumers_for(source_cell(&runtime, &right_source)).to_vec(); drop(plan);
-  let outcome = runtime.apply_host_input(RuntimeHostInput::single(left_source, RuntimeHostInputValue::F64(10.0))).unwrap();
-  let program_turn = outcome.turn.as_ref().unwrap();
-  assert_eq!(program_turn.interpreter_turns.len(), 1);
-  let reactive_turn = &program_turn.interpreter_turns[0].turn;
-  assert_eq!(left_calls.load(Ordering::SeqCst), left_calls_before + 1);
-  assert_eq!(right_calls.load(Ordering::SeqCst), right_calls_before);
-  assert!(reactive_turn.register_commit.staged_nodes.is_empty()); assert!(reactive_turn.register_commit.committed_nodes.is_empty()); assert!(reactive_turn.register_commit.dirty_cells.is_empty());
-  assert!(left_consumers.iter().any(|id| reactive_turn.before_commit.executed_nodes.contains(id))); assert!(!right_consumers.iter().any(|id| reactive_turn.before_commit.executed_nodes.contains(id))); assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 110.0); assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
+    let provider = TestResourceProvider::new()
+        .with_value(TEST_CLOCK_BASE_URI, "left", Value::F64(Ref::new(1.0)))
+        .with_value(TEST_CLOCK_BASE_URI, "right", Value::F64(Ref::new(2.0)));
+    let mut runtime = test_runtime(provider);
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "left");
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "right");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(&mut runtime, &subject, 91, "host:demo/left-branch");
+    grant_host_call(&mut runtime, &subject, 92, "host:demo/right-branch");
+    let left_calls = Arc::new(AtomicUsize::new(0));
+    let right_calls = Arc::new(AtomicUsize::new(0));
+    for (name, calls, add) in [
+        ("demo/left-branch", left_calls.clone(), 100.0),
+        ("demo/right-branch", right_calls.clone(), 200.0),
+    ] {
+        runtime
+            .register_mech_host_function(ClosureHostFunction::new(
+                name,
+                move |_services, _context, args| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let input = host_f64_argument(&args[0]);
+                    Ok(Value::F64(Ref::new(input + add)))
+                },
+            ))
+            .unwrap();
+    }
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(left), :read(right)}\nleft-output := demo/left-branch(@pulse/left)\nright-output := demo/right-branch(@pulse/right)").unwrap();
+    let left_calls_before = left_calls.load(Ordering::SeqCst);
+    let right_calls_before = right_calls.load(Ordering::SeqCst);
+    assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 101.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
+    let left_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "left").unwrap();
+    let right_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "right").unwrap();
+    let plan = runtime.program.interpreter().plan();
+    let left_consumers = plan
+        .borrow()
+        .reactive_consumers_for(source_cell(&runtime, &left_source))
+        .to_vec();
+    let right_consumers = plan
+        .borrow()
+        .reactive_consumers_for(source_cell(&runtime, &right_source))
+        .to_vec();
+    drop(plan);
+    let outcome = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            left_source,
+            RuntimeHostInputValue::F64(10.0),
+        ))
+        .unwrap();
+    let program_turn = outcome.turn.as_ref().unwrap();
+    assert_eq!(program_turn.interpreter_turns.len(), 1);
+    let reactive_turn = &program_turn.interpreter_turns[0].turn;
+    assert_eq!(left_calls.load(Ordering::SeqCst), left_calls_before + 1);
+    assert_eq!(right_calls.load(Ordering::SeqCst), right_calls_before);
+    assert!(reactive_turn.register_commit.staged_nodes.is_empty());
+    assert!(reactive_turn.register_commit.committed_nodes.is_empty());
+    assert!(reactive_turn.register_commit.dirty_cells.is_empty());
+    assert!(
+        left_consumers
+            .iter()
+            .any(|id| reactive_turn.before_commit.executed_nodes.contains(id))
+    );
+    assert!(
+        !right_consumers
+            .iter()
+            .any(|id| reactive_turn.before_commit.executed_nodes.contains(id))
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 110.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
 }
 
 #[test]
 fn live_host_string_output_recomputes_without_replacing_reference() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  grant_read(&mut runtime, "test://clock/ticks", "value");
-  let subject = runtime.runtime_context().unwrap().subject;
-  grant_host_call(&mut runtime, &subject, 45, "host:demo/live-label");
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-label", |_services, _context, args| {
-    let value = match &args[0] {
-      Value::F64(value) => *value.borrow(),
-      Value::MutableReference(value) => match &*value.borrow() {
-        Value::F64(value) => *value.borrow(),
-        other => panic!("expected f64 mutable reference, got {other:?}"),
-      },
-      other => panic!("expected f64 argument, got {other:?}"),
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    grant_read(&mut runtime, "test://clock/ticks", "value");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(&mut runtime, &subject, 45, "host:demo/live-label");
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new(
+            "demo/live-label",
+            |_services, _context, args| {
+                let value = match &args[0] {
+                    Value::F64(value) => *value.borrow(),
+                    Value::MutableReference(value) => match &*value.borrow() {
+                        Value::F64(value) => *value.borrow(),
+                        other => panic!("expected f64 mutable reference, got {other:?}"),
+                    },
+                    other => panic!("expected f64 argument, got {other:?}"),
+                };
+                Ok(Value::String(Ref::new(format!("tick:{value}"))))
+            },
+        ))
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-label(@pulse/value)",
+        )
+        .unwrap();
+    let before = runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("output"))
+        .unwrap();
+    let outer_pointer = before.as_ptr();
+    let inner_pointer = match &*before.borrow() {
+        Value::String(value) => value.as_ptr(),
+        other => panic!("expected string, got {other:?}"),
     };
-    Ok(Value::String(Ref::new(format!("tick:{value}"))))
-  })).unwrap();
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-label(@pulse/value)").unwrap();
-  let before = runtime.program.interpreter().symbols().borrow().get(hash_str("output")).unwrap();
-  let outer_pointer = before.as_ptr();
-  let inner_pointer = match &*before.borrow() {
-    Value::String(value) => value.as_ptr(),
-    other => panic!("expected string, got {other:?}"),
-  };
-  assert_eq!(string_value(&before.borrow()), "tick:1");
+    assert_eq!(string_value(&before.borrow()), "tick:1");
 
-  runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
+    runtime
+        .apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+            RuntimeHostInputValue::F64(9.0),
+        ))
+        .unwrap();
 
-  let after = runtime.program.interpreter().symbols().borrow().get(hash_str("output")).unwrap();
-  assert_eq!(outer_pointer, after.as_ptr());
-  match &*after.borrow() {
-    Value::String(value) => {
-      assert_eq!(inner_pointer, value.as_ptr());
-      assert_eq!(&*value.borrow(), "tick:9");
+    let after = runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("output"))
+        .unwrap();
+    assert_eq!(outer_pointer, after.as_ptr());
+    match &*after.borrow() {
+        Value::String(value) => {
+            assert_eq!(inner_pointer, value.as_ptr());
+            assert_eq!(&*value.borrow(), "tick:9");
+        }
+        other => panic!("expected string, got {other:?}"),
     }
-    other => panic!("expected string, got {other:?}"),
-  }
 }
 
 #[test]
 fn live_host_output_kind_change_preserves_previous_output() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  grant_read(&mut runtime, "test://clock/ticks", "value");
-  let subject = runtime.runtime_context().unwrap().subject;
-  grant_host_call(&mut runtime, &subject, 46, "host:demo/kind-change");
-  let calls = Arc::new(AtomicUsize::new(0));
-  let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/kind-change", move |_services, _context, args| {
-    let call = host_calls.fetch_add(1, Ordering::SeqCst);
-    if call == 0 {
-      let value = match &args[0] {
-        Value::F64(value) => *value.borrow(),
-        Value::MutableReference(value) => match &*value.borrow() {
-          Value::F64(value) => *value.borrow(),
-          other => panic!("expected f64 mutable reference, got {other:?}"),
-        },
-        other => panic!("expected f64 argument, got {other:?}"),
-      };
-      Ok(Value::F64(Ref::new(value + 1.0)))
-    } else {
-      Ok(Value::String(Ref::new("bad-kind".to_string())))
-    }
-  })).unwrap();
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/kind-change(@pulse/value)\noutput := host-result + 0").unwrap();
-  assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-  let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap();
-  let host_result_inner = match &*host_result.borrow() {
-    Value::F64(value) => value.as_ptr(),
-    other => panic!("expected f64 host result, got {other:?}"),
-  };
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    grant_read(&mut runtime, "test://clock/ticks", "value");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(&mut runtime, &subject, 46, "host:demo/kind-change");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let host_calls = calls.clone();
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new(
+            "demo/kind-change",
+            move |_services, _context, args| {
+                let call = host_calls.fetch_add(1, Ordering::SeqCst);
+                if call == 0 {
+                    let value = match &args[0] {
+                        Value::F64(value) => *value.borrow(),
+                        Value::MutableReference(value) => match &*value.borrow() {
+                            Value::F64(value) => *value.borrow(),
+                            other => panic!("expected f64 mutable reference, got {other:?}"),
+                        },
+                        other => panic!("expected f64 argument, got {other:?}"),
+                    };
+                    Ok(Value::F64(Ref::new(value + 1.0)))
+                } else {
+                    Ok(Value::String(Ref::new("bad-kind".to_string())))
+                }
+            },
+        ))
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/kind-change(@pulse/value)\noutput := host-result + 0").unwrap();
+    assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    let host_result = runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("host-result"))
+        .unwrap();
+    let host_result_inner = match &*host_result.borrow() {
+        Value::F64(value) => value.as_ptr(),
+        other => panic!("expected f64 host result, got {other:?}"),
+    };
 
-  let error = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap_err();
-  let rendered = format!("{error:?}");
-  assert!(rendered.contains("RuntimeHostOutputUpdateError"), "{rendered}");
-  assert!(calls.load(Ordering::SeqCst) >= 2);
-  let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap();
-  match &*host_result.borrow() {
-    Value::F64(value) => {
-      assert_eq!(host_result_inner, value.as_ptr());
-      assert_eq!(*value.borrow(), 2.0);
+    let error = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+            RuntimeHostInputValue::F64(9.0),
+        ))
+        .unwrap_err();
+    let rendered = format!("{error:?}");
+    assert!(
+        rendered.contains("RuntimeHostOutputUpdateError"),
+        "{rendered}"
+    );
+    assert!(calls.load(Ordering::SeqCst) >= 2);
+    let host_result = runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("host-result"))
+        .unwrap();
+    match &*host_result.borrow() {
+        Value::F64(value) => {
+            assert_eq!(host_result_inner, value.as_ptr());
+            assert_eq!(*value.borrow(), 2.0);
+        }
+        other => panic!("expected f64 host result, got {other:?}"),
     }
-    other => panic!("expected f64 host result, got {other:?}"),
-  }
-  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-  runtime.run_string("recovery := 1").unwrap();
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    runtime.run_string("recovery := 1").unwrap();
 }
 
 #[test]
 fn runtime_reactive_host_input_turn_failure_preserves_admitted_inputs() {
-  let (mut runtime, output) = test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0)); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-  let subject = runtime.runtime_context().unwrap().subject; grant_host_call(&mut runtime, &subject, 47, "host:demo/fails-after-first");
-  let calls = Arc::new(AtomicUsize::new(0)); let host_calls = calls.clone(); let fail_host = Arc::new(AtomicBool::new(false)); let fail_host_for_call = fail_host.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/fails-after-first", move |_services, _context, args| { host_calls.fetch_add(1, Ordering::SeqCst); if fail_host_for_call.load(Ordering::SeqCst) { return Err(MechError::new(DeliberateHostCallError, None)); } let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + 1.0))) })).unwrap();
-  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/fails-after-first(@pulse/value)\noutput := host-result + 0\n@out/line <- output").unwrap();
-  let calls_before = calls.load(Ordering::SeqCst); let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); let host_result_pointer = match &*host_result.borrow() { Value::F64(value) => value.as_ptr(), other => panic!("expected f64 host result, got {other:?}") }; let plan_before = plan_snapshot(&runtime); let lines_before = output.lines();
-  assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(output.lines().len(), 1); assert_eq!(runtime.persistent_send_count(), 1);
-  fail_host.store(true, Ordering::SeqCst); let error = runtime.apply_host_input(RuntimeHostInput::single(input_source.clone(), RuntimeHostInputValue::F64(9.0))).unwrap_err(); assert!(format!("{error:?}").contains("DeliberateHostCallError")); assert!(calls.load(Ordering::SeqCst) > calls_before); assert_eq!(f64_value(&source_value(&runtime, &input_source)), 9.0); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); match &*host_result.borrow() { Value::F64(value) => assert_eq!(value.as_ptr(), host_result_pointer), other => panic!("expected f64 host result, got {other:?}") }; assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(plan_snapshot(&runtime), plan_before); assert_eq!(output.lines(), lines_before); assert_eq!(runtime.persistent_send_count(), 1); runtime.run_string("recovery := 1").unwrap(); assert_eq!(f64_value(&symbol_value(&runtime, "recovery")), 1.0);
+    let (mut runtime, output) =
+        test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(&mut runtime, &subject, 47, "host:demo/fails-after-first");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let host_calls = calls.clone();
+    let fail_host = Arc::new(AtomicBool::new(false));
+    let fail_host_for_call = fail_host.clone();
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new(
+            "demo/fails-after-first",
+            move |_services, _context, args| {
+                host_calls.fetch_add(1, Ordering::SeqCst);
+                if fail_host_for_call.load(Ordering::SeqCst) {
+                    return Err(MechError::new(DeliberateHostCallError, None));
+                }
+                let input = host_f64_argument(&args[0]);
+                Ok(Value::F64(Ref::new(input + 1.0)))
+            },
+        ))
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/fails-after-first(@pulse/value)\noutput := host-result + 0\n@out/line <- output").unwrap();
+    let calls_before = calls.load(Ordering::SeqCst);
+    let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+    let host_result = runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("host-result"))
+        .unwrap();
+    let host_result_pointer = match &*host_result.borrow() {
+        Value::F64(value) => value.as_ptr(),
+        other => panic!("expected f64 host result, got {other:?}"),
+    };
+    let plan_before = plan_snapshot(&runtime);
+    let lines_before = output.lines();
+    assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    assert_eq!(output.lines().len(), 1);
+    assert_eq!(runtime.persistent_send_count(), 1);
+    fail_host.store(true, Ordering::SeqCst);
+    let error = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            input_source.clone(),
+            RuntimeHostInputValue::F64(9.0),
+        ))
+        .unwrap_err();
+    assert!(format!("{error:?}").contains("DeliberateHostCallError"));
+    assert!(calls.load(Ordering::SeqCst) > calls_before);
+    assert_eq!(f64_value(&source_value(&runtime, &input_source)), 9.0);
+    let host_result = runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("host-result"))
+        .unwrap();
+    match &*host_result.borrow() {
+        Value::F64(value) => assert_eq!(value.as_ptr(), host_result_pointer),
+        other => panic!("expected f64 host result, got {other:?}"),
+    };
+    assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+    assert_eq!(plan_snapshot(&runtime), plan_before);
+    assert_eq!(output.lines(), lines_before);
+    assert_eq!(runtime.persistent_send_count(), 1);
+    runtime.run_string("recovery := 1").unwrap();
+    assert_eq!(f64_value(&symbol_value(&runtime, "recovery")), 1.0);
 }
 
 #[test]
 fn live_host_empty_output_can_recompute() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  grant_read(&mut runtime, "test://clock/ticks", "value");
-  let subject = runtime.runtime_context().unwrap().subject;
-  grant_host_call(&mut runtime, &subject, 48, "host:demo/live-empty");
-  let calls = Arc::new(AtomicUsize::new(0));
-  let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-empty", move |_services, _context, _args| {
-    host_calls.fetch_add(1, Ordering::SeqCst);
-    Ok(Value::Empty)
-  })).unwrap();
-  let mut context = runtime.runtime_context().unwrap();
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-empty(@pulse/value)").unwrap();
-  assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    grant_read(&mut runtime, "test://clock/ticks", "value");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(&mut runtime, &subject, 48, "host:demo/live-empty");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let host_calls = calls.clone();
+    runtime
+        .register_mech_host_function(ClosureHostFunction::new(
+            "demo/live-empty",
+            move |_services, _context, _args| {
+                host_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Value::Empty)
+            },
+        ))
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-empty(@pulse/value)",
+        )
+        .unwrap();
+    assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
 
-  let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
-  assert!(outcome.turn.is_some());
-  assert!(calls.load(Ordering::SeqCst) >= 2);
-  assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
+    let outcome = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+            RuntimeHostInputValue::F64(9.0),
+        ))
+        .unwrap();
+    assert!(outcome.turn.is_some());
+    assert!(calls.load(Ordering::SeqCst) >= 2);
+    assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
 }
 
 #[test]
 fn runtime_reactive_host_input_preflight_failure_mutates_nothing() {
-  let provider = TestResourceProvider::new().with_value(TEST_SIGNALS_BASE_URI, "a", Value::F64(Ref::new(1.0))).with_value(TEST_SIGNALS_BASE_URI, "b", Value::F64(Ref::new(2.0)));
-  let (mut runtime, output) = test_runtime_with_output(provider); grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "a"); grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "b"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@signals := test://signals/inputs{:read(a), :read(b)}\nsum := @signals/a + @signals/b\n@out/line <- sum").unwrap();
-  let a_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "a").unwrap(); let b_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "b").unwrap(); let a_before = f64_value(&source_value(&runtime, &a_source)); let b_before = f64_value(&source_value(&runtime, &b_source)); let sum_before = f64_value(&symbol_value(&runtime, "sum")); let plan_before = plan_snapshot(&runtime); let lines_before = output.lines(); assert!(!runtime.program.interpreter().has_pending_reactive_registers());
-  let error = runtime.apply_host_input(RuntimeHostInput::new(vec![RuntimeHostInputUpdate { source: a_source.clone(), value: RuntimeHostInputValue::F64(10.0) }, RuntimeHostInputUpdate { source: b_source.clone(), value: RuntimeHostInputValue::String("bad".to_string()) }]).unwrap()).unwrap_err();
-  assert!(format!("{error:?}").contains("StableValueUpdateKindMismatch")); assert_eq!(f64_value(&source_value(&runtime, &a_source)), a_before); assert_eq!(f64_value(&source_value(&runtime, &b_source)), b_before); assert_eq!(f64_value(&symbol_value(&runtime, "sum")), sum_before); assert_eq!(plan_snapshot(&runtime), plan_before); assert!(!runtime.program.interpreter().has_pending_reactive_registers()); assert_eq!(output.lines(), lines_before);
+    let provider = TestResourceProvider::new()
+        .with_value(TEST_SIGNALS_BASE_URI, "a", Value::F64(Ref::new(1.0)))
+        .with_value(TEST_SIGNALS_BASE_URI, "b", Value::F64(Ref::new(2.0)));
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "a");
+    grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "b");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@signals := test://signals/inputs{:read(a), :read(b)}\nsum := @signals/a + @signals/b\n@out/line <- sum").unwrap();
+    let a_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "a").unwrap();
+    let b_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "b").unwrap();
+    let a_before = f64_value(&source_value(&runtime, &a_source));
+    let b_before = f64_value(&source_value(&runtime, &b_source));
+    let sum_before = f64_value(&symbol_value(&runtime, "sum"));
+    let plan_before = plan_snapshot(&runtime);
+    let lines_before = output.lines();
+    assert!(
+        !runtime
+            .program
+            .interpreter()
+            .has_pending_reactive_registers()
+    );
+    let error = runtime
+        .apply_host_input(
+            RuntimeHostInput::new(vec![
+                RuntimeHostInputUpdate {
+                    source: a_source.clone(),
+                    value: RuntimeHostInputValue::F64(10.0),
+                },
+                RuntimeHostInputUpdate {
+                    source: b_source.clone(),
+                    value: RuntimeHostInputValue::String("bad".to_string()),
+                },
+            ])
+            .unwrap(),
+        )
+        .unwrap_err();
+    assert!(format!("{error:?}").contains("StableValueUpdateKindMismatch"));
+    assert_eq!(f64_value(&source_value(&runtime, &a_source)), a_before);
+    assert_eq!(f64_value(&source_value(&runtime, &b_source)), b_before);
+    assert_eq!(f64_value(&symbol_value(&runtime, "sum")), sum_before);
+    assert_eq!(plan_snapshot(&runtime), plan_before);
+    assert!(
+        !runtime
+            .program
+            .interpreter()
+            .has_pending_reactive_registers()
+    );
+    assert_eq!(output.lines(), lines_before);
 }
 
 #[test]
 fn transactional_context_cannot_arm_live_program() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  let mut context = runtime.runtime_context().unwrap();
-  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
-  runtime.begin_transaction(&mut context).unwrap();
-  let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap_err());
-  assert!(error.contains("RuntimeTransactionalLiveProgramUnsupported"), "{error}");
-  assert!(runtime.live_context_template.is_none());
-  assert!(runtime.live_input_bindings.is_empty());
-  assert!(runtime.persistent_sends.is_empty());
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    let mut context = runtime.runtime_context().unwrap();
+    grant_read_to(
+        &mut runtime,
+        &context.subject,
+        "test://clock/ticks",
+        "value",
+    );
+    runtime.begin_transaction(&mut context).unwrap();
+    let error = format!(
+        "{:?}",
+        runtime
+            .run_string_with_context(
+                &mut context,
+                "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value"
+            )
+            .unwrap_err()
+    );
+    assert!(
+        error.contains("RuntimeTransactionalLiveProgramUnsupported"),
+        "{error}"
+    );
+    assert!(runtime.live_context_template.is_none());
+    assert!(runtime.live_input_bindings.is_empty());
+    assert!(runtime.persistent_sends.is_empty());
 }
 
 #[test]
 fn failed_source_does_not_leave_live_state_armed() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  let mut context_a = runtime.runtime_context().unwrap().with_subject("subject-a");
-  grant_read_to(&mut runtime, "subject-a", "test://clock/ticks", "value");
-  let error = runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\nmissing := @pulse/missing");
-  assert!(error.is_err());
-  assert!(runtime.live_context_template.is_none());
-  assert!(runtime.live_input_bindings.is_empty());
-  assert!(runtime.persistent_sends.is_empty());
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    let mut context_a = runtime.runtime_context().unwrap().with_subject("subject-a");
+    grant_read_to(&mut runtime, "subject-a", "test://clock/ticks", "value");
+    let error = runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\nmissing := @pulse/missing");
+    assert!(error.is_err());
+    assert!(runtime.live_context_template.is_none());
+    assert!(runtime.live_input_bindings.is_empty());
+    assert!(runtime.persistent_sends.is_empty());
 
-  let mut context_b = runtime.runtime_context().unwrap().with_subject("subject-b");
-  grant_read_to(&mut runtime, "subject-b", "test://clock/ticks", "value");
-  runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap();
+    let mut context_b = runtime.runtime_context().unwrap().with_subject("subject-b");
+    grant_read_to(&mut runtime, "subject-b", "test://clock/ticks", "value");
+    runtime
+        .run_string_with_context(
+            &mut context_b,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+        )
+        .unwrap();
 }
 
 #[test]
 fn duration_failure_restores_live_state() {
-  let mut config = RuntimeConfig::default();
-  config.limits.max_turn_duration_ms = Some(1);
-  let mut runtime = RuntimeBuilder::new()
-    .config(config)
-    .resource_provider(Box::new(test_provider_with("test://clock/ticks", "value", 1.0)))
-    .build()
-    .unwrap();
-  let mut context = runtime.runtime_context().unwrap();
-  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
-  grant_host_call(&mut runtime, &context.subject, 43, "host:demo/source-sleep");
-  register_sleep_host(&mut runtime, "demo/source-sleep");
-  let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nslow := demo/source-sleep(@pulse/value)").unwrap_err());
-  assert!(error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"), "{error}");
-  assert!(runtime.live_context_template.is_none());
-  assert!(runtime.live_input_bindings.is_empty());
-  assert!(runtime.persistent_sends.is_empty());
-  runtime.config.limits.max_turn_duration_ms = None;
-  runtime.run_string("recovery := 1").unwrap();
+    let mut config = RuntimeConfig::default();
+    config.limits.max_turn_duration_ms = Some(1);
+    let mut runtime = RuntimeBuilder::new()
+        .config(config)
+        .resource_provider(Box::new(test_provider_with(
+            "test://clock/ticks",
+            "value",
+            1.0,
+        )))
+        .build()
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    grant_read_to(
+        &mut runtime,
+        &context.subject,
+        "test://clock/ticks",
+        "value",
+    );
+    grant_host_call(&mut runtime, &context.subject, 43, "host:demo/source-sleep");
+    register_sleep_host(&mut runtime, "demo/source-sleep");
+    let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nslow := demo/source-sleep(@pulse/value)").unwrap_err());
+    assert!(
+        error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"),
+        "{error}"
+    );
+    assert!(runtime.live_context_template.is_none());
+    assert!(runtime.live_input_bindings.is_empty());
+    assert!(runtime.persistent_sends.is_empty());
+    runtime.config.limits.max_turn_duration_ms = None;
+    runtime.run_string("recovery := 1").unwrap();
 }
 
 #[test]
 fn live_turn_enforces_step_budget() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  let mut context = runtime.runtime_context().unwrap().with_budget(ResourceBudget::default().with_max_steps(1));
-  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
-  runtime.live_context_template.as_mut().unwrap().budget_limits.max_steps = Some(0);
-  let error = format!("{:?}", runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(2.0))).unwrap_err());
-  assert!(error.contains("ResourceBudgetExceeded"), "{error}");
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    let mut context = runtime
+        .runtime_context()
+        .unwrap()
+        .with_budget(ResourceBudget::default().with_max_steps(1));
+    grant_read_to(
+        &mut runtime,
+        &context.subject,
+        "test://clock/ticks",
+        "value",
+    );
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
+        )
+        .unwrap();
+    runtime
+        .live_context_template
+        .as_mut()
+        .unwrap()
+        .budget_limits
+        .max_steps = Some(0);
+    let error = format!(
+        "{:?}",
+        runtime
+            .apply_host_input(RuntimeHostInput::single(
+                RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+                RuntimeHostInputValue::F64(2.0)
+            ))
+            .unwrap_err()
+    );
+    assert!(error.contains("ResourceBudgetExceeded"), "{error}");
 
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  let mut context = runtime.runtime_context().unwrap().with_budget(ResourceBudget::default().with_max_steps(1));
-  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
-  let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(2.0))).unwrap();
-  assert!(outcome.turn.is_some());
-  let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(3.0))).unwrap();
-  assert!(outcome.turn.is_some());
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    let mut context = runtime
+        .runtime_context()
+        .unwrap()
+        .with_budget(ResourceBudget::default().with_max_steps(1));
+    grant_read_to(
+        &mut runtime,
+        &context.subject,
+        "test://clock/ticks",
+        "value",
+    );
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
+        )
+        .unwrap();
+    let outcome = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+            RuntimeHostInputValue::F64(2.0),
+        ))
+        .unwrap();
+    assert!(outcome.turn.is_some());
+    let outcome = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+            RuntimeHostInputValue::F64(3.0),
+        ))
+        .unwrap();
+    assert!(outcome.turn.is_some());
 }
 
 #[test]
 fn live_turn_enforces_duration_limit() {
-  let mut runtime = RuntimeBuilder::new()
-    .resource_provider(Box::new(test_provider_with("test://clock/ticks", "value", 1.0)))
-    .build()
-    .unwrap();
-  let mut context = runtime.runtime_context().unwrap();
-  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
-  grant_host_call(&mut runtime, &context.subject, 44, "host:demo/live-sleep");
-  register_sleep_host(&mut runtime, "demo/live-sleep");
-  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nslow := demo/live-sleep(@pulse/value)").unwrap();
-  runtime.config.limits.max_turn_duration_ms = Some(1);
-  let error = format!("{:?}", runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(2.0))).unwrap_err());
-  assert!(error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"), "{error}");
-  assert!(runtime.program().interpreter().symbols().borrow().contains(hash_str("slow")));
-  runtime.config.limits.max_turn_duration_ms = None;
-  runtime.run_string("recovery := 1").unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .resource_provider(Box::new(test_provider_with(
+            "test://clock/ticks",
+            "value",
+            1.0,
+        )))
+        .build()
+        .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    grant_read_to(
+        &mut runtime,
+        &context.subject,
+        "test://clock/ticks",
+        "value",
+    );
+    grant_host_call(&mut runtime, &context.subject, 44, "host:demo/live-sleep");
+    register_sleep_host(&mut runtime, "demo/live-sleep");
+    runtime
+        .run_string_with_context(
+            &mut context,
+            "@pulse := test://clock/ticks{:read(value)}\nslow := demo/live-sleep(@pulse/value)",
+        )
+        .unwrap();
+    runtime.config.limits.max_turn_duration_ms = Some(1);
+    let error = format!(
+        "{:?}",
+        runtime
+            .apply_host_input(RuntimeHostInput::single(
+                RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
+                RuntimeHostInputValue::F64(2.0)
+            ))
+            .unwrap_err()
+    );
+    assert!(
+        error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"),
+        "{error}"
+    );
+    assert!(
+        runtime
+            .program()
+            .interpreter()
+            .symbols()
+            .borrow()
+            .contains(hash_str("slow"))
+    );
+    runtime.config.limits.max_turn_duration_ms = None;
+    runtime.run_string("recovery := 1").unwrap();
 }
 
 #[test]
 fn changed_actor_message_rejects_live_context_reuse() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  let actor = ActorId(7);
-  let state = ObjectId(9);
-  let mut context_a = runtime.runtime_context().unwrap().with_subject("actor:7").with_actor(actor);
-  context_a.actor_state = Some(state);
-  context_a.actor_message = Some(MessageRecord::new(MessageId(1), actor, "tick", b"a".to_vec()));
-  grant_read_to(&mut runtime, "actor:7", "test://clock/ticks", "value");
-  runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap();
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    let actor = ActorId(7);
+    let state = ObjectId(9);
+    let mut context_a = runtime
+        .runtime_context()
+        .unwrap()
+        .with_subject("actor:7")
+        .with_actor(actor);
+    context_a.actor_state = Some(state);
+    context_a.actor_message = Some(MessageRecord::new(
+        MessageId(1),
+        actor,
+        "tick",
+        b"a".to_vec(),
+    ));
+    grant_read_to(&mut runtime, "actor:7", "test://clock/ticks", "value");
+    runtime
+        .run_string_with_context(
+            &mut context_a,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+        )
+        .unwrap();
 
-  let mut context_b = runtime.runtime_context().unwrap().with_subject("actor:7").with_actor(actor);
-  context_b.actor_state = Some(state);
-  context_b.actor_message = Some(MessageRecord::new(MessageId(2), actor, "tick", b"b".to_vec()));
-  let error = format!("{:?}", runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value").unwrap_err());
-  assert!(error.contains("RuntimeLiveContextMismatch"), "{error}");
+    let mut context_b = runtime
+        .runtime_context()
+        .unwrap()
+        .with_subject("actor:7")
+        .with_actor(actor);
+    context_b.actor_state = Some(state);
+    context_b.actor_message = Some(MessageRecord::new(
+        MessageId(2),
+        actor,
+        "tick",
+        b"b".to_vec(),
+    ));
+    let error = format!(
+        "{:?}",
+        runtime
+            .run_string_with_context(
+                &mut context_b,
+                "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value"
+            )
+            .unwrap_err()
+    );
+    assert!(error.contains("RuntimeLiveContextMismatch"), "{error}");
 }
 
 #[test]
 fn live_context_capability_order_does_not_cause_mismatch() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-  let mut context_a = runtime.runtime_context().unwrap().with_capabilities(vec![CapabilityId(1), CapabilityId(2)]);
-  let mut context_b = runtime.runtime_context().unwrap().with_capabilities(vec![CapabilityId(2), CapabilityId(1)]);
-  grant_read_to(&mut runtime, &context_a.subject, "test://clock/ticks", "value");
-  runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap();
-  runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value").unwrap();
+    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+    let mut context_a = runtime
+        .runtime_context()
+        .unwrap()
+        .with_capabilities(vec![CapabilityId(1), CapabilityId(2)]);
+    let mut context_b = runtime
+        .runtime_context()
+        .unwrap()
+        .with_capabilities(vec![CapabilityId(2), CapabilityId(1)]);
+    grant_read_to(
+        &mut runtime,
+        &context_a.subject,
+        "test://clock/ticks",
+        "value",
+    );
+    runtime
+        .run_string_with_context(
+            &mut context_a,
+            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+        )
+        .unwrap();
+    runtime
+        .run_string_with_context(
+            &mut context_b,
+            "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value",
+        )
+        .unwrap();
 }
 
 #[derive(Debug, Clone)]
 struct MockDriver {
-  name: String,
-  state: Rc<RefCell<MockDriverState>>,
-  events: Rc<RefCell<Vec<String>>>,
+    name: String,
+    state: Rc<RefCell<MockDriverState>>,
+    events: Rc<RefCell<Vec<String>>>,
 }
 
-const MOCK_DRIVER_BASE_URI: &str =
-  "test-input://clock/ticks";
+const MOCK_DRIVER_BASE_URI: &str = "test-input://clock/ticks";
 
-const MOCK_DRIVER_PATH: &str =
-  "value";
+const MOCK_DRIVER_PATH: &str = "value";
 
 #[derive(Debug, Default)]
 struct MockDriverState {
-  attach_count: usize,
-  start_count: usize,
-  stop_count: usize,
-  live: bool,
-  fail_attach: bool,
-  fail_start: bool,
-  fail_stop: bool,
-  attached_ingress: Option<RuntimeIngress>,
-  stop_observed_closed_ingress: bool,
-  log: Vec<String>,
+    attach_count: usize,
+    start_count: usize,
+    stop_count: usize,
+    live: bool,
+    fail_attach: bool,
+    fail_start: bool,
+    fail_stop: bool,
+    attached_ingress: Option<RuntimeIngress>,
+    stop_observed_closed_ingress: bool,
+    log: Vec<String>,
 }
 
 impl MockDriver {
-  fn new(name: &str, state: Rc<RefCell<MockDriverState>>) -> Self {
-    Self::with_events(name, state, Rc::new(RefCell::new(Vec::new())))
-  }
+    fn new(name: &str, state: Rc<RefCell<MockDriverState>>) -> Self {
+        Self::with_events(name, state, Rc::new(RefCell::new(Vec::new())))
+    }
 
-  fn with_events(name: &str, state: Rc<RefCell<MockDriverState>>, events: Rc<RefCell<Vec<String>>>) -> Self {
-    Self { name: name.to_string(), state, events }
-  }
+    fn with_events(
+        name: &str,
+        state: Rc<RefCell<MockDriverState>>,
+        events: Rc<RefCell<Vec<String>>>,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            state,
+            events,
+        }
+    }
 }
 
 impl RuntimeHostInputDriver for MockDriver {
-  fn drives(
-    &self,
-    source: &RuntimeHostInputSource,
-  ) -> bool {
-    source.base_uri() == MOCK_DRIVER_BASE_URI
-      && source.path() == MOCK_DRIVER_PATH
-  }
+    fn drives(&self, source: &RuntimeHostInputSource) -> bool {
+        source.base_uri() == MOCK_DRIVER_BASE_URI && source.path() == MOCK_DRIVER_PATH
+    }
 
-  fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
-    let mut state = self.state.borrow_mut();
-    state.attach_count += 1;
-    state.attached_ingress = Some(ingress);
-    let event = format!("attach:{}", self.name);
-    state.log.push(event.clone());
-    self.events.borrow_mut().push(event);
-    if state.fail_attach { return Err(mock_error("MockAttachError", format!("attach failed for {}", self.name))); }
-    Ok(())
-  }
+    fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
+        let mut state = self.state.borrow_mut();
+        state.attach_count += 1;
+        state.attached_ingress = Some(ingress);
+        let event = format!("attach:{}", self.name);
+        state.log.push(event.clone());
+        self.events.borrow_mut().push(event);
+        if state.fail_attach {
+            return Err(mock_error(
+                "MockAttachError",
+                format!("attach failed for {}", self.name),
+            ));
+        }
+        Ok(())
+    }
 
-  fn start(&mut self) -> MResult<()> {
-    let mut state = self.state.borrow_mut();
-    state.start_count += 1;
-    let event = format!("start:{}", self.name);
-    state.log.push(event.clone());
-    self.events.borrow_mut().push(event);
-    if state.fail_start { return Err(mock_error("MockStartError", format!("start failed for {}", self.name))); }
-    state.live = true;
-    Ok(())
-  }
+    fn start(&mut self) -> MResult<()> {
+        let mut state = self.state.borrow_mut();
+        state.start_count += 1;
+        let event = format!("start:{}", self.name);
+        state.log.push(event.clone());
+        self.events.borrow_mut().push(event);
+        if state.fail_start {
+            return Err(mock_error(
+                "MockStartError",
+                format!("start failed for {}", self.name),
+            ));
+        }
+        state.live = true;
+        Ok(())
+    }
 
-  fn stop(&mut self) -> MResult<()> {
-    let mut state = self.state.borrow_mut();
-    state.stop_count += 1;
-    let observed_closed = state.attached_ingress.as_ref().map(|ingress| ingress.is_closed().unwrap_or(false)).unwrap_or(false);
-    state.stop_observed_closed_ingress |= observed_closed;
-    let event = format!("stop:{}", self.name);
-    state.log.push(event.clone());
-    self.events.borrow_mut().push(event);
-    state.live = false;
-    if state.fail_stop { return Err(mock_error("MockStopError", format!("stop failed for {}", self.name))); }
-    Ok(())
-  }
+    fn stop(&mut self) -> MResult<()> {
+        let mut state = self.state.borrow_mut();
+        state.stop_count += 1;
+        let observed_closed = state
+            .attached_ingress
+            .as_ref()
+            .map(|ingress| ingress.is_closed().unwrap_or(false))
+            .unwrap_or(false);
+        state.stop_observed_closed_ingress |= observed_closed;
+        let event = format!("stop:{}", self.name);
+        state.log.push(event.clone());
+        self.events.borrow_mut().push(event);
+        state.live = false;
+        if state.fail_stop {
+            return Err(mock_error(
+                "MockStopError",
+                format!("stop failed for {}", self.name),
+            ));
+        }
+        Ok(())
+    }
 
-  fn is_live(&self) -> bool {
-    self.state.borrow().live
-  }
+    fn is_live(&self) -> bool {
+        self.state.borrow().live
+    }
 }
 
 #[derive(Debug)]
 struct MockDriverFactory {
-  manifest: HostManifestConfig,
-  drivers: Vec<MockDriver>,
+    manifest: HostManifestConfig,
+    drivers: Vec<MockDriver>,
 }
 
 impl MockDriverFactory {
-  fn new(drivers: Vec<MockDriver>) -> Self {
-    Self {
-      manifest: HostManifestConfig {
-        provider: "test-input".to_string(),
-        contexts: vec![HostContextManifest { name: "ticks".to_string(), base_uri_template: "test-input://{instance}/ticks".to_string(), operations: vec!["read".to_string()] }],
-      },
-      drivers,
+    fn new(drivers: Vec<MockDriver>) -> Self {
+        Self {
+            manifest: HostManifestConfig {
+                provider: "test-input".to_string(),
+                contexts: vec![HostContextManifest {
+                    name: "ticks".to_string(),
+                    base_uri_template: "test-input://{instance}/ticks".to_string(),
+                    operations: vec!["read".to_string()],
+                }],
+            },
+            drivers,
+        }
     }
-  }
 }
 
 impl RuntimeHostFactory for MockDriverFactory {
-  fn provider_name(&self) -> &str { "test-input" }
-  fn manifest(&self) -> &HostManifestConfig { &self.manifest }
-  fn validate_settings(&self, _instance_name: &str, _settings: &ConfigValue) -> MResult<()> { Ok(()) }
-  fn instantiate(&self, instance_name: &str, _settings: &ConfigValue) -> MResult<RuntimeHostInstallation> {
-    Ok(RuntimeHostInstallation {
-      interface: materialize_host_manifest(instance_name, &self.manifest)?,
-      resource_providers: Vec::<Box<dyn RuntimeResourceProvider>>::new(),
-      input_drivers: self.drivers.iter().cloned().map(|driver| Box::new(driver) as Box<dyn RuntimeHostInputDriver>).collect(),
-    })
-  }
+    fn provider_name(&self) -> &str {
+        "test-input"
+    }
+    fn manifest(&self) -> &HostManifestConfig {
+        &self.manifest
+    }
+    fn validate_settings(&self, _instance_name: &str, _settings: &ConfigValue) -> MResult<()> {
+        Ok(())
+    }
+    fn instantiate(
+        &self,
+        instance_name: &str,
+        _settings: &ConfigValue,
+    ) -> MResult<RuntimeHostInstallation> {
+        Ok(RuntimeHostInstallation {
+            interface: materialize_host_manifest(instance_name, &self.manifest)?,
+            resource_providers: Vec::<Box<dyn RuntimeResourceProvider>>::new(),
+            input_drivers: self
+                .drivers
+                .iter()
+                .cloned()
+                .map(|driver| Box::new(driver) as Box<dyn RuntimeHostInputDriver>)
+                .collect(),
+        })
+    }
 }
 
-fn drivers_with_events(states: &[(&str, Rc<RefCell<MockDriverState>>)]) -> (Vec<MockDriver>, Rc<RefCell<Vec<String>>>) {
-  let events = Rc::new(RefCell::new(Vec::new()));
-  let drivers = states
-    .iter()
-    .map(|(name, state)| MockDriver::with_events(name, state.clone(), events.clone()))
-    .collect();
-  (drivers, events)
+fn drivers_with_events(
+    states: &[(&str, Rc<RefCell<MockDriverState>>)],
+) -> (Vec<MockDriver>, Rc<RefCell<Vec<String>>>) {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let drivers = states
+        .iter()
+        .map(|(name, state)| MockDriver::with_events(name, state.clone(), events.clone()))
+        .collect();
+    (drivers, events)
 }
 
 fn runtime_with_drivers(drivers: Vec<MockDriver>) -> MResult<MechRuntime> {
-  RuntimeBuilder::new()
-    .host_factory(Box::new(MockDriverFactory::new(drivers)))?
-    .host_instance(HostInstanceConfig { name: "clock".to_string(), provider: "test-input".to_string(), settings: ConfigValue::Map(Default::default()) })
-    .build()
+    RuntimeBuilder::new()
+        .host_factory(Box::new(MockDriverFactory::new(drivers)))?
+        .host_instance(HostInstanceConfig {
+            name: "clock".to_string(),
+            provider: "test-input".to_string(),
+            settings: ConfigValue::Map(Default::default()),
+        })
+        .build()
 }
 
 #[test]
 fn build_attaches_but_does_not_start_input_drivers() {
-  let state = Rc::new(RefCell::new(MockDriverState::default()));
-  let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
-  assert_eq!(state.borrow().attach_count, 1);
-  assert_eq!(state.borrow().start_count, 0);
-  assert_eq!(state.borrow().stop_count, 0);
-  assert!(!state.borrow().live);
-  runtime.start_input_drivers().unwrap();
-  assert_eq!(state.borrow().start_count, 1);
-  assert!(state.borrow().live);
+    let state = Rc::new(RefCell::new(MockDriverState::default()));
+    let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
+    assert_eq!(state.borrow().attach_count, 1);
+    assert_eq!(state.borrow().start_count, 0);
+    assert_eq!(state.borrow().stop_count, 0);
+    assert!(!state.borrow().live);
+    runtime.start_input_drivers().unwrap();
+    assert_eq!(state.borrow().start_count, 1);
+    assert!(state.borrow().live);
 }
 
 #[test]
 fn attach_failure_closes_ingress_and_rolls_back_in_reverse_order() {
-  let a = Rc::new(RefCell::new(MockDriverState::default()));
-  let b = Rc::new(RefCell::new(MockDriverState { fail_attach: true, ..Default::default() }));
-  let c = Rc::new(RefCell::new(MockDriverState::default()));
-  let (drivers, events) = drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
-  let error = format!("{:?}", runtime_with_drivers(drivers).unwrap_err());
-  assert!(error.contains("MockAttachError"));
-  assert_eq!(a.borrow().attach_count, 1);
-  assert_eq!(b.borrow().attach_count, 1);
-  assert_eq!(c.borrow().attach_count, 0);
-  assert!(a.borrow().attached_ingress.as_ref().unwrap().is_closed().unwrap());
-  let stop_events: Vec<String> = events.borrow().iter().filter(|event| event.starts_with("stop:")).cloned().collect();
-  assert_eq!(stop_events, vec!["stop:b", "stop:a"]);
-  assert_eq!(a.borrow().stop_count, 1);
-  assert_eq!(b.borrow().stop_count, 1);
-  assert_eq!(c.borrow().stop_count, 0);
+    let a = Rc::new(RefCell::new(MockDriverState::default()));
+    let b = Rc::new(RefCell::new(MockDriverState {
+        fail_attach: true,
+        ..Default::default()
+    }));
+    let c = Rc::new(RefCell::new(MockDriverState::default()));
+    let (drivers, events) =
+        drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
+    let error = format!("{:?}", runtime_with_drivers(drivers).unwrap_err());
+    assert!(error.contains("MockAttachError"));
+    assert_eq!(a.borrow().attach_count, 1);
+    assert_eq!(b.borrow().attach_count, 1);
+    assert_eq!(c.borrow().attach_count, 0);
+    assert!(
+        a.borrow()
+            .attached_ingress
+            .as_ref()
+            .unwrap()
+            .is_closed()
+            .unwrap()
+    );
+    let stop_events: Vec<String> = events
+        .borrow()
+        .iter()
+        .filter(|event| event.starts_with("stop:"))
+        .cloned()
+        .collect();
+    assert_eq!(stop_events, vec!["stop:b", "stop:a"]);
+    assert_eq!(a.borrow().stop_count, 1);
+    assert_eq!(b.borrow().stop_count, 1);
+    assert_eq!(c.borrow().stop_count, 0);
 }
 
 #[test]
 fn start_failure_stops_every_driver_in_reverse_order() {
-  let a = Rc::new(RefCell::new(MockDriverState::default()));
-  let b = Rc::new(RefCell::new(MockDriverState { fail_start: true, ..Default::default() }));
-  let c = Rc::new(RefCell::new(MockDriverState::default()));
-  let (drivers, events) = drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
-  let mut runtime = runtime_with_drivers(drivers).unwrap();
-  let error = format!("{:?}", runtime.start_input_drivers().unwrap_err());
-  assert!(error.contains("MockStartError"));
-  let stop_events: Vec<String> = events.borrow().iter().filter(|event| event.starts_with("stop:")).cloned().collect();
-  assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
-  assert!(!a.borrow().live && !b.borrow().live && !c.borrow().live);
+    let a = Rc::new(RefCell::new(MockDriverState::default()));
+    let b = Rc::new(RefCell::new(MockDriverState {
+        fail_start: true,
+        ..Default::default()
+    }));
+    let c = Rc::new(RefCell::new(MockDriverState::default()));
+    let (drivers, events) =
+        drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
+    let mut runtime = runtime_with_drivers(drivers).unwrap();
+    let error = format!("{:?}", runtime.start_input_drivers().unwrap_err());
+    assert!(error.contains("MockStartError"));
+    let stop_events: Vec<String> = events
+        .borrow()
+        .iter()
+        .filter(|event| event.starts_with("stop:"))
+        .cloned()
+        .collect();
+    assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
+    assert!(!a.borrow().live && !b.borrow().live && !c.borrow().live);
 }
 
 #[test]
 fn stop_input_drivers_attempts_every_driver() {
-  let a = Rc::new(RefCell::new(MockDriverState::default()));
-  let b = Rc::new(RefCell::new(MockDriverState { fail_stop: true, ..Default::default() }));
-  let c = Rc::new(RefCell::new(MockDriverState::default()));
-  let (drivers, events) = drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
-  let mut runtime = runtime_with_drivers(drivers).unwrap();
-  runtime.start_input_drivers().unwrap();
-  let error = format!("{:?}", runtime.stop_input_drivers().unwrap_err());
-  assert!(error.contains("MockStopError"));
-  assert_eq!(a.borrow().stop_count, 1);
-  assert_eq!(b.borrow().stop_count, 1);
-  assert_eq!(c.borrow().stop_count, 1);
-  let stop_events: Vec<String> = events.borrow().iter().filter(|event| event.starts_with("stop:")).cloned().collect();
-  assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
+    let a = Rc::new(RefCell::new(MockDriverState::default()));
+    let b = Rc::new(RefCell::new(MockDriverState {
+        fail_stop: true,
+        ..Default::default()
+    }));
+    let c = Rc::new(RefCell::new(MockDriverState::default()));
+    let (drivers, events) =
+        drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
+    let mut runtime = runtime_with_drivers(drivers).unwrap();
+    runtime.start_input_drivers().unwrap();
+    let error = format!("{:?}", runtime.stop_input_drivers().unwrap_err());
+    assert!(error.contains("MockStopError"));
+    assert_eq!(a.borrow().stop_count, 1);
+    assert_eq!(b.borrow().stop_count, 1);
+    assert_eq!(c.borrow().stop_count, 1);
+    let stop_events: Vec<String> = events
+        .borrow()
+        .iter()
+        .filter(|event| event.starts_with("stop:"))
+        .cloned()
+        .collect();
+    assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
 }
 
 #[test]
 fn shutdown_closes_ingress_before_stopping_drivers() {
-  let state = Rc::new(RefCell::new(MockDriverState::default()));
-  let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
-  runtime.start_input_drivers().unwrap();
-  let ingress = state.borrow().attached_ingress.clone().unwrap();
-  runtime.shutdown().unwrap();
-  assert_eq!(state.borrow().stop_count, 1);
-  assert!(state.borrow().stop_observed_closed_ingress);
-  drop(runtime);
-  assert_eq!(state.borrow().stop_count, 1);
-  let source = RuntimeHostInputSource::new("test-input://clock/ticks", "value").unwrap();
-  let error = format!("{:?}", ingress.submit(RuntimeHostInput::single(source, RuntimeHostInputValue::F64(1.0))).unwrap_err());
-  assert!(error.contains("RuntimeIngressClosed"));
+    let state = Rc::new(RefCell::new(MockDriverState::default()));
+    let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
+    runtime.start_input_drivers().unwrap();
+    let ingress = state.borrow().attached_ingress.clone().unwrap();
+    runtime.shutdown().unwrap();
+    assert_eq!(state.borrow().stop_count, 1);
+    assert!(state.borrow().stop_observed_closed_ingress);
+    drop(runtime);
+    assert_eq!(state.borrow().stop_count, 1);
+    let source = RuntimeHostInputSource::new("test-input://clock/ticks", "value").unwrap();
+    let error = format!(
+        "{:?}",
+        ingress
+            .submit(RuntimeHostInput::single(
+                source,
+                RuntimeHostInputValue::F64(1.0)
+            ))
+            .unwrap_err()
+    );
+    assert!(error.contains("RuntimeIngressClosed"));
 }
 
 #[test]
 fn drop_stops_live_input_drivers() {
-  let state = Rc::new(RefCell::new(MockDriverState::default()));
-  {
-    let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
-    runtime.start_input_drivers().unwrap();
-    assert!(state.borrow().live);
-  }
-  assert_eq!(state.borrow().stop_count, 1);
-  assert!(!state.borrow().live);
+    let state = Rc::new(RefCell::new(MockDriverState::default()));
+    {
+        let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
+        runtime.start_input_drivers().unwrap();
+        assert!(state.borrow().live);
+    }
+    assert_eq!(state.borrow().stop_count, 1);
+    assert!(!state.borrow().live);
 }
-
 
 #[derive(Debug, Clone)]
-struct MockDriverError { name: &'static str, message: String }
+struct MockDriverError {
+    name: &'static str,
+    message: String,
+}
 impl MechErrorKind for MockDriverError {
-  fn name(&self) -> &str { self.name }
-  fn message(&self) -> String { self.message.clone() }
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn message(&self) -> String {
+        self.message.clone()
+    }
 }
 fn mock_error(name: &'static str, message: impl Into<String>) -> MechError {
-  MechError::new(MockDriverError { name, message: message.into() }, None)
+    MechError::new(
+        MockDriverError {
+            name,
+            message: message.into(),
+        },
+        None,
+    )
 }
 
 #[cfg(test)]
 mod persistent_send_tests {
-  use super::*;
-  use crate::runtime::execution::ACTIVATION_EFFECT_BARRIER_NAME;
-  use crate::RuntimeResourceWritePreflightRequest;
+    use super::*;
+    use crate::RuntimeResourceWritePreflightRequest;
+    use crate::runtime::execution::ACTIVATION_EFFECT_BARRIER_NAME;
 
-  const TEST_TIME_BASE_URI: &str =
-    "time://clock/clock";
+    const TEST_TIME_BASE_URI: &str = "time://clock/clock";
 
-  const TEST_TIME_PATHS: [&str; 5] = [
-    "unix-ms",
-    "hour",
-    "minute",
-    "second",
-    "millisecond",
-  ];
+    const TEST_TIME_PATHS: [&str; 5] = ["unix-ms", "hour", "minute", "second", "millisecond"];
 
-  fn test_time_source_matches(
-    source: &RuntimeHostInputSource,
-  ) -> bool {
-    source.base_uri() == TEST_TIME_BASE_URI
-      && TEST_TIME_PATHS.contains(&source.path())
-  }
-
-  #[derive(Clone, Copy, Debug)]
-  struct TimeSnapshot {
-    unix_ms: f64,
-    hour: f64,
-    minute: f64,
-    second: f64,
-    millisecond: f64,
-  }
-
-  #[derive(Debug)]
-  struct TimeResourceProvider {
-    snapshot: Rc<RefCell<TimeSnapshot>>,
-  }
-
-  impl RuntimeResourceProvider for TimeResourceProvider {
-    fn scheme(&self) -> &str { "time" }
-    fn base_uris(&self) -> Vec<String> { vec![TEST_TIME_BASE_URI.to_string()] }
-    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-      let snapshot = *self.snapshot.borrow();
-      let value = match request.path.as_str() {
-        "unix-ms" => snapshot.unix_ms,
-        "hour" => snapshot.hour,
-        "minute" => snapshot.minute,
-        "second" => snapshot.second,
-        "millisecond" => snapshot.millisecond,
-        other => return Err(MechError::new(PersistentSendTestError(format!("unknown time path {other}")), None)),
-      };
-      Ok(Value::F64(Ref::new(value)))
-    }
-  }
-
-  #[derive(Clone, Debug)]
-  struct ManualTimeInputDriver {
-    snapshot: Rc<RefCell<TimeSnapshot>>,
-    ingress: Rc<RefCell<Option<RuntimeIngress>>>,
-    live: Rc<RefCell<bool>>,
-  }
-
-  impl ManualTimeInputDriver {
-    fn new(snapshot: Rc<RefCell<TimeSnapshot>>) -> Self {
-      Self { snapshot, ingress: Rc::new(RefCell::new(None)), live: Rc::new(RefCell::new(false)) }
+    fn test_time_source_matches(source: &RuntimeHostInputSource) -> bool {
+        source.base_uri() == TEST_TIME_BASE_URI && TEST_TIME_PATHS.contains(&source.path())
     }
 
-    fn publish(&self, snapshot: TimeSnapshot) -> MResult<()> {
-      *self.snapshot.borrow_mut() = snapshot;
-      let ingress = self.ingress.borrow().clone().ok_or_else(|| MechError::new(PersistentSendTestError("driver is not attached".to_string()), None))?;
-      ingress.submit(RuntimeHostInput::new(vec![
-        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "unix-ms")?, value: RuntimeHostInputValue::F64(snapshot.unix_ms) },
-        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "hour")?, value: RuntimeHostInputValue::F64(snapshot.hour) },
-        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "minute")?, value: RuntimeHostInputValue::F64(snapshot.minute) },
-        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "second")?, value: RuntimeHostInputValue::F64(snapshot.second) },
-        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "millisecond")?, value: RuntimeHostInputValue::F64(snapshot.millisecond) },
-      ])?)
+    #[derive(Clone, Copy, Debug)]
+    struct TimeSnapshot {
+        unix_ms: f64,
+        hour: f64,
+        minute: f64,
+        second: f64,
+        millisecond: f64,
     }
-  }
 
-  impl RuntimeHostInputDriver for ManualTimeInputDriver {
-    fn drives(&self, source: &RuntimeHostInputSource) -> bool { test_time_source_matches(source) }
-    fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> { *self.ingress.borrow_mut() = Some(ingress); Ok(()) }
-    fn start(&mut self) -> MResult<()> { *self.live.borrow_mut() = true; Ok(()) }
-    fn stop(&mut self) -> MResult<()> { *self.live.borrow_mut() = false; Ok(()) }
-    fn is_live(&self) -> bool { *self.live.borrow() }
-  }
-
-  #[derive(Clone, Debug, Default)]
-  struct RecordingConsoleBackend {
-    lines: Rc<RefCell<Vec<String>>>,
-    fail_next: Rc<RefCell<Option<String>>>,
-  }
-
-  impl RecordingConsoleBackend {
-    fn lines(&self) -> Vec<String> { self.lines.borrow().clone() }
-    fn fail_next(&self, reason: impl Into<String>) { *self.fail_next.borrow_mut() = Some(reason.into()); }
-  }
-
-  #[derive(Debug)]
-  struct ConsoleResourceProvider { backend: RecordingConsoleBackend }
-
-  impl RuntimeResourceProvider for ConsoleResourceProvider {
-    fn scheme(&self) -> &str { "console" }
-    fn base_uris(&self) -> Vec<String> { vec!["console://console/output".to_string()] }
-    fn read(&self, _request: RuntimeResourceReadRequest) -> MResult<Value> { Err(MechError::new(PersistentSendTestError("console is write-only".to_string()), None)) }
-    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-      if request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send { Ok(()) } else { Err(MechError::new(PersistentSendTestError("bad console write".to_string()), None)) }
+    #[derive(Debug)]
+    struct TimeResourceProvider {
+        snapshot: Rc<RefCell<TimeSnapshot>>,
     }
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-      self.preflight_write(RuntimeResourceWritePreflightRequest {
-        base_uri: request.base_uri,
-        path: request.path,
-        context_name: request.context_name,
-        operation: request.operation,
-        intent: request.intent,
-      })?;
-      if let Some(reason) = self.backend.fail_next.borrow_mut().take() {
-        return Err(MechError::new(PersistentSendTestError(reason), None));
-      }
-      self.backend.lines.borrow_mut().push(format!("{}", request.value));
-      Ok(())
+
+    impl RuntimeResourceProvider for TimeResourceProvider {
+        fn scheme(&self) -> &str {
+            "time"
+        }
+        fn base_uris(&self) -> Vec<String> {
+            vec![TEST_TIME_BASE_URI.to_string()]
+        }
+        fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+            let snapshot = *self.snapshot.borrow();
+            let value = match request.path.as_str() {
+                "unix-ms" => snapshot.unix_ms,
+                "hour" => snapshot.hour,
+                "minute" => snapshot.minute,
+                "second" => snapshot.second,
+                "millisecond" => snapshot.millisecond,
+                other => {
+                    return Err(MechError::new(
+                        PersistentSendTestError(format!("unknown time path {other}")),
+                        None,
+                    ));
+                }
+            };
+            Ok(Value::F64(Ref::new(value)))
+        }
     }
-  }
 
-  #[derive(Debug, Clone)]
-  struct PersistentSendTestError(String);
+    #[derive(Clone, Debug)]
+    struct ManualTimeInputDriver {
+        snapshot: Rc<RefCell<TimeSnapshot>>,
+        ingress: Rc<RefCell<Option<RuntimeIngress>>>,
+        live: Rc<RefCell<bool>>,
+    }
 
-  impl MechErrorKind for PersistentSendTestError {
-    fn name(&self) -> &str { "PersistentSendTestError" }
-    fn message(&self) -> String { self.0.clone() }
-  }
+    impl ManualTimeInputDriver {
+        fn new(snapshot: Rc<RefCell<TimeSnapshot>>) -> Self {
+            Self {
+                snapshot,
+                ingress: Rc::new(RefCell::new(None)),
+                live: Rc::new(RefCell::new(false)),
+            }
+        }
 
-  const TIME_PATHS: &[&str] = &["unix-ms", "hour", "minute", "second", "millisecond"];
+        fn publish(&self, snapshot: TimeSnapshot) -> MResult<()> {
+            *self.snapshot.borrow_mut() = snapshot;
+            let ingress = self.ingress.borrow().clone().ok_or_else(|| {
+                MechError::new(
+                    PersistentSendTestError("driver is not attached".to_string()),
+                    None,
+                )
+            })?;
+            ingress.submit(RuntimeHostInput::new(vec![
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "unix-ms")?,
+                    value: RuntimeHostInputValue::F64(snapshot.unix_ms),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "hour")?,
+                    value: RuntimeHostInputValue::F64(snapshot.hour),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "minute")?,
+                    value: RuntimeHostInputValue::F64(snapshot.minute),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "second")?,
+                    value: RuntimeHostInputValue::F64(snapshot.second),
+                },
+                RuntimeHostInputUpdate {
+                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "millisecond")?,
+                    value: RuntimeHostInputValue::F64(snapshot.millisecond),
+                },
+            ])?)
+        }
+    }
 
-  fn snapshot(hour: f64, minute: f64, second: f64, millisecond: f64) -> TimeSnapshot {
-    TimeSnapshot { unix_ms: hour * 3_600_000.0 + minute * 60_000.0 + second * 1000.0 + millisecond, hour, minute, second, millisecond }
-  }
+    impl RuntimeHostInputDriver for ManualTimeInputDriver {
+        fn drives(&self, source: &RuntimeHostInputSource) -> bool {
+            test_time_source_matches(source)
+        }
+        fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
+            *self.ingress.borrow_mut() = Some(ingress);
+            Ok(())
+        }
+        fn start(&mut self) -> MResult<()> {
+            *self.live.borrow_mut() = true;
+            Ok(())
+        }
+        fn stop(&mut self) -> MResult<()> {
+            *self.live.borrow_mut() = false;
+            Ok(())
+        }
+        fn is_live(&self) -> bool {
+            *self.live.borrow()
+        }
+    }
 
-  fn grant(runtime: &mut MechRuntime, resource: &str, operation: RuntimeCapabilityOperation, paths: &[&str]) {
-    let subject = runtime.runtime_context().unwrap().subject;
-    runtime.grant_capability(RuntimeCapabilityGrant {
-      subject,
-      resource: resource.to_string(),
-      operations: vec![operation],
-      paths: paths.iter().map(|path| path.to_string()).collect(),
-    }).unwrap();
-  }
+    #[derive(Clone, Debug, Default)]
+    struct RecordingConsoleBackend {
+        lines: Rc<RefCell<Vec<String>>>,
+        fail_next: Rc<RefCell<Option<String>>>,
+    }
 
-  fn runtime_with_console(initial: TimeSnapshot, fail_next: bool) -> (MechRuntime, ManualTimeInputDriver, RecordingConsoleBackend) {
-    let shared = Rc::new(RefCell::new(initial));
-    let console = RecordingConsoleBackend::default();
-    if fail_next { console.fail_next("intentional console failure"); }
-    let mut runtime = RuntimeBuilder::new()
-      .resource_provider(Box::new(TimeResourceProvider { snapshot: shared.clone() }) as Box<dyn RuntimeResourceProvider>)
-      .resource_provider(Box::new(ConsoleResourceProvider { backend: console.clone() }) as Box<dyn RuntimeResourceProvider>)
-      .build()
-      .unwrap();
-    grant(&mut runtime, "time://clock/clock", RuntimeCapabilityOperation::Read, TIME_PATHS);
-    grant(&mut runtime, "console://console/output", RuntimeCapabilityOperation::Write, &["line"]);
-    let mut driver = ManualTimeInputDriver::new(shared);
-    driver.attach(runtime.ingress()).unwrap();
-    driver.start().unwrap();
-    (runtime, driver, console)
-  }
+    impl RecordingConsoleBackend {
+        fn lines(&self) -> Vec<String> {
+            self.lines.borrow().clone()
+        }
+        fn fail_next(&self, reason: impl Into<String>) {
+            *self.fail_next.borrow_mut() = Some(reason.into());
+        }
+    }
 
-  fn load(runtime: &mut MechRuntime, send_expression: &str) {
-    let source = format!(r#"@out := console://console/output{{:write(line)}}
+    #[derive(Debug)]
+    struct ConsoleResourceProvider {
+        backend: RecordingConsoleBackend,
+    }
+
+    impl RuntimeResourceProvider for ConsoleResourceProvider {
+        fn scheme(&self) -> &str {
+            "console"
+        }
+        fn base_uris(&self) -> Vec<String> {
+            vec!["console://console/output".to_string()]
+        }
+        fn read(&self, _request: RuntimeResourceReadRequest) -> MResult<Value> {
+            Err(MechError::new(
+                PersistentSendTestError("console is write-only".to_string()),
+                None,
+            ))
+        }
+        fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+            if request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send {
+                Ok(())
+            } else {
+                Err(MechError::new(
+                    PersistentSendTestError("bad console write".to_string()),
+                    None,
+                ))
+            }
+        }
+        fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+            self.preflight_write(RuntimeResourceWritePreflightRequest {
+                base_uri: request.base_uri,
+                path: request.path,
+                context_name: request.context_name,
+                operation: request.operation,
+                intent: request.intent,
+            })?;
+            if let Some(reason) = self.backend.fail_next.borrow_mut().take() {
+                return Err(MechError::new(PersistentSendTestError(reason), None));
+            }
+            self.backend
+                .lines
+                .borrow_mut()
+                .push(format!("{}", request.value));
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct PersistentSendTestError(String);
+
+    impl MechErrorKind for PersistentSendTestError {
+        fn name(&self) -> &str {
+            "PersistentSendTestError"
+        }
+        fn message(&self) -> String {
+            self.0.clone()
+        }
+    }
+
+    const TIME_PATHS: &[&str] = &["unix-ms", "hour", "minute", "second", "millisecond"];
+
+    fn grant_write_to(runtime: &mut MechRuntime, subject: &str, resource: &str, path: &str) {
+        runtime
+            .grant_capability(RuntimeCapabilityGrant {
+                subject: subject.to_string(),
+                resource: resource.to_string(),
+                operations: vec![RuntimeCapabilityOperation::Write],
+                paths: vec![path.to_string()],
+            })
+            .unwrap();
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct SequencedOutput {
+        attempts: Rc<RefCell<Vec<String>>>,
+        successes: Rc<RefCell<Vec<String>>>,
+        fail_once_at: Rc<RefCell<Option<usize>>>,
+    }
+
+    impl SequencedOutput {
+        fn attempts(&self) -> Vec<String> {
+            self.attempts.borrow().clone()
+        }
+        fn successes(&self) -> Vec<String> {
+            self.successes.borrow().clone()
+        }
+        fn fail_once_at(&self, attempt: usize) {
+            assert!(attempt > 0);
+            *self.fail_once_at.borrow_mut() = Some(attempt);
+        }
+    }
+
+    #[derive(Debug)]
+    struct SequencedOutputProvider {
+        backend: SequencedOutput,
+    }
+
+    impl RuntimeResourceProvider for SequencedOutputProvider {
+        fn scheme(&self) -> &str {
+            "test"
+        }
+        fn base_uris(&self) -> Vec<String> {
+            vec![TEST_OUTPUT_BASE_URI.to_string()]
+        }
+        fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+            Err(MechError::new(
+                PersistentSendTestError(format!(
+                    "sequenced output is write-only: {} / {}",
+                    request.base_uri, request.path,
+                )),
+                None,
+            ))
+        }
+        fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+            if request.base_uri == TEST_OUTPUT_BASE_URI
+                && request.path == "line"
+                && request.intent == RuntimeResourceWriteIntent::Send
+            {
+                Ok(())
+            } else {
+                Err(MechError::new(
+                    PersistentSendTestError(format!(
+                        "invalid sequenced output write: {} / {}",
+                        request.base_uri, request.path,
+                    )),
+                    None,
+                ))
+            }
+        }
+        fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+            self.preflight_write(RuntimeResourceWritePreflightRequest {
+                base_uri: request.base_uri.clone(),
+                path: request.path.clone(),
+                context_name: request.context_name.clone(),
+                operation: request.operation.clone(),
+                intent: request.intent,
+            })?;
+            let rendered = format!("{}", request.value);
+            let attempt_number = {
+                let mut attempts = self.backend.attempts.borrow_mut();
+                attempts.push(rendered.clone());
+                attempts.len()
+            };
+            let should_fail = {
+                let mut fail_once_at = self.backend.fail_once_at.borrow_mut();
+                if *fail_once_at == Some(attempt_number) {
+                    *fail_once_at = None;
+                    true
+                } else {
+                    false
+                }
+            };
+            if should_fail {
+                return Err(MechError::new(
+                    PersistentSendTestError(format!(
+                        "intentional output failure on attempt {attempt_number}"
+                    )),
+                    None,
+                ));
+            }
+            self.backend.successes.borrow_mut().push(rendered);
+            Ok(())
+        }
+    }
+
+    fn snapshot(hour: f64, minute: f64, second: f64, millisecond: f64) -> TimeSnapshot {
+        TimeSnapshot {
+            unix_ms: hour * 3_600_000.0 + minute * 60_000.0 + second * 1000.0 + millisecond,
+            hour,
+            minute,
+            second,
+            millisecond,
+        }
+    }
+
+    fn grant(
+        runtime: &mut MechRuntime,
+        resource: &str,
+        operation: RuntimeCapabilityOperation,
+        paths: &[&str],
+    ) {
+        let subject = runtime.runtime_context().unwrap().subject;
+        runtime
+            .grant_capability(RuntimeCapabilityGrant {
+                subject,
+                resource: resource.to_string(),
+                operations: vec![operation],
+                paths: paths.iter().map(|path| path.to_string()).collect(),
+            })
+            .unwrap();
+    }
+
+    fn runtime_with_console(
+        initial: TimeSnapshot,
+        fail_next: bool,
+    ) -> (MechRuntime, ManualTimeInputDriver, RecordingConsoleBackend) {
+        let shared = Rc::new(RefCell::new(initial));
+        let console = RecordingConsoleBackend::default();
+        if fail_next {
+            console.fail_next("intentional console failure");
+        }
+        let mut runtime = RuntimeBuilder::new()
+            .resource_provider(Box::new(TimeResourceProvider {
+                snapshot: shared.clone(),
+            }) as Box<dyn RuntimeResourceProvider>)
+            .resource_provider(Box::new(ConsoleResourceProvider {
+                backend: console.clone(),
+            }) as Box<dyn RuntimeResourceProvider>)
+            .build()
+            .unwrap();
+        grant(
+            &mut runtime,
+            "time://clock/clock",
+            RuntimeCapabilityOperation::Read,
+            TIME_PATHS,
+        );
+        grant(
+            &mut runtime,
+            "console://console/output",
+            RuntimeCapabilityOperation::Write,
+            &["line"],
+        );
+        let mut driver = ManualTimeInputDriver::new(shared);
+        driver.attach(runtime.ingress()).unwrap();
+        driver.start().unwrap();
+        (runtime, driver, console)
+    }
+
+    fn load(runtime: &mut MechRuntime, send_expression: &str) {
+        let source = format!(
+            r#"@out := console://console/output{{:write(line)}}
 @clock := time://clock/clock{{:read(unix-ms), :read(hour), :read(minute), :read(second), :read(millisecond)}}
 unix-ms := @clock/unix-ms
 hour := @clock/hour
@@ -1134,154 +2091,343 @@ millisecond := @clock/millisecond
 scalar-output := hour + minute
 clock-output := (hour, minute, second)
 @out/line <- {send_expression}
-"#);
-    runtime.run_string(&source).unwrap();
-  }
+"#
+        );
+        runtime.run_string(&source).unwrap();
+    }
 
-  fn publish(runtime: &mut MechRuntime, driver: &ManualTimeInputDriver, snapshot: TimeSnapshot) {
-    driver.publish(snapshot).unwrap();
-    let outcomes = runtime.drain_host_inputs(1).unwrap();
-    assert_eq!(outcomes.len(), 1);
-  }
+    fn publish(runtime: &mut MechRuntime, driver: &ManualTimeInputDriver, snapshot: TimeSnapshot) {
+        driver.publish(snapshot).unwrap();
+        let outcomes = runtime.drain_host_inputs(1).unwrap();
+        assert_eq!(outcomes.len(), 1);
+    }
 
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct ActivationPlanSnapshot {
+        nodes: Vec<ActivationNodeSnapshot>,
+        reactive_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>,
+        sampled_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>,
+    }
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct ActivationNodeSnapshot {
+        id: ReactiveNodeId,
+        plan_index: usize,
+        kind: ReactiveNodeKind,
+        inputs: Vec<(ReactiveCellId, ReactiveDependencyKind)>,
+        outputs: Vec<ReactiveCellId>,
+    }
+    fn activation_plan_snapshot(runtime: &MechRuntime) -> ActivationPlanSnapshot {
+        let plan = runtime.program.interpreter().plan();
+        let plan = plan.borrow();
+        let nodes = plan
+            .nodes
+            .iter()
+            .map(|n| ActivationNodeSnapshot {
+                id: n.id,
+                plan_index: n.plan_index,
+                kind: n.kind,
+                inputs: n.inputs.iter().map(|d| (d.cell, d.kind)).collect(),
+                outputs: n.outputs.clone(),
+            })
+            .collect();
+        let mut reactive_consumers = plan
+            .reactive_consumers
+            .iter()
+            .map(|(c, n)| (*c, n.clone()))
+            .collect::<Vec<_>>();
+        let mut sampled_consumers = plan
+            .sampled_consumers
+            .iter()
+            .map(|(c, n)| (*c, n.clone()))
+            .collect::<Vec<_>>();
+        reactive_consumers.sort_by_key(|(c, _)| c.get());
+        sampled_consumers.sort_by_key(|(c, _)| c.get());
+        ActivationPlanSnapshot {
+            nodes,
+            reactive_consumers,
+            sampled_consumers,
+        }
+    }
+    fn activation_nodes_for_trigger(
+        runtime: &MechRuntime,
+        trigger_name: &str,
+        kind: ReactiveNodeKind,
+    ) -> Vec<ReactiveNodeId> {
+        let c = symbol_cell(runtime, trigger_name);
+        let p = runtime.program.interpreter().plan();
+        p.borrow()
+            .nodes
+            .iter()
+            .filter(|n| {
+                n.kind == kind
+                    && n.inputs
+                        .iter()
+                        .any(|d| d.cell == c && d.kind == ReactiveDependencyKind::Reactive)
+            })
+            .map(|n| n.id)
+            .collect()
+    }
+    fn activation_barrier_for_trigger(runtime: &MechRuntime, trigger_name: &str) -> ReactiveNodeId {
+        let c = symbol_cell(runtime, trigger_name);
+        let p = runtime.program.interpreter().plan();
+        let barriers = p
+            .borrow()
+            .nodes
+            .iter()
+            .filter(|n| {
+                n.kind == ReactiveNodeKind::Combinational
+                    && n.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+                    && n.outputs.is_empty()
+                    && n.inputs
+                        .iter()
+                        .any(|d| d.cell == c && d.kind == ReactiveDependencyKind::Reactive)
+            })
+            .map(|n| n.id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            barriers.len(),
+            1,
+            "expected exactly one activation-effect barrier for trigger {trigger_name}"
+        );
+        barriers[0]
+    }
+    fn only_reactive_turn(outcome: &RuntimeHostInputOutcome) -> &ReactiveTurnOutcome {
+        let p = outcome
+            .turn
+            .as_ref()
+            .expect("expected a program input turn");
+        assert_eq!(
+            p.interpreter_turns.len(),
+            1,
+            "expected exactly one affected interpreter"
+        );
+        &p.interpreter_turns[0].turn
+    }
+    fn executed_count(turn: &ReactiveTurnOutcome, id: ReactiveNodeId) -> usize {
+        turn.before_commit
+            .executed_nodes
+            .iter()
+            .chain(turn.after_commit.executed_nodes.iter())
+            .filter(|x| **x == id)
+            .count()
+    }
+    fn apply_f64_input(r: &mut MechRuntime, b: &str, p: &str, v: f64) -> RuntimeHostInputOutcome {
+        r.apply_host_input(RuntimeHostInput::single(
+            RuntimeHostInputSource::new(b, p).unwrap(),
+            RuntimeHostInputValue::F64(v),
+        ))
+        .unwrap()
+    }
+    fn recorded_f64(o: &RecordingTestOutput, i: usize) -> f64 {
+        o.lines()[i].trim().parse().unwrap()
+    }
+    fn activation_send_count(r: &MechRuntime) -> usize {
+        r.persistent_sends
+            .iter()
+            .filter(|s| matches!(s.schedule, RuntimePersistentSendSchedule::Activation { .. }))
+            .count()
+    }
+    fn activation_rejection_runtime() -> (MechRuntime, RecordingTestOutput) {
+        let (mut r, o) = test_runtime_with_output(TestResourceProvider::new().with_value(
+            "test://render/timer",
+            "tick",
+            Value::F64(Ref::new(0.0)),
+        ));
+        grant_read(&mut r, "test://render/timer", "tick");
+        grant_write(&mut r, TEST_OUTPUT_BASE_URI, "line");
+        (r, o)
+    }
+    fn assert_rejected_activation_left_no_state(
+        r: &MechRuntime,
+        o: &RecordingTestOutput,
+        p: &ActivationPlanSnapshot,
+        s: usize,
+        b: &HashMap<RuntimeHostInputSource, Vec<mech_program::ProgramInputId>>,
+    ) {
+        assert_eq!(activation_plan_snapshot(r), *p);
+        assert_eq!(r.persistent_sends.len(), s);
+        assert_eq!(r.live_input_bindings, *b);
+        assert!(o.lines().is_empty());
+        assert!(
+            !r.program
+                .interpreter()
+                .plan()
+                .activation_registration_active()
+        );
+    }
 
-  #[derive(Clone, Debug, PartialEq, Eq)]
-  struct ActivationPlanSnapshot { nodes: Vec<ActivationNodeSnapshot>, reactive_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>, sampled_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)> }
-  #[derive(Clone, Debug, PartialEq, Eq)]
-  struct ActivationNodeSnapshot { id: ReactiveNodeId, plan_index: usize, kind: ReactiveNodeKind, function: String, inputs: Vec<(ReactiveCellId, ReactiveDependencyKind)>, outputs: Vec<ReactiveCellId> }
-  fn activation_plan_snapshot(runtime: &MechRuntime) -> ActivationPlanSnapshot { let plan=runtime.program.interpreter().plan(); let plan=plan.borrow(); let nodes=plan.nodes.iter().map(|n| ActivationNodeSnapshot{id:n.id,plan_index:n.plan_index,kind:n.kind,function: std::any::type_name_of_val(n.function.as_ref()).to_string(),inputs:n.inputs.iter().map(|d|(d.cell,d.kind)).collect(),outputs:n.outputs.clone()}).collect(); let mut reactive_consumers=plan.reactive_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();let mut sampled_consumers=plan.sampled_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();reactive_consumers.sort_by_key(|(c,_)|c.get());sampled_consumers.sort_by_key(|(c,_)|c.get());ActivationPlanSnapshot{nodes,reactive_consumers,sampled_consumers} }
-  fn activation_nodes_for_trigger(runtime:&MechRuntime, trigger_name:&str, kind:ReactiveNodeKind)->Vec<ReactiveNodeId>{let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();p.borrow().nodes.iter().filter(|n|n.kind==kind&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect()}
-  fn activation_barrier_for_trigger(runtime:&MechRuntime, trigger_name:&str)->ReactiveNodeId {let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();let barriers=p.borrow().nodes.iter().filter(|n|n.kind==ReactiveNodeKind::Combinational&&n.function.to_string()==ACTIVATION_EFFECT_BARRIER_NAME&&n.outputs.is_empty()&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect::<Vec<_>>();assert_eq!(barriers.len(),1,"expected exactly one activation-effect barrier for trigger {trigger_name}");barriers[0]}
-  fn only_reactive_turn(outcome:&RuntimeHostInputOutcome)->&ReactiveTurnOutcome{let p=outcome.turn.as_ref().expect("expected a program input turn");assert_eq!(p.interpreter_turns.len(),1,"expected exactly one affected interpreter");&p.interpreter_turns[0].turn}
-  fn executed_count(turn:&ReactiveTurnOutcome,id:ReactiveNodeId)->usize{turn.before_commit.executed_nodes.iter().chain(turn.after_commit.executed_nodes.iter()).filter(|x|**x==id).count()}
-  fn apply_f64_input(r:&mut MechRuntime,b:&str,p:&str,v:f64)->RuntimeHostInputOutcome{r.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new(b,p).unwrap(),RuntimeHostInputValue::F64(v))).unwrap()}
-  fn recorded_f64(o:&RecordingTestOutput,i:usize)->f64{o.lines()[i].trim().parse().unwrap()}
-  fn activation_send_count(r:&MechRuntime)->usize{r.persistent_sends.iter().filter(|s|matches!(s.schedule,RuntimePersistentSendSchedule::Activation{..})).count()}
-  fn activation_rejection_runtime()->(MechRuntime,RecordingTestOutput){let (mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))));grant_read(&mut r,"test://render/timer","tick");grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");(r,o)}
-  fn assert_rejected_activation_left_no_state(r:&MechRuntime,o:&RecordingTestOutput,p:&ActivationPlanSnapshot,s:usize,b:&HashMap<RuntimeHostInputSource,Vec<mech_program::ProgramInputId>>){assert_eq!(activation_plan_snapshot(r),*p);assert_eq!(r.persistent_sends.len(),s);assert_eq!(r.live_input_bindings,*b);assert!(o.lines().is_empty());assert!(!r.program.interpreter().plan().activation_registration_active());}
+    #[test]
+    fn persistent_send_uses_original_custom_subject() {
+        let initial = snapshot(1.0, 2.0, 3.0, 4.0);
+        let shared = Rc::new(RefCell::new(initial));
+        let console = RecordingConsoleBackend::default();
+        let mut runtime = RuntimeBuilder::new()
+            .resource_provider(Box::new(TimeResourceProvider {
+                snapshot: shared.clone(),
+            }) as Box<dyn RuntimeResourceProvider>)
+            .resource_provider(Box::new(ConsoleResourceProvider {
+                backend: console.clone(),
+            }) as Box<dyn RuntimeResourceProvider>)
+            .build()
+            .unwrap();
+        let subject = "task:live-custom";
+        runtime
+            .grant_capability(RuntimeCapabilityGrant {
+                subject: subject.to_string(),
+                resource: "time://clock/clock".to_string(),
+                operations: vec![RuntimeCapabilityOperation::Read],
+                paths: TIME_PATHS.iter().map(|path| path.to_string()).collect(),
+            })
+            .unwrap();
+        runtime
+            .grant_capability(RuntimeCapabilityGrant {
+                subject: subject.to_string(),
+                resource: "console://console/output".to_string(),
+                operations: vec![RuntimeCapabilityOperation::Write],
+                paths: vec!["line".to_string()],
+            })
+            .unwrap();
+        assert!(!runtime.has_capability_grant(
+            &runtime.runtime_context().unwrap().subject,
+            "console://console/output",
+            &RuntimeCapabilityOperation::Write,
+            "line"
+        ));
 
-  #[test]
-  fn persistent_send_uses_original_custom_subject() {
-    let initial = snapshot(1.0, 2.0, 3.0, 4.0);
-    let shared = Rc::new(RefCell::new(initial));
-    let console = RecordingConsoleBackend::default();
-    let mut runtime = RuntimeBuilder::new()
-      .resource_provider(Box::new(TimeResourceProvider { snapshot: shared.clone() }) as Box<dyn RuntimeResourceProvider>)
-      .resource_provider(Box::new(ConsoleResourceProvider { backend: console.clone() }) as Box<dyn RuntimeResourceProvider>)
-      .build()
-      .unwrap();
-    let subject = "task:live-custom";
-    runtime.grant_capability(RuntimeCapabilityGrant {
-      subject: subject.to_string(),
-      resource: "time://clock/clock".to_string(),
-      operations: vec![RuntimeCapabilityOperation::Read],
-      paths: TIME_PATHS.iter().map(|path| path.to_string()).collect(),
-    }).unwrap();
-    runtime.grant_capability(RuntimeCapabilityGrant {
-      subject: subject.to_string(),
-      resource: "console://console/output".to_string(),
-      operations: vec![RuntimeCapabilityOperation::Write],
-      paths: vec!["line".to_string()],
-    }).unwrap();
-    assert!(!runtime.has_capability_grant(&runtime.runtime_context().unwrap().subject, "console://console/output", &RuntimeCapabilityOperation::Write, "line"));
-
-    let mut context = runtime.runtime_context().unwrap().with_subject(subject);
-    runtime.run_string_with_context(&mut context, r#"@out := console://console/output{:write(line)}
+        let mut context = runtime.runtime_context().unwrap().with_subject(subject);
+        runtime
+            .run_string_with_context(
+                &mut context,
+                r#"@out := console://console/output{:write(line)}
 @clock := time://clock/clock{:read(hour)}
 hour := @clock/hour
 output := hour + 1
 @out/line <- output
-"#).unwrap();
-    assert_eq!(console.lines().len(), 1);
-    *shared.borrow_mut() = snapshot(1.0, 9.0, 3.0, 4.0);
-    let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("time://clock/clock", "hour").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
-    assert!(outcome.turn.is_some());
-    let lines = console.lines();
-    assert_eq!(lines.len(), 2);
-    assert!(lines.last().unwrap().contains("10"), "{lines:?}");
-  }
+"#,
+            )
+            .unwrap();
+        assert_eq!(console.lines().len(), 1);
+        *shared.borrow_mut() = snapshot(1.0, 9.0, 3.0, 4.0);
+        let outcome = runtime
+            .apply_host_input(RuntimeHostInput::single(
+                RuntimeHostInputSource::new("time://clock/clock", "hour").unwrap(),
+                RuntimeHostInputValue::F64(9.0),
+            ))
+            .unwrap();
+        assert!(outcome.turn.is_some());
+        let lines = console.lines();
+        assert_eq!(lines.len(), 2);
+        assert!(lines.last().unwrap().contains("10"), "{lines:?}");
+    }
 
-  #[test]
-  fn persistent_send_initial_evaluation_sends_once() {
-    let (mut runtime, _driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "scalar-output");
-    assert_eq!(console.lines().len(), 1);
-    assert_eq!(runtime.persistent_send_count(), 1);
-  }
+    #[test]
+    fn persistent_send_initial_evaluation_sends_once() {
+        let (mut runtime, _driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "scalar-output");
+        assert_eq!(console.lines().len(), 1);
+        assert_eq!(runtime.persistent_send_count(), 1);
+    }
 
-  #[test]
-  fn persistent_send_one_packet_sends_once_more_with_changed_value() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "scalar-output");
-    let initial = console.lines();
-    publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
-    let lines = console.lines();
-    assert_eq!(lines.len(), 2);
-    assert_ne!(lines[1], initial[0]);
-  }
+    #[test]
+    fn persistent_send_one_packet_sends_once_more_with_changed_value() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "scalar-output");
+        let initial = console.lines();
+        publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
+        let lines = console.lines();
+        assert_eq!(lines.len(), 2);
+        assert_ne!(lines[1], initial[0]);
+    }
 
-  #[test]
-  fn persistent_send_two_packets_produce_two_additional_values_in_order() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 1.0, 1.0, 0.0), false);
-    load(&mut runtime, "scalar-output");
-    publish(&mut runtime, &driver, snapshot(2.0, 3.0, 0.0, 0.0));
-    publish(&mut runtime, &driver, snapshot(4.0, 5.0, 0.0, 0.0));
-    let lines = console.lines();
-    assert_eq!(lines.len(), 3);
-    assert_ne!(lines[1], lines[2]);
-  }
+    #[test]
+    fn persistent_send_two_packets_produce_two_additional_values_in_order() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 1.0, 1.0, 0.0), false);
+        load(&mut runtime, "scalar-output");
+        publish(&mut runtime, &driver, snapshot(2.0, 3.0, 0.0, 0.0));
+        publish(&mut runtime, &driver, snapshot(4.0, 5.0, 0.0, 0.0));
+        let lines = console.lines();
+        assert_eq!(lines.len(), 3);
+        assert_ne!(lines[1], lines[2]);
+    }
 
-  #[test]
-  fn persistent_send_logical_packet_with_five_fields_sends_once() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "clock-output");
-    publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
-    assert_eq!(console.lines().len(), 2);
-  }
+    #[test]
+    fn persistent_send_logical_packet_with_five_fields_sends_once() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "clock-output");
+        publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
+        assert_eq!(console.lines().len(), 2);
+    }
 
-  #[test]
-  fn persistent_send_scalar_reads_new_value_after_solve() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "scalar-output");
-    publish(&mut runtime, &driver, snapshot(10.0, 20.0, 0.0, 0.0));
-    let lines = console.lines();
-    assert!(lines[1].contains("30"), "expected updated scalar in {:?}", lines);
-  }
+    #[test]
+    fn persistent_send_scalar_reads_new_value_after_solve() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "scalar-output");
+        publish(&mut runtime, &driver, snapshot(10.0, 20.0, 0.0, 0.0));
+        let lines = console.lines();
+        assert!(
+            lines[1].contains("30"),
+            "expected updated scalar in {:?}",
+            lines
+        );
+    }
 
-  #[test]
-  fn persistent_send_tuple_reads_new_values_after_solve() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "clock-output");
-    publish(&mut runtime, &driver, snapshot(10.0, 20.0, 30.0, 40.0));
-    let lines = console.lines();
-    assert!(lines[1].contains("10"), "expected updated tuple in {:?}", lines);
-    assert!(lines[1].contains("20"), "expected updated tuple in {:?}", lines);
-    assert!(lines[1].contains("30"), "expected updated tuple in {:?}", lines);
-  }
+    #[test]
+    fn persistent_send_tuple_reads_new_values_after_solve() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "clock-output");
+        publish(&mut runtime, &driver, snapshot(10.0, 20.0, 30.0, 40.0));
+        let lines = console.lines();
+        assert!(
+            lines[1].contains("10"),
+            "expected updated tuple in {:?}",
+            lines
+        );
+        assert!(
+            lines[1].contains("20"),
+            "expected updated tuple in {:?}",
+            lines
+        );
+        assert!(
+            lines[1].contains("30"),
+            "expected updated tuple in {:?}",
+            lines
+        );
+    }
 
-  #[test]
-  fn persistent_send_provider_failure_returns_from_drain() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "scalar-output");
-    console.fail_next("expected drain failure");
-    driver.publish(snapshot(5.0, 6.0, 7.0, 8.0)).unwrap();
-    let err = runtime.drain_host_inputs(1).unwrap_err();
-    assert!(format!("{err:?}").contains("expected drain failure"));
-  }
+    #[test]
+    fn persistent_send_provider_failure_returns_from_drain() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "scalar-output");
+        console.fail_next("expected drain failure");
+        driver.publish(snapshot(5.0, 6.0, 7.0, 8.0)).unwrap();
+        let err = runtime.drain_host_inputs(1).unwrap_err();
+        assert!(format!("{err:?}").contains("expected drain failure"));
+    }
 
-  #[test]
-  fn persistent_send_replay_does_not_register_another_send() {
-    let (mut runtime, driver, _console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    load(&mut runtime, "scalar-output");
-    assert_eq!(runtime.persistent_send_count(), 1);
-    publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
-    assert_eq!(runtime.persistent_send_count(), 1);
-  }
+    #[test]
+    fn persistent_send_replay_does_not_register_another_send() {
+        let (mut runtime, driver, _console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        load(&mut runtime, "scalar-output");
+        assert_eq!(runtime.persistent_send_count(), 1);
+        publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
+        assert_eq!(runtime.persistent_send_count(), 1);
+    }
 
-  #[test]
-  fn activation_send_registers_one_barrier_per_scope_and_replays_equal_triggers() {
-    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    runtime.run_string(r#"@out := console://console/output{:write(line)}
+    #[test]
+    fn activation_send_registers_one_barrier_per_scope_and_replays_equal_triggers() {
+        let (mut runtime, driver, console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        runtime
+            .run_string(
+                r#"@out := console://console/output{:write(line)}
 @clock := time://clock/clock{:read(hour)}
 render-tick := @clock/hour
 ~> render-tick {
@@ -1289,33 +2435,69 @@ render-tick := @clock/hour
   @out/line <- "second"
   @out/line <- "third"
 }
-"#).unwrap();
+"#,
+            )
+            .unwrap();
 
-    // Activation effects are registered, rather than evaluated, during load.
-    assert!(console.lines().is_empty());
-    assert_eq!(runtime.persistent_send_count(), 3);
-    let schedules: Vec<_> = runtime.persistent_sends.iter().map(|send| match send.schedule {
-      RuntimePersistentSendSchedule::Activation { barrier_node_id, .. } => barrier_node_id,
-      RuntimePersistentSendSchedule::EveryAcceptedTurn => panic!("activation send used top-level schedule"),
-    }).collect();
-    assert!(schedules.windows(2).all(|ids| ids[0] == ids[1]));
-    let barriers = runtime.program.interpreter().plan().borrow().nodes.iter().filter(|node| {
-      node.kind == mech_core::ReactiveNodeKind::Combinational
-        && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
-        && node.outputs.is_empty()
-    }).count();
-    assert_eq!(barriers, 1);
+        // Activation effects are registered, rather than evaluated, during load.
+        assert!(console.lines().is_empty());
+        assert_eq!(runtime.persistent_send_count(), 3);
+        let schedules: Vec<_> = runtime
+            .persistent_sends
+            .iter()
+            .map(|send| match send.schedule {
+                RuntimePersistentSendSchedule::Activation {
+                    barrier_node_id, ..
+                } => barrier_node_id,
+                RuntimePersistentSendSchedule::EveryAcceptedTurn => {
+                    panic!("activation send used top-level schedule")
+                }
+            })
+            .collect();
+        assert!(schedules.windows(2).all(|ids| ids[0] == ids[1]));
+        let barriers = runtime
+            .program
+            .interpreter()
+            .plan()
+            .borrow()
+            .nodes
+            .iter()
+            .filter(|node| {
+                node.kind == mech_core::ReactiveNodeKind::Combinational
+                    && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+                    && node.outputs.is_empty()
+            })
+            .count();
+        assert_eq!(barriers, 1);
 
-    // Equal admitted values still execute the barrier and replay every send.
-    publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
-    publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
-    assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
-  }
+        // Equal admitted values still execute the barrier and replay every send.
+        publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
+        publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
+        assert_eq!(
+            console.lines(),
+            vec![
+                "\"first\"",
+                "\"second\"",
+                "\"third\"",
+                "\"first\"",
+                "\"second\"",
+                "\"third\""
+            ]
+        );
+    }
 
-  #[test]
-  fn activation_two_clock_physics_render_acceptance() {
-    let provider=TestResourceProvider::new().with_value("test://physics/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://physics/timer","tick");grant_read(&mut runtime,"test://render/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
-    runtime.run_string(r#"@physics := test://physics/timer{:read(tick)}
+    #[test]
+    fn activation_two_clock_physics_render_acceptance() {
+        let provider = TestResourceProvider::new()
+            .with_value("test://physics/timer", "tick", Value::F64(Ref::new(0.0)))
+            .with_value("test://render/timer", "tick", Value::F64(Ref::new(0.0)));
+        let (mut runtime, output) = test_runtime_with_output(provider);
+        grant_read(&mut runtime, "test://physics/timer", "tick");
+        grant_read(&mut runtime, "test://render/timer", "tick");
+        grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+        runtime
+            .run_string(
+                r#"@physics := test://physics/timer{:read(tick)}
 @render := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 physics-tick := @physics/tick
@@ -1328,14 +2510,82 @@ render-tick := @render/tick
 ~> render-tick {
   @out/line <- x
 }
-"#).unwrap();let initial_plan=activation_plan_snapshot(&runtime);let render_barrier=activation_barrier_for_trigger(&runtime,"render-tick");let physics_combinational_nodes=activation_nodes_for_trigger(&runtime,"physics-tick",ReactiveNodeKind::Combinational);let x_register=register_node_for_symbol(&runtime,"x");assert!(!physics_combinational_nodes.is_empty());assert_eq!(f64_value(&symbol_value(&runtime,"x")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
-    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),1.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
-    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",2.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
-    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),1);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(executed_count(t,render_barrier),1);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),0)}assert!(!t.before_commit.pending_register_nodes.contains(&x_register));assert!(!t.register_commit.staged_nodes.contains(&x_register));assert!(!t.register_commit.committed_nodes.contains(&x_register));assert!(!t.after_commit.pending_register_nodes.contains(&x_register));assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
-    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),2);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(recorded_f64(&output,1),2.0);assert_eq!(executed_count(only_reactive_turn(&a),render_barrier),1);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
-  }
-  #[test]
-  fn activation_send_samples_latest_value_and_ignores_other_updates(){let(mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0))).with_value(TEST_SIGNALS_BASE_URI,"value",Value::F64(Ref::new(1.0))));for(b,p)in [("test://render/timer","tick"),("test://other/timer","tick"),(TEST_SIGNALS_BASE_URI,"value")]{grant_read(&mut r,b,p)}grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");r.run_string(r#"@render := test://render/timer{:read(tick)}
+"#,
+            )
+            .unwrap();
+        let initial_plan = activation_plan_snapshot(&runtime);
+        let render_barrier = activation_barrier_for_trigger(&runtime, "render-tick");
+        let physics_combinational_nodes =
+            activation_nodes_for_trigger(&runtime, "physics-tick", ReactiveNodeKind::Combinational);
+        let x_register = register_node_for_symbol(&runtime, "x");
+        assert!(!physics_combinational_nodes.is_empty());
+        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 0.0);
+        assert!(output.lines().is_empty());
+        assert_eq!(activation_send_count(&runtime), 1);
+        let a = apply_f64_input(&mut runtime, "test://physics/timer", "tick", 1.0);
+        let t = only_reactive_turn(&a);
+        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 1.0);
+        assert!(output.lines().is_empty());
+        assert_eq!(executed_count(t, render_barrier), 0);
+        for n in &physics_combinational_nodes {
+            assert_eq!(executed_count(t, *n), 1)
+        }
+        assert_eq!(t.register_commit.committed_nodes, vec![x_register]);
+        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
+        assert_eq!(activation_send_count(&runtime), 1);
+        let a = apply_f64_input(&mut runtime, "test://physics/timer", "tick", 2.0);
+        let t = only_reactive_turn(&a);
+        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 2.0);
+        assert!(output.lines().is_empty());
+        assert_eq!(executed_count(t, render_barrier), 0);
+        for n in &physics_combinational_nodes {
+            assert_eq!(executed_count(t, *n), 1)
+        }
+        assert_eq!(t.register_commit.committed_nodes, vec![x_register]);
+        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
+        assert_eq!(activation_send_count(&runtime), 1);
+        let a = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+        let t = only_reactive_turn(&a);
+        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 2.0);
+        assert_eq!(output.lines().len(), 1);
+        assert_eq!(recorded_f64(&output, 0), 2.0);
+        assert_eq!(executed_count(t, render_barrier), 1);
+        for n in &physics_combinational_nodes {
+            assert_eq!(executed_count(t, *n), 0)
+        }
+        assert!(!t.before_commit.pending_register_nodes.contains(&x_register));
+        assert!(!t.register_commit.staged_nodes.contains(&x_register));
+        assert!(!t.register_commit.committed_nodes.contains(&x_register));
+        assert!(!t.after_commit.pending_register_nodes.contains(&x_register));
+        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
+        assert_eq!(activation_send_count(&runtime), 1);
+        let a = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 2.0);
+        assert_eq!(output.lines().len(), 2);
+        assert_eq!(recorded_f64(&output, 0), 2.0);
+        assert_eq!(recorded_f64(&output, 1), 2.0);
+        assert_eq!(executed_count(only_reactive_turn(&a), render_barrier), 1);
+        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
+        assert_eq!(activation_send_count(&runtime), 1);
+    }
+    #[test]
+    fn activation_send_samples_latest_value_and_ignores_other_updates() {
+        let (mut r, o) = test_runtime_with_output(
+            TestResourceProvider::new()
+                .with_value("test://render/timer", "tick", Value::F64(Ref::new(0.0)))
+                .with_value("test://other/timer", "tick", Value::F64(Ref::new(0.0)))
+                .with_value(TEST_SIGNALS_BASE_URI, "value", Value::F64(Ref::new(1.0))),
+        );
+        for (b, p) in [
+            ("test://render/timer", "tick"),
+            ("test://other/timer", "tick"),
+            (TEST_SIGNALS_BASE_URI, "value"),
+        ] {
+            grant_read(&mut r, b, p)
+        }
+        grant_write(&mut r, TEST_OUTPUT_BASE_URI, "line");
+        r.run_string(
+            r#"@render := test://render/timer{:read(tick)}
 @other := test://other/timer{:read(tick)}
 @signals := test://signals/inputs{:read(value)}
 @out := test://effects/output{:write(line)}
@@ -1348,10 +2598,45 @@ sampled-value := @signals/value
 ~> other-tick {
   other-result := sampled-value + 1.0
 }
-"#).unwrap();let b=activation_barrier_for_trigger(&r,"render-tick");let ns=activation_nodes_for_trigger(&r,"other-tick",ReactiveNodeKind::Combinational);assert!(!ns.is_empty());assert!(o.lines().is_empty());let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",10.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://other/timer","tick",1.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);for n in ns{assert_eq!(executed_count(only_reactive_turn(&q),n),1)}let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),1);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",20.0);assert_eq!(o.lines().len(),1);assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),2);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(recorded_f64(&o,1),20.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);}
+"#,
+        )
+        .unwrap();
+        let b = activation_barrier_for_trigger(&r, "render-tick");
+        let ns = activation_nodes_for_trigger(&r, "other-tick", ReactiveNodeKind::Combinational);
+        assert!(!ns.is_empty());
+        assert!(o.lines().is_empty());
+        let q = apply_f64_input(&mut r, TEST_SIGNALS_BASE_URI, "value", 10.0);
+        assert!(o.lines().is_empty());
+        assert_eq!(executed_count(only_reactive_turn(&q), b), 0);
+        let q = apply_f64_input(&mut r, "test://other/timer", "tick", 1.0);
+        assert!(o.lines().is_empty());
+        assert_eq!(executed_count(only_reactive_turn(&q), b), 0);
+        for n in ns {
+            assert_eq!(executed_count(only_reactive_turn(&q), n), 1)
+        }
+        let q = apply_f64_input(&mut r, "test://render/timer", "tick", 1.0);
+        assert_eq!(o.lines().len(), 1);
+        assert_eq!(recorded_f64(&o, 0), 10.0);
+        assert_eq!(executed_count(only_reactive_turn(&q), b), 1);
+        let q = apply_f64_input(&mut r, TEST_SIGNALS_BASE_URI, "value", 20.0);
+        assert_eq!(o.lines().len(), 1);
+        assert_eq!(executed_count(only_reactive_turn(&q), b), 0);
+        let q = apply_f64_input(&mut r, "test://render/timer", "tick", 1.0);
+        assert_eq!(o.lines().len(), 2);
+        assert_eq!(recorded_f64(&o, 0), 10.0);
+        assert_eq!(recorded_f64(&o, 1), 20.0);
+        assert_eq!(executed_count(only_reactive_turn(&q), b), 1);
+    }
 
-  fn rejected(source:&str, check:impl FnOnce(MechError)){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();check(r.run_string(source).unwrap_err());assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
-  #[test] fn activation_send_rejects_local_register_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
+    #[test]
+    fn activation_send_rejects_local_register_mix() {
+        let (mut r, o) = activation_rejection_runtime();
+        let p = activation_plan_snapshot(&r);
+        let n = r.persistent_sends.len();
+        let b = r.live_input_bindings.clone();
+        let e = r
+            .run_string(
+                r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 ~x := 0.0
@@ -1359,8 +2644,25 @@ render-tick := @tick/tick
   x = x + 1.0
   @out/line <- x
 }
-"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
-  #[test] fn activation_send_rejects_local_op_assign_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
+"#,
+            )
+            .unwrap_err();
+        assert!(
+            e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>()
+                .is_some(),
+            "unexpected error: {e:?}"
+        );
+        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
+    }
+    #[test]
+    fn activation_send_rejects_local_op_assign_mix() {
+        let (mut r, o) = activation_rejection_runtime();
+        let p = activation_plan_snapshot(&r);
+        let n = r.persistent_sends.len();
+        let b = r.live_input_bindings.clone();
+        let e = r
+            .run_string(
+                r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 ~x := 0.0
@@ -1368,8 +2670,25 @@ render-tick := @tick/tick
   x += 1.0
   @out/line <- x
 }
-"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
-  #[test] fn activation_send_rejects_context_assignment_in_scope(){rejected(r#"@tick := test://render/timer{:read(tick)}
+"#,
+            )
+            .unwrap_err();
+        assert!(
+            e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>()
+                .is_some(),
+            "unexpected error: {e:?}"
+        );
+        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
+    }
+    #[test]
+    fn activation_send_rejects_context_assignment_in_scope() {
+        let (mut r, o) = activation_rejection_runtime();
+        let p = activation_plan_snapshot(&r);
+        let n = r.persistent_sends.len();
+        let b = r.live_input_bindings.clone();
+        let e = r
+            .run_string(
+                r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 x := 1.0
@@ -1377,29 +2696,377 @@ x := 1.0
   @out/line = x
   @out/line <- x
 }
-"#,|e|{let k=e.kind_as::<RuntimeInvalidOperationError>().expect("expected RuntimeInvalidOperationError");assert_eq!(k.operation,"direct_context_effect_placement");assert!(k.reason.contains("context assignment"),"unexpected placement reason: {}",k.reason);assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_none());});}
-  #[test] fn activation_send_rejects_isolated_registration(){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();let mut c=r.runtime_context().unwrap();let e=r.run_string_with_isolated_registration_for_test(&mut c,r#"@tick := test://render/timer{:read(tick)}
+"#,
+            )
+            .unwrap_err();
+        let k = e
+            .kind_as::<RuntimeInvalidOperationError>()
+            .expect("expected RuntimeInvalidOperationError");
+        assert_eq!(k.operation, "direct_context_effect_placement");
+        assert!(
+            k.reason.contains("context assignment"),
+            "unexpected placement reason: {}",
+            k.reason
+        );
+        assert!(
+            e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>()
+                .is_none()
+        );
+        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
+    }
+
+    #[test]
+    fn activation_send_rejects_isolated_registration() {
+        let (mut r, o) = activation_rejection_runtime();
+        let p = activation_plan_snapshot(&r);
+        let n = r.persistent_sends.len();
+        let b = r.live_input_bindings.clone();
+        let mut c = r.runtime_context().unwrap();
+        let e = r
+            .run_string_with_isolated_registration_for_test(
+                &mut c,
+                r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 ~> render-tick {
   @out/line <- render-tick
 }
-"#).unwrap_err();assert!(e.kind_as::<RuntimeIsolatedActivationSendUnsupported>().is_some(),"unexpected error: {e:?}");assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
+"#,
+            )
+            .unwrap_err();
+        assert!(
+            e.kind_as::<RuntimeIsolatedActivationSendUnsupported>()
+                .is_some(),
+            "unexpected error: {e:?}"
+        );
+        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
+    }
 
-  #[test]
-  fn activation_internal_barrier_is_not_user_callable() {
-    let (mut runtime, _driver, _console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-    let error = runtime.run_string("mech/runtime/activation-effect-barrier()").unwrap_err();
-    assert!(format!("{error:?}").contains("MissingFunction"));
-  }
+    #[test]
+    fn activation_send_reactive_failure_produces_no_writes() {
+        let provider = TestResourceProvider::new().with_value(
+            "test://render/timer",
+            "tick",
+            Value::F64(Ref::new(0.0)),
+        );
+        let (mut runtime, output) = test_runtime_with_output(provider);
+        grant_read(&mut runtime, "test://render/timer", "tick");
+        grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+        let subject = runtime.runtime_context().unwrap().subject;
+        grant_host_call(
+            &mut runtime,
+            &subject,
+            193,
+            "host:demo/activation-fail-second",
+        );
+        let calls = Arc::new(AtomicUsize::new(0));
+        let host_calls = calls.clone();
+        runtime
+            .register_mech_host_function(ClosureHostFunction::new(
+                "demo/activation-fail-second",
+                move |_services, _context, args| {
+                    let call_number = host_calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    if call_number == 2 {
+                        return Err(MechError::new(DeliberateHostCallError, None));
+                    }
+                    Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))
+                },
+            ))
+            .unwrap();
+        runtime
+            .run_string(
+                r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+
+render-tick := @tick/tick
+
+~> render-tick {
+  @out/line <-
+    demo/activation-fail-second(render-tick)
+}
+"#,
+            )
+            .unwrap();
+        let plan_before = activation_plan_snapshot(&runtime);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "host function must compile once during load"
+        );
+        assert!(output.lines().is_empty());
+        assert_eq!(activation_send_count(&runtime), 1);
+        let error = runtime
+            .apply_host_input(RuntimeHostInput::single(
+                RuntimeHostInputSource::new("test://render/timer", "tick").unwrap(),
+                RuntimeHostInputValue::F64(1.0),
+            ))
+            .unwrap_err();
+        assert!(
+            error.kind_as::<DeliberateHostCallError>().is_some(),
+            "unexpected error: {error:?}"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(output.lines().is_empty());
+        assert_eq!(activation_send_count(&runtime), 1);
+        assert_eq!(activation_plan_snapshot(&runtime), plan_before);
+        let retry = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+        assert!(retry.turn.is_some());
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(output.lines().len(), 1);
+        assert_eq!(recorded_f64(&output, 0), 1.0);
+        assert_eq!(activation_send_count(&runtime), 1);
+        assert_eq!(activation_plan_snapshot(&runtime), plan_before);
+    }
+
+    #[test]
+    fn activation_send_provider_failure_is_fail_fast_and_registration_is_retained() {
+        let provider = TestResourceProvider::new().with_value(
+            "test://render/timer",
+            "tick",
+            Value::F64(Ref::new(0.0)),
+        );
+        let output = SequencedOutput::default();
+        let mut runtime = RuntimeBuilder::new()
+            .resource_provider(Box::new(provider) as Box<dyn RuntimeResourceProvider>)
+            .resource_provider(Box::new(SequencedOutputProvider {
+                backend: output.clone(),
+            }) as Box<dyn RuntimeResourceProvider>)
+            .build()
+            .unwrap();
+        grant_read(&mut runtime, "test://render/timer", "tick");
+        grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+        runtime
+            .run_string(
+                r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+
+render-tick := @tick/tick
+latest := render-tick + 1.0
+
+~> render-tick {
+  @out/line <- "first"
+  @out/line <- "second"
+  @out/line <- "third"
+}
+"#,
+            )
+            .unwrap();
+        assert!(output.attempts().is_empty());
+        assert!(output.successes().is_empty());
+        assert_eq!(activation_send_count(&runtime), 3);
+        let plan_before = activation_plan_snapshot(&runtime);
+        output.fail_once_at(2);
+        let error = runtime
+            .apply_host_input(RuntimeHostInput::single(
+                RuntimeHostInputSource::new("test://render/timer", "tick").unwrap(),
+                RuntimeHostInputValue::F64(1.0),
+            ))
+            .unwrap_err();
+        assert!(
+            error.kind_as::<PersistentSendTestError>().is_some(),
+            "unexpected error: {error:?}"
+        );
+        assert_eq!(
+            output.attempts(),
+            vec!["\"first\"".to_string(), "\"second\"".to_string()]
+        );
+        assert_eq!(output.successes(), vec!["\"first\"".to_string()]);
+        assert_eq!(
+            f64_value(&symbol_value(&runtime, "latest")),
+            2.0,
+            "reactive state must remain committed"
+        );
+        assert_eq!(activation_send_count(&runtime), 3);
+        assert_eq!(activation_plan_snapshot(&runtime), plan_before);
+        let retry = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+        assert!(retry.turn.is_some());
+        assert_eq!(
+            output.attempts(),
+            vec![
+                "\"first\"".to_string(),
+                "\"second\"".to_string(),
+                "\"first\"".to_string(),
+                "\"second\"".to_string(),
+                "\"third\"".to_string()
+            ]
+        );
+        assert_eq!(
+            output.successes(),
+            vec![
+                "\"first\"".to_string(),
+                "\"first\"".to_string(),
+                "\"second\"".to_string(),
+                "\"third\"".to_string()
+            ]
+        );
+        assert_eq!(activation_send_count(&runtime), 3);
+        assert_eq!(activation_plan_snapshot(&runtime), plan_before);
+    }
+
+    #[test]
+    fn activation_send_preserves_custom_live_authority() {
+        let provider = TestResourceProvider::new().with_value(
+            "test://render/timer",
+            "tick",
+            Value::F64(Ref::new(0.0)),
+        );
+        let (mut runtime, output) = test_runtime_with_output(provider);
+        let default_subject = runtime.runtime_context().unwrap().subject;
+        let custom_subject = "task:activation-send-custom";
+        grant_read_to(&mut runtime, custom_subject, "test://render/timer", "tick");
+        grant_write_to(&mut runtime, custom_subject, TEST_OUTPUT_BASE_URI, "line");
+        assert!(!runtime.has_capability_grant(
+            &default_subject,
+            "test://render/timer",
+            &RuntimeCapabilityOperation::Read,
+            "tick"
+        ));
+        assert!(!runtime.has_capability_grant(
+            &default_subject,
+            TEST_OUTPUT_BASE_URI,
+            &RuntimeCapabilityOperation::Write,
+            "line"
+        ));
+        let mut context = runtime
+            .runtime_context()
+            .unwrap()
+            .with_subject(custom_subject);
+        let source = r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+
+render-tick := @tick/tick
+
+~> render-tick {
+  @out/line <- render-tick
+}
+"#;
+        runtime
+            .run_string_with_context(&mut context, source)
+            .unwrap();
+        assert!(output.lines().is_empty());
+        assert_eq!(activation_send_count(&runtime), 1);
+        let outcome = apply_f64_input(&mut runtime, "test://render/timer", "tick", 9.0);
+        assert!(outcome.turn.is_some());
+        assert_eq!(output.lines().len(), 1);
+        assert_eq!(recorded_f64(&output, 0), 9.0);
+        assert_eq!(activation_send_count(&runtime), 1);
+    }
+
+    #[test]
+    fn activation_send_internal_payload_name_does_not_collide_with_user_binding() {
+        let provider = TestResourceProvider::new().with_value(
+            "test://render/timer",
+            "tick",
+            Value::F64(Ref::new(0.0)),
+        );
+        let (mut runtime, output) = test_runtime_with_output(provider);
+        grant_read(&mut runtime, "test://render/timer", "tick");
+        grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+        runtime
+            .run_string(
+                r#"mech-internal-activation-send-value-0 := 41.0
+
+@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+
+render-tick := @tick/tick
+
+~> render-tick {
+  @out/line <- 7.0
+}
+
+after :=
+  mech-internal-activation-send-value-0 + 1.0
+"#,
+            )
+            .unwrap();
+        assert_eq!(
+            f64_value(&symbol_value(
+                &runtime,
+                "mech-internal-activation-send-value-0"
+            )),
+            41.0
+        );
+        assert_eq!(f64_value(&symbol_value(&runtime, "after")), 42.0);
+        assert!(output.lines().is_empty());
+        assert_eq!(activation_send_count(&runtime), 1);
+        let outcome = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+        assert!(outcome.turn.is_some());
+        assert_eq!(output.lines().len(), 1);
+        assert_eq!(recorded_f64(&output, 0), 7.0);
+    }
+
+    #[test]
+    fn activation_internal_barrier_is_not_user_callable() {
+        let (mut runtime, _driver, _console) =
+            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+        let error = runtime
+            .run_string("mech/runtime/activation-effect-barrier()")
+            .unwrap_err();
+        assert!(format!("{error:?}").contains("MissingFunction"));
+    }
 }
 
 #[test]
 fn runtime_reactive_host_input_preserves_deferred_registers_across_packets() {
-  let mut runtime = test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0)); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
-  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0").unwrap();
-  let a = register_node_for_symbol(&runtime, "a"); let b = register_node_for_symbol(&runtime, "b"); let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
-  assert_eq!(f64_value(&symbol_value(&runtime, "a")), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "middle")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0);
-  let first = runtime.apply_host_input(RuntimeHostInput::single(source.clone(), RuntimeHostInputValue::F64(10.0))).unwrap(); let turn = &first.turn.as_ref().unwrap().interpreter_turns[0].turn; assert_eq!(turn.register_commit.committed_nodes, vec![a]); assert_eq!(turn.after_commit.pending_register_nodes, vec![b]); assert_eq!((f64_value(&symbol_value(&runtime, "a")), f64_value(&symbol_value(&runtime, "middle")), f64_value(&symbol_value(&runtime, "b")), f64_value(&symbol_value(&runtime, "output"))), (10.0, 11.0, 2.0, 3.0)); assert!(runtime.program.interpreter().has_pending_reactive_registers());
-  let second = runtime.apply_host_input(RuntimeHostInput::single(source, RuntimeHostInputValue::F64(20.0))).unwrap(); let turn = &second.turn.as_ref().unwrap().interpreter_turns[0].turn; assert_eq!(turn.before_commit.pending_register_nodes, vec![a]); assert_eq!(turn.register_commit.committed_nodes, vec![a, b]); assert_eq!(turn.after_commit.pending_register_nodes, vec![b]); assert_eq!((f64_value(&symbol_value(&runtime, "a")), f64_value(&symbol_value(&runtime, "middle")), f64_value(&symbol_value(&runtime, "b")), f64_value(&symbol_value(&runtime, "output"))), (20.0, 21.0, 11.0, 12.0)); assert!(runtime.program.interpreter().has_pending_reactive_registers());
+    let mut runtime = test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0").unwrap();
+    let a = register_node_for_symbol(&runtime, "a");
+    let b = register_node_for_symbol(&runtime, "b");
+    let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+    assert_eq!(f64_value(&symbol_value(&runtime, "a")), 1.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "middle")), 2.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0);
+    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0);
+    let first = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            source.clone(),
+            RuntimeHostInputValue::F64(10.0),
+        ))
+        .unwrap();
+    let turn = &first.turn.as_ref().unwrap().interpreter_turns[0].turn;
+    assert_eq!(turn.register_commit.committed_nodes, vec![a]);
+    assert_eq!(turn.after_commit.pending_register_nodes, vec![b]);
+    assert_eq!(
+        (
+            f64_value(&symbol_value(&runtime, "a")),
+            f64_value(&symbol_value(&runtime, "middle")),
+            f64_value(&symbol_value(&runtime, "b")),
+            f64_value(&symbol_value(&runtime, "output"))
+        ),
+        (10.0, 11.0, 2.0, 3.0)
+    );
+    assert!(
+        runtime
+            .program
+            .interpreter()
+            .has_pending_reactive_registers()
+    );
+    let second = runtime
+        .apply_host_input(RuntimeHostInput::single(
+            source,
+            RuntimeHostInputValue::F64(20.0),
+        ))
+        .unwrap();
+    let turn = &second.turn.as_ref().unwrap().interpreter_turns[0].turn;
+    assert_eq!(turn.before_commit.pending_register_nodes, vec![a]);
+    assert_eq!(turn.register_commit.committed_nodes, vec![a, b]);
+    assert_eq!(turn.after_commit.pending_register_nodes, vec![b]);
+    assert_eq!(
+        (
+            f64_value(&symbol_value(&runtime, "a")),
+            f64_value(&symbol_value(&runtime, "middle")),
+            f64_value(&symbol_value(&runtime, "b")),
+            f64_value(&symbol_value(&runtime, "output"))
+        ),
+        (20.0, 21.0, 11.0, 12.0)
+    );
+    assert!(
+        runtime
+            .program
+            .interpreter()
+            .has_pending_reactive_registers()
+    );
 }

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1261,6 +1261,47 @@ output := hour + 1
     publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
     assert_eq!(runtime.persistent_send_count(), 1);
   }
+
+  #[test]
+  fn activation_send_registers_one_barrier_per_scope_and_replays_equal_triggers() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    runtime.run_string(r#"@out := console://console/output{:write(line)}
+@clock := time://clock/clock{:read(hour)}
+render-tick := @clock/hour
+~> render-tick {
+  @out/line <- "first"
+  @out/line <- "second"
+  @out/line <- "third"
+}
+"#).unwrap();
+
+    // Activation effects are registered, rather than evaluated, during load.
+    assert!(console.lines().is_empty());
+    assert_eq!(runtime.persistent_send_count(), 3);
+    let schedules: Vec<_> = runtime.persistent_sends.iter().map(|send| match send.schedule {
+      RuntimePersistentSendSchedule::Activation { barrier_node_id, .. } => barrier_node_id,
+      RuntimePersistentSendSchedule::EveryAcceptedTurn => panic!("activation send used top-level schedule"),
+    }).collect();
+    assert!(schedules.windows(2).all(|ids| ids[0] == ids[1]));
+    let barriers = runtime.program.interpreter().plan().borrow().nodes.iter().filter(|node| {
+      node.kind == mech_core::ReactiveNodeKind::Combinational
+        && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+        && node.outputs.is_empty()
+    }).count();
+    assert_eq!(barriers, 1);
+
+    // Equal admitted values still execute the barrier and replay every send.
+    publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
+    publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
+    assert_eq!(console.lines(), vec!["first", "second", "third", "first", "second", "third"]);
+  }
+
+  #[test]
+  fn activation_internal_barrier_is_not_user_callable() {
+    let (mut runtime, _driver, _console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    let error = runtime.run_string("mech/runtime/activation-effect-barrier()").unwrap_err();
+    assert!(format!("{error:?}").contains("MissingFunction"));
+  }
 }
 
 #[test]

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -407,6 +407,77 @@ fn runtime_reactive_host_input_unbound_packet_does_not_advance_pending_registers
 }
 
 #[test]
+fn patterned_activation_guard_rejects_runtime_host_before_elaboration() {
+  let mut runtime = test_runtime(TestResourceProvider::new());
+  let subject = runtime.runtime_context().unwrap().subject;
+  grant_host_call(&mut runtime, &subject, 43, "host:demo/audit");
+  let calls = Arc::new(AtomicUsize::new(0));
+  let host_calls = calls.clone();
+  runtime
+    .register_mech_host_function(ClosureHostFunction::new(
+      "demo/audit",
+      move |_services, _context, _args| {
+        host_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Value::Bool(Ref::new(true)))
+      },
+    ))
+    .unwrap();
+  runtime
+    .run_string("event := (:released, 1.0)\nsentinel := 7.0")
+    .unwrap();
+  let plan_before = plan_snapshot(&runtime);
+  let symbols_before = runtime.program.interpreter().symbols().borrow().snapshot();
+  let registrations_before = runtime
+    .program
+    .interpreter()
+    .plan()
+    .pattern_activation_registrations()
+    .to_vec();
+
+  let error = runtime
+    .run_string(
+      r#"
+~> event
+  | :pressed(x), demo/audit(x) => {
+      selected := x + 0.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+    )
+    .unwrap_err();
+
+  assert_eq!(error.kind_name(), "ActivationPatternGuardMustBePure");
+  assert_eq!(calls.load(Ordering::SeqCst), 0);
+  assert_eq!(plan_snapshot(&runtime), plan_before);
+  assert_eq!(
+    runtime.program.interpreter().symbols().borrow().snapshot(),
+    symbols_before,
+  );
+  let registrations_after = runtime
+    .program
+    .interpreter()
+    .plan()
+    .pattern_activation_registrations()
+    .to_vec();
+  assert_eq!(registrations_after, registrations_before);
+  assert!(!runtime
+    .program
+    .interpreter()
+    .plan()
+    .activation_registration_active());
+  assert!(!runtime.program.interpreter().has_pending_reactive_registers());
+  assert!(runtime
+    .program
+    .interpreter()
+    .symbols()
+    .borrow()
+    .get(hash_str("selected"))
+    .is_none());
+}
+
+#[test]
 fn live_input_recomputes_runtime_host_function() {
   let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
   grant_read(&mut runtime, "test://clock/ticks", "value");

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
 use std::thread;
@@ -1486,6 +1486,478 @@ render-tick := @clock/hour
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
+  }
+
+  #[test]
+  fn activation_send_snapshots_fixed_payloads_before_same_trigger_register_commit() {
+    let provider = TestResourceProvider::new().with_value(
+      "test://render/timer",
+      "tick",
+      Value::F64(Ref::new(0.0)),
+    );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~state := 0.0
+
+~> render-tick {
+  state = state + 1.0
+}
+
+~> render-tick {
+  @out/line <- state
+  @out/line <- state + 0.0
+}
+"#).unwrap();
+
+    let plan = activation_plan_snapshot(&runtime);
+    let register = register_node_for_symbol(&runtime, "state");
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 0.0);
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_send_count(&runtime), 2);
+
+    let first = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(
+      only_reactive_turn(&first).register_commit.committed_nodes,
+      vec![register]
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 1.0);
+    assert_eq!(output.lines(), vec!["0", "0"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let equal = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(
+      only_reactive_turn(&equal).register_commit.committed_nodes,
+      vec![register]
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 2.0);
+    assert_eq!(output.lines(), vec!["0", "0", "1", "1"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+  }
+
+  #[test]
+  fn activation_send_registration_is_atomic_on_fixed_elaboration_failure() {
+    let (mut runtime, output) = activation_rejection_runtime();
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+render-tick := @tick/tick
+"#).unwrap();
+    let plan = activation_plan_snapshot(&runtime);
+    let sends = runtime.persistent_sends.len();
+    let bindings = runtime.live_input_bindings.clone();
+
+    let error = runtime.run_string(r#"@out := test://effects/output{:write(line)}
+~> render-tick {
+  @out/line <- render-tick
+  registered-first := render-tick + 1.0
+  failure :=
+    function-that-does-not-exist(registered-first)
+}
+"#).unwrap_err();
+
+    assert!(
+      error.kind_name().contains("Function"),
+      "unexpected elaboration error: {error:?}"
+    );
+    assert_rejected_activation_left_no_state(
+      &runtime,
+      &output,
+      &plan,
+      sends,
+      &bindings,
+    );
+    assert!(
+      !runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .contains(hash_str("registered-first"))
+    );
+    assert!(
+      !runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .contains(hash_str("failure"))
+    );
+  }
+
+  #[test]
+  fn activation_send_duration_failure_does_not_release_fixed_or_patterned_effects() {
+    let provider = TestResourceProvider::new().with_value(
+      "test://render/timer",
+      "tick",
+      Value::F64(Ref::new(0.0)),
+    );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(
+      &mut runtime,
+      &subject,
+      195,
+      "host:demo/activation-duration-sleep",
+    );
+    register_sleep_host(
+      &mut runtime,
+      "demo/activation-duration-sleep",
+    );
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+
+~> render-tick {
+  @out/line <-
+    demo/activation-duration-sleep(render-tick)
+}
+
+~> render-tick
+  | selected => {
+      @out/line <- selected + 10.0
+    }
+"#).unwrap();
+
+    let plan = activation_plan_snapshot(&runtime);
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_send_count(&runtime), 2);
+
+    runtime.config.limits.max_turn_duration_ms = Some(1);
+    let error = runtime.apply_host_input(RuntimeHostInput::single(
+      RuntimeHostInputSource::new(
+        "test://render/timer",
+        "tick",
+      ).unwrap(),
+      RuntimeHostInputValue::F64(1.0),
+    )).unwrap_err();
+    let error = format!("{error:?}");
+    assert!(
+      error.contains("turn_duration_ms")
+        || error.contains("ResourceBudgetExceeded"),
+      "{error}"
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+
+    runtime.config.limits.max_turn_duration_ms = None;
+    let retry = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert!(retry.turn.is_some());
+    assert_eq!(output.lines(), vec!["1", "11"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+  }
+
+  #[test]
+  fn patterned_activation_sends_only_from_the_selected_arm() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick
+  | 99.0 => {
+      @out/line <- 99.0
+    }
+  | selected, selected > 0.0 => {
+      @out/line <- selected
+    }
+  | * => {
+      @out/line <- -1.0
+    }
+"#).unwrap();
+    assert!(output.lines().is_empty(),"patterned effects ran during load");assert_eq!(activation_send_count(&runtime),3);
+    let barriers=runtime.persistent_sends.iter().map(|send|match send.schedule{RuntimePersistentSendSchedule::Activation{barrier_node_id,..}=>barrier_node_id,RuntimePersistentSendSchedule::EveryAcceptedTurn=>panic!("patterned activation send used top-level schedule")}).collect::<Vec<_>>();
+    assert_eq!(barriers.iter().copied().collect::<HashSet<_>>().len(),3,"each effectful arm must own a distinct barrier");
+    let plan=activation_plan_snapshot(&runtime);
+    let first=apply_f64_input(&mut runtime,"test://render/timer","tick",5.0);let turn=only_reactive_turn(&first);assert_eq!(output.lines(),vec!["5"]);assert_eq!((executed_count(turn,barriers[0]),executed_count(turn,barriers[1]),executed_count(turn,barriers[2])),(0,1,0));assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let equal=apply_f64_input(&mut runtime,"test://render/timer","tick",5.0);let turn=only_reactive_turn(&equal);assert_eq!(output.lines(),vec!["5","5"]);assert_eq!((executed_count(turn,barriers[0]),executed_count(turn,barriers[1]),executed_count(turn,barriers[2])),(0,1,0));assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let fallback=apply_f64_input(&mut runtime,"test://render/timer","tick",-5.0);let turn=only_reactive_turn(&fallback);assert_eq!(output.lines(),vec!["5","5","-1"]);assert_eq!((executed_count(turn,barriers[0]),executed_count(turn,barriers[1]),executed_count(turn,barriers[2])),(0,0,1));assert_eq!(activation_plan_snapshot(&runtime),plan);assert_eq!(activation_send_count(&runtime),3);
+  }
+
+  #[test]
+  fn patterned_activation_samples_outer_effect_values_only_on_its_trigger() {
+    let provider = TestResourceProvider::new()
+      .with_value(
+        "test://render/timer",
+        "tick",
+        Value::F64(Ref::new(0.0)),
+      )
+      .with_value(
+        TEST_SIGNALS_BASE_URI,
+        "value",
+        Value::F64(Ref::new(1.0)),
+      );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "value");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@signals := test://signals/inputs{:read(value)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+scene := @signals/value
+~> render-tick
+  | *, scene > 0.0 => {
+      @out/line <- scene
+    }
+  | * => {}
+"#).unwrap();
+
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_send_count(&runtime), 1);
+    let barrier = runtime
+      .persistent_sends
+      .iter()
+      .find_map(|send| match send.schedule {
+        RuntimePersistentSendSchedule::Activation { barrier_node_id, .. } => {
+          Some(barrier_node_id)
+        }
+        RuntimePersistentSendSchedule::EveryAcceptedTurn => None,
+      })
+      .unwrap();
+    let plan = activation_plan_snapshot(&runtime);
+
+    let scene_only = apply_f64_input(
+      &mut runtime,
+      TEST_SIGNALS_BASE_URI,
+      "value",
+      -1.0,
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(executed_count(only_reactive_turn(&scene_only), barrier), 0);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let guard_false = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(executed_count(only_reactive_turn(&guard_false), barrier), 0);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let scene_only = apply_f64_input(
+      &mut runtime,
+      TEST_SIGNALS_BASE_URI,
+      "value",
+      10.0,
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(executed_count(only_reactive_turn(&scene_only), barrier), 0);
+
+    let render = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(output.lines(), vec!["10"]);
+    assert_eq!(executed_count(only_reactive_turn(&render), barrier), 1);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let scene_only = apply_f64_input(
+      &mut runtime,
+      TEST_SIGNALS_BASE_URI,
+      "value",
+      20.0,
+    );
+    assert_eq!(output.lines(), vec!["10"]);
+    assert_eq!(executed_count(only_reactive_turn(&scene_only), barrier), 0);
+
+    let equal_render = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(output.lines(), vec!["10", "20"]);
+    assert_eq!(executed_count(only_reactive_turn(&equal_render), barrier), 1);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 1);
+  }
+
+  #[test]
+  fn patterned_activation_send_registration_is_atomic_on_elaboration_failure() {
+    let(mut runtime,output)=activation_rejection_runtime();
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+render-tick := @tick/tick
+"#).unwrap();
+    let plan=activation_plan_snapshot(&runtime);let sends=runtime.persistent_sends.len();let bindings=runtime.live_input_bindings.clone();
+    let error=runtime.run_string(r#"@out := test://effects/output{:write(line)}
+~> render-tick
+  | selected => {
+      @out/line <- selected
+    }
+  | * => {
+      failure := function-that-does-not-exist(1.0)
+    }
+"#).unwrap_err();
+    assert!(error.kind_name().contains("Function"),"unexpected elaboration error: {error:?}");
+    assert_rejected_activation_left_no_state(&runtime,&output,&plan,sends,&bindings);
+  }
+
+  #[test]
+  fn patterned_activation_send_rejects_isolated_registration() {
+    let(mut runtime,output)=activation_rejection_runtime();let plan=activation_plan_snapshot(&runtime);let sends=runtime.persistent_sends.len();let bindings=runtime.live_input_bindings.clone();let mut context=runtime.runtime_context().unwrap();
+    let error=runtime.run_string_with_isolated_registration_for_test(&mut context,r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick
+  | selected, selected > 0.0 => {
+      @out/line <- selected
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap_err();
+    assert!(error.kind_as::<RuntimeIsolatedActivationSendUnsupported>().is_some(),"unexpected error: {error:?}");
+    assert_rejected_activation_left_no_state(&runtime,&output,&plan,sends,&bindings);
+  }
+
+  #[test]
+  fn patterned_activation_send_preserves_custom_live_authority() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);let default_subject=runtime.runtime_context().unwrap().subject;let custom_subject="task:patterned-activation-send-custom";grant_read_to(&mut runtime,custom_subject,"test://render/timer","tick");grant_write_to(&mut runtime,custom_subject,TEST_OUTPUT_BASE_URI,"line");
+    assert!(!runtime.has_capability_grant(&default_subject,"test://render/timer",&RuntimeCapabilityOperation::Read,"tick"));assert!(!runtime.has_capability_grant(&default_subject,TEST_OUTPUT_BASE_URI,&RuntimeCapabilityOperation::Write,"line"));
+    let mut context=runtime.runtime_context().unwrap().with_subject(custom_subject);
+    runtime.run_string_with_context(&mut context,r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick
+  | selected, selected > 0.0 => {
+      @out/line <- selected
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap();
+    assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let outcome=apply_f64_input(&mut runtime,"test://render/timer","tick",9.0);assert!(outcome.turn.is_some());assert_eq!(output.lines(),vec!["9"]);assert_eq!(activation_send_count(&runtime),1);
+  }
+
+  #[test]
+  fn patterned_activation_snapshots_effects_before_commit_and_releases_after_success() {
+    let provider = TestResourceProvider::new().with_value(
+      "test://render/timer",
+      "tick",
+      Value::F64(Ref::new(0.0)),
+    );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~state := 0.0
+~> render-tick
+  | amount, amount > 0.0 => {
+      state = state + amount
+      @out/line <- state
+      @out/line <- state + 0.0
+    }
+  | ignored => {
+      fallback := ignored
+    }
+"#).unwrap();
+    let plan = activation_plan_snapshot(&runtime);
+    let register = register_node_for_symbol(&runtime, "state");
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 0.0);
+    assert!(output.lines().is_empty());
+
+    let first = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+    let first_turn = only_reactive_turn(&first);
+    assert_eq!(
+      first_turn.register_commit.committed_nodes,
+      vec![register]
+    );
+    assert!(first_turn.after_commit.pending_register_nodes.is_empty());
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 1.0);
+    assert_eq!(output.lines(), vec!["0", "0"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let equal = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+    let equal_turn = only_reactive_turn(&equal);
+    assert_eq!(
+      equal_turn.register_commit.committed_nodes,
+      vec![register]
+    );
+    assert!(equal_turn.after_commit.pending_register_nodes.is_empty());
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 2.0);
+    assert_eq!(output.lines(), vec!["0", "0", "1", "1"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+  }
+
+  #[test]
+  fn patterned_activation_register_batch_failure_does_not_leak_or_replay_send() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_read(&mut runtime,"test://other/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@other := test://other/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+other-tick := @other/tick
+other-value := other-tick + 1.0
+~state := 0.0
+~> render-tick
+  | amount, amount > 0.0 => {
+      state = state + amount
+      state = state + amount + 1.0
+      @out/line <- state
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap();
+    let plan=activation_plan_snapshot(&runtime);assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let error=runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://render/timer","tick").unwrap(),RuntimeHostInputValue::F64(1.0))).unwrap_err();assert!(format!("{error:?}").contains("ReactiveRegisterOutputConflict"),"unexpected error: {error:?}");assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let unrelated_error=runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://other/timer","tick").unwrap(),RuntimeHostInputValue::F64(7.0))).unwrap_err();assert!(format!("{unrelated_error:?}").contains("ReactiveRegisterOutputConflict"),"unexpected carried-batch error: {unrelated_error:?}");assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);assert_eq!(activation_send_count(&runtime),1);
+  }
+
+  #[test]
+  fn failed_patterned_body_does_not_replay_send_on_unrelated_turn() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_read(&mut runtime,"test://other/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    let subject=runtime.runtime_context().unwrap().subject;grant_host_call(&mut runtime,&subject,194,"host:demo/patterned-body-fail-second");let calls=Arc::new(AtomicUsize::new(0));let host_calls=calls.clone();
+    runtime.register_mech_host_function(ClosureHostFunction::new("demo/patterned-body-fail-second",move |_services,_context,args|{let call=host_calls.fetch_add(1,Ordering::SeqCst)+1;if call==2{return Err(MechError::new(DeliberateHostCallError,None));}Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))})).unwrap();
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@other := test://other/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+other-tick := @other/tick
+other-value := other-tick + 1.0
+~state := 0.0
+~> render-tick
+  | amount, amount > 0.0 => {
+      state = demo/patterned-body-fail-second(state + amount)
+      @out/line <- state
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap();
+    let plan=activation_plan_snapshot(&runtime);assert_eq!(calls.load(Ordering::SeqCst),1);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let error=runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://render/timer","tick").unwrap(),RuntimeHostInputValue::F64(1.0))).unwrap_err();assert!(error.kind_as::<DeliberateHostCallError>().is_some());assert_eq!(calls.load(Ordering::SeqCst),2);assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let unrelated=apply_f64_input(&mut runtime,"test://other/timer","tick",7.0);assert!(unrelated.turn.is_some());assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let retry=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);assert!(retry.turn.is_some());assert_eq!(calls.load(Ordering::SeqCst),3);assert_eq!(f64_value(&symbol_value(&runtime,"state")),1.0);assert_eq!(output.lines(),vec!["0"]);assert_eq!(activation_plan_snapshot(&runtime),plan);assert_eq!(activation_send_count(&runtime),1);
   }
 
   #[test]

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -960,6 +960,7 @@ fn mock_error(name: &'static str, message: impl Into<String>) -> MechError {
 #[cfg(test)]
 mod persistent_send_tests {
   use super::*;
+  use crate::runtime::execution::ACTIVATION_EFFECT_BARRIER_NAME;
   use crate::RuntimeResourceWritePreflightRequest;
 
   const TEST_TIME_BASE_URI: &str =
@@ -1293,7 +1294,7 @@ render-tick := @clock/hour
     // Equal admitted values still execute the barrier and replay every send.
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
-    assert_eq!(console.lines(), vec!["first", "second", "third", "first", "second", "third"]);
+    assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
   }
 
   #[test]

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,1916 +1,1096 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
-};
+use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
 use std::thread;
 use std::time::Duration;
 
-use mech_core::{
-    MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId,
-    ReactiveNodeKind, ReactiveTurnOutcome, Ref, Value, hash_str,
-};
+use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, ReactiveTurnOutcome, Ref, Value};
 
 use super::*;
 use crate::{
-    BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
-    ClosureHostFunction, ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
-    RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInput, RuntimeHostInputOutcome,
-    RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInstallation,
-    RuntimeIngress, RuntimeResourceProvider, RuntimeResourceReadRequest,
-    RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
-    materialize_host_manifest,
+  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+  ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
+  RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
+  RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInputOutcome, RuntimeIngress,
+  RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, RuntimeResourceWriteIntent, ClosureHostFunction, materialize_host_manifest,
 };
 
-const TEST_CLOCK_BASE_URI: &str = "test://clock/ticks";
-const TEST_TIMER_BASE_URI: &str = "test://timer/state";
-const TEST_SIGNALS_BASE_URI: &str = "test://signals/inputs";
-const TEST_OUTPUT_BASE_URI: &str = "test://effects/output";
+const TEST_CLOCK_BASE_URI: &str =
+  "test://clock/ticks";
+const TEST_TIMER_BASE_URI: &str =
+  "test://timer/state";
+const TEST_SIGNALS_BASE_URI: &str =
+  "test://signals/inputs";
+const TEST_OUTPUT_BASE_URI: &str =
+  "test://effects/output";
 
 #[derive(Debug, Clone)]
 struct TestFixtureError(String);
 impl MechErrorKind for TestFixtureError {
-    fn name(&self) -> &str {
-        "TestFixtureError"
-    }
-    fn message(&self) -> String {
-        self.0.clone()
-    }
+  fn name(&self) -> &str { "TestFixtureError" }
+  fn message(&self) -> String { self.0.clone() }
 }
 
 #[derive(Debug, Default)]
-struct TestResourceProvider {
-    values: BTreeMap<String, BTreeMap<String, Value>>,
-}
+struct TestResourceProvider { values: BTreeMap<String, BTreeMap<String, Value>> }
 impl TestResourceProvider {
-    fn new() -> Self {
-        Self::default()
-    }
-    fn with_value(mut self, base_uri: &str, path: &str, value: Value) -> Self {
-        assert!(
-            base_uri.starts_with("test://"),
-            "test fixture resource must use test://"
-        );
-        assert!(!path.is_empty(), "test fixture path must not be empty");
-        self.values
-            .entry(base_uri.to_string())
-            .or_default()
-            .insert(path.to_string(), value);
-        self
-    }
+  fn new() -> Self { Self::default() }
+  fn with_value(mut self, base_uri: &str, path: &str, value: Value) -> Self {
+    assert!(base_uri.starts_with("test://"), "test fixture resource must use test://");
+    assert!(!path.is_empty(), "test fixture path must not be empty");
+    self.values.entry(base_uri.to_string()).or_default().insert(path.to_string(), value);
+    self
+  }
 }
 impl RuntimeResourceProvider for TestResourceProvider {
-    fn scheme(&self) -> &str {
-        "test"
-    }
-    fn base_uris(&self) -> Vec<String> {
-        self.values.keys().cloned().collect()
-    }
-    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-        self.values
-            .get(&request.base_uri)
-            .and_then(|paths| paths.get(&request.path))
-            .cloned()
-            .ok_or_else(|| {
-                MechError::new(
-                    TestFixtureError(format!(
-                        "missing test resource {} / {}",
-                        request.base_uri, request.path
-                    )),
-                    None,
-                )
-            })
-    }
+  fn scheme(&self) -> &str { "test" }
+  fn base_uris(&self) -> Vec<String> { self.values.keys().cloned().collect() }
+  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+    self.values.get(&request.base_uri).and_then(|paths| paths.get(&request.path)).cloned().ok_or_else(|| MechError::new(TestFixtureError(format!("missing test resource {} / {}", request.base_uri, request.path)), None))
+  }
 }
 
 #[derive(Clone, Debug, Default)]
-struct RecordingTestOutput {
-    lines: Rc<RefCell<Vec<String>>>,
-}
-impl RecordingTestOutput {
-    fn lines(&self) -> Vec<String> {
-        self.lines.borrow().clone()
-    }
-}
+struct RecordingTestOutput { lines: Rc<RefCell<Vec<String>>> }
+impl RecordingTestOutput { fn lines(&self) -> Vec<String> { self.lines.borrow().clone() } }
 #[derive(Debug)]
-struct TestOutputProvider {
-    backend: RecordingTestOutput,
-}
+struct TestOutputProvider { backend: RecordingTestOutput }
 impl RuntimeResourceProvider for TestOutputProvider {
-    fn scheme(&self) -> &str {
-        "test"
-    }
-    fn base_uris(&self) -> Vec<String> {
-        vec![TEST_OUTPUT_BASE_URI.to_string()]
-    }
-    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-        Err(MechError::new(
-            TestFixtureError(format!(
-                "test output is write-only: {} / {}",
-                request.base_uri, request.path
-            )),
-            None,
-        ))
-    }
-    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-        if request.base_uri == TEST_OUTPUT_BASE_URI
-            && request.path == "line"
-            && request.intent == RuntimeResourceWriteIntent::Send
-        {
-            Ok(())
-        } else {
-            Err(MechError::new(
-                TestFixtureError(format!(
-                    "invalid test output write: {} / {}",
-                    request.base_uri, request.path
-                )),
-                None,
-            ))
-        }
-    }
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-        self.preflight_write(RuntimeResourceWritePreflightRequest {
-            base_uri: request.base_uri.clone(),
-            path: request.path.clone(),
-            context_name: request.context_name.clone(),
-            operation: request.operation.clone(),
-            intent: request.intent,
-        })?;
-        self.backend
-            .lines
-            .borrow_mut()
-            .push(format!("{}", request.value));
-        Ok(())
-    }
+  fn scheme(&self) -> &str { "test" }
+  fn base_uris(&self) -> Vec<String> { vec![TEST_OUTPUT_BASE_URI.to_string()] }
+  fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> { Err(MechError::new(TestFixtureError(format!("test output is write-only: {} / {}", request.base_uri, request.path)), None)) }
+  fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+    if request.base_uri == TEST_OUTPUT_BASE_URI && request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send { Ok(()) } else { Err(MechError::new(TestFixtureError(format!("invalid test output write: {} / {}", request.base_uri, request.path)), None)) }
+  }
+  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    self.preflight_write(RuntimeResourceWritePreflightRequest { base_uri: request.base_uri.clone(), path: request.path.clone(), context_name: request.context_name.clone(), operation: request.operation.clone(), intent: request.intent })?;
+    self.backend.lines.borrow_mut().push(format!("{}", request.value)); Ok(())
+  }
 }
 
 fn f64_value(value: &Value) -> f64 {
-    match value {
-        Value::F64(value) => *value.borrow(),
-        other => panic!("expected f64, got {other:?}"),
-    }
+  match value {
+    Value::F64(value) => *value.borrow(),
+    other => panic!("expected f64, got {other:?}"),
+  }
 }
 
 fn host_f64_argument(value: &Value) -> f64 {
-    match value {
-        Value::F64(value) => *value.borrow(),
-        Value::MutableReference(value) => match &*value.borrow() {
-            Value::F64(value) => *value.borrow(),
-            other => panic!("expected f64 mutable reference, got {other:?}"),
-        },
-        other => panic!("expected f64 host argument, got {other:?}"),
-    }
+  match value {
+    Value::F64(value) => *value.borrow(),
+    Value::MutableReference(value) => match &*value.borrow() {
+      Value::F64(value) => *value.borrow(),
+      other => panic!("expected f64 mutable reference, got {other:?}"),
+    },
+    other => panic!("expected f64 host argument, got {other:?}"),
+  }
 }
 
 fn string_value(value: &Value) -> String {
-    match value {
-        Value::String(value) => value.borrow().clone(),
-        other => panic!("expected string, got {other:?}"),
-    }
+  match value {
+    Value::String(value) => value.borrow().clone(),
+    other => panic!("expected string, got {other:?}"),
+  }
 }
 
 #[derive(Debug, Clone)]
 struct DeliberateHostCallError;
 impl MechErrorKind for DeliberateHostCallError {
-    fn name(&self) -> &str {
-        "DeliberateHostCallError"
-    }
-    fn message(&self) -> String {
-        "deliberate host call failure".to_string()
-    }
+  fn name(&self) -> &str { "DeliberateHostCallError" }
+  fn message(&self) -> String { "deliberate host call failure".to_string() }
 }
 
 fn symbol_value(runtime: &MechRuntime, name: &str) -> Value {
-    runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str(name))
-        .unwrap_or_else(|| panic!("missing symbol {name}"))
-        .borrow()
-        .clone()
+  runtime
+    .program
+    .interpreter()
+    .symbols()
+    .borrow()
+    .get(hash_str(name))
+    .unwrap_or_else(|| panic!("missing symbol {name}"))
+    .borrow()
+    .clone()
 }
 
+
 fn source_value(runtime: &MechRuntime, source: &RuntimeHostInputSource) -> Value {
-    let input = runtime
-        .live_input_bindings
-        .get(source)
-        .and_then(|inputs| inputs.first())
-        .unwrap_or_else(|| {
-            panic!(
-                "missing binding for {} / {}",
-                source.base_uri(),
-                source.path()
-            )
-        });
-    runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(input.symbol_id)
-        .unwrap_or_else(|| panic!("missing symbol {}", input.symbol_id))
-        .borrow()
-        .clone()
+  let input = runtime
+    .live_input_bindings
+    .get(source)
+    .and_then(|inputs| inputs.first())
+    .unwrap_or_else(|| panic!("missing binding for {} / {}", source.base_uri(), source.path()));
+  runtime
+    .program
+    .interpreter()
+    .symbols()
+    .borrow()
+    .get(input.symbol_id)
+    .unwrap_or_else(|| panic!("missing symbol {}", input.symbol_id))
+    .borrow()
+    .clone()
 }
 
 fn symbol_cell(runtime: &MechRuntime, name: &str) -> ReactiveCellId {
-    let cells = symbol_value(runtime, name).reactive_root_cell_ids();
-    assert_eq!(cells.len(), 1, "symbol {name} must have one root cell");
-    cells[0]
+  let cells = symbol_value(runtime, name).reactive_root_cell_ids();
+  assert_eq!(cells.len(), 1, "symbol {name} must have one root cell");
+  cells[0]
 }
 
 fn source_cell(runtime: &MechRuntime, source: &RuntimeHostInputSource) -> ReactiveCellId {
-    let cells = source_value(runtime, source).reactive_root_cell_ids();
-    assert_eq!(cells.len(), 1, "source must have one root cell");
-    cells[0]
+  let cells = source_value(runtime, source).reactive_root_cell_ids();
+  assert_eq!(cells.len(), 1, "source must have one root cell");
+  cells[0]
 }
 
 fn register_node_for_symbol(runtime: &MechRuntime, name: &str) -> ReactiveNodeId {
-    let output = symbol_cell(runtime, name);
-    let plan = runtime.program.interpreter().plan();
-    let plan = plan.borrow();
-    let nodes = plan
-        .nodes
-        .iter()
-        .filter(|node| node.kind == ReactiveNodeKind::Register && node.outputs.contains(&output))
-        .map(|node| node.id)
-        .collect::<Vec<_>>();
-    assert_eq!(nodes.len(), 1, "symbol {name} must have one register node");
-    nodes[0]
+  let output = symbol_cell(runtime, name);
+  let plan = runtime.program.interpreter().plan();
+  let plan = plan.borrow();
+  let nodes = plan.nodes.iter().filter(|node| node.kind == ReactiveNodeKind::Register && node.outputs.contains(&output)).map(|node| node.id).collect::<Vec<_>>();
+  assert_eq!(nodes.len(), 1, "symbol {name} must have one register node");
+  nodes[0]
 }
 
-fn combinational_node_for_output_and_inputs(
-    runtime: &MechRuntime,
-    output: ReactiveCellId,
-    required_inputs: &[ReactiveCellId],
-) -> ReactiveNodeId {
-    let plan = runtime.program.interpreter().plan();
-    let plan = plan.borrow();
-    let nodes = plan
-        .nodes
-        .iter()
-        .filter(|node| {
-            node.kind == ReactiveNodeKind::Combinational
-                && node.outputs.contains(&output)
-                && required_inputs.iter().all(|required| {
-                    node.inputs.iter().any(|dependency| {
-                        dependency.cell == *required
-                            && dependency.kind == ReactiveDependencyKind::Reactive
-                    })
-                })
-        })
-        .map(|node| node.id)
-        .collect::<Vec<_>>();
-    assert_eq!(nodes.len(), 1, "expected one matching combinational node");
-    nodes[0]
+fn combinational_node_for_output_and_inputs(runtime: &MechRuntime, output: ReactiveCellId, required_inputs: &[ReactiveCellId]) -> ReactiveNodeId {
+  let plan = runtime.program.interpreter().plan();
+  let plan = plan.borrow();
+  let nodes = plan.nodes.iter().filter(|node| node.kind == ReactiveNodeKind::Combinational && node.outputs.contains(&output) && required_inputs.iter().all(|required| node.inputs.iter().any(|dependency| dependency.cell == *required && dependency.kind == ReactiveDependencyKind::Reactive))).map(|node| node.id).collect::<Vec<_>>();
+  assert_eq!(nodes.len(), 1, "expected one matching combinational node");
+  nodes[0]
 }
 
 fn plan_snapshot(runtime: &MechRuntime) -> (usize, Vec<ReactiveNodeId>, Vec<Vec<ReactiveCellId>>) {
-    let plan = runtime.program.interpreter().plan();
-    let plan = plan.borrow();
-    (
-        plan.len(),
-        plan.nodes.iter().map(|node| node.id).collect(),
-        plan.nodes.iter().map(|node| node.outputs.clone()).collect(),
-    )
+  let plan = runtime.program.interpreter().plan();
+  let plan = plan.borrow();
+  (plan.len(), plan.nodes.iter().map(|node| node.id).collect(), plan.nodes.iter().map(|node| node.outputs.clone()).collect())
 }
 
 fn test_provider_with(base_uri: &str, path: &str, value: f64) -> TestResourceProvider {
-    TestResourceProvider::new().with_value(base_uri, path, Value::F64(Ref::new(value)))
+  TestResourceProvider::new()
+    .with_value(base_uri, path, Value::F64(Ref::new(value)))
 }
 
 fn grant_read(runtime: &mut MechRuntime, resource: &str, path: &str) {
-    let subject = runtime.runtime_context().unwrap().subject;
-    runtime
-        .grant_capability(RuntimeCapabilityGrant {
-            subject,
-            resource: resource.to_string(),
-            operations: vec![RuntimeCapabilityOperation::Read],
-            paths: vec![path.to_string()],
-        })
-        .unwrap();
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject,
+    resource: resource.to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec![path.to_string()],
+  }).unwrap();
 }
 
 fn grant_write(runtime: &mut MechRuntime, resource: &str, path: &str) {
-    let subject = runtime.runtime_context().unwrap().subject;
-    runtime
-        .grant_capability(RuntimeCapabilityGrant {
-            subject,
-            resource: resource.to_string(),
-            operations: vec![RuntimeCapabilityOperation::Write],
-            paths: vec![path.to_string()],
-        })
-        .unwrap();
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(RuntimeCapabilityGrant { subject, resource: resource.to_string(), operations: vec![RuntimeCapabilityOperation::Write], paths: vec![path.to_string()] }).unwrap();
 }
 
-fn grant_read_to(runtime: &mut MechRuntime, subject: &str, resource: &str, path: &str) {
-    runtime
-        .grant_capability(RuntimeCapabilityGrant {
-            subject: subject.to_string(),
-            resource: resource.to_string(),
-            operations: vec![RuntimeCapabilityOperation::Read],
-            paths: vec![path.to_string()],
-        })
-        .unwrap();
+fn grant_read_to(
+  runtime: &mut MechRuntime,
+  subject: &str,
+  resource: &str,
+  path: &str,
+) {
+  runtime
+    .grant_capability(
+      RuntimeCapabilityGrant {
+        subject: subject.to_string(),
+        resource: resource.to_string(),
+        operations: vec![
+          RuntimeCapabilityOperation::Read,
+        ],
+        paths: vec![path.to_string()],
+      },
+    )
+    .unwrap();
 }
 
-fn grant_host_call(runtime: &mut MechRuntime, subject: &str, id: u64, resource: &str) {
-    runtime
-        .grant_capability(Arc::new(BasicCapability::new(
-            CapabilityId(id.into()),
-            &BasicSubject::new(subject),
-            &BasicResource::new(resource),
-            [BasicOperation::new("call")],
-        )))
-        .unwrap();
+fn grant_host_call(
+  runtime: &mut MechRuntime,
+  subject: &str,
+  id: u64,
+  resource: &str,
+) {
+  runtime
+    .grant_capability(
+      Arc::new(
+        BasicCapability::new(
+          CapabilityId(id.into()),
+          &BasicSubject::new(subject),
+          &BasicResource::new(resource),
+          [
+            BasicOperation::new("call"),
+          ],
+        ),
+      ),
+    )
+    .unwrap();
 }
 
-fn register_sleep_host(runtime: &mut MechRuntime, name: &str) {
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new(
-            name,
-            move |_services, _context, args| {
-                thread::sleep(Duration::from_millis(5));
+fn register_sleep_host(
+  runtime: &mut MechRuntime,
+  name: &str,
+) {
+  runtime
+    .register_mech_host_function(
+      ClosureHostFunction::new(
+        name,
+        move |_services, _context, args| {
+          thread::sleep(
+            Duration::from_millis(5),
+          );
 
-                match args.first() {
-                    Some(Value::F64(value)) => Ok(Value::F64(Ref::new(*value.borrow()))),
+          match args.first() {
+            Some(Value::F64(value)) =>
+              Ok(Value::F64(
+                Ref::new(*value.borrow()),
+              )),
 
-                    Some(Value::MutableReference(value)) => match &*value.borrow() {
-                        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow()))),
+            Some(Value::MutableReference(value)) =>
+              match &*value.borrow() {
+                Value::F64(value) =>
+                  Ok(Value::F64(
+                    Ref::new(*value.borrow()),
+                  )),
 
-                        other => panic!("expected f64 mutable reference, got {other:?}",),
-                    },
+                other =>
+                  panic!(
+                    "expected f64 mutable reference, got {other:?}",
+                  ),
+              },
 
-                    other => panic!("expected f64 argument, got {other:?}",),
-                }
-            },
-        ))
-        .unwrap();
+            other =>
+              panic!(
+                "expected f64 argument, got {other:?}",
+              ),
+          }
+        },
+      ),
+    )
+    .unwrap();
 }
 
 fn test_runtime(provider: TestResourceProvider) -> MechRuntime {
-    RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .build()
-        .unwrap()
+  RuntimeBuilder::new()
+    .resource_provider(Box::new(provider))
+    .build()
+    .unwrap()
 }
 
 fn test_runtime_with_output(provider: TestResourceProvider) -> (MechRuntime, RecordingTestOutput) {
-    let output = RecordingTestOutput::default();
-    let runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(provider))
-        .resource_provider(Box::new(TestOutputProvider {
-            backend: output.clone(),
-        }))
-        .build()
-        .unwrap();
-    (runtime, output)
+  let output = RecordingTestOutput::default();
+  let runtime = RuntimeBuilder::new()
+    .resource_provider(Box::new(provider))
+    .resource_provider(Box::new(TestOutputProvider { backend: output.clone() }))
+    .build()
+    .unwrap();
+  (runtime, output)
 }
 
 #[test]
 fn canonical_host_input_updates_live_context_read() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    grant_read(&mut runtime, "test://clock/ticks", "value");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
-        )
-        .unwrap();
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  grant_read(&mut runtime, "test://clock/ticks", "value");
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
 
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-    let canonical = RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap();
-    assert!(runtime.live_input_bindings.contains_key(&canonical));
-    assert!(
-        runtime
-            .live_input_bindings
-            .keys()
-            .all(|source| !source.base_uri().contains("pulse") && !source.path().contains("pulse"))
-    );
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+  let canonical = RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap();
+  assert!(runtime.live_input_bindings.contains_key(&canonical));
+  assert!(runtime.live_input_bindings.keys().all(|source| !source.base_uri().contains("pulse") && !source.path().contains("pulse")));
 
-    let alias = RuntimeHostInputSource::new("test://pulse", "value").unwrap();
-    let outcome = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            alias,
-            RuntimeHostInputValue::F64(5.0),
-        ))
-        .unwrap();
-    assert_eq!(outcome.update_count, 1);
-    assert_eq!(outcome.ignored_update_count, 1);
-    assert_eq!(outcome.binding_count, 0);
-    assert!(outcome.turn.is_none());
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+  let alias = RuntimeHostInputSource::new("test://pulse", "value").unwrap();
+  let outcome = runtime
+    .apply_host_input(RuntimeHostInput::single(alias, RuntimeHostInputValue::F64(5.0)))
+    .unwrap();
+  assert_eq!(outcome.update_count, 1);
+  assert_eq!(outcome.ignored_update_count, 1);
+  assert_eq!(outcome.binding_count, 0);
+  assert!(outcome.turn.is_none());
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
 
-    runtime
-        .ingress()
-        .submit(RuntimeHostInput::single(
-            canonical,
-            RuntimeHostInputValue::F64(5.0),
-        ))
-        .unwrap();
-    let outcomes = runtime.drain_host_inputs(1).unwrap();
-    assert_eq!(outcomes.len(), 1);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+  runtime.ingress().submit(RuntimeHostInput::single(canonical, RuntimeHostInputValue::F64(5.0))).unwrap();
+  let outcomes = runtime.drain_host_inputs(1).unwrap();
+  assert_eq!(outcomes.len(), 1);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
 }
 
 #[test]
 fn runtime_reactive_host_input_batches_bound_updates_into_one_turn() {
-    let provider = TestResourceProvider::new()
-        .with_value(TEST_CLOCK_BASE_URI, "a", Value::F64(Ref::new(1.0)))
-        .with_value(TEST_CLOCK_BASE_URI, "b", Value::F64(Ref::new(2.0)));
-    let mut runtime = test_runtime(provider);
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "a");
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "b");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(a), :read(b)}\nsum := @pulse/a + @pulse/b",
-        )
-        .unwrap();
-    let a_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "a").unwrap();
-    let b_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "b").unwrap();
-    let sum_node = combinational_node_for_output_and_inputs(
-        &runtime,
-        symbol_cell(&runtime, "sum"),
-        &[
-            source_cell(&runtime, &a_source),
-            source_cell(&runtime, &b_source),
-        ],
-    );
-    let root_interpreter_id = runtime.program.interpreter().id;
-    let outcome = runtime
-        .apply_host_input(
-            RuntimeHostInput::new(vec![
-                RuntimeHostInputUpdate {
-                    source: a_source.clone(),
-                    value: RuntimeHostInputValue::F64(10.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: b_source.clone(),
-                    value: RuntimeHostInputValue::F64(20.0),
-                },
-            ])
-            .unwrap(),
-        )
-        .unwrap();
-    let program_turn = outcome.turn.as_ref().unwrap();
-    let interpreter_turn = &program_turn.interpreter_turns[0];
-    let reactive_turn = &interpreter_turn.turn;
-    assert_eq!(outcome.update_count, 2);
-    assert_eq!(outcome.ignored_update_count, 0);
-    assert_eq!(outcome.binding_count, 2);
-    assert_eq!(program_turn.updated_count, 2);
-    assert_eq!(program_turn.interpreter_turns.len(), 1);
-    assert_eq!(interpreter_turn.interpreter_id, root_interpreter_id);
-    assert!(!interpreter_turn.dirty_cells.is_empty());
-    assert_eq!(
-        reactive_turn
-            .before_commit
-            .executed_nodes
-            .iter()
-            .filter(|node| **node == sum_node)
-            .count(),
-        1
-    );
-    assert!(reactive_turn.register_commit.staged_nodes.is_empty());
-    assert!(reactive_turn.register_commit.committed_nodes.is_empty());
-    assert!(reactive_turn.register_commit.dirty_cells.is_empty());
-    assert_eq!(f64_value(&source_value(&runtime, &a_source)), 10.0);
-    assert_eq!(f64_value(&source_value(&runtime, &b_source)), 20.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "sum")), 30.0);
+  let provider = TestResourceProvider::new()
+    .with_value(TEST_CLOCK_BASE_URI, "a", Value::F64(Ref::new(1.0)))
+    .with_value(TEST_CLOCK_BASE_URI, "b", Value::F64(Ref::new(2.0)));
+  let mut runtime = test_runtime(provider);
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "a");
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "b");
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(a), :read(b)}\nsum := @pulse/a + @pulse/b").unwrap();
+  let a_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "a").unwrap();
+  let b_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "b").unwrap();
+  let sum_node = combinational_node_for_output_and_inputs(&runtime, symbol_cell(&runtime, "sum"), &[source_cell(&runtime, &a_source), source_cell(&runtime, &b_source)]);
+  let root_interpreter_id = runtime.program.interpreter().id;
+  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![
+    RuntimeHostInputUpdate { source: a_source.clone(), value: RuntimeHostInputValue::F64(10.0) },
+    RuntimeHostInputUpdate { source: b_source.clone(), value: RuntimeHostInputValue::F64(20.0) },
+  ]).unwrap()).unwrap();
+  let program_turn = outcome.turn.as_ref().unwrap();
+  let interpreter_turn = &program_turn.interpreter_turns[0];
+  let reactive_turn = &interpreter_turn.turn;
+  assert_eq!(outcome.update_count, 2); assert_eq!(outcome.ignored_update_count, 0); assert_eq!(outcome.binding_count, 2);
+  assert_eq!(program_turn.updated_count, 2); assert_eq!(program_turn.interpreter_turns.len(), 1); assert_eq!(interpreter_turn.interpreter_id, root_interpreter_id); assert!(!interpreter_turn.dirty_cells.is_empty());
+  assert_eq!(reactive_turn.before_commit.executed_nodes.iter().filter(|node| **node == sum_node).count(), 1);
+  assert!(reactive_turn.register_commit.staged_nodes.is_empty()); assert!(reactive_turn.register_commit.committed_nodes.is_empty()); assert!(reactive_turn.register_commit.dirty_cells.is_empty());
+  assert_eq!(f64_value(&source_value(&runtime, &a_source)), 10.0); assert_eq!(f64_value(&source_value(&runtime, &b_source)), 20.0); assert_eq!(f64_value(&symbol_value(&runtime, "sum")), 30.0);
 }
 
 #[test]
 fn packet_with_bound_and_unbound_sources_updates_bound_inputs() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    grant_read(&mut runtime, "test://clock/ticks", "value");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
-        )
-        .unwrap();
-    let outcome = runtime
-        .apply_host_input(
-            RuntimeHostInput::new(vec![
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-                    value: RuntimeHostInputValue::F64(5.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://clock/ticks", "missing").unwrap(),
-                    value: RuntimeHostInputValue::F64(9.0),
-                },
-            ])
-            .unwrap(),
-        )
-        .unwrap();
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  grant_read(&mut runtime, "test://clock/ticks", "value");
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
+  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), value: RuntimeHostInputValue::F64(5.0) },
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://clock/ticks", "missing").unwrap(), value: RuntimeHostInputValue::F64(9.0) },
+  ]).unwrap()).unwrap();
 
-    assert_eq!(outcome.update_count, 2);
-    assert_eq!(outcome.ignored_update_count, 1);
-    assert_eq!(outcome.binding_count, 1);
-    assert!(outcome.turn.is_some());
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
-    assert_eq!(
-        f64_value(&source_value(
-            &runtime,
-            &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap()
-        )),
-        5.0
-    );
+  assert_eq!(outcome.update_count, 2);
+  assert_eq!(outcome.ignored_update_count, 1);
+  assert_eq!(outcome.binding_count, 1);
+  assert!(outcome.turn.is_some());
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap())), 5.0);
 }
+
 
 #[test]
 fn partial_snapshot_updates_bound_fields_and_ignores_unbound_fields() {
-    let provider = TestResourceProvider::new()
-        .with_value(TEST_TIMER_BASE_URI, "tick", Value::F64(Ref::new(1.0)))
-        .with_value(
-            TEST_TIMER_BASE_URI,
-            "delta-seconds",
-            Value::F64(Ref::new(0.1)),
-        );
-    let mut runtime = test_runtime(provider);
-    grant_read(&mut runtime, "test://timer/state", "tick");
-    grant_read(&mut runtime, "test://timer/state", "delta-seconds");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@timer := test://timer/state{:read(tick), :read(delta-seconds)}\noutput := @timer/tick + @timer/delta-seconds").unwrap();
+  let provider = TestResourceProvider::new()
+    .with_value(TEST_TIMER_BASE_URI, "tick", Value::F64(Ref::new(1.0)))
+    .with_value(TEST_TIMER_BASE_URI, "delta-seconds", Value::F64(Ref::new(0.1)));
+  let mut runtime = test_runtime(provider);
+  grant_read(&mut runtime, "test://timer/state", "tick");
+  grant_read(&mut runtime, "test://timer/state", "delta-seconds");
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@timer := test://timer/state{:read(tick), :read(delta-seconds)}\noutput := @timer/tick + @timer/delta-seconds").unwrap();
 
-    let outcome = runtime
-        .apply_host_input(
-            RuntimeHostInput::new(vec![
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://timer/state", "tick").unwrap(),
-                    value: RuntimeHostInputValue::F64(10.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://timer/state", "elapsed-ms")
-                        .unwrap(),
-                    value: RuntimeHostInputValue::F64(1000.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://timer/state", "delta-ms").unwrap(),
-                    value: RuntimeHostInputValue::F64(16.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://timer/state", "elapsed-seconds")
-                        .unwrap(),
-                    value: RuntimeHostInputValue::F64(1.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://timer/state", "delta-seconds")
-                        .unwrap(),
-                    value: RuntimeHostInputValue::F64(0.25),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new("test://timer/state", "skipped-steps")
-                        .unwrap(),
-                    value: RuntimeHostInputValue::F64(0.0),
-                },
-            ])
-            .unwrap(),
-        )
-        .unwrap();
+  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "tick").unwrap(), value: RuntimeHostInputValue::F64(10.0) },
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "elapsed-ms").unwrap(), value: RuntimeHostInputValue::F64(1000.0) },
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "delta-ms").unwrap(), value: RuntimeHostInputValue::F64(16.0) },
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "elapsed-seconds").unwrap(), value: RuntimeHostInputValue::F64(1.0) },
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "delta-seconds").unwrap(), value: RuntimeHostInputValue::F64(0.25) },
+    RuntimeHostInputUpdate { source: RuntimeHostInputSource::new("test://timer/state", "skipped-steps").unwrap(), value: RuntimeHostInputValue::F64(0.0) },
+  ]).unwrap()).unwrap();
 
-    assert_eq!(outcome.update_count, 6);
-    assert_eq!(outcome.ignored_update_count, 4);
-    assert_eq!(outcome.binding_count, 2);
-    assert!(outcome.turn.is_some());
-    assert_eq!(
-        f64_value(&source_value(
-            &runtime,
-            &RuntimeHostInputSource::new("test://timer/state", "tick").unwrap()
-        )),
-        10.0
-    );
-    assert_eq!(
-        f64_value(&source_value(
-            &runtime,
-            &RuntimeHostInputSource::new("test://timer/state", "delta-seconds").unwrap()
-        )),
-        0.25
-    );
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.25);
+  assert_eq!(outcome.update_count, 6);
+  assert_eq!(outcome.ignored_update_count, 4);
+  assert_eq!(outcome.binding_count, 2);
+  assert!(outcome.turn.is_some());
+  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://timer/state", "tick").unwrap())), 10.0);
+  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://timer/state", "delta-seconds").unwrap())), 0.25);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.25);
 }
 
 #[test]
 fn runtime_reactive_host_input_unbound_packet_does_not_advance_pending_registers() {
-    let (mut runtime, output) =
-        test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
-    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0\n@out/line <- output").unwrap();
-    assert_eq!(output.lines().len(), 1);
-    let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
-    runtime
-        .apply_host_input(RuntimeHostInput::single(
-            source,
-            RuntimeHostInputValue::F64(10.0),
-        ))
-        .unwrap();
-    assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0);
-    assert!(
-        runtime
-            .program
-            .interpreter()
-            .has_pending_reactive_registers()
-    );
-    assert_eq!(output.lines().len(), 2);
-    let b_before = f64_value(&symbol_value(&runtime, "b"));
-    let output_before = f64_value(&symbol_value(&runtime, "output"));
-    let lines_before = output.lines();
-    let outcome = runtime
-        .apply_host_input(
-            RuntimeHostInput::new(vec![
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-a").unwrap(),
-                    value: RuntimeHostInputValue::F64(5.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-b").unwrap(),
-                    value: RuntimeHostInputValue::F64(9.0),
-                },
-            ])
-            .unwrap(),
-        )
-        .unwrap();
-    assert_eq!(outcome.update_count, 2);
-    assert_eq!(outcome.ignored_update_count, 2);
-    assert_eq!(outcome.binding_count, 0);
-    assert!(outcome.turn.is_none());
-    assert_eq!(f64_value(&symbol_value(&runtime, "b")), b_before);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), output_before);
-    assert!(
-        runtime
-            .program
-            .interpreter()
-            .has_pending_reactive_registers()
-    );
-    assert_eq!(output.lines(), lines_before);
+  let (mut runtime, output) = test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0\n@out/line <- output").unwrap();
+  assert_eq!(output.lines().len(), 1);
+  let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); runtime.apply_host_input(RuntimeHostInput::single(source, RuntimeHostInputValue::F64(10.0))).unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0); assert!(runtime.program.interpreter().has_pending_reactive_registers()); assert_eq!(output.lines().len(), 2);
+  let b_before = f64_value(&symbol_value(&runtime, "b")); let output_before = f64_value(&symbol_value(&runtime, "output")); let lines_before = output.lines();
+  let outcome = runtime.apply_host_input(RuntimeHostInput::new(vec![RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-a").unwrap(), value: RuntimeHostInputValue::F64(5.0) }, RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing-b").unwrap(), value: RuntimeHostInputValue::F64(9.0) }]).unwrap()).unwrap();
+  assert_eq!(outcome.update_count, 2); assert_eq!(outcome.ignored_update_count, 2); assert_eq!(outcome.binding_count, 0); assert!(outcome.turn.is_none()); assert_eq!(f64_value(&symbol_value(&runtime, "b")), b_before); assert_eq!(f64_value(&symbol_value(&runtime, "output")), output_before); assert!(runtime.program.interpreter().has_pending_reactive_registers()); assert_eq!(output.lines(), lines_before);
 }
 
 #[test]
 fn live_input_recomputes_runtime_host_function() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    grant_read(&mut runtime, "test://clock/ticks", "value");
-    runtime
-        .grant_capability(Arc::new(BasicCapability::new(
-            CapabilityId(42),
-            &BasicSubject::new(&runtime.runtime_context().unwrap().subject),
-            &BasicResource::new("host:demo/live-plus-one"),
-            [BasicOperation::new("call")],
-        )))
-        .unwrap();
-    let calls = Arc::new(AtomicUsize::new(0));
-    let host_calls = calls.clone();
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new(
-            "demo/live-plus-one",
-            move |_services, _context, args| {
-                host_calls.fetch_add(1, Ordering::SeqCst);
-                match &args[0] {
-                    Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
-                    Value::MutableReference(value) => match &*value.borrow() {
-                        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
-                        other => panic!("expected f64 mutable reference, got {other:?}"),
-                    },
-                    other => panic!("expected f64 argument, got {other:?}"),
-                }
-            },
-        ))
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-plus-one(@pulse/value) + 0").unwrap();
-    let initial_calls = calls.load(Ordering::SeqCst);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  grant_read(&mut runtime, "test://clock/ticks", "value");
+  runtime
+    .grant_capability(Arc::new(BasicCapability::new(
+      CapabilityId(42),
+      &BasicSubject::new(&runtime.runtime_context().unwrap().subject),
+      &BasicResource::new("host:demo/live-plus-one"),
+      [BasicOperation::new("call")],
+    )))
+    .unwrap();
+  let calls = Arc::new(AtomicUsize::new(0));
+  let host_calls = calls.clone();
+  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-plus-one", move |_services, _context, args| {
+    host_calls.fetch_add(1, Ordering::SeqCst);
+    match &args[0] {
+      Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
+      Value::MutableReference(value) => match &*value.borrow() {
+        Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
+        other => panic!("expected f64 mutable reference, got {other:?}"),
+      },
+      other => panic!("expected f64 argument, got {other:?}"),
+    }
+  })).unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-plus-one(@pulse/value) + 0").unwrap();
+  let initial_calls = calls.load(Ordering::SeqCst);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
 
-    runtime
-        .apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-            RuntimeHostInputValue::F64(9.0),
-        ))
-        .unwrap();
+  runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
 
-    assert!(calls.load(Ordering::SeqCst) > initial_calls);
-    assert_eq!(
-        f64_value(&source_value(
-            &runtime,
-            &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap()
-        )),
-        9.0
-    );
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+  assert!(calls.load(Ordering::SeqCst) > initial_calls);
+  assert_eq!(f64_value(&source_value(&runtime, &RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap())), 9.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
 }
 
 #[test]
 fn runtime_reactive_host_input_executes_only_reachable_branch() {
-    let provider = TestResourceProvider::new()
-        .with_value(TEST_CLOCK_BASE_URI, "left", Value::F64(Ref::new(1.0)))
-        .with_value(TEST_CLOCK_BASE_URI, "right", Value::F64(Ref::new(2.0)));
-    let mut runtime = test_runtime(provider);
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "left");
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "right");
-    let subject = runtime.runtime_context().unwrap().subject;
-    grant_host_call(&mut runtime, &subject, 91, "host:demo/left-branch");
-    grant_host_call(&mut runtime, &subject, 92, "host:demo/right-branch");
-    let left_calls = Arc::new(AtomicUsize::new(0));
-    let right_calls = Arc::new(AtomicUsize::new(0));
-    for (name, calls, add) in [
-        ("demo/left-branch", left_calls.clone(), 100.0),
-        ("demo/right-branch", right_calls.clone(), 200.0),
-    ] {
-        runtime
-            .register_mech_host_function(ClosureHostFunction::new(
-                name,
-                move |_services, _context, args| {
-                    calls.fetch_add(1, Ordering::SeqCst);
-                    let input = host_f64_argument(&args[0]);
-                    Ok(Value::F64(Ref::new(input + add)))
-                },
-            ))
-            .unwrap();
-    }
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(left), :read(right)}\nleft-output := demo/left-branch(@pulse/left)\nright-output := demo/right-branch(@pulse/right)").unwrap();
-    let left_calls_before = left_calls.load(Ordering::SeqCst);
-    let right_calls_before = right_calls.load(Ordering::SeqCst);
-    assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 101.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
-    let left_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "left").unwrap();
-    let right_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "right").unwrap();
-    let plan = runtime.program.interpreter().plan();
-    let left_consumers = plan
-        .borrow()
-        .reactive_consumers_for(source_cell(&runtime, &left_source))
-        .to_vec();
-    let right_consumers = plan
-        .borrow()
-        .reactive_consumers_for(source_cell(&runtime, &right_source))
-        .to_vec();
-    drop(plan);
-    let outcome = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            left_source,
-            RuntimeHostInputValue::F64(10.0),
-        ))
-        .unwrap();
-    let program_turn = outcome.turn.as_ref().unwrap();
-    assert_eq!(program_turn.interpreter_turns.len(), 1);
-    let reactive_turn = &program_turn.interpreter_turns[0].turn;
-    assert_eq!(left_calls.load(Ordering::SeqCst), left_calls_before + 1);
-    assert_eq!(right_calls.load(Ordering::SeqCst), right_calls_before);
-    assert!(reactive_turn.register_commit.staged_nodes.is_empty());
-    assert!(reactive_turn.register_commit.committed_nodes.is_empty());
-    assert!(reactive_turn.register_commit.dirty_cells.is_empty());
-    assert!(
-        left_consumers
-            .iter()
-            .any(|id| reactive_turn.before_commit.executed_nodes.contains(id))
-    );
-    assert!(
-        !right_consumers
-            .iter()
-            .any(|id| reactive_turn.before_commit.executed_nodes.contains(id))
-    );
-    assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 110.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
+  let provider = TestResourceProvider::new().with_value(TEST_CLOCK_BASE_URI, "left", Value::F64(Ref::new(1.0))).with_value(TEST_CLOCK_BASE_URI, "right", Value::F64(Ref::new(2.0)));
+  let mut runtime = test_runtime(provider);
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "left"); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "right");
+  let subject = runtime.runtime_context().unwrap().subject;
+  grant_host_call(&mut runtime, &subject, 91, "host:demo/left-branch"); grant_host_call(&mut runtime, &subject, 92, "host:demo/right-branch");
+  let left_calls = Arc::new(AtomicUsize::new(0)); let right_calls = Arc::new(AtomicUsize::new(0));
+  for (name, calls, add) in [("demo/left-branch", left_calls.clone(), 100.0), ("demo/right-branch", right_calls.clone(), 200.0)] {
+    runtime.register_mech_host_function(ClosureHostFunction::new(name, move |_services, _context, args| { calls.fetch_add(1, Ordering::SeqCst); let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + add))) })).unwrap();
+  }
+  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(left), :read(right)}\nleft-output := demo/left-branch(@pulse/left)\nright-output := demo/right-branch(@pulse/right)").unwrap();
+  let left_calls_before = left_calls.load(Ordering::SeqCst);
+  let right_calls_before = right_calls.load(Ordering::SeqCst);
+  assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 101.0); assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
+  let left_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "left").unwrap(); let right_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "right").unwrap();
+  let plan = runtime.program.interpreter().plan(); let left_consumers = plan.borrow().reactive_consumers_for(source_cell(&runtime, &left_source)).to_vec(); let right_consumers = plan.borrow().reactive_consumers_for(source_cell(&runtime, &right_source)).to_vec(); drop(plan);
+  let outcome = runtime.apply_host_input(RuntimeHostInput::single(left_source, RuntimeHostInputValue::F64(10.0))).unwrap();
+  let program_turn = outcome.turn.as_ref().unwrap();
+  assert_eq!(program_turn.interpreter_turns.len(), 1);
+  let reactive_turn = &program_turn.interpreter_turns[0].turn;
+  assert_eq!(left_calls.load(Ordering::SeqCst), left_calls_before + 1);
+  assert_eq!(right_calls.load(Ordering::SeqCst), right_calls_before);
+  assert!(reactive_turn.register_commit.staged_nodes.is_empty()); assert!(reactive_turn.register_commit.committed_nodes.is_empty()); assert!(reactive_turn.register_commit.dirty_cells.is_empty());
+  assert!(left_consumers.iter().any(|id| reactive_turn.before_commit.executed_nodes.contains(id))); assert!(!right_consumers.iter().any(|id| reactive_turn.before_commit.executed_nodes.contains(id))); assert_eq!(f64_value(&symbol_value(&runtime, "left-output")), 110.0); assert_eq!(f64_value(&symbol_value(&runtime, "right-output")), 202.0);
 }
 
 #[test]
 fn live_host_string_output_recomputes_without_replacing_reference() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    grant_read(&mut runtime, "test://clock/ticks", "value");
-    let subject = runtime.runtime_context().unwrap().subject;
-    grant_host_call(&mut runtime, &subject, 45, "host:demo/live-label");
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new(
-            "demo/live-label",
-            |_services, _context, args| {
-                let value = match &args[0] {
-                    Value::F64(value) => *value.borrow(),
-                    Value::MutableReference(value) => match &*value.borrow() {
-                        Value::F64(value) => *value.borrow(),
-                        other => panic!("expected f64 mutable reference, got {other:?}"),
-                    },
-                    other => panic!("expected f64 argument, got {other:?}"),
-                };
-                Ok(Value::String(Ref::new(format!("tick:{value}"))))
-            },
-        ))
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-label(@pulse/value)",
-        )
-        .unwrap();
-    let before = runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str("output"))
-        .unwrap();
-    let outer_pointer = before.as_ptr();
-    let inner_pointer = match &*before.borrow() {
-        Value::String(value) => value.as_ptr(),
-        other => panic!("expected string, got {other:?}"),
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  grant_read(&mut runtime, "test://clock/ticks", "value");
+  let subject = runtime.runtime_context().unwrap().subject;
+  grant_host_call(&mut runtime, &subject, 45, "host:demo/live-label");
+  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-label", |_services, _context, args| {
+    let value = match &args[0] {
+      Value::F64(value) => *value.borrow(),
+      Value::MutableReference(value) => match &*value.borrow() {
+        Value::F64(value) => *value.borrow(),
+        other => panic!("expected f64 mutable reference, got {other:?}"),
+      },
+      other => panic!("expected f64 argument, got {other:?}"),
     };
-    assert_eq!(string_value(&before.borrow()), "tick:1");
+    Ok(Value::String(Ref::new(format!("tick:{value}"))))
+  })).unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-label(@pulse/value)").unwrap();
+  let before = runtime.program.interpreter().symbols().borrow().get(hash_str("output")).unwrap();
+  let outer_pointer = before.as_ptr();
+  let inner_pointer = match &*before.borrow() {
+    Value::String(value) => value.as_ptr(),
+    other => panic!("expected string, got {other:?}"),
+  };
+  assert_eq!(string_value(&before.borrow()), "tick:1");
 
-    runtime
-        .apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-            RuntimeHostInputValue::F64(9.0),
-        ))
-        .unwrap();
+  runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
 
-    let after = runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str("output"))
-        .unwrap();
-    assert_eq!(outer_pointer, after.as_ptr());
-    match &*after.borrow() {
-        Value::String(value) => {
-            assert_eq!(inner_pointer, value.as_ptr());
-            assert_eq!(&*value.borrow(), "tick:9");
-        }
-        other => panic!("expected string, got {other:?}"),
+  let after = runtime.program.interpreter().symbols().borrow().get(hash_str("output")).unwrap();
+  assert_eq!(outer_pointer, after.as_ptr());
+  match &*after.borrow() {
+    Value::String(value) => {
+      assert_eq!(inner_pointer, value.as_ptr());
+      assert_eq!(&*value.borrow(), "tick:9");
     }
+    other => panic!("expected string, got {other:?}"),
+  }
 }
 
 #[test]
 fn live_host_output_kind_change_preserves_previous_output() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    grant_read(&mut runtime, "test://clock/ticks", "value");
-    let subject = runtime.runtime_context().unwrap().subject;
-    grant_host_call(&mut runtime, &subject, 46, "host:demo/kind-change");
-    let calls = Arc::new(AtomicUsize::new(0));
-    let host_calls = calls.clone();
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new(
-            "demo/kind-change",
-            move |_services, _context, args| {
-                let call = host_calls.fetch_add(1, Ordering::SeqCst);
-                if call == 0 {
-                    let value = match &args[0] {
-                        Value::F64(value) => *value.borrow(),
-                        Value::MutableReference(value) => match &*value.borrow() {
-                            Value::F64(value) => *value.borrow(),
-                            other => panic!("expected f64 mutable reference, got {other:?}"),
-                        },
-                        other => panic!("expected f64 argument, got {other:?}"),
-                    };
-                    Ok(Value::F64(Ref::new(value + 1.0)))
-                } else {
-                    Ok(Value::String(Ref::new("bad-kind".to_string())))
-                }
-            },
-        ))
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/kind-change(@pulse/value)\noutput := host-result + 0").unwrap();
-    assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-    let host_result = runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str("host-result"))
-        .unwrap();
-    let host_result_inner = match &*host_result.borrow() {
-        Value::F64(value) => value.as_ptr(),
-        other => panic!("expected f64 host result, got {other:?}"),
-    };
-
-    let error = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-            RuntimeHostInputValue::F64(9.0),
-        ))
-        .unwrap_err();
-    let rendered = format!("{error:?}");
-    assert!(
-        rendered.contains("RuntimeHostOutputUpdateError"),
-        "{rendered}"
-    );
-    assert!(calls.load(Ordering::SeqCst) >= 2);
-    let host_result = runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str("host-result"))
-        .unwrap();
-    match &*host_result.borrow() {
-        Value::F64(value) => {
-            assert_eq!(host_result_inner, value.as_ptr());
-            assert_eq!(*value.borrow(), 2.0);
-        }
-        other => panic!("expected f64 host result, got {other:?}"),
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  grant_read(&mut runtime, "test://clock/ticks", "value");
+  let subject = runtime.runtime_context().unwrap().subject;
+  grant_host_call(&mut runtime, &subject, 46, "host:demo/kind-change");
+  let calls = Arc::new(AtomicUsize::new(0));
+  let host_calls = calls.clone();
+  runtime.register_mech_host_function(ClosureHostFunction::new("demo/kind-change", move |_services, _context, args| {
+    let call = host_calls.fetch_add(1, Ordering::SeqCst);
+    if call == 0 {
+      let value = match &args[0] {
+        Value::F64(value) => *value.borrow(),
+        Value::MutableReference(value) => match &*value.borrow() {
+          Value::F64(value) => *value.borrow(),
+          other => panic!("expected f64 mutable reference, got {other:?}"),
+        },
+        other => panic!("expected f64 argument, got {other:?}"),
+      };
+      Ok(Value::F64(Ref::new(value + 1.0)))
+    } else {
+      Ok(Value::String(Ref::new("bad-kind".to_string())))
     }
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-    runtime.run_string("recovery := 1").unwrap();
+  })).unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/kind-change(@pulse/value)\noutput := host-result + 0").unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+  let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap();
+  let host_result_inner = match &*host_result.borrow() {
+    Value::F64(value) => value.as_ptr(),
+    other => panic!("expected f64 host result, got {other:?}"),
+  };
+
+  let error = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap_err();
+  let rendered = format!("{error:?}");
+  assert!(rendered.contains("RuntimeHostOutputUpdateError"), "{rendered}");
+  assert!(calls.load(Ordering::SeqCst) >= 2);
+  let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap();
+  match &*host_result.borrow() {
+    Value::F64(value) => {
+      assert_eq!(host_result_inner, value.as_ptr());
+      assert_eq!(*value.borrow(), 2.0);
+    }
+    other => panic!("expected f64 host result, got {other:?}"),
+  }
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+  runtime.run_string("recovery := 1").unwrap();
 }
 
 #[test]
 fn runtime_reactive_host_input_turn_failure_preserves_admitted_inputs() {
-    let (mut runtime, output) =
-        test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
-    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-    let subject = runtime.runtime_context().unwrap().subject;
-    grant_host_call(&mut runtime, &subject, 47, "host:demo/fails-after-first");
-    let calls = Arc::new(AtomicUsize::new(0));
-    let host_calls = calls.clone();
-    let fail_host = Arc::new(AtomicBool::new(false));
-    let fail_host_for_call = fail_host.clone();
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new(
-            "demo/fails-after-first",
-            move |_services, _context, args| {
-                host_calls.fetch_add(1, Ordering::SeqCst);
-                if fail_host_for_call.load(Ordering::SeqCst) {
-                    return Err(MechError::new(DeliberateHostCallError, None));
-                }
-                let input = host_f64_argument(&args[0]);
-                Ok(Value::F64(Ref::new(input + 1.0)))
-            },
-        ))
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/fails-after-first(@pulse/value)\noutput := host-result + 0\n@out/line <- output").unwrap();
-    let calls_before = calls.load(Ordering::SeqCst);
-    let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
-    let host_result = runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str("host-result"))
-        .unwrap();
-    let host_result_pointer = match &*host_result.borrow() {
-        Value::F64(value) => value.as_ptr(),
-        other => panic!("expected f64 host result, got {other:?}"),
-    };
-    let plan_before = plan_snapshot(&runtime);
-    let lines_before = output.lines();
-    assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-    assert_eq!(output.lines().len(), 1);
-    assert_eq!(runtime.persistent_send_count(), 1);
-    fail_host.store(true, Ordering::SeqCst);
-    let error = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            input_source.clone(),
-            RuntimeHostInputValue::F64(9.0),
-        ))
-        .unwrap_err();
-    assert!(format!("{error:?}").contains("DeliberateHostCallError"));
-    assert!(calls.load(Ordering::SeqCst) > calls_before);
-    assert_eq!(f64_value(&source_value(&runtime, &input_source)), 9.0);
-    let host_result = runtime
-        .program
-        .interpreter()
-        .symbols()
-        .borrow()
-        .get(hash_str("host-result"))
-        .unwrap();
-    match &*host_result.borrow() {
-        Value::F64(value) => assert_eq!(value.as_ptr(), host_result_pointer),
-        other => panic!("expected f64 host result, got {other:?}"),
-    };
-    assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
-    assert_eq!(plan_snapshot(&runtime), plan_before);
-    assert_eq!(output.lines(), lines_before);
-    assert_eq!(runtime.persistent_send_count(), 1);
-    runtime.run_string("recovery := 1").unwrap();
-    assert_eq!(f64_value(&symbol_value(&runtime, "recovery")), 1.0);
+  let (mut runtime, output) = test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0)); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+  let subject = runtime.runtime_context().unwrap().subject; grant_host_call(&mut runtime, &subject, 47, "host:demo/fails-after-first");
+  let calls = Arc::new(AtomicUsize::new(0)); let host_calls = calls.clone(); let fail_host = Arc::new(AtomicBool::new(false)); let fail_host_for_call = fail_host.clone();
+  runtime.register_mech_host_function(ClosureHostFunction::new("demo/fails-after-first", move |_services, _context, args| { host_calls.fetch_add(1, Ordering::SeqCst); if fail_host_for_call.load(Ordering::SeqCst) { return Err(MechError::new(DeliberateHostCallError, None)); } let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + 1.0))) })).unwrap();
+  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/fails-after-first(@pulse/value)\noutput := host-result + 0\n@out/line <- output").unwrap();
+  let calls_before = calls.load(Ordering::SeqCst); let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); let host_result_pointer = match &*host_result.borrow() { Value::F64(value) => value.as_ptr(), other => panic!("expected f64 host result, got {other:?}") }; let plan_before = plan_snapshot(&runtime); let lines_before = output.lines();
+  assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(output.lines().len(), 1); assert_eq!(runtime.persistent_send_count(), 1);
+  fail_host.store(true, Ordering::SeqCst); let error = runtime.apply_host_input(RuntimeHostInput::single(input_source.clone(), RuntimeHostInputValue::F64(9.0))).unwrap_err(); assert!(format!("{error:?}").contains("DeliberateHostCallError")); assert!(calls.load(Ordering::SeqCst) > calls_before); assert_eq!(f64_value(&source_value(&runtime, &input_source)), 9.0); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); match &*host_result.borrow() { Value::F64(value) => assert_eq!(value.as_ptr(), host_result_pointer), other => panic!("expected f64 host result, got {other:?}") }; assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(plan_snapshot(&runtime), plan_before); assert_eq!(output.lines(), lines_before); assert_eq!(runtime.persistent_send_count(), 1); runtime.run_string("recovery := 1").unwrap(); assert_eq!(f64_value(&symbol_value(&runtime, "recovery")), 1.0);
 }
 
 #[test]
 fn live_host_empty_output_can_recompute() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    grant_read(&mut runtime, "test://clock/ticks", "value");
-    let subject = runtime.runtime_context().unwrap().subject;
-    grant_host_call(&mut runtime, &subject, 48, "host:demo/live-empty");
-    let calls = Arc::new(AtomicUsize::new(0));
-    let host_calls = calls.clone();
-    runtime
-        .register_mech_host_function(ClosureHostFunction::new(
-            "demo/live-empty",
-            move |_services, _context, _args| {
-                host_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(Value::Empty)
-            },
-        ))
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-empty(@pulse/value)",
-        )
-        .unwrap();
-    assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  grant_read(&mut runtime, "test://clock/ticks", "value");
+  let subject = runtime.runtime_context().unwrap().subject;
+  grant_host_call(&mut runtime, &subject, 48, "host:demo/live-empty");
+  let calls = Arc::new(AtomicUsize::new(0));
+  let host_calls = calls.clone();
+  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-empty", move |_services, _context, _args| {
+    host_calls.fetch_add(1, Ordering::SeqCst);
+    Ok(Value::Empty)
+  })).unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := demo/live-empty(@pulse/value)").unwrap();
+  assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
 
-    let outcome = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-            RuntimeHostInputValue::F64(9.0),
-        ))
-        .unwrap();
-    assert!(outcome.turn.is_some());
-    assert!(calls.load(Ordering::SeqCst) >= 2);
-    assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
+  let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
+  assert!(outcome.turn.is_some());
+  assert!(calls.load(Ordering::SeqCst) >= 2);
+  assert_eq!(symbol_value(&runtime, "output"), Value::Empty);
 }
 
 #[test]
 fn runtime_reactive_host_input_preflight_failure_mutates_nothing() {
-    let provider = TestResourceProvider::new()
-        .with_value(TEST_SIGNALS_BASE_URI, "a", Value::F64(Ref::new(1.0)))
-        .with_value(TEST_SIGNALS_BASE_URI, "b", Value::F64(Ref::new(2.0)));
-    let (mut runtime, output) = test_runtime_with_output(provider);
-    grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "a");
-    grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "b");
-    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@signals := test://signals/inputs{:read(a), :read(b)}\nsum := @signals/a + @signals/b\n@out/line <- sum").unwrap();
-    let a_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "a").unwrap();
-    let b_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "b").unwrap();
-    let a_before = f64_value(&source_value(&runtime, &a_source));
-    let b_before = f64_value(&source_value(&runtime, &b_source));
-    let sum_before = f64_value(&symbol_value(&runtime, "sum"));
-    let plan_before = plan_snapshot(&runtime);
-    let lines_before = output.lines();
-    assert!(
-        !runtime
-            .program
-            .interpreter()
-            .has_pending_reactive_registers()
-    );
-    let error = runtime
-        .apply_host_input(
-            RuntimeHostInput::new(vec![
-                RuntimeHostInputUpdate {
-                    source: a_source.clone(),
-                    value: RuntimeHostInputValue::F64(10.0),
-                },
-                RuntimeHostInputUpdate {
-                    source: b_source.clone(),
-                    value: RuntimeHostInputValue::String("bad".to_string()),
-                },
-            ])
-            .unwrap(),
-        )
-        .unwrap_err();
-    assert!(format!("{error:?}").contains("StableValueUpdateKindMismatch"));
-    assert_eq!(f64_value(&source_value(&runtime, &a_source)), a_before);
-    assert_eq!(f64_value(&source_value(&runtime, &b_source)), b_before);
-    assert_eq!(f64_value(&symbol_value(&runtime, "sum")), sum_before);
-    assert_eq!(plan_snapshot(&runtime), plan_before);
-    assert!(
-        !runtime
-            .program
-            .interpreter()
-            .has_pending_reactive_registers()
-    );
-    assert_eq!(output.lines(), lines_before);
+  let provider = TestResourceProvider::new().with_value(TEST_SIGNALS_BASE_URI, "a", Value::F64(Ref::new(1.0))).with_value(TEST_SIGNALS_BASE_URI, "b", Value::F64(Ref::new(2.0)));
+  let (mut runtime, output) = test_runtime_with_output(provider); grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "a"); grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "b"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@signals := test://signals/inputs{:read(a), :read(b)}\nsum := @signals/a + @signals/b\n@out/line <- sum").unwrap();
+  let a_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "a").unwrap(); let b_source = RuntimeHostInputSource::new(TEST_SIGNALS_BASE_URI, "b").unwrap(); let a_before = f64_value(&source_value(&runtime, &a_source)); let b_before = f64_value(&source_value(&runtime, &b_source)); let sum_before = f64_value(&symbol_value(&runtime, "sum")); let plan_before = plan_snapshot(&runtime); let lines_before = output.lines(); assert!(!runtime.program.interpreter().has_pending_reactive_registers());
+  let error = runtime.apply_host_input(RuntimeHostInput::new(vec![RuntimeHostInputUpdate { source: a_source.clone(), value: RuntimeHostInputValue::F64(10.0) }, RuntimeHostInputUpdate { source: b_source.clone(), value: RuntimeHostInputValue::String("bad".to_string()) }]).unwrap()).unwrap_err();
+  assert!(format!("{error:?}").contains("StableValueUpdateKindMismatch")); assert_eq!(f64_value(&source_value(&runtime, &a_source)), a_before); assert_eq!(f64_value(&source_value(&runtime, &b_source)), b_before); assert_eq!(f64_value(&symbol_value(&runtime, "sum")), sum_before); assert_eq!(plan_snapshot(&runtime), plan_before); assert!(!runtime.program.interpreter().has_pending_reactive_registers()); assert_eq!(output.lines(), lines_before);
 }
 
 #[test]
 fn transactional_context_cannot_arm_live_program() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    let mut context = runtime.runtime_context().unwrap();
-    grant_read_to(
-        &mut runtime,
-        &context.subject,
-        "test://clock/ticks",
-        "value",
-    );
-    runtime.begin_transaction(&mut context).unwrap();
-    let error = format!(
-        "{:?}",
-        runtime
-            .run_string_with_context(
-                &mut context,
-                "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value"
-            )
-            .unwrap_err()
-    );
-    assert!(
-        error.contains("RuntimeTransactionalLiveProgramUnsupported"),
-        "{error}"
-    );
-    assert!(runtime.live_context_template.is_none());
-    assert!(runtime.live_input_bindings.is_empty());
-    assert!(runtime.persistent_sends.is_empty());
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let mut context = runtime.runtime_context().unwrap();
+  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
+  runtime.begin_transaction(&mut context).unwrap();
+  let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap_err());
+  assert!(error.contains("RuntimeTransactionalLiveProgramUnsupported"), "{error}");
+  assert!(runtime.live_context_template.is_none());
+  assert!(runtime.live_input_bindings.is_empty());
+  assert!(runtime.persistent_sends.is_empty());
 }
 
 #[test]
 fn failed_source_does_not_leave_live_state_armed() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    let mut context_a = runtime.runtime_context().unwrap().with_subject("subject-a");
-    grant_read_to(&mut runtime, "subject-a", "test://clock/ticks", "value");
-    let error = runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\nmissing := @pulse/missing");
-    assert!(error.is_err());
-    assert!(runtime.live_context_template.is_none());
-    assert!(runtime.live_input_bindings.is_empty());
-    assert!(runtime.persistent_sends.is_empty());
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let mut context_a = runtime.runtime_context().unwrap().with_subject("subject-a");
+  grant_read_to(&mut runtime, "subject-a", "test://clock/ticks", "value");
+  let error = runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\nmissing := @pulse/missing");
+  assert!(error.is_err());
+  assert!(runtime.live_context_template.is_none());
+  assert!(runtime.live_input_bindings.is_empty());
+  assert!(runtime.persistent_sends.is_empty());
 
-    let mut context_b = runtime.runtime_context().unwrap().with_subject("subject-b");
-    grant_read_to(&mut runtime, "subject-b", "test://clock/ticks", "value");
-    runtime
-        .run_string_with_context(
-            &mut context_b,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
-        )
-        .unwrap();
+  let mut context_b = runtime.runtime_context().unwrap().with_subject("subject-b");
+  grant_read_to(&mut runtime, "subject-b", "test://clock/ticks", "value");
+  runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap();
 }
 
 #[test]
 fn duration_failure_restores_live_state() {
-    let mut config = RuntimeConfig::default();
-    config.limits.max_turn_duration_ms = Some(1);
-    let mut runtime = RuntimeBuilder::new()
-        .config(config)
-        .resource_provider(Box::new(test_provider_with(
-            "test://clock/ticks",
-            "value",
-            1.0,
-        )))
-        .build()
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    grant_read_to(
-        &mut runtime,
-        &context.subject,
-        "test://clock/ticks",
-        "value",
-    );
-    grant_host_call(&mut runtime, &context.subject, 43, "host:demo/source-sleep");
-    register_sleep_host(&mut runtime, "demo/source-sleep");
-    let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nslow := demo/source-sleep(@pulse/value)").unwrap_err());
-    assert!(
-        error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"),
-        "{error}"
-    );
-    assert!(runtime.live_context_template.is_none());
-    assert!(runtime.live_input_bindings.is_empty());
-    assert!(runtime.persistent_sends.is_empty());
-    runtime.config.limits.max_turn_duration_ms = None;
-    runtime.run_string("recovery := 1").unwrap();
+  let mut config = RuntimeConfig::default();
+  config.limits.max_turn_duration_ms = Some(1);
+  let mut runtime = RuntimeBuilder::new()
+    .config(config)
+    .resource_provider(Box::new(test_provider_with("test://clock/ticks", "value", 1.0)))
+    .build()
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
+  grant_host_call(&mut runtime, &context.subject, 43, "host:demo/source-sleep");
+  register_sleep_host(&mut runtime, "demo/source-sleep");
+  let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nslow := demo/source-sleep(@pulse/value)").unwrap_err());
+  assert!(error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"), "{error}");
+  assert!(runtime.live_context_template.is_none());
+  assert!(runtime.live_input_bindings.is_empty());
+  assert!(runtime.persistent_sends.is_empty());
+  runtime.config.limits.max_turn_duration_ms = None;
+  runtime.run_string("recovery := 1").unwrap();
 }
 
 #[test]
 fn live_turn_enforces_step_budget() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    let mut context = runtime
-        .runtime_context()
-        .unwrap()
-        .with_budget(ResourceBudget::default().with_max_steps(1));
-    grant_read_to(
-        &mut runtime,
-        &context.subject,
-        "test://clock/ticks",
-        "value",
-    );
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
-        )
-        .unwrap();
-    runtime
-        .live_context_template
-        .as_mut()
-        .unwrap()
-        .budget_limits
-        .max_steps = Some(0);
-    let error = format!(
-        "{:?}",
-        runtime
-            .apply_host_input(RuntimeHostInput::single(
-                RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-                RuntimeHostInputValue::F64(2.0)
-            ))
-            .unwrap_err()
-    );
-    assert!(error.contains("ResourceBudgetExceeded"), "{error}");
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let mut context = runtime.runtime_context().unwrap().with_budget(ResourceBudget::default().with_max_steps(1));
+  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
+  runtime.live_context_template.as_mut().unwrap().budget_limits.max_steps = Some(0);
+  let error = format!("{:?}", runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(2.0))).unwrap_err());
+  assert!(error.contains("ResourceBudgetExceeded"), "{error}");
 
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    let mut context = runtime
-        .runtime_context()
-        .unwrap()
-        .with_budget(ResourceBudget::default().with_max_steps(1));
-    grant_read_to(
-        &mut runtime,
-        &context.subject,
-        "test://clock/ticks",
-        "value",
-    );
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
-        )
-        .unwrap();
-    let outcome = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-            RuntimeHostInputValue::F64(2.0),
-        ))
-        .unwrap();
-    assert!(outcome.turn.is_some());
-    let outcome = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-            RuntimeHostInputValue::F64(3.0),
-        ))
-        .unwrap();
-    assert!(outcome.turn.is_some());
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let mut context = runtime.runtime_context().unwrap().with_budget(ResourceBudget::default().with_max_steps(1));
+  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2").unwrap();
+  let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(2.0))).unwrap();
+  assert!(outcome.turn.is_some());
+  let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(3.0))).unwrap();
+  assert!(outcome.turn.is_some());
 }
 
 #[test]
 fn live_turn_enforces_duration_limit() {
-    let mut runtime = RuntimeBuilder::new()
-        .resource_provider(Box::new(test_provider_with(
-            "test://clock/ticks",
-            "value",
-            1.0,
-        )))
-        .build()
-        .unwrap();
-    let mut context = runtime.runtime_context().unwrap();
-    grant_read_to(
-        &mut runtime,
-        &context.subject,
-        "test://clock/ticks",
-        "value",
-    );
-    grant_host_call(&mut runtime, &context.subject, 44, "host:demo/live-sleep");
-    register_sleep_host(&mut runtime, "demo/live-sleep");
-    runtime
-        .run_string_with_context(
-            &mut context,
-            "@pulse := test://clock/ticks{:read(value)}\nslow := demo/live-sleep(@pulse/value)",
-        )
-        .unwrap();
-    runtime.config.limits.max_turn_duration_ms = Some(1);
-    let error = format!(
-        "{:?}",
-        runtime
-            .apply_host_input(RuntimeHostInput::single(
-                RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(),
-                RuntimeHostInputValue::F64(2.0)
-            ))
-            .unwrap_err()
-    );
-    assert!(
-        error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"),
-        "{error}"
-    );
-    assert!(
-        runtime
-            .program()
-            .interpreter()
-            .symbols()
-            .borrow()
-            .contains(hash_str("slow"))
-    );
-    runtime.config.limits.max_turn_duration_ms = None;
-    runtime.run_string("recovery := 1").unwrap();
+  let mut runtime = RuntimeBuilder::new()
+    .resource_provider(Box::new(test_provider_with("test://clock/ticks", "value", 1.0)))
+    .build()
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
+  grant_host_call(&mut runtime, &context.subject, 44, "host:demo/live-sleep");
+  register_sleep_host(&mut runtime, "demo/live-sleep");
+  runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\nslow := demo/live-sleep(@pulse/value)").unwrap();
+  runtime.config.limits.max_turn_duration_ms = Some(1);
+  let error = format!("{:?}", runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://clock/ticks", "value").unwrap(), RuntimeHostInputValue::F64(2.0))).unwrap_err());
+  assert!(error.contains("turn_duration_ms") || error.contains("ResourceBudgetExceeded"), "{error}");
+  assert!(runtime.program().interpreter().symbols().borrow().contains(hash_str("slow")));
+  runtime.config.limits.max_turn_duration_ms = None;
+  runtime.run_string("recovery := 1").unwrap();
 }
 
 #[test]
 fn changed_actor_message_rejects_live_context_reuse() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    let actor = ActorId(7);
-    let state = ObjectId(9);
-    let mut context_a = runtime
-        .runtime_context()
-        .unwrap()
-        .with_subject("actor:7")
-        .with_actor(actor);
-    context_a.actor_state = Some(state);
-    context_a.actor_message = Some(MessageRecord::new(
-        MessageId(1),
-        actor,
-        "tick",
-        b"a".to_vec(),
-    ));
-    grant_read_to(&mut runtime, "actor:7", "test://clock/ticks", "value");
-    runtime
-        .run_string_with_context(
-            &mut context_a,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
-        )
-        .unwrap();
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let actor = ActorId(7);
+  let state = ObjectId(9);
+  let mut context_a = runtime.runtime_context().unwrap().with_subject("actor:7").with_actor(actor);
+  context_a.actor_state = Some(state);
+  context_a.actor_message = Some(MessageRecord::new(MessageId(1), actor, "tick", b"a".to_vec()));
+  grant_read_to(&mut runtime, "actor:7", "test://clock/ticks", "value");
+  runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap();
 
-    let mut context_b = runtime
-        .runtime_context()
-        .unwrap()
-        .with_subject("actor:7")
-        .with_actor(actor);
-    context_b.actor_state = Some(state);
-    context_b.actor_message = Some(MessageRecord::new(
-        MessageId(2),
-        actor,
-        "tick",
-        b"b".to_vec(),
-    ));
-    let error = format!(
-        "{:?}",
-        runtime
-            .run_string_with_context(
-                &mut context_b,
-                "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value"
-            )
-            .unwrap_err()
-    );
-    assert!(error.contains("RuntimeLiveContextMismatch"), "{error}");
+  let mut context_b = runtime.runtime_context().unwrap().with_subject("actor:7").with_actor(actor);
+  context_b.actor_state = Some(state);
+  context_b.actor_message = Some(MessageRecord::new(MessageId(2), actor, "tick", b"b".to_vec()));
+  let error = format!("{:?}", runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value").unwrap_err());
+  assert!(error.contains("RuntimeLiveContextMismatch"), "{error}");
 }
 
 #[test]
 fn live_context_capability_order_does_not_cause_mismatch() {
-    let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
-    let mut context_a = runtime
-        .runtime_context()
-        .unwrap()
-        .with_capabilities(vec![CapabilityId(1), CapabilityId(2)]);
-    let mut context_b = runtime
-        .runtime_context()
-        .unwrap()
-        .with_capabilities(vec![CapabilityId(2), CapabilityId(1)]);
-    grant_read_to(
-        &mut runtime,
-        &context_a.subject,
-        "test://clock/ticks",
-        "value",
-    );
-    runtime
-        .run_string_with_context(
-            &mut context_a,
-            "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
-        )
-        .unwrap();
-    runtime
-        .run_string_with_context(
-            &mut context_b,
-            "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value",
-        )
-        .unwrap();
+  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let mut context_a = runtime.runtime_context().unwrap().with_capabilities(vec![CapabilityId(1), CapabilityId(2)]);
+  let mut context_b = runtime.runtime_context().unwrap().with_capabilities(vec![CapabilityId(2), CapabilityId(1)]);
+  grant_read_to(&mut runtime, &context_a.subject, "test://clock/ticks", "value");
+  runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap();
+  runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value").unwrap();
 }
 
 #[derive(Debug, Clone)]
 struct MockDriver {
-    name: String,
-    state: Rc<RefCell<MockDriverState>>,
-    events: Rc<RefCell<Vec<String>>>,
+  name: String,
+  state: Rc<RefCell<MockDriverState>>,
+  events: Rc<RefCell<Vec<String>>>,
 }
 
-const MOCK_DRIVER_BASE_URI: &str = "test-input://clock/ticks";
+const MOCK_DRIVER_BASE_URI: &str =
+  "test-input://clock/ticks";
 
-const MOCK_DRIVER_PATH: &str = "value";
+const MOCK_DRIVER_PATH: &str =
+  "value";
 
 #[derive(Debug, Default)]
 struct MockDriverState {
-    attach_count: usize,
-    start_count: usize,
-    stop_count: usize,
-    live: bool,
-    fail_attach: bool,
-    fail_start: bool,
-    fail_stop: bool,
-    attached_ingress: Option<RuntimeIngress>,
-    stop_observed_closed_ingress: bool,
-    log: Vec<String>,
+  attach_count: usize,
+  start_count: usize,
+  stop_count: usize,
+  live: bool,
+  fail_attach: bool,
+  fail_start: bool,
+  fail_stop: bool,
+  attached_ingress: Option<RuntimeIngress>,
+  stop_observed_closed_ingress: bool,
+  log: Vec<String>,
 }
 
 impl MockDriver {
-    fn new(name: &str, state: Rc<RefCell<MockDriverState>>) -> Self {
-        Self::with_events(name, state, Rc::new(RefCell::new(Vec::new())))
-    }
+  fn new(name: &str, state: Rc<RefCell<MockDriverState>>) -> Self {
+    Self::with_events(name, state, Rc::new(RefCell::new(Vec::new())))
+  }
 
-    fn with_events(
-        name: &str,
-        state: Rc<RefCell<MockDriverState>>,
-        events: Rc<RefCell<Vec<String>>>,
-    ) -> Self {
-        Self {
-            name: name.to_string(),
-            state,
-            events,
-        }
-    }
+  fn with_events(name: &str, state: Rc<RefCell<MockDriverState>>, events: Rc<RefCell<Vec<String>>>) -> Self {
+    Self { name: name.to_string(), state, events }
+  }
 }
 
 impl RuntimeHostInputDriver for MockDriver {
-    fn drives(&self, source: &RuntimeHostInputSource) -> bool {
-        source.base_uri() == MOCK_DRIVER_BASE_URI && source.path() == MOCK_DRIVER_PATH
-    }
+  fn drives(
+    &self,
+    source: &RuntimeHostInputSource,
+  ) -> bool {
+    source.base_uri() == MOCK_DRIVER_BASE_URI
+      && source.path() == MOCK_DRIVER_PATH
+  }
 
-    fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
-        let mut state = self.state.borrow_mut();
-        state.attach_count += 1;
-        state.attached_ingress = Some(ingress);
-        let event = format!("attach:{}", self.name);
-        state.log.push(event.clone());
-        self.events.borrow_mut().push(event);
-        if state.fail_attach {
-            return Err(mock_error(
-                "MockAttachError",
-                format!("attach failed for {}", self.name),
-            ));
-        }
-        Ok(())
-    }
+  fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
+    let mut state = self.state.borrow_mut();
+    state.attach_count += 1;
+    state.attached_ingress = Some(ingress);
+    let event = format!("attach:{}", self.name);
+    state.log.push(event.clone());
+    self.events.borrow_mut().push(event);
+    if state.fail_attach { return Err(mock_error("MockAttachError", format!("attach failed for {}", self.name))); }
+    Ok(())
+  }
 
-    fn start(&mut self) -> MResult<()> {
-        let mut state = self.state.borrow_mut();
-        state.start_count += 1;
-        let event = format!("start:{}", self.name);
-        state.log.push(event.clone());
-        self.events.borrow_mut().push(event);
-        if state.fail_start {
-            return Err(mock_error(
-                "MockStartError",
-                format!("start failed for {}", self.name),
-            ));
-        }
-        state.live = true;
-        Ok(())
-    }
+  fn start(&mut self) -> MResult<()> {
+    let mut state = self.state.borrow_mut();
+    state.start_count += 1;
+    let event = format!("start:{}", self.name);
+    state.log.push(event.clone());
+    self.events.borrow_mut().push(event);
+    if state.fail_start { return Err(mock_error("MockStartError", format!("start failed for {}", self.name))); }
+    state.live = true;
+    Ok(())
+  }
 
-    fn stop(&mut self) -> MResult<()> {
-        let mut state = self.state.borrow_mut();
-        state.stop_count += 1;
-        let observed_closed = state
-            .attached_ingress
-            .as_ref()
-            .map(|ingress| ingress.is_closed().unwrap_or(false))
-            .unwrap_or(false);
-        state.stop_observed_closed_ingress |= observed_closed;
-        let event = format!("stop:{}", self.name);
-        state.log.push(event.clone());
-        self.events.borrow_mut().push(event);
-        state.live = false;
-        if state.fail_stop {
-            return Err(mock_error(
-                "MockStopError",
-                format!("stop failed for {}", self.name),
-            ));
-        }
-        Ok(())
-    }
+  fn stop(&mut self) -> MResult<()> {
+    let mut state = self.state.borrow_mut();
+    state.stop_count += 1;
+    let observed_closed = state.attached_ingress.as_ref().map(|ingress| ingress.is_closed().unwrap_or(false)).unwrap_or(false);
+    state.stop_observed_closed_ingress |= observed_closed;
+    let event = format!("stop:{}", self.name);
+    state.log.push(event.clone());
+    self.events.borrow_mut().push(event);
+    state.live = false;
+    if state.fail_stop { return Err(mock_error("MockStopError", format!("stop failed for {}", self.name))); }
+    Ok(())
+  }
 
-    fn is_live(&self) -> bool {
-        self.state.borrow().live
-    }
+  fn is_live(&self) -> bool {
+    self.state.borrow().live
+  }
 }
 
 #[derive(Debug)]
 struct MockDriverFactory {
-    manifest: HostManifestConfig,
-    drivers: Vec<MockDriver>,
+  manifest: HostManifestConfig,
+  drivers: Vec<MockDriver>,
 }
 
 impl MockDriverFactory {
-    fn new(drivers: Vec<MockDriver>) -> Self {
-        Self {
-            manifest: HostManifestConfig {
-                provider: "test-input".to_string(),
-                contexts: vec![HostContextManifest {
-                    name: "ticks".to_string(),
-                    base_uri_template: "test-input://{instance}/ticks".to_string(),
-                    operations: vec!["read".to_string()],
-                }],
-            },
-            drivers,
-        }
+  fn new(drivers: Vec<MockDriver>) -> Self {
+    Self {
+      manifest: HostManifestConfig {
+        provider: "test-input".to_string(),
+        contexts: vec![HostContextManifest { name: "ticks".to_string(), base_uri_template: "test-input://{instance}/ticks".to_string(), operations: vec!["read".to_string()] }],
+      },
+      drivers,
     }
+  }
 }
 
 impl RuntimeHostFactory for MockDriverFactory {
-    fn provider_name(&self) -> &str {
-        "test-input"
-    }
-    fn manifest(&self) -> &HostManifestConfig {
-        &self.manifest
-    }
-    fn validate_settings(&self, _instance_name: &str, _settings: &ConfigValue) -> MResult<()> {
-        Ok(())
-    }
-    fn instantiate(
-        &self,
-        instance_name: &str,
-        _settings: &ConfigValue,
-    ) -> MResult<RuntimeHostInstallation> {
-        Ok(RuntimeHostInstallation {
-            interface: materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: Vec::<Box<dyn RuntimeResourceProvider>>::new(),
-            input_drivers: self
-                .drivers
-                .iter()
-                .cloned()
-                .map(|driver| Box::new(driver) as Box<dyn RuntimeHostInputDriver>)
-                .collect(),
-        })
-    }
+  fn provider_name(&self) -> &str { "test-input" }
+  fn manifest(&self) -> &HostManifestConfig { &self.manifest }
+  fn validate_settings(&self, _instance_name: &str, _settings: &ConfigValue) -> MResult<()> { Ok(()) }
+  fn instantiate(&self, instance_name: &str, _settings: &ConfigValue) -> MResult<RuntimeHostInstallation> {
+    Ok(RuntimeHostInstallation {
+      interface: materialize_host_manifest(instance_name, &self.manifest)?,
+      resource_providers: Vec::<Box<dyn RuntimeResourceProvider>>::new(),
+      input_drivers: self.drivers.iter().cloned().map(|driver| Box::new(driver) as Box<dyn RuntimeHostInputDriver>).collect(),
+    })
+  }
 }
 
-fn drivers_with_events(
-    states: &[(&str, Rc<RefCell<MockDriverState>>)],
-) -> (Vec<MockDriver>, Rc<RefCell<Vec<String>>>) {
-    let events = Rc::new(RefCell::new(Vec::new()));
-    let drivers = states
-        .iter()
-        .map(|(name, state)| MockDriver::with_events(name, state.clone(), events.clone()))
-        .collect();
-    (drivers, events)
+fn drivers_with_events(states: &[(&str, Rc<RefCell<MockDriverState>>)]) -> (Vec<MockDriver>, Rc<RefCell<Vec<String>>>) {
+  let events = Rc::new(RefCell::new(Vec::new()));
+  let drivers = states
+    .iter()
+    .map(|(name, state)| MockDriver::with_events(name, state.clone(), events.clone()))
+    .collect();
+  (drivers, events)
 }
 
 fn runtime_with_drivers(drivers: Vec<MockDriver>) -> MResult<MechRuntime> {
-    RuntimeBuilder::new()
-        .host_factory(Box::new(MockDriverFactory::new(drivers)))?
-        .host_instance(HostInstanceConfig {
-            name: "clock".to_string(),
-            provider: "test-input".to_string(),
-            settings: ConfigValue::Map(Default::default()),
-        })
-        .build()
+  RuntimeBuilder::new()
+    .host_factory(Box::new(MockDriverFactory::new(drivers)))?
+    .host_instance(HostInstanceConfig { name: "clock".to_string(), provider: "test-input".to_string(), settings: ConfigValue::Map(Default::default()) })
+    .build()
 }
 
 #[test]
 fn build_attaches_but_does_not_start_input_drivers() {
-    let state = Rc::new(RefCell::new(MockDriverState::default()));
-    let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
-    assert_eq!(state.borrow().attach_count, 1);
-    assert_eq!(state.borrow().start_count, 0);
-    assert_eq!(state.borrow().stop_count, 0);
-    assert!(!state.borrow().live);
-    runtime.start_input_drivers().unwrap();
-    assert_eq!(state.borrow().start_count, 1);
-    assert!(state.borrow().live);
+  let state = Rc::new(RefCell::new(MockDriverState::default()));
+  let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
+  assert_eq!(state.borrow().attach_count, 1);
+  assert_eq!(state.borrow().start_count, 0);
+  assert_eq!(state.borrow().stop_count, 0);
+  assert!(!state.borrow().live);
+  runtime.start_input_drivers().unwrap();
+  assert_eq!(state.borrow().start_count, 1);
+  assert!(state.borrow().live);
 }
 
 #[test]
 fn attach_failure_closes_ingress_and_rolls_back_in_reverse_order() {
-    let a = Rc::new(RefCell::new(MockDriverState::default()));
-    let b = Rc::new(RefCell::new(MockDriverState {
-        fail_attach: true,
-        ..Default::default()
-    }));
-    let c = Rc::new(RefCell::new(MockDriverState::default()));
-    let (drivers, events) =
-        drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
-    let error = format!("{:?}", runtime_with_drivers(drivers).unwrap_err());
-    assert!(error.contains("MockAttachError"));
-    assert_eq!(a.borrow().attach_count, 1);
-    assert_eq!(b.borrow().attach_count, 1);
-    assert_eq!(c.borrow().attach_count, 0);
-    assert!(
-        a.borrow()
-            .attached_ingress
-            .as_ref()
-            .unwrap()
-            .is_closed()
-            .unwrap()
-    );
-    let stop_events: Vec<String> = events
-        .borrow()
-        .iter()
-        .filter(|event| event.starts_with("stop:"))
-        .cloned()
-        .collect();
-    assert_eq!(stop_events, vec!["stop:b", "stop:a"]);
-    assert_eq!(a.borrow().stop_count, 1);
-    assert_eq!(b.borrow().stop_count, 1);
-    assert_eq!(c.borrow().stop_count, 0);
+  let a = Rc::new(RefCell::new(MockDriverState::default()));
+  let b = Rc::new(RefCell::new(MockDriverState { fail_attach: true, ..Default::default() }));
+  let c = Rc::new(RefCell::new(MockDriverState::default()));
+  let (drivers, events) = drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
+  let error = format!("{:?}", runtime_with_drivers(drivers).unwrap_err());
+  assert!(error.contains("MockAttachError"));
+  assert_eq!(a.borrow().attach_count, 1);
+  assert_eq!(b.borrow().attach_count, 1);
+  assert_eq!(c.borrow().attach_count, 0);
+  assert!(a.borrow().attached_ingress.as_ref().unwrap().is_closed().unwrap());
+  let stop_events: Vec<String> = events.borrow().iter().filter(|event| event.starts_with("stop:")).cloned().collect();
+  assert_eq!(stop_events, vec!["stop:b", "stop:a"]);
+  assert_eq!(a.borrow().stop_count, 1);
+  assert_eq!(b.borrow().stop_count, 1);
+  assert_eq!(c.borrow().stop_count, 0);
 }
 
 #[test]
 fn start_failure_stops_every_driver_in_reverse_order() {
-    let a = Rc::new(RefCell::new(MockDriverState::default()));
-    let b = Rc::new(RefCell::new(MockDriverState {
-        fail_start: true,
-        ..Default::default()
-    }));
-    let c = Rc::new(RefCell::new(MockDriverState::default()));
-    let (drivers, events) =
-        drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
-    let mut runtime = runtime_with_drivers(drivers).unwrap();
-    let error = format!("{:?}", runtime.start_input_drivers().unwrap_err());
-    assert!(error.contains("MockStartError"));
-    let stop_events: Vec<String> = events
-        .borrow()
-        .iter()
-        .filter(|event| event.starts_with("stop:"))
-        .cloned()
-        .collect();
-    assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
-    assert!(!a.borrow().live && !b.borrow().live && !c.borrow().live);
+  let a = Rc::new(RefCell::new(MockDriverState::default()));
+  let b = Rc::new(RefCell::new(MockDriverState { fail_start: true, ..Default::default() }));
+  let c = Rc::new(RefCell::new(MockDriverState::default()));
+  let (drivers, events) = drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
+  let mut runtime = runtime_with_drivers(drivers).unwrap();
+  let error = format!("{:?}", runtime.start_input_drivers().unwrap_err());
+  assert!(error.contains("MockStartError"));
+  let stop_events: Vec<String> = events.borrow().iter().filter(|event| event.starts_with("stop:")).cloned().collect();
+  assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
+  assert!(!a.borrow().live && !b.borrow().live && !c.borrow().live);
 }
 
 #[test]
 fn stop_input_drivers_attempts_every_driver() {
-    let a = Rc::new(RefCell::new(MockDriverState::default()));
-    let b = Rc::new(RefCell::new(MockDriverState {
-        fail_stop: true,
-        ..Default::default()
-    }));
-    let c = Rc::new(RefCell::new(MockDriverState::default()));
-    let (drivers, events) =
-        drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
-    let mut runtime = runtime_with_drivers(drivers).unwrap();
-    runtime.start_input_drivers().unwrap();
-    let error = format!("{:?}", runtime.stop_input_drivers().unwrap_err());
-    assert!(error.contains("MockStopError"));
-    assert_eq!(a.borrow().stop_count, 1);
-    assert_eq!(b.borrow().stop_count, 1);
-    assert_eq!(c.borrow().stop_count, 1);
-    let stop_events: Vec<String> = events
-        .borrow()
-        .iter()
-        .filter(|event| event.starts_with("stop:"))
-        .cloned()
-        .collect();
-    assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
+  let a = Rc::new(RefCell::new(MockDriverState::default()));
+  let b = Rc::new(RefCell::new(MockDriverState { fail_stop: true, ..Default::default() }));
+  let c = Rc::new(RefCell::new(MockDriverState::default()));
+  let (drivers, events) = drivers_with_events(&[("a", a.clone()), ("b", b.clone()), ("c", c.clone())]);
+  let mut runtime = runtime_with_drivers(drivers).unwrap();
+  runtime.start_input_drivers().unwrap();
+  let error = format!("{:?}", runtime.stop_input_drivers().unwrap_err());
+  assert!(error.contains("MockStopError"));
+  assert_eq!(a.borrow().stop_count, 1);
+  assert_eq!(b.borrow().stop_count, 1);
+  assert_eq!(c.borrow().stop_count, 1);
+  let stop_events: Vec<String> = events.borrow().iter().filter(|event| event.starts_with("stop:")).cloned().collect();
+  assert_eq!(stop_events, vec!["stop:c", "stop:b", "stop:a"]);
 }
 
 #[test]
 fn shutdown_closes_ingress_before_stopping_drivers() {
-    let state = Rc::new(RefCell::new(MockDriverState::default()));
-    let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
-    runtime.start_input_drivers().unwrap();
-    let ingress = state.borrow().attached_ingress.clone().unwrap();
-    runtime.shutdown().unwrap();
-    assert_eq!(state.borrow().stop_count, 1);
-    assert!(state.borrow().stop_observed_closed_ingress);
-    drop(runtime);
-    assert_eq!(state.borrow().stop_count, 1);
-    let source = RuntimeHostInputSource::new("test-input://clock/ticks", "value").unwrap();
-    let error = format!(
-        "{:?}",
-        ingress
-            .submit(RuntimeHostInput::single(
-                source,
-                RuntimeHostInputValue::F64(1.0)
-            ))
-            .unwrap_err()
-    );
-    assert!(error.contains("RuntimeIngressClosed"));
+  let state = Rc::new(RefCell::new(MockDriverState::default()));
+  let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
+  runtime.start_input_drivers().unwrap();
+  let ingress = state.borrow().attached_ingress.clone().unwrap();
+  runtime.shutdown().unwrap();
+  assert_eq!(state.borrow().stop_count, 1);
+  assert!(state.borrow().stop_observed_closed_ingress);
+  drop(runtime);
+  assert_eq!(state.borrow().stop_count, 1);
+  let source = RuntimeHostInputSource::new("test-input://clock/ticks", "value").unwrap();
+  let error = format!("{:?}", ingress.submit(RuntimeHostInput::single(source, RuntimeHostInputValue::F64(1.0))).unwrap_err());
+  assert!(error.contains("RuntimeIngressClosed"));
 }
 
 #[test]
 fn drop_stops_live_input_drivers() {
-    let state = Rc::new(RefCell::new(MockDriverState::default()));
-    {
-        let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
-        runtime.start_input_drivers().unwrap();
-        assert!(state.borrow().live);
-    }
-    assert_eq!(state.borrow().stop_count, 1);
-    assert!(!state.borrow().live);
+  let state = Rc::new(RefCell::new(MockDriverState::default()));
+  {
+    let mut runtime = runtime_with_drivers(vec![MockDriver::new("a", state.clone())]).unwrap();
+    runtime.start_input_drivers().unwrap();
+    assert!(state.borrow().live);
+  }
+  assert_eq!(state.borrow().stop_count, 1);
+  assert!(!state.borrow().live);
 }
 
+
 #[derive(Debug, Clone)]
-struct MockDriverError {
-    name: &'static str,
-    message: String,
-}
+struct MockDriverError { name: &'static str, message: String }
 impl MechErrorKind for MockDriverError {
-    fn name(&self) -> &str {
-        self.name
-    }
-    fn message(&self) -> String {
-        self.message.clone()
-    }
+  fn name(&self) -> &str { self.name }
+  fn message(&self) -> String { self.message.clone() }
 }
 fn mock_error(name: &'static str, message: impl Into<String>) -> MechError {
-    MechError::new(
-        MockDriverError {
-            name,
-            message: message.into(),
-        },
-        None,
-    )
+  MechError::new(MockDriverError { name, message: message.into() }, None)
 }
 
 #[cfg(test)]
 mod persistent_send_tests {
-    use super::*;
-    use crate::RuntimeResourceWritePreflightRequest;
-    use crate::runtime::execution::ACTIVATION_EFFECT_BARRIER_NAME;
+  use super::*;
+  use crate::runtime::execution::ACTIVATION_EFFECT_BARRIER_NAME;
+  use crate::RuntimeResourceWritePreflightRequest;
 
-    const TEST_TIME_BASE_URI: &str = "time://clock/clock";
+  const TEST_TIME_BASE_URI: &str =
+    "time://clock/clock";
 
-    const TEST_TIME_PATHS: [&str; 5] = ["unix-ms", "hour", "minute", "second", "millisecond"];
+  const TEST_TIME_PATHS: [&str; 5] = [
+    "unix-ms",
+    "hour",
+    "minute",
+    "second",
+    "millisecond",
+  ];
 
-    fn test_time_source_matches(source: &RuntimeHostInputSource) -> bool {
-        source.base_uri() == TEST_TIME_BASE_URI && TEST_TIME_PATHS.contains(&source.path())
+  fn test_time_source_matches(
+    source: &RuntimeHostInputSource,
+  ) -> bool {
+    source.base_uri() == TEST_TIME_BASE_URI
+      && TEST_TIME_PATHS.contains(&source.path())
+  }
+
+  #[derive(Clone, Copy, Debug)]
+  struct TimeSnapshot {
+    unix_ms: f64,
+    hour: f64,
+    minute: f64,
+    second: f64,
+    millisecond: f64,
+  }
+
+  #[derive(Debug)]
+  struct TimeResourceProvider {
+    snapshot: Rc<RefCell<TimeSnapshot>>,
+  }
+
+  impl RuntimeResourceProvider for TimeResourceProvider {
+    fn scheme(&self) -> &str { "time" }
+    fn base_uris(&self) -> Vec<String> { vec![TEST_TIME_BASE_URI.to_string()] }
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+      let snapshot = *self.snapshot.borrow();
+      let value = match request.path.as_str() {
+        "unix-ms" => snapshot.unix_ms,
+        "hour" => snapshot.hour,
+        "minute" => snapshot.minute,
+        "second" => snapshot.second,
+        "millisecond" => snapshot.millisecond,
+        other => return Err(MechError::new(PersistentSendTestError(format!("unknown time path {other}")), None)),
+      };
+      Ok(Value::F64(Ref::new(value)))
+    }
+  }
+
+  #[derive(Clone, Debug)]
+  struct ManualTimeInputDriver {
+    snapshot: Rc<RefCell<TimeSnapshot>>,
+    ingress: Rc<RefCell<Option<RuntimeIngress>>>,
+    live: Rc<RefCell<bool>>,
+  }
+
+  impl ManualTimeInputDriver {
+    fn new(snapshot: Rc<RefCell<TimeSnapshot>>) -> Self {
+      Self { snapshot, ingress: Rc::new(RefCell::new(None)), live: Rc::new(RefCell::new(false)) }
     }
 
-    #[derive(Clone, Copy, Debug)]
-    struct TimeSnapshot {
-        unix_ms: f64,
-        hour: f64,
-        minute: f64,
-        second: f64,
-        millisecond: f64,
+    fn publish(&self, snapshot: TimeSnapshot) -> MResult<()> {
+      *self.snapshot.borrow_mut() = snapshot;
+      let ingress = self.ingress.borrow().clone().ok_or_else(|| MechError::new(PersistentSendTestError("driver is not attached".to_string()), None))?;
+      ingress.submit(RuntimeHostInput::new(vec![
+        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "unix-ms")?, value: RuntimeHostInputValue::F64(snapshot.unix_ms) },
+        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "hour")?, value: RuntimeHostInputValue::F64(snapshot.hour) },
+        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "minute")?, value: RuntimeHostInputValue::F64(snapshot.minute) },
+        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "second")?, value: RuntimeHostInputValue::F64(snapshot.second) },
+        RuntimeHostInputUpdate { source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "millisecond")?, value: RuntimeHostInputValue::F64(snapshot.millisecond) },
+      ])?)
     }
+  }
 
-    #[derive(Debug)]
-    struct TimeResourceProvider {
-        snapshot: Rc<RefCell<TimeSnapshot>>,
+  impl RuntimeHostInputDriver for ManualTimeInputDriver {
+    fn drives(&self, source: &RuntimeHostInputSource) -> bool { test_time_source_matches(source) }
+    fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> { *self.ingress.borrow_mut() = Some(ingress); Ok(()) }
+    fn start(&mut self) -> MResult<()> { *self.live.borrow_mut() = true; Ok(()) }
+    fn stop(&mut self) -> MResult<()> { *self.live.borrow_mut() = false; Ok(()) }
+    fn is_live(&self) -> bool { *self.live.borrow() }
+  }
+
+  #[derive(Clone, Debug, Default)]
+  struct RecordingConsoleBackend {
+    lines: Rc<RefCell<Vec<String>>>,
+    fail_next: Rc<RefCell<Option<String>>>,
+  }
+
+  impl RecordingConsoleBackend {
+    fn lines(&self) -> Vec<String> { self.lines.borrow().clone() }
+    fn fail_next(&self, reason: impl Into<String>) { *self.fail_next.borrow_mut() = Some(reason.into()); }
+  }
+
+  #[derive(Debug)]
+  struct ConsoleResourceProvider { backend: RecordingConsoleBackend }
+
+  impl RuntimeResourceProvider for ConsoleResourceProvider {
+    fn scheme(&self) -> &str { "console" }
+    fn base_uris(&self) -> Vec<String> { vec!["console://console/output".to_string()] }
+    fn read(&self, _request: RuntimeResourceReadRequest) -> MResult<Value> { Err(MechError::new(PersistentSendTestError("console is write-only".to_string()), None)) }
+    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+      if request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send { Ok(()) } else { Err(MechError::new(PersistentSendTestError("bad console write".to_string()), None)) }
     }
-
-    impl RuntimeResourceProvider for TimeResourceProvider {
-        fn scheme(&self) -> &str {
-            "time"
-        }
-        fn base_uris(&self) -> Vec<String> {
-            vec![TEST_TIME_BASE_URI.to_string()]
-        }
-        fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-            let snapshot = *self.snapshot.borrow();
-            let value = match request.path.as_str() {
-                "unix-ms" => snapshot.unix_ms,
-                "hour" => snapshot.hour,
-                "minute" => snapshot.minute,
-                "second" => snapshot.second,
-                "millisecond" => snapshot.millisecond,
-                other => {
-                    return Err(MechError::new(
-                        PersistentSendTestError(format!("unknown time path {other}")),
-                        None,
-                    ));
-                }
-            };
-            Ok(Value::F64(Ref::new(value)))
-        }
+    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+      self.preflight_write(RuntimeResourceWritePreflightRequest {
+        base_uri: request.base_uri,
+        path: request.path,
+        context_name: request.context_name,
+        operation: request.operation,
+        intent: request.intent,
+      })?;
+      if let Some(reason) = self.backend.fail_next.borrow_mut().take() {
+        return Err(MechError::new(PersistentSendTestError(reason), None));
+      }
+      self.backend.lines.borrow_mut().push(format!("{}", request.value));
+      Ok(())
     }
+  }
 
-    #[derive(Clone, Debug)]
-    struct ManualTimeInputDriver {
-        snapshot: Rc<RefCell<TimeSnapshot>>,
-        ingress: Rc<RefCell<Option<RuntimeIngress>>>,
-        live: Rc<RefCell<bool>>,
-    }
+  #[derive(Debug, Clone)]
+  struct PersistentSendTestError(String);
 
-    impl ManualTimeInputDriver {
-        fn new(snapshot: Rc<RefCell<TimeSnapshot>>) -> Self {
-            Self {
-                snapshot,
-                ingress: Rc::new(RefCell::new(None)),
-                live: Rc::new(RefCell::new(false)),
-            }
-        }
+  impl MechErrorKind for PersistentSendTestError {
+    fn name(&self) -> &str { "PersistentSendTestError" }
+    fn message(&self) -> String { self.0.clone() }
+  }
 
-        fn publish(&self, snapshot: TimeSnapshot) -> MResult<()> {
-            *self.snapshot.borrow_mut() = snapshot;
-            let ingress = self.ingress.borrow().clone().ok_or_else(|| {
-                MechError::new(
-                    PersistentSendTestError("driver is not attached".to_string()),
-                    None,
-                )
-            })?;
-            ingress.submit(RuntimeHostInput::new(vec![
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "unix-ms")?,
-                    value: RuntimeHostInputValue::F64(snapshot.unix_ms),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "hour")?,
-                    value: RuntimeHostInputValue::F64(snapshot.hour),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "minute")?,
-                    value: RuntimeHostInputValue::F64(snapshot.minute),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "second")?,
-                    value: RuntimeHostInputValue::F64(snapshot.second),
-                },
-                RuntimeHostInputUpdate {
-                    source: RuntimeHostInputSource::new(TEST_TIME_BASE_URI, "millisecond")?,
-                    value: RuntimeHostInputValue::F64(snapshot.millisecond),
-                },
-            ])?)
-        }
-    }
-
-    impl RuntimeHostInputDriver for ManualTimeInputDriver {
-        fn drives(&self, source: &RuntimeHostInputSource) -> bool {
-            test_time_source_matches(source)
-        }
-        fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
-            *self.ingress.borrow_mut() = Some(ingress);
-            Ok(())
-        }
-        fn start(&mut self) -> MResult<()> {
-            *self.live.borrow_mut() = true;
-            Ok(())
-        }
-        fn stop(&mut self) -> MResult<()> {
-            *self.live.borrow_mut() = false;
-            Ok(())
-        }
-        fn is_live(&self) -> bool {
-            *self.live.borrow()
-        }
-    }
-
-    #[derive(Clone, Debug, Default)]
-    struct RecordingConsoleBackend {
-        lines: Rc<RefCell<Vec<String>>>,
-        fail_next: Rc<RefCell<Option<String>>>,
-    }
-
-    impl RecordingConsoleBackend {
-        fn lines(&self) -> Vec<String> {
-            self.lines.borrow().clone()
-        }
-        fn fail_next(&self, reason: impl Into<String>) {
-            *self.fail_next.borrow_mut() = Some(reason.into());
-        }
-    }
-
-    #[derive(Debug)]
-    struct ConsoleResourceProvider {
-        backend: RecordingConsoleBackend,
-    }
-
-    impl RuntimeResourceProvider for ConsoleResourceProvider {
-        fn scheme(&self) -> &str {
-            "console"
-        }
-        fn base_uris(&self) -> Vec<String> {
-            vec!["console://console/output".to_string()]
-        }
-        fn read(&self, _request: RuntimeResourceReadRequest) -> MResult<Value> {
-            Err(MechError::new(
-                PersistentSendTestError("console is write-only".to_string()),
-                None,
-            ))
-        }
-        fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
-            if request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send {
-                Ok(())
-            } else {
-                Err(MechError::new(
-                    PersistentSendTestError("bad console write".to_string()),
-                    None,
-                ))
-            }
-        }
-        fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
-            self.preflight_write(RuntimeResourceWritePreflightRequest {
-                base_uri: request.base_uri,
-                path: request.path,
-                context_name: request.context_name,
-                operation: request.operation,
-                intent: request.intent,
-            })?;
-            if let Some(reason) = self.backend.fail_next.borrow_mut().take() {
-                return Err(MechError::new(PersistentSendTestError(reason), None));
-            }
-            self.backend
-                .lines
-                .borrow_mut()
-                .push(format!("{}", request.value));
-            Ok(())
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct PersistentSendTestError(String);
-
-    impl MechErrorKind for PersistentSendTestError {
-        fn name(&self) -> &str {
-            "PersistentSendTestError"
-        }
-        fn message(&self) -> String {
-            self.0.clone()
-        }
-    }
-
-    const TIME_PATHS: &[&str] = &["unix-ms", "hour", "minute", "second", "millisecond"];
+  const TIME_PATHS: &[&str] = &["unix-ms", "hour", "minute", "second", "millisecond"];
 
     fn grant_write_to(runtime: &mut MechRuntime, subject: &str, resource: &str, path: &str) {
         runtime
@@ -2016,72 +1196,40 @@ mod persistent_send_tests {
         }
     }
 
-    fn snapshot(hour: f64, minute: f64, second: f64, millisecond: f64) -> TimeSnapshot {
-        TimeSnapshot {
-            unix_ms: hour * 3_600_000.0 + minute * 60_000.0 + second * 1000.0 + millisecond,
-            hour,
-            minute,
-            second,
-            millisecond,
-        }
-    }
 
-    fn grant(
-        runtime: &mut MechRuntime,
-        resource: &str,
-        operation: RuntimeCapabilityOperation,
-        paths: &[&str],
-    ) {
-        let subject = runtime.runtime_context().unwrap().subject;
-        runtime
-            .grant_capability(RuntimeCapabilityGrant {
-                subject,
-                resource: resource.to_string(),
-                operations: vec![operation],
-                paths: paths.iter().map(|path| path.to_string()).collect(),
-            })
-            .unwrap();
-    }
+  fn snapshot(hour: f64, minute: f64, second: f64, millisecond: f64) -> TimeSnapshot {
+    TimeSnapshot { unix_ms: hour * 3_600_000.0 + minute * 60_000.0 + second * 1000.0 + millisecond, hour, minute, second, millisecond }
+  }
 
-    fn runtime_with_console(
-        initial: TimeSnapshot,
-        fail_next: bool,
-    ) -> (MechRuntime, ManualTimeInputDriver, RecordingConsoleBackend) {
-        let shared = Rc::new(RefCell::new(initial));
-        let console = RecordingConsoleBackend::default();
-        if fail_next {
-            console.fail_next("intentional console failure");
-        }
-        let mut runtime = RuntimeBuilder::new()
-            .resource_provider(Box::new(TimeResourceProvider {
-                snapshot: shared.clone(),
-            }) as Box<dyn RuntimeResourceProvider>)
-            .resource_provider(Box::new(ConsoleResourceProvider {
-                backend: console.clone(),
-            }) as Box<dyn RuntimeResourceProvider>)
-            .build()
-            .unwrap();
-        grant(
-            &mut runtime,
-            "time://clock/clock",
-            RuntimeCapabilityOperation::Read,
-            TIME_PATHS,
-        );
-        grant(
-            &mut runtime,
-            "console://console/output",
-            RuntimeCapabilityOperation::Write,
-            &["line"],
-        );
-        let mut driver = ManualTimeInputDriver::new(shared);
-        driver.attach(runtime.ingress()).unwrap();
-        driver.start().unwrap();
-        (runtime, driver, console)
-    }
+  fn grant(runtime: &mut MechRuntime, resource: &str, operation: RuntimeCapabilityOperation, paths: &[&str]) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: resource.to_string(),
+      operations: vec![operation],
+      paths: paths.iter().map(|path| path.to_string()).collect(),
+    }).unwrap();
+  }
 
-    fn load(runtime: &mut MechRuntime, send_expression: &str) {
-        let source = format!(
-            r#"@out := console://console/output{{:write(line)}}
+  fn runtime_with_console(initial: TimeSnapshot, fail_next: bool) -> (MechRuntime, ManualTimeInputDriver, RecordingConsoleBackend) {
+    let shared = Rc::new(RefCell::new(initial));
+    let console = RecordingConsoleBackend::default();
+    if fail_next { console.fail_next("intentional console failure"); }
+    let mut runtime = RuntimeBuilder::new()
+      .resource_provider(Box::new(TimeResourceProvider { snapshot: shared.clone() }) as Box<dyn RuntimeResourceProvider>)
+      .resource_provider(Box::new(ConsoleResourceProvider { backend: console.clone() }) as Box<dyn RuntimeResourceProvider>)
+      .build()
+      .unwrap();
+    grant(&mut runtime, "time://clock/clock", RuntimeCapabilityOperation::Read, TIME_PATHS);
+    grant(&mut runtime, "console://console/output", RuntimeCapabilityOperation::Write, &["line"]);
+    let mut driver = ManualTimeInputDriver::new(shared);
+    driver.attach(runtime.ingress()).unwrap();
+    driver.start().unwrap();
+    (runtime, driver, console)
+  }
+
+  fn load(runtime: &mut MechRuntime, send_expression: &str) {
+    let source = format!(r#"@out := console://console/output{{:write(line)}}
 @clock := time://clock/clock{{:read(unix-ms), :read(hour), :read(minute), :read(second), :read(millisecond)}}
 unix-ms := @clock/unix-ms
 hour := @clock/hour
@@ -2091,343 +1239,154 @@ millisecond := @clock/millisecond
 scalar-output := hour + minute
 clock-output := (hour, minute, second)
 @out/line <- {send_expression}
-"#
-        );
-        runtime.run_string(&source).unwrap();
-    }
+"#);
+    runtime.run_string(&source).unwrap();
+  }
 
-    fn publish(runtime: &mut MechRuntime, driver: &ManualTimeInputDriver, snapshot: TimeSnapshot) {
-        driver.publish(snapshot).unwrap();
-        let outcomes = runtime.drain_host_inputs(1).unwrap();
-        assert_eq!(outcomes.len(), 1);
-    }
+  fn publish(runtime: &mut MechRuntime, driver: &ManualTimeInputDriver, snapshot: TimeSnapshot) {
+    driver.publish(snapshot).unwrap();
+    let outcomes = runtime.drain_host_inputs(1).unwrap();
+    assert_eq!(outcomes.len(), 1);
+  }
 
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    struct ActivationPlanSnapshot {
-        nodes: Vec<ActivationNodeSnapshot>,
-        reactive_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>,
-        sampled_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>,
-    }
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    struct ActivationNodeSnapshot {
-        id: ReactiveNodeId,
-        plan_index: usize,
-        kind: ReactiveNodeKind,
-        inputs: Vec<(ReactiveCellId, ReactiveDependencyKind)>,
-        outputs: Vec<ReactiveCellId>,
-    }
-    fn activation_plan_snapshot(runtime: &MechRuntime) -> ActivationPlanSnapshot {
-        let plan = runtime.program.interpreter().plan();
-        let plan = plan.borrow();
-        let nodes = plan
-            .nodes
-            .iter()
-            .map(|n| ActivationNodeSnapshot {
-                id: n.id,
-                plan_index: n.plan_index,
-                kind: n.kind,
-                inputs: n.inputs.iter().map(|d| (d.cell, d.kind)).collect(),
-                outputs: n.outputs.clone(),
-            })
-            .collect();
-        let mut reactive_consumers = plan
-            .reactive_consumers
-            .iter()
-            .map(|(c, n)| (*c, n.clone()))
-            .collect::<Vec<_>>();
-        let mut sampled_consumers = plan
-            .sampled_consumers
-            .iter()
-            .map(|(c, n)| (*c, n.clone()))
-            .collect::<Vec<_>>();
-        reactive_consumers.sort_by_key(|(c, _)| c.get());
-        sampled_consumers.sort_by_key(|(c, _)| c.get());
-        ActivationPlanSnapshot {
-            nodes,
-            reactive_consumers,
-            sampled_consumers,
-        }
-    }
-    fn activation_nodes_for_trigger(
-        runtime: &MechRuntime,
-        trigger_name: &str,
-        kind: ReactiveNodeKind,
-    ) -> Vec<ReactiveNodeId> {
-        let c = symbol_cell(runtime, trigger_name);
-        let p = runtime.program.interpreter().plan();
-        p.borrow()
-            .nodes
-            .iter()
-            .filter(|n| {
-                n.kind == kind
-                    && n.inputs
-                        .iter()
-                        .any(|d| d.cell == c && d.kind == ReactiveDependencyKind::Reactive)
-            })
-            .map(|n| n.id)
-            .collect()
-    }
-    fn activation_barrier_for_trigger(runtime: &MechRuntime, trigger_name: &str) -> ReactiveNodeId {
-        let c = symbol_cell(runtime, trigger_name);
-        let p = runtime.program.interpreter().plan();
-        let barriers = p
-            .borrow()
-            .nodes
-            .iter()
-            .filter(|n| {
-                n.kind == ReactiveNodeKind::Combinational
-                    && n.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
-                    && n.outputs.is_empty()
-                    && n.inputs
-                        .iter()
-                        .any(|d| d.cell == c && d.kind == ReactiveDependencyKind::Reactive)
-            })
-            .map(|n| n.id)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            barriers.len(),
-            1,
-            "expected exactly one activation-effect barrier for trigger {trigger_name}"
-        );
-        barriers[0]
-    }
-    fn only_reactive_turn(outcome: &RuntimeHostInputOutcome) -> &ReactiveTurnOutcome {
-        let p = outcome
-            .turn
-            .as_ref()
-            .expect("expected a program input turn");
-        assert_eq!(
-            p.interpreter_turns.len(),
-            1,
-            "expected exactly one affected interpreter"
-        );
-        &p.interpreter_turns[0].turn
-    }
-    fn executed_count(turn: &ReactiveTurnOutcome, id: ReactiveNodeId) -> usize {
-        turn.before_commit
-            .executed_nodes
-            .iter()
-            .chain(turn.after_commit.executed_nodes.iter())
-            .filter(|x| **x == id)
-            .count()
-    }
-    fn apply_f64_input(r: &mut MechRuntime, b: &str, p: &str, v: f64) -> RuntimeHostInputOutcome {
-        r.apply_host_input(RuntimeHostInput::single(
-            RuntimeHostInputSource::new(b, p).unwrap(),
-            RuntimeHostInputValue::F64(v),
-        ))
-        .unwrap()
-    }
-    fn recorded_f64(o: &RecordingTestOutput, i: usize) -> f64 {
-        o.lines()[i].trim().parse().unwrap()
-    }
-    fn activation_send_count(r: &MechRuntime) -> usize {
-        r.persistent_sends
-            .iter()
-            .filter(|s| matches!(s.schedule, RuntimePersistentSendSchedule::Activation { .. }))
-            .count()
-    }
-    fn activation_rejection_runtime() -> (MechRuntime, RecordingTestOutput) {
-        let (mut r, o) = test_runtime_with_output(TestResourceProvider::new().with_value(
-            "test://render/timer",
-            "tick",
-            Value::F64(Ref::new(0.0)),
-        ));
-        grant_read(&mut r, "test://render/timer", "tick");
-        grant_write(&mut r, TEST_OUTPUT_BASE_URI, "line");
-        (r, o)
-    }
-    fn assert_rejected_activation_left_no_state(
-        r: &MechRuntime,
-        o: &RecordingTestOutput,
-        p: &ActivationPlanSnapshot,
-        s: usize,
-        b: &HashMap<RuntimeHostInputSource, Vec<mech_program::ProgramInputId>>,
-    ) {
-        assert_eq!(activation_plan_snapshot(r), *p);
-        assert_eq!(r.persistent_sends.len(), s);
-        assert_eq!(r.live_input_bindings, *b);
-        assert!(o.lines().is_empty());
-        assert!(
-            !r.program
-                .interpreter()
-                .plan()
-                .activation_registration_active()
-        );
-    }
 
-    #[test]
-    fn persistent_send_uses_original_custom_subject() {
-        let initial = snapshot(1.0, 2.0, 3.0, 4.0);
-        let shared = Rc::new(RefCell::new(initial));
-        let console = RecordingConsoleBackend::default();
-        let mut runtime = RuntimeBuilder::new()
-            .resource_provider(Box::new(TimeResourceProvider {
-                snapshot: shared.clone(),
-            }) as Box<dyn RuntimeResourceProvider>)
-            .resource_provider(Box::new(ConsoleResourceProvider {
-                backend: console.clone(),
-            }) as Box<dyn RuntimeResourceProvider>)
-            .build()
-            .unwrap();
-        let subject = "task:live-custom";
-        runtime
-            .grant_capability(RuntimeCapabilityGrant {
-                subject: subject.to_string(),
-                resource: "time://clock/clock".to_string(),
-                operations: vec![RuntimeCapabilityOperation::Read],
-                paths: TIME_PATHS.iter().map(|path| path.to_string()).collect(),
-            })
-            .unwrap();
-        runtime
-            .grant_capability(RuntimeCapabilityGrant {
-                subject: subject.to_string(),
-                resource: "console://console/output".to_string(),
-                operations: vec![RuntimeCapabilityOperation::Write],
-                paths: vec!["line".to_string()],
-            })
-            .unwrap();
-        assert!(!runtime.has_capability_grant(
-            &runtime.runtime_context().unwrap().subject,
-            "console://console/output",
-            &RuntimeCapabilityOperation::Write,
-            "line"
-        ));
+  #[derive(Clone, Debug, PartialEq, Eq)]
+  struct ActivationPlanSnapshot { nodes: Vec<ActivationNodeSnapshot>, reactive_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>, sampled_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)> }
+  #[derive(Clone, Debug, PartialEq, Eq)]
+  struct ActivationNodeSnapshot { id: ReactiveNodeId, plan_index: usize, kind: ReactiveNodeKind, inputs: Vec<(ReactiveCellId, ReactiveDependencyKind)>, outputs: Vec<ReactiveCellId> }
+  fn activation_plan_snapshot(runtime: &MechRuntime) -> ActivationPlanSnapshot { let plan=runtime.program.interpreter().plan(); let plan=plan.borrow(); let nodes=plan.nodes.iter().map(|n| ActivationNodeSnapshot{id:n.id,plan_index:n.plan_index,kind:n.kind,inputs:n.inputs.iter().map(|d|(d.cell,d.kind)).collect(),outputs:n.outputs.clone()}).collect(); let mut reactive_consumers=plan.reactive_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();let mut sampled_consumers=plan.sampled_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();reactive_consumers.sort_by_key(|(c,_)|c.get());sampled_consumers.sort_by_key(|(c,_)|c.get());ActivationPlanSnapshot{nodes,reactive_consumers,sampled_consumers} }
+  fn activation_nodes_for_trigger(runtime:&MechRuntime, trigger_name:&str, kind:ReactiveNodeKind)->Vec<ReactiveNodeId>{let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();p.borrow().nodes.iter().filter(|n|n.kind==kind&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect()}
+  fn activation_barrier_for_trigger(runtime:&MechRuntime, trigger_name:&str)->ReactiveNodeId {let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();let barriers=p.borrow().nodes.iter().filter(|n|n.kind==ReactiveNodeKind::Combinational&&n.function.to_string()==ACTIVATION_EFFECT_BARRIER_NAME&&n.outputs.is_empty()&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect::<Vec<_>>();assert_eq!(barriers.len(),1,"expected exactly one activation-effect barrier for trigger {trigger_name}");barriers[0]}
+  fn only_reactive_turn(outcome:&RuntimeHostInputOutcome)->&ReactiveTurnOutcome{let p=outcome.turn.as_ref().expect("expected a program input turn");assert_eq!(p.interpreter_turns.len(),1,"expected exactly one affected interpreter");&p.interpreter_turns[0].turn}
+  fn executed_count(turn:&ReactiveTurnOutcome,id:ReactiveNodeId)->usize{turn.before_commit.executed_nodes.iter().chain(turn.after_commit.executed_nodes.iter()).filter(|x|**x==id).count()}
+  fn apply_f64_input(r:&mut MechRuntime,b:&str,p:&str,v:f64)->RuntimeHostInputOutcome{r.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new(b,p).unwrap(),RuntimeHostInputValue::F64(v))).unwrap()}
+  fn recorded_f64(o:&RecordingTestOutput,i:usize)->f64{o.lines()[i].trim().parse().unwrap()}
+  fn activation_send_count(r:&MechRuntime)->usize{r.persistent_sends.iter().filter(|s|matches!(s.schedule,RuntimePersistentSendSchedule::Activation{..})).count()}
+  fn activation_rejection_runtime()->(MechRuntime,RecordingTestOutput){let (mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))));grant_read(&mut r,"test://render/timer","tick");grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");(r,o)}
+  fn assert_rejected_activation_left_no_state(r:&MechRuntime,o:&RecordingTestOutput,p:&ActivationPlanSnapshot,s:usize,b:&HashMap<RuntimeHostInputSource,Vec<mech_program::ProgramInputId>>){assert_eq!(activation_plan_snapshot(r),*p);assert_eq!(r.persistent_sends.len(),s);assert_eq!(r.live_input_bindings,*b);assert!(o.lines().is_empty());assert!(!r.program.interpreter().plan().activation_registration_active());}
 
-        let mut context = runtime.runtime_context().unwrap().with_subject(subject);
-        runtime
-            .run_string_with_context(
-                &mut context,
-                r#"@out := console://console/output{:write(line)}
+  #[test]
+  fn persistent_send_uses_original_custom_subject() {
+    let initial = snapshot(1.0, 2.0, 3.0, 4.0);
+    let shared = Rc::new(RefCell::new(initial));
+    let console = RecordingConsoleBackend::default();
+    let mut runtime = RuntimeBuilder::new()
+      .resource_provider(Box::new(TimeResourceProvider { snapshot: shared.clone() }) as Box<dyn RuntimeResourceProvider>)
+      .resource_provider(Box::new(ConsoleResourceProvider { backend: console.clone() }) as Box<dyn RuntimeResourceProvider>)
+      .build()
+      .unwrap();
+    let subject = "task:live-custom";
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.to_string(),
+      resource: "time://clock/clock".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: TIME_PATHS.iter().map(|path| path.to_string()).collect(),
+    }).unwrap();
+    runtime.grant_capability(RuntimeCapabilityGrant {
+      subject: subject.to_string(),
+      resource: "console://console/output".to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: vec!["line".to_string()],
+    }).unwrap();
+    assert!(!runtime.has_capability_grant(&runtime.runtime_context().unwrap().subject, "console://console/output", &RuntimeCapabilityOperation::Write, "line"));
+
+    let mut context = runtime.runtime_context().unwrap().with_subject(subject);
+    runtime.run_string_with_context(&mut context, r#"@out := console://console/output{:write(line)}
 @clock := time://clock/clock{:read(hour)}
 hour := @clock/hour
 output := hour + 1
 @out/line <- output
-"#,
-            )
-            .unwrap();
-        assert_eq!(console.lines().len(), 1);
-        *shared.borrow_mut() = snapshot(1.0, 9.0, 3.0, 4.0);
-        let outcome = runtime
-            .apply_host_input(RuntimeHostInput::single(
-                RuntimeHostInputSource::new("time://clock/clock", "hour").unwrap(),
-                RuntimeHostInputValue::F64(9.0),
-            ))
-            .unwrap();
-        assert!(outcome.turn.is_some());
-        let lines = console.lines();
-        assert_eq!(lines.len(), 2);
-        assert!(lines.last().unwrap().contains("10"), "{lines:?}");
-    }
+"#).unwrap();
+    assert_eq!(console.lines().len(), 1);
+    *shared.borrow_mut() = snapshot(1.0, 9.0, 3.0, 4.0);
+    let outcome = runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("time://clock/clock", "hour").unwrap(), RuntimeHostInputValue::F64(9.0))).unwrap();
+    assert!(outcome.turn.is_some());
+    let lines = console.lines();
+    assert_eq!(lines.len(), 2);
+    assert!(lines.last().unwrap().contains("10"), "{lines:?}");
+  }
 
-    #[test]
-    fn persistent_send_initial_evaluation_sends_once() {
-        let (mut runtime, _driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "scalar-output");
-        assert_eq!(console.lines().len(), 1);
-        assert_eq!(runtime.persistent_send_count(), 1);
-    }
+  #[test]
+  fn persistent_send_initial_evaluation_sends_once() {
+    let (mut runtime, _driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "scalar-output");
+    assert_eq!(console.lines().len(), 1);
+    assert_eq!(runtime.persistent_send_count(), 1);
+  }
 
-    #[test]
-    fn persistent_send_one_packet_sends_once_more_with_changed_value() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "scalar-output");
-        let initial = console.lines();
-        publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
-        let lines = console.lines();
-        assert_eq!(lines.len(), 2);
-        assert_ne!(lines[1], initial[0]);
-    }
+  #[test]
+  fn persistent_send_one_packet_sends_once_more_with_changed_value() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "scalar-output");
+    let initial = console.lines();
+    publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
+    let lines = console.lines();
+    assert_eq!(lines.len(), 2);
+    assert_ne!(lines[1], initial[0]);
+  }
 
-    #[test]
-    fn persistent_send_two_packets_produce_two_additional_values_in_order() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 1.0, 1.0, 0.0), false);
-        load(&mut runtime, "scalar-output");
-        publish(&mut runtime, &driver, snapshot(2.0, 3.0, 0.0, 0.0));
-        publish(&mut runtime, &driver, snapshot(4.0, 5.0, 0.0, 0.0));
-        let lines = console.lines();
-        assert_eq!(lines.len(), 3);
-        assert_ne!(lines[1], lines[2]);
-    }
+  #[test]
+  fn persistent_send_two_packets_produce_two_additional_values_in_order() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 1.0, 1.0, 0.0), false);
+    load(&mut runtime, "scalar-output");
+    publish(&mut runtime, &driver, snapshot(2.0, 3.0, 0.0, 0.0));
+    publish(&mut runtime, &driver, snapshot(4.0, 5.0, 0.0, 0.0));
+    let lines = console.lines();
+    assert_eq!(lines.len(), 3);
+    assert_ne!(lines[1], lines[2]);
+  }
 
-    #[test]
-    fn persistent_send_logical_packet_with_five_fields_sends_once() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "clock-output");
-        publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
-        assert_eq!(console.lines().len(), 2);
-    }
+  #[test]
+  fn persistent_send_logical_packet_with_five_fields_sends_once() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "clock-output");
+    publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
+    assert_eq!(console.lines().len(), 2);
+  }
 
-    #[test]
-    fn persistent_send_scalar_reads_new_value_after_solve() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "scalar-output");
-        publish(&mut runtime, &driver, snapshot(10.0, 20.0, 0.0, 0.0));
-        let lines = console.lines();
-        assert!(
-            lines[1].contains("30"),
-            "expected updated scalar in {:?}",
-            lines
-        );
-    }
+  #[test]
+  fn persistent_send_scalar_reads_new_value_after_solve() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "scalar-output");
+    publish(&mut runtime, &driver, snapshot(10.0, 20.0, 0.0, 0.0));
+    let lines = console.lines();
+    assert!(lines[1].contains("30"), "expected updated scalar in {:?}", lines);
+  }
 
-    #[test]
-    fn persistent_send_tuple_reads_new_values_after_solve() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "clock-output");
-        publish(&mut runtime, &driver, snapshot(10.0, 20.0, 30.0, 40.0));
-        let lines = console.lines();
-        assert!(
-            lines[1].contains("10"),
-            "expected updated tuple in {:?}",
-            lines
-        );
-        assert!(
-            lines[1].contains("20"),
-            "expected updated tuple in {:?}",
-            lines
-        );
-        assert!(
-            lines[1].contains("30"),
-            "expected updated tuple in {:?}",
-            lines
-        );
-    }
+  #[test]
+  fn persistent_send_tuple_reads_new_values_after_solve() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "clock-output");
+    publish(&mut runtime, &driver, snapshot(10.0, 20.0, 30.0, 40.0));
+    let lines = console.lines();
+    assert!(lines[1].contains("10"), "expected updated tuple in {:?}", lines);
+    assert!(lines[1].contains("20"), "expected updated tuple in {:?}", lines);
+    assert!(lines[1].contains("30"), "expected updated tuple in {:?}", lines);
+  }
 
-    #[test]
-    fn persistent_send_provider_failure_returns_from_drain() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "scalar-output");
-        console.fail_next("expected drain failure");
-        driver.publish(snapshot(5.0, 6.0, 7.0, 8.0)).unwrap();
-        let err = runtime.drain_host_inputs(1).unwrap_err();
-        assert!(format!("{err:?}").contains("expected drain failure"));
-    }
+  #[test]
+  fn persistent_send_provider_failure_returns_from_drain() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "scalar-output");
+    console.fail_next("expected drain failure");
+    driver.publish(snapshot(5.0, 6.0, 7.0, 8.0)).unwrap();
+    let err = runtime.drain_host_inputs(1).unwrap_err();
+    assert!(format!("{err:?}").contains("expected drain failure"));
+  }
 
-    #[test]
-    fn persistent_send_replay_does_not_register_another_send() {
-        let (mut runtime, driver, _console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        load(&mut runtime, "scalar-output");
-        assert_eq!(runtime.persistent_send_count(), 1);
-        publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
-        assert_eq!(runtime.persistent_send_count(), 1);
-    }
+  #[test]
+  fn persistent_send_replay_does_not_register_another_send() {
+    let (mut runtime, driver, _console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    load(&mut runtime, "scalar-output");
+    assert_eq!(runtime.persistent_send_count(), 1);
+    publish(&mut runtime, &driver, snapshot(5.0, 6.0, 7.0, 8.0));
+    assert_eq!(runtime.persistent_send_count(), 1);
+  }
 
-    #[test]
-    fn activation_send_registers_one_barrier_per_scope_and_replays_equal_triggers() {
-        let (mut runtime, driver, console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        runtime
-            .run_string(
-                r#"@out := console://console/output{:write(line)}
+  #[test]
+  fn activation_send_registers_one_barrier_per_scope_and_replays_equal_triggers() {
+    let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    runtime.run_string(r#"@out := console://console/output{:write(line)}
 @clock := time://clock/clock{:read(hour)}
 render-tick := @clock/hour
 ~> render-tick {
@@ -2435,69 +1394,33 @@ render-tick := @clock/hour
   @out/line <- "second"
   @out/line <- "third"
 }
-"#,
-            )
-            .unwrap();
+"#).unwrap();
 
-        // Activation effects are registered, rather than evaluated, during load.
-        assert!(console.lines().is_empty());
-        assert_eq!(runtime.persistent_send_count(), 3);
-        let schedules: Vec<_> = runtime
-            .persistent_sends
-            .iter()
-            .map(|send| match send.schedule {
-                RuntimePersistentSendSchedule::Activation {
-                    barrier_node_id, ..
-                } => barrier_node_id,
-                RuntimePersistentSendSchedule::EveryAcceptedTurn => {
-                    panic!("activation send used top-level schedule")
-                }
-            })
-            .collect();
-        assert!(schedules.windows(2).all(|ids| ids[0] == ids[1]));
-        let barriers = runtime
-            .program
-            .interpreter()
-            .plan()
-            .borrow()
-            .nodes
-            .iter()
-            .filter(|node| {
-                node.kind == mech_core::ReactiveNodeKind::Combinational
-                    && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
-                    && node.outputs.is_empty()
-            })
-            .count();
-        assert_eq!(barriers, 1);
+    // Activation effects are registered, rather than evaluated, during load.
+    assert!(console.lines().is_empty());
+    assert_eq!(runtime.persistent_send_count(), 3);
+    let schedules: Vec<_> = runtime.persistent_sends.iter().map(|send| match send.schedule {
+      RuntimePersistentSendSchedule::Activation { barrier_node_id, .. } => barrier_node_id,
+      RuntimePersistentSendSchedule::EveryAcceptedTurn => panic!("activation send used top-level schedule"),
+    }).collect();
+    assert!(schedules.windows(2).all(|ids| ids[0] == ids[1]));
+    let barriers = runtime.program.interpreter().plan().borrow().nodes.iter().filter(|node| {
+      node.kind == mech_core::ReactiveNodeKind::Combinational
+        && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+        && node.outputs.is_empty()
+    }).count();
+    assert_eq!(barriers, 1);
 
-        // Equal admitted values still execute the barrier and replay every send.
-        publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
-        publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
-        assert_eq!(
-            console.lines(),
-            vec![
-                "\"first\"",
-                "\"second\"",
-                "\"third\"",
-                "\"first\"",
-                "\"second\"",
-                "\"third\""
-            ]
-        );
-    }
+    // Equal admitted values still execute the barrier and replay every send.
+    publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
+    publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
+    assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
+  }
 
-    #[test]
-    fn activation_two_clock_physics_render_acceptance() {
-        let provider = TestResourceProvider::new()
-            .with_value("test://physics/timer", "tick", Value::F64(Ref::new(0.0)))
-            .with_value("test://render/timer", "tick", Value::F64(Ref::new(0.0)));
-        let (mut runtime, output) = test_runtime_with_output(provider);
-        grant_read(&mut runtime, "test://physics/timer", "tick");
-        grant_read(&mut runtime, "test://render/timer", "tick");
-        grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
-        runtime
-            .run_string(
-                r#"@physics := test://physics/timer{:read(tick)}
+  #[test]
+  fn activation_two_clock_physics_render_acceptance() {
+    let provider=TestResourceProvider::new().with_value("test://physics/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://physics/timer","tick");grant_read(&mut runtime,"test://render/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@physics := test://physics/timer{:read(tick)}
 @render := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 physics-tick := @physics/tick
@@ -2510,82 +1433,14 @@ render-tick := @render/tick
 ~> render-tick {
   @out/line <- x
 }
-"#,
-            )
-            .unwrap();
-        let initial_plan = activation_plan_snapshot(&runtime);
-        let render_barrier = activation_barrier_for_trigger(&runtime, "render-tick");
-        let physics_combinational_nodes =
-            activation_nodes_for_trigger(&runtime, "physics-tick", ReactiveNodeKind::Combinational);
-        let x_register = register_node_for_symbol(&runtime, "x");
-        assert!(!physics_combinational_nodes.is_empty());
-        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 0.0);
-        assert!(output.lines().is_empty());
-        assert_eq!(activation_send_count(&runtime), 1);
-        let a = apply_f64_input(&mut runtime, "test://physics/timer", "tick", 1.0);
-        let t = only_reactive_turn(&a);
-        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 1.0);
-        assert!(output.lines().is_empty());
-        assert_eq!(executed_count(t, render_barrier), 0);
-        for n in &physics_combinational_nodes {
-            assert_eq!(executed_count(t, *n), 1)
-        }
-        assert_eq!(t.register_commit.committed_nodes, vec![x_register]);
-        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
-        assert_eq!(activation_send_count(&runtime), 1);
-        let a = apply_f64_input(&mut runtime, "test://physics/timer", "tick", 2.0);
-        let t = only_reactive_turn(&a);
-        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 2.0);
-        assert!(output.lines().is_empty());
-        assert_eq!(executed_count(t, render_barrier), 0);
-        for n in &physics_combinational_nodes {
-            assert_eq!(executed_count(t, *n), 1)
-        }
-        assert_eq!(t.register_commit.committed_nodes, vec![x_register]);
-        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
-        assert_eq!(activation_send_count(&runtime), 1);
-        let a = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
-        let t = only_reactive_turn(&a);
-        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 2.0);
-        assert_eq!(output.lines().len(), 1);
-        assert_eq!(recorded_f64(&output, 0), 2.0);
-        assert_eq!(executed_count(t, render_barrier), 1);
-        for n in &physics_combinational_nodes {
-            assert_eq!(executed_count(t, *n), 0)
-        }
-        assert!(!t.before_commit.pending_register_nodes.contains(&x_register));
-        assert!(!t.register_commit.staged_nodes.contains(&x_register));
-        assert!(!t.register_commit.committed_nodes.contains(&x_register));
-        assert!(!t.after_commit.pending_register_nodes.contains(&x_register));
-        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
-        assert_eq!(activation_send_count(&runtime), 1);
-        let a = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
-        assert_eq!(f64_value(&symbol_value(&runtime, "x")), 2.0);
-        assert_eq!(output.lines().len(), 2);
-        assert_eq!(recorded_f64(&output, 0), 2.0);
-        assert_eq!(recorded_f64(&output, 1), 2.0);
-        assert_eq!(executed_count(only_reactive_turn(&a), render_barrier), 1);
-        assert_eq!(activation_plan_snapshot(&runtime), initial_plan);
-        assert_eq!(activation_send_count(&runtime), 1);
-    }
-    #[test]
-    fn activation_send_samples_latest_value_and_ignores_other_updates() {
-        let (mut r, o) = test_runtime_with_output(
-            TestResourceProvider::new()
-                .with_value("test://render/timer", "tick", Value::F64(Ref::new(0.0)))
-                .with_value("test://other/timer", "tick", Value::F64(Ref::new(0.0)))
-                .with_value(TEST_SIGNALS_BASE_URI, "value", Value::F64(Ref::new(1.0))),
-        );
-        for (b, p) in [
-            ("test://render/timer", "tick"),
-            ("test://other/timer", "tick"),
-            (TEST_SIGNALS_BASE_URI, "value"),
-        ] {
-            grant_read(&mut r, b, p)
-        }
-        grant_write(&mut r, TEST_OUTPUT_BASE_URI, "line");
-        r.run_string(
-            r#"@render := test://render/timer{:read(tick)}
+"#).unwrap();let initial_plan=activation_plan_snapshot(&runtime);let render_barrier=activation_barrier_for_trigger(&runtime,"render-tick");let physics_combinational_nodes=activation_nodes_for_trigger(&runtime,"physics-tick",ReactiveNodeKind::Combinational);let x_register=register_node_for_symbol(&runtime,"x");assert!(!physics_combinational_nodes.is_empty());assert_eq!(f64_value(&symbol_value(&runtime,"x")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),1.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",2.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),1);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(executed_count(t,render_barrier),1);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),0)}assert!(!t.before_commit.pending_register_nodes.contains(&x_register));assert!(!t.register_commit.staged_nodes.contains(&x_register));assert!(!t.register_commit.committed_nodes.contains(&x_register));assert!(!t.after_commit.pending_register_nodes.contains(&x_register));assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),2);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(recorded_f64(&output,1),2.0);assert_eq!(executed_count(only_reactive_turn(&a),render_barrier),1);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+  }
+  #[test]
+  fn activation_send_samples_latest_value_and_ignores_other_updates(){let(mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0))).with_value(TEST_SIGNALS_BASE_URI,"value",Value::F64(Ref::new(1.0))));for(b,p)in [("test://render/timer","tick"),("test://other/timer","tick"),(TEST_SIGNALS_BASE_URI,"value")]{grant_read(&mut r,b,p)}grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");r.run_string(r#"@render := test://render/timer{:read(tick)}
 @other := test://other/timer{:read(tick)}
 @signals := test://signals/inputs{:read(value)}
 @out := test://effects/output{:write(line)}
@@ -2598,45 +1453,10 @@ sampled-value := @signals/value
 ~> other-tick {
   other-result := sampled-value + 1.0
 }
-"#,
-        )
-        .unwrap();
-        let b = activation_barrier_for_trigger(&r, "render-tick");
-        let ns = activation_nodes_for_trigger(&r, "other-tick", ReactiveNodeKind::Combinational);
-        assert!(!ns.is_empty());
-        assert!(o.lines().is_empty());
-        let q = apply_f64_input(&mut r, TEST_SIGNALS_BASE_URI, "value", 10.0);
-        assert!(o.lines().is_empty());
-        assert_eq!(executed_count(only_reactive_turn(&q), b), 0);
-        let q = apply_f64_input(&mut r, "test://other/timer", "tick", 1.0);
-        assert!(o.lines().is_empty());
-        assert_eq!(executed_count(only_reactive_turn(&q), b), 0);
-        for n in ns {
-            assert_eq!(executed_count(only_reactive_turn(&q), n), 1)
-        }
-        let q = apply_f64_input(&mut r, "test://render/timer", "tick", 1.0);
-        assert_eq!(o.lines().len(), 1);
-        assert_eq!(recorded_f64(&o, 0), 10.0);
-        assert_eq!(executed_count(only_reactive_turn(&q), b), 1);
-        let q = apply_f64_input(&mut r, TEST_SIGNALS_BASE_URI, "value", 20.0);
-        assert_eq!(o.lines().len(), 1);
-        assert_eq!(executed_count(only_reactive_turn(&q), b), 0);
-        let q = apply_f64_input(&mut r, "test://render/timer", "tick", 1.0);
-        assert_eq!(o.lines().len(), 2);
-        assert_eq!(recorded_f64(&o, 0), 10.0);
-        assert_eq!(recorded_f64(&o, 1), 20.0);
-        assert_eq!(executed_count(only_reactive_turn(&q), b), 1);
-    }
+"#).unwrap();let b=activation_barrier_for_trigger(&r,"render-tick");let ns=activation_nodes_for_trigger(&r,"other-tick",ReactiveNodeKind::Combinational);assert!(!ns.is_empty());assert!(o.lines().is_empty());let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",10.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://other/timer","tick",1.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);for n in ns{assert_eq!(executed_count(only_reactive_turn(&q),n),1)}let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),1);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",20.0);assert_eq!(o.lines().len(),1);assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),2);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(recorded_f64(&o,1),20.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);}
 
-    #[test]
-    fn activation_send_rejects_local_register_mix() {
-        let (mut r, o) = activation_rejection_runtime();
-        let p = activation_plan_snapshot(&r);
-        let n = r.persistent_sends.len();
-        let b = r.live_input_bindings.clone();
-        let e = r
-            .run_string(
-                r#"@tick := test://render/timer{:read(tick)}
+  fn rejected(source:&str, check:impl FnOnce(MechError)){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();check(r.run_string(source).unwrap_err());assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
+  #[test] fn activation_send_rejects_local_register_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 ~x := 0.0
@@ -2644,25 +1464,8 @@ render-tick := @tick/tick
   x = x + 1.0
   @out/line <- x
 }
-"#,
-            )
-            .unwrap_err();
-        assert!(
-            e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>()
-                .is_some(),
-            "unexpected error: {e:?}"
-        );
-        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
-    }
-    #[test]
-    fn activation_send_rejects_local_op_assign_mix() {
-        let (mut r, o) = activation_rejection_runtime();
-        let p = activation_plan_snapshot(&r);
-        let n = r.persistent_sends.len();
-        let b = r.live_input_bindings.clone();
-        let e = r
-            .run_string(
-                r#"@tick := test://render/timer{:read(tick)}
+"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
+  #[test] fn activation_send_rejects_local_op_assign_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 ~x := 0.0
@@ -2670,25 +1473,8 @@ render-tick := @tick/tick
   x += 1.0
   @out/line <- x
 }
-"#,
-            )
-            .unwrap_err();
-        assert!(
-            e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>()
-                .is_some(),
-            "unexpected error: {e:?}"
-        );
-        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
-    }
-    #[test]
-    fn activation_send_rejects_context_assignment_in_scope() {
-        let (mut r, o) = activation_rejection_runtime();
-        let p = activation_plan_snapshot(&r);
-        let n = r.persistent_sends.len();
-        let b = r.live_input_bindings.clone();
-        let e = r
-            .run_string(
-                r#"@tick := test://render/timer{:read(tick)}
+"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
+  #[test] fn activation_send_rejects_context_assignment_in_scope(){rejected(r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 x := 1.0
@@ -2696,51 +1482,14 @@ x := 1.0
   @out/line = x
   @out/line <- x
 }
-"#,
-            )
-            .unwrap_err();
-        let k = e
-            .kind_as::<RuntimeInvalidOperationError>()
-            .expect("expected RuntimeInvalidOperationError");
-        assert_eq!(k.operation, "direct_context_effect_placement");
-        assert!(
-            k.reason.contains("context assignment"),
-            "unexpected placement reason: {}",
-            k.reason
-        );
-        assert!(
-            e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>()
-                .is_none()
-        );
-        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
-    }
-
-    #[test]
-    fn activation_send_rejects_isolated_registration() {
-        let (mut r, o) = activation_rejection_runtime();
-        let p = activation_plan_snapshot(&r);
-        let n = r.persistent_sends.len();
-        let b = r.live_input_bindings.clone();
-        let mut c = r.runtime_context().unwrap();
-        let e = r
-            .run_string_with_isolated_registration_for_test(
-                &mut c,
-                r#"@tick := test://render/timer{:read(tick)}
+"#,|e|{let k=e.kind_as::<RuntimeInvalidOperationError>().expect("expected RuntimeInvalidOperationError");assert_eq!(k.operation,"direct_context_effect_placement");assert!(k.reason.contains("context assignment"),"unexpected placement reason: {}",k.reason);assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_none());});}
+  #[test] fn activation_send_rejects_isolated_registration(){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();let mut c=r.runtime_context().unwrap();let e=r.run_string_with_isolated_registration_for_test(&mut c,r#"@tick := test://render/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
 render-tick := @tick/tick
 ~> render-tick {
   @out/line <- render-tick
 }
-"#,
-            )
-            .unwrap_err();
-        assert!(
-            e.kind_as::<RuntimeIsolatedActivationSendUnsupported>()
-                .is_some(),
-            "unexpected error: {e:?}"
-        );
-        assert_rejected_activation_left_no_state(&r, &o, &p, n, &b);
-    }
+"#).unwrap_err();assert!(e.kind_as::<RuntimeIsolatedActivationSendUnsupported>().is_some(),"unexpected error: {e:?}");assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
 
     #[test]
     fn activation_send_reactive_failure_produces_no_writes() {
@@ -2996,77 +1745,20 @@ after :=
         assert_eq!(recorded_f64(&output, 0), 7.0);
     }
 
-    #[test]
-    fn activation_internal_barrier_is_not_user_callable() {
-        let (mut runtime, _driver, _console) =
-            runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
-        let error = runtime
-            .run_string("mech/runtime/activation-effect-barrier()")
-            .unwrap_err();
-        assert!(format!("{error:?}").contains("MissingFunction"));
-    }
+  #[test]
+  fn activation_internal_barrier_is_not_user_callable() {
+    let (mut runtime, _driver, _console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
+    let error = runtime.run_string("mech/runtime/activation-effect-barrier()").unwrap_err();
+    assert!(format!("{error:?}").contains("MissingFunction"));
+  }
 }
 
 #[test]
 fn runtime_reactive_host_input_preserves_deferred_registers_across_packets() {
-    let mut runtime = test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
-    grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
-    let mut context = runtime.runtime_context().unwrap();
-    runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0").unwrap();
-    let a = register_node_for_symbol(&runtime, "a");
-    let b = register_node_for_symbol(&runtime, "b");
-    let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
-    assert_eq!(f64_value(&symbol_value(&runtime, "a")), 1.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "middle")), 2.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0);
-    assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0);
-    let first = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            source.clone(),
-            RuntimeHostInputValue::F64(10.0),
-        ))
-        .unwrap();
-    let turn = &first.turn.as_ref().unwrap().interpreter_turns[0].turn;
-    assert_eq!(turn.register_commit.committed_nodes, vec![a]);
-    assert_eq!(turn.after_commit.pending_register_nodes, vec![b]);
-    assert_eq!(
-        (
-            f64_value(&symbol_value(&runtime, "a")),
-            f64_value(&symbol_value(&runtime, "middle")),
-            f64_value(&symbol_value(&runtime, "b")),
-            f64_value(&symbol_value(&runtime, "output"))
-        ),
-        (10.0, 11.0, 2.0, 3.0)
-    );
-    assert!(
-        runtime
-            .program
-            .interpreter()
-            .has_pending_reactive_registers()
-    );
-    let second = runtime
-        .apply_host_input(RuntimeHostInput::single(
-            source,
-            RuntimeHostInputValue::F64(20.0),
-        ))
-        .unwrap();
-    let turn = &second.turn.as_ref().unwrap().interpreter_turns[0].turn;
-    assert_eq!(turn.before_commit.pending_register_nodes, vec![a]);
-    assert_eq!(turn.register_commit.committed_nodes, vec![a, b]);
-    assert_eq!(turn.after_commit.pending_register_nodes, vec![b]);
-    assert_eq!(
-        (
-            f64_value(&symbol_value(&runtime, "a")),
-            f64_value(&symbol_value(&runtime, "middle")),
-            f64_value(&symbol_value(&runtime, "b")),
-            f64_value(&symbol_value(&runtime, "output"))
-        ),
-        (20.0, 21.0, 11.0, 12.0)
-    );
-    assert!(
-        runtime
-            .program
-            .interpreter()
-            .has_pending_reactive_registers()
-    );
+  let mut runtime = test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0)); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\n~a := 0.0\n~b := 0.0\na = @pulse/value\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0").unwrap();
+  let a = register_node_for_symbol(&runtime, "a"); let b = register_node_for_symbol(&runtime, "b"); let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "a")), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "middle")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "b")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 3.0);
+  let first = runtime.apply_host_input(RuntimeHostInput::single(source.clone(), RuntimeHostInputValue::F64(10.0))).unwrap(); let turn = &first.turn.as_ref().unwrap().interpreter_turns[0].turn; assert_eq!(turn.register_commit.committed_nodes, vec![a]); assert_eq!(turn.after_commit.pending_register_nodes, vec![b]); assert_eq!((f64_value(&symbol_value(&runtime, "a")), f64_value(&symbol_value(&runtime, "middle")), f64_value(&symbol_value(&runtime, "b")), f64_value(&symbol_value(&runtime, "output"))), (10.0, 11.0, 2.0, 3.0)); assert!(runtime.program.interpreter().has_pending_reactive_registers());
+  let second = runtime.apply_host_input(RuntimeHostInput::single(source, RuntimeHostInputValue::F64(20.0))).unwrap(); let turn = &second.turn.as_ref().unwrap().interpreter_turns[0].turn; assert_eq!(turn.before_commit.pending_register_nodes, vec![a]); assert_eq!(turn.register_commit.committed_nodes, vec![a, b]); assert_eq!(turn.after_commit.pending_register_nodes, vec![b]); assert_eq!((f64_value(&symbol_value(&runtime, "a")), f64_value(&symbol_value(&runtime, "middle")), f64_value(&symbol_value(&runtime, "b")), f64_value(&symbol_value(&runtime, "output"))), (20.0, 21.0, 11.0, 12.0)); assert!(runtime.program.interpreter().has_pending_reactive_registers());
 }

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -155,6 +155,13 @@ struct RuntimePersistentSend {
   binding: RuntimeContextBinding,
   path: String,
   value: ValRef,
+  schedule: RuntimePersistentSendSchedule,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RuntimePersistentSendSchedule {
+  EveryAcceptedTurn,
+  Activation { interpreter_id: u64, marker_node_id: mech_core::ReactiveNodeId },
 }
 
 use crate::capability::{

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -161,7 +161,7 @@ struct RuntimePersistentSend {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RuntimePersistentSendSchedule {
   EveryAcceptedTurn,
-  Activation { interpreter_id: u64, marker_node_id: mech_core::ReactiveNodeId },
+  Activation { interpreter_id: u64, barrier_node_id: mech_core::ReactiveNodeId },
 }
 
 use crate::capability::{

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3360,6 +3360,126 @@ result := \"x\"?
 }
 
 #[test]
+fn activation_arm_pattern_context_read_fails_preflight_before_stdout_write() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@env := cli://env{:read(HOME)}
+@out/line <- \"must-not-write\"
+event := \"x\"
+~> event
+  | (@env/HOME) => {
+      selected := true
+    }
+  | * => {
+      selected := false
+    }
+",
+  );
+
+  assert!(result.is_err(), "activation arm context read should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeCapabilityGrantDenied") || error.contains("context_read"),
+    "expected context read preflight error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
+fn activation_arm_context_read_pattern_is_lowered_when_allowed() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  state.lock().unwrap().env.insert(
+    "MECH_ACTIVATION_PATTERN".to_string(),
+    "expected".to_string(),
+  );
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject,
+    resource: "cli://cli/env".to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec!["MECH_ACTIVATION_PATTERN".to_string()],
+  }).unwrap();
+
+  let result = runtime.run_string(
+    "@env := cli://env{:read(MECH_ACTIVATION_PATTERN)}
+event := \"expected\"
+~> event
+  | (@env/MECH_ACTIVATION_PATTERN) => {
+      selected := true
+    }
+  | * => {
+      selected := false
+    }
+",
+  );
+
+  assert!(result.is_ok(), "allowed activation context pattern failed: {result:?}");
+  assert_eq!(runtime.live_input_binding_count(), 1);
+  let registration = {
+    let plan = runtime.program().interpreter().plan();
+    let registrations = plan.pattern_activation_registrations();
+    assert_eq!(registrations.len(), 1);
+    registrations[0].clone()
+  };
+
+  let update = runtime.apply_host_input(RuntimeHostInput::single(
+    RuntimeHostInputSource::new("cli://env", "MECH_ACTIVATION_PATTERN").unwrap(),
+    RuntimeHostInputValue::String("next".to_string()),
+  )).unwrap();
+  assert_eq!(update.binding_count, 1);
+  assert_eq!(update.ignored_update_count, 0);
+  if let Some(turn) = &update.turn {
+    for interpreter_turn in &turn.interpreter_turns {
+      let executed_nodes = interpreter_turn
+        .turn
+        .before_commit
+        .executed_nodes
+        .iter()
+        .chain(interpreter_turn.turn.after_commit.executed_nodes.iter())
+        .copied()
+        .collect::<Vec<_>>();
+      assert!(!executed_nodes.contains(&registration.scope_pulse_node));
+      assert!(!executed_nodes.contains(&registration.selector_node));
+      for arm in &registration.arms {
+        assert!(!executed_nodes.contains(&arm.matcher_node));
+        assert!(!executed_nodes.contains(&arm.finalizer_node));
+        assert!(!executed_nodes.contains(&arm.gate_node));
+      }
+    }
+  }
+
+  let trigger = {
+    let symbols = runtime.program().interpreter().symbols();
+    let event = symbols.borrow().get(hash_str("event")).unwrap().borrow().clone();
+    event.reactive_root_cell_ids()[0]
+  };
+  let trigger_turn = runtime
+    .program_mut()
+    .interpreter_mut()
+    .advance_reactive_turn(&[trigger])
+    .unwrap();
+  let changed_nodes = trigger_turn
+    .before_commit
+    .changed_nodes
+    .iter()
+    .chain(trigger_turn.after_commit.changed_nodes.iter())
+    .copied()
+    .collect::<Vec<_>>();
+  assert!(!changed_nodes.contains(&registration.arms[0].gate_node));
+  assert!(
+    changed_nodes.contains(&registration.arms[1].gate_node),
+    "the trigger did not sample the updated pattern value",
+  );
+}
+
+#[test]
 fn fsm_pipe_transition_context_read_fails_preflight_before_stdout_write() {
   let (mut runtime, state) = runtime_with_recording_cli();
   grant_runtime_stdout_line(&mut runtime);

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -1,0 +1,39 @@
+//! Parser for the source activation block (`~> trigger { ... }`).
+use crate::*;
+use mech_core::nodes::*;
+use nom::{Err, combinator::cut};
+
+/// activation-scope := "~>", whitespace0, expression, whitespace0, "{", mech-code, "}" ;
+/// The header deliberately uses the ordinary expression parser; semantic validation
+/// of the stable-reference restriction belongs to elaboration.
+pub fn activation_scope(input: ParseString) -> ParseResult<ActivationScope> {
+  let (input, _) = tag("~>")(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, trigger) = cut(expression)(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, _) = cut(left_brace)(input)?;
+  let (input, _) = whitespace0(input)?;
+  let (input, parsed) = mech_code(input)?;
+  let (input, _) = cut(right_brace)(input)?;
+  Ok((input, ActivationScope { trigger, body: parsed.code }))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  #[test]
+  fn activation_scope_parses_wildcard_block_form() {
+    let program = parse("~> tick {\n  output := x + 1\n}").expect("activation scope parses");
+    let code = &program.body.sections[0].elements;
+    assert!(format!("{:?}", code).contains("ActivationScope"));
+  }
+  #[test]
+  fn activation_scope_does_not_conflict_with_mutable_definition() {
+    let program = parse("~x := 10\n~> tick {\n output := x + 1\n}").expect("parse");
+    assert!(format!("{:?}", program).contains("ActivationScope"));
+  }
+  #[test]
+  fn activation_scope_parses_nested_record_literal() {
+    assert!(parse("~> tick {\n point := { x: x, y: y }\n}").is_ok());
+  }
+}

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -10,9 +10,13 @@ pub fn activation_scope(input: ParseString) -> ParseResult<ActivationScope> {
   let (input, _) = whitespace0(input)?;
   let (input, body) = if let Ok((input, _)) = left_brace(input.clone()) {
     let (input, _) = whitespace0(input)?;
-    let (input, parsed) = mech_code(input)?;
-    let (input, _) = cut(right_brace)(input)?;
-    (input, ActivationBody::Block(parsed.code))
+    if let Ok((input, _)) = right_brace(input.clone()) {
+      (input, ActivationBody::Block(Vec::new()))
+    } else {
+      let (input, parsed) = mech_code(input)?;
+      let (input, _) = cut(right_brace)(input)?;
+      (input, ActivationBody::Block(parsed.code))
+    }
   } else {
     let (input, arms) = cut(many1(activation_arm))(input)?;
     let (input, _) = opt(period)(input)?;
@@ -29,9 +33,13 @@ fn activation_arm(input: ParseString) -> ParseResult<ActivationArm> {
   let (input, _) = whitespace0(input)?;
   if let Ok((input, _)) = left_brace(input.clone()) {
     let (input, _) = whitespace0(input)?;
-    let (input, parsed) = mech_code(input)?;
-    let (input, _) = cut(right_brace)(input)?;
-    Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(parsed.code) }))
+    if let Ok((input, _)) = right_brace(input.clone()) {
+      Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(Vec::new()) }))
+    } else {
+      let (input, parsed) = mech_code(input)?;
+      let (input, _) = cut(right_brace)(input)?;
+      Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(parsed.code) }))
+    }
   } else {
     let (input, expression) = expression(input)?;
     let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
@@ -45,6 +53,29 @@ mod tests {
   #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
   #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
   #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
+  #[test] fn activation_scope_parses_empty_fixed_and_pattern_blocks() {
+    let fixed = parse("~> tick {}").unwrap();
+    let SectionElement::MechCode(fixed) = &fixed.body.sections[0].elements[0] else {
+      panic!("expected fixed activation code");
+    };
+    assert!(matches!(
+      &fixed[0].0,
+      MechCode::ActivationScope(ActivationScope { body: ActivationBody::Block(body), .. })
+        if body.is_empty()
+    ));
+
+    let patterned = parse("~> tick\n | value, value > 0 => {\n output := value\n }\n | * => {}").unwrap();
+    let SectionElement::MechCode(patterned) = &patterned.body.sections[0].elements[0] else {
+      panic!("expected patterned activation code");
+    };
+    let MechCode::ActivationScope(ActivationScope {
+      body: ActivationBody::PatternArms(arms),
+      ..
+    }) = &patterned[0].0 else {
+      panic!("expected patterned activation");
+    };
+    assert!(matches!(&arms[1].body, ActivationArmBody::Block(body) if body.is_empty()));
+  }
   #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); let SectionElement::MechCode(code) = &p.body.sections[0].elements[0] else { panic!("expected Mech code") }; assert!(matches!(&code[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
   #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -45,6 +45,6 @@ mod tests {
   #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
   #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
   #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
-  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); assert!(matches!(p.body.sections[0].elements[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
+  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); let SectionElement::MechCode(code) = &p.body.sections[0].elements[0] else { panic!("expected Mech code") }; assert!(matches!(&code[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
   #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -1,21 +1,20 @@
 //! Parser for the source activation block (`~> trigger { ... }`).
 use crate::*;
 use mech_core::nodes::*;
-use nom::{Err, combinator::cut};
+use nom::combinator::cut;
 
 /// activation-scope := "~>", whitespace0, expression, whitespace0, "{", mech-code, "}" ;
 /// The header deliberately uses the ordinary expression parser; semantic validation
 /// of the stable-reference restriction belongs to elaboration.
 pub fn activation_scope(input: ParseString) -> ParseResult<ActivationScope> {
-  let (input, _) = tag("~>")(input)?;
-  let (input, _) = whitespace0(input)?;
+  let (input, operator) = async_transition_operator(input)?;
   let (input, trigger) = cut(expression)(input)?;
   let (input, _) = whitespace0(input)?;
   let (input, _) = cut(left_brace)(input)?;
   let (input, _) = whitespace0(input)?;
   let (input, parsed) = mech_code(input)?;
   let (input, _) = cut(right_brace)(input)?;
-  Ok((input, ActivationScope { trigger, body: parsed.code }))
+  Ok((input, ActivationScope { operator, trigger, body: parsed.code }))
 }
 
 #[cfg(test)]

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -1,38 +1,50 @@
-//! Parser for the source activation block (`~> trigger { ... }`).
+//! Parser for source activation scopes.
 use crate::*;
 use mech_core::nodes::*;
-use nom::combinator::cut;
+use nom::{branch::alt, combinator::{cut, opt}, multi::many1, sequence::preceded};
 
-/// activation-scope := "~>", whitespace0, expression, whitespace0, "{", mech-code, "}" ;
-/// The header deliberately uses the ordinary expression parser; semantic validation
-/// of the stable-reference restriction belongs to elaboration.
+/// activation-scope := "~>" expression ("{" mech-code "}" | activation-arm+) ;
 pub fn activation_scope(input: ParseString) -> ParseResult<ActivationScope> {
   let (input, operator) = async_transition_operator(input)?;
   let (input, trigger) = cut(expression)(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, _) = cut(left_brace)(input)?;
+  let (input, body) = if let Ok((input, _)) = left_brace(input.clone()) {
+    let (input, _) = whitespace0(input)?;
+    let (input, parsed) = mech_code(input)?;
+    let (input, _) = cut(right_brace)(input)?;
+    (input, ActivationBody::Block(parsed.code))
+  } else {
+    let (input, arms) = cut(many1(activation_arm))(input)?;
+    let (input, _) = opt(period)(input)?;
+    (input, ActivationBody::PatternArms(arms))
+  };
+  Ok((input, ActivationScope { operator, trigger, body }))
+}
+
+fn activation_arm(input: ParseString) -> ParseResult<ActivationArm> {
+  let (input, _) = crate::state_machines::guard_operator(input)?;
+  let (input, pattern) = crate::patterns::pattern(input)?;
+  let (input, guard) = opt(preceded(list_separator, preceded(whitespace0, expression)))(input)?;
+  let (input, _) = output_operator(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, parsed) = mech_code(input)?;
-  let (input, _) = cut(right_brace)(input)?;
-  Ok((input, ActivationScope { operator, trigger, body: parsed.code }))
+  if let Ok((input, _)) = left_brace(input.clone()) {
+    let (input, _) = whitespace0(input)?;
+    let (input, parsed) = mech_code(input)?;
+    let (input, _) = cut(right_brace)(input)?;
+    Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(parsed.code) }))
+  } else {
+    let (input, expression) = expression(input)?;
+    let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
+    Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Expression(expression) }))
+  }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  #[test]
-  fn activation_scope_parses_wildcard_block_form() {
-    let program = parse("~> tick {\n  output := x + 1\n}").expect("activation scope parses");
-    let code = &program.body.sections[0].elements;
-    assert!(format!("{:?}", code).contains("ActivationScope"));
-  }
-  #[test]
-  fn activation_scope_does_not_conflict_with_mutable_definition() {
-    let program = parse("~x := 10\n~> tick {\n output := x + 1\n}").expect("parse");
-    assert!(format!("{:?}", program).contains("ActivationScope"));
-  }
-  #[test]
-  fn activation_scope_parses_nested_record_literal() {
-    assert!(parse("~> tick {\n point := { x: x, y: y }\n}").is_ok());
-  }
+  #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
+  #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
+  #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
+  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); assert!(matches!(p.body.sections[0].elements[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
+  #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2011,24 +2011,36 @@ impl Formatter {
   }
 
   pub fn activation_scope(&mut self, node: &ActivationScope) -> String {
-    let mut lines = vec![format!("{} {} {{", node.operator.to_string(), self.expression(&node.trigger))];
-    for (code, comment) in &node.body {
-      let source = match code {
-        MechCode::Comment(value) => self.comment(value),
-        MechCode::ActivationScope(value) => self.activation_scope(value),
-        MechCode::Expression(value) => self.expression(value),
-        MechCode::FsmSpecification(value) => self.fsm_specification(value),
-        MechCode::FsmImplementation(value) => self.fsm_implementation(value),
-        MechCode::FunctionDefine(value) => self.function_define(value),
-        MechCode::Import(value) => self.module_import(value),
-        MechCode::Statement(value) => self.statement(value),
-        MechCode::Error(token, _) => token.to_string(),
-      };
-      lines.extend(source.lines().map(|line| format!("  {line}")));
-      if let Some(value) = comment { lines.push(format!("  {}", self.comment(value))); }
+    let header = format!("{} {}", node.operator.to_string(), self.expression(&node.trigger));
+    match &node.body {
+      ActivationBody::Block(body) => {
+        let mut lines = vec![format!("{header} {{")];
+        lines.extend(self.activation_block_lines(body, 2));
+        lines.push("}".to_string());
+        lines.join("\n")
+      }
+      ActivationBody::PatternArms(arms) => {
+        let mut lines = vec![header];
+        for (index, arm) in arms.iter().enumerate() {
+          let guard = arm.guard.as_ref().map(|guard| format!(", {}", self.expression(guard))).unwrap_or_default();
+          let prefix = format!("  | {}{} =>", self.pattern(&arm.pattern), guard);
+          match &arm.body {
+            ActivationArmBody::Block(body) => { lines.push(format!("{prefix} {{")); lines.extend(self.activation_block_lines(body, 6)); lines.push("  }".to_string()); }
+            ActivationArmBody::Expression(expression) => { let period = if index + 1 == arms.len() { "." } else { "" }; lines.push(format!("{prefix} {}{period}", self.expression(expression))); }
+          }
+        }
+        lines.join("\n")
+      }
     }
-    lines.push("}".to_string());
-    lines.join("\n")
+  }
+
+  fn activation_block_lines(&mut self, body: &Vec<(MechCode, Option<Comment>)>, indent: usize) -> Vec<String> {
+    let padding = " ".repeat(indent); let mut lines = vec![];
+    for (code, comment) in body {
+      let source = match code { MechCode::Comment(value) => self.comment(value), MechCode::ActivationScope(value) => self.activation_scope(value), MechCode::Expression(value) => self.expression(value), MechCode::FsmSpecification(value) => self.fsm_specification(value), MechCode::FsmImplementation(value) => self.fsm_implementation(value), MechCode::FunctionDefine(value) => self.function_define(value), MechCode::Import(value) => self.module_import(value), MechCode::Statement(value) => self.statement(value), MechCode::Error(token, _) => token.to_string() };
+      lines.extend(source.lines().map(|line| format!("{padding}{line}"))); if let Some(value) = comment { lines.push(format!("{padding}{}", self.comment(value))); }
+    }
+    lines
   }
 
   pub fn statement(&mut self, node: &Statement) -> String {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -680,7 +680,7 @@ impl Formatter {
     for (code,cmmnt) in &block.code {
       let c = match code {
         MechCode::Comment(cmnt) => self.comment(cmnt),
-        MechCode::ActivationScope(scope) => format!("~> {} {{ … }}", self.expression(&scope.trigger)),
+        MechCode::ActivationScope(scope) => self.activation_scope(scope),
         MechCode::Expression(expr) => self.expression(expr),
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
@@ -1542,7 +1542,7 @@ impl Formatter {
     for (code,cmmnt) in node {
       let c = match code {
         MechCode::Comment(cmnt) => self.comment(cmnt),
-        MechCode::ActivationScope(scope) => format!("~> {} {{ … }}", self.expression(&scope.trigger)),
+        MechCode::ActivationScope(scope) => self.activation_scope(scope),
         MechCode::Expression(expr) => self.expression(expr),
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
@@ -2008,6 +2008,27 @@ impl Formatter {
     } else {
       format!("{} {} {}", name, ":=", expression)
     }
+  }
+
+  pub fn activation_scope(&mut self, node: &ActivationScope) -> String {
+    let mut lines = vec![format!("{} {} {{", node.operator.to_string(), self.expression(&node.trigger))];
+    for (code, comment) in &node.body {
+      let source = match code {
+        MechCode::Comment(value) => self.comment(value),
+        MechCode::ActivationScope(value) => self.activation_scope(value),
+        MechCode::Expression(value) => self.expression(value),
+        MechCode::FsmSpecification(value) => self.fsm_specification(value),
+        MechCode::FsmImplementation(value) => self.fsm_implementation(value),
+        MechCode::FunctionDefine(value) => self.function_define(value),
+        MechCode::Import(value) => self.module_import(value),
+        MechCode::Statement(value) => self.statement(value),
+        MechCode::Error(token, _) => token.to_string(),
+      };
+      lines.extend(source.lines().map(|line| format!("  {line}")));
+      if let Some(value) = comment { lines.push(format!("  {}", self.comment(value))); }
+    }
+    lines.push("}".to_string());
+    lines.join("\n")
   }
 
   pub fn statement(&mut self, node: &Statement) -> String {

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -680,6 +680,7 @@ impl Formatter {
     for (code,cmmnt) in &block.code {
       let c = match code {
         MechCode::Comment(cmnt) => self.comment(cmnt),
+        MechCode::ActivationScope(scope) => format!("~> {} {{ … }}", self.expression(&scope.trigger)),
         MechCode::Expression(expr) => self.expression(expr),
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
@@ -1541,6 +1542,7 @@ impl Formatter {
     for (code,cmmnt) in node {
       let c = match code {
         MechCode::Comment(cmnt) => self.comment(cmnt),
+        MechCode::ActivationScope(scope) => format!("~> {} {{ … }}", self.expression(&scope.trigger)),
         MechCode::Expression(expr) => self.expression(expr),
         MechCode::FsmImplementation(fsm_impl) => self.fsm_implementation(fsm_impl),
         MechCode::FsmSpecification(fsm_spec) => self.fsm_specification(fsm_spec),

--- a/src/syntax/src/lib.rs
+++ b/src/syntax/src/lib.rs
@@ -44,6 +44,7 @@ pub mod mechdown;
 pub mod imports;
 pub mod expressions;
 pub mod statements;
+pub mod activation;
 pub mod structures;
 pub mod base;
 pub mod parser;
@@ -64,6 +65,7 @@ pub use crate::parser::*;
 pub use crate::mechdown::*;
 pub use crate::expressions::*;
 pub use crate::statements::*;
+pub use crate::activation::*;
 pub use crate::structures::*;
 pub use crate::base::*;
 #[cfg(feature = "formatter")]

--- a/src/syntax/src/parser.rs
+++ b/src/syntax/src/parser.rs
@@ -318,10 +318,11 @@ where
 // 4. Public interface
 // ---------------------
 
-// mech_code_alt := fsm_specification | fsm_implementation | function_define | statement | expression | comment ;
+// mech_code_alt := activation_scope | fsm_specification | fsm_implementation | function_define | statement | expression | comment ;
 pub fn mech_code_alt(input: ParseString) -> ParseResult<MechCode> {
   let (input, _) = whitespace0(input)?;
   let parsers: Vec<(&str, Box<dyn Fn(ParseString) -> ParseResult<MechCode>>)> = vec![
+    ("activation_scope", Box::new(|i| activation_scope(i).map(|(i, v)| (i, MechCode::ActivationScope(v))))),
     ("fsm_specification", Box::new(|i| fsm_specification(i).map(|(i, v)| (i, MechCode::FsmSpecification(v))))),
     ("fsm_implementation", Box::new(|i| fsm_implementation(i).map(|(i, v)| (i, MechCode::FsmImplementation(v))))),
     ("function_define", Box::new(|i| function_define(i).map(|(i, v)| (i, MechCode::FunctionDefine(v))))),

--- a/src/syntax/src/parser.rs
+++ b/src/syntax/src/parser.rs
@@ -342,11 +342,11 @@ pub fn mech_code_alt(input: ParseString) -> ParseResult<MechCode> {
 
 }
 
-/// code-terminal := *space-tab, ?(?semicolon, *space-tab, comment), (new-line | ";" | eof), *whitespace ;
+/// code-terminal := *space-tab, ?(?semicolon, *space-tab, comment), (new-line | ";" | right-brace | eof), *whitespace ;
 pub fn code_terminal(input: ParseString) -> ParseResult<Option<Comment>> {
   let (input, _) = many0(space_tab)(input)?;
   let (input, cmmnt) = opt(tuple((opt(semicolon), many0(space_tab), comment)))(input)?;
-  let (input, _) = alt((null(new_line), null(semicolon), null(eof), null(peek(mika_section_close))))(input)?;
+  let (input, _) = alt((null(new_line), null(semicolon), null(peek(right_brace)), null(eof), null(peek(mika_section_close))))(input)?;
   let (input, _) = whitespace0(input)?;
   let cmmt = match cmmnt {
     Some((_, _, cmnt)) => Some(cmnt),

--- a/src/syntax/src/patterns.rs
+++ b/src/syntax/src/patterns.rs
@@ -54,11 +54,7 @@ fn spread_operator(input: ParseString) -> ParseResult<()> {
 }
 
 fn pattern_array_item(input: ParseString) -> ParseResult<Pattern> {
-  if let Ok((input, _)) = wildcard(input.clone()) {
-    return Ok((input, Pattern::Wildcard));
-  }
-  let (input, expr) = expression(input)?;
-  Ok((input, Pattern::Expression(expr)))
+  pattern(input)
 }
 
 #[derive(Clone)]
@@ -256,4 +252,76 @@ pub fn pattern_tuple(input: ParseString) -> ParseResult<PatternTuple> {
   let (input, _) = whitespace0(input)?;
   let (input, _) = right_parenthesis(input)?;
   Ok((input, PatternTuple(patterns)))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn parse_array_pattern(source: &str) -> PatternArray {
+    let graphemes = crate::graphemes::init_tag(source);
+    let input = ParseString::new(&graphemes);
+    let (remaining, parsed) = pattern(input).expect("expected array pattern to parse");
+    assert!(remaining.is_empty(), "expected the whole array pattern to be consumed");
+    match parsed {
+      Pattern::Array(array) => array,
+      other => panic!("expected Pattern::Array, got {:?}", other),
+    }
+  }
+
+  #[test]
+  fn array_items_accept_recursive_patterns_around_spread() {
+    let array = parse_array_pattern("[(left, right), ..., :some((payload, nested))]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Tuple(_)]));
+    assert!(matches!(
+      array.spread,
+      Some(PatternArraySpread {
+        kind: PatternArraySpreadKind::Spread,
+        binding: None,
+      })
+    ));
+    let [Pattern::TupleStruct(variant)] = array.suffix.as_slice() else {
+      panic!("expected a tagged suffix pattern");
+    };
+    assert_eq!(variant.patterns.len(), 1);
+    assert!(matches!(variant.patterns[0], Pattern::Tuple(_)));
+  }
+
+  #[test]
+  fn array_rest_binding_accepts_recursive_pattern() {
+    let array = parse_array_pattern("[(:head(value), other) | :tail((left, right))]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Tuple(_)]));
+    let Some(PatternArraySpread {
+      kind: PatternArraySpreadKind::Rest,
+      binding: Some(binding),
+    }) = array.spread else {
+      panic!("expected a recursively patterned rest binding");
+    };
+    assert!(matches!(*binding, Pattern::TupleStruct(_)));
+    assert!(array.suffix.is_empty());
+  }
+
+  #[test]
+  fn array_rest_binding_accepts_nested_array_pattern() {
+    let array = parse_array_pattern("[head | [second, ..., last]]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Expression(_)]));
+    let Some(PatternArraySpread {
+      kind: PatternArraySpreadKind::Rest,
+      binding: Some(binding),
+    }) = array.spread else {
+      panic!("expected an array-patterned rest binding");
+    };
+    let Pattern::Array(nested) = *binding else {
+      panic!("expected the rest binding to be an array pattern");
+    };
+    assert_eq!(nested.prefix.len(), 1);
+    assert!(matches!(
+      nested.spread,
+      Some(PatternArraySpread {
+        kind: PatternArraySpreadKind::Spread,
+        binding: None,
+      })
+    ));
+    assert_eq!(nested.suffix.len(), 1);
+  }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -407,6 +407,66 @@ test_interpreter!(
   Value::U64(Ref::new(42))
 );
 test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_recursive_rest_across_function_fsm_match_and_comprehension,
+  r#"
+probe(xs<[u64]>) => <u64>
+  | [head | [second, ..., last]] => head + second + last
+  | * => 0u64.
+
+#Probe(xs<[u64]>) => <u64>
+  ├ :Scan(xs<[u64]>)
+  └ :Done(out<u64>).
+
+#Probe(xs) -> :Scan(xs)
+  :Scan([head | [second, ..., last]]) -> :Done(head + second + last)
+  :Scan(*) -> :Done(0u64)
+  :Done(out) => out.
+
+value := [1u64 2u64 3u64 4u64]
+function-result := probe(value)
+fsm-result := #Probe(value)
+match-result := value?
+  | [head | [second, ..., last]] => head + second + last
+  | * => 0u64.
+comprehension-result := [head + second + last | [head | [second, ..., last]] <- {value}]
+function-result + fsm-result + match-result + comprehension-result[1]
+"#,
+  Value::U64(Ref::new(28))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_repeated_binding_and_first_arm_across_dispatch_contexts,
+  r#"
+probe(xs<[u64]>) => <u64>
+  | [x, x] => x
+  | [x, ...] => 99u64
+  | * => 0u64.
+
+#Probe(xs<[u64]>) => <u64>
+  ├ :Scan(xs<[u64]>)
+  └ :Done(out<u64>).
+
+#Probe(xs) -> :Scan(xs)
+  :Scan([x, x]) -> :Done(x)
+  :Scan([x, ...]) -> :Done(99u64)
+  :Scan(*) -> :Done(0u64)
+  :Done(out) => out.
+
+equal := [3u64 3u64]
+unequal := [3u64 4u64]
+function-result := probe(equal)
+fsm-result := #Probe(equal)
+match-equal := equal? | [x, x] => x | [x, ...] => 99u64 | * => 0u64.
+match-unequal := unequal? | [x, x] => x | [x, ...] => 99u64 | * => 0u64.
+generated := [x | [x, x] <- {equal, unequal}]
+function-result + fsm-result + match-equal + match-unequal + generated[1]
+"#,
+  Value::U64(Ref::new(111))
+);
 test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>
   ├ :Start(arr<[u64]>)
@@ -1635,6 +1695,65 @@ test_interpreter!(interpret_set_comprehension, r#"{ x * x | x <- {1,2,3,4}, y :=
 test_interpreter!(interpret_set_comprehension_variable, r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0))]))));
 test_interpreter!(interpret_set_comprehension_tuple, r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(25.0)), Value::F64(Ref::new(49.0))]))));
 test_interpreter!(interpret_set_comprehension_fof, r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(8.0))]))));
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_repeated_binding,
+  r#"pairs := {(1u64, 1u64), (1u64, 2u64), (3u64, 3u64)}; {x | (x, x) <- pairs}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(1)), Value::U64(Ref::new(3))])))
+);
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_typed_and_expression_values,
+  r#"pairs := {(1u64, 10u64), (2u64, 20u64)}; expected := 1u64; {x | (expected + 0u64, x) <- pairs}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(10))])))
+);
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_nested_tuple,
+  r#"values := {((1u64, 2u64), 3u64), ((4u64, 5u64), 6u64)}; {a + b + c | ((a, b), c) <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(6)), Value::U64(Ref::new(15))])))
+);
+
+#[cfg(all(feature = "u64", feature = "atom"))]
+test_interpreter!(
+  pattern_conformance_comprehension_atom_tuple,
+  r#"events := {(:ready, 7u64), (:ready, 9u64)}; {x | :ready(x) <- events}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(7)), Value::U64(Ref::new(9))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_exact_array,
+  r#"values := {[1u64 2u64], [3u64 4u64]}; {a + b | [a, b] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(3)), Value::U64(Ref::new(7))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_prefix_suffix_spread,
+  r#"values := {[1u64 2u64 3u64 4u64], [5u64 6u64 7u64 8u64]}; {head + last | [head, ..., last] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(5)), Value::U64(Ref::new(13))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_bound_rest,
+  r#"values := {[1u64 2u64 3u64], [4u64 5u64 6u64]}; {tail | [head | tail] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![
+    Value::MatrixU64(Matrix::from_vec(vec![2, 3], 1, 2)),
+    Value::MatrixU64(Matrix::from_vec(vec![5, 6], 1, 2)),
+  ])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_recursive_rest_pattern,
+  r#"values := {[1u64 2u64 3u64 4u64], [5u64 6u64 7u64 8u64]}; {head + second + last | [head | [second, ..., last]] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(7)), Value::U64(Ref::new(19))])))
+);
 
 test_interpreter!(interpret_matrix_comprehension, r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2)));
 test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -118,7 +118,7 @@ test_interpreter!(
 #[cfg(feature = "u64")]
 test_interpreter!(
   interpret_option_match_scalar_some,
-  "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
+  "x<u64?> := 4u64; x? | value, value > 3u64 => value | * => 0u64.",
   Value::U64(Ref::new(4))
 );
 #[cfg(feature = "u64")]
@@ -353,6 +353,20 @@ test_interpreter!(
   Value::U64(Ref::new(3))
 );
 
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_match_structural_failure_skips_guard,
+  "pair := (1u64, 2u64)\nresult := pair?\n  | (x, 0u64), missing-capture > 0u64 => x\n  | * => 9u64.\nresult + 0u64",
+  Value::U64(Ref::new(9))
+);
+
+#[cfg(all(feature = "u64", feature = "f64"))]
+test_interpreter!(
+  interpret_match_fractional_f64_literal_does_not_equal_u64,
+  "value := 1u64\nresult := value?\n  | 1.5 => 99u64\n  | * => 7u64.\nresult + 0u64",
+  Value::U64(Ref::new(7))
+);
+
 test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64", Value::U64(Ref::new(9)));
 #[test]
 fn interpret_tagged_union_match_requires_exhaustive_arms() {
@@ -377,9 +391,21 @@ test_interpreter!(
   "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
   Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
 );
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_function_multi_argument_wildcard_arm_matches,
+  "multi-default(left<u64>, right<u64>) => <u64>\n  | * => 9u64.\n\nmulti-default(1u64, 2u64)",
+  Value::U64(Ref::new(9))
+);
 test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) => <u64>\n  | [x …] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
 test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x … y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
 test_interpreter!(interpret_fsm_accepts_unsized_vector_input, "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(5)));
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_fsm_pattern_binding_does_not_replace_input,
+  "#RestoreInput(input<u64>) => <u64>\n  ├ :Start(value<u64>)\n  └ :Done(value<u64>).\n\n#RestoreInput(input<u64>) -> :Start(7u64)\n  :Start(input) -> :Done(0u64)\n  :Done(*) => input.\n\n#RestoreInput(42u64)",
+  Value::U64(Ref::new(42))
+);
 test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
 test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -912,6 +912,47 @@ ys := { x | (x, @env/MECH_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop"
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
+fn mech_run_matrix_generator_context_pattern_is_literal_filter() {
+  let root = temp_root("matrix-generator-pattern-literal");
+  let source = root.join("matrix_generator_pattern_literal.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @env := cli/env
++> @out := cli/stdout
+
+ys := [ x | (x, @env/MECH_MATRIX_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop", "other")] ]
+@out/line <- ys
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source)
+    .current_dir(&root)
+    .env("MECH_MATRIX_GENERATOR_PATTERN_TEST", "secret")
+    .output()
+    .unwrap();
+
+  let combined = combined_output(&output);
+  assert!(
+    output.status.success(),
+    "matrix generator context-pattern program failed:\n{combined}"
+  );
+  assert!(
+    combined.contains("keep"),
+    "matrix generator context pattern should retain matching tuple:\n{combined}"
+  );
+  assert!(
+    !combined.contains("drop"),
+    "matrix generator context pattern should reject nonmatching tuple:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
 fn mech_run_undeclared_context_read_is_preflighted_before_send() {
   let root = temp_root("undeclared-context-read");
   let source = root.join("undeclared_context_read.mec");


### PR DESCRIPTION
## Motivation

Mech needs first-class clock-domain bodies for physics, rendering, timers, and other trigger-driven work. This PR is the complete integrated activation implementation—not a syntax-only change—and spans parsing, formatting, source traversal, pattern matching, reactive planning, live host inputs, register transactions, and activation-scoped context sends.

## Syntax and integration

- Add fixed activation bodies with `~> trigger { ... }`.
- Add patterned activation bodies with ordered `| pattern, guard => { ... }` arms.
- Integrate activation nodes through the AST, parser, formatter, resolver index, runtime preflight, CLI source visitors, interpreter, and feature-gated builds.
- Accept empty activation bodies and inline closing braces.
- Require the trigger to be an existing variable backed by reactive storage; arbitrary trigger expressions are rejected.

## Fixed activations

Fixed bodies are statically registered against their trigger. The trigger is reactive, outer dependencies are sampled at the activation boundary, and body-local combinational dependencies remain reactive within that trigger domain.

- Registration does not commit body registers or release context sends.
- Equal-valued admitted trigger packets remain distinct activation events.
- Whole-register writes use the existing staging machinery and atomically commit as one batch.
- Register commits do not re-run the same activation body.
- Plan topology remains stable across triggers.
- Runtime context sends use deep body-time payload snapshots, one activation effect barrier per body, retained live authority, and post-commit release.

## Patterned activations and guards

Patterned dispatch uses the shared structural matcher for literals, bindings, repeated bindings, tuples, tagged atom/enum tuples, arrays, spread/rest patterns, typed values, and composite captures.

- Each arm owns private capture proposals and committed capture storage.
- Structural match and guard evaluation do not mutate body-visible captures.
- Guards run only for structurally matching arms and must be statically pure.
- Source order selects the first eligible arm.
- Only the selected arm commits captures and pulses its body graph.
- A final unguarded irrefutable compiled pattern is exhaustive. This includes `*`, a binding such as `dt`, and type-valid irrefutable structural patterns.
- Selected patterned bodies may stage whole-register writes and activation-scoped context sends.
- Losing, unmatched, guard-false, and failed arms do not commit registers or release context sends.
- Equal trigger packets dispatch again without growing the plan.

## Transaction ordering

A patterned activation turn is ordered as:

```text
match patterns and evaluate eligible guards
→ select the first eligible arm
→ commit only the selected arm's captures
→ evaluate the selected body and snapshot context-send payloads
→ stage and validate the complete register batch
→ atomically commit registers
→ perform post-commit propagation
→ validate the turn-duration budget
→ release the selected arm's context sends
```

Host input admission and register commit are separate transaction boundaries. A failed register staging batch mutates no register, and a failed body/register phase does not release context sends. Accepted input values and already committed registers are not rolled back by later post-commit or provider errors.

At registration time, fixed register writes and context sends remain dormant. Pattern dispatch may initialize and commit the first eligible arm's captures without pulsing its body. Runtime host/native function compilation can still perform elaboration-time work, so “no initialization effects” applies specifically to register commits and activation-scoped context sends, not arbitrary native host calls.

## Sampled dependencies and live clocks

- Outer dependencies are sampled and cannot independently schedule an activation body.
- Trigger and activation-local dependencies are reactive within the activation domain.
- Live host-input packets are admitted as batches and drive one reactive turn per accepted packet, including equal-valued packets.
- `activation_two_clock_physics_render_acceptance` proves independent in-memory physics/render triggers: physics packets alone update state, render packets alone emit the latest committed state, neither path schedules the other, and topology/send registrations remain stable.

## Native and browser project paths

The hosted project jobs pass on the current head:

- Native: `target/debug/mech run examples/analog-clock`, loading `examples/analog-clock/mech.mcfg` and `examples/analog-clock/clock.mec`.
- Browser: `mech serve examples/analog-clock` uses the same `mech.mcfg` and `clock.mec` through the generic `/_mech/project.js` bootstrap. Hosted CI also builds the WASM project package and runs the generic timer/table/scene and time/console/scene tests in headless Chrome.

The repository does **not** yet contain a committed native/browser two-trigger activation project. The current two-clock activation proof is the in-memory runtime acceptance test above; the analog-clock and generic timer/scene paths validate native/browser project loading and host integration, not a two-frequency activation application.

## Current limitations and review blockers

- Fixed bodies currently reject mixing local register writes with context sends; patterned bodies support the combined state/effect ordering.
- Patterned indexed writes are rejected. Fixed indexed/subscript assignments are currently accepted but bypass activation-aware staging and can mutate during elaboration; they must be treated as unsupported until fixed validation rejects them or indexed staging is implemented.
- Fixed trigger-write validation compares symbol names rather than reactive root cells, so a write through a trigger alias can bypass the self-trigger prohibition.
- Patterned activation dispatch is interpreter-only and cannot be bytecode-compiled.
- Nested activations, mutable definitions, imports, and function/FSM definitions remain restricted in activation bodies.
- Activation-scoped context sends require retained live registration and are rejected for isolated-snapshot registration.
- Context-send provider batches are source-ordered and fail fast but are not externally atomic; an earlier provider write cannot be rolled back if a later write fails.
- Runtime host/native calls are not context-send effects and are not protected by the activation effect barrier; they may run once during elaboration, including while statically elaborating an arm that is not selected at runtime.
- Fixed-body locals remain visible in the enclosing symbol table; patterned-arm locals and captures are private.

## Integrated review and validation

The complete `3aa058cf8..e34ef8dc` diff was reviewed: 36 files, 10,185 additions, and 942 deletions. The review confirmed that sampled-cell isolation, fixed elaboration rollback, deep effect snapshots, duration-before-send ordering, irrefutable-pattern exhaustiveness, and empty/inline parsing are present in the current head.

Full hosted CI completed successfully for exact head `e34ef8dc50e7c374f8038c59fca5a09ef8009dee` in [workflow run 30002850405](https://github.com/mech-lang/mech/actions/runs/30002850405):

- `cargo`
- `Cargo language tests`
- `Cargo runtime and host tests`
- `Project native`
- `Project browser`
- `Run-only CLI`
- `Windows CLI`
- `Dynamic modules`

All eight jobs passed. The PR remains draft pending resolution or explicit acceptance of the fixed trigger-alias and indexed-write review blockers.