### PR TITLE
Add patterned activation AST and syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,12 @@ jobs:
           cargo test -p mech-interpreter dirty_scheduler_updates_only_reachable_combinational_nodes -- --nocapture
           cargo test -p mech-interpreter dirty_scheduler_stops_at_register_boundary -- --nocapture
 
+          # Patterned activation and transactional rollback coverage.
+          cargo test -p mech-core reactive_plan_rollback_ -- --nocapture
+          cargo test -p mech-core plan_rollback_ -- --nocapture
+          cargo test -p mech-interpreter activation_capture_slot_ -- --nocapture
+          cargo test -p mech-interpreter activation_pattern_ -- --nocapture
+
           # Two-phase register staging and atomic commit coverage.
           cargo test -p mech-core reactive_register_commit_ -- --nocapture
           cargo test -p mech-interpreter register_commit_ -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           rustup toolchain install nightly-2026-03-03 --profile minimal
           rustup default nightly-2026-03-03
 
-      - name: Build and test
+      - name: Check feature boundaries and examples
         run: |
           # Linked-stdlib CLI build for examples that import named modules.
           cargo build --bin mech --features linked_stdlib
@@ -49,168 +49,70 @@ jobs:
           cargo check -p mech-interpreter --no-default-features --features program
           cargo check -p mech-program --no-default-features --features program
 
-          cargo test interpret
-          cargo test bytecode
+      - name: Disk report at end
+        if: always()
+        run: bash scripts/ci-disk-report.sh
 
-          # Whole-value assignment reactive graph coverage.
-          cargo test -p mech-interpreter whole_variable_assignment_registers_state_node -- --nocapture
-          cargo test -p mech-interpreter whole_add_assignment_registers_state_node -- --nocapture
-          cargo test -p mech-interpreter whole_add_assignment_alias_is_sampled_once -- --nocapture
-          cargo test -p mech-interpreter decoded_whole_variable_assignment_matches_source_graph -- --nocapture
-          cargo test -p mech-interpreter decoded_whole_add_assignment_matches_source_graph -- --nocapture
-          cargo test -p mech-interpreter whole_matrix_assignment_uses_root_cells -- --nocapture
+  cargo-language:
+    name: Cargo language tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          # Deterministic dirty-cell scheduler coverage.
-          cargo test -p mech-core reactive_dirty_scheduler_ -- --nocapture
-          cargo test -p mech-interpreter dirty_scheduler_updates_only_reachable_combinational_nodes -- --nocapture
-          cargo test -p mech-interpreter dirty_scheduler_stops_at_register_boundary -- --nocapture
+      - name: Disk report at start
+        run: bash scripts/ci-disk-report.sh
 
-          # Patterned activation and transactional rollback coverage.
-          cargo test -p mech-core reactive_plan_rollback_ -- --nocapture
-          cargo test -p mech-core plan_rollback_ -- --nocapture
-          cargo test -p mech-interpreter activation_capture_slot_ -- --nocapture
-          cargo test -p mech-interpreter activation_pattern_ -- --nocapture
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
 
-          # Two-phase register staging and atomic commit coverage.
-          cargo test -p mech-core reactive_register_commit_ -- --nocapture
-          cargo test -p mech-interpreter register_commit_ -- --nocapture
-          cargo test -p mech-core reactive_turn_ -- --nocapture
-          interpreter_state_tests="$(
-            cargo test \
-              -p mech-interpreter \
-              --lib \
-              reactive_turn_interpreter_state_ \
-              -- --list
-          )"
-          printf '%s\n' "$interpreter_state_tests"
-          for test_name in \
-            reactive_turn_interpreter_state_persists_between_calls \
-            reactive_turn_interpreter_state_clear_plan_resets_pending \
-            reactive_turn_interpreter_state_clone_preserves_pending
-          do
-            if ! grep -Fq "${test_name}: test" <<<"$interpreter_state_tests"; then
-              echo "::error::missing interpreter test ${test_name}"
-              exit 1
-            fi
-          done
-          cargo test \
-            -p mech-interpreter \
-            --lib \
-            reactive_turn_interpreter_state_ \
-            -- --nocapture
-          decoded_symbol_tests="$(
-            cargo test \
-              -p mech-interpreter \
-              --lib \
-              decoded_variable_definition_symbol_metadata_ \
-              -- --list
-          )"
-          printf '%s\n' "$decoded_symbol_tests"
-          if ! grep -Fq "decoded_variable_definition_symbol_metadata_round_trips: test" <<<"$decoded_symbol_tests"
-          then
-            echo "::error::missing decoded variable-definition symbol metadata test"
-            exit 1
-          fi
-          cargo test \
-            -p mech-interpreter \
-            --lib \
-            decoded_variable_definition_symbol_metadata_ \
-            -- --nocapture
-          cargo test -p mech-interpreter reactive_turn_ -- --nocapture
-          cargo test -p mech-interpreter decoded_reactive_turn_ -- --nocapture
-          program_turn_tests="$(
-            cargo test \
-              -p mech-program \
-              --lib \
-              program_reactive_turn_ \
-              -- --list
-          )"
-          printf '%s\n' "$program_turn_tests"
-          for test_name in \
-            program_reactive_turn_updates_only_reachable_branch \
-            program_reactive_turn_batches_inputs_into_one_turn \
-            program_reactive_turn_preserves_deferred_registers_between_calls \
-            program_reactive_turn_legacy_update_api_does_not_execute_plan \
-            program_reactive_turn_preflight_failure_mutates_nothing \
-            program_reactive_turn_rejects_root_alias_duplicate \
-            program_reactive_turn_empty_batch_is_noop \
-            program_reactive_turn_orders_nested_interpreters_deterministically \
-            program_reactive_turn_decoded_plan_reuses_identity
-          do
-            if ! grep -Fq "${test_name}: test" <<<"$program_turn_tests"; then
-              echo "::error::missing program test ${test_name}"
-              exit 1
-            fi
-          done
-          cargo test \
-            -p mech-program \
-            --lib \
-            program_reactive_turn_ \
-            -- --nocapture
+      - name: Run root interpreter and bytecode tests
+        run: |
+          cargo test --test interpreter --test bytecode
+          cargo test --lib bytecode
 
-          # Pointer-register initialization identity coverage.
-          cargo test \
-            -p mech-core \
-            compile_context_initializes_pointer_register_once \
-            -- --nocapture
-          cargo test \
-            -p mech-core \
-            pointer_register_scalar_initializes_once \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            pointer_register_matrix_initializes_once \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_four_args_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_n_args_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_rdn_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            vertical_concatenate_n_args_reuses_repeated_matrix_register \
-            -- --nocapture
+      - name: Run complete core and interpreter suites
+        run: cargo test -p mech-core -p mech-interpreter
 
-          # Runtime package tests.
-          runtime_turn_tests="$(
-            cargo test \
-              -p mech-runtime \
-              --lib \
-              runtime_reactive_host_input_ \
-              -- --list
-          )"
+      - name: Run complete program library suite
+        run: cargo test -p mech-program --lib
 
-          printf '%s\n' "$runtime_turn_tests"
+      - name: Disk report at end
+        if: always()
+        run: bash scripts/ci-disk-report.sh
 
-          for test_name in \
-            runtime_reactive_host_input_batches_bound_updates_into_one_turn \
-            runtime_reactive_host_input_executes_only_reachable_branch \
-            runtime_reactive_host_input_preserves_deferred_registers_across_packets \
-            runtime_reactive_host_input_unbound_packet_does_not_advance_pending_registers \
-            runtime_reactive_host_input_preflight_failure_mutates_nothing \
-            runtime_reactive_host_input_turn_failure_preserves_admitted_inputs
-          do
-            grep -Fq \
-              "${test_name}: test" \
-              <<<"$runtime_turn_tests" \
-              || {
-                echo \
-                  "::error::missing runtime reactive host-input test ${test_name}"
-                exit 1
-              }
-          done
+  cargo-runtime:
+    name: Cargo runtime and host tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          # The complete runtime suite executes the six guarded tests.
-          cargo test -p mech-runtime --lib --tests
+      - name: Disk report at start
+        run: bash scripts/ci-disk-report.sh
 
-          # CLI host and context-send regression coverage.
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
+
+      - name: Run complete runtime suite
+        run: cargo test -p mech-runtime --lib --tests
+
+      - name: Run CLI host and context-send regression coverage
+        run: |
           cargo test -p mech-syntax --test context_parser
           cargo test -p mech-host-cli --features provider --test provider
           cargo test --features "run repl pretty_print" --test mech_cli_host
@@ -220,10 +122,6 @@ jobs:
 
       - name: Disk report at end
         if: always()
-        run: bash scripts/ci-disk-report.sh
-
-      - name: Disk report on failure
-        if: failure()
         run: bash scripts/ci-disk-report.sh
 
   project-native:

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -161,7 +161,7 @@ fn mech_code_contains_context_addressed_source(code: &MechCode) -> bool {
     match code {
         MechCode::ActivationScope(scope) => {
             expression_contains_context_addressed_source(&scope.trigger)
-                || scope.body.iter().any(|(body_code, _)| mech_code_contains_context_addressed_source(body_code))
+                || activation_body_contains_context_addressed_source(&scope.body)
         }
         MechCode::Import(import) => matches!(import.alias, Some(ModuleImportAlias::Context(_))),
         MechCode::Statement(statement) => statement_contains_context_addressed_source(statement),
@@ -180,6 +180,30 @@ fn mech_code_contains_context_addressed_source(code: &MechCode) -> bool {
         }
         MechCode::FsmImplementation(fsm) => fsm_contains_context_addressed_source(fsm),
         _ => false,
+    }
+}
+
+fn activation_body_contains_context_addressed_source(body: &ActivationBody) -> bool {
+    match body {
+        ActivationBody::Block(codes) => codes
+            .iter()
+            .any(|(code, _)| mech_code_contains_context_addressed_source(code)),
+        ActivationBody::PatternArms(arms) => arms.iter().any(|arm| {
+            pattern_contains_context_addressed_source(&arm.pattern)
+                || arm
+                    .guard
+                    .as_ref()
+                    .map(expression_contains_context_addressed_source)
+                    .unwrap_or(false)
+                || match &arm.body {
+                    ActivationArmBody::Block(codes) => codes
+                        .iter()
+                        .any(|(code, _)| mech_code_contains_context_addressed_source(code)),
+                    ActivationArmBody::Expression(expression) => {
+                        expression_contains_context_addressed_source(expression)
+                    }
+                }
+        }),
     }
 }
 

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -940,6 +940,31 @@ impl ReactivePlan {
     self.pattern_activation_registrations.push(registration);
   }
 
+  /// Records an input that is read when another reactive cause schedules the
+  /// node. Updating this cell alone must not schedule the node.
+  pub fn add_sampled_dependency(
+    &mut self,
+    node_id: ReactiveNodeId,
+    cell: ReactiveCellId,
+  ) -> bool {
+    let Some(node) = self.nodes.get_mut(node_id) else {
+      return false;
+    };
+    if let Some(existing) = node.inputs.iter().find(|dependency| dependency.cell == cell) {
+      return existing.kind == ReactiveDependencyKind::Sampled
+        || existing.kind == ReactiveDependencyKind::Reactive;
+    }
+    node.inputs.push(ReactiveDependency {
+      cell,
+      kind: ReactiveDependencyKind::Sampled,
+    });
+    let consumers = self.sampled_consumers.entry(cell).or_default();
+    if !consumers.contains(&node_id) {
+      consumers.push(node_id);
+    }
+    true
+  }
+
   pub fn reactive_consumers_for(&self, cell: ReactiveCellId) -> &[ReactiveNodeId] {
     self.reactive_consumers
       .get(&cell)

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -621,10 +621,32 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct ReactivePlanCheckpoint { node_len:usize, pattern_activation_registration_len:usize }
-#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct PlanCheckpoint { reactive:ReactivePlanCheckpoint, activation_registration_depth:usize }
-#[derive(Debug,Clone)] pub struct ReactivePlanRollbackInvariantError { pub checkpoint_nodes:usize,pub current_nodes:usize,pub checkpoint_registrations:usize,pub current_registrations:usize }
-impl MechErrorKind for ReactivePlanRollbackInvariantError { fn name(&self)->&str{"ReactivePlanRollbackInvariant"} fn message(&self)->String{format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.",self.current_nodes,self.current_registrations,self.checkpoint_nodes,self.checkpoint_registrations)} }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReactivePlanCheckpoint {
+  node_len: usize,
+  pattern_activation_registration_len: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlanCheckpoint {
+  reactive: ReactivePlanCheckpoint,
+  activation_registration_depth: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactivePlanRollbackInvariantError {
+  pub checkpoint_nodes: usize,
+  pub current_nodes: usize,
+  pub checkpoint_registrations: usize,
+  pub current_registrations: usize,
+}
+
+impl MechErrorKind for ReactivePlanRollbackInvariantError {
+  fn name(&self) -> &str { "ReactivePlanRollbackInvariant" }
+  fn message(&self) -> String {
+    format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.", self.current_nodes, self.current_registrations, self.checkpoint_nodes, self.checkpoint_registrations)
+  }
+}
 
 impl ReactivePlan {
   fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -648,10 +648,38 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
   }
 }
 
+#[derive(Debug, Clone)]
+pub struct ActivationRegistrationRollbackInvariantError { pub checkpoint_depth: usize, pub current_depth: usize }
+impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
+  fn name(&self) -> &str { "ActivationRegistrationRollbackInvariant" }
+  fn message(&self) -> String { format!("Cannot roll the activation registration stack back from depth {} to future depth {}.", self.current_depth, self.checkpoint_depth) }
+}
+
 impl ReactivePlan {
-  fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }
-  pub fn checkpoint(&self)->ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len:self.nodes.len(), pattern_activation_registration_len:self.pattern_activation_registrations.len() } }
-  pub fn rollback(&mut self, checkpoint:ReactivePlanCheckpoint)->MResult<()> { if checkpoint.node_len>self.nodes.len()||checkpoint.pattern_activation_registration_len>self.pattern_activation_registrations.len(){return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.node_len,current_nodes:self.nodes.len(),checkpoint_registrations:checkpoint.pattern_activation_registration_len,current_registrations:self.pattern_activation_registrations.len()},None))} self.nodes.truncate(checkpoint.node_len);self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);self.rebuild_consumer_indexes();Ok(()) }
+  fn rebuild_consumer_indexes(&mut self) {
+    self.reactive_consumers.clear();
+    self.sampled_consumers.clear();
+    for node in &self.nodes {
+      for dependency in &node.inputs {
+        let consumers = match dependency.kind { ReactiveDependencyKind::Reactive => &mut self.reactive_consumers, ReactiveDependencyKind::Sampled => &mut self.sampled_consumers };
+        let consumers = consumers.entry(dependency.cell).or_default();
+        if !consumers.contains(&node.id) { consumers.push(node.id); }
+      }
+    }
+  }
+  fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
+    if checkpoint.node_len > self.nodes.len() || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len() {
+      return Err(MechError::new(ReactivePlanRollbackInvariantError { checkpoint_nodes: checkpoint.node_len, current_nodes: self.nodes.len(), checkpoint_registrations: checkpoint.pattern_activation_registration_len, current_registrations: self.pattern_activation_registrations.len() }, None));
+    }
+    Ok(())
+  }
+  fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
+    self.nodes.truncate(checkpoint.node_len);
+    self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);
+    self.rebuild_consumer_indexes();
+  }
+  pub fn checkpoint(&self) -> ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len: self.nodes.len(), pattern_activation_registration_len: self.pattern_activation_registrations.len() } }
+  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> { self.validate_rollback(checkpoint)?; self.apply_rollback(checkpoint); Ok(()) }
 
   pub fn new() -> Self {
     Self {
@@ -1048,9 +1076,15 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
-  pub fn checkpoint(&self)->PlanCheckpoint { PlanCheckpoint { reactive:self.0.borrow().checkpoint(),activation_registration_depth:self.1.borrow().len() } }
-  pub fn rollback(&self, checkpoint:PlanCheckpoint)->MResult<()> { {let mut scopes=self.1.borrow_mut();if checkpoint.activation_registration_depth>scopes.len(){let p=self.0.borrow();return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.reactive.node_len,current_nodes:p.nodes.len(),checkpoint_registrations:checkpoint.reactive.pattern_activation_registration_len,current_registrations:p.pattern_activation_registrations.len()},None))}scopes.truncate(checkpoint.activation_registration_depth);}self.0.borrow_mut().rollback(checkpoint.reactive) }
-  pub fn activation_registration_depth(&self)->usize {self.1.borrow().len()}
+  pub fn checkpoint(&self) -> PlanCheckpoint { PlanCheckpoint { reactive: self.0.borrow().checkpoint(), activation_registration_depth: self.1.borrow().len() } }
+  pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
+    { let reactive = self.0.borrow(); reactive.validate_rollback(checkpoint.reactive)?; }
+    { let scopes = self.1.borrow(); let current_depth = scopes.len(); if checkpoint.activation_registration_depth > current_depth { return Err(MechError::new(ActivationRegistrationRollbackInvariantError { checkpoint_depth: checkpoint.activation_registration_depth, current_depth }, None)); } }
+    self.0.borrow_mut().apply_rollback(checkpoint.reactive);
+    self.1.borrow_mut().truncate(checkpoint.activation_registration_depth);
+    Ok(())
+  }
+  pub fn activation_registration_depth(&self) -> usize { self.1.borrow().len() }
 
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
@@ -1883,6 +1917,32 @@ mod reactive_turn_tests {
   }
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
+
+  #[test]
+  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
+    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
+    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+  }
+  #[test]
+  fn reactive_plan_rollback_truncates_pattern_registrations() {
+    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  }
+  #[test]
+  fn plan_rollback_restores_activation_registration_depth() {
+    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
+  }
+  #[test]
+  fn plan_rollback_invalid_checkpoint_is_atomic() {
+    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
+    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  }
+
 }
 
 // Function Registry

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -649,37 +649,84 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
 }
 
 #[derive(Debug, Clone)]
-pub struct ActivationRegistrationRollbackInvariantError { pub checkpoint_depth: usize, pub current_depth: usize }
+pub struct ActivationRegistrationRollbackInvariantError {
+  pub checkpoint_depth: usize,
+  pub current_depth: usize,
+}
+
 impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
-  fn name(&self) -> &str { "ActivationRegistrationRollbackInvariant" }
-  fn message(&self) -> String { format!("Cannot roll the activation registration stack back from depth {} to future depth {}.", self.current_depth, self.checkpoint_depth) }
+  fn name(&self) -> &str {
+    "ActivationRegistrationRollbackInvariant"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Cannot roll the activation registration stack back from depth {} to future depth {}.",
+      self.current_depth,
+      self.checkpoint_depth,
+    )
+  }
 }
 
 impl ReactivePlan {
   fn rebuild_consumer_indexes(&mut self) {
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
+
     for node in &self.nodes {
       for dependency in &node.inputs {
-        let consumers = match dependency.kind { ReactiveDependencyKind::Reactive => &mut self.reactive_consumers, ReactiveDependencyKind::Sampled => &mut self.sampled_consumers };
+        let consumers = match dependency.kind {
+          ReactiveDependencyKind::Reactive => &mut self.reactive_consumers,
+          ReactiveDependencyKind::Sampled => &mut self.sampled_consumers,
+        };
+
         let consumers = consumers.entry(dependency.cell).or_default();
-        if !consumers.contains(&node.id) { consumers.push(node.id); }
+
+        if !consumers.contains(&node.id) {
+          consumers.push(node.id);
+        }
       }
     }
   }
+
   fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
-    if checkpoint.node_len > self.nodes.len() || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len() {
-      return Err(MechError::new(ReactivePlanRollbackInvariantError { checkpoint_nodes: checkpoint.node_len, current_nodes: self.nodes.len(), checkpoint_registrations: checkpoint.pattern_activation_registration_len, current_registrations: self.pattern_activation_registrations.len() }, None));
+    if checkpoint.node_len > self.nodes.len()
+      || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len()
+    {
+      return Err(MechError::new(
+        ReactivePlanRollbackInvariantError {
+          checkpoint_nodes: checkpoint.node_len,
+          current_nodes: self.nodes.len(),
+          checkpoint_registrations: checkpoint.pattern_activation_registration_len,
+          current_registrations: self.pattern_activation_registrations.len(),
+        },
+        None,
+      ));
     }
+
     Ok(())
   }
+
   fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
     self.nodes.truncate(checkpoint.node_len);
-    self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);
+    self
+      .pattern_activation_registrations
+      .truncate(checkpoint.pattern_activation_registration_len);
     self.rebuild_consumer_indexes();
   }
-  pub fn checkpoint(&self) -> ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len: self.nodes.len(), pattern_activation_registration_len: self.pattern_activation_registrations.len() } }
-  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> { self.validate_rollback(checkpoint)?; self.apply_rollback(checkpoint); Ok(()) }
+
+  pub fn checkpoint(&self) -> ReactivePlanCheckpoint {
+    ReactivePlanCheckpoint {
+      node_len: self.nodes.len(),
+      pattern_activation_registration_len: self.pattern_activation_registrations.len(),
+    }
+  }
+
+  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
+    self.validate_rollback(checkpoint)?;
+    self.apply_rollback(checkpoint);
+    Ok(())
+  }
 
   pub fn new() -> Self {
     Self {
@@ -1076,15 +1123,46 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
-  pub fn checkpoint(&self) -> PlanCheckpoint { PlanCheckpoint { reactive: self.0.borrow().checkpoint(), activation_registration_depth: self.1.borrow().len() } }
+  pub fn checkpoint(&self) -> PlanCheckpoint {
+    PlanCheckpoint {
+      reactive: self.0.borrow().checkpoint(),
+      activation_registration_depth: self.1.borrow().len(),
+    }
+  }
+
   pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
-    { let reactive = self.0.borrow(); reactive.validate_rollback(checkpoint.reactive)?; }
-    { let scopes = self.1.borrow(); let current_depth = scopes.len(); if checkpoint.activation_registration_depth > current_depth { return Err(MechError::new(ActivationRegistrationRollbackInvariantError { checkpoint_depth: checkpoint.activation_registration_depth, current_depth }, None)); } }
+    {
+      let reactive = self.0.borrow();
+      reactive.validate_rollback(checkpoint.reactive)?;
+    }
+
+    {
+      let scopes = self.1.borrow();
+      let current_depth = scopes.len();
+
+      if checkpoint.activation_registration_depth > current_depth {
+        return Err(MechError::new(
+          ActivationRegistrationRollbackInvariantError {
+            checkpoint_depth: checkpoint.activation_registration_depth,
+            current_depth,
+          },
+          None,
+        ));
+      }
+    }
+
     self.0.borrow_mut().apply_rollback(checkpoint.reactive);
-    self.1.borrow_mut().truncate(checkpoint.activation_registration_depth);
+    self
+      .1
+      .borrow_mut()
+      .truncate(checkpoint.activation_registration_depth);
+
     Ok(())
   }
-  pub fn activation_registration_depth(&self) -> usize { self.1.borrow().len() }
+
+  pub fn activation_registration_depth(&self) -> usize {
+    self.1.borrow().len()
+  }
 
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
@@ -1839,6 +1917,30 @@ mod reactive_plan_tests {
   fn reactive_dirty_scheduler_stops_on_error() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,ao,ac)=scheduler_node(&mut p,"A",&[d.clone()],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l.clone(),true);let(_,_,bc)=scheduler_node(&mut p,"B",&[ao],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);let e=p.solve_dirty_cells(&d.reactive_root_cell_ids()).unwrap_err();assert!(e.kind_message().contains("A"));assert_eq!(*ac.borrow(),1);assert_eq!(*bc.borrow(),0); }
   #[cfg(feature = "f64")] #[test]
   fn reactive_dirty_scheduler_empty_dirty_set_is_noop() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,_,c)=scheduler_node(&mut p,"A",&[d],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);assert_eq!(p.solve_dirty_cells(&[]).unwrap(),ReactivePlanSolveOutcome::default());assert_eq!(*c.borrow(),0); }
+  #[test]
+  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
+    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
+    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+  }
+  #[test]
+  fn reactive_plan_rollback_truncates_pattern_registrations() {
+    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  }
+  #[test]
+  fn plan_rollback_restores_activation_registration_depth() {
+    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
+  }
+  #[test]
+  fn plan_rollback_invalid_checkpoint_is_atomic() {
+    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
+    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  }
 }
 
 
@@ -1918,30 +2020,7 @@ mod reactive_turn_tests {
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
 
-  #[test]
-  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
-    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
-    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
-    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
-    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
-  }
-  #[test]
-  fn reactive_plan_rollback_truncates_pattern_registrations() {
-    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
-  }
-  #[test]
-  fn plan_rollback_restores_activation_registration_depth() {
-    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
-  }
-  #[test]
-  fn plan_rollback_invalid_checkpoint_is_atomic() {
-    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
-    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
-    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-  }
+
 
 }
 

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -409,6 +409,29 @@ impl MechFunctionCompiler for UserFunction {
 
 pub type ReactiveNodeId = usize;
 
+/// Read-only registration information for a patterned activation.
+///
+/// This belongs to the plan, rather than to a turn, so consumers can inspect
+/// the statically registered dispatch graph without relying on transient
+/// scheduler state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationRegistration {
+  pub scope_pulse_node: ReactiveNodeId,
+  pub selector_node: ReactiveNodeId,
+  pub arms: Vec<PatternActivationArmRegistration>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationArmRegistration {
+  pub matcher_node: ReactiveNodeId,
+  pub finalizer_node: ReactiveNodeId,
+  pub gate_node: ReactiveNodeId,
+  pub pulse_cell: ReactiveCellId,
+  /// Half-open range of plan nodes registered for this arm's body.
+  pub body_node_start: usize,
+  pub body_node_end: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReactiveDependencyKind {
   Reactive,
@@ -491,6 +514,7 @@ pub struct ReactivePlan {
   pub nodes: Vec<ReactivePlanNode>,
   pub reactive_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pub sampled_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
+  pattern_activation_registrations: Vec<PatternActivationRegistration>,
 }
 
 #[derive(Debug, Clone)]
@@ -594,6 +618,7 @@ impl ReactivePlan {
       nodes: Vec::new(),
       reactive_consumers: HashMap::new(),
       sampled_consumers: HashMap::new(),
+      pattern_activation_registrations: Vec::new(),
     }
   }
 
@@ -609,6 +634,7 @@ impl ReactivePlan {
     self.nodes.clear();
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
+    self.pattern_activation_registrations.clear();
   }
 
   pub fn iter(&self) -> impl Iterator<Item = &Box<dyn MechFunction>> {
@@ -789,6 +815,14 @@ impl ReactivePlan {
 
   pub fn node(&self, node_id: ReactiveNodeId) -> Option<&ReactivePlanNode> {
     self.nodes.get(node_id)
+  }
+
+  pub fn pattern_activation_registrations(&self) -> &[PatternActivationRegistration] {
+    &self.pattern_activation_registrations
+  }
+
+  pub fn register_pattern_activation(&mut self, registration: PatternActivationRegistration) {
+    self.pattern_activation_registrations.push(registration);
   }
 
   pub fn reactive_consumers_for(&self, cell: ReactiveCellId) -> &[ReactiveNodeId] {
@@ -1022,6 +1056,10 @@ impl Plan {
 
   pub fn get_functions(&self) -> std::cell::Ref<'_, ReactivePlan> {
     self.0.borrow()
+  }
+
+  pub fn pattern_activation_registrations(&self) -> std::cell::Ref<'_, Vec<PatternActivationRegistration>> {
+    std::cell::Ref::map(self.0.borrow(), |plan| &plan.pattern_activation_registrations)
   }
 
   pub fn len(&self) -> usize {

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -1919,10 +1919,23 @@ mod reactive_plan_tests {
   fn reactive_dirty_scheduler_empty_dirty_set_is_noop() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,_,c)=scheduler_node(&mut p,"A",&[d],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);assert_eq!(p.solve_dirty_cells(&[]).unwrap(),ReactivePlanSolveOutcome::default());assert_eq!(*c.borrow(),0); }
   #[test]
   fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
-    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
-    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
-    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
-    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+    let reactive_input = Value::Index(Ref::new(1));
+    let sampled_input = Value::Index(Ref::new(2));
+    let reactive_cell = reactive_input.reactive_root_cell_ids()[0];
+    let sampled_cell = sampled_input.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new();
+    let base = plan.register(Box::new(TestFunction::new("base")), &[reactive_input]).unwrap();
+    let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[sampled_input]).unwrap();
+    plan.rollback(checkpoint).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan.nodes[0].id, base);
+    assert_eq!(plan.nodes[0].plan_index, 0);
+    assert_eq!(plan.nodes[0].inputs, vec![ReactiveDependency { cell: reactive_cell, kind: ReactiveDependencyKind::Reactive }]);
+    assert_eq!(plan.reactive_consumers_for(reactive_cell), &[base]);
+    assert!(plan.sampled_consumers_for(sampled_cell).is_empty());
+    assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail)));
+    assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
   }
   #[test]
   fn reactive_plan_rollback_truncates_pattern_registrations() {
@@ -1938,7 +1951,9 @@ mod reactive_plan_tests {
     let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
     let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
     assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    let valid_reactive_checkpoint = { let reactive_plan = plan.borrow(); reactive_plan.checkpoint() };
+    let invalid_scope_checkpoint = PlanCheckpoint { reactive: valid_reactive_checkpoint, activation_registration_depth: depth_before + 1 };
+    let error = plan.rollback(invalid_scope_checkpoint).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
     assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
   }
 }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -621,7 +621,16 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct ReactivePlanCheckpoint { node_len:usize, pattern_activation_registration_len:usize }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct PlanCheckpoint { reactive:ReactivePlanCheckpoint, activation_registration_depth:usize }
