### PR TITLE
test: cover activation-scoped sends

### DIFF
--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -342,6 +342,20 @@ impl MechRuntime {
     result
   }
 
+  #[cfg(test)]
+  pub(super) fn run_string_with_isolated_registration_for_test(
+    &mut self,
+    context: &mut RuntimeContext,
+    source: &str,
+  ) -> MResult<Value> {
+    self.with_live_registration_mode(
+      crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+      |runtime| {
+        runtime.run_string_with_context(context, source)
+      },
+    )
+  }
+
   fn is_manifest_context_import(import: &mech_core::ModuleImport) -> bool {
     matches!(import.alias, Some(mech_core::ModuleImportAlias::Context(_)))
   }

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,18 +1,18 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
 use std::thread;
 use std::time::Duration;
 
-use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, Ref, Value};
+use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, ReactiveTurnOutcome, Ref, Value};
 
 use super::*;
 use crate::{
   BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
   ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
   RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
-  RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeIngress,
+  RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInputOutcome, RuntimeIngress,
   RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, RuntimeResourceWriteIntent, ClosureHostFunction, materialize_host_manifest,
 };
 
@@ -1145,6 +1145,21 @@ clock-output := (hour, minute, second)
   }
 
 
+  #[derive(Clone, Debug, PartialEq, Eq)]
+  struct ActivationPlanSnapshot { nodes: Vec<ActivationNodeSnapshot>, reactive_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)>, sampled_consumers: Vec<(ReactiveCellId, Vec<ReactiveNodeId>)> }
+  #[derive(Clone, Debug, PartialEq, Eq)]
+  struct ActivationNodeSnapshot { id: ReactiveNodeId, plan_index: usize, kind: ReactiveNodeKind, function: String, inputs: Vec<(ReactiveCellId, ReactiveDependencyKind)>, outputs: Vec<ReactiveCellId> }
+  fn activation_plan_snapshot(runtime: &MechRuntime) -> ActivationPlanSnapshot { let plan=runtime.program.interpreter().plan(); let plan=plan.borrow(); let nodes=plan.nodes.iter().map(|n| ActivationNodeSnapshot{id:n.id,plan_index:n.plan_index,kind:n.kind,function: std::any::type_name_of_val(n.function.as_ref()).to_string(),inputs:n.inputs.iter().map(|d|(d.cell,d.kind)).collect(),outputs:n.outputs.clone()}).collect(); let mut reactive_consumers=plan.reactive_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();let mut sampled_consumers=plan.sampled_consumers.iter().map(|(c,n)|(*c,n.clone())).collect::<Vec<_>>();reactive_consumers.sort_by_key(|(c,_)|c.get());sampled_consumers.sort_by_key(|(c,_)|c.get());ActivationPlanSnapshot{nodes,reactive_consumers,sampled_consumers} }
+  fn activation_nodes_for_trigger(runtime:&MechRuntime, trigger_name:&str, kind:ReactiveNodeKind)->Vec<ReactiveNodeId>{let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();p.borrow().nodes.iter().filter(|n|n.kind==kind&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect()}
+  fn activation_barrier_for_trigger(runtime:&MechRuntime, trigger_name:&str)->ReactiveNodeId {let c=symbol_cell(runtime,trigger_name);let p=runtime.program.interpreter().plan();let barriers=p.borrow().nodes.iter().filter(|n|n.kind==ReactiveNodeKind::Combinational&&n.function.to_string()==ACTIVATION_EFFECT_BARRIER_NAME&&n.outputs.is_empty()&&n.inputs.iter().any(|d|d.cell==c&&d.kind==ReactiveDependencyKind::Reactive)).map(|n|n.id).collect::<Vec<_>>();assert_eq!(barriers.len(),1,"expected exactly one activation-effect barrier for trigger {trigger_name}");barriers[0]}
+  fn only_reactive_turn(outcome:&RuntimeHostInputOutcome)->&ReactiveTurnOutcome{let p=outcome.turn.as_ref().expect("expected a program input turn");assert_eq!(p.interpreter_turns.len(),1,"expected exactly one affected interpreter");&p.interpreter_turns[0].turn}
+  fn executed_count(turn:&ReactiveTurnOutcome,id:ReactiveNodeId)->usize{turn.before_commit.executed_nodes.iter().chain(turn.after_commit.executed_nodes.iter()).filter(|x|**x==id).count()}
+  fn apply_f64_input(r:&mut MechRuntime,b:&str,p:&str,v:f64)->RuntimeHostInputOutcome{r.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new(b,p).unwrap(),RuntimeHostInputValue::F64(v))).unwrap()}
+  fn recorded_f64(o:&RecordingTestOutput,i:usize)->f64{o.lines()[i].trim().parse().unwrap()}
+  fn activation_send_count(r:&MechRuntime)->usize{r.persistent_sends.iter().filter(|s|matches!(s.schedule,RuntimePersistentSendSchedule::Activation{..})).count()}
+  fn activation_rejection_runtime()->(MechRuntime,RecordingTestOutput){let (mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))));grant_read(&mut r,"test://render/timer","tick");grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");(r,o)}
+  fn assert_rejected_activation_left_no_state(r:&MechRuntime,o:&RecordingTestOutput,p:&ActivationPlanSnapshot,s:usize,b:&HashMap<RuntimeHostInputSource,Vec<mech_program::ProgramInputId>>){assert_eq!(activation_plan_snapshot(r),*p);assert_eq!(r.persistent_sends.len(),s);assert_eq!(r.live_input_bindings,*b);assert!(o.lines().is_empty());assert!(!r.program.interpreter().plan().activation_registration_active());}
+
   #[test]
   fn persistent_send_uses_original_custom_subject() {
     let initial = snapshot(1.0, 2.0, 3.0, 4.0);
@@ -1296,6 +1311,80 @@ render-tick := @clock/hour
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
   }