+#[derive(Debug,Clone)] pub struct ReactivePlanRollbackInvariantError { pub checkpoint_nodes:usize,pub current_nodes:usize,pub checkpoint_registrations:usize,pub current_registrations:usize }
+impl MechErrorKind for ReactivePlanRollbackInvariantError { fn name(&self)->&str{"ReactivePlanRollbackInvariant"} fn message(&self)->String{format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.",self.current_nodes,self.current_registrations,self.checkpoint_nodes,self.checkpoint_registrations)} }
+
 impl ReactivePlan {
+  fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }
+  pub fn checkpoint(&self)->ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len:self.nodes.len(), pattern_activation_registration_len:self.pattern_activation_registrations.len() } }
+  pub fn rollback(&mut self, checkpoint:ReactivePlanCheckpoint)->MResult<()> { if checkpoint.node_len>self.nodes.len()||checkpoint.pattern_activation_registration_len>self.pattern_activation_registrations.len(){return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.node_len,current_nodes:self.nodes.len(),checkpoint_registrations:checkpoint.pattern_activation_registration_len,current_registrations:self.pattern_activation_registrations.len()},None))} self.nodes.truncate(checkpoint.node_len);self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);self.rebuild_consumer_indexes();Ok(()) }
+
   pub fn new() -> Self {
     Self {
       nodes: Vec::new(),
@@ -1017,6 +1026,10 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
+  pub fn checkpoint(&self)->PlanCheckpoint { PlanCheckpoint { reactive:self.0.borrow().checkpoint(),activation_registration_depth:self.1.borrow().len() } }
+  pub fn rollback(&self, checkpoint:PlanCheckpoint)->MResult<()> { {let mut scopes=self.1.borrow_mut();if checkpoint.activation_registration_depth>scopes.len(){let p=self.0.borrow();return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.reactive.node_len,current_nodes:p.nodes.len(),checkpoint_registrations:checkpoint.reactive.pattern_activation_registration_len,current_registrations:p.pattern_activation_registrations.len()},None))}scopes.truncate(checkpoint.activation_registration_depth);}self.0.borrow_mut().rollback(checkpoint.reactive) }
+  pub fn activation_registration_depth(&self)->usize {self.1.borrow().len()}
+
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
   }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -430,6 +430,15 @@ pub struct PatternActivationArmRegistration {
   /// Half-open range of plan nodes registered for this arm's body.
   pub body_node_start: usize,
   pub body_node_end: usize,
+  pub captures: Vec<PatternActivationCaptureRegistration>,
+}
+
+/// Stable storage made available to a single patterned activation arm.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationCaptureRegistration {
+  pub id: u64,
+  pub kind: ValueKind,
+  pub cell: ReactiveCellId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1007,18 +1007,54 @@ impl MechCode {
 pub struct ActivationScope {
   pub operator: Token,
   pub trigger: Expression,
-  pub body: Vec<(MechCode, Option<Comment>)>,
+  pub body: ActivationBody,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ActivationBody {
+  Block(Vec<(MechCode, Option<Comment>)>),
+  PatternArms(Vec<ActivationArm>),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ActivationArm {
+  pub pattern: Pattern,
+  pub guard: Option<Expression>,
+  pub body: ActivationArmBody,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ActivationArmBody {
+  Block(Vec<(MechCode, Option<Comment>)>),
+  Expression(Expression),
 }
 
 impl ActivationScope {
   pub fn tokens(&self) -> Vec<Token> {
     let mut tokens = vec![self.operator.clone()];
     tokens.append(&mut self.trigger.tokens());
-    for (code, comment) in &self.body {
-      tokens.append(&mut code.tokens());
-      if let Some(comment) = comment { tokens.append(&mut comment.tokens()); }
+    match &self.body {
+      ActivationBody::Block(body) => append_activation_block_tokens(&mut tokens, body),
+      ActivationBody::PatternArms(arms) => for arm in arms {
+        tokens.append(&mut arm.pattern.tokens());
+        if let Some(guard) = &arm.guard { tokens.append(&mut guard.tokens()); }
+        match &arm.body {
+          ActivationArmBody::Block(body) => append_activation_block_tokens(&mut tokens, body),
+          ActivationArmBody::Expression(expression) => tokens.append(&mut expression.tokens()),
+        }
+      },
     }
     tokens
+  }
+}
+
+fn append_activation_block_tokens(tokens: &mut Vec<Token>, body: &[(MechCode, Option<Comment>)]) {
+  for (code, comment) in body {
+    tokens.append(&mut code.tokens());
+    if let Some(comment) = comment { tokens.append(&mut comment.tokens()); }
   }
 }
 

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1982,6 +1982,22 @@ impl Identifier {
   }
 }
 
+/// Constructs an identifier reserved for sampled runtime pattern values. The
+/// leading NUL cannot be produced by Mech source syntax, so source names always
+/// retain ordinary binding semantics.
+pub fn internal_pattern_value_identifier(name: &str) -> Identifier {
+  let mut chars = Vec::with_capacity(name.chars().count() + 1);
+  chars.push('\0');
+  chars.extend(name.chars());
+  Identifier {
+    name: Token::new(TokenKind::Identifier, SourceRange::default(), chars),
+  }
+}
+
+pub fn is_internal_pattern_value_identifier(identifier: &Identifier) -> bool {
+  identifier.name.chars.first() == Some(&'\0')
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Emoji {

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -1022,7 +1022,7 @@ impl ConstElem for Value {
     }
   }
   fn value_kind(&self) -> ValueKind {
-    self.value_kind()
+    self.kind()
   }
   fn align() -> u8 {
     1
@@ -1185,6 +1185,19 @@ impl ConstElem for ValueKind {
         }
         let row_count = cursor.read_u32::<LittleEndian>().expect("read table row count") as usize;
         ValueKind::Table(fields, row_count)
+      }
+      #[cfg(feature = "tuple")]
+      27 => {
+        let element_count = cursor.read_u32::<LittleEndian>().expect("read tuple kind length") as usize;
+        let mut elements = Vec::with_capacity(element_count);
+        for _ in 0..element_count {
+          let kind = ValueKind::from_le(&bytes[cursor.position() as usize..]);
+          let mut encoded = Vec::new();
+          kind.write_le(&mut encoded);
+          cursor.set_position(cursor.position() + encoded.len() as u64);
+          elements.push(kind);
+        }
+        ValueKind::Tuple(elements)
       }
       #[cfg(feature = "set")]
       29 => {

--- a/src/core/src/program/program.rs
+++ b/src/core/src/program/program.rs
@@ -460,6 +460,14 @@ impl ParsedProgram {
           let table = MechTable::from_le(&data);
           Value::Table(Ref::new(table))
         }
+        #[cfg(feature = "tuple")]
+        TypeTag::Tuple => {
+          if data.len() < 4 {
+            return Err(MechError::new(ConstantTooShortError { type_name: "tuple" }, None).with_compiler_loc());
+          }
+          let tuple = MechTuple::from_le(&data);
+          Value::Tuple(Ref::new(tuple))
+        }
         _ => {
           return Err(
             MechError::new(

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -5,8 +5,13 @@ use crate::*;
 
 pub type SymbolTableRef= Ref<SymbolTable>;
 
-#[derive(Clone, Debug)]
-pub struct SymbolTableSnapshot { symbols: HashMap<u64, ValRef>, mutable_variables: HashMap<u64, ValRef>, dictionary: Dictionary, reverse_lookup: HashMap<*const Ref<Value>, u64> }
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SymbolTableSnapshot {
+  symbols: HashMap<u64, ValRef>,
+  mutable_variables: HashMap<u64, ValRef>,
+  dictionary: Dictionary,
+  reverse_lookup: HashMap<*const Ref<Value>, u64>,
+}
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
@@ -17,8 +22,21 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
-  pub fn snapshot(&self) -> SymbolTableSnapshot { SymbolTableSnapshot { symbols:self.symbols.clone(), mutable_variables:self.mutable_variables.clone(), dictionary:self.dictionary.borrow().clone(), reverse_lookup:self.reverse_lookup.clone() } }
-  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) { self.symbols=snapshot.symbols; self.mutable_variables=snapshot.mutable_variables; *self.dictionary.borrow_mut()=snapshot.dictionary; self.reverse_lookup=snapshot.reverse_lookup; }
+  pub fn snapshot(&self) -> SymbolTableSnapshot {
+    SymbolTableSnapshot {
+      symbols: self.symbols.clone(),
+      mutable_variables: self.mutable_variables.clone(),
+      dictionary: self.dictionary.borrow().clone(),
+      reverse_lookup: self.reverse_lookup.clone(),
+    }
+  }
+
+  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) {
+    self.symbols = snapshot.symbols;
+    self.mutable_variables = snapshot.mutable_variables;
+    *self.dictionary.borrow_mut() = snapshot.dictionary;
+    self.reverse_lookup = snapshot.reverse_lookup;
+  }
 
 
   pub fn new() -> SymbolTable {
@@ -56,6 +74,35 @@ impl SymbolTable {
     cell.clone()
   }
 
+}
+
+#[cfg(test)]
+mod snapshot_tests {
+  use super::*;
+
+  #[test]
+  fn symbol_table_snapshot_restores_all_indexes_and_identity() {
+    let mut table = SymbolTable::new();
+    let outer = hash_str("outer");
+    let temporary = hash_str("temporary");
+    let outer_ref = table.insert(outer, Value::Index(Ref::new(1)), true);
+    table.dictionary.borrow_mut().insert(outer, "outer".to_string());
+    let outer_addr = outer_ref.addr();
+    let original_snapshot = table.snapshot();
+
+    table.insert(outer, Value::Index(Ref::new(2)), false);
+    table.insert(temporary, Value::Index(Ref::new(3)), false);
+    table.dictionary.borrow_mut().insert(outer, "changed".to_string());
+    table.dictionary.borrow_mut().insert(temporary, "temporary".to_string());
+    assert_ne!(table.snapshot(), original_snapshot);
+
+    table.restore(original_snapshot.clone());
+    assert_eq!(table.snapshot(), original_snapshot);
+    assert!(!table.contains(temporary));
+    assert!(table.get_mutable(outer).is_some());
+    assert_eq!(table.get(outer).unwrap().addr(), outer_addr);
+    assert_eq!(table.get_symbol_name_by_id(outer).as_deref(), Some("outer"));
+  }
 }
 
 #[cfg(feature = "pretty_print")]

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -1,9 +1,12 @@
 use crate::*;
 
-// Symbol Table 
+// Symbol Table
 // ----------------------------------------------------------------------------
 
 pub type SymbolTableRef= Ref<SymbolTable>;
+
+#[derive(Clone, Debug)]
+pub struct SymbolTableSnapshot { symbols: HashMap<u64, ValRef>, mutable_variables: HashMap<u64, ValRef>, dictionary: Dictionary, reverse_lookup: HashMap<*const Ref<Value>, u64> }
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
@@ -14,6 +17,9 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
+  pub fn snapshot(&self) -> SymbolTableSnapshot { SymbolTableSnapshot { symbols:self.symbols.clone(), mutable_variables:self.mutable_variables.clone(), dictionary:self.dictionary.borrow().clone(), reverse_lookup:self.reverse_lookup.clone() } }
+  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) { self.symbols=snapshot.symbols; self.mutable_variables=snapshot.mutable_variables; *self.dictionary.borrow_mut()=snapshot.dictionary; self.reverse_lookup=snapshot.reverse_lookup; }
+
 
   pub fn new() -> SymbolTable {
     Self {

--- a/src/core/src/structures/matrix.rs
+++ b/src/core/src/structures/matrix.rs
@@ -509,9 +509,64 @@ impl<T> Matrix<T> {
   }
 }
 
-impl<T> Matrix<T> 
+impl<T> Matrix<T>
 where T: Debug + Clone + PartialEq + 'static
 {
+
+  /// Returns whether `replace_payload_from` can update this matrix without
+  /// replacing its reactive root.
+  pub fn can_replace_payload_from(&self, source: &Matrix<T>) -> bool {
+    let rows = source.rows();
+    let cols = source.cols();
+    match self {
+      #[cfg(feature = "row_vectord")]
+      Matrix::RowDVector(_) => rows == 1,
+      #[cfg(feature = "vectord")]
+      Matrix::DVector(_) => cols == 1,
+      #[cfg(feature = "matrixd")]
+      Matrix::DMatrix(_) => true,
+      _ => self.shape() == source.shape(),
+    }
+  }
+
+  /// Replaces the payload stored by this matrix without replacing its reactive
+  /// root. Dynamic matrices may change dimensions; fixed matrices require the
+  /// source shape to remain identical.
+  pub fn replace_payload_from(&self, source: &Matrix<T>) -> bool {
+    if !self.can_replace_payload_from(source) {
+      return false;
+    }
+    let rows = source.rows();
+    let cols = source.cols();
+    let elements = source.as_vec();
+    match self {
+      #[cfg(feature = "row_vectord")]
+      Matrix::RowDVector(destination) if rows == 1 => {
+        destination
+          .borrow_mut()
+          .clone_from(&RowDVector::from_vec(elements));
+        true
+      }
+      #[cfg(feature = "vectord")]
+      Matrix::DVector(destination) if cols == 1 => {
+        destination
+          .borrow_mut()
+          .clone_from(&DVector::from_vec(elements));
+        true
+      }
+      #[cfg(feature = "matrixd")]
+      Matrix::DMatrix(destination) => {
+        destination
+          .borrow_mut()
+          .clone_from(&DMatrix::from_vec(rows, cols, elements));
+        true
+      }
+      _ => {
+        self.set(elements);
+        true
+      }
+    }
+  }
 
   pub fn append(&mut self, other: &Matrix<T>) -> MResult<()> {
     match (&self, &other) {

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1254,6 +1254,8 @@ impl Value {
       Value::Set(r) => &*(r as *const Ref<MechSet> as *const Ref<T>),
       #[cfg(feature = "table")]
       Value::Table(r) => &*(r as *const Ref<MechTable> as *const Ref<T>),
+      #[cfg(feature = "tuple")]
+      Value::Tuple(r) => &*(r as *const Ref<MechTuple> as *const Ref<T>),
       x => panic!("Unsupported type for as_unchecked: {:?}.", x),
     }
   }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -16,23 +16,52 @@ activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cel
 #[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
 #[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
 fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
-fn slot(v:&Value)->Option<Value> { match detached(v) {
-  Value::F64(_)=>Some(Value::F64(Ref::new(0.))), Value::F32(_)=>Some(Value::F32(Ref::new(0.))),
-  Value::I64(_)=>Some(Value::I64(Ref::new(0))), Value::I32(_)=>Some(Value::I32(Ref::new(0))), Value::I16(_)=>Some(Value::I16(Ref::new(0))), Value::I8(_)=>Some(Value::I8(Ref::new(0))),
-  Value::U64(_)=>Some(Value::U64(Ref::new(0))), Value::U32(_)=>Some(Value::U32(Ref::new(0))), Value::U16(_)=>Some(Value::U16(Ref::new(0))), Value::U8(_)=>Some(Value::U8(Ref::new(0))),
-  Value::Bool(_)=>Some(Value::Bool(Ref::new(false))), Value::String(_)=>Some(Value::String(Ref::new(String::new()))), Value::Index(_)=>Some(Value::Index(Ref::new(0))), Value::Atom(a)=>Some(Value::Atom(Ref::new(a.borrow().clone()))), _=>None } }
-fn compile(pat:&Pattern, sample:&Value, i:&Interpreter, caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern> { match pat {
- Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}),
- Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash(); if let Some(n)=caps.iter().position(|c|c.id==id){return Ok(CompiledActivationPattern::Capture{capture_index:n})}; let value=slot(sample).ok_or_else(||MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))?; caps.push(Capture{id,kind:sample.kind(),slot:value}); Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})},
- Pattern::Tuple(t)=> {let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; let e=&tv.borrow().elements; if e.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(e.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
- Pattern::TupleStruct(t)=> { let tag=t.name.hash(); let payload=match detached(sample) { Value::Enum(e)=>{let e=e.borrow(); e.variants.iter().find(|(id,_)|*id==tag).and_then(|(_,x)|x.as_ref()).cloned().into_iter().collect::<Vec<_>>()}, Value::Tuple(x)=>{let x=x.borrow(); if x.elements.first().map(|v|matches!(detached(v),Value::Atom(a) if a.borrow().id()==tag)).unwrap_or(false){x.elements.iter().skip(1).map(|v|(**v).clone()).collect()}else{Vec::new()}}, _=>Vec::new()}; if payload.len()!=t.patterns.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::TupleStruct{tag,payload:t.patterns.iter().zip(payload.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
- _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens())) }}
-fn matches_pattern(p:&CompiledActivationPattern,v:&Value, proposed:&mut Vec<Option<Value>>)->bool {match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}},CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false},CompiledActivationPattern::TupleStruct{tag,payload}=>match detached(v){Value::Enum(e)=>{let e=e.borrow();match e.variants.iter().find(|(id,_)|id==tag){Some((_,Some(v))) if payload.len()==1=>matches_pattern(&payload[0],v,proposed),Some((_,None))=>payload.is_empty(),_=>false}},Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==payload.len()+1&&matches!(detached(&t.elements[0]),Value::Atom(a) if a.borrow().id()==*tag)&&payload.iter().zip(t.elements.iter().skip(1)).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}}}
-macro_rules! copy_slot {($s:expr,$v:expr,$($x:ident),*)=>{match ($s,$v){$((Value::$x(a),Value::$x(b))=>{*a.borrow_mut()=*b.borrow();Ok(())},)* _=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}}
-fn commit(s:&Value,v:&Value)->MResult<()> {copy_slot!(s,detached(v),F64,F32,I64,I32,I16,I8,U64,U32,U16,U8,Bool,String,Index,Atom)}
+fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) { let source=source.borrow(); destination.borrow_mut().clone_from(&*source); }
+fn create_capture_slot(sample:&Value)->MResult<Value>{match detached(sample){
+#[cfg(feature="u8")] Value::U8(v)=>Ok(Value::U8(Ref::new(*v.borrow()))),
+#[cfg(feature="u16")] Value::U16(v)=>Ok(Value::U16(Ref::new(*v.borrow()))),
+#[cfg(feature="u32")] Value::U32(v)=>Ok(Value::U32(Ref::new(*v.borrow()))),
+#[cfg(feature="u64")] Value::U64(v)=>Ok(Value::U64(Ref::new(*v.borrow()))),
+#[cfg(feature="u128")] Value::U128(v)=>Ok(Value::U128(Ref::new(*v.borrow()))),
+#[cfg(feature="i8")] Value::I8(v)=>Ok(Value::I8(Ref::new(*v.borrow()))),
+#[cfg(feature="i16")] Value::I16(v)=>Ok(Value::I16(Ref::new(*v.borrow()))),
+#[cfg(feature="i32")] Value::I32(v)=>Ok(Value::I32(Ref::new(*v.borrow()))),
+#[cfg(feature="i64")] Value::I64(v)=>Ok(Value::I64(Ref::new(*v.borrow()))),
+#[cfg(feature="i128")] Value::I128(v)=>Ok(Value::I128(Ref::new(*v.borrow()))),
+#[cfg(feature="f32")] Value::F32(v)=>Ok(Value::F32(Ref::new(*v.borrow()))),
+#[cfg(feature="f64")] Value::F64(v)=>Ok(Value::F64(Ref::new(*v.borrow()))),
+#[cfg(feature="complex")] Value::C64(v)=>Ok(Value::C64(Ref::new(v.borrow().clone()))),
+#[cfg(feature="rational")] Value::R64(v)=>Ok(Value::R64(Ref::new(v.borrow().clone()))),
+#[cfg(any(feature="bool",feature="variable_define"))] Value::Bool(v)=>Ok(Value::Bool(Ref::new(*v.borrow()))),
+#[cfg(any(feature="string",feature="variable_define"))] Value::String(v)=>Ok(Value::String(Ref::new(v.borrow().clone()))),
+Value::Index(v)=>Ok(Value::Index(Ref::new(*v.borrow()))),
+#[cfg(feature="atom")] Value::Atom(v)=>Ok(Value::Atom(Ref::new(v.borrow().clone()))),
+_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
+fn commit_capture_slot(destination:&Value,source:&Value)->MResult<()>{let source=detached(source);match(destination,&source){
+#[cfg(feature="u8")] (Value::U8(a),Value::U8(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u16")] (Value::U16(a),Value::U16(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u32")] (Value::U32(a),Value::U32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u64")] (Value::U64(a),Value::U64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u128")] (Value::U128(a),Value::U128(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i8")] (Value::I8(a),Value::I8(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i16")] (Value::I16(a),Value::I16(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i32")] (Value::I32(a),Value::I32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i64")] (Value::I64(a),Value::I64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i128")] (Value::I128(a),Value::I128(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="f32")] (Value::F32(a),Value::F32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="f64")] (Value::F64(a),Value::F64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="complex")] (Value::C64(a),Value::C64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="rational")] (Value::R64(a),Value::R64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(any(feature="bool",feature="variable_define"))] (Value::Bool(a),Value::Bool(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(any(feature="string",feature="variable_define"))] (Value::String(a),Value::String(b))=>{clone_ref_value(a,b);Ok(())},
+(Value::Index(a),Value::Index(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="atom")] (Value::Atom(a),Value::Atom(b))=>{clone_ref_value(a,b);Ok(())},
+_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
+fn compile(pat:&Pattern,sample:&Value,i:&Interpreter,caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern>{match pat { Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}), Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash();if let Some(n)=caps.iter().position(|c|c.id==id){Ok(CompiledActivationPattern::Capture{capture_index:n})}else{let value=create_capture_slot(sample).map_err(|e|e.with_tokens(pat.tokens()))?;caps.push(Capture{id,kind:sample.kind(),slot:value});Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})}}, #[cfg(feature="tuple")] Pattern::Tuple(t)=>{let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))};let tv=tv.borrow();if tv.elements.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(tv.elements.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})}, _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens()))}}
+fn matches_pattern(p:&CompiledActivationPattern,v:&Value,proposed:&mut Vec<Option<Value>>)->bool{match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}}, #[cfg(feature="tuple")] CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}, CompiledActivationPattern::TupleStruct{..}=>false, #[cfg(not(feature="tuple"))] CompiledActivationPattern::Tuple{..}=>false}}
 fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
 struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
-struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
+struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit_capture_slot(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
 struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
 struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
 struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1214,4 +1214,690 @@ mod tests {
             commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
     }
+
+    type PlanSnapshot = (
+        usize,
+        Vec<(
+            ReactiveNodeId,
+            usize,
+            ReactiveNodeKind,
+            Vec<u64>,
+            Vec<(u64, ReactiveDependencyKind)>,
+        )>,
+        Vec<(u64, Vec<ReactiveNodeId>)>,
+        Vec<(u64, Vec<ReactiveNodeId>)>,
+        Vec<PatternActivationRegistration>,
+        usize,
+    );
+
+    fn interpret(source: &str) -> Interpreter {
+        let tree = mech_syntax::parser::parse(source).unwrap();
+        let mut interpreter = Interpreter::new_with_full_stdlib(0);
+        interpreter.interpret(&tree).unwrap();
+        interpreter
+    }
+
+    fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MResult<Value> {
+        let tree = mech_syntax::parser::parse(source).unwrap();
+        interpreter.interpret(&tree)
+    }
+
+    fn symbol_ref(interpreter: &Interpreter, name: &str) -> ValRef {
+        interpreter
+            .symbols()
+            .borrow()
+            .get(hash_str(name))
+            .unwrap_or_else(|| panic!("missing symbol `{name}`"))
+    }
+    fn symbol(interpreter: &Interpreter, name: &str) -> Value {
+        symbol_ref(interpreter, name).borrow().clone()
+    }
+    fn root_cell(interpreter: &Interpreter, name: &str) -> ReactiveCellId {
+        symbol(interpreter, name).reactive_root_cell_ids()[0]
+    }
+    fn registration(interpreter: &Interpreter) -> PatternActivationRegistration {
+        let plan = interpreter.plan();
+        let registrations = plan.pattern_activation_registrations();
+        assert_eq!(registrations.len(), 1);
+        registrations[0].clone()
+    }
+    fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
+        let plan = interpreter.plan();
+        let depth = plan.activation_registration_depth();
+        let plan = plan.borrow();
+        let nodes = plan
+            .nodes
+            .iter()
+            .map(|node| {
+                (
+                    node.id,
+                    node.plan_index,
+                    node.kind,
+                    node.outputs.iter().map(|cell| cell.get()).collect(),
+                    node.inputs
+                        .iter()
+                        .map(|dependency| (dependency.cell.get(), dependency.kind))
+                        .collect(),
+                )
+            })
+            .collect();
+        let mut reactive = plan
+            .reactive_consumers
+            .iter()
+            .map(|(cell, nodes)| (cell.get(), nodes.clone()))
+            .collect::<Vec<_>>();
+        reactive.sort_by_key(|(cell, _)| *cell);
+        let mut sampled = plan
+            .sampled_consumers
+            .iter()
+            .map(|(cell, nodes)| (cell.get(), nodes.clone()))
+            .collect::<Vec<_>>();
+        sampled.sort_by_key(|(cell, _)| *cell);
+        (
+            plan.len(),
+            nodes,
+            reactive,
+            sampled,
+            plan.pattern_activation_registrations().to_vec(),
+            depth,
+        )
+    }
+    fn turn_executed_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .executed_nodes
+            .iter()
+            .chain(outcome.after_commit.executed_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn turn_changed_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .changed_nodes
+            .iter()
+            .chain(outcome.after_commit.changed_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn turn_unchanged_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .unchanged_nodes
+            .iter()
+            .chain(outcome.after_commit.unchanged_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn body_output_f64(interpreter: &Interpreter, arm_index: usize) -> f64 {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm_index];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        for id in (arm.body_node_start..arm.body_node_end).rev() {
+            if let Ok(value) = plan.node(id).unwrap().function.out().as_f64() {
+                return *value.borrow();
+            }
+        }
+        panic!("no f64 output")
+    }
+    fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
+        match symbol(interpreter, "event") {
+            Value::Enum(event) => {
+                let id = event.borrow().id;
+                let names = interpreter
+                    .state
+                    .borrow()
+                    .enums
+                    .get(&id)
+                    .unwrap()
+                    .names
+                    .clone();
+                *event.borrow_mut() = MechEnum {
+                    id,
+                    variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
+                    names,
+                };
+            }
+            Value::Tuple(_) => set_atom_tuple_event(interpreter, variant, payload),
+            _ => panic!("event is neither enum nor tagged tuple"),
+        }
+    }
+    fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
+        let Value::Tuple(event) = symbol(interpreter, "event") else {
+            panic!("event is not tuple")
+        };
+        *event.borrow_mut() = MechTuple::from_vec(vec![
+            Value::Atom(Ref::new(MechAtom::from_name(tag))),
+            Value::F64(Ref::new(payload)),
+        ]);
+    }
+    fn set_tuple_event(interpreter: &Interpreter, values: Vec<Value>) {
+        let Value::Tuple(event) = symbol(interpreter, "event") else {
+            panic!("event is not tuple")
+        };
+        *event.borrow_mut() = MechTuple::from_vec(values);
+    }
+    fn selected_arm_index(
+        registration: &PatternActivationRegistration,
+        outcome: &ReactiveTurnOutcome,
+    ) -> usize {
+        let changed = turn_changed_nodes(outcome);
+        registration
+            .arms
+            .iter()
+            .position(|arm| changed.contains(&arm.gate_node))
+            .expect("no selected gate")
+    }
+    fn assert_dispatch_turn(
+        interpreter: &Interpreter,
+        topology: &PlanSnapshot,
+        outcome: &ReactiveTurnOutcome,
+        expected_arm: usize,
+        output: f64,
+    ) {
+        let registration = registration(interpreter);
+        let executed = turn_executed_nodes(outcome);
+        let changed = turn_changed_nodes(outcome);
+        let unchanged = turn_unchanged_nodes(outcome);
+        assert_eq!(
+            executed
+                .iter()
+                .filter(|id| **id == registration.scope_pulse_node)
+                .count(),
+            1
+        );
+        assert_eq!(
+            executed
+                .iter()
+                .filter(|id| **id == registration.selector_node)
+                .count(),
+            1
+        );
+        assert_eq!(selected_arm_index(&registration, outcome), expected_arm);
+        for (index, arm) in registration.arms.iter().enumerate() {
+            for node in [arm.matcher_node, arm.finalizer_node, arm.gate_node] {
+                assert_eq!(executed.iter().filter(|id| **id == node).count(), 1);
+            }
+            if index == expected_arm {
+                assert!(changed.contains(&arm.gate_node));
+                assert!(!unchanged.contains(&arm.gate_node));
+                for node in arm.body_node_start..arm.body_node_end {
+                    assert_eq!(executed.iter().filter(|id| **id == node).count(), 1);
+                }
+            } else {
+                assert!(unchanged.contains(&arm.gate_node));
+                assert!(!changed.contains(&arm.gate_node));
+                for node in arm.body_node_start..arm.body_node_end {
+                    assert!(!executed.contains(&node));
+                }
+            }
+        }
+        assert_eq!(body_output_f64(interpreter, expected_arm), output);
+        assert_eq!(&plan_snapshot(interpreter), topology);
+    }
+
+    const ENUM_ACTIVATION: &str = r#"event := (:pressed, 0.0)
+
+~> event
+  | :pressed(x) => {
+      selected := x + 0.0
+    }
+  | :released(x) => {
+      selected := x + 1000.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn load_enum_activation() -> (
+        Interpreter,
+        ReactiveCellId,
+        PatternActivationRegistration,
+        PlanSnapshot,
+    ) {
+        let interpreter = interpret(ENUM_ACTIVATION);
+        let trigger = root_cell(&interpreter, "event");
+        let registration = registration(&interpreter);
+        assert_eq!(registration.arms.len(), 3);
+        assert_eq!(registration.arms[0].captures.len(), 1);
+        assert_eq!(registration.arms[1].captures.len(), 1);
+        assert!(registration.arms[2].captures.is_empty());
+        assert!(!interpreter.symbols().borrow().contains(hash_str("x")));
+        assert!(
+            !interpreter
+                .symbols()
+                .borrow()
+                .contains(hash_str("selected"))
+        );
+        let topology = plan_snapshot(&interpreter);
+        (interpreter, trigger, registration, topology)
+    }
+
+    #[test]
+    fn activation_pattern_selects_pressed_released_and_wildcard() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        for (name, payload, arm, output) in [
+            ("pressed", 10., 0, 10.),
+            ("released", 20., 1, 1020.),
+            ("other", 30., 2, -1.),
+        ] {
+            set_enum_event(&i, name, payload);
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, arm, output);
+        }
+    }
+    #[test]
+    fn activation_pattern_enum_arms_compile_independent_of_initial_variant() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        assert_eq!(r.arms[1].captures[0].kind, ValueKind::F64);
+        set_enum_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+    }
+    #[test]
+    fn activation_pattern_enum_payload_capture_is_available() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        let cell = r.arms[0].captures[0].cell;
+        assert!(
+            i.plan().borrow().nodes[r.arms[0].body_node_start..r.arms[0].body_node_end]
+                .iter()
+                .any(|n| n.inputs.iter().any(|d| d.cell == cell))
+        );
+        set_enum_event(&i, "pressed", 10.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 10.);
+    }
+    #[test]
+    fn activation_pattern_equal_packets_dispatch_repeatedly() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        set_enum_event(&i, "pressed", 30.);
+        for _ in 0..2 {
+            let o = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &o, 0, 30.);
+        }
+    }
+    #[test]
+    fn activation_pattern_unselected_arm_nodes_do_not_execute() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        set_enum_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+        let executed = turn_executed_nodes(&o);
+        for arm in [&r.arms[0], &r.arms[2]] {
+            for node in arm.body_node_start..arm.body_node_end {
+                assert!(!executed.contains(&node));
+            }
+        }
+    }
+    #[test]
+    fn activation_pattern_switching_arms_does_not_grow_plan() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        for (name, payload) in [
+            ("pressed", 10.),
+            ("released", 20.),
+            ("other", 30.),
+            ("pressed", 30.),
+            ("pressed", 30.),
+        ] {
+            set_enum_event(&i, name, payload);
+            i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+    #[test]
+    fn activation_pattern_capture_storage_identity_is_stable() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        let captures = r
+            .arms
+            .iter()
+            .flat_map(|arm| arm.captures.iter())
+            .map(|capture| (capture.id, capture.kind.clone(), capture.cell))
+            .collect::<Vec<_>>();
+        for (name, payload) in [("pressed", 10.), ("released", 20.), ("other", 30.)] {
+            set_enum_event(&i, name, payload);
+            i.advance_reactive_turn(&[trigger]).unwrap();
+            let current = registration(&i)
+                .arms
+                .iter()
+                .flat_map(|arm| arm.captures.iter())
+                .map(|capture| (capture.id, capture.kind.clone(), capture.cell))
+                .collect::<Vec<_>>();
+            assert_eq!(current, captures);
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+
+    const ATOM_TUPLE_ACTIVATION: &str = r#"
+event := (:pressed, 0.0)
+~> event
+  | :pressed(x) => {
+      selected := x + 0.0
+    }
+  | :released(x) => {
+      selected := x + 1000.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn load_atom_tuple_activation() -> (
+        Interpreter,
+        ReactiveCellId,
+        PatternActivationRegistration,
+        PlanSnapshot,
+    ) {
+        let i = interpret(ATOM_TUPLE_ACTIVATION);
+        let trigger = root_cell(&i, "event");
+        let r = registration(&i);
+        let topology = plan_snapshot(&i);
+        (i, trigger, r, topology)
+    }
+    #[test]
+    fn activation_pattern_atom_tagged_tuple_selects_arm() {
+        let (mut i, trigger, _, topology) = load_atom_tuple_activation();
+        for (tag, payload, arm, output) in [
+            ("pressed", 10., 0, 10.),
+            ("released", 20., 1, 1020.),
+            ("other", 30., 2, -1.),
+        ] {
+            set_atom_tuple_event(&i, tag, payload);
+            let o = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &o, arm, output);
+        }
+    }
+    #[test]
+    fn activation_pattern_atom_tagged_tuple_captures_payload() {
+        let (mut i, trigger, r, topology) = load_atom_tuple_activation();
+        assert_eq!(r.arms[0].captures[0].kind, ValueKind::F64);
+        let cell = r.arms[0].captures[0].cell;
+        assert!(
+            i.plan().borrow().nodes[r.arms[0].body_node_start..r.arms[0].body_node_end]
+                .iter()
+                .any(|n| n.inputs.iter().any(|d| d.cell == cell))
+        );
+        set_atom_tuple_event(&i, "pressed", 10.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 10.);
+    }
+    #[test]
+    fn activation_pattern_atom_tuple_arms_compile_independent_of_initial_tag() {
+        let (mut i, trigger, r, topology) = load_atom_tuple_activation();
+        assert_eq!(r.arms[0].captures[0].kind, ValueKind::F64);
+        assert_eq!(r.arms[1].captures[0].kind, ValueKind::F64);
+        set_atom_tuple_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+    }
+
+    const FLAT_TUPLE_ACTIVATION: &str = r#"
+event := (1.0, 2.0)
+~> event
+  | (x, y) => {
+      selected := x * 10.0 + y
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    const NESTED_TUPLE_ACTIVATION: &str = r#"
+event := ((1.0, 2.0), 3.0)
+~> event
+  | ((x, y), z) => {
+      selected := x * 100.0 + y * 10.0 + z
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    const REPEATED_CAPTURE_ACTIVATION: &str = r#"
+event := (1.0, 1.0)
+~> event
+  | (x, x) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn tuple_fixture(source: &str) -> (Interpreter, ReactiveCellId, PlanSnapshot) {
+        let i = interpret(source);
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        (i, trigger, topology)
+    }
+    #[test]
+    fn activation_pattern_tuple_captures_elements() {
+        let (mut i, trigger, topology) = tuple_fixture(FLAT_TUPLE_ACTIVATION);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 34.);
+    }
+    #[test]
+    fn activation_pattern_nested_tuple_captures_elements() {
+        let (mut i, trigger, topology) = tuple_fixture(NESTED_TUPLE_ACTIVATION);
+        set_tuple_event(
+            &i,
+            vec![
+                Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                    Value::F64(Ref::new(4.)),
+                    Value::F64(Ref::new(5.)),
+                ]))),
+                Value::F64(Ref::new(6.)),
+            ],
+        );
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 456.);
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_requires_equal_values() {
+        let (mut i, trigger, topology) = tuple_fixture(REPEATED_CAPTURE_ACTIVATION);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(2.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 2.);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(3.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, -1.);
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_kind_mismatch_is_structured() {
+        let mut i = interpret("event := (1.0, \"one\")");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, x) => {
+      selected := x
+    }\n  | * => {
+      selected := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("x")));
+        assert!(!i.symbols().borrow().contains(hash_str("selected")));
+    }
+
+    #[test]
+    fn activation_pattern_capture_does_not_leak() {
+        let (mut i, trigger, topology) = tuple_fixture(FLAT_TUPLE_ACTIVATION);
+        for name in ["x", "y", "selected"] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 34.);
+    }
+    #[test]
+    fn activation_pattern_capture_shadows_and_restores_outer_symbol() {
+        let mut i = interpret("event := (1.0, 2.0)\nx := 99.0");
+        let outer = symbol_ref(&i, "x");
+        let address = outer.addr();
+        interpret_more(
+            &mut i,
+            "~> event\n  | (x, y) => {
+      selected := x + y
+    }\n  | * => {
+      selected := -1.0
+    }",
+        )
+        .unwrap();
+        assert_eq!(*symbol(&i, "x").as_f64().unwrap().borrow(), 99.);
+        assert_eq!(symbol_ref(&i, "x").addr(), address);
+        assert!(!i.symbols().borrow().contains(hash_str("y")));
+        assert!(!i.symbols().borrow().contains(hash_str("selected")));
+        let topology = plan_snapshot(&i);
+        let trigger = root_cell(&i, "event");
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 7.);
+    }
+    #[test]
+    fn activation_pattern_arm_definitions_do_not_leak_between_arms() {
+        let mut i = interpret("event := (1.0, 2.0)");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, y) => {
+      first-local := x + y
+    }\n  | (a, b) => {
+      second-local := first-local + a + b
+    }\n  | * => {
+      fallback := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "UndefinedVariable");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        for name in [
+            "first-local",
+            "second-local",
+            "fallback",
+            "x",
+            "y",
+            "a",
+            "b",
+        ] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+    }
+
+    fn failed_elaboration_fixture() -> (
+        Interpreter,
+        SymbolTableSnapshot,
+        Dictionary,
+        PlanSnapshot,
+        ValRef,
+        usize,
+    ) {
+        let i = interpret("event := (1.0, 2.0)\nouter := 99.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let outer = symbol_ref(&i, "outer");
+        let address = outer.addr();
+        (i, symbols, dictionary, topology, outer, address)
+    }
+    fn assert_failed_elaboration_restored() -> (
+        Interpreter,
+        SymbolTableSnapshot,
+        Dictionary,
+        PlanSnapshot,
+        usize,
+    ) {
+        let (mut i, symbols, dictionary, topology, outer, address) = failed_elaboration_fixture();
+        let error=interpret_more(&mut i,"~> event\n  | (x, y) => {\n      local-atom := :temporary\n      local-first := x + y\n      local-failure := function-that-does-not-exist(local-first)\n    }\n  | * => {
+      fallback := 0.0
+    }").unwrap_err();
+        assert!(error.kind_name().contains("Function"));
+        assert!(!i.dictionary().borrow().contains_key(&hash_str("temporary")));
+        for name in [
+            "local-atom",
+            "local-first",
+            "local-failure",
+            "fallback",
+            "x",
+            "y",
+        ] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+        assert_eq!(*symbol(&i, "outer").as_f64().unwrap().borrow(), 99.);
+        assert_eq!(symbol_ref(&i, "outer").addr(), address);
+        drop(outer);
+        (i, symbols, dictionary, topology, address)
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_symbol_table() {
+        let (i, symbols, _, _, _) = assert_failed_elaboration_restored();
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_program_dictionary() {
+        let (i, _, dictionary, _, _) = assert_failed_elaboration_restored();
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_plan() {
+        let (i, _, _, topology, _) = assert_failed_elaboration_restored();
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+    #[test]
+    fn activation_pattern_preflight_error_does_not_modify_plan() {
+        let mut i = interpret("event := (1.0, \"one\")");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, x) => {
+      selected := x
+    }\n  | * => {
+      selected := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+    #[test]
+    fn activation_pattern_recursive_preflight_rejects_nested_activation() {
+        let mut i = interpret("event := 1.0\ntick := 0.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | 1.0 => {\n      ~> tick {\n        nested := 1.0\n      }\n    }\n  | * => {\n      fallback := 0.0\n    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternDefinitionUnsupported");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("nested")));
+        assert!(!i.symbols().borrow().contains(hash_str("fallback")));
+    }
+    #[test]
+    fn activation_pattern_recursive_preflight_rejects_context_declaration() {
+        let mut i = interpret("event := 1.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | 1.0 => {
+      @temporary := test://resource
+    }\n  | * => {
+      fallback := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternDefinitionUnsupported");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("fallback")));
+    }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,99 +1,59 @@
-#![cfg(all(
-  feature = "functions",
-  feature = "symbol_table",
-))]
-
-//! Static scheduling support for patterned activation scopes.
-//!
-//! The small dispatch nodes in this file deliberately contain no syntax and
-//! are registered once while a source tree is elaborated.  A reactive turn
-//! only moves generation counters through that already-built graph.
-
+#![cfg(all(feature = "functions", feature = "symbol_table"))]
+//! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
 
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternExpressionUnsupported;
-impl MechErrorKind for ActivationPatternExpressionUnsupported { fn name(&self)->&str{"ActivationPatternExpressionUnsupported"} fn message(&self)->String{"This activation pattern is not supported.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternCaptureKindUnsupported;
-impl MechErrorKind for ActivationPatternCaptureKindUnsupported { fn name(&self)->&str{"ActivationPatternCaptureKindUnsupported"} fn message(&self)->String{"The capture kind cannot be inferred from the activation trigger.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternArmsNonExhaustive;
-impl MechErrorKind for ActivationPatternArmsNonExhaustive { fn name(&self)->&str{"ActivationPatternArmsNonExhaustive"} fn message(&self)->String{"Patterned activations require a final unguarded wildcard arm.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternWildcardMustBeLast;
-impl MechErrorKind for ActivationPatternWildcardMustBeLast { fn name(&self)->&str{"ActivationPatternWildcardMustBeLast"} fn message(&self)->String{"The wildcard activation arm must be last.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternGuardMustBePure;
-impl MechErrorKind for ActivationPatternGuardMustBePure { fn name(&self)->&str{"ActivationPatternGuardMustBePure"} fn message(&self)->String{"Patterned activation guards must be pure.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternRegisterWriteUnsupported;
-impl MechErrorKind for ActivationPatternRegisterWriteUnsupported { fn name(&self)->&str{"ActivationPatternRegisterWriteUnsupported"} fn message(&self)->String{"Patterned activation register writes are not supported.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternContextEffectUnsupported;
-impl MechErrorKind for ActivationPatternContextEffectUnsupported { fn name(&self)->&str{"ActivationPatternContextEffectUnsupported"} fn message(&self)->String{"Patterned activation context effects are not supported.".into()} }
+macro_rules! activation_error {($n:ident,$m:expr)=>{#[derive(Debug,Clone)] pub(crate) struct $n; impl MechErrorKind for $n {fn name(&self)->&str{stringify!($n)} fn message(&self)->String{$m.into()}}};}
+activation_error!(ActivationPatternExpressionUnsupported,"This activation pattern is not supported.");
+activation_error!(ActivationPatternCaptureKindUnsupported,"The capture kind cannot be inferred from the activation trigger.");
+activation_error!(ActivationPatternArmsNonExhaustive,"Patterned activations require a final unguarded wildcard arm.");
+activation_error!(ActivationPatternWildcardMustBeLast,"The wildcard activation arm must be last.");
+activation_error!(ActivationPatternGuardMustBePure,"Patterned activation guards are not supported yet.");
+activation_error!(ActivationPatternRegisterWriteUnsupported,"Patterned activation register writes are not supported.");
+activation_error!(ActivationPatternContextEffectUnsupported,"Patterned activation context effects are not supported.");
+activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cells disagree with the resolved trigger.");
 
-#[derive(Clone, Debug)]
-enum CompiledActivationPattern { Wildcard, Literal(Value) }
+#[derive(Clone,Debug)] enum CompiledActivationPattern { Wildcard, Literal{expected:Value}, Capture{capture_index:usize}, Tuple{elements:Vec<Self>}, TupleStruct{tag:u64,payload:Vec<Self>} }
+#[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
+#[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
+fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
+fn slot(v:&Value)->Option<Value> { match detached(v) {
+  Value::F64(_)=>Some(Value::F64(Ref::new(0.))), Value::F32(_)=>Some(Value::F32(Ref::new(0.))),
+  Value::I64(_)=>Some(Value::I64(Ref::new(0))), Value::I32(_)=>Some(Value::I32(Ref::new(0))), Value::I16(_)=>Some(Value::I16(Ref::new(0))), Value::I8(_)=>Some(Value::I8(Ref::new(0))),
+  Value::U64(_)=>Some(Value::U64(Ref::new(0))), Value::U32(_)=>Some(Value::U32(Ref::new(0))), Value::U16(_)=>Some(Value::U16(Ref::new(0))), Value::U8(_)=>Some(Value::U8(Ref::new(0))),
+  Value::Bool(_)=>Some(Value::Bool(Ref::new(false))), Value::String(_)=>Some(Value::String(Ref::new(String::new()))), Value::Index(_)=>Some(Value::Index(Ref::new(0))), Value::Atom(a)=>Some(Value::Atom(Ref::new(a.borrow().clone()))), _=>None } }
+fn compile(pat:&Pattern, sample:&Value, i:&Interpreter, caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern> { match pat {
+ Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}),
+ Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash(); if let Some(n)=caps.iter().position(|c|c.id==id){return Ok(CompiledActivationPattern::Capture{capture_index:n})}; let value=slot(sample).ok_or_else(||MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))?; caps.push(Capture{id,kind:sample.kind(),slot:value}); Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})},
+ Pattern::Tuple(t)=> {let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; let e=&tv.borrow().elements; if e.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(e.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
+ Pattern::TupleStruct(t)=> { let tag=t.name.hash(); let payload=match detached(sample) { Value::Enum(e)=>{let e=e.borrow(); e.variants.iter().find(|(id,_)|*id==tag).and_then(|(_,x)|x.as_ref()).cloned().into_iter().collect::<Vec<_>>()}, Value::Tuple(x)=>{let x=x.borrow(); if x.elements.first().map(|v|matches!(detached(v),Value::Atom(a) if a.borrow().id()==tag)).unwrap_or(false){x.elements.iter().skip(1).map(|v|(**v).clone()).collect()}else{Vec::new()}}, _=>Vec::new()}; if payload.len()!=t.patterns.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::TupleStruct{tag,payload:t.patterns.iter().zip(payload.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
+ _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens())) }}
+fn matches_pattern(p:&CompiledActivationPattern,v:&Value, proposed:&mut Vec<Option<Value>>)->bool {match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}},CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false},CompiledActivationPattern::TupleStruct{tag,payload}=>match detached(v){Value::Enum(e)=>{let e=e.borrow();match e.variants.iter().find(|(id,_)|id==tag){Some((_,Some(v))) if payload.len()==1=>matches_pattern(&payload[0],v,proposed),Some((_,None))=>payload.is_empty(),_=>false}},Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==payload.len()+1&&matches!(detached(&t.elements[0]),Value::Atom(a) if a.borrow().id()==*tag)&&payload.iter().zip(t.elements.iter().skip(1)).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}}}
+macro_rules! copy_slot {($s:expr,$v:expr,$($x:ident),*)=>{match ($s,$v){$((Value::$x(a),Value::$x(b))=>{*a.borrow_mut()=*b.borrow();Ok(())},)* _=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}}
+fn commit(s:&Value,v:&Value)->MResult<()> {copy_slot!(s,detached(v),F64,F32,I64,I32,I16,I8,U64,U32,U16,U8,Bool,String,Index,Atom)}
+fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
+struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
+struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
+struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
+struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
+struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}
 
-fn compile_pattern(pattern: &Pattern, interpreter: &Interpreter) -> MResult<CompiledActivationPattern> {
-  match pattern {
-    Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
-    Pattern::Expression(Expression::Literal(literal)) => Ok(CompiledActivationPattern::Literal(crate::literal(literal, interpreter)?)),
-    // A variable is deliberately not treated as a catch-all: doing so loses
-    // the type and stable backing reference required for a capture slot.
-    Pattern::Expression(Expression::Var(_)) => Err(MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(pattern.tokens())),
-    _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None).with_tokens(pattern.tokens())),
-  }
-}
+#[cfg(feature="compiler")] macro_rules! interpreter_only {($t:ty)=>{impl MechFunctionCompiler for $t { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }};}
+#[cfg(feature="compiler")] interpreter_only!(ScopePulse);
+#[cfg(feature="compiler")] interpreter_only!(Matcher);
+#[cfg(feature="compiler")] interpreter_only!(Finalize);
+#[cfg(feature="compiler")] interpreter_only!(Select);
+#[cfg(feature="compiler")] interpreter_only!(Gate);
 
-fn generation() -> (Ref<usize>, Value) { let cell=Ref::new(0usize); let value=Value::Index(cell.clone()); (cell,value) }
-
-struct ScopePulse { out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for ScopePulse { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for ScopePulse {
-  fn solve(&self) {}
-  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
-  fn out(&self)->Value { Value::Index(self.out.clone()) }
-  fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>> { Some(vec![ReactiveDependencyScope::Root]) }
-  fn to_string(&self)->String{"ActivationPatternScopePulse".into()}
-}
-struct Matcher { pattern: CompiledActivationPattern, trigger: Value, matched: Ref<bool>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Matcher { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Matcher {
-  fn solve(&self) {}
-  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.matched.borrow_mut()=match &self.pattern { CompiledActivationPattern::Wildcard=>true, CompiledActivationPattern::Literal(value)=>value==&self.trigger }; *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
-  fn out(&self)->Value{Value::Index(self.out.clone())}
-  fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}
-  fn to_string(&self)->String{"ActivationPatternMatcher".into()}
-}
-struct Finalize { matched: Ref<bool>, eligible: Ref<bool>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Finalize { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Finalize { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmFinalize".into()} }
-struct Select { eligible: Vec<Ref<bool>>, selected: Ref<usize>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Select { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Select { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternSelectArm".into()} }
-struct Gate { arm: usize, selected: Ref<usize>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Gate { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Gate { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if *self.selected.borrow()==self.arm {*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} else {Ok(ReactiveSolveStatus::Unchanged)}} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmGate".into()} }
-
-/// Elaborates the static, combinational dispatch graph for literal and
-/// wildcard patterned activation arms.  Unsupported destructuring is rejected
-/// during elaboration rather than deferred to a reactive turn.
-pub(crate) fn elaborate_patterned_activation(scope: &ActivationScope, arms: &[ActivationArm], trigger: Value, trigger_cells: Vec<ReactiveCellId>, interpreter: &Interpreter) -> MResult<Value> {
-  let final_arm=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
-  if !matches!(final_arm.pattern,Pattern::Wildcard) || final_arm.guard.is_some() { return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens())); }
-  if arms[..arms.len()-1].iter().any(|arm|matches!(arm.pattern,Pattern::Wildcard)) { return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens())); }
-  if arms.iter().any(|arm|arm.guard.is_some()) { return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens())); }
-  for arm in arms { if let ActivationArmBody::Block(body)=&arm.body { for (code,_) in body { match code { MechCode::Statement(Statement::VariableAssign(_)) | MechCode::Statement(Statement::OpAssign(_)) => return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())), MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())), _=>{} } } } }
-  let patterns=arms.iter().map(|arm|compile_pattern(&arm.pattern,interpreter)).collect::<MResult<Vec<_>>>()?;
-  let plan=interpreter.plan();
-  let (scope_generation,scope_value)=generation();
-  let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_generation}), &[trigger.clone()])?;
-  let mut matcher_nodes=Vec::new(); let mut completions=Vec::new(); let mut matched=Vec::new();
-  for pattern in patterns { let (complete,complete_value)=generation(); let flag=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Matcher{pattern,trigger:trigger.clone(),matched:flag.clone(),out:complete}), &[scope_value.clone(),trigger.clone()])?; matcher_nodes.push(id); completions.push(complete_value); matched.push(flag); }
-  let mut finalizer_nodes=Vec::new(); let mut eligible=Vec::new(); let mut arm_complete=Vec::new();
-  for (flag, complete) in matched.iter().zip(completions.iter()) { let (done,done_value)=generation(); let ok=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Finalize{matched:flag.clone(),eligible:ok.clone(),out:done}), &[complete.clone()])?; finalizer_nodes.push(id); eligible.push(ok); arm_complete.push(done_value); }
-  let (selection,selection_value)=generation(); let selected=Ref::new(usize::MAX); let selector_node=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:selection}), &arm_complete)?;
-  let mut gate_nodes=Vec::new(); let mut pulses=Vec::new();
-  for arm in 0..arms.len() { let (pulse,pulse_value)=generation(); let id=plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:pulse}), &[selection_value.clone()])?; gate_nodes.push(id); pulses.push(pulse_value); }
-  let mut registrations=Vec::new();
-  for (arm,pulse) in arms.iter().zip(pulses.iter()) { let start=plan.len(); plan.push_activation_registration_scope(pulse.reactive_root_cell_ids()); let result=match &arm.body { ActivationArmBody::Block(body)=>{for (code,_) in body { crate::mech_code(code,interpreter)?; } Ok(())}, ActivationArmBody::Expression(expression)=>{crate::expression(expression,None,interpreter).map(|_|())} }; plan.pop_activation_registration_scope(); result?; registrations.push((start,plan.len())); }
-  let registration=PatternActivationRegistration { scope_pulse_node:scope_node, selector_node, arms:(0..arms.len()).map(|i|PatternActivationArmRegistration{matcher_node:matcher_nodes[i],finalizer_node:finalizer_nodes[i],gate_node:gate_nodes[i],pulse_cell:pulses[i].reactive_root_cell_ids()[0],body_node_start:registrations[i].0,body_node_end:registrations[i].1}).collect() };
-  plan.borrow_mut().register_pattern_activation(registration);
-  let _=trigger_cells; // The scope pulse's Root dependency is the trigger's root storage.
-  Ok(Value::Empty)
+pub(crate) fn elaborate_patterned_activation(scope:&ActivationScope,arms:&[ActivationArm],trigger:Value,trigger_cells:Vec<ReactiveCellId>,i:&Interpreter)->MResult<Value>{
+ let last=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
+ if !matches!(last.pattern,Pattern::Wildcard)||last.guard.is_some(){return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))} if arms[..arms.len()-1].iter().any(|x|matches!(x.pattern,Pattern::Wildcard)){return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens()))} if arms.iter().any(|x|x.guard.is_some()){return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens()))}
+ for arm in arms {if let ActivationArmBody::Block(body)=&arm.body{for(code,_)in body{match code{MechCode::Statement(Statement::VariableAssign(_))|MechCode::Statement(Statement::OpAssign(_))=>return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())),MechCode::Statement(Statement::ContextSend(_))=>return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())),_=>{}}}}}
+ let mut compiled=Vec::new();for arm in arms{let mut captures=Vec::new();let pattern=compile(&arm.pattern,&trigger,i,&mut captures)?;compiled.push(CompiledArm{pattern,captures})}
+ if trigger.reactive_root_cell_ids()!=trigger_cells{return Err(MechError::new(ActivationPatternTriggerInvariant,None).with_tokens(scope.tokens()))}
+ let plan=i.plan();let(scope_gen,scope_v)=generation();let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_gen}),&[trigger.clone()])?;
+ let(mut matcher_nodes,mut completions,mut matched)=(Vec::new(),Vec::new(),Vec::new());for arm in &compiled{let(o,v)=generation();let f=Ref::new(false);let n=plan.borrow_mut().register(Box::new(Matcher{pattern:arm.pattern.clone(),trigger:trigger.clone(),captures:arm.captures.clone(),matched:f.clone(),out:o}),&[scope_v.clone(),trigger.clone()])?;matcher_nodes.push(n);completions.push(v);matched.push(f)}
+ let(mut finalizers,mut eligible,mut done)=(Vec::new(),Vec::new(),Vec::new());for(f,c)in matched.iter().zip(completions.iter()){let(o,v)=generation();let e=Ref::new(false);finalizers.push(plan.borrow_mut().register(Box::new(Finalize{matched:f.clone(),eligible:e.clone(),out:o}),&[c.clone()])?);eligible.push(e);done.push(v)} let(o,selection)=generation();let selected=Ref::new(usize::MAX);let selector=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:o}),&done)?;
+ let(mut gates,mut pulses)=(Vec::new(),Vec::new());for arm in 0..arms.len(){let(o,v)=generation();gates.push(plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:o}),&[selection.clone()])?);pulses.push(v)}
+ let mut ranges=Vec::new();for(arm,compiled_arm)in arms.iter().zip(compiled.iter()){let symbols=i.symbols();let mut s=symbols.borrow_mut();let old=compiled_arm.captures.iter().map(|c|(c.id,s.symbols.get(&c.id).cloned(),s.mutable_variables.get(&c.id).cloned())).collect::<Vec<_>>();for c in &compiled_arm.captures{s.insert(c.id,c.slot.clone(),false);}drop(s);let start=plan.len();plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());let result=match &arm.body{ActivationArmBody::Block(b)=>{for(c,_)in b{crate::mech_code(c,i)?;}Ok(())},ActivationArmBody::Expression(e)=>crate::expression(e,None,i).map(|_|())};plan.pop_activation_registration_scope();let mut s=symbols.borrow_mut();for(id,oldv,oldm)in old{s.symbols.remove(&id);s.mutable_variables.remove(&id);if let Some(v)=oldv{s.symbols.insert(id,v);}if let Some(v)=oldm{s.mutable_variables.insert(id,v);}}drop(s);result?;ranges.push((start,plan.len()))}
+ let registration=PatternActivationRegistration{scope_pulse_node:scope_node,selector_node:selector,arms:(0..arms.len()).map(|n|PatternActivationArmRegistration{matcher_node:matcher_nodes[n],finalizer_node:finalizers[n],gate_node:gates[n],pulse_cell:pulses[n].reactive_root_cell_ids()[0],body_node_start:ranges[n].0,body_node_end:ranges[n].1,captures:compiled[n].captures.iter().map(|c|PatternActivationCaptureRegistration{id:c.id,kind:c.kind.clone(),cell:c.slot.reactive_root_cell_ids()[0]}).collect()}).collect()};plan.borrow_mut().register_pattern_activation(registration);Ok(Value::Empty)
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -17,10 +17,6 @@ macro_rules! activation_error {
     };
 }
 activation_error!(
-    ActivationPatternExpressionUnsupported,
-    "This activation pattern is not supported."
-);
-activation_error!(
     ActivationPatternCaptureKindUnsupported,
     "The capture kind cannot be inferred from the activation trigger."
 );
@@ -49,28 +45,6 @@ activation_error!(
     "Activation trigger root cells disagree with the resolved trigger."
 );
 
-#[derive(Clone, Debug)]
-enum CompiledActivationPattern {
-    Wildcard,
-    Literal {
-        expected: Value,
-    },
-    Capture {
-        capture_index: usize,
-    },
-    Tuple {
-        elements: Vec<CompiledActivationPattern>,
-    },
-    EnumVariant {
-        enum_id: u64,
-        variant_id: u64,
-        payload: Option<Box<CompiledActivationPattern>>,
-    },
-    AtomTuple {
-        tag_id: u64,
-        payload: Vec<CompiledActivationPattern>,
-    },
-}
 #[derive(Clone)]
 struct ActivationPatternCapture {
     id: u64,
@@ -80,7 +54,7 @@ struct ActivationPatternCapture {
 }
 #[derive(Clone)]
 struct PreflightActivationArm {
-    pattern: CompiledActivationPattern,
+    pattern: CompiledPattern,
     captures: Vec<ActivationPatternCapture>,
 }
 struct PreflightPatternedActivation {
@@ -247,257 +221,54 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
         )),
     }
 }
-fn compile_activation_literal(l: &Literal, i: &Interpreter) -> MResult<Value> {
-    match l {
-        Literal::Empty(_) => Ok(Value::Empty),
-        #[cfg(feature = "bool")]
-        Literal::Boolean(t) => Ok(crate::boolean(t)),
-        #[cfg(feature = "string")]
-        Literal::String(v) => Ok(crate::string(v)),
-        #[cfg(feature = "atom")]
-        Literal::Atom(a) => Ok(Value::Atom(Ref::new(MechAtom::new(a.name.hash())))),
-        Literal::Number(Number::Real(RealNumber::TypedInteger(_)))
-        | Literal::TypedLiteral(_)
-        | Literal::Kind(_) => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
-        Literal::Number(n) => crate::number(n, i),
-        _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+
+fn capture_kinds_are_storage_compatible(destination: &ValueKind, source: &ValueKind) -> bool {
+    let destination = destination.deref_kind();
+    let source = source.deref_kind();
+    #[cfg(feature = "atom")]
+    if matches!(
+        (&destination, &source),
+        (ValueKind::Atom(_, _), ValueKind::Atom(_, _))
+    ) {
+        return true;
     }
+    destination == source
 }
-#[cfg(feature = "enum")]
-fn compile_enum_variant_pattern(
-    t: &PatternTupleStruct,
-    enum_id: u64,
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let variant_id = t.name.hash();
-    let def = i
-        .state
-        .borrow()
-        .enums
-        .get(&enum_id)
-        .cloned()
-        .ok_or_else(|| {
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
-        })?;
-    let declared = def
-        .variants
-        .iter()
-        .find(|(id, _)| *id == variant_id)
-        .map(|(_, p)| p.clone())
-        .ok_or_else(|| {
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
-        })?;
-    let payload = match (t.patterns.as_slice(), declared) {
-        ([], None) => None,
-        ([p], Some(Value::Kind(k))) => Some(Box::new(compile_activation_pattern(p, &k, i, c)?)),
-        _ => {
-            return Err(
+
+struct ReactiveBindingSink<'a> {
+    captures: &'a [ActivationPatternCapture],
+}
+
+impl PatternBindingSink for ReactiveBindingSink<'_> {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()> {
+        if !pattern_match.matched {
+            return Ok(());
+        }
+
+        // Validate every destination before mutating any stable capture cell.
+        for binding in &pattern_match.bindings {
+            let capture = self.captures.get(binding.index).ok_or_else(|| {
                 MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                    .with_tokens(t.tokens()),
-            );
-        }
-    };
-    Ok(CompiledActivationPattern::EnumVariant {
-        enum_id,
-        variant_id,
-        payload,
-    })
-}
-#[cfg(all(feature = "tuple", feature = "atom"))]
-fn compile_atom_tuple_pattern(
-    t: &PatternTupleStruct,
-    kinds: &[ValueKind],
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let Some(first) = kinds.first() else {
-        return Err(
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
-        );
-    };
-    if !matches!(first.deref_kind(), ValueKind::Atom(_, _)) || t.patterns.len() != kinds.len() - 1 {
-        return Err(
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
-        );
-    };
-    let payload = t
-        .patterns
-        .iter()
-        .zip(kinds.iter().skip(1))
-        .map(|(p, k)| compile_activation_pattern(p, k, i, c))
-        .collect::<MResult<_>>()?;
-    Ok(CompiledActivationPattern::AtomTuple {
-        tag_id: t.name.hash(),
-        payload,
-    })
-}
-fn compile_activation_pattern(
-    p: &Pattern,
-    kind: &ValueKind,
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let kind = kind.deref_kind();
-    match p {
-        Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
-        Pattern::Expression(Expression::Literal(l)) => {
-            let expected = compile_activation_literal(l, i)?;
-            if expected.kind().deref_kind() != kind {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
+            })?;
+            let source = detached(&binding.value);
+            if capture.id != binding.id
+                || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
+                || std::mem::discriminant(&capture.slot) != std::mem::discriminant(&source)
+            {
+                return Err(MechError::new(
+                    ActivationPatternCaptureKindUnsupported,
+                    None,
+                ));
             }
-            Ok(CompiledActivationPattern::Literal { expected })
         }
-        Pattern::Expression(Expression::Var(v)) => {
-            let id = v.name.hash();
-            if let Some(n) = c.iter().position(|x| x.id == id) {
-                if c[n].kind.deref_kind() != kind {
-                    return Err(
-                        MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                            .with_tokens(p.tokens()),
-                    );
-                }
-                return Ok(CompiledActivationPattern::Capture { capture_index: n });
-            }
-            let slot =
-                create_capture_slot_for_kind(&kind).map_err(|e| e.with_tokens(p.tokens()))?;
-            c.push(ActivationPatternCapture {
-                id,
-                name: v.name.to_string(),
-                kind,
-                slot,
-            });
-            Ok(CompiledActivationPattern::Capture {
-                capture_index: c.len() - 1,
-            })
+
+        for binding in &pattern_match.bindings {
+            commit_capture_slot(&self.captures[binding.index].slot, &binding.value)?;
         }
-        #[cfg(feature = "tuple")]
-        Pattern::Tuple(t) => {
-            let ValueKind::Tuple(k) = kind else {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
-            };
-            if t.0.len() != k.len() {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
-            }
-            Ok(CompiledActivationPattern::Tuple {
-                elements: t
-                    .0
-                    .iter()
-                    .zip(k.iter())
-                    .map(|(p, k)| compile_activation_pattern(p, k, i, c))
-                    .collect::<MResult<_>>()?,
-            })
-        }
-        Pattern::TupleStruct(t) => match kind {
-            #[cfg(feature = "enum")]
-            ValueKind::Enum(id, _) => compile_enum_variant_pattern(t, id, i, c),
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            ValueKind::Tuple(k) => compile_atom_tuple_pattern(t, &k, i, c),
-            _ => Err(
-                MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                    .with_tokens(p.tokens()),
-            ),
-        },
-        _ => {
-            Err(MechError::new(ActivationPatternExpressionUnsupported, None)
-                .with_tokens(p.tokens()))
-        }
+        Ok(())
     }
 }
-fn matches_pattern(
-    p: &CompiledActivationPattern,
-    v: &Value,
-    proposed: &mut Vec<Option<Value>>,
-) -> bool {
-    match p {
-        CompiledActivationPattern::Wildcard => true,
-        CompiledActivationPattern::Literal { expected } => expected == &detached(v),
-        CompiledActivationPattern::Capture { capture_index } => {
-            let x = detached(v);
-            match &proposed[*capture_index] {
-                Some(y) => y == &x,
-                None => {
-                    proposed[*capture_index] = Some(x);
-                    true
-                }
-            }
-        }
-        #[cfg(feature = "tuple")]
-        CompiledActivationPattern::Tuple { elements } => match detached(v) {
-            Value::Tuple(t) => {
-                let t = t.borrow();
-                t.elements.len() == elements.len()
-                    && elements
-                        .iter()
-                        .zip(t.elements.iter())
-                        .all(|(p, v)| matches_pattern(p, v, proposed))
-            }
-            _ => false,
-        },
-        CompiledActivationPattern::EnumVariant {
-            enum_id,
-            variant_id,
-            payload,
-        } => {
-            #[cfg(feature = "enum")]
-            {
-                let Value::Enum(e) = detached(v) else {
-                    return false;
-                };
-                let e = e.borrow();
-                if e.id != *enum_id || e.variants.len() != 1 {
-                    return false;
-                }
-                let (id, value) = &e.variants[0];
-                id == variant_id
-                    && match (payload, value) {
-                        (None, None) => true,
-                        (Some(p), Some(v)) => matches_pattern(p, v, proposed),
-                        _ => false,
-                    }
-            }
-            #[cfg(not(feature = "enum"))]
-            {
-                false
-            }
-        }
-        CompiledActivationPattern::AtomTuple { tag_id, payload } => {
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            {
-                let Value::Tuple(t) = detached(v) else {
-                    return false;
-                };
-                let t = t.borrow();
-                if t.elements.len() != payload.len() + 1 {
-                    return false;
-                }
-                let Value::Atom(tag) = detached(&t.elements[0]) else {
-                    return false;
-                };
-                tag.borrow().id() == *tag_id
-                    && payload
-                        .iter()
-                        .zip(t.elements.iter().skip(1))
-                        .all(|(p, v)| matches_pattern(p, v, proposed))
-            }
-            #[cfg(not(all(feature = "tuple", feature = "atom")))]
-            {
-                false
-            }
-        }
-        #[cfg(not(feature = "tuple"))]
-        CompiledActivationPattern::Tuple { .. } => false,
-    }
-}
+
 fn generation() -> (Ref<usize>, Value) {
     let r = Ref::new(0);
     (r.clone(), Value::Index(r))
@@ -522,8 +293,9 @@ impl MechFunctionImpl for ScopePulse {
     }
 }
 struct Matcher {
-    pattern: CompiledActivationPattern,
+    pattern: CompiledPattern,
     trigger: Value,
+    expression_values: Vec<Value>,
     captures: Vec<ActivationPatternCapture>,
     matched: Ref<bool>,
     out: Ref<usize>,
@@ -531,27 +303,28 @@ struct Matcher {
 impl MechFunctionImpl for Matcher {
     fn solve(&self) {}
     fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
-        let mut p = vec![None; self.captures.len()];
-        let ok = matches_pattern(&self.pattern, &self.trigger, &mut p);
-        if ok {
-            for (c, v) in self.captures.iter().zip(p.iter()) {
-                if let Some(v) = v {
-                    commit_capture_slot(&c.slot, v)?
-                }
-            }
+        let pattern_match = match_compiled_pattern_with_values(
+            &self.pattern,
+            &self.trigger,
+            &self.expression_values,
+        )?;
+        ReactiveBindingSink {
+            captures: &self.captures,
         }
-        *self.matched.borrow_mut() = ok;
+        .commit(&pattern_match)?;
+        *self.matched.borrow_mut() = pattern_match.matched;
         *self.out.borrow_mut() += 1;
         Ok(ReactiveSolveStatus::Changed)
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
     }
-    fn reactive_dependency_kinds(&self, _: usize) -> Option<Vec<ReactiveDependencyKind>> {
-        Some(vec![
-            ReactiveDependencyKind::Reactive,
-            ReactiveDependencyKind::Sampled,
-        ])
+    fn reactive_dependency_kinds(&self, argument_count: usize) -> Option<Vec<ReactiveDependencyKind>> {
+        let mut kinds = vec![ReactiveDependencyKind::Sampled; argument_count];
+        if let Some(scope_pulse) = kinds.first_mut() {
+            *scope_pulse = ReactiveDependencyKind::Reactive;
+        }
+        Some(kinds)
     }
     fn to_string(&self) -> String {
         "ActivationPatternMatcher".into()
@@ -687,8 +460,25 @@ fn preflight_patterned_activation(
     let trigger_kind = trigger.kind().deref_kind();
     let mut compiled = Vec::new();
     for a in arms {
-        let mut captures = Vec::new();
-        let pattern = compile_activation_pattern(&a.pattern, &trigger_kind, i, &mut captures)?;
+        let pattern = compile_pattern(&a.pattern, Some(&trigger_kind), i)?;
+        let captures = pattern
+            .binding_specs()
+            .into_iter()
+            .map(|binding| {
+                let kind = binding.kind.ok_or_else(|| {
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(a.pattern.tokens())
+                })?;
+                let slot = create_capture_slot_for_kind(&kind)
+                    .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
+                Ok(ActivationPatternCapture {
+                    id: binding.id,
+                    name: binding.name,
+                    kind,
+                    slot,
+                })
+            })
+            .collect::<MResult<Vec<_>>>()?;
         compiled.push(PreflightActivationArm { pattern, captures });
     }
     Ok(PreflightPatternedActivation {
@@ -1007,23 +797,38 @@ fn elaborate_patterned_activation_inner(
     }
     let compiled = preflight.arms;
     let plan = i.plan();
+    let pattern_expression_values = compiled
+        .iter()
+        .map(|arm| {
+            arm.pattern
+                .expressions()
+                .iter()
+                .map(|expression| crate::expression(expression, None, i))
+                .collect::<MResult<Vec<_>>>()
+        })
+        .collect::<MResult<Vec<_>>>()?;
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
         .borrow_mut()
         .register(Box::new(ScopePulse { out: scope_gen }), &[trigger.clone()])?;
     let (mut matcher_nodes, mut completions, mut matched) = (Vec::new(), Vec::new(), Vec::new());
-    for arm in &compiled {
+    for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
         let (o, v) = generation();
         let f = Ref::new(false);
+        let mut inputs = Vec::with_capacity(2 + expression_values.len());
+        inputs.push(scope_v.clone());
+        inputs.push(trigger.clone());
+        inputs.extend(expression_values.iter().cloned());
         let n = plan.borrow_mut().register(
             Box::new(Matcher {
                 pattern: arm.pattern.clone(),
                 trigger: trigger.clone(),
+                expression_values: expression_values.clone(),
                 captures: arm.captures.clone(),
                 matched: f.clone(),
                 out: o,
             }),
-            &[scope_v.clone(), trigger.clone()],
+            &inputs,
         )?;
         matcher_nodes.push(n);
         completions.push(v);
@@ -1206,6 +1011,46 @@ mod tests {
         assert_eq!(slot.reactive_root_cell_ids(), cells);
     }
 
+    #[cfg(feature = "atom")]
+    #[test]
+    fn activation_atom_capture_accepts_a_new_atom_value() {
+        let mut interpreter = interpret(
+            r#"
+event := :first
+~> event
+  | captured => {
+      selected := captured
+    }
+  | * => {
+      selected := :fallback
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        let registration = registration(&interpreter);
+        let Value::Atom(event) = symbol(&interpreter, "event") else {
+            panic!("event is not an atom")
+        };
+        *event.borrow_mut() = MechAtom::from_name("second");
+
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&registration, &outcome), 0);
+        let selected_atom = {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            (registration.arms[0].body_node_start..registration.arms[0].body_node_end)
+                .rev()
+                .find_map(|node| match detached(&plan.node(node).unwrap().function.out()) {
+                    Value::Atom(atom) => Some(atom.borrow().id()),
+                    _ => None,
+                })
+                .expect("no atom output in selected arm body")
+        };
+        assert_eq!(selected_atom, hash_str("second"));
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn activation_capture_slot_rejects_kind_mismatch() {
@@ -1360,6 +1205,30 @@ mod tests {
             names,
         };
     }
+    fn set_unit_enum_event(interpreter: &Interpreter, variant: &str) {
+        let event_value = symbol(interpreter, "event");
+        if let Value::Atom(event) = &event_value {
+            *event.borrow_mut() = MechAtom::from_name(variant);
+            return;
+        }
+        let Value::Enum(event) = event_value else {
+            panic!("event is neither an atom nor an enum");
+        };
+        let enum_id = event.borrow().id;
+        let names = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .expect("event enum definition is missing")
+            .names
+            .clone();
+        *event.borrow_mut() = MechEnum {
+            id: enum_id,
+            variants: vec![(hash_str(variant), None)],
+            names,
+        };
+    }
     fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
         let Value::Tuple(event) = symbol(interpreter, "event") else {
             panic!("event is not tuple")
@@ -1374,6 +1243,13 @@ mod tests {
             panic!("event is not tuple")
         };
         *event.borrow_mut() = MechTuple::from_vec(values);
+    }
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    fn set_f64_matrix_event(interpreter: &Interpreter, values: Vec<f64>) {
+        let Value::MatrixF64(event) = symbol(interpreter, "event") else {
+            panic!("event is not an f64 matrix")
+        };
+        event.set(values);
     }
     fn selected_arm_index(
         registration: &PatternActivationRegistration,
@@ -1570,6 +1446,28 @@ event<event-kind> := :pressed(0.0)
             assert_eq!(plan_snapshot(&i), topology);
         }
     }
+
+    #[test]
+    fn activation_pattern_matches_payload_free_enum_variant() {
+        let mut i = interpret(
+            r#"
+<signal> := :ready | :other
+event<signal> := :other
+~> event
+  | :ready => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        set_unit_enum_event(&i, "ready");
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+    }
     #[test]
     fn activation_pattern_capture_storage_identity_is_stable() {
         let (mut i, trigger, r, topology) = load_enum_activation();
@@ -1724,8 +1622,166 @@ event := (1.0, 1.0)
         let o = i.advance_reactive_turn(&[trigger]).unwrap();
         assert_dispatch_turn(&i, &topology, &o, 1, -1.);
     }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
-    fn activation_pattern_repeated_capture_kind_mismatch_is_structured() {
+    fn activation_array_pattern_samples_expression_only_on_trigger() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 1.0]
+threshold := 2.0
+~> event
+  | [x, threshold + 0.0, x] => {
+      selected := x + 100.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let registration = registration(&i);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let dependency_nodes = turn_executed_nodes(&dependency_turn);
+        assert!(!dependency_nodes.contains(&registration.scope_pulse_node));
+        assert!(!dependency_nodes.contains(&registration.selector_node));
+        for arm in &registration.arms {
+            assert!(!dependency_nodes.contains(&arm.matcher_node));
+            assert!(!dependency_nodes.contains(&arm.finalizer_node));
+            assert!(!dependency_nodes.contains(&arm.gate_node));
+        }
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 104.0);
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 5.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_pattern_supports_prefix_suffix_and_anonymous_spread() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0 1.0]
+~> event
+  | [x, ..., x] => {
+      selected := x + 10.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 11.0);
+
+        set_f64_matrix_event(&i, vec![1.0, 2.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_rest_segment_accepts_nested_array_pattern() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0 4.0]
+~> event
+  | [head | [second, ..., last]] => {
+      selected := head * 100.0 + second * 10.0 + last
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 124.0);
+    }
+
+    #[cfg(feature = "u64")]
+    #[test]
+    fn activation_typed_literal_pattern_uses_shared_value_matching() {
+        let mut i = interpret(
+            r#"
+event := 1u64
+~> event
+  | 1u64 => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+    }
+
+    #[test]
+    fn activation_whole_composite_capture_fails_before_plan_mutation() {
+        let mut i = interpret("event := (1.0, 2.0)");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | whole => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("whole")));
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_rest_capture_reports_storage_gap_before_plan_mutation() {
+        let mut i = interpret("event := [1.0 2.0 3.0]");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | [head | rest] => {
+      selected := head
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("head")));
+        assert!(!i.symbols().borrow().contains(hash_str("rest")));
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_kind_mismatch_uses_canonical_error() {
         let mut i = interpret("event := (1.0, \"one\")");
         let topology = plan_snapshot(&i);
         let error = interpret_more(
@@ -1737,7 +1793,7 @@ event := (1.0, 1.0)
     }",
         )
         .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(error.kind_name(), "PatternCompileError");
         assert_eq!(plan_snapshot(&i), topology);
         assert!(!i.symbols().borrow().contains(hash_str("x")));
         assert!(!i.symbols().borrow().contains(hash_str("selected")));
@@ -1883,7 +1939,7 @@ event := (1.0, 1.0)
     }",
         )
         .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(error.kind_name(), "PatternCompileError");
         assert_eq!(plan_snapshot(&i), topology);
     }
     #[test]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -81,7 +81,19 @@ fn detached(v: &Value) -> Value {
 fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
     destination.borrow_mut().clone_from(&*source.borrow())
 }
-fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
+#[cfg(feature = "matrix")]
+fn capture_matrix_dimensions(shape: &[usize]) -> MResult<(usize, usize)> {
+    match shape {
+        [] => Ok((1, 0)),
+        [rows, cols] => Ok((*rows, *cols)),
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+
+fn create_capture_slot_for_kind(kind: &ValueKind, interpreter: &Interpreter) -> MResult<Value> {
     match kind.deref_kind() {
         #[cfg(feature = "u8")]
         ValueKind::U8 => Ok(Value::U8(Ref::new(0))),
@@ -118,13 +130,309 @@ fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
         ValueKind::Index => Ok(Value::Index(Ref::new(0))),
         #[cfg(feature = "atom")]
         ValueKind::Atom(id, _) => Ok(Value::Atom(Ref::new(MechAtom::new(id)))),
+        #[cfg(feature = "tuple")]
+        ValueKind::Tuple(kinds) => Ok(Value::Tuple(Ref::new(MechTuple::from_vec(
+            kinds
+                .iter()
+                .map(|kind| create_capture_slot_for_kind(kind, interpreter))
+                .collect::<MResult<Vec<_>>>()?,
+        )))),
+        #[cfg(feature = "enum")]
+        ValueKind::Enum(id, _) => Ok(Value::Enum(Ref::new(MechEnum {
+            id,
+            variants: Vec::new(),
+            names: interpreter.dictionary(),
+        }))),
+        #[cfg(feature = "record")]
+        ValueKind::Record(fields) => {
+            let values = fields
+                .iter()
+                .map(|(name, kind)| {
+                    Ok(((hash_str(name), name.clone()), create_capture_slot_for_kind(kind, interpreter)?))
+                })
+                .collect::<MResult<Vec<_>>>()?;
+            Ok(Value::Record(Ref::new(MechRecord::from_vec(values))))
+        }
+        #[cfg(feature = "map")]
+        ValueKind::Map(key_kind, value_kind) => Ok(Value::Map(Ref::new(MechMap {
+            key_kind: *key_kind,
+            value_kind: *value_kind,
+            num_elements: 0,
+            map: Default::default(),
+        }))),
+        #[cfg(feature = "set")]
+        ValueKind::Set(element_kind, size) => Ok(Value::Set(Ref::new(MechSet::new(
+            *element_kind,
+            size.unwrap_or(0),
+        )))),
+        #[cfg(feature = "table")]
+        ValueKind::Table(columns, rows) => {
+            let mut names = Vec::with_capacity(columns.len());
+            let mut kinds = Vec::with_capacity(columns.len());
+            let mut values = Vec::with_capacity(columns.len());
+            for (name, kind) in columns {
+                names.push(name);
+                kinds.push(kind.clone());
+                let default = create_capture_slot_for_kind(&kind, interpreter)?;
+                values.push(vec![default; rows]);
+            }
+            Ok(Value::Table(Ref::new(MechTable::new_table(
+                names, kinds, values,
+            ))))
+        }
+        #[cfg(feature = "matrix")]
+        ValueKind::Matrix(element_kind, shape) => {
+            let (rows, cols) = capture_matrix_dimensions(&shape)?;
+            let count = rows.saturating_mul(cols);
+            match *element_kind {
+                ValueKind::Index => Ok(Value::MatrixIndex(Matrix::from_vec(
+                    vec![0; count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "bool")]
+                ValueKind::Bool => Ok(Value::MatrixBool(Matrix::from_vec(
+                    vec![false; count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "u8")]
+                ValueKind::U8 => Ok(Value::MatrixU8(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u16")]
+                ValueKind::U16 => Ok(Value::MatrixU16(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u32")]
+                ValueKind::U32 => Ok(Value::MatrixU32(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u64")]
+                ValueKind::U64 => Ok(Value::MatrixU64(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u128")]
+                ValueKind::U128 => Ok(Value::MatrixU128(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i8")]
+                ValueKind::I8 => Ok(Value::MatrixI8(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i16")]
+                ValueKind::I16 => Ok(Value::MatrixI16(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i32")]
+                ValueKind::I32 => Ok(Value::MatrixI32(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i64")]
+                ValueKind::I64 => Ok(Value::MatrixI64(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i128")]
+                ValueKind::I128 => Ok(Value::MatrixI128(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "f32")]
+                ValueKind::F32 => Ok(Value::MatrixF32(Matrix::from_vec(vec![0.0; count], rows, cols))),
+                #[cfg(feature = "f64")]
+                ValueKind::F64 => Ok(Value::MatrixF64(Matrix::from_vec(vec![0.0; count], rows, cols))),
+                #[cfg(feature = "string")]
+                ValueKind::String => Ok(Value::MatrixString(Matrix::from_vec(
+                    vec![String::new(); count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "rational")]
+                ValueKind::R64 => Ok(Value::MatrixR64(Matrix::from_vec(
+                    vec![R64::default(); count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "complex")]
+                ValueKind::C64 => Ok(Value::MatrixC64(Matrix::from_vec(
+                    vec![C64::default(); count],
+                    rows,
+                    cols,
+                ))),
+                element_kind => {
+                    let default = create_capture_slot_for_kind(&element_kind, interpreter)
+                        .unwrap_or(Value::EmptyKind(element_kind));
+                    Ok(Value::MatrixValue(Matrix::from_vec(
+                        vec![default; count],
+                        rows,
+                        cols,
+                    )))
+                }
+            }
+        }
         _ => Err(MechError::new(
             ActivationPatternCaptureKindUnsupported,
             None,
         )),
     }
 }
+
+fn capture_slot_accepts_payload(destination: &Value, source: &Value) -> bool {
+    let source = detached(source);
+    match (destination, &source) {
+        #[cfg(feature = "tuple")]
+        (Value::Tuple(destination), Value::Tuple(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.elements.len() == source.elements.len()
+                && destination
+                    .elements
+                    .iter()
+                    .zip(&source.elements)
+                    .all(|(destination, source)| {
+                        capture_slot_accepts_payload(destination, source)
+                    })
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(destination), Value::Enum(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            if destination.id != source.id || destination.variants.is_empty() {
+                return destination.id == source.id;
+            }
+            let same_variants = destination.variants.len() == source.variants.len()
+                && destination
+                    .variants
+                    .iter()
+                    .zip(&source.variants)
+                    .all(|((destination_id, _), (source_id, _))| {
+                        destination_id == source_id
+                    });
+            !same_variants
+                || destination.variants.iter().zip(&source.variants).all(
+                    |((_, destination), (_, source))| match (destination, source) {
+                        (Some(destination), Some(source)) => {
+                            capture_slot_accepts_payload(destination, source)
+                        }
+                        (None, None) => true,
+                        _ => false,
+                    },
+                )
+        }
+        #[cfg(feature = "record")]
+        (Value::Record(destination), Value::Record(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.data.len() == source.data.len()
+                && destination.data.iter().zip(&source.data).all(
+                    |((destination_id, destination), (source_id, source))| {
+                        destination_id == source_id
+                            && capture_slot_accepts_payload(destination, source)
+                    },
+                )
+        }
+        #[cfg(feature = "map")]
+        (Value::Map(destination), Value::Map(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            if destination.map.is_empty() || destination.map.len() != source.map.len() {
+                return true;
+            }
+            let same_keys = destination
+                .map
+                .keys()
+                .zip(source.map.keys())
+                .all(|(destination, source)| destination == source);
+            !same_keys
+                || destination
+                    .map
+                    .values()
+                    .zip(source.map.values())
+                    .all(|(destination, source)| {
+                        capture_slot_accepts_payload(destination, source)
+                    })
+        }
+        #[cfg(feature = "table")]
+        (Value::Table(destination), Value::Table(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.rows == source.rows
+                && destination.data.len() == source.data.len()
+                && destination.data.iter().zip(&source.data).all(
+                    |(
+                        (destination_id, (destination_kind, destination)),
+                        (source_id, (source_kind, source)),
+                    )| {
+                        destination_id == source_id
+                            && destination_kind == source_kind
+                            && destination.can_replace_payload_from(source)
+                    },
+                )
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixIndex(destination), Value::MatrixIndex(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        (Value::MatrixBool(destination), Value::MatrixBool(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        (Value::MatrixU8(destination), Value::MatrixU8(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        (Value::MatrixU16(destination), Value::MatrixU16(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        (Value::MatrixU32(destination), Value::MatrixU32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        (Value::MatrixU64(destination), Value::MatrixU64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        (Value::MatrixU128(destination), Value::MatrixU128(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        (Value::MatrixI8(destination), Value::MatrixI8(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        (Value::MatrixI16(destination), Value::MatrixI16(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        (Value::MatrixI32(destination), Value::MatrixI32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        (Value::MatrixI64(destination), Value::MatrixI64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        (Value::MatrixI128(destination), Value::MatrixI128(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        (Value::MatrixF32(destination), Value::MatrixF32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        (Value::MatrixF64(destination), Value::MatrixF64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        (Value::MatrixString(destination), Value::MatrixString(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        (Value::MatrixR64(destination), Value::MatrixR64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        (Value::MatrixC64(destination), Value::MatrixC64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixValue(destination), Value::MatrixValue(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        (destination, source) => {
+            std::mem::discriminant(destination) == std::mem::discriminant(source)
+        }
+    }
+}
+
 fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
+    if !capture_slot_accepts_payload(destination, source) {
+        return Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        ));
+    }
     match (destination, &detached(source)) {
         #[cfg(feature = "u8")]
         (Value::U8(a), Value::U8(b)) => {
@@ -215,6 +523,124 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
             clone_ref_value(a, b);
             Ok(())
         }
+        #[cfg(feature = "tuple")]
+        (Value::Tuple(a), Value::Tuple(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for (destination, source) in a.elements.iter().zip(&b.elements) {
+                commit_capture_slot(destination, source)?;
+            }
+            Ok(())
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(a), Value::Enum(b)) => {
+            let preserve_payload_cells = {
+                let a = a.borrow();
+                let b = b.borrow();
+                !a.variants.is_empty()
+                    && a.variants.len() == b.variants.len()
+                    && a.variants
+                        .iter()
+                        .zip(&b.variants)
+                        .all(|((a, _), (b, _))| a == b)
+            };
+            if preserve_payload_cells {
+                let a = a.borrow();
+                let b = b.borrow();
+                for ((_, destination), (_, source)) in a.variants.iter().zip(&b.variants) {
+                    if let (Some(destination), Some(source)) = (destination, source) {
+                        commit_capture_slot(destination, source)?;
+                    }
+                }
+            } else {
+                clone_ref_value(a, b);
+            }
+            Ok(())
+        }
+        #[cfg(feature = "record")]
+        (Value::Record(a), Value::Record(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for ((_, destination), (_, source)) in a.data.iter().zip(&b.data) {
+                commit_capture_slot(destination, source)?;
+            }
+            Ok(())
+        }
+        #[cfg(feature = "map")]
+        (Value::Map(a), Value::Map(b)) => {
+            let preserve_value_cells = {
+                let a = a.borrow();
+                let b = b.borrow();
+                !a.map.is_empty()
+                    && a.map.len() == b.map.len()
+                    && a.map.keys().zip(b.map.keys()).all(|(a, b)| a == b)
+            };
+            if preserve_value_cells {
+                let a = a.borrow();
+                let b = b.borrow();
+                for ((_, destination), (_, source)) in a.map.iter().zip(&b.map) {
+                    commit_capture_slot(destination, source)?;
+                }
+            } else {
+                clone_ref_value(a, b);
+            }
+            Ok(())
+        }
+        #[cfg(feature = "set")]
+        (Value::Set(a), Value::Set(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "table")]
+        (Value::Table(a), Value::Table(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for ((_, (_, destination)), (_, (_, source))) in a.data.iter().zip(&b.data) {
+                if !destination.replace_payload_from(source) {
+                    return Err(MechError::new(
+                        ActivationPatternCaptureKindUnsupported,
+                        None,
+                    ));
+                }
+            }
+            Ok(())
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixIndex(a), Value::MatrixIndex(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        (Value::MatrixBool(a), Value::MatrixBool(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        (Value::MatrixU8(a), Value::MatrixU8(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        (Value::MatrixU16(a), Value::MatrixU16(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        (Value::MatrixU32(a), Value::MatrixU32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        (Value::MatrixU64(a), Value::MatrixU64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        (Value::MatrixU128(a), Value::MatrixU128(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        (Value::MatrixI8(a), Value::MatrixI8(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        (Value::MatrixI16(a), Value::MatrixI16(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        (Value::MatrixI32(a), Value::MatrixI32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        (Value::MatrixI64(a), Value::MatrixI64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        (Value::MatrixI128(a), Value::MatrixI128(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        (Value::MatrixF32(a), Value::MatrixF32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        (Value::MatrixF64(a), Value::MatrixF64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        (Value::MatrixString(a), Value::MatrixString(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        (Value::MatrixR64(a), Value::MatrixR64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        (Value::MatrixC64(a), Value::MatrixC64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(feature = "matrix")]
+        (Value::MatrixValue(a), Value::MatrixValue(b)) if a.replace_payload_from(b) => Ok(()),
         _ => Err(MechError::new(
             ActivationPatternCaptureKindUnsupported,
             None,
@@ -229,6 +655,23 @@ fn capture_kinds_are_storage_compatible(destination: &ValueKind, source: &ValueK
     if matches!(
         (&destination, &source),
         (ValueKind::Atom(_, _), ValueKind::Atom(_, _))
+    ) {
+        return true;
+    }
+    #[cfg(feature = "enum")]
+    if matches!(
+        (&destination, &source),
+        (ValueKind::Enum(destination, _), ValueKind::Enum(source, _)) if destination == source
+    ) {
+        return true;
+    }
+    #[cfg(feature = "matrix")]
+    if matches!(
+        (&destination, &source),
+        (
+            ValueKind::Matrix(destination_element, destination_shape),
+            ValueKind::Matrix(source_element, _)
+        ) if destination_shape.is_empty() && destination_element == source_element
     ) {
         return true;
     }
@@ -253,7 +696,7 @@ impl PatternBindingSink for ReactiveBindingSink<'_> {
             let source = detached(&binding.value);
             if capture.id != binding.id
                 || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
-                || std::mem::discriminant(&capture.slot) != std::mem::discriminant(&source)
+                || !capture_slot_accepts_payload(&capture.slot, &source)
             {
                 return Err(MechError::new(
                     ActivationPatternCaptureKindUnsupported,
@@ -469,7 +912,7 @@ fn preflight_patterned_activation(
                     MechError::new(ActivationPatternCaptureKindUnsupported, None)
                         .with_tokens(a.pattern.tokens())
                 })?;
-                let slot = create_capture_slot_for_kind(&kind)
+                let slot = create_capture_slot_for_kind(&kind, i)
                     .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
                 Ok(ActivationPatternCapture {
                     id: binding.id,
@@ -783,7 +1226,17 @@ fn elaborate_patterned_arm_body(
     }
     symbols.borrow_mut().restore(symbol_snapshot);
     body_result?;
-    Ok((body_node_start, plan.len()))
+    let body_node_end = plan.len();
+    {
+        let mut plan = plan.borrow_mut();
+        for node in body_node_start..body_node_end {
+            for capture in captures {
+                let cell = capture.slot.reactive_root_cell_ids()[0];
+                debug_assert!(plan.add_sampled_dependency(node, cell));
+            }
+        }
+    }
+    Ok((body_node_start, body_node_end))
 }
 
 fn elaborate_patterned_activation_inner(
@@ -797,6 +1250,8 @@ fn elaborate_patterned_activation_inner(
     }
     let compiled = preflight.arms;
     let plan = i.plan();
+    let _persistent_user_function_plan =
+        crate::functions::PersistentUserFunctionPlanScope::enter(i);
     let pattern_expression_values = compiled
         .iter()
         .map(|arm| {
@@ -807,6 +1262,15 @@ fn elaborate_patterned_activation_inner(
                 .collect::<MResult<Vec<_>>>()
         })
         .collect::<MResult<Vec<_>>>()?;
+    drop(_persistent_user_function_plan);
+    for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
+        let pattern_match =
+            match_compiled_pattern_with_values(&arm.pattern, &trigger, expression_values)?;
+        ReactiveBindingSink {
+            captures: &arm.captures,
+        }
+        .commit(&pattern_match)?;
+    }
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
         .borrow_mut()
@@ -936,6 +1400,7 @@ pub(crate) fn elaborate_patterned_activation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
         let mut cases = Vec::new();
@@ -988,8 +1453,9 @@ mod tests {
 
     #[test]
     fn activation_capture_slot_supports_all_enabled_scalar_kinds() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
         for (kind, source) in scalar_capture_cases() {
-            let slot = create_capture_slot_for_kind(&kind).unwrap();
+            let slot = create_capture_slot_for_kind(&kind, &interpreter).unwrap();
             let cells_before = slot.reactive_root_cell_ids();
             assert_eq!(cells_before.len(), 1);
             commit_capture_slot(&slot, &source).unwrap();
@@ -1001,7 +1467,8 @@ mod tests {
     #[cfg(any(feature = "string", feature = "variable_define"))]
     #[test]
     fn activation_capture_slot_preserves_identity_across_updates() {
-        let slot = create_capture_slot_for_kind(&ValueKind::String).unwrap();
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let slot = create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap();
         let cells = slot.reactive_root_cell_ids();
         commit_capture_slot(&slot, &Value::String(Ref::new("first".to_string()))).unwrap();
         assert_eq!(slot, Value::String(Ref::new("first".to_string())));
@@ -1009,6 +1476,108 @@ mod tests {
         commit_capture_slot(&slot, &Value::String(Ref::new("second".to_string()))).unwrap();
         assert_eq!(slot, Value::String(Ref::new("second".to_string())));
         assert_eq!(slot.reactive_root_cell_ids(), cells);
+    }
+
+    #[cfg(all(
+        feature = "tuple",
+        feature = "enum",
+        feature = "record",
+        feature = "map",
+        feature = "set",
+        feature = "table",
+        feature = "string",
+        feature = "f64"
+    ))]
+    #[test]
+    fn activation_capture_slots_support_enabled_composite_value_kinds() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let enum_id = hash_str("capture-enum");
+        let variant_id = hash_str("payload");
+        let names = Ref::new(HashMap::from([
+            (enum_id, "capture-enum".to_string()),
+            (variant_id, "payload".to_string()),
+        ]));
+        let cases = vec![
+            Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                Value::F64(Ref::new(1.0)),
+                Value::String(Ref::new("tuple".to_string())),
+            ]))),
+            Value::Enum(Ref::new(MechEnum {
+                id: enum_id,
+                variants: vec![(variant_id, Some(Value::F64(Ref::new(2.0))))],
+                names,
+            })),
+            Value::Record(Ref::new(MechRecord::new(vec![
+                ("field", Value::F64(Ref::new(3.0))),
+            ]))),
+            Value::Map(Ref::new(MechMap::from_vec(vec![(
+                Value::String(Ref::new("key".to_string())),
+                Value::F64(Ref::new(4.0)),
+            )]))),
+            Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new(
+                "member".to_string(),
+            ))]))),
+            Value::Table(Ref::new(MechTable::new_table(
+                vec!["column".to_string()],
+                vec![ValueKind::F64],
+                vec![vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(6.0))]],
+            ))),
+        ];
+
+        for source in cases {
+            let kind = source.kind();
+            let slot = create_capture_slot_for_kind(&kind, &interpreter).unwrap();
+            let cells = slot.reactive_root_cell_ids();
+            assert_eq!(cells.len(), 1, "missing stable root for {kind}");
+            commit_capture_slot(&slot, &source).unwrap();
+            assert_eq!(slot, source);
+            assert_eq!(slot.reactive_root_cell_ids(), cells);
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "string"))]
+    #[test]
+    fn activation_capture_commit_validates_every_binding_before_mutation() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let number = ActivationPatternCapture {
+            id: hash_str("number"),
+            name: "number".to_string(),
+            kind: ValueKind::F64,
+            slot: create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap(),
+        };
+        let text = ActivationPatternCapture {
+            id: hash_str("text"),
+            name: "text".to_string(),
+            kind: ValueKind::String,
+            slot: create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap(),
+        };
+        let captures = vec![number, text];
+        let attempted = PatternMatch {
+            matched: true,
+            bindings: vec![
+                PatternBinding {
+                    index: 0,
+                    id: hash_str("number"),
+                    name: "number".to_string(),
+                    kind: ValueKind::F64,
+                    value: Value::F64(Ref::new(9.0)),
+                },
+                PatternBinding {
+                    index: 1,
+                    id: hash_str("text"),
+                    name: "text".to_string(),
+                    kind: ValueKind::F64,
+                    value: Value::F64(Ref::new(10.0)),
+                },
+            ],
+        };
+
+        let error = ReactiveBindingSink { captures: &captures }
+            .commit(&attempted)
+            .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(captures[0].slot, Value::F64(Ref::new(0.0)));
+        assert_eq!(captures[1].slot, Value::String(Ref::new(String::new())));
     }
 
     #[cfg(feature = "atom")]
@@ -1054,7 +1623,8 @@ event := :first
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn activation_capture_slot_rejects_kind_mismatch() {
-        let slot = create_capture_slot_for_kind(&ValueKind::F64).unwrap();
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let slot = create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap();
         let error =
             commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
@@ -1185,6 +1755,19 @@ event := :first
             }
         }
         panic!("no f64 output")
+    }
+    fn body_output(interpreter: &Interpreter, arm_index: usize) -> Value {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm_index];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        detached(
+            &plan
+                .node(arm.body_node_end - 1)
+                .expect("missing activation body node")
+                .function
+                .out(),
+        )
     }
     fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
         let Value::Enum(event) = symbol(interpreter, "event") else {
@@ -1669,6 +2252,49 @@ threshold := 2.0
 
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
+    fn activation_pattern_samples_current_user_function_output_on_trigger() {
+        let mut i = interpret(
+            r#"
+sample(value<f64>) => <f64>
+  | value + 0.0.
+
+event := [1.0 2.0 1.0]
+threshold := 2.0
+~> event
+  | [x, sample(threshold), x] => {
+      selected := x + 100.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let activation = registration(&i);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let dependency_nodes = turn_executed_nodes(&dependency_turn);
+        assert!(!dependency_nodes.contains(&activation.scope_pulse_node));
+        assert!(!dependency_nodes.contains(&activation.selector_node));
+        for arm in &activation.arms {
+            assert!(!dependency_nodes.contains(&arm.matcher_node));
+            assert!(!dependency_nodes.contains(&arm.finalizer_node));
+            assert!(!dependency_nodes.contains(&arm.gate_node));
+        }
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 104.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
     fn activation_array_pattern_supports_prefix_suffix_and_anonymous_spread() {
         let mut i = interpret(
             r#"
@@ -1736,49 +2362,142 @@ event := 1u64
     }
 
     #[test]
-    fn activation_whole_composite_capture_fails_before_plan_mutation() {
-        let mut i = interpret("event := (1.0, 2.0)");
-        let topology = plan_snapshot(&i);
-        let error = interpret_more(
-            &mut i,
+    fn activation_whole_composite_capture_is_stable_and_visible_to_the_body() {
+        let mut i = interpret(
             r#"
+event := (1.0, 2.0)
 ~> event
   | whole => {
-      selected := 1.0
+      selected := whole
+    }
+  | * => {
+      selected := (-1.0, -1.0)
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let capture = &activation.arms[0].captures[0];
+        assert_eq!(capture.kind, ValueKind::Tuple(vec![ValueKind::F64, ValueKind::F64]));
+        let body_inputs = i.plan().borrow().nodes
+            [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+            .iter()
+            .flat_map(|node| node.inputs.iter().map(|dependency| dependency.cell))
+            .collect::<Vec<_>>();
+        assert!(
+            body_inputs.contains(&capture.cell),
+            "capture cell {:?} is absent from body inputs {:?}",
+            capture.cell,
+            body_inputs
+        );
+        let topology = plan_snapshot(&i);
+        for values in [[3.0, 4.0], [5.0, 6.0]] {
+            set_tuple_event(
+                &i,
+                values
+                    .into_iter()
+                    .map(|value| Value::F64(Ref::new(value)))
+                    .collect(),
+            );
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            assert_eq!(
+                body_output(&i, 0),
+                Value::Tuple(Ref::new(MechTuple::from_vec(
+                    values
+                        .into_iter()
+                        .map(|value| Value::F64(Ref::new(value)))
+                        .collect(),
+                )))
+            );
+            assert_eq!(registration(&i).arms[0].captures[0].cell, capture.cell);
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+
+    #[test]
+    fn activation_whole_tuple_capture_keeps_element_access_attached() {
+        let mut i = interpret(
+            r#"
+event := (1.0, 2.0)
+~> event
+  | whole => {
+      selected := whole.1 * 10.0 + whole.2
     }
   | * => {
       selected := -1.0
     }
 "#,
-        )
-        .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(plan_snapshot(&i), topology);
-        assert!(!i.symbols().borrow().contains(hash_str("whole")));
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        for (values, expected) in [([3.0, 4.0], 34.0), ([5.0, 6.0], 56.0)] {
+            set_tuple_event(
+                &i,
+                values
+                    .into_iter()
+                    .map(|value| Value::F64(Ref::new(value)))
+                    .collect(),
+            );
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, 0, expected);
+        }
     }
 
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
-    fn activation_array_rest_capture_reports_storage_gap_before_plan_mutation() {
-        let mut i = interpret("event := [1.0 2.0 3.0]");
-        let topology = plan_snapshot(&i);
-        let error = interpret_more(
-            &mut i,
+    fn activation_array_rest_capture_preserves_kind_payload_and_identity() {
+        let mut i = interpret(
             r#"
+event := [1.0 2.0 3.0 4.0 5.0]
 ~> event
   | [head | rest] => {
-      selected := head
+      selected := rest
     }
   | * => {
-      selected := -1.0
+      selected := [-1.0]
     }
 "#,
-        )
-        .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(plan_snapshot(&i), topology);
-        assert!(!i.symbols().borrow().contains(hash_str("head")));
-        assert!(!i.symbols().borrow().contains(hash_str("rest")));
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let rest_capture = &activation.arms[0].captures[1];
+        assert_eq!(
+            rest_capture.kind,
+            ValueKind::Matrix(Box::new(ValueKind::F64), Vec::new())
+        );
+        assert!(
+            i.plan().borrow().nodes
+                [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+                .iter()
+                .any(|node| node
+                    .inputs
+                    .iter()
+                    .any(|dependency| dependency.cell == rest_capture.cell))
+        );
+        let topology = plan_snapshot(&i);
+        let Value::MatrixF64(event) = symbol(&i, "event") else {
+            panic!("event is not an f64 matrix")
+        };
+        for values in [
+            vec![10.0, 20.0, 30.0, 40.0, 50.0],
+            vec![11.0, 21.0, 31.0, 41.0, 51.0, 61.0],
+        ] {
+            let source = Matrix::from_vec(values.clone(), 1, values.len());
+            assert!(event.replace_payload_from(&source));
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            let Value::MatrixF64(rest) = body_output(&i, 0) else {
+                panic!("rest output is not an f64 matrix")
+            };
+            assert_eq!(rest.shape(), vec![1, values.len() - 1]);
+            assert_eq!(rest.as_vec(), values[1..]);
+            assert_eq!(
+                registration(&i).arms[0].captures[1].cell,
+                rest_capture.cell
+            );
+            assert_eq!(plan_snapshot(&i), topology);
+        }
     }
     #[test]
     fn activation_pattern_repeated_capture_kind_mismatch_uses_canonical_error() {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1127,3 +1127,91 @@ pub(crate) fn elaborate_patterned_activation(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
+        let mut cases = Vec::new();
+        #[cfg(feature = "u8")]
+        cases.push((ValueKind::U8, Value::U8(Ref::new(8))));
+        #[cfg(feature = "u16")]
+        cases.push((ValueKind::U16, Value::U16(Ref::new(16))));
+        #[cfg(feature = "u32")]
+        cases.push((ValueKind::U32, Value::U32(Ref::new(32))));
+        #[cfg(feature = "u64")]
+        cases.push((ValueKind::U64, Value::U64(Ref::new(64))));
+        #[cfg(feature = "u128")]
+        cases.push((ValueKind::U128, Value::U128(Ref::new(128))));
+        #[cfg(feature = "i8")]
+        cases.push((ValueKind::I8, Value::I8(Ref::new(-8))));
+        #[cfg(feature = "i16")]
+        cases.push((ValueKind::I16, Value::I16(Ref::new(-16))));
+        #[cfg(feature = "i32")]
+        cases.push((ValueKind::I32, Value::I32(Ref::new(-32))));
+        #[cfg(feature = "i64")]
+        cases.push((ValueKind::I64, Value::I64(Ref::new(-64))));
+        #[cfg(feature = "i128")]
+        cases.push((ValueKind::I128, Value::I128(Ref::new(-128))));
+        #[cfg(feature = "f32")]
+        cases.push((ValueKind::F32, Value::F32(Ref::new(3.25))));
+        #[cfg(feature = "f64")]
+        cases.push((ValueKind::F64, Value::F64(Ref::new(6.5))));
+        #[cfg(feature = "complex")]
+        cases.push((ValueKind::C64, Value::C64(Ref::new(C64::new(3.0, 4.0)))));
+        #[cfg(feature = "rational")]
+        cases.push((ValueKind::R64, Value::R64(Ref::new(R64::new(3, 4)))));
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        cases.push((ValueKind::Bool, Value::Bool(Ref::new(true))));
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        cases.push((
+            ValueKind::String,
+            Value::String(Ref::new("captured".to_string())),
+        ));
+        cases.push((ValueKind::Index, Value::Index(Ref::new(42))));
+        #[cfg(feature = "atom")]
+        {
+            let atom = MechAtom::from_name("captured");
+            cases.push((
+                ValueKind::Atom(atom.id(), atom.name()),
+                Value::Atom(Ref::new(atom)),
+            ));
+        }
+        cases
+    }
+
+    #[test]
+    fn activation_capture_slot_supports_all_enabled_scalar_kinds() {
+        for (kind, source) in scalar_capture_cases() {
+            let slot = create_capture_slot_for_kind(&kind).unwrap();
+            let cells_before = slot.reactive_root_cell_ids();
+            assert_eq!(cells_before.len(), 1);
+            commit_capture_slot(&slot, &source).unwrap();
+            assert_eq!(slot, source);
+            assert_eq!(slot.reactive_root_cell_ids(), cells_before);
+        }
+    }
+
+    #[cfg(any(feature = "string", feature = "variable_define"))]
+    #[test]
+    fn activation_capture_slot_preserves_identity_across_updates() {
+        let slot = create_capture_slot_for_kind(&ValueKind::String).unwrap();
+        let cells = slot.reactive_root_cell_ids();
+        commit_capture_slot(&slot, &Value::String(Ref::new("first".to_string()))).unwrap();
+        assert_eq!(slot, Value::String(Ref::new("first".to_string())));
+        assert_eq!(slot.reactive_root_cell_ids(), cells);
+        commit_capture_slot(&slot, &Value::String(Ref::new("second".to_string()))).unwrap();
+        assert_eq!(slot, Value::String(Ref::new("second".to_string())));
+        assert_eq!(slot.reactive_root_cell_ids(), cells);
+    }
+
+    #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
+    #[test]
+    fn activation_capture_slot_rejects_kind_mismatch() {
+        let slot = create_capture_slot_for_kind(&ValueKind::F64).unwrap();
+        let error =
+            commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+    }
+}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1231,14 +1231,14 @@ mod tests {
     );
 
     fn interpret(source: &str) -> Interpreter {
-        let tree = mech_syntax::parser::parse(source).unwrap();
+        let tree = mech_syntax::parser::parse(source.trim_start()).unwrap();
         let mut interpreter = Interpreter::new_with_full_stdlib(0);
         interpreter.interpret(&tree).unwrap();
         interpreter
     }
 
     fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MResult<Value> {
-        let tree = mech_syntax::parser::parse(source).unwrap();
+        let tree = mech_syntax::parser::parse(source.trim_start()).unwrap();
         interpreter.interpret(&tree)
     }
 
@@ -1342,26 +1342,23 @@ mod tests {
         panic!("no f64 output")
     }
     fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
-        match symbol(interpreter, "event") {
-            Value::Enum(event) => {
-                let id = event.borrow().id;
-                let names = interpreter
-                    .state
-                    .borrow()
-                    .enums
-                    .get(&id)
-                    .unwrap()
-                    .names
-                    .clone();
-                *event.borrow_mut() = MechEnum {
-                    id,
-                    variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
-                    names,
-                };
-            }
-            Value::Tuple(_) => set_atom_tuple_event(interpreter, variant, payload),
-            _ => panic!("event is neither enum nor tagged tuple"),
-        }
+        let Value::Enum(event) = symbol(interpreter, "event") else {
+            panic!("event is not an enum");
+        };
+        let enum_id = event.borrow().id;
+        let names = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .expect("event enum definition is missing")
+            .names
+            .clone();
+        *event.borrow_mut() = MechEnum {
+            id: enum_id,
+            variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
+            names,
+        };
     }
     fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
         let Value::Tuple(event) = symbol(interpreter, "event") else {
@@ -1437,7 +1434,12 @@ mod tests {
         assert_eq!(&plan_snapshot(interpreter), topology);
     }
 
-    const ENUM_ACTIVATION: &str = r#"event := (:pressed, 0.0)
+    const ENUM_ACTIVATION: &str = r#"
+<Event> := :pressed(f64)
+  | :released(f64)
+  | :other(f64)
+
+event := :pressed(0.0)
 
 ~> event
   | :pressed(x) => {
@@ -1457,11 +1459,34 @@ mod tests {
         PlanSnapshot,
     ) {
         let interpreter = interpret(ENUM_ACTIVATION);
+        assert!(matches!(symbol(&interpreter, "event"), Value::Enum(_)));
+        let enum_id = match symbol(&interpreter, "event") {
+            Value::Enum(event) => event.borrow().id,
+            value => panic!("expected enum event, found {:?}", value.kind()),
+        };
+        let enum_definition = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .cloned()
+            .expect("event enum definition is missing");
+        for variant in ["pressed", "released", "other"] {
+            assert!(
+                enum_definition
+                    .variants
+                    .iter()
+                    .any(|(variant_id, _)| *variant_id == hash_str(variant)),
+                "missing enum variant `{variant}`"
+            );
+        }
         let trigger = root_cell(&interpreter, "event");
         let registration = registration(&interpreter);
         assert_eq!(registration.arms.len(), 3);
         assert_eq!(registration.arms[0].captures.len(), 1);
         assert_eq!(registration.arms[1].captures.len(), 1);
+        assert_eq!(registration.arms[0].captures[0].kind, ValueKind::F64);
+        assert_eq!(registration.arms[1].captures[0].kind, ValueKind::F64);
         assert!(registration.arms[2].captures.is_empty());
         assert!(!interpreter.symbols().borrow().contains(hash_str("x")));
         assert!(
@@ -1885,6 +1910,7 @@ event := (1.0, 1.0)
         let symbols = i.symbols().borrow().snapshot();
         let dictionary = i.dictionary().borrow().clone();
         let topology = plan_snapshot(&i);
+        let context_bindings = i.context_bindings.borrow().clone();
         let error = interpret_more(
             &mut i,
             "~> event\n  | 1.0 => {
@@ -1898,6 +1924,13 @@ event := (1.0, 1.0)
         assert_eq!(i.symbols().borrow().snapshot(), symbols);
         assert_eq!(*i.dictionary().borrow(), dictionary);
         assert_eq!(plan_snapshot(&i), topology);
+        assert_eq!(*i.context_bindings.borrow(), context_bindings);
+        assert!(
+            !i.context_bindings
+                .borrow()
+                .contains_key(&hash_str("temporary"))
+        );
+        assert!(i.plan().pattern_activation_registrations().is_empty());
         assert!(!i.symbols().borrow().contains(hash_str("fallback")));
     }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1435,11 +1435,11 @@ mod tests {
     }
 
     const ENUM_ACTIVATION: &str = r#"
-<Event> := :pressed(f64)
-  | :released(f64)
-  | :other(f64)
+<event-kind> := :pressed<f64>
+  | :released<f64>
+  | :other<f64>
 
-event := :pressed(0.0)
+event<event-kind> := :pressed(0.0)
 
 ~> event
   | :pressed(x) => {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -109,10 +109,34 @@ fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
 }
 fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
     match kind.deref_kind() {
+        #[cfg(feature = "u8")]
+        ValueKind::U8 => Ok(Value::U8(Ref::new(0))),
+        #[cfg(feature = "u16")]
+        ValueKind::U16 => Ok(Value::U16(Ref::new(0))),
+        #[cfg(feature = "u32")]
+        ValueKind::U32 => Ok(Value::U32(Ref::new(0))),
+        #[cfg(feature = "u64")]
+        ValueKind::U64 => Ok(Value::U64(Ref::new(0))),
+        #[cfg(feature = "u128")]
+        ValueKind::U128 => Ok(Value::U128(Ref::new(0))),
+        #[cfg(feature = "i8")]
+        ValueKind::I8 => Ok(Value::I8(Ref::new(0))),
+        #[cfg(feature = "i16")]
+        ValueKind::I16 => Ok(Value::I16(Ref::new(0))),
+        #[cfg(feature = "i32")]
+        ValueKind::I32 => Ok(Value::I32(Ref::new(0))),
+        #[cfg(feature = "i64")]
+        ValueKind::I64 => Ok(Value::I64(Ref::new(0))),
+        #[cfg(feature = "i128")]
+        ValueKind::I128 => Ok(Value::I128(Ref::new(0))),
         #[cfg(feature = "f64")]
         ValueKind::F64 => Ok(Value::F64(Ref::new(0.0))),
         #[cfg(feature = "f32")]
         ValueKind::F32 => Ok(Value::F32(Ref::new(0.0))),
+        #[cfg(feature = "complex")]
+        ValueKind::C64 => Ok(Value::C64(Ref::new(C64::default()))),
+        #[cfg(feature = "rational")]
+        ValueKind::R64 => Ok(Value::R64(Ref::new(R64::default()))),
         #[cfg(any(feature = "bool", feature = "variable_define"))]
         ValueKind::Bool => Ok(Value::Bool(Ref::new(false))),
         #[cfg(any(feature = "string", feature = "variable_define"))]
@@ -128,6 +152,56 @@ fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
 }
 fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
     match (destination, &detached(source)) {
+        #[cfg(feature = "u8")]
+        (Value::U8(a), Value::U8(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u16")]
+        (Value::U16(a), Value::U16(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u32")]
+        (Value::U32(a), Value::U32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u64")]
+        (Value::U64(a), Value::U64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u128")]
+        (Value::U128(a), Value::U128(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i8")]
+        (Value::I8(a), Value::I8(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i16")]
+        (Value::I16(a), Value::I16(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i32")]
+        (Value::I32(a), Value::I32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i64")]
+        (Value::I64(a), Value::I64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i128")]
+        (Value::I128(a), Value::I128(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
         #[cfg(feature = "f64")]
         (Value::F64(a), Value::F64(b)) => {
             clone_ref_value(a, b);
@@ -135,6 +209,16 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
         }
         #[cfg(feature = "f32")]
         (Value::F32(a), Value::F32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "complex")]
+        (Value::C64(a), Value::C64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "rational")]
+        (Value::R64(a), Value::R64(b)) => {
             clone_ref_value(a, b);
             Ok(())
         }
@@ -592,33 +676,8 @@ fn preflight_patterned_activation(
             MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
         );
     }
-    for a in arms {
-        if let ActivationArmBody::Block(body) = &a.body {
-            for (code, _) in body {
-                match code {
-                    MechCode::Statement(Statement::VariableAssign(_))
-                    | MechCode::Statement(Statement::OpAssign(_)) => {
-                        return Err(MechError::new(
-                            ActivationPatternRegisterWriteUnsupported,
-                            None,
-                        )
-                        .with_tokens(code.tokens()));
-                    }
-                    MechCode::Statement(Statement::ContextSend(_)) => {
-                        return Err(MechError::new(
-                            ActivationPatternContextEffectUnsupported,
-                            None,
-                        )
-                        .with_tokens(code.tokens()));
-                    }
-                    MechCode::Statement(Statement::VariableDefine(d)) if d.mutable => {
-                        return Err(MechError::new(ActivationPatternDefinitionUnsupported, None)
-                            .with_tokens(code.tokens()));
-                    }
-                    _ => {}
-                }
-            }
-        }
+    for arm in arms {
+        validate_patterned_arm_body(&arm.body)?;
     }
     if trigger.reactive_root_cell_ids() != trigger_cells {
         return Err(
@@ -638,14 +697,314 @@ fn preflight_patterned_activation(
     })
 }
 
+fn validation_error(kind: impl MechErrorKind + 'static, tokens: Vec<Token>) -> MResult<()> {
+    Err(MechError::new(kind, None).with_tokens(tokens))
+}
+
+fn validate_patterned_arm_body(body: &ActivationArmBody) -> MResult<()> {
+    match body {
+        ActivationArmBody::Block(body) => {
+            for (code, _) in body {
+                validate_patterned_code(code)?;
+            }
+            Ok(())
+        }
+        ActivationArmBody::Expression(expression) => validate_patterned_expression(expression),
+    }
+}
+fn validate_patterned_code(code: &MechCode) -> MResult<()> {
+    match code {
+        MechCode::Comment(_) => Ok(()),
+        MechCode::Expression(expression) => validate_patterned_expression(expression),
+        MechCode::Statement(statement) => validate_patterned_statement(statement),
+        MechCode::ActivationScope(_)
+        | MechCode::FunctionDefine(_)
+        | MechCode::FsmSpecification(_)
+        | MechCode::FsmImplementation(_)
+        | MechCode::Import(_)
+        | MechCode::Error(_, _) => {
+            validation_error(ActivationPatternDefinitionUnsupported, code.tokens())
+        }
+    }
+}
+fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
+    match statement {
+        Statement::VariableDefine(definition)
+            if !definition.mutable && definition.var.context.is_none() =>
+        {
+            validate_patterned_expression(&definition.expression)
+        }
+        Statement::VariableDefine(definition) if definition.var.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                statement.tokens(),
+            )
+        }
+        Statement::VariableDefine(_) => {
+            validation_error(ActivationPatternDefinitionUnsupported, statement.tokens())
+        }
+        Statement::VariableAssign(assignment) if assignment.target.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                statement.tokens(),
+            )
+        }
+        Statement::VariableAssign(_) => validation_error(
+            ActivationPatternRegisterWriteUnsupported,
+            statement.tokens(),
+        ),
+        Statement::OpAssign(assignment) if assignment.target.context.is_some() => validation_error(
+            ActivationPatternContextEffectUnsupported,
+            statement.tokens(),
+        ),
+        Statement::OpAssign(_) => validation_error(
+            ActivationPatternRegisterWriteUnsupported,
+            statement.tokens(),
+        ),
+        Statement::ContextSend(_) => validation_error(
+            ActivationPatternContextEffectUnsupported,
+            statement.tokens(),
+        ),
+        _ => validation_error(ActivationPatternDefinitionUnsupported, statement.tokens()),
+    }
+}
+fn validate_patterned_expression(expression: &Expression) -> MResult<()> {
+    match expression {
+        Expression::Literal(_) | Expression::Var(_) => Ok(()),
+        Expression::Slice(slice) => validate_patterned_slice(slice),
+        Expression::Formula(factor) => validate_patterned_factor(factor),
+        Expression::FunctionCall(call) => {
+            for (_, expression) in &call.args {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Expression::Match(matched) => {
+            validate_patterned_expression(&matched.source)?;
+            for arm in &matched.arms {
+                validate_patterned_pattern(&arm.pattern)?;
+                if let Some(guard) = &arm.guard {
+                    validate_patterned_expression(guard)?;
+                }
+                validate_patterned_expression(&arm.expression)?;
+            }
+            Ok(())
+        }
+        Expression::Range(range) => validate_patterned_range(range),
+        Expression::Structure(structure) => validate_patterned_structure(structure),
+        Expression::SetComprehension(comprehension) => {
+            validate_patterned_expression(&comprehension.expression)?;
+            for qualifier in &comprehension.qualifiers {
+                validate_patterned_qualifier(qualifier)?;
+            }
+            Ok(())
+        }
+        Expression::MatrixComprehension(comprehension) => {
+            validate_patterned_expression(&comprehension.expression)?;
+            for qualifier in &comprehension.qualifiers {
+                validate_patterned_qualifier(qualifier)?;
+            }
+            Ok(())
+        }
+        Expression::FsmPipe(_) => {
+            validation_error(ActivationPatternDefinitionUnsupported, expression.tokens())
+        }
+    }
+}
+fn validate_patterned_pattern(pattern: &Pattern) -> MResult<()> {
+    match pattern {
+        Pattern::Expression(expression) => validate_patterned_expression(expression),
+        Pattern::Tuple(tuple) => {
+            for pattern in &tuple.0 {
+                validate_patterned_pattern(pattern)?;
+            }
+            Ok(())
+        }
+        Pattern::TupleStruct(tuple) => {
+            for pattern in &tuple.patterns {
+                validate_patterned_pattern(pattern)?;
+            }
+            Ok(())
+        }
+        Pattern::Array(array) => {
+            for pattern in array.prefix.iter().chain(&array.suffix) {
+                validate_patterned_pattern(pattern)?;
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    validate_patterned_pattern(binding)?;
+                }
+            }
+            Ok(())
+        }
+        Pattern::Wildcard => Ok(()),
+    }
+}
+fn validate_patterned_factor(factor: &Factor) -> MResult<()> {
+    match factor {
+        Factor::Expression(expression) => validate_patterned_expression(expression),
+        Factor::Negate(factor)
+        | Factor::Not(factor)
+        | Factor::Parenthetical(factor)
+        | Factor::Transpose(factor) => validate_patterned_factor(factor),
+        Factor::Term(term) => {
+            validate_patterned_factor(&term.lhs)?;
+            for (_, factor) in &term.rhs {
+                validate_patterned_factor(factor)?;
+            }
+            Ok(())
+        }
+    }
+}
+fn validate_patterned_range(range: &RangeExpression) -> MResult<()> {
+    validate_patterned_factor(&range.start)?;
+    if let Some((_, increment)) = &range.increment {
+        validate_patterned_factor(increment)?;
+    }
+    validate_patterned_factor(&range.terminal)
+}
+fn validate_patterned_slice(slice: &Slice) -> MResult<()> {
+    for subscript in &slice.subscript {
+        validate_patterned_subscript(subscript)?;
+    }
+    Ok(())
+}
+fn validate_patterned_subscript(subscript: &Subscript) -> MResult<()> {
+    match subscript {
+        Subscript::Brace(subscripts) | Subscript::Bracket(subscripts) => {
+            for subscript in subscripts {
+                validate_patterned_subscript(subscript)?;
+            }
+            Ok(())
+        }
+        Subscript::Formula(factor) => validate_patterned_factor(factor),
+        Subscript::Range(range) => validate_patterned_range(range),
+        Subscript::All | Subscript::Dot(_) | Subscript::DotInt(_) | Subscript::Swizzle(_) => Ok(()),
+    }
+}
+fn validate_patterned_structure(structure: &Structure) -> MResult<()> {
+    match structure {
+        Structure::Empty => Ok(()),
+        Structure::Map(map) => {
+            for mapping in &map.elements {
+                validate_patterned_expression(&mapping.key)?;
+                validate_patterned_expression(&mapping.value)?;
+            }
+            Ok(())
+        }
+        Structure::Matrix(matrix) => {
+            for row in &matrix.rows {
+                for column in &row.columns {
+                    validate_patterned_expression(&column.element)?;
+                }
+            }
+            Ok(())
+        }
+        Structure::Record(record) => {
+            for binding in &record.bindings {
+                validate_patterned_expression(&binding.value)?;
+            }
+            Ok(())
+        }
+        Structure::Set(set) => {
+            for expression in &set.elements {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Structure::Table(table) => {
+            for row in &table.rows {
+                for column in &row.columns {
+                    validate_patterned_expression(&column.element)?;
+                }
+            }
+            Ok(())
+        }
+        Structure::Tuple(tuple) => {
+            for expression in &tuple.elements {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Structure::TupleStruct(tuple) => validate_patterned_expression(&tuple.value),
+    }
+}
+fn validate_patterned_qualifier(qualifier: &ComprehensionQualifier) -> MResult<()> {
+    match qualifier {
+        ComprehensionQualifier::Generator((pattern, expression)) => {
+            validate_patterned_pattern(pattern)?;
+            validate_patterned_expression(expression)
+        }
+        ComprehensionQualifier::Filter(expression) => validate_patterned_expression(expression),
+        ComprehensionQualifier::Let(definition) if definition.mutable => {
+            validation_error(ActivationPatternDefinitionUnsupported, definition.tokens())
+        }
+        ComprehensionQualifier::Let(definition) if definition.var.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                definition.tokens(),
+            )
+        }
+        ComprehensionQualifier::Let(definition) => {
+            validate_patterned_expression(&definition.expression)
+        }
+    }
+}
+
+fn elaborate_patterned_arm_body(
+    arm: &ActivationArm,
+    captures: &[ActivationPatternCapture],
+    pulse: &Value,
+    interpreter: &Interpreter,
+) -> MResult<(usize, usize)> {
+    let symbols = interpreter.symbols();
+    let symbol_snapshot = symbols.borrow().snapshot();
+    let plan = interpreter.plan();
+    let original_scope_depth = plan.activation_registration_depth();
+    {
+        let mut symbols = symbols.borrow_mut();
+        for capture in captures {
+            symbols.mutable_variables.remove(&capture.id);
+            symbols.insert(capture.id, capture.slot.clone(), false);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(capture.id, capture.name.clone());
+        }
+    }
+    let body_node_start = plan.len();
+    plan.push_activation_registration_scope(pulse.reactive_root_cell_ids());
+    let body_result = (|| -> MResult<()> {
+        match &arm.body {
+            ActivationArmBody::Block(body) => {
+                for (code, _) in body {
+                    crate::mech_code(code, interpreter)?;
+                }
+                Ok(())
+            }
+            ActivationArmBody::Expression(expression) => {
+                crate::expression(expression, None, interpreter)?;
+                Ok(())
+            }
+        }
+    })();
+    while plan.activation_registration_depth() > original_scope_depth {
+        plan.pop_activation_registration_scope();
+    }
+    symbols.borrow_mut().restore(symbol_snapshot);
+    body_result?;
+    Ok((body_node_start, plan.len()))
+}
+
 fn elaborate_patterned_activation_inner(
-    scope: &ActivationScope,
     arms: &[ActivationArm],
     trigger: Value,
-    trigger_cells: Vec<ReactiveCellId>,
+    preflight: PreflightPatternedActivation,
     i: &Interpreter,
 ) -> MResult<Value> {
-    let preflight = preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, i)?;
+    if trigger.kind().deref_kind() != preflight.trigger_kind {
+        return Err(MechError::new(ActivationPatternTriggerInvariant, None));
+    }
     let compiled = preflight.arms;
     let plan = i.plan();
     let (scope_gen, scope_v) = generation();
@@ -668,7 +1027,7 @@ fn elaborate_patterned_activation_inner(
         )?;
         matcher_nodes.push(n);
         completions.push(v);
-        matched.push(f)
+        matched.push(f);
     }
     let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
     for (f, c) in matched.iter().zip(completions.iter()) {
@@ -683,7 +1042,7 @@ fn elaborate_patterned_activation_inner(
             &[c.clone()],
         )?);
         eligible.push(e);
-        done.push(v)
+        done.push(v);
     }
     let (o, selection) = generation();
     let selected = Ref::new(usize::MAX);
@@ -706,34 +1065,16 @@ fn elaborate_patterned_activation_inner(
             }),
             &[selection.clone()],
         )?);
-        pulses.push(v)
+        pulses.push(v);
     }
     let mut ranges = Vec::new();
-    for (arm, compiled_arm) in arms.iter().zip(compiled.iter()) {
-        let symbols = i.symbols();
-        let snapshot = symbols.borrow().snapshot();
-        {
-            let mut s = symbols.borrow_mut();
-            for c in &compiled_arm.captures {
-                s.insert(c.id, c.slot.clone(), false);
-                s.dictionary.borrow_mut().insert(c.id, c.name.clone());
-            }
-        }
-        let start = plan.len();
-        plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());
-        let result = match &arm.body {
-            ActivationArmBody::Block(b) => {
-                for (c, _) in b {
-                    crate::mech_code(c, i)?;
-                }
-                Ok(())
-            }
-            ActivationArmBody::Expression(e) => crate::expression(e, None, i).map(|_| ()),
-        };
-        plan.pop_activation_registration_scope();
-        symbols.borrow_mut().restore(snapshot);
-        result?;
-        ranges.push((start, plan.len()))
+    for (arm, compiled_arm) in arms.iter().zip(&compiled) {
+        ranges.push(elaborate_patterned_arm_body(
+            arm,
+            &compiled_arm.captures,
+            &pulses[ranges.len()],
+            i,
+        )?);
     }
     let registration = PatternActivationRegistration {
         scope_pulse_node: scope_node,
@@ -769,13 +1110,20 @@ pub(crate) fn elaborate_patterned_activation(
     trigger_cells: Vec<ReactiveCellId>,
     interpreter: &Interpreter,
 ) -> MResult<Value> {
+    let preflight =
+        preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, interpreter)?;
     let plan = interpreter.plan();
     let checkpoint = plan.checkpoint();
-    match elaborate_patterned_activation_inner(scope, arms, trigger, trigger_cells, interpreter) {
+    let program_dictionary = interpreter.state.borrow().dictionary.clone();
+    let dictionary_snapshot = program_dictionary.borrow().clone();
+    match elaborate_patterned_activation_inner(arms, trigger, preflight, interpreter) {
         Ok(value) => Ok(value),
         Err(error) => {
-            plan.rollback(checkpoint)?;
-            Err(error)
+            *program_dictionary.borrow_mut() = dictionary_snapshot;
+            match plan.rollback(checkpoint) {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(rollback_error),
+            }
         }
     }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,0 +1,28 @@
+//! Patterned activation elaboration.
+//!
+//! This module is deliberately kept separate from `mechdown`: activation
+//! scheduling is interpreter infrastructure rather than syntax dispatch.
+//! Fixed-body scopes continue to use the established registration path while
+//! patterned scopes are elaborated here as the activation graph grows.
+
+use crate::*;
+
+/// Describes the internal generation cells used by a patterned activation.
+///
+/// Keeping this descriptor independent of syntax is important: the reactive
+/// plan owns these cells for the lifetime of the loaded program, so a dispatch
+/// never needs to create or rebuild plan nodes.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PatternActivationGenerations {
+    pub scope: Option<ReactiveCellId>,
+    pub selection: Option<ReactiveCellId>,
+    pub arms: Vec<PatternActivationArmGenerations>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PatternActivationArmGenerations {
+    pub matched: Option<ReactiveCellId>,
+    pub guard_start: Option<ReactiveCellId>,
+    pub complete: Option<ReactiveCellId>,
+    pub pulse: Option<ReactiveCellId>,
+}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,3 +1,8 @@
+#![cfg(all(
+  feature = "functions",
+  feature = "symbol_table",
+))]
+
 //! Static scheduling support for patterned activation scopes.
 //!
 //! The small dispatch nodes in this file deliberately contain no syntax and

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -2,87 +2,780 @@
 //! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
 
-macro_rules! activation_error {($n:ident,$m:expr)=>{#[derive(Debug,Clone)] pub(crate) struct $n; impl MechErrorKind for $n {fn name(&self)->&str{stringify!($n)} fn message(&self)->String{$m.into()}}};}
-activation_error!(ActivationPatternExpressionUnsupported,"This activation pattern is not supported.");
-activation_error!(ActivationPatternCaptureKindUnsupported,"The capture kind cannot be inferred from the activation trigger.");
-activation_error!(ActivationPatternArmsNonExhaustive,"Patterned activations require a final unguarded wildcard arm.");
-activation_error!(ActivationPatternWildcardMustBeLast,"The wildcard activation arm must be last.");
-activation_error!(ActivationPatternGuardMustBePure,"Patterned activation guards are not supported yet.");
-activation_error!(ActivationPatternRegisterWriteUnsupported,"Patterned activation register writes are not supported.");
-activation_error!(ActivationPatternContextEffectUnsupported,"Patterned activation context effects are not supported.");
-activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cells disagree with the resolved trigger.");
+macro_rules! activation_error {
+    ($n:ident,$m:expr) => {
+        #[derive(Debug, Clone)]
+        pub(crate) struct $n;
+        impl MechErrorKind for $n {
+            fn name(&self) -> &str {
+                stringify!($n)
+            }
+            fn message(&self) -> String {
+                $m.into()
+            }
+        }
+    };
+}
+activation_error!(
+    ActivationPatternExpressionUnsupported,
+    "This activation pattern is not supported."
+);
+activation_error!(
+    ActivationPatternCaptureKindUnsupported,
+    "The capture kind cannot be inferred from the activation trigger."
+);
+activation_error!(
+    ActivationPatternArmsNonExhaustive,
+    "Patterned activations require a final unguarded wildcard arm."
+);
+activation_error!(
+    ActivationPatternWildcardMustBeLast,
+    "The wildcard activation arm must be last."
+);
+activation_error!(
+    ActivationPatternGuardMustBePure,
+    "Patterned activation guards are not supported yet."
+);
+activation_error!(
+    ActivationPatternRegisterWriteUnsupported,
+    "Patterned activation register writes are not supported."
+);
+activation_error!(
+    ActivationPatternContextEffectUnsupported,
+    "Patterned activation context effects are not supported."
+);
+activation_error!(
+    ActivationPatternTriggerInvariant,
+    "Activation trigger root cells disagree with the resolved trigger."
+);
 
-#[derive(Clone,Debug)] enum CompiledActivationPattern { Wildcard, Literal{expected:Value}, Capture{capture_index:usize}, Tuple{elements:Vec<Self>}, TupleStruct{tag:u64,payload:Vec<Self>} }
-#[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
-#[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
-fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
-fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) { let source=source.borrow(); destination.borrow_mut().clone_from(&*source); }
-fn create_capture_slot(sample:&Value)->MResult<Value>{match detached(sample){
-#[cfg(feature="u8")] Value::U8(v)=>Ok(Value::U8(Ref::new(*v.borrow()))),
-#[cfg(feature="u16")] Value::U16(v)=>Ok(Value::U16(Ref::new(*v.borrow()))),
-#[cfg(feature="u32")] Value::U32(v)=>Ok(Value::U32(Ref::new(*v.borrow()))),
-#[cfg(feature="u64")] Value::U64(v)=>Ok(Value::U64(Ref::new(*v.borrow()))),
-#[cfg(feature="u128")] Value::U128(v)=>Ok(Value::U128(Ref::new(*v.borrow()))),
-#[cfg(feature="i8")] Value::I8(v)=>Ok(Value::I8(Ref::new(*v.borrow()))),
-#[cfg(feature="i16")] Value::I16(v)=>Ok(Value::I16(Ref::new(*v.borrow()))),
-#[cfg(feature="i32")] Value::I32(v)=>Ok(Value::I32(Ref::new(*v.borrow()))),
-#[cfg(feature="i64")] Value::I64(v)=>Ok(Value::I64(Ref::new(*v.borrow()))),
-#[cfg(feature="i128")] Value::I128(v)=>Ok(Value::I128(Ref::new(*v.borrow()))),
-#[cfg(feature="f32")] Value::F32(v)=>Ok(Value::F32(Ref::new(*v.borrow()))),
-#[cfg(feature="f64")] Value::F64(v)=>Ok(Value::F64(Ref::new(*v.borrow()))),
-#[cfg(feature="complex")] Value::C64(v)=>Ok(Value::C64(Ref::new(v.borrow().clone()))),
-#[cfg(feature="rational")] Value::R64(v)=>Ok(Value::R64(Ref::new(v.borrow().clone()))),
-#[cfg(any(feature="bool",feature="variable_define"))] Value::Bool(v)=>Ok(Value::Bool(Ref::new(*v.borrow()))),
-#[cfg(any(feature="string",feature="variable_define"))] Value::String(v)=>Ok(Value::String(Ref::new(v.borrow().clone()))),
-Value::Index(v)=>Ok(Value::Index(Ref::new(*v.borrow()))),
-#[cfg(feature="atom")] Value::Atom(v)=>Ok(Value::Atom(Ref::new(v.borrow().clone()))),
-_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
-fn commit_capture_slot(destination:&Value,source:&Value)->MResult<()>{let source=detached(source);match(destination,&source){
-#[cfg(feature="u8")] (Value::U8(a),Value::U8(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u16")] (Value::U16(a),Value::U16(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u32")] (Value::U32(a),Value::U32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u64")] (Value::U64(a),Value::U64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u128")] (Value::U128(a),Value::U128(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i8")] (Value::I8(a),Value::I8(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i16")] (Value::I16(a),Value::I16(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i32")] (Value::I32(a),Value::I32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i64")] (Value::I64(a),Value::I64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i128")] (Value::I128(a),Value::I128(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="f32")] (Value::F32(a),Value::F32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="f64")] (Value::F64(a),Value::F64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="complex")] (Value::C64(a),Value::C64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="rational")] (Value::R64(a),Value::R64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(any(feature="bool",feature="variable_define"))] (Value::Bool(a),Value::Bool(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(any(feature="string",feature="variable_define"))] (Value::String(a),Value::String(b))=>{clone_ref_value(a,b);Ok(())},
-(Value::Index(a),Value::Index(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="atom")] (Value::Atom(a),Value::Atom(b))=>{clone_ref_value(a,b);Ok(())},
-_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
-fn compile(pat:&Pattern,sample:&Value,i:&Interpreter,caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern>{match pat { Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}), Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash();if let Some(n)=caps.iter().position(|c|c.id==id){Ok(CompiledActivationPattern::Capture{capture_index:n})}else{let value=create_capture_slot(sample).map_err(|e|e.with_tokens(pat.tokens()))?;caps.push(Capture{id,kind:sample.kind(),slot:value});Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})}}, #[cfg(feature="tuple")] Pattern::Tuple(t)=>{let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))};let tv=tv.borrow();if tv.elements.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(tv.elements.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})}, _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens()))}}
-fn matches_pattern(p:&CompiledActivationPattern,v:&Value,proposed:&mut Vec<Option<Value>>)->bool{match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}}, #[cfg(feature="tuple")] CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}, CompiledActivationPattern::TupleStruct{..}=>false, #[cfg(not(feature="tuple"))] CompiledActivationPattern::Tuple{..}=>false}}
-fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
-struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
-struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit_capture_slot(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
-struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
-struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
-struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}
+#[derive(Clone, Debug)]
+enum CompiledActivationPattern {
+    Wildcard,
+    Literal {
+        expected: Value,
+    },
+    Capture {
+        capture_index: usize,
+    },
+    Tuple {
+        elements: Vec<CompiledActivationPattern>,
+    },
+    EnumVariant {
+        enum_id: u64,
+        variant_id: u64,
+        payload: Option<Box<CompiledActivationPattern>>,
+    },
+    AtomTuple {
+        tag_id: u64,
+        payload: Vec<CompiledActivationPattern>,
+    },
+}
+#[derive(Clone)]
+struct ActivationPatternCapture {
+    id: u64,
+    name: String,
+    kind: ValueKind,
+    slot: Value,
+}
+#[derive(Clone)]
+struct PreflightActivationArm {
+    pattern: CompiledActivationPattern,
+    captures: Vec<ActivationPatternCapture>,
+}
+struct PreflightPatternedActivation {
+    trigger_kind: ValueKind,
+    arms: Vec<PreflightActivationArm>,
+}
+#[derive(Debug, Clone)]
+pub(crate) struct ActivationPatternDefinitionUnsupported;
+impl MechErrorKind for ActivationPatternDefinitionUnsupported {
+    fn name(&self) -> &str {
+        "ActivationPatternDefinitionUnsupported"
+    }
+    fn message(&self) -> String {
+        "This definition or declaration is not supported inside a patterned activation arm."
+            .to_string()
+    }
+}
+fn detached(v: &Value) -> Value {
+    match v {
+        Value::MutableReference(r) => detached(&r.borrow()),
+        _ => v.clone(),
+    }
+}
+fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
+    destination.borrow_mut().clone_from(&*source.borrow())
+}
+fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
+    match kind.deref_kind() {
+        #[cfg(feature = "f64")]
+        ValueKind::F64 => Ok(Value::F64(Ref::new(0.0))),
+        #[cfg(feature = "f32")]
+        ValueKind::F32 => Ok(Value::F32(Ref::new(0.0))),
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        ValueKind::Bool => Ok(Value::Bool(Ref::new(false))),
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        ValueKind::String => Ok(Value::String(Ref::new(String::new()))),
+        ValueKind::Index => Ok(Value::Index(Ref::new(0))),
+        #[cfg(feature = "atom")]
+        ValueKind::Atom(id, _) => Ok(Value::Atom(Ref::new(MechAtom::new(id)))),
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
+    match (destination, &detached(source)) {
+        #[cfg(feature = "f64")]
+        (Value::F64(a), Value::F64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "f32")]
+        (Value::F32(a), Value::F32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        (Value::Bool(a), Value::Bool(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        (Value::String(a), Value::String(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        (Value::Index(a), Value::Index(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "atom")]
+        (Value::Atom(a), Value::Atom(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+fn compile_activation_literal(l: &Literal, i: &Interpreter) -> MResult<Value> {
+    match l {
+        Literal::Empty(_) => Ok(Value::Empty),
+        #[cfg(feature = "bool")]
+        Literal::Boolean(t) => Ok(crate::boolean(t)),
+        #[cfg(feature = "string")]
+        Literal::String(v) => Ok(crate::string(v)),
+        #[cfg(feature = "atom")]
+        Literal::Atom(a) => Ok(Value::Atom(Ref::new(MechAtom::new(a.name.hash())))),
+        Literal::Number(Number::Real(RealNumber::TypedInteger(_)))
+        | Literal::TypedLiteral(_)
+        | Literal::Kind(_) => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+        Literal::Number(n) => crate::number(n, i),
+        _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+    }
+}
+#[cfg(feature = "enum")]
+fn compile_enum_variant_pattern(
+    t: &PatternTupleStruct,
+    enum_id: u64,
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let variant_id = t.name.hash();
+    let def = i
+        .state
+        .borrow()
+        .enums
+        .get(&enum_id)
+        .cloned()
+        .ok_or_else(|| {
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
+        })?;
+    let declared = def
+        .variants
+        .iter()
+        .find(|(id, _)| *id == variant_id)
+        .map(|(_, p)| p.clone())
+        .ok_or_else(|| {
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
+        })?;
+    let payload = match (t.patterns.as_slice(), declared) {
+        ([], None) => None,
+        ([p], Some(Value::Kind(k))) => Some(Box::new(compile_activation_pattern(p, &k, i, c)?)),
+        _ => {
+            return Err(
+                MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                    .with_tokens(t.tokens()),
+            );
+        }
+    };
+    Ok(CompiledActivationPattern::EnumVariant {
+        enum_id,
+        variant_id,
+        payload,
+    })
+}
+#[cfg(all(feature = "tuple", feature = "atom"))]
+fn compile_atom_tuple_pattern(
+    t: &PatternTupleStruct,
+    kinds: &[ValueKind],
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let Some(first) = kinds.first() else {
+        return Err(
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
+        );
+    };
+    if !matches!(first.deref_kind(), ValueKind::Atom(_, _)) || t.patterns.len() != kinds.len() - 1 {
+        return Err(
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
+        );
+    };
+    let payload = t
+        .patterns
+        .iter()
+        .zip(kinds.iter().skip(1))
+        .map(|(p, k)| compile_activation_pattern(p, k, i, c))
+        .collect::<MResult<_>>()?;
+    Ok(CompiledActivationPattern::AtomTuple {
+        tag_id: t.name.hash(),
+        payload,
+    })
+}
+fn compile_activation_pattern(
+    p: &Pattern,
+    kind: &ValueKind,
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let kind = kind.deref_kind();
+    match p {
+        Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
+        Pattern::Expression(Expression::Literal(l)) => {
+            let expected = compile_activation_literal(l, i)?;
+            if expected.kind().deref_kind() != kind {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            }
+            Ok(CompiledActivationPattern::Literal { expected })
+        }
+        Pattern::Expression(Expression::Var(v)) => {
+            let id = v.name.hash();
+            if let Some(n) = c.iter().position(|x| x.id == id) {
+                if c[n].kind.deref_kind() != kind {
+                    return Err(
+                        MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                            .with_tokens(p.tokens()),
+                    );
+                }
+                return Ok(CompiledActivationPattern::Capture { capture_index: n });
+            }
+            let slot =
+                create_capture_slot_for_kind(&kind).map_err(|e| e.with_tokens(p.tokens()))?;
+            c.push(ActivationPatternCapture {
+                id,
+                name: v.name.to_string(),
+                kind,
+                slot,
+            });
+            Ok(CompiledActivationPattern::Capture {
+                capture_index: c.len() - 1,
+            })
+        }
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(t) => {
+            let ValueKind::Tuple(k) = kind else {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            };
+            if t.0.len() != k.len() {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            }
+            Ok(CompiledActivationPattern::Tuple {
+                elements: t
+                    .0
+                    .iter()
+                    .zip(k.iter())
+                    .map(|(p, k)| compile_activation_pattern(p, k, i, c))
+                    .collect::<MResult<_>>()?,
+            })
+        }
+        Pattern::TupleStruct(t) => match kind {
+            #[cfg(feature = "enum")]
+            ValueKind::Enum(id, _) => compile_enum_variant_pattern(t, id, i, c),
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            ValueKind::Tuple(k) => compile_atom_tuple_pattern(t, &k, i, c),
+            _ => Err(
+                MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                    .with_tokens(p.tokens()),
+            ),
+        },
+        _ => {
+            Err(MechError::new(ActivationPatternExpressionUnsupported, None)
+                .with_tokens(p.tokens()))
+        }
+    }
+}
+fn matches_pattern(
+    p: &CompiledActivationPattern,
+    v: &Value,
+    proposed: &mut Vec<Option<Value>>,
+) -> bool {
+    match p {
+        CompiledActivationPattern::Wildcard => true,
+        CompiledActivationPattern::Literal { expected } => expected == &detached(v),
+        CompiledActivationPattern::Capture { capture_index } => {
+            let x = detached(v);
+            match &proposed[*capture_index] {
+                Some(y) => y == &x,
+                None => {
+                    proposed[*capture_index] = Some(x);
+                    true
+                }
+            }
+        }
+        #[cfg(feature = "tuple")]
+        CompiledActivationPattern::Tuple { elements } => match detached(v) {
+            Value::Tuple(t) => {
+                let t = t.borrow();
+                t.elements.len() == elements.len()
+                    && elements
+                        .iter()
+                        .zip(t.elements.iter())
+                        .all(|(p, v)| matches_pattern(p, v, proposed))
+            }
+            _ => false,
+        },
+        CompiledActivationPattern::EnumVariant {
+            enum_id,
+            variant_id,
+            payload,
+        } => {
+            #[cfg(feature = "enum")]
+            {
+                let Value::Enum(e) = detached(v) else {
+                    return false;
+                };
+                let e = e.borrow();
+                if e.id != *enum_id || e.variants.len() != 1 {
+                    return false;
+                }
+                let (id, value) = &e.variants[0];
+                id == variant_id
+                    && match (payload, value) {
+                        (None, None) => true,
+                        (Some(p), Some(v)) => matches_pattern(p, v, proposed),
+                        _ => false,
+                    }
+            }
+            #[cfg(not(feature = "enum"))]
+            {
+                false
+            }
+        }
+        CompiledActivationPattern::AtomTuple { tag_id, payload } => {
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            {
+                let Value::Tuple(t) = detached(v) else {
+                    return false;
+                };
+                let t = t.borrow();
+                if t.elements.len() != payload.len() + 1 {
+                    return false;
+                }
+                let Value::Atom(tag) = detached(&t.elements[0]) else {
+                    return false;
+                };
+                tag.borrow().id() == *tag_id
+                    && payload
+                        .iter()
+                        .zip(t.elements.iter().skip(1))
+                        .all(|(p, v)| matches_pattern(p, v, proposed))
+            }
+            #[cfg(not(all(feature = "tuple", feature = "atom")))]
+            {
+                false
+            }
+        }
+        #[cfg(not(feature = "tuple"))]
+        CompiledActivationPattern::Tuple { .. } => false,
+    }
+}
+fn generation() -> (Ref<usize>, Value) {
+    let r = Ref::new(0);
+    (r.clone(), Value::Index(r))
+}
+struct ScopePulse {
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for ScopePulse {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn reactive_dependency_scopes(&self, _: usize) -> Option<Vec<ReactiveDependencyScope>> {
+        Some(vec![ReactiveDependencyScope::Root])
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternScopePulse".into()
+    }
+}
+struct Matcher {
+    pattern: CompiledActivationPattern,
+    trigger: Value,
+    captures: Vec<ActivationPatternCapture>,
+    matched: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Matcher {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        let mut p = vec![None; self.captures.len()];
+        let ok = matches_pattern(&self.pattern, &self.trigger, &mut p);
+        if ok {
+            for (c, v) in self.captures.iter().zip(p.iter()) {
+                if let Some(v) = v {
+                    commit_capture_slot(&c.slot, v)?
+                }
+            }
+        }
+        *self.matched.borrow_mut() = ok;
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn reactive_dependency_kinds(&self, _: usize) -> Option<Vec<ReactiveDependencyKind>> {
+        Some(vec![
+            ReactiveDependencyKind::Reactive,
+            ReactiveDependencyKind::Sampled,
+        ])
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternMatcher".into()
+    }
+}
+struct Finalize {
+    matched: Ref<bool>,
+    eligible: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Finalize {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.eligible.borrow_mut() = *self.matched.borrow();
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternArmFinalize".into()
+    }
+}
+struct Select {
+    eligible: Vec<Ref<bool>>,
+    selected: Ref<usize>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Select {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.selected.borrow_mut() = self
+            .eligible
+            .iter()
+            .position(|x| *x.borrow())
+            .unwrap_or(usize::MAX);
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternSelectArm".into()
+    }
+}
+struct Gate {
+    arm: usize,
+    selected: Ref<usize>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Gate {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        if *self.selected.borrow() == self.arm {
+            *self.out.borrow_mut() += 1;
+            Ok(ReactiveSolveStatus::Changed)
+        } else {
+            Ok(ReactiveSolveStatus::Unchanged)
+        }
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternArmGate".into()
+    }
+}
 
-#[cfg(feature="compiler")] macro_rules! interpreter_only {($t:ty)=>{impl MechFunctionCompiler for $t { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }};}
-#[cfg(feature="compiler")] interpreter_only!(ScopePulse);
-#[cfg(feature="compiler")] interpreter_only!(Matcher);
-#[cfg(feature="compiler")] interpreter_only!(Finalize);
-#[cfg(feature="compiler")] interpreter_only!(Select);
-#[cfg(feature="compiler")] interpreter_only!(Gate);
+#[cfg(feature = "compiler")]
+macro_rules! interpreter_only {
+    ($t:ty) => {
+        impl MechFunctionCompiler for $t {
+            fn compile(&self, _: &mut CompileCtx) -> MResult<Register> {
+                Err(MechError::new(
+                    GenericError {
+                        msg: "Activation pattern dispatch is interpreter-only.".into(),
+                    },
+                    None,
+                ))
+            }
+        }
+    };
+}
+#[cfg(feature = "compiler")]
+interpreter_only!(ScopePulse);
+#[cfg(feature = "compiler")]
+interpreter_only!(Matcher);
+#[cfg(feature = "compiler")]
+interpreter_only!(Finalize);
+#[cfg(feature = "compiler")]
+interpreter_only!(Select);
+#[cfg(feature = "compiler")]
+interpreter_only!(Gate);
 
-pub(crate) fn elaborate_patterned_activation(scope:&ActivationScope,arms:&[ActivationArm],trigger:Value,trigger_cells:Vec<ReactiveCellId>,i:&Interpreter)->MResult<Value>{
- let last=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
- if !matches!(last.pattern,Pattern::Wildcard)||last.guard.is_some(){return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))} if arms[..arms.len()-1].iter().any(|x|matches!(x.pattern,Pattern::Wildcard)){return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens()))} if arms.iter().any(|x|x.guard.is_some()){return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens()))}
- for arm in arms {if let ActivationArmBody::Block(body)=&arm.body{for(code,_)in body{match code{MechCode::Statement(Statement::VariableAssign(_))|MechCode::Statement(Statement::OpAssign(_))=>return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())),MechCode::Statement(Statement::ContextSend(_))=>return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())),_=>{}}}}}
- let mut compiled=Vec::new();for arm in arms{let mut captures=Vec::new();let pattern=compile(&arm.pattern,&trigger,i,&mut captures)?;compiled.push(CompiledArm{pattern,captures})}
- if trigger.reactive_root_cell_ids()!=trigger_cells{return Err(MechError::new(ActivationPatternTriggerInvariant,None).with_tokens(scope.tokens()))}
- let plan=i.plan();let(scope_gen,scope_v)=generation();let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_gen}),&[trigger.clone()])?;
- let(mut matcher_nodes,mut completions,mut matched)=(Vec::new(),Vec::new(),Vec::new());for arm in &compiled{let(o,v)=generation();let f=Ref::new(false);let n=plan.borrow_mut().register(Box::new(Matcher{pattern:arm.pattern.clone(),trigger:trigger.clone(),captures:arm.captures.clone(),matched:f.clone(),out:o}),&[scope_v.clone(),trigger.clone()])?;matcher_nodes.push(n);completions.push(v);matched.push(f)}
- let(mut finalizers,mut eligible,mut done)=(Vec::new(),Vec::new(),Vec::new());for(f,c)in matched.iter().zip(completions.iter()){let(o,v)=generation();let e=Ref::new(false);finalizers.push(plan.borrow_mut().register(Box::new(Finalize{matched:f.clone(),eligible:e.clone(),out:o}),&[c.clone()])?);eligible.push(e);done.push(v)} let(o,selection)=generation();let selected=Ref::new(usize::MAX);let selector=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:o}),&done)?;
- let(mut gates,mut pulses)=(Vec::new(),Vec::new());for arm in 0..arms.len(){let(o,v)=generation();gates.push(plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:o}),&[selection.clone()])?);pulses.push(v)}
- let mut ranges=Vec::new();for(arm,compiled_arm)in arms.iter().zip(compiled.iter()){let symbols=i.symbols();let mut s=symbols.borrow_mut();let old=compiled_arm.captures.iter().map(|c|(c.id,s.symbols.get(&c.id).cloned(),s.mutable_variables.get(&c.id).cloned())).collect::<Vec<_>>();for c in &compiled_arm.captures{s.insert(c.id,c.slot.clone(),false);}drop(s);let start=plan.len();plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());let result=match &arm.body{ActivationArmBody::Block(b)=>{for(c,_)in b{crate::mech_code(c,i)?;}Ok(())},ActivationArmBody::Expression(e)=>crate::expression(e,None,i).map(|_|())};plan.pop_activation_registration_scope();let mut s=symbols.borrow_mut();for(id,oldv,oldm)in old{s.symbols.remove(&id);s.mutable_variables.remove(&id);if let Some(v)=oldv{s.symbols.insert(id,v);}if let Some(v)=oldm{s.mutable_variables.insert(id,v);}}drop(s);result?;ranges.push((start,plan.len()))}
- let registration=PatternActivationRegistration{scope_pulse_node:scope_node,selector_node:selector,arms:(0..arms.len()).map(|n|PatternActivationArmRegistration{matcher_node:matcher_nodes[n],finalizer_node:finalizers[n],gate_node:gates[n],pulse_cell:pulses[n].reactive_root_cell_ids()[0],body_node_start:ranges[n].0,body_node_end:ranges[n].1,captures:compiled[n].captures.iter().map(|c|PatternActivationCaptureRegistration{id:c.id,kind:c.kind.clone(),cell:c.slot.reactive_root_cell_ids()[0]}).collect()}).collect()};plan.borrow_mut().register_pattern_activation(registration);Ok(Value::Empty)
+fn preflight_patterned_activation(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: &Value,
+    trigger_cells: &[ReactiveCellId],
+    i: &Interpreter,
+) -> MResult<PreflightPatternedActivation> {
+    let last = arms.last().ok_or_else(|| {
+        MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+    })?;
+    if !matches!(last.pattern, Pattern::Wildcard) || last.guard.is_some() {
+        return Err(
+            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms[..arms.len() - 1]
+        .iter()
+        .any(|a| matches!(a.pattern, Pattern::Wildcard))
+    {
+        return Err(
+            MechError::new(ActivationPatternWildcardMustBeLast, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms.iter().any(|a| a.guard.is_some()) {
+        return Err(
+            MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
+        );
+    }
+    for a in arms {
+        if let ActivationArmBody::Block(body) = &a.body {
+            for (code, _) in body {
+                match code {
+                    MechCode::Statement(Statement::VariableAssign(_))
+                    | MechCode::Statement(Statement::OpAssign(_)) => {
+                        return Err(MechError::new(
+                            ActivationPatternRegisterWriteUnsupported,
+                            None,
+                        )
+                        .with_tokens(code.tokens()));
+                    }
+                    MechCode::Statement(Statement::ContextSend(_)) => {
+                        return Err(MechError::new(
+                            ActivationPatternContextEffectUnsupported,
+                            None,
+                        )
+                        .with_tokens(code.tokens()));
+                    }
+                    MechCode::Statement(Statement::VariableDefine(d)) if d.mutable => {
+                        return Err(MechError::new(ActivationPatternDefinitionUnsupported, None)
+                            .with_tokens(code.tokens()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if trigger.reactive_root_cell_ids() != trigger_cells {
+        return Err(
+            MechError::new(ActivationPatternTriggerInvariant, None).with_tokens(scope.tokens())
+        );
+    }
+    let trigger_kind = trigger.kind().deref_kind();
+    let mut compiled = Vec::new();
+    for a in arms {
+        let mut captures = Vec::new();
+        let pattern = compile_activation_pattern(&a.pattern, &trigger_kind, i, &mut captures)?;
+        compiled.push(PreflightActivationArm { pattern, captures });
+    }
+    Ok(PreflightPatternedActivation {
+        trigger_kind,
+        arms: compiled,
+    })
+}
+
+fn elaborate_patterned_activation_inner(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: Value,
+    trigger_cells: Vec<ReactiveCellId>,
+    i: &Interpreter,
+) -> MResult<Value> {
+    let preflight = preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, i)?;
+    let compiled = preflight.arms;
+    let plan = i.plan();
+    let (scope_gen, scope_v) = generation();
+    let scope_node = plan
+        .borrow_mut()
+        .register(Box::new(ScopePulse { out: scope_gen }), &[trigger.clone()])?;
+    let (mut matcher_nodes, mut completions, mut matched) = (Vec::new(), Vec::new(), Vec::new());
+    for arm in &compiled {
+        let (o, v) = generation();
+        let f = Ref::new(false);
+        let n = plan.borrow_mut().register(
+            Box::new(Matcher {
+                pattern: arm.pattern.clone(),
+                trigger: trigger.clone(),
+                captures: arm.captures.clone(),
+                matched: f.clone(),
+                out: o,
+            }),
+            &[scope_v.clone(), trigger.clone()],
+        )?;
+        matcher_nodes.push(n);
+        completions.push(v);
+        matched.push(f)
+    }
+    let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
+    for (f, c) in matched.iter().zip(completions.iter()) {
+        let (o, v) = generation();
+        let e = Ref::new(false);
+        finalizers.push(plan.borrow_mut().register(
+            Box::new(Finalize {
+                matched: f.clone(),
+                eligible: e.clone(),
+                out: o,
+            }),
+            &[c.clone()],
+        )?);
+        eligible.push(e);
+        done.push(v)
+    }
+    let (o, selection) = generation();
+    let selected = Ref::new(usize::MAX);
+    let selector = plan.borrow_mut().register(
+        Box::new(Select {
+            eligible: eligible.clone(),
+            selected: selected.clone(),
+            out: o,
+        }),
+        &done,
+    )?;
+    let (mut gates, mut pulses) = (Vec::new(), Vec::new());
+    for arm in 0..arms.len() {
+        let (o, v) = generation();
+        gates.push(plan.borrow_mut().register(
+            Box::new(Gate {
+                arm,
+                selected: selected.clone(),
+                out: o,
+            }),
+            &[selection.clone()],
+        )?);
+        pulses.push(v)
+    }
+    let mut ranges = Vec::new();
+    for (arm, compiled_arm) in arms.iter().zip(compiled.iter()) {
+        let symbols = i.symbols();
+        let snapshot = symbols.borrow().snapshot();
+        {
+            let mut s = symbols.borrow_mut();
+            for c in &compiled_arm.captures {
+                s.insert(c.id, c.slot.clone(), false);
+                s.dictionary.borrow_mut().insert(c.id, c.name.clone());
+            }
+        }
+        let start = plan.len();
+        plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());
+        let result = match &arm.body {
+            ActivationArmBody::Block(b) => {
+                for (c, _) in b {
+                    crate::mech_code(c, i)?;
+                }
+                Ok(())
+            }
+            ActivationArmBody::Expression(e) => crate::expression(e, None, i).map(|_| ()),
+        };
+        plan.pop_activation_registration_scope();
+        symbols.borrow_mut().restore(snapshot);
+        result?;
+        ranges.push((start, plan.len()))
+    }
+    let registration = PatternActivationRegistration {
+        scope_pulse_node: scope_node,
+        selector_node: selector,
+        arms: (0..arms.len())
+            .map(|n| PatternActivationArmRegistration {
+                matcher_node: matcher_nodes[n],
+                finalizer_node: finalizers[n],
+                gate_node: gates[n],
+                pulse_cell: pulses[n].reactive_root_cell_ids()[0],
+                body_node_start: ranges[n].0,
+                body_node_end: ranges[n].1,
+                captures: compiled[n]
+                    .captures
+                    .iter()
+                    .map(|c| PatternActivationCaptureRegistration {
+                        id: c.id,
+                        kind: c.kind.clone(),
+                        cell: c.slot.reactive_root_cell_ids()[0],
+                    })
+                    .collect(),
+            })
+            .collect(),
+    };
+    plan.borrow_mut().register_pattern_activation(registration);
+    Ok(Value::Empty)
+}
+
+pub(crate) fn elaborate_patterned_activation(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: Value,
+    trigger_cells: Vec<ReactiveCellId>,
+    interpreter: &Interpreter,
+) -> MResult<Value> {
+    let plan = interpreter.plan();
+    let checkpoint = plan.checkpoint();
+    match elaborate_patterned_activation_inner(scope, arms, trigger, trigger_cells, interpreter) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            plan.rollback(checkpoint)?;
+            Err(error)
+        }
+    }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,28 +1,94 @@
-//! Patterned activation elaboration.
+//! Static scheduling support for patterned activation scopes.
 //!
-//! This module is deliberately kept separate from `mechdown`: activation
-//! scheduling is interpreter infrastructure rather than syntax dispatch.
-//! Fixed-body scopes continue to use the established registration path while
-//! patterned scopes are elaborated here as the activation graph grows.
+//! The small dispatch nodes in this file deliberately contain no syntax and
+//! are registered once while a source tree is elaborated.  A reactive turn
+//! only moves generation counters through that already-built graph.
 
 use crate::*;
 
-/// Describes the internal generation cells used by a patterned activation.
-///
-/// Keeping this descriptor independent of syntax is important: the reactive
-/// plan owns these cells for the lifetime of the loaded program, so a dispatch
-/// never needs to create or rebuild plan nodes.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PatternActivationGenerations {
-    pub scope: Option<ReactiveCellId>,
-    pub selection: Option<ReactiveCellId>,
-    pub arms: Vec<PatternActivationArmGenerations>,
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternExpressionUnsupported;
+impl MechErrorKind for ActivationPatternExpressionUnsupported { fn name(&self)->&str{"ActivationPatternExpressionUnsupported"} fn message(&self)->String{"This activation pattern is not supported.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternCaptureKindUnsupported;
+impl MechErrorKind for ActivationPatternCaptureKindUnsupported { fn name(&self)->&str{"ActivationPatternCaptureKindUnsupported"} fn message(&self)->String{"The capture kind cannot be inferred from the activation trigger.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternArmsNonExhaustive;
+impl MechErrorKind for ActivationPatternArmsNonExhaustive { fn name(&self)->&str{"ActivationPatternArmsNonExhaustive"} fn message(&self)->String{"Patterned activations require a final unguarded wildcard arm.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternWildcardMustBeLast;
+impl MechErrorKind for ActivationPatternWildcardMustBeLast { fn name(&self)->&str{"ActivationPatternWildcardMustBeLast"} fn message(&self)->String{"The wildcard activation arm must be last.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternGuardMustBePure;
+impl MechErrorKind for ActivationPatternGuardMustBePure { fn name(&self)->&str{"ActivationPatternGuardMustBePure"} fn message(&self)->String{"Patterned activation guards must be pure.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternRegisterWriteUnsupported;
+impl MechErrorKind for ActivationPatternRegisterWriteUnsupported { fn name(&self)->&str{"ActivationPatternRegisterWriteUnsupported"} fn message(&self)->String{"Patterned activation register writes are not supported.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternContextEffectUnsupported;
+impl MechErrorKind for ActivationPatternContextEffectUnsupported { fn name(&self)->&str{"ActivationPatternContextEffectUnsupported"} fn message(&self)->String{"Patterned activation context effects are not supported.".into()} }
+
+#[derive(Clone, Debug)]
+enum CompiledActivationPattern { Wildcard, Literal(Value) }
+
+fn compile_pattern(pattern: &Pattern, interpreter: &Interpreter) -> MResult<CompiledActivationPattern> {
+  match pattern {
+    Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
+    Pattern::Expression(Expression::Literal(literal)) => Ok(CompiledActivationPattern::Literal(crate::literal(literal, interpreter)?)),
+    // A variable is deliberately not treated as a catch-all: doing so loses
+    // the type and stable backing reference required for a capture slot.
+    Pattern::Expression(Expression::Var(_)) => Err(MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(pattern.tokens())),
+    _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None).with_tokens(pattern.tokens())),
+  }
 }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PatternActivationArmGenerations {
-    pub matched: Option<ReactiveCellId>,
-    pub guard_start: Option<ReactiveCellId>,
-    pub complete: Option<ReactiveCellId>,
-    pub pulse: Option<ReactiveCellId>,
+fn generation() -> (Ref<usize>, Value) { let cell=Ref::new(0usize); let value=Value::Index(cell.clone()); (cell,value) }
+
+struct ScopePulse { out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for ScopePulse { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for ScopePulse {
+  fn solve(&self) {}
+  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
+  fn out(&self)->Value { Value::Index(self.out.clone()) }
+  fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>> { Some(vec![ReactiveDependencyScope::Root]) }
+  fn to_string(&self)->String{"ActivationPatternScopePulse".into()}
+}
+struct Matcher { pattern: CompiledActivationPattern, trigger: Value, matched: Ref<bool>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Matcher { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Matcher {
+  fn solve(&self) {}
+  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.matched.borrow_mut()=match &self.pattern { CompiledActivationPattern::Wildcard=>true, CompiledActivationPattern::Literal(value)=>value==&self.trigger }; *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
+  fn out(&self)->Value{Value::Index(self.out.clone())}
+  fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}
+  fn to_string(&self)->String{"ActivationPatternMatcher".into()}
+}
+struct Finalize { matched: Ref<bool>, eligible: Ref<bool>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Finalize { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Finalize { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmFinalize".into()} }
+struct Select { eligible: Vec<Ref<bool>>, selected: Ref<usize>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Select { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Select { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternSelectArm".into()} }
+struct Gate { arm: usize, selected: Ref<usize>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Gate { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Gate { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if *self.selected.borrow()==self.arm {*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} else {Ok(ReactiveSolveStatus::Unchanged)}} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmGate".into()} }
+
+/// Elaborates the static, combinational dispatch graph for literal and
+/// wildcard patterned activation arms.  Unsupported destructuring is rejected
+/// during elaboration rather than deferred to a reactive turn.
+pub(crate) fn elaborate_patterned_activation(scope: &ActivationScope, arms: &[ActivationArm], trigger: Value, trigger_cells: Vec<ReactiveCellId>, interpreter: &Interpreter) -> MResult<Value> {
+  let final_arm=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
+  if !matches!(final_arm.pattern,Pattern::Wildcard) || final_arm.guard.is_some() { return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens())); }
+  if arms[..arms.len()-1].iter().any(|arm|matches!(arm.pattern,Pattern::Wildcard)) { return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens())); }
+  if arms.iter().any(|arm|arm.guard.is_some()) { return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens())); }
+  for arm in arms { if let ActivationArmBody::Block(body)=&arm.body { for (code,_) in body { match code { MechCode::Statement(Statement::VariableAssign(_)) | MechCode::Statement(Statement::OpAssign(_)) => return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())), MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())), _=>{} } } } }
+  let patterns=arms.iter().map(|arm|compile_pattern(&arm.pattern,interpreter)).collect::<MResult<Vec<_>>>()?;
+  let plan=interpreter.plan();
+  let (scope_generation,scope_value)=generation();
+  let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_generation}), &[trigger.clone()])?;
+  let mut matcher_nodes=Vec::new(); let mut completions=Vec::new(); let mut matched=Vec::new();
+  for pattern in patterns { let (complete,complete_value)=generation(); let flag=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Matcher{pattern,trigger:trigger.clone(),matched:flag.clone(),out:complete}), &[scope_value.clone(),trigger.clone()])?; matcher_nodes.push(id); completions.push(complete_value); matched.push(flag); }
+  let mut finalizer_nodes=Vec::new(); let mut eligible=Vec::new(); let mut arm_complete=Vec::new();
+  for (flag, complete) in matched.iter().zip(completions.iter()) { let (done,done_value)=generation(); let ok=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Finalize{matched:flag.clone(),eligible:ok.clone(),out:done}), &[complete.clone()])?; finalizer_nodes.push(id); eligible.push(ok); arm_complete.push(done_value); }
+  let (selection,selection_value)=generation(); let selected=Ref::new(usize::MAX); let selector_node=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:selection}), &arm_complete)?;
+  let mut gate_nodes=Vec::new(); let mut pulses=Vec::new();
+  for arm in 0..arms.len() { let (pulse,pulse_value)=generation(); let id=plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:pulse}), &[selection_value.clone()])?; gate_nodes.push(id); pulses.push(pulse_value); }
+  let mut registrations=Vec::new();
+  for (arm,pulse) in arms.iter().zip(pulses.iter()) { let start=plan.len(); plan.push_activation_registration_scope(pulse.reactive_root_cell_ids()); let result=match &arm.body { ActivationArmBody::Block(body)=>{for (code,_) in body { crate::mech_code(code,interpreter)?; } Ok(())}, ActivationArmBody::Expression(expression)=>{crate::expression(expression,None,interpreter).map(|_|())} }; plan.pop_activation_registration_scope(); result?; registrations.push((start,plan.len())); }
+  let registration=PatternActivationRegistration { scope_pulse_node:scope_node, selector_node, arms:(0..arms.len()).map(|i|PatternActivationArmRegistration{matcher_node:matcher_nodes[i],finalizer_node:finalizer_nodes[i],gate_node:gate_nodes[i],pulse_cell:pulses[i].reactive_root_cell_ids()[0],body_node_start:registrations[i].0,body_node_end:registrations[i].1}).collect() };
+  plan.borrow_mut().register_pattern_activation(registration);
+  let _=trigger_cells; // The scope pulse's Root dependency is the trigger's root storage.
+  Ok(Value::Empty)
 }

--- a/src/interpreter/src/builtins.rs
+++ b/src/interpreter/src/builtins.rs
@@ -165,6 +165,7 @@ fn is_prelude_name(name: &str) -> bool {
         "SetSize",
         "Set1D",
         "Table",
+        "TupleAccessElement",
     ];
     EXACT.contains(&name) || PREFIXES.iter().any(|prefix| name.starts_with(prefix))
 }

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1406,19 +1406,21 @@ pub fn match_expression(
         let mut guard_env = base_env.clone();
         let matched = match &arm.pattern {
             Pattern::Wildcard => true,
-            _ => crate::patterns::pattern_matches_value_with_semantics(
+            _ => crate::patterns::pattern_matches_value(
                 &arm.pattern,
                 &detached_source,
                 &mut guard_env,
                 p,
-                crate::patterns::PatternMatchSemantics::OptionGuard,
             )?,
         };
+        if !matched {
+            continue;
+        }
         let passed_guard = match &arm.guard {
             Some(guard) => guard_expression_true(guard, &guard_env, p)?,
             None => true,
         };
-        if matched && passed_guard {
+        if passed_guard {
             #[cfg(feature = "matrix")]
             if value_contains_empty(&detached_source) && is_identity_option_matrix_arm(arm) {
                 if let Some(wildcard_arm) = match_expr
@@ -1561,19 +1563,21 @@ fn match_validate_arm_kinds(
         let mut arm_env = base_env.clone();
         let applicable = match arm.pattern {
             Pattern::Wildcard => true,
-            _ => crate::patterns::pattern_matches_value_with_semantics(
+            _ => crate::patterns::pattern_matches_value(
                 &arm.pattern,
                 source,
                 &mut arm_env,
                 p,
-                crate::patterns::PatternMatchSemantics::OptionGuard,
             )?,
         };
+        if !applicable {
+            continue;
+        }
         let passed_guard = match &arm.guard {
             Some(guard) => guard_expression_true(guard, &arm_env, p)?,
             None => true,
         };
-        if !(applicable && passed_guard) {
+        if !passed_guard {
             continue;
         }
         let arm_value = expression(&arm.expression, Some(&arm_env), p)?;

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -45,7 +45,7 @@ pub fn pattern_match_value(
     match pattern {
         Pattern::Wildcard => Ok(()),
         Pattern::Expression(expr) => match expr {
-            Expression::Var(var) => {
+            Expression::Var(var) if crate::patterns::pattern_var_is_binding(var) => {
                 let id = &var.name.hash();
                 match env.get(id) {
                     Some(existing) if existing == value => Ok(()),

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -36,86 +36,6 @@ pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter)
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
-pub fn pattern_match_value(
-    pattern: &Pattern,
-    value: &Value,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<()> {
-    match pattern {
-        Pattern::Wildcard => Ok(()),
-        Pattern::Expression(expr) => match expr {
-            Expression::Var(var) if crate::patterns::pattern_var_is_binding(var) => {
-                let id = &var.name.hash();
-                match env.get(id) {
-                    Some(existing) if existing == value => Ok(()),
-                    Some(existing) => Err(MechError::new(
-                        PatternMatchError {
-                            var: var.name.to_string(),
-                            expected: existing.to_string(),
-                            found: value.to_string(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                    None => {
-                        env.insert(id.clone(), value.clone());
-                        Ok(())
-                    }
-                }
-            }
-            _ => {
-                let expected = expression(expr, Some(env), p)?;
-                if detach_comprehension_value(&expected) == detach_comprehension_value(value) {
-                    Ok(())
-                } else {
-                    Err(MechError::new(
-                        PatternMatchError {
-                            var: "<expression>".to_string(),
-                            expected: expected.to_string(),
-                            found: value.to_string(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc())
-                }
-            }
-        },
-        #[cfg(feature = "tuple")]
-        Pattern::Tuple(pat_tuple) => match value {
-            Value::Tuple(values) => {
-                let values_brrw = values.borrow();
-                if pat_tuple.0.len() != values_brrw.elements.len() {
-                    return Err(MechError::new(
-                        ArityMismatchError {
-                            expected: pat_tuple.0.len(),
-                            found: values_brrw.elements.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc());
-                }
-                for (pttrn, val) in pat_tuple.0.iter().zip(values_brrw.elements.iter()) {
-                    pattern_match_value(pttrn, val, env, p)?;
-                }
-                Ok(())
-            }
-            _ => Err(MechError::new(
-                PatternExpectedTupleError {
-                    found: value.kind(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        },
-        Pattern::TupleStruct(pat_struct) => {
-            todo!("Implement tuple struct pattern matching")
-        }
-        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
-    }
-}
-
-#[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
 fn comprehension_environments(
     qualifiers: &[ComprehensionQualifier],
     comprehension_id: u64,
@@ -128,12 +48,19 @@ fn comprehension_environments(
     for qual in qualifiers {
         envs = match qual {
             ComprehensionQualifier::Generator((pttrn, expr)) => {
+                let compiled = crate::patterns::compile_pattern(pttrn, None, &new_p)?;
                 let mut new_envs = Vec::new();
                 for env in &envs {
                     let collection = expression(expr, Some(env), &new_p)?;
                     for elmnt in comprehension_generator_values(&collection)? {
                         let mut new_env = env.clone();
-                        if pattern_match_value(pttrn, &elmnt, &mut new_env, &new_p).is_ok() {
+                        let pattern_match =
+                            crate::patterns::match_compiled_pattern_with_environment_constraints(
+                                &compiled, &elmnt, &new_env, &new_p,
+                            )?;
+                        if pattern_match.matched {
+                            crate::patterns::EnvironmentBindingSink::new(&mut new_env)
+                                .commit(&pattern_match)?;
                             new_envs.push(new_env);
                         }
                     }

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -603,7 +603,7 @@ fn coerce_function_output_kind(
 struct FunctionScope {
   state: Ref<ProgramState>,
   previous_symbols: SymbolTableRef,
-  previous_plan: Plan,
+  previous_plan: Option<Plan>,
   previous_environment: Option<SymbolTableRef>,
 }
 
@@ -617,7 +617,11 @@ impl FunctionScope {
     local_symbols.dictionary = state_brrw.dictionary.clone();
     let local_symbols = Ref::new(local_symbols);
     let previous_symbols = std::mem::replace(&mut state_brrw.symbol_table, local_symbols);
-    let previous_plan = std::mem::replace(&mut state_brrw.plan, Plan::new());
+    let previous_plan = if *p.persistent_user_function_plan_depth.borrow() > 0 {
+      None
+    } else {
+      Some(std::mem::replace(&mut state_brrw.plan, Plan::new()))
+    };
     let previous_environment = state_brrw.environment.take();
     drop(state_brrw);
 
@@ -635,8 +639,30 @@ impl Drop for FunctionScope {
   fn drop(&mut self) {
     let mut state_brrw = self.state.borrow_mut();
     state_brrw.symbol_table = self.previous_symbols.clone();
-    state_brrw.plan = self.previous_plan.clone();
+    if let Some(previous_plan) = &self.previous_plan {
+      state_brrw.plan = previous_plan.clone();
+    }
     state_brrw.environment = self.previous_environment.clone();
+  }
+}
+
+pub(crate) struct PersistentUserFunctionPlanScope {
+  depth: Ref<usize>,
+}
+
+impl PersistentUserFunctionPlanScope {
+  pub(crate) fn enter(interpreter: &Interpreter) -> Self {
+    let depth = interpreter.persistent_user_function_plan_depth.clone();
+    *depth.borrow_mut() += 1;
+    Self { depth }
+  }
+}
+
+impl Drop for PersistentUserFunctionPlanScope {
+  fn drop(&mut self) {
+    let mut depth = self.depth.borrow_mut();
+    debug_assert!(*depth > 0);
+    *depth -= 1;
   }
 }
 

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -41,6 +41,8 @@ pub struct Interpreter {
   #[cfg(feature = "functions")]
   reactive_turn_state: ReactiveTurnState,
   #[cfg(feature = "functions")]
+  pub(crate) persistent_user_function_plan_depth: Ref<usize>,
+  #[cfg(feature = "functions")]
   pub stack: Vec<Frame>,
   registers: Vec<Value>,
   constants: Vec<Value>,
@@ -79,6 +81,8 @@ impl Clone for Interpreter {
       state: Ref::new(self.state.borrow().clone()),
       #[cfg(feature = "functions")]
       reactive_turn_state: self.reactive_turn_state.clone(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: self.persistent_user_function_plan_depth.clone(),
       #[cfg(feature = "functions")]
       stack: self.stack.clone(),
       registers: self.registers.clone(),
@@ -139,6 +143,8 @@ impl Interpreter {
       state: Ref::new(state),
       #[cfg(feature = "functions")]
       reactive_turn_state: ReactiveTurnState::default(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: Ref::new(0),
       #[cfg(feature = "functions")]
       stack: Vec::new(),
       registers: Vec::new(),

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -100,6 +100,10 @@ pub mod builtins;
 #[cfg(feature = "functions")]
 pub mod modules;
 pub mod expressions;
+#[cfg(all(
+  feature = "functions",
+  feature = "symbol_table",
+))]
 pub mod activation;
 #[cfg(feature = "functions")]
 pub mod functions;

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -100,6 +100,7 @@ pub mod builtins;
 #[cfg(feature = "functions")]
 pub mod modules;
 pub mod expressions;
+pub mod activation;
 #[cfg(feature = "functions")]
 pub mod functions;
 pub mod interpreter;

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -452,16 +452,21 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 
 #[cfg(all(feature = "functions", feature = "symbol_table"))]
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
- let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
- let result=(|| -> MResult<Value> { for (code,_) in &scope.body { mech_code(code,p)?; } Ok(Value::Empty) })();
- plan.pop_activation_registration_scope(); result
+  let ActivationBody::Block(body) = &scope.body else {
+    return Err(MechError::new(ActivationScopeRegistrationUnsupported, None).with_tokens(scope.tokens()));
+  };
+  let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+  let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
+  plan.pop_activation_registration_scope(); result
 }
 #[cfg(not(all(feature = "functions", feature = "symbol_table")))]
 fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> { Err(MechError::new(ActivationScopeRegistrationUnsupported,None).with_tokens(scope.tokens())) }
 
 fn activation_scope(scope: &ActivationScope, p: &Interpreter) -> MResult<Value> {
   let var = match &scope.trigger { Expression::Var(var) => var, _ => return Err(MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens())) };
-  validate_activation_body(&scope.body, var.name.hash())?;
+  if let ActivationBody::Block(body) = &scope.body {
+    validate_activation_body(body, var.name.hash())?;
+  }
   let trigger_cells = activation_trigger_cells(scope, var, p)?;
   elaborate_activation_scope(scope, p, trigger_cells)
 }

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -452,12 +452,20 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 
 #[cfg(all(feature = "functions", feature = "symbol_table"))]
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
-  let ActivationBody::Block(body) = &scope.body else {
-    return Err(MechError::new(ActivationScopeRegistrationUnsupported, None).with_tokens(scope.tokens()));
-  };
-  let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
-  let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
-  plan.pop_activation_registration_scope(); result
+  match &scope.body {
+    ActivationBody::Block(body) => {
+      let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+      let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
+      plan.pop_activation_registration_scope(); result
+    }
+    ActivationBody::PatternArms(arms) => {
+      let trigger = match &scope.trigger {
+        Expression::Var(var) => p.state.borrow().get_symbol(var.name.hash()).map(|value| value.borrow().clone()),
+        _ => None,
+      }.ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
+      crate::activation::elaborate_patterned_activation(scope, arms, trigger, trigger_cells, p)
+    }
+  }
 }
 #[cfg(not(all(feature = "functions", feature = "symbol_table")))]
 fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> { Err(MechError::new(ActivationScopeRegistrationUnsupported,None).with_tokens(scope.tokens())) }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,8 +1,6 @@
 use crate::*;
 use std::collections::HashMap;
 
-const RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX: &str = "mech-internal-context-";
-
 // Patterns
 // ----------------------------------------------------------------------------
 
@@ -795,9 +793,40 @@ pub fn match_compiled_pattern(
     env: &Environment,
     interpreter: &Interpreter,
 ) -> MResult<PatternMatch> {
+    match_compiled_pattern_with_environment(pattern, value, env, interpreter, false)
+}
+
+/// Matches a compiled pattern while treating bindings already present in the
+/// environment as equality constraints. This is used by comprehension
+/// generators, where a later generator may refer to a name introduced by an
+/// earlier qualifier.
+pub fn match_compiled_pattern_with_environment_constraints(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+) -> MResult<PatternMatch> {
+    match_compiled_pattern_with_environment(pattern, value, env, interpreter, true)
+}
+
+fn match_compiled_pattern_with_environment(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+    seed_existing_bindings: bool,
+) -> MResult<PatternMatch> {
     let specs = pattern.binding_specs();
+    let proposed = if seed_existing_bindings {
+        specs
+            .iter()
+            .map(|spec| env.get(&spec.id).map(deep_detach_value))
+            .collect()
+    } else {
+        vec![None; specs.len()]
+    };
     let mut state = PatternMatchState {
-        proposed: vec![None; specs.len()],
+        proposed,
         binding_specs: specs,
         expression_source: PatternExpressionSource::Interpreter { env, interpreter },
     };
@@ -1221,12 +1250,7 @@ fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
 }
 
 pub(crate) fn pattern_var_is_binding(var: &Var) -> bool {
-    var.context.is_none()
-        // Runtime context inputs are sampled pattern values, never captures.
-        && !var
-            .name
-            .to_string()
-            .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX)
+    var.context.is_none() && !is_internal_pattern_value_identifier(&var.name)
 }
 
 fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
@@ -1320,5 +1344,90 @@ mod tests {
             .commit(&pattern_match)
             .unwrap();
         assert_eq!(env.get(&id), Some(&Value::U64(Ref::new(9))));
+    }
+
+    #[test]
+    fn existing_environment_bindings_are_constraints_inside_the_matcher() {
+        let x_id = hash_str("x");
+        let y_id = hash_str("y");
+        let pattern = CompiledPattern::Tuple {
+            elements: vec![
+                CompiledPattern::Binding {
+                    binding_index: 0,
+                    id: x_id,
+                    name: "x".to_string(),
+                    expected_kind: Some(ValueKind::U64),
+                },
+                CompiledPattern::Binding {
+                    binding_index: 1,
+                    id: y_id,
+                    name: "y".to_string(),
+                    expected_kind: Some(ValueKind::U64),
+                },
+            ],
+        };
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let mut env = Environment::from([(x_id, Value::U64(Ref::new(1)))]);
+
+        let mismatch = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(2)),
+            Value::U64(Ref::new(3)),
+        ])));
+        let pattern_match = match_compiled_pattern_with_environment_constraints(
+            &pattern,
+            &mismatch,
+            &env,
+            &interpreter,
+        )
+        .unwrap();
+        assert!(!pattern_match.matched);
+        assert!(pattern_match.bindings.is_empty());
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env, Environment::from([(x_id, Value::U64(Ref::new(1)))]));
+
+        let match_value = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(1)),
+            Value::U64(Ref::new(3)),
+        ])));
+        let pattern_match = match_compiled_pattern_with_environment_constraints(
+            &pattern,
+            &match_value,
+            &env,
+            &interpreter,
+        )
+        .unwrap();
+        assert!(pattern_match.matched);
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env.get(&x_id), Some(&Value::U64(Ref::new(1))));
+        assert_eq!(env.get(&y_id), Some(&Value::U64(Ref::new(3))));
+    }
+
+    #[test]
+    fn spellable_internal_looking_name_remains_an_ordinary_binding() {
+        let source_name = "mech-internal-context-user-value";
+        let source_identifier = Identifier {
+            name: Token::new(
+                TokenKind::Identifier,
+                SourceRange::default(),
+                source_name.chars().collect(),
+            ),
+        };
+        let source_var = Var {
+            name: source_identifier,
+            context: None,
+            kind: None,
+        };
+        assert!(pattern_var_is_binding(&source_var));
+
+        let internal_var = Var {
+            name: internal_pattern_value_identifier("context-value"),
+            context: None,
+            kind: None,
+        };
+        assert!(!pattern_var_is_binding(&internal_var));
     }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,518 +1,1324 @@
 use crate::*;
+use std::collections::HashMap;
+
+const RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX: &str = "mech-internal-context-";
 
 // Patterns
 // ----------------------------------------------------------------------------
 
-// Implements pattern matching. Handles matching runtime Values against 
-// Pattern AST nodes, binding variables into an Environment. 
- 
-// Supports destructuring of tuples, arrays/matrices, and tagged tuple-structs, 
-// and reconstructing values from patterns.
+// Pattern matching is split into two phases. Compilation assigns stable indexes
+// to bindings and value expressions and validates any structure made known by
+// an expected kind. Matching then stages bindings in private storage and only
+// returns them after the complete pattern succeeds.
 
-// Used by functinos, state machines, and option guards.
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PatternMatchSemantics {
-  Standard,     // Standard semantics: pattern expressions are evaluated once and compared to the value.
-  OptionGuard,  // Option guard semantics: pattern expressions are evaluated for each value and must evaluate to true for all to match.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternBindingSpec {
+    pub index: usize,
+    pub id: u64,
+    pub name: String,
+    pub kind: Option<ValueKind>,
 }
 
-// Entry point for multi-argument dispatch. When a function is called with 
-// multiple arguments, this wraps them as if they were a tuple and delegates 
-// to pattern_matches_value.
-pub fn pattern_matches_arguments(pattern: &Pattern, args: &Vec<Value>, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
-  if args.is_empty() {
-    return match pattern {
-      Pattern::Wildcard => Ok(true),
-      #[cfg(feature = "tuple")]
-      Pattern::Tuple(pattern_tuple) => Ok(pattern_tuple.0.is_empty()),
-      _ => Ok(false),
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatternBinding {
+    pub index: usize,
+    pub id: u64,
+    pub name: String,
+    pub kind: ValueKind,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatternMatch {
+    pub matched: bool,
+    pub bindings: Vec<PatternBinding>,
+}
+
+impl PatternMatch {
+    fn no_match() -> Self {
+        Self {
+            matched: false,
+            bindings: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompiledPatternArraySpread {
+    pub kind: PatternArraySpreadKind,
+    pub binding: Option<Box<CompiledPattern>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CompiledPattern {
+    Wildcard,
+    Binding {
+        binding_index: usize,
+        id: u64,
+        name: String,
+        expected_kind: Option<ValueKind>,
+    },
+    ExpressionValue {
+        expression_index: usize,
+        expression: Expression,
+    },
+    Tuple {
+        elements: Vec<CompiledPattern>,
+    },
+    Array {
+        prefix: Vec<CompiledPattern>,
+        spread: Option<CompiledPatternArraySpread>,
+        suffix: Vec<CompiledPattern>,
+    },
+    EnumVariant {
+        enum_id: Option<u64>,
+        variant_id: u64,
+        payload: Option<Box<CompiledPattern>>,
+    },
+    AtomTuple {
+        tag_id: u64,
+        payload: Vec<CompiledPattern>,
+    },
+}
+
+impl CompiledPattern {
+    /// Unique binding slots in stable compiler-assigned order.
+    pub fn binding_specs(&self) -> Vec<PatternBindingSpec> {
+        fn collect(pattern: &CompiledPattern, specs: &mut Vec<Option<PatternBindingSpec>>) {
+            match pattern {
+                CompiledPattern::Binding {
+                    binding_index,
+                    id,
+                    name,
+                    expected_kind,
+                } => {
+                    if specs.len() <= *binding_index {
+                        specs.resize(*binding_index + 1, None);
+                    }
+                    match &mut specs[*binding_index] {
+                        Some(spec) if spec.kind.is_none() && expected_kind.is_some() => {
+                            spec.kind = expected_kind.clone();
+                        }
+                        Some(_) => {}
+                        slot @ None => {
+                            *slot = Some(PatternBindingSpec {
+                                index: *binding_index,
+                                id: *id,
+                                name: name.clone(),
+                                kind: expected_kind.clone(),
+                            });
+                        }
+                    }
+                }
+                CompiledPattern::Tuple { elements } => {
+                    for element in elements {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                } => {
+                    for element in prefix {
+                        collect(element, specs);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        collect(binding, specs);
+                    }
+                    for element in suffix {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::EnumVariant { payload, .. } => {
+                    if let Some(payload) = payload {
+                        collect(payload, specs);
+                    }
+                }
+                CompiledPattern::AtomTuple { payload, .. } => {
+                    for element in payload {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::Wildcard | CompiledPattern::ExpressionValue { .. } => {}
+            }
+        }
+
+        let mut specs = Vec::new();
+        collect(self, &mut specs);
+        specs.into_iter().flatten().collect()
+    }
+
+    /// Non-binding expressions in stable compiler-assigned order.
+    pub fn expressions(&self) -> Vec<Expression> {
+        fn collect(pattern: &CompiledPattern, expressions: &mut Vec<Option<Expression>>) {
+            match pattern {
+                CompiledPattern::ExpressionValue {
+                    expression_index,
+                    expression,
+                } => {
+                    if expressions.len() <= *expression_index {
+                        expressions.resize(*expression_index + 1, None);
+                    }
+                    expressions[*expression_index] = Some(expression.clone());
+                }
+                CompiledPattern::Tuple { elements } => {
+                    for element in elements {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                } => {
+                    for element in prefix {
+                        collect(element, expressions);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        collect(binding, expressions);
+                    }
+                    for element in suffix {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::EnumVariant { payload, .. } => {
+                    if let Some(payload) = payload {
+                        collect(payload, expressions);
+                    }
+                }
+                CompiledPattern::AtomTuple { payload, .. } => {
+                    for element in payload {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::Wildcard | CompiledPattern::Binding { .. } => {}
+            }
+        }
+
+        let mut expressions = Vec::new();
+        collect(self, &mut expressions);
+        expressions.into_iter().flatten().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternCompileError {
+    pub reason: String,
+}
+
+impl MechErrorKind for PatternCompileError {
+    fn name(&self) -> &str {
+        "PatternCompileError"
+    }
+
+    fn message(&self) -> String {
+        self.reason.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternExpressionValueMissing {
+    pub index: usize,
+}
+
+impl MechErrorKind for PatternExpressionValueMissing {
+    fn name(&self) -> &str {
+        "PatternExpressionValueMissing"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "No sampled value was provided for pattern expression {}.",
+            self.index
+        )
+    }
+}
+
+#[derive(Default)]
+struct PatternCompiler {
+    bindings: Vec<PatternBindingSpec>,
+    binding_ids: HashMap<u64, usize>,
+    next_expression: usize,
+}
+
+impl PatternCompiler {
+    fn error(&self, pattern: &Pattern, reason: impl Into<String>) -> MechError {
+        MechError::new(
+            PatternCompileError {
+                reason: reason.into(),
+            },
+            None,
+        )
+        .with_compiler_loc()
+        .with_tokens(pattern.tokens())
+    }
+
+    fn compile_binding(
+        &mut self,
+        pattern: &Pattern,
+        id: u64,
+        name: String,
+        expected_kind: Option<&ValueKind>,
+    ) -> MResult<CompiledPattern> {
+        let expected_kind = expected_kind.map(ValueKind::deref_kind);
+        if let Some(index) = self.binding_ids.get(&id).copied() {
+            let existing_kind = self.bindings[index].kind.clone();
+            match (&existing_kind, &expected_kind) {
+                (Some(existing), Some(expected)) if existing != expected => {
+                    return Err(self.error(
+                        pattern,
+                        format!(
+                            "Repeated binding '{}' has incompatible kinds '{}' and '{}'.",
+                            name, existing, expected
+                        ),
+                    ));
+                }
+                (None, Some(expected)) => self.bindings[index].kind = Some(expected.clone()),
+                _ => {}
+            }
+            return Ok(CompiledPattern::Binding {
+                binding_index: index,
+                id,
+                name,
+                expected_kind,
+            });
+        }
+
+        let index = self.bindings.len();
+        self.binding_ids.insert(id, index);
+        self.bindings.push(PatternBindingSpec {
+            index,
+            id,
+            name: name.clone(),
+            kind: expected_kind.clone(),
+        });
+        Ok(CompiledPattern::Binding {
+            binding_index: index,
+            id,
+            name,
+            expected_kind,
+        })
+    }
+
+    fn compile_expression(&mut self, expression: &Expression) -> CompiledPattern {
+        let expression_index = self.next_expression;
+        self.next_expression += 1;
+        CompiledPattern::ExpressionValue {
+            expression_index,
+            expression: expression.clone(),
+        }
+    }
+
+    fn compile(
+        &mut self,
+        pattern: &Pattern,
+        expected_kind: Option<&ValueKind>,
+        interpreter: &Interpreter,
+    ) -> MResult<CompiledPattern> {
+        match pattern {
+            Pattern::Wildcard => Ok(CompiledPattern::Wildcard),
+            Pattern::Expression(expression) => {
+                #[cfg(feature = "enum")]
+                if let Expression::Literal(Literal::Atom(atom)) = expression {
+                    if let Some(ValueKind::Enum(enum_id, _)) =
+                        expected_kind.map(ValueKind::deref_kind)
+                    {
+                        let variant_id = atom.name.hash();
+                        let enum_definition = interpreter
+                            .state
+                            .borrow()
+                            .enums
+                            .get(&enum_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!("Enum kind '{}' has no registered definition.", enum_id),
+                                )
+                            })?;
+                        let declared_payload = enum_definition
+                            .variants
+                            .iter()
+                            .find(|(id, _)| *id == variant_id)
+                            .map(|(_, payload)| payload)
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "'{}' is not a variant of the expected enum.",
+                                        atom.name.to_string()
+                                    ),
+                                )
+                            })?;
+                        if declared_payload.is_some() {
+                            return Err(self.error(
+                                pattern,
+                                "Enum variant pattern is missing its payload pattern.",
+                            ));
+                        }
+                        return Ok(CompiledPattern::EnumVariant {
+                            enum_id: Some(enum_id),
+                            variant_id,
+                            payload: None,
+                        });
+                    }
+                }
+                if let Some(var) = extract_pattern_variable(expression) {
+                    self.compile_binding(
+                        pattern,
+                        var.name.hash(),
+                        var.name.to_string(),
+                        expected_kind,
+                    )
+                } else {
+                    Ok(self.compile_expression(expression))
+                }
+            }
+            Pattern::Tuple(tuple) => {
+                let expected_elements = match expected_kind.map(ValueKind::deref_kind) {
+                    Some(ValueKind::Tuple(elements)) => {
+                        if elements.len() != tuple.0.len() {
+                            return Err(self.error(
+                pattern,
+                format!(
+                  "Tuple pattern has arity {}, but the expected tuple kind has arity {}.",
+                  tuple.0.len(),
+                  elements.len()
+                ),
+              ));
+                        }
+                        Some(elements)
+                    }
+                    Some(kind) => {
+                        return Err(self.error(
+                            pattern,
+                            format!("Tuple pattern cannot match expected kind '{}'.", kind),
+                        ));
+                    }
+                    None => None,
+                };
+                let elements = tuple
+                    .0
+                    .iter()
+                    .enumerate()
+                    .map(|(index, element)| {
+                        self.compile(
+                            element,
+                            expected_elements.as_ref().map(|kinds| &kinds[index]),
+                            interpreter,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(CompiledPattern::Tuple { elements })
+            }
+            Pattern::Array(array) => {
+                let (element_kind, rest_kind) = match expected_kind.map(ValueKind::deref_kind) {
+                    Some(ValueKind::Matrix(element, _)) => {
+                        let element = *element;
+                        (
+                            Some(element.clone()),
+                            Some(ValueKind::Matrix(Box::new(element), Vec::new())),
+                        )
+                    }
+                    Some(kind) => {
+                        return Err(self.error(
+                            pattern,
+                            format!("Array pattern cannot match expected kind '{}'.", kind),
+                        ));
+                    }
+                    None => (None, None),
+                };
+                let prefix = array
+                    .prefix
+                    .iter()
+                    .map(|element| self.compile(element, element_kind.as_ref(), interpreter))
+                    .collect::<MResult<Vec<_>>>()?;
+                let spread = match &array.spread {
+                    Some(spread) => Some(CompiledPatternArraySpread {
+                        kind: spread.kind.clone(),
+                        binding: match &spread.binding {
+                            Some(binding) => Some(Box::new(self.compile(
+                                binding,
+                                rest_kind.as_ref(),
+                                interpreter,
+                            )?)),
+                            None => None,
+                        },
+                    }),
+                    None => None,
+                };
+                let suffix = array
+                    .suffix
+                    .iter()
+                    .map(|element| self.compile(element, element_kind.as_ref(), interpreter))
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                })
+            }
+            Pattern::TupleStruct(tuple_struct) => match expected_kind.map(ValueKind::deref_kind) {
+                Some(ValueKind::Enum(enum_id, _)) => {
+                    #[cfg(feature = "enum")]
+                    {
+                        let enum_definition = interpreter
+                            .state
+                            .borrow()
+                            .enums
+                            .get(&enum_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "Enum kind '{}' has no registered definition.",
+                                        enum_id
+                                    ),
+                                )
+                            })?;
+                        let variant_id = tuple_struct.name.hash();
+                        let declared_payload = enum_definition
+                            .variants
+                            .iter()
+                            .find(|(id, _)| *id == variant_id)
+                            .map(|(_, payload)| payload.clone())
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "'{}' is not a variant of the expected enum.",
+                                        tuple_struct.name.to_string()
+                                    ),
+                                )
+                            })?;
+                        let payload = match (tuple_struct.patterns.as_slice(), declared_payload) {
+                            ([], None) => None,
+                            ([payload_pattern], Some(Value::Kind(payload_kind))) => Some(Box::new(
+                                self.compile(payload_pattern, Some(&payload_kind), interpreter)?,
+                            )),
+                            _ => {
+                                return Err(self.error(
+                    pattern,
+                    "Enum variant pattern payload arity does not match its definition.",
+                  ));
+                            }
+                        };
+                        return Ok(CompiledPattern::EnumVariant {
+                            enum_id: Some(enum_id),
+                            variant_id,
+                            payload,
+                        });
+                    }
+                    #[cfg(not(feature = "enum"))]
+                    {
+                        return Err(self.error(pattern, "Enum patterns are not enabled."));
+                    }
+                }
+                Some(ValueKind::Tuple(kinds)) => {
+                    if kinds.len() != tuple_struct.patterns.len() + 1
+                        || !matches!(kinds.first(), Some(ValueKind::Atom(_, _)))
+                    {
+                        return Err(self.error(
+                pattern,
+                "Atom-tagged tuple pattern arity does not match the expected tuple kind.",
+              ));
+                    }
+                    let payload = tuple_struct
+                        .patterns
+                        .iter()
+                        .zip(kinds.iter().skip(1))
+                        .map(|(payload, kind)| self.compile(payload, Some(kind), interpreter))
+                        .collect::<MResult<Vec<_>>>()?;
+                    Ok(CompiledPattern::AtomTuple {
+                        tag_id: tuple_struct.name.hash(),
+                        payload,
+                    })
+                }
+                Some(kind) => Err(self.error(
+                    pattern,
+                    format!(
+                        "Tagged tuple pattern cannot match expected kind '{}'.",
+                        kind
+                    ),
+                )),
+                None => self.compile_untyped_tuple_struct(pattern, tuple_struct, interpreter),
+            },
+        }
+    }
+
+    fn compile_untyped_tuple_struct(
+        &mut self,
+        _pattern: &Pattern,
+        tuple_struct: &PatternTupleStruct,
+        interpreter: &Interpreter,
+    ) -> MResult<CompiledPattern> {
+        let payload = tuple_struct
+            .patterns
+            .iter()
+            .map(|payload| self.compile(payload, None, interpreter))
+            .collect::<MResult<Vec<_>>>()?;
+        Ok(CompiledPattern::AtomTuple {
+            tag_id: tuple_struct.name.hash(),
+            payload,
+        })
+    }
+}
+
+pub fn compile_pattern(
+    pattern: &Pattern,
+    expected_kind: Option<&ValueKind>,
+    interpreter: &Interpreter,
+) -> MResult<CompiledPattern> {
+    PatternCompiler::default().compile(pattern, expected_kind, interpreter)
+}
+
+enum PatternExpressionSource<'a> {
+    Interpreter {
+        env: &'a Environment,
+        interpreter: &'a Interpreter,
+    },
+    Sampled(&'a [Value]),
+}
+
+struct PatternMatchState<'a> {
+    binding_specs: Vec<PatternBindingSpec>,
+    proposed: Vec<Option<Value>>,
+    expression_source: PatternExpressionSource<'a>,
+}
+
+impl PatternMatchState<'_> {
+    fn expression_value(
+        &self,
+        expression_index: usize,
+        expression_node: &Expression,
+    ) -> MResult<Value> {
+        match &self.expression_source {
+            PatternExpressionSource::Interpreter { env, interpreter } => {
+                // Expression patterns read the arm's outer environment. Proposed
+                // captures are intentionally invisible; capture-dependent
+                // conditions belong in an explicit arm guard.
+                expression(expression_node, Some(env), interpreter)
+            }
+            PatternExpressionSource::Sampled(values) => {
+                values.get(expression_index).cloned().ok_or_else(|| {
+                    MechError::new(
+                        PatternExpressionValueMissing {
+                            index: expression_index,
+                        },
+                        None,
+                    )
+                    .with_compiler_loc()
+                    .with_tokens(expression_node.tokens())
+                })
+            }
+        }
+    }
+
+    fn matches(&mut self, pattern: &CompiledPattern, value: &Value) -> MResult<bool> {
+        let value = deep_detach_value(value);
+        match pattern {
+            CompiledPattern::Wildcard => Ok(true),
+            CompiledPattern::Binding { binding_index, .. } => {
+                if let Some(existing) = &self.proposed[*binding_index] {
+                    Ok(existing == &value)
+                } else {
+                    self.proposed[*binding_index] = Some(value);
+                    Ok(true)
+                }
+            }
+            CompiledPattern::ExpressionValue {
+                expression_index,
+                expression,
+            } => {
+                let expected =
+                    deep_detach_value(&self.expression_value(*expression_index, expression)?);
+                Ok(values_match(&expected, &value))
+            }
+            CompiledPattern::Tuple { elements } => {
+                #[cfg(feature = "tuple")]
+                if let Value::Tuple(tuple) = value {
+                    let tuple = tuple.borrow();
+                    if tuple.elements.len() != elements.len() {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in elements.iter().zip(tuple.elements.iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            CompiledPattern::Array {
+                prefix,
+                spread,
+                suffix,
+            } => {
+                #[cfg(feature = "matrix")]
+                {
+                    let values = match matrix_like_values(&value) {
+                        Some(values) => values,
+                        None => return Ok(false),
+                    };
+                    if values.len() < prefix.len() + suffix.len() {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in prefix.iter().zip(values.iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    let suffix_start = values.len() - suffix.len();
+                    for (pattern, value) in suffix.iter().zip(values[suffix_start..].iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    if spread.is_none() && values.len() != prefix.len() + suffix.len() {
+                        return Ok(false);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        let middle = capture_middle_matrix(&value, prefix.len(), suffix_start);
+                        if !self.matches(binding, &middle)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                #[cfg(not(feature = "matrix"))]
+                Ok(false)
+            }
+            CompiledPattern::EnumVariant {
+                enum_id,
+                variant_id,
+                payload,
+            } => {
+                #[cfg(feature = "enum")]
+                if let Value::Enum(enum_value) = value {
+                    let enum_value = enum_value.borrow();
+                    if enum_id.is_some_and(|expected| expected != enum_value.id)
+                        || enum_value.variants.len() != 1
+                    {
+                        return Ok(false);
+                    }
+                    let (actual_variant, actual_payload) = &enum_value.variants[0];
+                    if actual_variant != variant_id {
+                        return Ok(false);
+                    }
+                    return match (payload, actual_payload) {
+                        (None, None) => Ok(true),
+                        (Some(pattern), Some(value)) => self.matches(pattern, value),
+                        _ => Ok(false),
+                    };
+                }
+                Ok(false)
+            }
+            CompiledPattern::AtomTuple { tag_id, payload } => {
+                #[cfg(feature = "enum")]
+                if let Value::Enum(enum_value) = &value {
+                    let enum_value = enum_value.borrow();
+                    if enum_value.variants.len() != 1 {
+                        return Ok(false);
+                    }
+                    let (actual_variant, actual_payload) = &enum_value.variants[0];
+                    if actual_variant != tag_id {
+                        return Ok(false);
+                    }
+                    return match (payload.as_slice(), actual_payload) {
+                        ([], None) => Ok(true),
+                        ([pattern], Some(value)) => self.matches(pattern, value),
+                        _ => Ok(false),
+                    };
+                }
+                #[cfg(all(feature = "tuple", feature = "atom"))]
+                if let Value::Tuple(tuple) = &value {
+                    let tuple = tuple.borrow();
+                    if tuple.elements.len() != payload.len() + 1 {
+                        return Ok(false);
+                    }
+                    let tag = deep_detach_value(&tuple.elements[0]);
+                    let Value::Atom(tag) = tag else {
+                        return Ok(false);
+                    };
+                    if tag.borrow().id() != *tag_id {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in payload.iter().zip(tuple.elements.iter().skip(1)) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    fn finish(self, matched: bool) -> PatternMatch {
+        if !matched {
+            return PatternMatch::no_match();
+        }
+        let bindings = self
+            .binding_specs
+            .into_iter()
+            .zip(self.proposed)
+            .filter_map(|(spec, value)| {
+                value.map(|value| PatternBinding {
+                    index: spec.index,
+                    id: spec.id,
+                    name: spec.name,
+                    kind: value.kind().deref_kind(),
+                    value,
+                })
+            })
+            .collect();
+        PatternMatch {
+            matched: true,
+            bindings,
+        }
+    }
+}
+
+pub fn match_compiled_pattern(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+) -> MResult<PatternMatch> {
+    let specs = pattern.binding_specs();
+    let mut state = PatternMatchState {
+        proposed: vec![None; specs.len()],
+        binding_specs: specs,
+        expression_source: PatternExpressionSource::Interpreter { env, interpreter },
     };
-  }
-  if args.len() == 1 {
-    return pattern_matches_value(pattern, &args[0], env, p);
-  }
-  match pattern {
-    Pattern::Tuple(pattern_tuple) => {
-      if pattern_tuple.0.len() != args.len() {
-        return Ok(false);
-      }
-      for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
-        if !pattern_matches_value(pat, arg, env, p)? {
-          return Ok(false);
-        }
-      }
-      Ok(true)
+    let matched = state.matches(pattern, value)?;
+    Ok(state.finish(matched))
+}
+
+pub fn match_compiled_pattern_with_values(
+    pattern: &CompiledPattern,
+    value: &Value,
+    expression_values: &[Value],
+) -> MResult<PatternMatch> {
+    let specs = pattern.binding_specs();
+    let mut state = PatternMatchState {
+        proposed: vec![None; specs.len()],
+        binding_specs: specs,
+        expression_source: PatternExpressionSource::Sampled(expression_values),
+    };
+    let matched = state.matches(pattern, value)?;
+    Ok(state.finish(matched))
+}
+
+pub trait PatternBindingSink {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()>;
+}
+
+pub struct EnvironmentBindingSink<'a> {
+    env: &'a mut Environment,
+}
+
+impl<'a> EnvironmentBindingSink<'a> {
+    pub fn new(env: &'a mut Environment) -> Self {
+        Self { env }
     }
-    _ => Ok(false),
-  }
 }
 
-pub fn pattern_matches_value(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
-  pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
-}
-
-// Takes a semantics mode. Dispatches on pattern kind:
-// Wildcard - always succeeds, binds nothing.
-// - Tuple - recursively matches element-wise against a Value::Tuple, requiring equal arity.
-// - Array - matches prefix and suffix element-wise against any matrix-like value, with optional spread binding (…) for the middle slice.
-// - Expression(Var()) - if the variable is already in the environment, checks equality (used for repeated variable patterns).
-// - Expression(other) - attempts to extract a variable id from more complex expression wrappers (parentheticals, single-term formulas) and handles them like Var.
-// - TupleStruct - matches a tagged tuple
-pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter, semantics: PatternMatchSemantics) -> MResult<bool> {
-  let detached_value = deep_detach_value(value);
-  match pattern {
-    Pattern::Wildcard => Ok(true),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pattern_tuple) => {
-      match detached_value {
-        Value::Tuple(tuple) => {
-          let tuple_brrw = tuple.borrow();
-          if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-            return Ok(false);
-          }
-          for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-              return Ok(false);
+impl PatternBindingSink for EnvironmentBindingSink<'_> {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()> {
+        if pattern_match.matched {
+            for binding in &pattern_match.bindings {
+                self.env.insert(binding.id, binding.value.clone());
             }
-          }
-          return Ok(true);
         }
-        _ => {return Ok(false);},
-      }
-      return Ok(false);
+        Ok(())
     }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(pattern_array) => {
-      let values = match matrix_like_values(&detached_value) {
-        Some(values) => values,
-        None => return Ok(false),
-      };
-      if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
-        return Ok(false);
-      }
-      for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
-        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-          return Ok(false);
-        }
-      }
-      let suffix_start = values.len() - pattern_array.suffix.len();
-      for (pat, val) in pattern_array
-          .suffix
-          .iter()
-          .zip(values[suffix_start..].iter())
-      {
-        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-          return Ok(false);
-        }
-      }
+}
 
-      // If there's no spread, the number of values must match exactly. 
-      // If there is a spread, there can be any number of values in the middle.
-      if pattern_array.spread.is_none() && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len()
-      {
-        return Ok(false);
-      }
-      if let Some(spread) = &pattern_array.spread {
-        if let Some(binding) = &spread.binding {
-          let middle_start = pattern_array.prefix.len();
-          #[cfg(feature = "matrix")]
-          let captured = capture_middle_matrix(&detached_value, middle_start, suffix_start);
-          if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
-          {
-            return Ok(false);
-          }
-        }
-      }
-      Ok(true)
-    }
-    Pattern::Expression(Expression::Var(var)) => {
-      let var_id = var.name.hash();
-      if let Some(existing) = env.get(&var_id) {
-        Ok(existing == &detached_value)
-      } else {
-        env.insert(var_id, detached_value);
-        Ok(true)
-      }
-    }
-    Pattern::Expression(expr) => {
-      if let Some(var_id) = extract_pattern_variable_id(expr) {
-        if let Some(existing) = env.get(&var_id) {
-          return Ok(existing == &detached_value);
-        }
-        env.insert(var_id, detached_value);
+pub fn pattern_matches_arguments(
+    pattern: &Pattern,
+    args: &Vec<Value>,
+    env: &mut Environment,
+    interpreter: &Interpreter,
+) -> MResult<bool> {
+    if matches!(pattern, Pattern::Wildcard) {
         return Ok(true);
-      }
-      let expected = expression(expr, Some(env), p)?;
-      if semantics == PatternMatchSemantics::OptionGuard {
-        #[cfg(feature = "bool")]
-        if let Value::Bool(flag) = &expected {
-          if matches!(expr, Expression::Literal(Literal::Boolean(_))) {
-            return Ok(values_match(&deep_detach_value(&expected), &detached_value));
-          }
-          return Ok(*flag.borrow());
-        }
-      }
-      Ok(values_match(&deep_detach_value(&expected), &detached_value))
     }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(pat_struct) => {
-      match detached_value {
-        #[cfg(feature = "enum")]
-        Value::Enum(enum_value) => {
-          let enum_brrw = enum_value.borrow();
-          if enum_brrw.variants.len() != 1 {
-            return Ok(false);
-          }
-          let (variant_id, payload) = &enum_brrw.variants[0];
-          let expected_variant_id = pat_struct.name.hash();
-          if *variant_id != expected_variant_id {
-            return Ok(false);
-          }
-          match payload {
-            Some(payload_value) => {
-              if pat_struct.patterns.len() != 1 {
-                return Ok(false);
-              }
-              return pattern_matches_value_with_semantics(
-                &pat_struct.patterns[0],
-                payload_value,
-                env,
-                p,
-                semantics,
-              );
-            }
-            None => {
-              return Ok(pat_struct.patterns.is_empty());
-            }
-          }
-        }
-        Value::Tuple(tuple) => {
-          let tuple_brrw = tuple.borrow();
-          if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
-            return Ok(false);
-          }
-          let expected_state = atom(&Atom {name: pat_struct.name.clone(),},p);
-          if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
-            return Ok(false);
-          }
-          for (pat, val) in pat_struct
-              .patterns
-              .iter()
-              .zip(tuple_brrw.elements.iter().skip(1))
-          {
-            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-              return Ok(false);
-            }
-          }
-          return Ok(true);
-        }
-        _ => return Ok(false),
-      }
-      return Ok(false);
+    if args.len() == 1 {
+        return pattern_matches_value(pattern, &args[0], env, interpreter);
     }
-    x => Err(MechError::new(FeatureNotEnabledError, Some(format!("Pattern not enabled: {:?}", x))).with_compiler_loc().with_tokens(x.tokens())), 
-  }
+    #[cfg(feature = "tuple")]
+    {
+        let arguments = Value::Tuple(Ref::new(MechTuple::from_vec(args.clone())));
+        return pattern_matches_value(pattern, &arguments, env, interpreter);
+    }
+    #[cfg(not(feature = "tuple"))]
+    {
+        Ok(args.is_empty() && matches!(pattern, Pattern::Wildcard))
+    }
 }
 
+pub fn pattern_matches_value(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    interpreter: &Interpreter,
+) -> MResult<bool> {
+    let compiled = compile_pattern(pattern, None, interpreter)?;
+    let pattern_match = match_compiled_pattern(&compiled, value, env, interpreter)?;
+    EnvironmentBindingSink::new(env).commit(&pattern_match)?;
+    Ok(pattern_match.matched)
+}
 
-// Collects all variable ids introduced by a pattern (via 
-// collect_pattern_variable_ids) and removes them from the environment. Used 
+// Collects all variable ids introduced by a pattern (via
+// collect_pattern_variable_ids) and removes them from the environment. Used
 // to undo bindings when a pattern arm fails or needs to be retried.
 pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
-  let mut ids = Vec::new();
-  collect_pattern_variable_ids(pattern, &mut ids);
-  for var_id in ids {
-    env.remove(&var_id);
-  }
+    let mut ids = Vec::new();
+    collect_pattern_variable_ids(pattern, &mut ids);
+    for var_id in ids {
+        env.remove(&var_id);
+    }
 }
-
 
 // Reconstructs a Value from a pattern using the current environment. This is the inverse of matching. used to extract or re-emit bound values.
 pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
-  match pattern {
-    Pattern::Wildcard => Ok(Value::Empty),
-    Pattern::Expression(expr) => expression(expr, Some(env), p),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pattern_tuple) => {
-      let mut values = Vec::with_capacity(pattern_tuple.0.len());
-      for inner in &pattern_tuple.0 {
-        values.push(pattern_to_value(inner, env, p)?);
-      }
-      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+    match pattern {
+        Pattern::Wildcard => Ok(Value::Empty),
+        Pattern::Expression(expr) => expression(expr, Some(env), p),
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(pattern_tuple) => {
+            let mut values = Vec::with_capacity(pattern_tuple.0.len());
+            for inner in &pattern_tuple.0 {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+        }
+        #[cfg(feature = "matrix")]
+        Pattern::Array(array) => {
+            let mut values = Vec::new();
+            for inner in &array.prefix {
+                let inner_value = pattern_to_value(inner, env, p)?;
+                if let Some(inner_values) = matrix_like_values(&inner_value) {
+                    values.extend(inner_values);
+                } else {
+                    values.push(inner_value);
+                }
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    let bound = pattern_to_value(binding, env, p)?;
+                    if let Some(bound_values) = matrix_like_values(&bound) {
+                        values.extend(bound_values);
+                    } else {
+                        values.push(bound);
+                    }
+                }
+            }
+            for inner in &array.suffix {
+                let inner_value = pattern_to_value(inner, env, p)?;
+                if let Some(inner_values) = matrix_like_values(&inner_value) {
+                    values.extend(inner_values);
+                } else {
+                    values.push(inner_value);
+                }
+            }
+            return Ok(build_row_matrix_from_values(values));
+        }
+        #[cfg(all(feature = "tuple", feature = "atom"))]
+        Pattern::TupleStruct(pattern_tuple_struct) => {
+            #[cfg(feature = "enum")]
+            {
+                let variant_id = pattern_tuple_struct.name.hash();
+                if let Some((enum_id, enum_def)) = p.state.borrow().enums.iter().find(|(_, enm)| {
+                    enm.variants
+                        .iter()
+                        .any(|(known_variant, _)| *known_variant == variant_id)
+                }) {
+                    let payload = if pattern_tuple_struct.patterns.len() == 1 {
+                        Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
+                    } else if pattern_tuple_struct.patterns.is_empty() {
+                        None
+                    } else {
+                        return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
+                    };
+                    let enm = MechEnum {
+                        id: *enum_id,
+                        variants: vec![(variant_id, payload)],
+                        names: enum_def.names.clone(),
+                    };
+                    return Ok(Value::Enum(Ref::new(enm)));
+                }
+            }
+            let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
+            values.push(atom(
+                &Atom {
+                    name: pattern_tuple_struct.name.clone(),
+                },
+                p,
+            ));
+            for inner in &pattern_tuple_struct.patterns {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+        }
+        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
     }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(array) => {
-      let mut values = Vec::new();
-      for inner in &array.prefix {
-        let inner_value = pattern_to_value(inner, env, p)?;
-        if let Some(inner_values) = matrix_like_values(&inner_value) {
-          values.extend(inner_values);
-        } else {
-          values.push(inner_value);
-        }
-      }
-      if let Some(spread) = &array.spread {
-        if let Some(binding) = &spread.binding {
-          let bound = pattern_to_value(binding, env, p)?;
-          if let Some(bound_values) = matrix_like_values(&bound) {
-            values.extend(bound_values);
-          } else {
-            values.push(bound);
-          }
-        }
-      }
-      for inner in &array.suffix {
-        let inner_value = pattern_to_value(inner, env, p)?;
-        if let Some(inner_values) = matrix_like_values(&inner_value) {
-          values.extend(inner_values);
-        } else {
-          values.push(inner_value);
-        }
-      }
-      return Ok(build_row_matrix_from_values(values));
-    }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(pattern_tuple_struct) => {
-      #[cfg(feature = "enum")]
-      {
-        let variant_id = pattern_tuple_struct.name.hash();
-        if let Some((enum_id, enum_def)) = p
-          .state
-          .borrow()
-          .enums
-          .iter()
-          .find(|(_, enm)| enm.variants.iter().any(|(known_variant, _)| *known_variant == variant_id))
-        {
-          let payload = if pattern_tuple_struct.patterns.len() == 1 {
-            Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
-          } else if pattern_tuple_struct.patterns.is_empty() {
-            None
-          } else {
-            return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
-          };
-          let enm = MechEnum {
-            id: *enum_id,
-            variants: vec![(variant_id, payload)],
-            names: enum_def.names.clone(),
-          };
-          return Ok(Value::Enum(Ref::new(enm)));
-        }
-      }
-      let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
-      values.push(atom(&Atom {name: pattern_tuple_struct.name.clone()}, p));
-      for inner in &pattern_tuple_struct.patterns {
-        values.push(pattern_to_value(inner, env, p)?);
-      }
-      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
-    }
-    _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
-  }
 }
 
-// Mutable reference unwrapper. Recursively follows Value::MutableReference 
-// chains until it reaches a plain value, then clones it. Ensures the pattern 
+// Mutable reference unwrapper. Recursively follows Value::MutableReference
+// chains until it reaches a plain value, then clones it. Ensures the pattern
 // matcher always works on an owned, non-reference value.
 fn deep_detach_value(value: &Value) -> Value {
-  match value {
-    Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
-    _ => value.clone(),
-  }
+    match value {
+        Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
+        _ => value.clone(),
+    }
 }
 
-// Variable id harvester. Recursively walks a pattern and pushes the hashed ids 
-// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples, 
-// arrays (including spread bindings), and tuple-structs. Used by 
+// Variable id harvester. Recursively walks a pattern and pushes the hashed ids
+// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples,
+// arrays (including spread bindings), and tuple-structs. Used by
 // clear_pattern_bindings.
 fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
-  match pattern {
-    Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(tuple) => {
-      for item in &tuple.0 {
-        collect_pattern_variable_ids(item, ids);
-      }
-    }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(array) => {
-      for item in &array.prefix {
-        collect_pattern_variable_ids(item, ids);
-      }
-      if let Some(spread) = &array.spread {
-        if let Some(binding) = &spread.binding {
-          collect_pattern_variable_ids(binding, ids);
+    match pattern {
+        Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(tuple) => {
+            for item in &tuple.0 {
+                collect_pattern_variable_ids(item, ids);
+            }
         }
-      }
-      for item in &array.suffix {
-        collect_pattern_variable_ids(item, ids);
-      }
+        #[cfg(feature = "matrix")]
+        Pattern::Array(array) => {
+            for item in &array.prefix {
+                collect_pattern_variable_ids(item, ids);
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    collect_pattern_variable_ids(binding, ids);
+                }
+            }
+            for item in &array.suffix {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        #[cfg(all(feature = "tuple", feature = "atom"))]
+        Pattern::TupleStruct(tuple_struct) => {
+            for item in &tuple_struct.patterns {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        _ => {}
     }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(tuple_struct) => {
-      for item in &tuple_struct.patterns {
-        collect_pattern_variable_ids(item, ids);
-      }
-    }
-    _ => {}
-  }
 }
 
 #[cfg(feature = "matrix")]
 fn capture_middle_matrix(value: &Value, start: usize, end: usize) -> Value {
-  let cols = end.saturating_sub(start);
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Value::MatrixIndex(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Value::MatrixBool(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Value::MatrixU8(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Value::MatrixU16(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Value::MatrixU32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Value::MatrixU64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Value::MatrixU128(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Value::MatrixI8(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Value::MatrixI16(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Value::MatrixI32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Value::MatrixI64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Value::MatrixI128(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Value::MatrixF32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Value::MatrixF64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Value::MatrixString(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Value::MatrixR64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Value::MatrixC64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Value::MatrixValue(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    _ => {
-      let values = matrix_like_values(value).unwrap_or_default();
-      Value::MatrixValue(Matrix::from_vec(values[start..end].to_vec(), 1, cols))
+    let cols = end.saturating_sub(start);
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Value::MatrixIndex(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Value::MatrixBool(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Value::MatrixU8(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Value::MatrixU16(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Value::MatrixU32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Value::MatrixU64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Value::MatrixU128(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Value::MatrixI8(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Value::MatrixI16(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Value::MatrixI32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Value::MatrixI64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Value::MatrixI128(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Value::MatrixF32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Value::MatrixF64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Value::MatrixString(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Value::MatrixR64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Value::MatrixC64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Value::MatrixValue(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        _ => {
+            let values = matrix_like_values(value).unwrap_or_default();
+            Value::MatrixValue(Matrix::from_vec(values[start..end].to_vec(), 1, cols))
+        }
     }
-  }
 }
 
 // Used by the Array pattern arm to get a uniform element list regardless of the matrix's concrete numeric type.
 pub(crate) fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| Value::Index(Ref::new(value)))
-          .collect(),
-    ),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| value.to_value())
-          .collect(),
-    ),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| value.to_value())
-          .collect(),
-    ),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Some(matrix.as_vec()),
-    _ => None,
-  }
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| Value::Index(Ref::new(value)))
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Some(matrix.as_vec()),
+        _ => None,
+    }
 }
 
 #[cfg(feature = "matrix")]
 fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
-  let cols = values.len();
-  #[cfg(feature = "u64")]
-  if values.iter().all(|value| matches!(value, Value::U64(_))) {
-    let data = values
-      .iter()
-      .map(|value| match value {
-        Value::U64(x) => *x.borrow(),
-        _ => unreachable!(),
-      })
-      .collect::<Vec<u64>>();
-    return Value::MatrixU64(Matrix::from_vec(data, 1, cols));
-  }
-  Value::MatrixValue(Matrix::from_vec(values, 1, cols))
+    let cols = values.len();
+    #[cfg(feature = "u64")]
+    if values.iter().all(|value| matches!(value, Value::U64(_))) {
+        let data = values
+            .iter()
+            .map(|value| match value {
+                Value::U64(x) => *x.borrow(),
+                _ => unreachable!(),
+            })
+            .collect::<Vec<u64>>();
+        return Value::MatrixU64(Matrix::from_vec(data, 1, cols));
+    }
+    Value::MatrixValue(Matrix::from_vec(values, 1, cols))
 }
 
-fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
-  match expr {
-    Expression::Var(var) => Some(var.name.hash()),
-    Expression::Formula(factor) => match factor {
-      Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
-      Factor::Term(term) if term.rhs.is_empty() => extract_pattern_variable_id_from_term(&term.lhs),
-      _ => None,
-    },
-    _ => None,
-  }
+fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
+    match expr {
+        Expression::Var(var)
+            if var.context.is_none()
+                // Runtime context inputs are sampled pattern values, never captures.
+                && !var
+                    .name
+                    .to_string()
+                    .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX) =>
+        {
+            Some(var)
+        }
+        Expression::Var(_) => None,
+        Expression::Formula(factor) => match factor {
+            Factor::Expression(inner_expr) => extract_pattern_variable(inner_expr),
+            Factor::Term(term) if term.rhs.is_empty() => {
+                extract_pattern_variable_from_term(&term.lhs)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
-fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
-  match factor {
-    Factor::Expression(expr) => extract_pattern_variable_id(expr),
-    Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
-    _ => None,
-  }
+fn extract_pattern_variable_from_term(factor: &Factor) -> Option<&Var> {
+    match factor {
+        Factor::Expression(expr) => extract_pattern_variable(expr),
+        Factor::Parenthetical(inner) => extract_pattern_variable_from_term(inner),
+        _ => None,
+    }
 }
 
 // TODO: This needs to be expanded to handle all types.
 fn values_match(expected: &Value, actual: &Value) -> bool {
-  if expected == actual {
-    return true;
-  }
-  match (expected, actual) {
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-    _ => {}
-  }
-  false
+    if expected == actual {
+        return true;
+    }
+    match (expected, actual) {
+        #[cfg(all(feature = "atom", feature = "enum"))]
+        (Value::Atom(atom), Value::Enum(enum_value))
+        | (Value::Enum(enum_value), Value::Atom(atom)) => {
+            let enum_value = enum_value.borrow();
+            return enum_value.variants.len() == 1
+                && enum_value.variants[0].0 == atom.borrow().id()
+                && enum_value.variants[0].1.is_none();
+        }
+        #[cfg(all(feature = "u64", feature = "f64"))]
+        (Value::F64(x), Value::U64(y)) => {
+            let x = *x.borrow();
+            return x.is_finite()
+                && x >= 0.0
+                && x.fract() == 0.0
+                && x < 18_446_744_073_709_551_616.0
+                && (x as u64) == *y.borrow();
+        }
+        #[cfg(all(feature = "u64", feature = "f64"))]
+        (Value::U64(x), Value::F64(y)) => {
+            let y = *y.borrow();
+            return y.is_finite()
+                && y >= 0.0
+                && y.fract() == 0.0
+                && y < 18_446_744_073_709_551_616.0
+                && *x.borrow() == (y as u64);
+        }
+        _ => {}
+    }
+    false
+}
+
+#[cfg(all(test, feature = "tuple", feature = "u64"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_compiled_match_returns_no_bindings_and_cannot_mutate_sink() {
+        let id = hash_str("x");
+        let binding = CompiledPattern::Binding {
+            binding_index: 0,
+            id,
+            name: "x".to_string(),
+            expected_kind: Some(ValueKind::U64),
+        };
+        let pattern = CompiledPattern::Tuple {
+            elements: vec![binding.clone(), binding],
+        };
+        let value = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(1)),
+            Value::U64(Ref::new(2)),
+        ])));
+
+        let pattern_match = match_compiled_pattern_with_values(&pattern, &value, &[]).unwrap();
+        assert!(!pattern_match.matched);
+        assert!(pattern_match.bindings.is_empty());
+
+        let mut env = Environment::new();
+        env.insert(id, Value::U64(Ref::new(9)));
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env.get(&id), Some(&Value::U64(Ref::new(9))));
+    }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1220,18 +1220,18 @@ fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
     Value::MatrixValue(Matrix::from_vec(values, 1, cols))
 }
 
+pub(crate) fn pattern_var_is_binding(var: &Var) -> bool {
+    var.context.is_none()
+        // Runtime context inputs are sampled pattern values, never captures.
+        && !var
+            .name
+            .to_string()
+            .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX)
+}
+
 fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
     match expr {
-        Expression::Var(var)
-            if var.context.is_none()
-                // Runtime context inputs are sampled pattern values, never captures.
-                && !var
-                    .name
-                    .to_string()
-                    .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX) =>
-        {
-            Some(var)
-        }
+        Expression::Var(var) if pattern_var_is_binding(var) => Some(var),
         Expression::Var(_) => None,
         Expression::Formula(factor) => match factor {
             Factor::Expression(inner_expr) => extract_pattern_variable(inner_expr),

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -137,6 +137,16 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       )
     )
   );
+  let compiled_arm_patterns = fsm
+    .arms
+    .iter()
+    .map(|arm| match arm {
+      FsmArm::Guard(pattern, _) | FsmArm::Transition(pattern, _) => {
+        compile_pattern(pattern, None, p).map(Some)
+      }
+      FsmArm::Comment(_) => Ok(None),
+    })
+    .collect::<MResult<Vec<_>>>()?;
   // Step through the FSM, applying transitions until we hit a terminal state (no applicable transitions) or exceed the step limit.
   for step in 0..p.max_steps {
     trace_println!(
@@ -152,9 +162,14 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       match arm {
         FsmArm::Comment(_) => continue,
         FsmArm::Transition(pattern, transitions) => {
-          let mut arm_env = call_env.clone();
-          clear_pattern_bindings(pattern, &mut arm_env);
-          let matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          let base_env = call_env.clone();
+          let compiled_pattern = compiled_arm_patterns[arm_idx]
+            .as_ref()
+            .expect("transition arm pattern was not compiled");
+          let pattern_match = match_compiled_pattern(compiled_pattern, state, &base_env, p)?;
+          let matched = pattern_match.matched;
+          let mut arm_env = base_env.clone();
+          EnvironmentBindingSink::new(&mut arm_env).commit(&pattern_match)?;
           trace_println!(
             p,
             "{}",
@@ -170,6 +185,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
           if matched {
             let previous_state = summarize_value(state);
             let out = apply_transitions(transitions, state, &mut arm_env, p)?;
+            restore_arm_local_bindings(&pattern_match, &base_env, &mut arm_env);
             *call_env = arm_env;
             if let Some(value) = out {
               trace_println!(
@@ -199,9 +215,14 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
           }
         }
         FsmArm::Guard(pattern, guards) => {
-          let mut arm_env = call_env.clone();
-          clear_pattern_bindings(pattern, &mut arm_env);
-          let pattern_matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          let base_env = call_env.clone();
+          let compiled_pattern = compiled_arm_patterns[arm_idx]
+            .as_ref()
+            .expect("guard arm pattern was not compiled");
+          let pattern_match = match_compiled_pattern(compiled_pattern, state, &base_env, p)?;
+          let pattern_matched = pattern_match.matched;
+          let mut arm_env = base_env.clone();
+          EnvironmentBindingSink::new(&mut arm_env).commit(&pattern_match)?;
           trace_println!(
             p,
             "{}",
@@ -255,6 +276,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
             }
             let previous_state = summarize_value(state);
             let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
+            restore_arm_local_bindings(&pattern_match, &base_env, &mut arm_env);
             *call_env = arm_env;
             if let Some(value) = out {
               trace_println!(
@@ -304,6 +326,20 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
     None,
   )
   .with_compiler_loc())
+}
+
+fn restore_arm_local_bindings(
+  pattern_match: &PatternMatch,
+  base_env: &Environment,
+  arm_env: &mut Environment,
+) {
+  for binding in &pattern_match.bindings {
+    if let Some(original) = base_env.get(&binding.id) {
+      arm_env.insert(binding.id, original.clone());
+    } else {
+      arm_env.remove(&binding.id);
+    }
+  }
 }
 
 fn validate_fsm_state_coverage(fsm: &FsmImplementation, fsm_pipe: &FsmPipe) -> MResult<()> {

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -84,7 +84,7 @@ mod activation_scope_tests {
     use super::*;
     use std::collections::HashSet;
 
-    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick { left := x - radius\n doubled := left * 2.0 }";
+    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick {\n left := x - radius\n doubled := left * 2.0\n}";
     const REGISTER: &str =
         "tick := 0.0\n~x := 10.0\n\n~> tick {\n  next-x := x + 1.0\n  x = next-x\n}";
     const TWO_REGISTERS: &str = "tick := 0.0\n\n~x := 0.0\n~y := 0.0\n\n~> tick {\n  next-x := x + 1.0\n  next-y := y + 2.0\n\n  x = next-x\n  y = next-y\n}";
@@ -371,23 +371,31 @@ mod activation_scope_tests {
     }
     #[test]
     fn activation_scope_rejects_whole_assignment_to_trigger() {
-        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick = tick + 1.0 }").unwrap();
         let mut i = Interpreter::new_with_full_stdlib(0);
+        let setup = mech_syntax::parser::parse("~tick := 0.0").unwrap();
+        i.interpret(&setup).unwrap();
+        let before = snapshot(&i);
+        let t = mech_syntax::parser::parse("~> tick {\n tick = tick + 1.0\n}").unwrap();
         assert!(
             format!("{:?}", i.interpret(&t).unwrap_err())
                 .contains("ActivationScopeTriggerWriteUnsupported")
         );
-        assert!(i.plan().borrow().nodes.is_empty());
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.plan().activation_registration_active());
     }
     #[test]
     fn activation_scope_rejects_operator_assignment_to_trigger() {
-        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick += 1.0 }").unwrap();
         let mut i = Interpreter::new_with_full_stdlib(0);
+        let setup = mech_syntax::parser::parse("~tick := 0.0").unwrap();
+        i.interpret(&setup).unwrap();
+        let before = snapshot(&i);
+        let t = mech_syntax::parser::parse("~> tick {\n tick += 1.0\n}").unwrap();
         assert!(
             format!("{:?}", i.interpret(&t).unwrap_err())
                 .contains("ActivationScopeTriggerWriteUnsupported")
         );
-        assert!(i.plan().borrow().nodes.is_empty());
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.plan().activation_registration_active());
     }
     #[test]
     fn activation_scope_plan_is_stable_across_triggers() {

--- a/src/interpreter/src/stdlib/access/tuple.rs
+++ b/src/interpreter/src/stdlib/access/tuple.rs
@@ -15,6 +15,23 @@ impl MechFunctionImpl for TupleAccessElement {
   fn out(&self) -> Value { self.out.clone() }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
+impl MechFunctionFactory for TupleAccessElement {
+  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+    match args {
+      FunctionArgs::Nullary(out) => Ok(Box::new(Self { out })),
+      _ => Err(MechError::new(
+        IncorrectNumberOfArguments { expected: 0, found: args.len() },
+        None,
+      ).with_compiler_loc()),
+    }
+  }
+}
+register_descriptor! {
+  FunctionDescriptor {
+    name: "TupleAccessElement",
+    ptr: TupleAccessElement::new,
+  }
+}
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for TupleAccessElement {
   fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
@@ -23,7 +40,7 @@ impl MechFunctionCompiler for TupleAccessElement {
     ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Tuple));
     ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Access));
     ctx.emit_nullop(
-      hash_str(stringify!("TupleAccessElement")),
+      hash_str("TupleAccessElement"),
       registers[0],
     );
     return Ok(registers[0]);

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -1,6 +1,7 @@
 use mech_core::{
-    ComprehensionQualifier, ContextBase, ContextCapabilityScope, Expression, Factor, FsmArm,
-    FsmImplementation, FunctionDefine, MResult, MechCode, MechError, Pattern, Program,
+    ActivationArmBody, ActivationBody, ComprehensionQualifier, ContextBase,
+    ContextCapabilityScope, Expression, Factor, FsmArm, FsmImplementation, FunctionDefine,
+    MResult, MechCode, MechError, Pattern, Program,
     RangeExpression, SectionElement, SourceRange, Statement, Structure, Subscript, Term, Token,
     Transition,
 };
@@ -399,7 +400,31 @@ fn index_mech_code_address_references(
     match code {
         MechCode::ActivationScope(activation) => {
             index_expression_address_references(index, scope, order, &activation.trigger);
-            for (body_code, _) in &activation.body { index_mech_code_address_references(index, scope, order, body_code); }
+            match &activation.body {
+                ActivationBody::Block(body) => {
+                    for (body_code, _) in body {
+                        index_mech_code_address_references(index, scope, order, body_code);
+                    }
+                }
+                ActivationBody::PatternArms(arms) => {
+                    for arm in arms {
+                        index_pattern_address_references(index, scope, order, &arm.pattern);
+                        if let Some(guard) = &arm.guard {
+                            index_expression_address_references(index, scope, order, guard);
+                        }
+                        match &arm.body {
+                            ActivationArmBody::Block(body) => {
+                                for (body_code, _) in body {
+                                    index_mech_code_address_references(index, scope, order, body_code);
+                                }
+                            }
+                            ActivationArmBody::Expression(expression) => {
+                                index_expression_address_references(index, scope, order, expression);
+                            }
+                        }
+                    }
+                }
+            }
         }
         MechCode::Import(import) => {
             for declaration in module_import_declarations(import) {
@@ -995,6 +1020,58 @@ result := x?
                 .any(|reference| reference.target == "env" && reference.name == "SECRET"),
             "expected match pattern addressed read to be indexed"
         );
+    }
+
+    #[test]
+    fn source_index_records_activation_body_and_arm_address_references() {
+        let activation = MechCode::ActivationScope(mech_core::ActivationScope {
+            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            trigger: addressed_var("trigger", "EVENT"),
+            body: ActivationBody::PatternArms(vec![
+                mech_core::ActivationArm {
+                    // This nested pattern expression must be visited too; patterns are
+                    // expressions in their own right and can contain addressed reads.
+                    pattern: Pattern::Tuple(mech_core::PatternTuple(vec![
+                        Pattern::Expression(addressed_var("pattern", "NESTED")),
+                    ])),
+                    guard: Some(addressed_var("guard", "ENABLED")),
+                    body: ActivationArmBody::Block(vec![(
+                        MechCode::Expression(addressed_var("block", "VALUE")),
+                        None,
+                    )]),
+                },
+                mech_core::ActivationArm {
+                    pattern: Pattern::Wildcard,
+                    guard: None,
+                    body: ActivationArmBody::Expression(addressed_var("expression", "VALUE")),
+                },
+            ]),
+        });
+        let fixed = MechCode::ActivationScope(mech_core::ActivationScope {
+            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            trigger: addressed_var("fixed_trigger", "EVENT"),
+            body: ActivationBody::Block(vec![(
+                MechCode::Expression(addressed_var("fixed", "VALUE")),
+                None,
+            )]),
+        });
+        let mut program = program_with_code(activation);
+        program.body.sections[0]
+            .elements
+            .push(SectionElement::MechCode(vec![(fixed, None)]));
+
+        let index = SourceIndex::from_program(&program);
+        for (target, name) in [
+            ("fixed", "VALUE"),
+            ("guard", "ENABLED"),
+            ("block", "VALUE"),
+            ("expression", "VALUE"),
+            ("pattern", "NESTED"),
+        ] {
+            assert!(index.program_address_references().iter().any(|reference| {
+                reference.target == target && reference.name == name
+            }), "expected activation reference @{target}/{name} to be indexed");
+        }
     }
 
     #[test]

--- a/src/runtime/src/resolver/index.rs
+++ b/src/runtime/src/resolver/index.rs
@@ -1025,7 +1025,7 @@ result := x?
     #[test]
     fn source_index_records_activation_body_and_arm_address_references() {
         let activation = MechCode::ActivationScope(mech_core::ActivationScope {
-            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            operator: Token::new(mech_core::TokenKind::AsyncTransitionOperator, SourceRange::default(), vec!['~', '>']),
             trigger: addressed_var("trigger", "EVENT"),
             body: ActivationBody::PatternArms(vec![
                 mech_core::ActivationArm {
@@ -1048,7 +1048,7 @@ result := x?
             ]),
         });
         let fixed = MechCode::ActivationScope(mech_core::ActivationScope {
-            operator: Token::new(mech_core::TokenKind::Activation, SourceRange::default(), vec![]),
+            operator: Token::new(mech_core::TokenKind::AsyncTransitionOperator, SourceRange::default(), vec!['~', '>']),
             trigger: addressed_var("fixed_trigger", "EVENT"),
             body: ActivationBody::Block(vec![(
                 MechCode::Expression(addressed_var("fixed", "VALUE")),
@@ -1062,7 +1062,9 @@ result := x?
 
         let index = SourceIndex::from_program(&program);
         for (target, name) in [
+            ("trigger", "EVENT"),
             ("fixed", "VALUE"),
+            ("fixed_trigger", "EVENT"),
             ("guard", "ENABLED"),
             ("block", "VALUE"),
             ("expression", "VALUE"),

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1297,10 +1297,29 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
         self.flush_direct_execution(program, pending, result)?;
+        // Pure patterned scopes are lowered structurally and then handed to
+        // the interpreter's static patterned-dispatch elaborator.  Effects
+        // remain intentionally unsupported in this path.
+        if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          let mut lowered = scope.clone();
+          lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+          let mut lowered_arms = Vec::with_capacity(arms.len());
+          for arm in arms {
+            let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
+            let body = match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
+              mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+            };
+            lowered_arms.push(mech_core::ActivationArm { pattern: arm.pattern.clone(), guard, body });
+          }
+          lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
+          program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          return Ok(());
+        }
         let mut lowered = scope.clone();
         lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
         let mut registrations = Vec::new();
-        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => { return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet lowered".to_string() }, None)); } };
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => unreachable!() };
         lowered.body = mech_core::ActivationBody::Block(vec![]);
         let lowered_body = match &mut lowered.body { mech_core::ActivationBody::Block(body) => body, _ => unreachable!() };
         for (body_code, body_comment) in scope_body {
@@ -1482,7 +1501,17 @@ impl MechRuntime {
     match code {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
-        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet supported".to_string() }, None)) };
+        if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          for arm in arms {
+            if let Some(guard) = &arm.guard { self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?; }
+            match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => for (code, _) in body { self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?; },
+              mech_core::ActivationArmBody::Expression(expression) => self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?,
+            }
+          }
+          return Ok(());
+        }
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => unreachable!() };
         let has_send = scope_body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
         // Only writes to local registers conflict with an effectful activation.
         // Context-addressed assignments have their own, operation-specific

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -542,6 +542,8 @@ impl MechRuntime {
     value: Value,
   ) -> MResult<mech_core::Expression> {
     self.validate_live_context_candidate(context)?;
+    // The interpreter recognizes this prefix as a sampled pattern value rather
+    // than a source-level capture name.
     let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
     let symbol_id = hash_str(&name);
     let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
@@ -949,92 +951,53 @@ impl MechRuntime {
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<mech_core::Expression> {
-    if let Some(expression) = self.literalize_match_pattern_context_read_expression(
-      context,
+    if let Some(expression) = self.resolve_interpreter_address_pattern_expression(
       program,
       registry,
       expression,
     )? {
       return Ok(expression);
     }
-
     self.resolve_context_reads_in_expression(context, program, registry, expression)
   }
 
-  fn literalize_match_pattern_context_read_expression(
+  fn resolve_interpreter_address_pattern_expression(
     &mut self,
-    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<Option<mech_core::Expression>> {
     match expression {
       mech_core::Expression::Var(var) => {
-        self.literalize_match_pattern_context_read_var(context, program, registry, var)
+        let Some(var_context) = &var.context else {
+          return Ok(None);
+        };
+        let target = var_context.to_string();
+        if registry.get(&target).is_some() {
+          return Ok(None);
+        }
+
+        let address = format!("@{target}/{}", var.name.to_string());
+        let value = {
+          let symbols = program.interpreter().symbols();
+          let symbols = symbols.borrow();
+          symbols
+            .get(hash_str(&address))
+            .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
+        };
+        match value {
+          Some(value) => self.resolved_pattern_value_expression(value).map(Some),
+          None => Ok(None),
+        }
       }
       mech_core::Expression::Formula(factor) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, factor)
+        self.resolve_interpreter_address_pattern_factor(program, registry, factor)
       }
       _ => Ok(None),
     }
   }
 
-  fn literalize_match_pattern_context_read_factor(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-  ) -> MResult<Option<mech_core::Expression>> {
-    match factor {
-      mech_core::Factor::Expression(expression) => {
-        self.literalize_match_pattern_context_read_expression(context, program, registry, expression)
-      }
-      mech_core::Factor::Parenthetical(inner) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
-      }
-      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, &term.lhs)
-      }
-      _ => Ok(None),
-    }
-  }
-
-  fn literalize_match_pattern_context_read_var(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    var: &mech_core::Var,
-  ) -> MResult<Option<mech_core::Expression>> {
-    let Some(var_context) = &var.context else {
-      return Ok(None);
-    };
-
-    let target = var_context.to_string();
-    let path = var.name.to_string();
-    if let Some(binding) = registry.get(&target) {
-      let value = self.read_context_resource(context, binding, &path)?;
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    let address_key = format!("@{target}/{path}");
-    let value = {
-      let symbols = program.interpreter().symbols();
-      let symbols = symbols.borrow();
-      symbols
-        .get(hash_str(&address_key))
-        .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
-    };
-
-    if let Some(value) = value {
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    Ok(None)
-  }
-
-  fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
+  fn resolved_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
     let value = resolve_runtime_value(value);
     match value {
       Value::String(value) => {
@@ -1062,9 +1025,31 @@ impl MechRuntime {
         vec!['_'],
       )))),
       other => Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "context_match_pattern",
-        reason: format!("context match patterns currently support string, bool, and empty values; got {other:?}"),
+        operation: "interpreter_address_pattern",
+        reason: format!(
+          "interpreter-address patterns currently support string, bool, and empty values; got {other:?}",
+        ),
       }, None)),
+    }
+  }
+
+  fn resolve_interpreter_address_pattern_factor(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.resolve_interpreter_address_pattern_expression(program, registry, expression)
+      }
+      mech_core::Factor::Parenthetical(inner) => {
+        self.resolve_interpreter_address_pattern_factor(program, registry, inner)
+      }
+      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
+        self.resolve_interpreter_address_pattern_factor(program, registry, &term.lhs)
+      }
+      _ => Ok(None),
     }
   }
 
@@ -1305,12 +1290,18 @@ impl MechRuntime {
           lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
           let mut lowered_arms = Vec::with_capacity(arms.len());
           for arm in arms {
+            let pattern = self.resolve_context_reads_in_match_pattern(
+              context,
+              program,
+              registry,
+              &arm.pattern,
+            )?;
             let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
             let body = match &arm.body {
               mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
               mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
             };
-            lowered_arms.push(mech_core::ActivationArm { pattern: arm.pattern.clone(), guard, body });
+            lowered_arms.push(mech_core::ActivationArm { pattern, guard, body });
           }
           lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
@@ -1503,6 +1494,12 @@ impl MechRuntime {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
           for arm in arms {
+            self.preflight_pattern_context_reads(
+              context,
+              registry,
+              &arm.pattern,
+              addressed_read_preflight,
+            )?;
             if let Some(guard) = &arm.guard { self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?; }
             match &arm.body {
               mech_core::ActivationArmBody::Block(body) => for (code, _) in body { self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?; },

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -542,10 +542,13 @@ impl MechRuntime {
     value: Value,
   ) -> MResult<mech_core::Expression> {
     self.validate_live_context_candidate(context)?;
-    // The interpreter recognizes this prefix as a sampled pattern value rather
-    // than a source-level capture name.
-    let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
-    let symbol_id = hash_str(&name);
+    let identifier = mech_core::internal_pattern_value_identifier(&format!(
+      "context-{}-{}",
+      hash_str(source.base_uri()),
+      hash_str(source.path())
+    ));
+    let name = identifier.to_string();
+    let symbol_id = identifier.hash();
     let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
     if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
       let bindings = self.live_input_bindings.entry(source).or_default();
@@ -555,7 +558,7 @@ impl MechRuntime {
       self.commit_live_context_candidate(context);
     }
     let var = mech_core::Var {
-      name: identifier_from_str(&name),
+      name: identifier,
       context: None,
       kind: None,
     };

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1194,7 +1194,10 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         let mut scope = scope.clone();
         scope.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
-        scope.body = scope.body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?;
+        scope.body = match scope.body {
+          mech_core::ActivationBody::Block(body) => mech_core::ActivationBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
+          mech_core::ActivationBody::PatternArms(arms) => mech_core::ActivationBody::PatternArms(arms),
+        };
         Ok(mech_core::MechCode::ActivationScope(scope))
       },
       mech_core::MechCode::Statement(statement) => Ok(mech_core::MechCode::Statement(
@@ -1297,8 +1300,10 @@ impl MechRuntime {
         let mut lowered = scope.clone();
         lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
         let mut registrations = Vec::new();
-        lowered.body.clear();
-        for (body_code, body_comment) in &scope.body {
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => { return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet lowered".to_string() }, None)); } };
+        lowered.body = mech_core::ActivationBody::Block(vec![]);
+        let lowered_body = match &mut lowered.body { mech_core::ActivationBody::Block(body) => body, _ => unreachable!() };
+        for (body_code, body_comment) in scope_body {
           match body_code {
             mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
               let context_name = send.target.context.as_ref().unwrap().to_string();
@@ -1306,17 +1311,17 @@ impl MechRuntime {
               let index = self.persistent_sends.len() + registrations.len();
               let value_name = format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
               let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
-              lowered.body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
+              lowered_body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
               registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
             }
-            _ => lowered.body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
+            _ => lowered_body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
           }
         }
         if registrations.is_empty() {
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
           return Ok(());
         }
-        lowered.body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
+        lowered_body.push((mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall { name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME), args: vec![] })), None));
         self.validate_live_context_candidate(context)?;
         let plan_start = program.interpreter().plan().borrow().nodes.len();
         program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
@@ -1477,18 +1482,19 @@ impl MechRuntime {
     match code {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
-        let has_send = scope.body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet supported".to_string() }, None)) };
+        let has_send = scope_body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
         // Only writes to local registers conflict with an effectful activation.
         // Context-addressed assignments have their own, operation-specific
         // placement error below (they are top-level only).
-        let has_register = scope.body.iter().any(|(code, _)| match code {
+        let has_register = scope_body.iter().any(|(code, _)| match code {
           mech_core::MechCode::Statement(mech_core::Statement::VariableAssign(assign)) => assign.target.context.is_none(),
           mech_core::MechCode::Statement(mech_core::Statement::OpAssign(assign)) => assign.target.context.is_none(),
           _ => false,
         });
         if has_send && has_register { return Err(MechError::new(ActivationScopeEffectWithRegisterUnsupported, None)); }
         if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot { return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None)); }
-        for (body_code, _) in &scope.body {
+        for (body_code, _) in scope_body {
           self.preflight_code_context_capabilities(context, registry, body_code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?;
         }
         Ok(())

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3360,6 +3360,126 @@ result := \"x\"?
 }
 
 #[test]
+fn activation_arm_pattern_context_read_fails_preflight_before_stdout_write() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@env := cli://env{:read(HOME)}
+@out/line <- \"must-not-write\"
+event := \"x\"
+~> event
+  | (@env/HOME) => {
+      selected := true
+    }
+  | * => {
+      selected := false
+    }
+",
+  );
+
+  assert!(result.is_err(), "activation arm context read should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeCapabilityGrantDenied") || error.contains("context_read"),
+    "expected context read preflight error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
+fn activation_arm_context_read_pattern_is_lowered_when_allowed() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  state.lock().unwrap().env.insert(
+    "MECH_ACTIVATION_PATTERN".to_string(),
+    "expected".to_string(),
+  );
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject,
+    resource: "cli://cli/env".to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec!["MECH_ACTIVATION_PATTERN".to_string()],
+  }).unwrap();
+
+  let result = runtime.run_string(
+    "@env := cli://env{:read(MECH_ACTIVATION_PATTERN)}
+event := \"expected\"
+~> event
+  | (@env/MECH_ACTIVATION_PATTERN) => {
+      selected := true
+    }
+  | * => {
+      selected := false
+    }
+",
+  );
+
+  assert!(result.is_ok(), "allowed activation context pattern failed: {result:?}");
+  assert_eq!(runtime.live_input_binding_count(), 1);
+  let registration = {
+    let plan = runtime.program().interpreter().plan();
+    let registrations = plan.pattern_activation_registrations();
+    assert_eq!(registrations.len(), 1);
+    registrations[0].clone()
+  };
+
+  let update = runtime.apply_host_input(RuntimeHostInput::single(
+    RuntimeHostInputSource::new("cli://env", "MECH_ACTIVATION_PATTERN").unwrap(),
+    RuntimeHostInputValue::String("next".to_string()),
+  )).unwrap();
+  assert_eq!(update.binding_count, 1);
+  assert_eq!(update.ignored_update_count, 0);
+  if let Some(turn) = &update.turn {
+    for interpreter_turn in &turn.interpreter_turns {
+      let executed_nodes = interpreter_turn
+        .turn
+        .before_commit
+        .executed_nodes
+        .iter()
+        .chain(interpreter_turn.turn.after_commit.executed_nodes.iter())
+        .copied()
+        .collect::<Vec<_>>();
+      assert!(!executed_nodes.contains(&registration.scope_pulse_node));
+      assert!(!executed_nodes.contains(&registration.selector_node));
+      for arm in &registration.arms {
+        assert!(!executed_nodes.contains(&arm.matcher_node));
+        assert!(!executed_nodes.contains(&arm.finalizer_node));
+        assert!(!executed_nodes.contains(&arm.gate_node));
+      }
+    }
+  }
+
+  let trigger = {
+    let symbols = runtime.program().interpreter().symbols();
+    let event = symbols.borrow().get(hash_str("event")).unwrap().borrow().clone();
+    event.reactive_root_cell_ids()[0]
+  };
+  let trigger_turn = runtime
+    .program_mut()
+    .interpreter_mut()
+    .advance_reactive_turn(&[trigger])
+    .unwrap();
+  let changed_nodes = trigger_turn
+    .before_commit
+    .changed_nodes
+    .iter()
+    .chain(trigger_turn.after_commit.changed_nodes.iter())
+    .copied()
+    .collect::<Vec<_>>();
+  assert!(!changed_nodes.contains(&registration.arms[0].gate_node));
+  assert!(
+    changed_nodes.contains(&registration.arms[1].gate_node),
+    "the trigger did not sample the updated pattern value",
+  );
+}
+
+#[test]
 fn fsm_pipe_transition_context_read_fails_preflight_before_stdout_write() {
   let (mut runtime, state) = runtime_with_recording_cli();
   grant_runtime_stdout_line(&mut runtime);

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -45,6 +45,6 @@ mod tests {
   #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
   #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
   #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
-  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); assert!(matches!(p.body.sections[0].elements[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
+  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); let SectionElement::MechCode(code) = &p.body.sections[0].elements[0] else { panic!("expected Mech code") }; assert!(matches!(&code[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
   #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -1,38 +1,50 @@
-//! Parser for the source activation block (`~> trigger { ... }`).
+//! Parser for source activation scopes.
 use crate::*;
 use mech_core::nodes::*;
-use nom::combinator::cut;
+use nom::{branch::alt, combinator::{cut, opt}, multi::many1, sequence::preceded};
 
-/// activation-scope := "~>", whitespace0, expression, whitespace0, "{", mech-code, "}" ;
-/// The header deliberately uses the ordinary expression parser; semantic validation
-/// of the stable-reference restriction belongs to elaboration.
+/// activation-scope := "~>" expression ("{" mech-code "}" | activation-arm+) ;
 pub fn activation_scope(input: ParseString) -> ParseResult<ActivationScope> {
   let (input, operator) = async_transition_operator(input)?;
   let (input, trigger) = cut(expression)(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, _) = cut(left_brace)(input)?;
+  let (input, body) = if let Ok((input, _)) = left_brace(input.clone()) {
+    let (input, _) = whitespace0(input)?;
+    let (input, parsed) = mech_code(input)?;
+    let (input, _) = cut(right_brace)(input)?;
+    (input, ActivationBody::Block(parsed.code))
+  } else {
+    let (input, arms) = cut(many1(activation_arm))(input)?;
+    let (input, _) = opt(period)(input)?;
+    (input, ActivationBody::PatternArms(arms))
+  };
+  Ok((input, ActivationScope { operator, trigger, body }))
+}
+
+fn activation_arm(input: ParseString) -> ParseResult<ActivationArm> {
+  let (input, _) = crate::state_machines::guard_operator(input)?;
+  let (input, pattern) = crate::patterns::pattern(input)?;
+  let (input, guard) = opt(preceded(list_separator, preceded(whitespace0, expression)))(input)?;
+  let (input, _) = output_operator(input)?;
   let (input, _) = whitespace0(input)?;
-  let (input, parsed) = mech_code(input)?;
-  let (input, _) = cut(right_brace)(input)?;
-  Ok((input, ActivationScope { operator, trigger, body: parsed.code }))
+  if let Ok((input, _)) = left_brace(input.clone()) {
+    let (input, _) = whitespace0(input)?;
+    let (input, parsed) = mech_code(input)?;
+    let (input, _) = cut(right_brace)(input)?;
+    Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(parsed.code) }))
+  } else {
+    let (input, expression) = expression(input)?;
+    let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
+    Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Expression(expression) }))
+  }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  #[test]
-  fn activation_scope_parses_wildcard_block_form() {
-    let program = parse("~> tick {\n  output := x + 1\n}").expect("activation scope parses");
-    let code = &program.body.sections[0].elements;
-    assert!(format!("{:?}", code).contains("ActivationScope"));
-  }
-  #[test]
-  fn activation_scope_does_not_conflict_with_mutable_definition() {
-    let program = parse("~x := 10\n~> tick {\n output := x + 1\n}").expect("parse");
-    assert!(format!("{:?}", program).contains("ActivationScope"));
-  }
-  #[test]
-  fn activation_scope_parses_nested_record_literal() {
-    assert!(parse("~> tick {\n point := { x: x, y: y }\n}").is_ok());
-  }
+  #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
+  #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
+  #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
+  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); assert!(matches!(p.body.sections[0].elements[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
+  #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2011,24 +2011,36 @@ impl Formatter {
   }
 
   pub fn activation_scope(&mut self, node: &ActivationScope) -> String {
-    let mut lines = vec![format!("{} {} {{", node.operator.to_string(), self.expression(&node.trigger))];
-    for (code, comment) in &node.body {
-      let source = match code {
-        MechCode::Comment(value) => self.comment(value),
-        MechCode::ActivationScope(value) => self.activation_scope(value),
-        MechCode::Expression(value) => self.expression(value),
-        MechCode::FsmSpecification(value) => self.fsm_specification(value),
-        MechCode::FsmImplementation(value) => self.fsm_implementation(value),
-        MechCode::FunctionDefine(value) => self.function_define(value),
-        MechCode::Import(value) => self.module_import(value),
-        MechCode::Statement(value) => self.statement(value),
-        MechCode::Error(token, _) => token.to_string(),
-      };
-      lines.extend(source.lines().map(|line| format!("  {line}")));
-      if let Some(value) = comment { lines.push(format!("  {}", self.comment(value))); }
+    let header = format!("{} {}", node.operator.to_string(), self.expression(&node.trigger));
+    match &node.body {
+      ActivationBody::Block(body) => {
+        let mut lines = vec![format!("{header} {{")];
+        lines.extend(self.activation_block_lines(body, 2));
+        lines.push("}".to_string());
+        lines.join("\n")
+      }
+      ActivationBody::PatternArms(arms) => {
+        let mut lines = vec![header];
+        for (index, arm) in arms.iter().enumerate() {
+          let guard = arm.guard.as_ref().map(|guard| format!(", {}", self.expression(guard))).unwrap_or_default();
+          let prefix = format!("  | {}{} =>", self.pattern(&arm.pattern), guard);
+          match &arm.body {
+            ActivationArmBody::Block(body) => { lines.push(format!("{prefix} {{")); lines.extend(self.activation_block_lines(body, 6)); lines.push("  }".to_string()); }
+            ActivationArmBody::Expression(expression) => { let period = if index + 1 == arms.len() { "." } else { "" }; lines.push(format!("{prefix} {}{period}", self.expression(expression))); }
+          }
+        }
+        lines.join("\n")
+      }
     }
-    lines.push("}".to_string());
-    lines.join("\n")
+  }
+
+  fn activation_block_lines(&mut self, body: &Vec<(MechCode, Option<Comment>)>, indent: usize) -> Vec<String> {
+    let padding = " ".repeat(indent); let mut lines = vec![];
+    for (code, comment) in body {
+      let source = match code { MechCode::Comment(value) => self.comment(value), MechCode::ActivationScope(value) => self.activation_scope(value), MechCode::Expression(value) => self.expression(value), MechCode::FsmSpecification(value) => self.fsm_specification(value), MechCode::FsmImplementation(value) => self.fsm_implementation(value), MechCode::FunctionDefine(value) => self.function_define(value), MechCode::Import(value) => self.module_import(value), MechCode::Statement(value) => self.statement(value), MechCode::Error(token, _) => token.to_string() };
+      lines.extend(source.lines().map(|line| format!("{padding}{line}"))); if let Some(value) = comment { lines.push(format!("{padding}{}", self.comment(value))); }
+    }
+    lines
   }
 
   pub fn statement(&mut self, node: &Statement) -> String {

--- a/src/syntax/src/patterns.rs
+++ b/src/syntax/src/patterns.rs
@@ -54,11 +54,7 @@ fn spread_operator(input: ParseString) -> ParseResult<()> {
 }
 
 fn pattern_array_item(input: ParseString) -> ParseResult<Pattern> {
-  if let Ok((input, _)) = wildcard(input.clone()) {
-    return Ok((input, Pattern::Wildcard));
-  }
-  let (input, expr) = expression(input)?;
-  Ok((input, Pattern::Expression(expr)))
+  pattern(input)
 }
 
 #[derive(Clone)]
@@ -256,4 +252,76 @@ pub fn pattern_tuple(input: ParseString) -> ParseResult<PatternTuple> {
   let (input, _) = whitespace0(input)?;
   let (input, _) = right_parenthesis(input)?;
   Ok((input, PatternTuple(patterns)))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn parse_array_pattern(source: &str) -> PatternArray {
+    let graphemes = crate::graphemes::init_tag(source);
+    let input = ParseString::new(&graphemes);
+    let (remaining, parsed) = pattern(input).expect("expected array pattern to parse");
+    assert!(remaining.is_empty(), "expected the whole array pattern to be consumed");
+    match parsed {
+      Pattern::Array(array) => array,
+      other => panic!("expected Pattern::Array, got {:?}", other),
+    }
+  }
+
+  #[test]
+  fn array_items_accept_recursive_patterns_around_spread() {
+    let array = parse_array_pattern("[(left, right), ..., :some((payload, nested))]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Tuple(_)]));
+    assert!(matches!(
+      array.spread,
+      Some(PatternArraySpread {
+        kind: PatternArraySpreadKind::Spread,
+        binding: None,
+      })
+    ));
+    let [Pattern::TupleStruct(variant)] = array.suffix.as_slice() else {
+      panic!("expected a tagged suffix pattern");
+    };
+    assert_eq!(variant.patterns.len(), 1);
+    assert!(matches!(variant.patterns[0], Pattern::Tuple(_)));
+  }
+
+  #[test]
+  fn array_rest_binding_accepts_recursive_pattern() {
+    let array = parse_array_pattern("[(:head(value), other) | :tail((left, right))]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Tuple(_)]));
+    let Some(PatternArraySpread {
+      kind: PatternArraySpreadKind::Rest,
+      binding: Some(binding),
+    }) = array.spread else {
+      panic!("expected a recursively patterned rest binding");
+    };
+    assert!(matches!(*binding, Pattern::TupleStruct(_)));
+    assert!(array.suffix.is_empty());
+  }
+
+  #[test]
+  fn array_rest_binding_accepts_nested_array_pattern() {
+    let array = parse_array_pattern("[head | [second, ..., last]]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Expression(_)]));
+    let Some(PatternArraySpread {
+      kind: PatternArraySpreadKind::Rest,
+      binding: Some(binding),
+    }) = array.spread else {
+      panic!("expected an array-patterned rest binding");
+    };
+    let Pattern::Array(nested) = *binding else {
+      panic!("expected the rest binding to be an array pattern");
+    };
+    assert_eq!(nested.prefix.len(), 1);
+    assert!(matches!(
+      nested.spread,
+      Some(PatternArraySpread {
+        kind: PatternArraySpreadKind::Spread,
+        binding: None,
+      })
+    ));
+    assert_eq!(nested.suffix.len(), 1);
+  }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -407,6 +407,66 @@ test_interpreter!(
   Value::U64(Ref::new(42))
 );
 test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_recursive_rest_across_function_fsm_match_and_comprehension,
+  r#"
+probe(xs<[u64]>) => <u64>
+  | [head | [second, ..., last]] => head + second + last
+  | * => 0u64.
+
+#Probe(xs<[u64]>) => <u64>
+  ├ :Scan(xs<[u64]>)
+  └ :Done(out<u64>).
+
+#Probe(xs) -> :Scan(xs)
+  :Scan([head | [second, ..., last]]) -> :Done(head + second + last)
+  :Scan(*) -> :Done(0u64)
+  :Done(out) => out.
+
+value := [1u64 2u64 3u64 4u64]
+function-result := probe(value)
+fsm-result := #Probe(value)
+match-result := value?
+  | [head | [second, ..., last]] => head + second + last
+  | * => 0u64.
+comprehension-result := [head + second + last | [head | [second, ..., last]] <- {value}]
+function-result + fsm-result + match-result + comprehension-result[1]
+"#,
+  Value::U64(Ref::new(28))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_repeated_binding_and_first_arm_across_dispatch_contexts,
+  r#"
+probe(xs<[u64]>) => <u64>
+  | [x, x] => x
+  | [x, ...] => 99u64
+  | * => 0u64.
+
+#Probe(xs<[u64]>) => <u64>
+  ├ :Scan(xs<[u64]>)
+  └ :Done(out<u64>).
+
+#Probe(xs) -> :Scan(xs)
+  :Scan([x, x]) -> :Done(x)
+  :Scan([x, ...]) -> :Done(99u64)
+  :Scan(*) -> :Done(0u64)
+  :Done(out) => out.
+
+equal := [3u64 3u64]
+unequal := [3u64 4u64]
+function-result := probe(equal)
+fsm-result := #Probe(equal)
+match-equal := equal? | [x, x] => x | [x, ...] => 99u64 | * => 0u64.
+match-unequal := unequal? | [x, x] => x | [x, ...] => 99u64 | * => 0u64.
+generated := [x | [x, x] <- {equal, unequal}]
+function-result + fsm-result + match-equal + match-unequal + generated[1]
+"#,
+  Value::U64(Ref::new(111))
+);
 test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>
   ├ :Start(arr<[u64]>)
@@ -1635,6 +1695,65 @@ test_interpreter!(interpret_set_comprehension, r#"{ x * x | x <- {1,2,3,4}, y :=
 test_interpreter!(interpret_set_comprehension_variable, r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0))]))));
 test_interpreter!(interpret_set_comprehension_tuple, r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(25.0)), Value::F64(Ref::new(49.0))]))));
 test_interpreter!(interpret_set_comprehension_fof, r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(8.0))]))));
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_repeated_binding,
+  r#"pairs := {(1u64, 1u64), (1u64, 2u64), (3u64, 3u64)}; {x | (x, x) <- pairs}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(1)), Value::U64(Ref::new(3))])))
+);
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_typed_and_expression_values,
+  r#"pairs := {(1u64, 10u64), (2u64, 20u64)}; expected := 1u64; {x | (expected + 0u64, x) <- pairs}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(10))])))
+);
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_nested_tuple,
+  r#"values := {((1u64, 2u64), 3u64), ((4u64, 5u64), 6u64)}; {a + b + c | ((a, b), c) <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(6)), Value::U64(Ref::new(15))])))
+);
+
+#[cfg(all(feature = "u64", feature = "atom"))]
+test_interpreter!(
+  pattern_conformance_comprehension_atom_tuple,
+  r#"events := {(:ready, 7u64), (:ready, 9u64)}; {x | :ready(x) <- events}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(7)), Value::U64(Ref::new(9))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_exact_array,
+  r#"values := {[1u64 2u64], [3u64 4u64]}; {a + b | [a, b] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(3)), Value::U64(Ref::new(7))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_prefix_suffix_spread,
+  r#"values := {[1u64 2u64 3u64 4u64], [5u64 6u64 7u64 8u64]}; {head + last | [head, ..., last] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(5)), Value::U64(Ref::new(13))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_bound_rest,
+  r#"values := {[1u64 2u64 3u64], [4u64 5u64 6u64]}; {tail | [head | tail] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![
+    Value::MatrixU64(Matrix::from_vec(vec![2, 3], 1, 2)),
+    Value::MatrixU64(Matrix::from_vec(vec![5, 6], 1, 2)),
+  ])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_recursive_rest_pattern,
+  r#"values := {[1u64 2u64 3u64 4u64], [5u64 6u64 7u64 8u64]}; {head + second + last | [head | [second, ..., last]] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(7)), Value::U64(Ref::new(19))])))
+);
 
 test_interpreter!(interpret_matrix_comprehension, r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2)));
 test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -118,7 +118,7 @@ test_interpreter!(
 #[cfg(feature = "u64")]
 test_interpreter!(
   interpret_option_match_scalar_some,
-  "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
+  "x<u64?> := 4u64; x? | value, value > 3u64 => value | * => 0u64.",
   Value::U64(Ref::new(4))
 );
 #[cfg(feature = "u64")]
@@ -353,6 +353,20 @@ test_interpreter!(
   Value::U64(Ref::new(3))
 );
 
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_match_structural_failure_skips_guard,
+  "pair := (1u64, 2u64)\nresult := pair?\n  | (x, 0u64), missing-capture > 0u64 => x\n  | * => 9u64.\nresult + 0u64",
+  Value::U64(Ref::new(9))
+);
+
+#[cfg(all(feature = "u64", feature = "f64"))]
+test_interpreter!(
+  interpret_match_fractional_f64_literal_does_not_equal_u64,
+  "value := 1u64\nresult := value?\n  | 1.5 => 99u64\n  | * => 7u64.\nresult + 0u64",
+  Value::U64(Ref::new(7))
+);
+
 test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64", Value::U64(Ref::new(9)));
 #[test]
 fn interpret_tagged_union_match_requires_exhaustive_arms() {
@@ -377,9 +391,21 @@ test_interpreter!(
   "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
   Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
 );
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_function_multi_argument_wildcard_arm_matches,
+  "multi-default(left<u64>, right<u64>) => <u64>\n  | * => 9u64.\n\nmulti-default(1u64, 2u64)",
+  Value::U64(Ref::new(9))
+);
 test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) => <u64>\n  | [x …] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
 test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x … y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
 test_interpreter!(interpret_fsm_accepts_unsized_vector_input, "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(5)));
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_fsm_pattern_binding_does_not_replace_input,
+  "#RestoreInput(input<u64>) => <u64>\n  ├ :Start(value<u64>)\n  └ :Done(value<u64>).\n\n#RestoreInput(input<u64>) -> :Start(7u64)\n  :Start(input) -> :Done(0u64)\n  :Done(*) => input.\n\n#RestoreInput(42u64)",
+  Value::U64(Ref::new(42))
+);
 test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
 test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -912,6 +912,47 @@ ys := { x | (x, @env/MECH_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop"
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
+fn mech_run_matrix_generator_context_pattern_is_literal_filter() {
+  let root = temp_root("matrix-generator-pattern-literal");
+  let source = root.join("matrix_generator_pattern_literal.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @env := cli/env
++> @out := cli/stdout
+
+ys := [ x | (x, @env/MECH_MATRIX_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop", "other")] ]
+@out/line <- ys
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source)
+    .current_dir(&root)
+    .env("MECH_MATRIX_GENERATOR_PATTERN_TEST", "secret")
+    .output()
+    .unwrap();
+
+  let combined = combined_output(&output);
+  assert!(
+    output.status.success(),
+    "matrix generator context-pattern program failed:\n{combined}"
+  );
+  assert!(
+    combined.contains("keep"),
+    "matrix generator context pattern should retain matching tuple:\n{combined}"
+  );
+  assert!(
+    !combined.contains("drop"),
+    "matrix generator context pattern should reject nonmatching tuple:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
 fn mech_run_undeclared_context_read_is_preflighted_before_send() {
   let root = temp_root("undeclared-context-read");
   let source = root.join("undeclared_context_read.mec");


### PR DESCRIPTION
### Motivation
- Introduce first-class patterned activation bodies so the parser and formatter recognize both fixed `{ ... }` activation blocks and `| pattern [, guard] => { ... }| expression` arm lists without changing the existing fixed-body semantics.

### Description
- Add new AST variants in `src/core/src/nodes.rs`: `ActivationBody`, `ActivationArm`, and `ActivationArmBody`, and update `ActivationScope::tokens()` to include patterns, guards, block and expression tokens.
- Extend the parser in `src/syntax/src/activation.rs` to accept either a block body (`{ ... }`) or one-or-more pattern arms (`| pattern [, guard] => body`), and preserve comments and an optional final period for expression-style arm lists; add focused syntax tests for these cases.
- Update the formatter in `src/syntax/src/formatter.rs` to render both fixed block bodies and patterned arm lists with the required indentation, guard formatting, one-arm-per-line layout, and final period handling for expression arms.
- Preserve the fixed-body interpreter path by restricting the existing elaboration and lowering code to `ActivationBody::Block` only; runtime-side code in `src/runtime/src/runtime/execution.rs` and `src/interpreter/src/mechdown.rs` was updated to recognize the new `ActivationBody` enum and to continue lowering/validating fixed block bodies while returning a clear unsupported path for patterned arms (patterned bodies are parsed/formatted but not yet lowered/executed).
- Files touched (high level): `src/core/src/nodes.rs`, `src/syntax/src/activation.rs`, `src/syntax/src/formatter.rs`, `src/interpreter/src/mechdown.rs`, `src/runtime/src/runtime/execution.rs`.

### Testing
- Added syntax unit tests in `src/syntax/src/activation.rs`: `activation_scope_parses_fixed_block_body`, `activation_scope_parses_pattern_block_and_expression_arms`, `activation_scope_parses_pattern_guard`, `activation_scope_pattern_body_does_not_parse_as_match_expression`, and retained the mutable-definition ambiguity test.
- Ran `cargo check -p mech-syntax` and `cargo check -p mech-interpreter`, which completed successfully.
- Ran `cargo check -p mech-runtime`, which completed successfully in this run; patterned activation arms remain parsed/formatted but currently produce a controlled unsupported/early-error path at interpreter/runtime lowering until the full patterned-activation scheduler and runtime semantics are implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5feb6f5450832a915edb01e3c15f07)