+
+  #[test]
+  fn activation_two_clock_physics_render_acceptance() {
+    let provider=TestResourceProvider::new().with_value("test://physics/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://physics/timer","tick");grant_read(&mut runtime,"test://render/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@physics := test://physics/timer{:read(tick)}
+@render := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+physics-tick := @physics/tick
+render-tick := @render/tick
+~x := 0.0
+~> physics-tick {
+  next-x := x + 1.0
+  x = next-x
+}
+~> render-tick {
+  @out/line <- x
+}
+"#).unwrap();let initial_plan=activation_plan_snapshot(&runtime);let render_barrier=activation_barrier_for_trigger(&runtime,"render-tick");let physics_combinational_nodes=activation_nodes_for_trigger(&runtime,"physics-tick",ReactiveNodeKind::Combinational);let x_register=register_node_for_symbol(&runtime,"x");assert!(!physics_combinational_nodes.is_empty());assert_eq!(f64_value(&symbol_value(&runtime,"x")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),1.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://physics/timer","tick",2.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert!(output.lines().is_empty());assert_eq!(executed_count(t,render_barrier),0);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),1)}assert_eq!(t.register_commit.committed_nodes,vec![x_register]);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);let t=only_reactive_turn(&a);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),1);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(executed_count(t,render_barrier),1);for n in &physics_combinational_nodes{assert_eq!(executed_count(t,*n),0)}assert!(!t.before_commit.pending_register_nodes.contains(&x_register));assert!(!t.register_commit.staged_nodes.contains(&x_register));assert!(!t.register_commit.committed_nodes.contains(&x_register));assert!(!t.after_commit.pending_register_nodes.contains(&x_register));assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+    let a=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);assert_eq!(f64_value(&symbol_value(&runtime,"x")),2.0);assert_eq!(output.lines().len(),2);assert_eq!(recorded_f64(&output,0),2.0);assert_eq!(recorded_f64(&output,1),2.0);assert_eq!(executed_count(only_reactive_turn(&a),render_barrier),1);assert_eq!(activation_plan_snapshot(&runtime),initial_plan);assert_eq!(activation_send_count(&runtime),1);
+  }
+  #[test]
+  fn activation_send_samples_latest_value_and_ignores_other_updates(){let(mut r,o)=test_runtime_with_output(TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0))).with_value(TEST_SIGNALS_BASE_URI,"value",Value::F64(Ref::new(1.0))));for(b,p)in [("test://render/timer","tick"),("test://other/timer","tick"),(TEST_SIGNALS_BASE_URI,"value")]{grant_read(&mut r,b,p)}grant_write(&mut r,TEST_OUTPUT_BASE_URI,"line");r.run_string(r#"@render := test://render/timer{:read(tick)}
+@other := test://other/timer{:read(tick)}
+@signals := test://signals/inputs{:read(value)}
+@out := test://effects/output{:write(line)}
+render-tick := @render/tick
+other-tick := @other/tick
+sampled-value := @signals/value
+~> render-tick {
+  @out/line <- sampled-value
+}
+~> other-tick {
+  other-result := sampled-value + 1.0
+}
+"#).unwrap();let b=activation_barrier_for_trigger(&r,"render-tick");let ns=activation_nodes_for_trigger(&r,"other-tick",ReactiveNodeKind::Combinational);assert!(!ns.is_empty());assert!(o.lines().is_empty());let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",10.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://other/timer","tick",1.0);assert!(o.lines().is_empty());assert_eq!(executed_count(only_reactive_turn(&q),b),0);for n in ns{assert_eq!(executed_count(only_reactive_turn(&q),n),1)}let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),1);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);let q=apply_f64_input(&mut r,TEST_SIGNALS_BASE_URI,"value",20.0);assert_eq!(o.lines().len(),1);assert_eq!(executed_count(only_reactive_turn(&q),b),0);let q=apply_f64_input(&mut r,"test://render/timer","tick",1.0);assert_eq!(o.lines().len(),2);assert_eq!(recorded_f64(&o,0),10.0);assert_eq!(recorded_f64(&o,1),20.0);assert_eq!(executed_count(only_reactive_turn(&q),b),1);}
+
+  fn rejected(source:&str, check:impl FnOnce(MechError)){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();check(r.run_string(source).unwrap_err());assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
+  #[test] fn activation_send_rejects_local_register_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~x := 0.0
+~> render-tick {
+  x = x + 1.0
+  @out/line <- x
+}
+"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
+  #[test] fn activation_send_rejects_local_op_assign_mix(){rejected(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~x := 0.0
+~> render-tick {
+  x += 1.0
+  @out/line <- x
+}
+"#,|e|assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_some(),"unexpected error: {e:?}"));}
+  #[test] fn activation_send_rejects_context_assignment_in_scope(){rejected(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+x := 1.0
+~> render-tick {
+  @out/line = x
+  @out/line <- x
+}
+"#,|e|{let k=e.kind_as::<RuntimeInvalidOperationError>().expect("expected RuntimeInvalidOperationError");assert_eq!(k.operation,"direct_context_effect_placement");assert!(k.reason.contains("context assignment"),"unexpected placement reason: {}",k.reason);assert!(e.kind_as::<ActivationScopeEffectWithRegisterUnsupported>().is_none());});}
+  #[test] fn activation_send_rejects_isolated_registration(){let(mut r,o)=activation_rejection_runtime();let p=activation_plan_snapshot(&r);let n=r.persistent_sends.len();let b=r.live_input_bindings.clone();let mut c=r.runtime_context().unwrap();let e=r.run_string_with_isolated_registration_for_test(&mut c,r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick {
+  @out/line <- render-tick
+}
+"#).unwrap_err();assert!(e.kind_as::<RuntimeIsolatedActivationSendUnsupported>().is_some(),"unexpected error: {e:?}");assert_rejected_activation_left_no_state(&r,&o,&p,n,&b);}
 
   #[test]
   fn activation_internal_barrier_is_not_user_callable() {


### PR DESCRIPTION
### Motivation

- Add the missing runtime acceptance tests that exercise activation-scoped context sends, sampled inputs, unrelated triggers, and rejection semantics to ensure activation-send behavior is correct and non-leaking.

### Description

- Add a test-only entry point `run_string_with_isolated_registration_for_test` in `src/runtime/src/runtime/execution.rs` to exercise isolated registration mode without exposing `with_live_registration_mode` publicly.
- Extend `src/runtime/src/runtime/input_tests.rs` imports and add activation-plan snapshot types and helpers including `activation_plan_snapshot`, `activation_nodes_for_trigger`, `activation_barrier_for_trigger`, `only_reactive_turn`, `executed_count`, `apply_f64_input`, `recorded_f64`, `activation_send_count`, `activation_rejection_runtime`, `assert_rejected_activation_left_no_state`, and `rejected` to inspect and assert planner/turn/send state precisely.
- Add acceptance tests inside the existing `persistent_send_tests` module: `activation_two_clock_physics_render_acceptance`, `activation_send_samples_latest_value_and_ignores_other_updates`, and the rejection tests `activation_send_rejects_local_register_mix`, `activation_send_rejects_local_op_assign_mix`, `activation_send_rejects_context_assignment_in_scope`, and `activation_send_rejects_isolated_registration` that verify typed errors and non-leakage.
- Minor test helper tweak to stringify node function identity using `std::any::type_name_of_val` to make plan snapshots deterministic for comparisons.

### Testing

- Ran the activation-send listing and unit test sets and verified success: `cargo test -p mech-runtime --lib activation_send_ -- --list` — exit status 0.
- Ran the activation-send tests with output: `cargo test -p mech-runtime --lib activation_send_ -- --nocapture` — all added activation-send tests passed (6/6) — exit status 0.
- Ran the two-clock acceptance test: `cargo test -p mech-runtime --lib activation_two_clock_physics_render_acceptance -- --nocapture` — test passed — exit status 0.
- Ran the persistent-send group and related runtime tests: `cargo test -p mech-runtime --lib persistent_send_ -- --nocapture` — all persistent-send tests passed — exit status 0.

Files changed:
- `src/runtime/src/runtime/input_tests.rs` — added helpers and tests.
- `src/runtime/src/runtime/execution.rs` — added test-only isolated-registration entry point.

All added tests validate: physics vs render separation, render uses latest sampled value, equal render values still produce separate sends, render barrier executes only on render turns, rejection tests return the typed errors and leave plan/send/bindings/provider state unchanged. All executed commands above completed successfully (exit status 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fb8ef7614832ab0699db1b01ccf6c)