### PR TITLE
Implement patterned activation dispatch foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,12 @@ jobs:
           cargo test -p mech-interpreter dirty_scheduler_updates_only_reachable_combinational_nodes -- --nocapture
           cargo test -p mech-interpreter dirty_scheduler_stops_at_register_boundary -- --nocapture
 
+          # Patterned activation and transactional rollback coverage.
+          cargo test -p mech-core reactive_plan_rollback_ -- --nocapture
+          cargo test -p mech-core plan_rollback_ -- --nocapture
+          cargo test -p mech-interpreter activation_capture_slot_ -- --nocapture
+          cargo test -p mech-interpreter activation_pattern_ -- --nocapture
+
           # Two-phase register staging and atomic commit coverage.
           cargo test -p mech-core reactive_register_commit_ -- --nocapture
           cargo test -p mech-interpreter register_commit_ -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           rustup toolchain install nightly-2026-03-03 --profile minimal
           rustup default nightly-2026-03-03
 
-      - name: Build and test
+      - name: Check feature boundaries and examples
         run: |
           # Linked-stdlib CLI build for examples that import named modules.
           cargo build --bin mech --features linked_stdlib
@@ -49,168 +49,70 @@ jobs:
           cargo check -p mech-interpreter --no-default-features --features program
           cargo check -p mech-program --no-default-features --features program
 
-          cargo test interpret
-          cargo test bytecode
+      - name: Disk report at end
+        if: always()
+        run: bash scripts/ci-disk-report.sh
 
-          # Whole-value assignment reactive graph coverage.
-          cargo test -p mech-interpreter whole_variable_assignment_registers_state_node -- --nocapture
-          cargo test -p mech-interpreter whole_add_assignment_registers_state_node -- --nocapture
-          cargo test -p mech-interpreter whole_add_assignment_alias_is_sampled_once -- --nocapture
-          cargo test -p mech-interpreter decoded_whole_variable_assignment_matches_source_graph -- --nocapture
-          cargo test -p mech-interpreter decoded_whole_add_assignment_matches_source_graph -- --nocapture
-          cargo test -p mech-interpreter whole_matrix_assignment_uses_root_cells -- --nocapture
+  cargo-language:
+    name: Cargo language tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          # Deterministic dirty-cell scheduler coverage.
-          cargo test -p mech-core reactive_dirty_scheduler_ -- --nocapture
-          cargo test -p mech-interpreter dirty_scheduler_updates_only_reachable_combinational_nodes -- --nocapture
-          cargo test -p mech-interpreter dirty_scheduler_stops_at_register_boundary -- --nocapture
+      - name: Disk report at start
+        run: bash scripts/ci-disk-report.sh
 
-          # Patterned activation and transactional rollback coverage.
-          cargo test -p mech-core reactive_plan_rollback_ -- --nocapture
-          cargo test -p mech-core plan_rollback_ -- --nocapture
-          cargo test -p mech-interpreter activation_capture_slot_ -- --nocapture
-          cargo test -p mech-interpreter activation_pattern_ -- --nocapture
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
 
-          # Two-phase register staging and atomic commit coverage.
-          cargo test -p mech-core reactive_register_commit_ -- --nocapture
-          cargo test -p mech-interpreter register_commit_ -- --nocapture
-          cargo test -p mech-core reactive_turn_ -- --nocapture
-          interpreter_state_tests="$(
-            cargo test \
-              -p mech-interpreter \
-              --lib \
-              reactive_turn_interpreter_state_ \
-              -- --list
-          )"
-          printf '%s\n' "$interpreter_state_tests"
-          for test_name in \
-            reactive_turn_interpreter_state_persists_between_calls \
-            reactive_turn_interpreter_state_clear_plan_resets_pending \
-            reactive_turn_interpreter_state_clone_preserves_pending
-          do
-            if ! grep -Fq "${test_name}: test" <<<"$interpreter_state_tests"; then
-              echo "::error::missing interpreter test ${test_name}"
-              exit 1
-            fi
-          done
-          cargo test \
-            -p mech-interpreter \
-            --lib \
-            reactive_turn_interpreter_state_ \
-            -- --nocapture
-          decoded_symbol_tests="$(
-            cargo test \
-              -p mech-interpreter \
-              --lib \
-              decoded_variable_definition_symbol_metadata_ \
-              -- --list
-          )"
-          printf '%s\n' "$decoded_symbol_tests"
-          if ! grep -Fq "decoded_variable_definition_symbol_metadata_round_trips: test" <<<"$decoded_symbol_tests"
-          then
-            echo "::error::missing decoded variable-definition symbol metadata test"
-            exit 1
-          fi
-          cargo test \
-            -p mech-interpreter \
-            --lib \
-            decoded_variable_definition_symbol_metadata_ \
-            -- --nocapture
-          cargo test -p mech-interpreter reactive_turn_ -- --nocapture
-          cargo test -p mech-interpreter decoded_reactive_turn_ -- --nocapture
-          program_turn_tests="$(
-            cargo test \
-              -p mech-program \
-              --lib \
-              program_reactive_turn_ \
-              -- --list
-          )"
-          printf '%s\n' "$program_turn_tests"
-          for test_name in \
-            program_reactive_turn_updates_only_reachable_branch \
-            program_reactive_turn_batches_inputs_into_one_turn \
-            program_reactive_turn_preserves_deferred_registers_between_calls \
-            program_reactive_turn_legacy_update_api_does_not_execute_plan \
-            program_reactive_turn_preflight_failure_mutates_nothing \
-            program_reactive_turn_rejects_root_alias_duplicate \
-            program_reactive_turn_empty_batch_is_noop \
-            program_reactive_turn_orders_nested_interpreters_deterministically \
-            program_reactive_turn_decoded_plan_reuses_identity
-          do
-            if ! grep -Fq "${test_name}: test" <<<"$program_turn_tests"; then
-              echo "::error::missing program test ${test_name}"
-              exit 1
-            fi
-          done
-          cargo test \
-            -p mech-program \
-            --lib \
-            program_reactive_turn_ \
-            -- --nocapture
+      - name: Run root interpreter and bytecode tests
+        run: |
+          cargo test --test interpreter --test bytecode
+          cargo test --lib bytecode
 
-          # Pointer-register initialization identity coverage.
-          cargo test \
-            -p mech-core \
-            compile_context_initializes_pointer_register_once \
-            -- --nocapture
-          cargo test \
-            -p mech-core \
-            pointer_register_scalar_initializes_once \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            pointer_register_matrix_initializes_once \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_four_args_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_n_args_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            horizontal_concatenate_rdn_reuses_repeated_matrix_register \
-            -- --nocapture
-          cargo test \
-            -p mech-interpreter \
-            vertical_concatenate_n_args_reuses_repeated_matrix_register \
-            -- --nocapture
+      - name: Run complete core and interpreter suites
+        run: cargo test -p mech-core -p mech-interpreter
 
-          # Runtime package tests.
-          runtime_turn_tests="$(
-            cargo test \
-              -p mech-runtime \
-              --lib \
-              runtime_reactive_host_input_ \
-              -- --list
-          )"
+      - name: Run complete program library suite
+        run: cargo test -p mech-program --lib
 
-          printf '%s\n' "$runtime_turn_tests"
+      - name: Disk report at end
+        if: always()
+        run: bash scripts/ci-disk-report.sh
 
-          for test_name in \
-            runtime_reactive_host_input_batches_bound_updates_into_one_turn \
-            runtime_reactive_host_input_executes_only_reachable_branch \
-            runtime_reactive_host_input_preserves_deferred_registers_across_packets \
-            runtime_reactive_host_input_unbound_packet_does_not_advance_pending_registers \
-            runtime_reactive_host_input_preflight_failure_mutates_nothing \
-            runtime_reactive_host_input_turn_failure_preserves_admitted_inputs
-          do
-            grep -Fq \
-              "${test_name}: test" \
-              <<<"$runtime_turn_tests" \
-              || {
-                echo \
-                  "::error::missing runtime reactive host-input test ${test_name}"
-                exit 1
-              }
-          done
+  cargo-runtime:
+    name: Cargo runtime and host tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-          # The complete runtime suite executes the six guarded tests.
-          cargo test -p mech-runtime --lib --tests
+      - name: Disk report at start
+        run: bash scripts/ci-disk-report.sh
 
-          # CLI host and context-send regression coverage.
+      - name: Install Rust nightly-2026-03-03
+        run: |
+          rustup show
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
+
+      - name: Run complete runtime suite
+        run: cargo test -p mech-runtime --lib --tests
+
+      - name: Run CLI host and context-send regression coverage
+        run: |
           cargo test -p mech-syntax --test context_parser
           cargo test -p mech-host-cli --features provider --test provider
           cargo test --features "run repl pretty_print" --test mech_cli_host
@@ -220,10 +122,6 @@ jobs:
 
       - name: Disk report at end
         if: always()
-        run: bash scripts/ci-disk-report.sh
-
-      - name: Disk report on failure
-        if: failure()
         run: bash scripts/ci-disk-report.sh
 
   project-native:

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -621,10 +621,32 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct ReactivePlanCheckpoint { node_len:usize, pattern_activation_registration_len:usize }
-#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct PlanCheckpoint { reactive:ReactivePlanCheckpoint, activation_registration_depth:usize }
-#[derive(Debug,Clone)] pub struct ReactivePlanRollbackInvariantError { pub checkpoint_nodes:usize,pub current_nodes:usize,pub checkpoint_registrations:usize,pub current_registrations:usize }
-impl MechErrorKind for ReactivePlanRollbackInvariantError { fn name(&self)->&str{"ReactivePlanRollbackInvariant"} fn message(&self)->String{format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.",self.current_nodes,self.current_registrations,self.checkpoint_nodes,self.checkpoint_registrations)} }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReactivePlanCheckpoint {
+  node_len: usize,
+  pattern_activation_registration_len: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlanCheckpoint {
+  reactive: ReactivePlanCheckpoint,
+  activation_registration_depth: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactivePlanRollbackInvariantError {
+  pub checkpoint_nodes: usize,
+  pub current_nodes: usize,
+  pub checkpoint_registrations: usize,
+  pub current_registrations: usize,
+}
+
+impl MechErrorKind for ReactivePlanRollbackInvariantError {
+  fn name(&self) -> &str { "ReactivePlanRollbackInvariant" }
+  fn message(&self) -> String {
+    format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.", self.current_nodes, self.current_registrations, self.checkpoint_nodes, self.checkpoint_registrations)
+  }
+}
 
 impl ReactivePlan {
   fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -648,10 +648,38 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
   }
 }
 
+#[derive(Debug, Clone)]
+pub struct ActivationRegistrationRollbackInvariantError { pub checkpoint_depth: usize, pub current_depth: usize }
+impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
+  fn name(&self) -> &str { "ActivationRegistrationRollbackInvariant" }
+  fn message(&self) -> String { format!("Cannot roll the activation registration stack back from depth {} to future depth {}.", self.current_depth, self.checkpoint_depth) }
+}
+
 impl ReactivePlan {
-  fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }
-  pub fn checkpoint(&self)->ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len:self.nodes.len(), pattern_activation_registration_len:self.pattern_activation_registrations.len() } }
-  pub fn rollback(&mut self, checkpoint:ReactivePlanCheckpoint)->MResult<()> { if checkpoint.node_len>self.nodes.len()||checkpoint.pattern_activation_registration_len>self.pattern_activation_registrations.len(){return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.node_len,current_nodes:self.nodes.len(),checkpoint_registrations:checkpoint.pattern_activation_registration_len,current_registrations:self.pattern_activation_registrations.len()},None))} self.nodes.truncate(checkpoint.node_len);self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);self.rebuild_consumer_indexes();Ok(()) }
+  fn rebuild_consumer_indexes(&mut self) {
+    self.reactive_consumers.clear();
+    self.sampled_consumers.clear();
+    for node in &self.nodes {
+      for dependency in &node.inputs {
+        let consumers = match dependency.kind { ReactiveDependencyKind::Reactive => &mut self.reactive_consumers, ReactiveDependencyKind::Sampled => &mut self.sampled_consumers };
+        let consumers = consumers.entry(dependency.cell).or_default();
+        if !consumers.contains(&node.id) { consumers.push(node.id); }
+      }
+    }
+  }
+  fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
+    if checkpoint.node_len > self.nodes.len() || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len() {
+      return Err(MechError::new(ReactivePlanRollbackInvariantError { checkpoint_nodes: checkpoint.node_len, current_nodes: self.nodes.len(), checkpoint_registrations: checkpoint.pattern_activation_registration_len, current_registrations: self.pattern_activation_registrations.len() }, None));
+    }
+    Ok(())
+  }
+  fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
+    self.nodes.truncate(checkpoint.node_len);
+    self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);
+    self.rebuild_consumer_indexes();
+  }
+  pub fn checkpoint(&self) -> ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len: self.nodes.len(), pattern_activation_registration_len: self.pattern_activation_registrations.len() } }
+  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> { self.validate_rollback(checkpoint)?; self.apply_rollback(checkpoint); Ok(()) }
 
   pub fn new() -> Self {
     Self {
@@ -1048,9 +1076,15 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
-  pub fn checkpoint(&self)->PlanCheckpoint { PlanCheckpoint { reactive:self.0.borrow().checkpoint(),activation_registration_depth:self.1.borrow().len() } }
-  pub fn rollback(&self, checkpoint:PlanCheckpoint)->MResult<()> { {let mut scopes=self.1.borrow_mut();if checkpoint.activation_registration_depth>scopes.len(){let p=self.0.borrow();return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.reactive.node_len,current_nodes:p.nodes.len(),checkpoint_registrations:checkpoint.reactive.pattern_activation_registration_len,current_registrations:p.pattern_activation_registrations.len()},None))}scopes.truncate(checkpoint.activation_registration_depth);}self.0.borrow_mut().rollback(checkpoint.reactive) }
-  pub fn activation_registration_depth(&self)->usize {self.1.borrow().len()}
+  pub fn checkpoint(&self) -> PlanCheckpoint { PlanCheckpoint { reactive: self.0.borrow().checkpoint(), activation_registration_depth: self.1.borrow().len() } }
+  pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
+    { let reactive = self.0.borrow(); reactive.validate_rollback(checkpoint.reactive)?; }
+    { let scopes = self.1.borrow(); let current_depth = scopes.len(); if checkpoint.activation_registration_depth > current_depth { return Err(MechError::new(ActivationRegistrationRollbackInvariantError { checkpoint_depth: checkpoint.activation_registration_depth, current_depth }, None)); } }
+    self.0.borrow_mut().apply_rollback(checkpoint.reactive);
+    self.1.borrow_mut().truncate(checkpoint.activation_registration_depth);
+    Ok(())
+  }
+  pub fn activation_registration_depth(&self) -> usize { self.1.borrow().len() }
 
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
@@ -1883,6 +1917,32 @@ mod reactive_turn_tests {
   }
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
+
+  #[test]
+  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
+    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
+    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+  }
+  #[test]
+  fn reactive_plan_rollback_truncates_pattern_registrations() {
+    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  }
+  #[test]
+  fn plan_rollback_restores_activation_registration_depth() {
+    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
+  }
+  #[test]
+  fn plan_rollback_invalid_checkpoint_is_atomic() {
+    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
+    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  }
+
 }
 
 // Function Registry

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -649,37 +649,84 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
 }
 
 #[derive(Debug, Clone)]
-pub struct ActivationRegistrationRollbackInvariantError { pub checkpoint_depth: usize, pub current_depth: usize }
+pub struct ActivationRegistrationRollbackInvariantError {
+  pub checkpoint_depth: usize,
+  pub current_depth: usize,
+}
+
 impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
-  fn name(&self) -> &str { "ActivationRegistrationRollbackInvariant" }
-  fn message(&self) -> String { format!("Cannot roll the activation registration stack back from depth {} to future depth {}.", self.current_depth, self.checkpoint_depth) }
+  fn name(&self) -> &str {
+    "ActivationRegistrationRollbackInvariant"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Cannot roll the activation registration stack back from depth {} to future depth {}.",
+      self.current_depth,
+      self.checkpoint_depth,
+    )
+  }
 }
 
 impl ReactivePlan {
   fn rebuild_consumer_indexes(&mut self) {
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
+
     for node in &self.nodes {
       for dependency in &node.inputs {
-        let consumers = match dependency.kind { ReactiveDependencyKind::Reactive => &mut self.reactive_consumers, ReactiveDependencyKind::Sampled => &mut self.sampled_consumers };
+        let consumers = match dependency.kind {
+          ReactiveDependencyKind::Reactive => &mut self.reactive_consumers,
+          ReactiveDependencyKind::Sampled => &mut self.sampled_consumers,
+        };
+
         let consumers = consumers.entry(dependency.cell).or_default();
-        if !consumers.contains(&node.id) { consumers.push(node.id); }
+
+        if !consumers.contains(&node.id) {
+          consumers.push(node.id);
+        }
       }
     }
   }
+
   fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
-    if checkpoint.node_len > self.nodes.len() || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len() {
-      return Err(MechError::new(ReactivePlanRollbackInvariantError { checkpoint_nodes: checkpoint.node_len, current_nodes: self.nodes.len(), checkpoint_registrations: checkpoint.pattern_activation_registration_len, current_registrations: self.pattern_activation_registrations.len() }, None));
+    if checkpoint.node_len > self.nodes.len()
+      || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len()
+    {
+      return Err(MechError::new(
+        ReactivePlanRollbackInvariantError {
+          checkpoint_nodes: checkpoint.node_len,
+          current_nodes: self.nodes.len(),
+          checkpoint_registrations: checkpoint.pattern_activation_registration_len,
+          current_registrations: self.pattern_activation_registrations.len(),
+        },
+        None,
+      ));
     }
+
     Ok(())
   }
+
   fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
     self.nodes.truncate(checkpoint.node_len);
-    self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);
+    self
+      .pattern_activation_registrations
+      .truncate(checkpoint.pattern_activation_registration_len);
     self.rebuild_consumer_indexes();
   }
-  pub fn checkpoint(&self) -> ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len: self.nodes.len(), pattern_activation_registration_len: self.pattern_activation_registrations.len() } }
-  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> { self.validate_rollback(checkpoint)?; self.apply_rollback(checkpoint); Ok(()) }
+
+  pub fn checkpoint(&self) -> ReactivePlanCheckpoint {
+    ReactivePlanCheckpoint {
+      node_len: self.nodes.len(),
+      pattern_activation_registration_len: self.pattern_activation_registrations.len(),
+    }
+  }
+
+  pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
+    self.validate_rollback(checkpoint)?;
+    self.apply_rollback(checkpoint);
+    Ok(())
+  }
 
   pub fn new() -> Self {
     Self {
@@ -1076,15 +1123,46 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
-  pub fn checkpoint(&self) -> PlanCheckpoint { PlanCheckpoint { reactive: self.0.borrow().checkpoint(), activation_registration_depth: self.1.borrow().len() } }
+  pub fn checkpoint(&self) -> PlanCheckpoint {
+    PlanCheckpoint {
+      reactive: self.0.borrow().checkpoint(),
+      activation_registration_depth: self.1.borrow().len(),
+    }
+  }
+
   pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
-    { let reactive = self.0.borrow(); reactive.validate_rollback(checkpoint.reactive)?; }
-    { let scopes = self.1.borrow(); let current_depth = scopes.len(); if checkpoint.activation_registration_depth > current_depth { return Err(MechError::new(ActivationRegistrationRollbackInvariantError { checkpoint_depth: checkpoint.activation_registration_depth, current_depth }, None)); } }
+    {
+      let reactive = self.0.borrow();
+      reactive.validate_rollback(checkpoint.reactive)?;
+    }
+
+    {
+      let scopes = self.1.borrow();
+      let current_depth = scopes.len();
+
+      if checkpoint.activation_registration_depth > current_depth {
+        return Err(MechError::new(
+          ActivationRegistrationRollbackInvariantError {
+            checkpoint_depth: checkpoint.activation_registration_depth,
+            current_depth,
+          },
+          None,
+        ));
+      }
+    }
+
     self.0.borrow_mut().apply_rollback(checkpoint.reactive);
-    self.1.borrow_mut().truncate(checkpoint.activation_registration_depth);
+    self
+      .1
+      .borrow_mut()
+      .truncate(checkpoint.activation_registration_depth);
+
     Ok(())
   }
-  pub fn activation_registration_depth(&self) -> usize { self.1.borrow().len() }
+
+  pub fn activation_registration_depth(&self) -> usize {
+    self.1.borrow().len()
+  }
 
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
@@ -1839,6 +1917,30 @@ mod reactive_plan_tests {
   fn reactive_dirty_scheduler_stops_on_error() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,ao,ac)=scheduler_node(&mut p,"A",&[d.clone()],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l.clone(),true);let(_,_,bc)=scheduler_node(&mut p,"B",&[ao],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);let e=p.solve_dirty_cells(&d.reactive_root_cell_ids()).unwrap_err();assert!(e.kind_message().contains("A"));assert_eq!(*ac.borrow(),1);assert_eq!(*bc.borrow(),0); }
   #[cfg(feature = "f64")] #[test]
   fn reactive_dirty_scheduler_empty_dirty_set_is_noop() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,_,c)=scheduler_node(&mut p,"A",&[d],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);assert_eq!(p.solve_dirty_cells(&[]).unwrap(),ReactivePlanSolveOutcome::default());assert_eq!(*c.borrow(),0); }
+  #[test]
+  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
+    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
+    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+  }
+  #[test]
+  fn reactive_plan_rollback_truncates_pattern_registrations() {
+    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  }
+  #[test]
+  fn plan_rollback_restores_activation_registration_depth() {
+    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
+  }
+  #[test]
+  fn plan_rollback_invalid_checkpoint_is_atomic() {
+    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
+    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  }
 }
 
 
@@ -1918,30 +2020,7 @@ mod reactive_turn_tests {
   #[test] fn reactive_turn_reuses_existing_plan() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);reg(&mut p,input.clone(),sink.clone(),false);comb(&mut p,sink.clone(),Ref::new(2.),false);let len=p.len();let ids=p.nodes.iter().map(|n|n.id).collect::<Vec<_>>();let outputs=p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>();let mut s=ReactiveTurnState::default();for value in [10.,20.] {*input.borrow_mut()=value;p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(p.len(),len);assert_eq!(p.nodes.iter().map(|n|n.id).collect::<Vec<_>>(),ids);assert_eq!(p.nodes.iter().map(|n|n.outputs.clone()).collect::<Vec<_>>(),outputs);} }
   #[test] fn reactive_turn_pre_commit_failure_preserves_carried_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let(carried,solve,stage,commit)=reg(&mut p,Ref::new(2.),Ref::new(3.),false);comb(&mut p,input.clone(),Ref::new(0.),true);let mut state=ReactiveTurnState{pending_register_nodes:vec![carried]};let error=p.advance_reactive_turn(&mut state,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(error.kind_message().contains("solve failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow()),(0,0,0));assert_eq!(state.pending_register_nodes,vec![carried]); }
 
-  #[test]
-  fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
-    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
-    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
-    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
-    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
-  }
-  #[test]
-  fn reactive_plan_rollback_truncates_pattern_registrations() {
-    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
-  }
-  #[test]
-  fn plan_rollback_restores_activation_registration_depth() {
-    let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
-  }
-  #[test]
-  fn plan_rollback_invalid_checkpoint_is_atomic() {
-    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
-    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
-    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-  }
+
 
 }
 

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -409,6 +409,29 @@ impl MechFunctionCompiler for UserFunction {
 
 pub type ReactiveNodeId = usize;
 
+/// Read-only registration information for a patterned activation.
+///
+/// This belongs to the plan, rather than to a turn, so consumers can inspect
+/// the statically registered dispatch graph without relying on transient
+/// scheduler state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationRegistration {
+  pub scope_pulse_node: ReactiveNodeId,
+  pub selector_node: ReactiveNodeId,
+  pub arms: Vec<PatternActivationArmRegistration>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationArmRegistration {
+  pub matcher_node: ReactiveNodeId,
+  pub finalizer_node: ReactiveNodeId,
+  pub gate_node: ReactiveNodeId,
+  pub pulse_cell: ReactiveCellId,
+  /// Half-open range of plan nodes registered for this arm's body.
+  pub body_node_start: usize,
+  pub body_node_end: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReactiveDependencyKind {
   Reactive,
@@ -491,6 +514,7 @@ pub struct ReactivePlan {
   pub nodes: Vec<ReactivePlanNode>,
   pub reactive_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pub sampled_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
+  pattern_activation_registrations: Vec<PatternActivationRegistration>,
 }
 
 #[derive(Debug, Clone)]
@@ -594,6 +618,7 @@ impl ReactivePlan {
       nodes: Vec::new(),
       reactive_consumers: HashMap::new(),
       sampled_consumers: HashMap::new(),
+      pattern_activation_registrations: Vec::new(),
     }
   }
 
@@ -609,6 +634,7 @@ impl ReactivePlan {
     self.nodes.clear();
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
+    self.pattern_activation_registrations.clear();
   }
 
   pub fn iter(&self) -> impl Iterator<Item = &Box<dyn MechFunction>> {
@@ -789,6 +815,14 @@ impl ReactivePlan {
 
   pub fn node(&self, node_id: ReactiveNodeId) -> Option<&ReactivePlanNode> {
     self.nodes.get(node_id)
+  }
+
+  pub fn pattern_activation_registrations(&self) -> &[PatternActivationRegistration] {
+    &self.pattern_activation_registrations
+  }
+
+  pub fn register_pattern_activation(&mut self, registration: PatternActivationRegistration) {
+    self.pattern_activation_registrations.push(registration);
   }
 
   pub fn reactive_consumers_for(&self, cell: ReactiveCellId) -> &[ReactiveNodeId] {
@@ -1022,6 +1056,10 @@ impl Plan {
 
   pub fn get_functions(&self) -> std::cell::Ref<'_, ReactivePlan> {
     self.0.borrow()
+  }
+
+  pub fn pattern_activation_registrations(&self) -> std::cell::Ref<'_, Vec<PatternActivationRegistration>> {
+    std::cell::Ref::map(self.0.borrow(), |plan| &plan.pattern_activation_registrations)
   }
 
   pub fn len(&self) -> usize {

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -1919,10 +1919,23 @@ mod reactive_plan_tests {
   fn reactive_dirty_scheduler_empty_dirty_set_is_noop() { let mut p=ReactivePlan::new();let l=Rc::new(RefCell::new(vec![]));let d=scheduler_source();let(_,_,c)=scheduler_node(&mut p,"A",&[d],ReactiveNodeKind::Combinational,ReactiveSolveStatus::Changed,l,false);assert_eq!(p.solve_dirty_cells(&[]).unwrap(),ReactivePlanSolveOutcome::default());assert_eq!(*c.borrow(),0); }
   #[test]
   fn reactive_plan_rollback_truncates_nodes_and_rebuilds_consumers() {
-    let a = Value::Index(Ref::new(1)); let b = Value::Index(Ref::new(2)); let ac = a.reactive_root_cell_ids()[0]; let bc = b.reactive_root_cell_ids()[0];
-    let mut plan = ReactivePlan::new(); let base = plan.register(Box::new(TestFunction::new("base")), &[a]).unwrap(); let checkpoint = plan.checkpoint();
-    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[b]).unwrap();
-    plan.rollback(checkpoint).unwrap(); assert_eq!(plan.len(), 1); assert_eq!(plan.nodes[0].id, base); assert_eq!(plan.reactive_consumers_for(ac), &[base]); assert!(plan.sampled_consumers_for(bc).is_empty()); assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail))); assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
+    let reactive_input = Value::Index(Ref::new(1));
+    let sampled_input = Value::Index(Ref::new(2));
+    let reactive_cell = reactive_input.reactive_root_cell_ids()[0];
+    let sampled_cell = sampled_input.reactive_root_cell_ids()[0];
+    let mut plan = ReactivePlan::new();
+    let base = plan.register(Box::new(TestFunction::new("base")), &[reactive_input]).unwrap();
+    let checkpoint = plan.checkpoint();
+    let tail = plan.register(Box::new(TestFunction::new("tail").with_dependency_kinds(Some(vec![ReactiveDependencyKind::Sampled]))), &[sampled_input]).unwrap();
+    plan.rollback(checkpoint).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan.nodes[0].id, base);
+    assert_eq!(plan.nodes[0].plan_index, 0);
+    assert_eq!(plan.nodes[0].inputs, vec![ReactiveDependency { cell: reactive_cell, kind: ReactiveDependencyKind::Reactive }]);
+    assert_eq!(plan.reactive_consumers_for(reactive_cell), &[base]);
+    assert!(plan.sampled_consumers_for(sampled_cell).is_empty());
+    assert!(plan.reactive_consumers.values().all(|nodes| !nodes.contains(&tail)));
+    assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
   }
   #[test]
   fn reactive_plan_rollback_truncates_pattern_registrations() {
@@ -1938,7 +1951,9 @@ mod reactive_plan_tests {
     let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
     let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
     assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let error = plan.rollback(PlanCheckpoint { reactive: plan.borrow().checkpoint(), activation_registration_depth: depth_before + 1 }).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
+    let valid_reactive_checkpoint = { let reactive_plan = plan.borrow(); reactive_plan.checkpoint() };
+    let invalid_scope_checkpoint = PlanCheckpoint { reactive: valid_reactive_checkpoint, activation_registration_depth: depth_before + 1 };
+    let error = plan.rollback(invalid_scope_checkpoint).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
     assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
   }
 }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -621,7 +621,16 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct ReactivePlanCheckpoint { node_len:usize, pattern_activation_registration_len:usize }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub struct PlanCheckpoint { reactive:ReactivePlanCheckpoint, activation_registration_depth:usize }
+#[derive(Debug,Clone)] pub struct ReactivePlanRollbackInvariantError { pub checkpoint_nodes:usize,pub current_nodes:usize,pub checkpoint_registrations:usize,pub current_registrations:usize }
+impl MechErrorKind for ReactivePlanRollbackInvariantError { fn name(&self)->&str{"ReactivePlanRollbackInvariant"} fn message(&self)->String{format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.",self.current_nodes,self.current_registrations,self.checkpoint_nodes,self.checkpoint_registrations)} }
+
 impl ReactivePlan {
+  fn rebuild_consumer_indexes(&mut self) { self.reactive_consumers.clear(); self.sampled_consumers.clear(); for node in &self.nodes { for dependency in &node.inputs { let consumers=match dependency.kind { ReactiveDependencyKind::Reactive=>&mut self.reactive_consumers, ReactiveDependencyKind::Sampled=>&mut self.sampled_consumers }; consumers.entry(dependency.cell).or_default().push(node.id); } } }
+  pub fn checkpoint(&self)->ReactivePlanCheckpoint { ReactivePlanCheckpoint { node_len:self.nodes.len(), pattern_activation_registration_len:self.pattern_activation_registrations.len() } }
+  pub fn rollback(&mut self, checkpoint:ReactivePlanCheckpoint)->MResult<()> { if checkpoint.node_len>self.nodes.len()||checkpoint.pattern_activation_registration_len>self.pattern_activation_registrations.len(){return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.node_len,current_nodes:self.nodes.len(),checkpoint_registrations:checkpoint.pattern_activation_registration_len,current_registrations:self.pattern_activation_registrations.len()},None))} self.nodes.truncate(checkpoint.node_len);self.pattern_activation_registrations.truncate(checkpoint.pattern_activation_registration_len);self.rebuild_consumer_indexes();Ok(()) }
+
   pub fn new() -> Self {
     Self {
       nodes: Vec::new(),
@@ -1017,6 +1026,10 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
+  pub fn checkpoint(&self)->PlanCheckpoint { PlanCheckpoint { reactive:self.0.borrow().checkpoint(),activation_registration_depth:self.1.borrow().len() } }
+  pub fn rollback(&self, checkpoint:PlanCheckpoint)->MResult<()> { {let mut scopes=self.1.borrow_mut();if checkpoint.activation_registration_depth>scopes.len(){let p=self.0.borrow();return Err(MechError::new(ReactivePlanRollbackInvariantError{checkpoint_nodes:checkpoint.reactive.node_len,current_nodes:p.nodes.len(),checkpoint_registrations:checkpoint.reactive.pattern_activation_registration_len,current_registrations:p.pattern_activation_registrations.len()},None))}scopes.truncate(checkpoint.activation_registration_depth);}self.0.borrow_mut().rollback(checkpoint.reactive) }
+  pub fn activation_registration_depth(&self)->usize {self.1.borrow().len()}
+
   pub fn new() -> Self {
     Self(Ref::new(ReactivePlan::new()), Ref::new(Vec::new()))
   }

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -430,6 +430,15 @@ pub struct PatternActivationArmRegistration {
   /// Half-open range of plan nodes registered for this arm's body.
   pub body_node_start: usize,
   pub body_node_end: usize,
+  pub captures: Vec<PatternActivationCaptureRegistration>,
+}
+
+/// Stable storage made available to a single patterned activation arm.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternActivationCaptureRegistration {
+  pub id: u64,
+  pub kind: ValueKind,
+  pub cell: ReactiveCellId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -1022,7 +1022,7 @@ impl ConstElem for Value {
     }
   }
   fn value_kind(&self) -> ValueKind {
-    self.value_kind()
+    self.kind()
   }
   fn align() -> u8 {
     1
@@ -1185,6 +1185,19 @@ impl ConstElem for ValueKind {
         }
         let row_count = cursor.read_u32::<LittleEndian>().expect("read table row count") as usize;
         ValueKind::Table(fields, row_count)
+      }
+      #[cfg(feature = "tuple")]
+      27 => {
+        let element_count = cursor.read_u32::<LittleEndian>().expect("read tuple kind length") as usize;
+        let mut elements = Vec::with_capacity(element_count);
+        for _ in 0..element_count {
+          let kind = ValueKind::from_le(&bytes[cursor.position() as usize..]);
+          let mut encoded = Vec::new();
+          kind.write_le(&mut encoded);
+          cursor.set_position(cursor.position() + encoded.len() as u64);
+          elements.push(kind);
+        }
+        ValueKind::Tuple(elements)
       }
       #[cfg(feature = "set")]
       29 => {

--- a/src/core/src/program/program.rs
+++ b/src/core/src/program/program.rs
@@ -460,6 +460,14 @@ impl ParsedProgram {
           let table = MechTable::from_le(&data);
           Value::Table(Ref::new(table))
         }
+        #[cfg(feature = "tuple")]
+        TypeTag::Tuple => {
+          if data.len() < 4 {
+            return Err(MechError::new(ConstantTooShortError { type_name: "tuple" }, None).with_compiler_loc());
+          }
+          let tuple = MechTuple::from_le(&data);
+          Value::Tuple(Ref::new(tuple))
+        }
         _ => {
           return Err(
             MechError::new(

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -5,8 +5,13 @@ use crate::*;
 
 pub type SymbolTableRef= Ref<SymbolTable>;
 
-#[derive(Clone, Debug)]
-pub struct SymbolTableSnapshot { symbols: HashMap<u64, ValRef>, mutable_variables: HashMap<u64, ValRef>, dictionary: Dictionary, reverse_lookup: HashMap<*const Ref<Value>, u64> }
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SymbolTableSnapshot {
+  symbols: HashMap<u64, ValRef>,
+  mutable_variables: HashMap<u64, ValRef>,
+  dictionary: Dictionary,
+  reverse_lookup: HashMap<*const Ref<Value>, u64>,
+}
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
@@ -17,8 +22,21 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
-  pub fn snapshot(&self) -> SymbolTableSnapshot { SymbolTableSnapshot { symbols:self.symbols.clone(), mutable_variables:self.mutable_variables.clone(), dictionary:self.dictionary.borrow().clone(), reverse_lookup:self.reverse_lookup.clone() } }
-  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) { self.symbols=snapshot.symbols; self.mutable_variables=snapshot.mutable_variables; *self.dictionary.borrow_mut()=snapshot.dictionary; self.reverse_lookup=snapshot.reverse_lookup; }
+  pub fn snapshot(&self) -> SymbolTableSnapshot {
+    SymbolTableSnapshot {
+      symbols: self.symbols.clone(),
+      mutable_variables: self.mutable_variables.clone(),
+      dictionary: self.dictionary.borrow().clone(),
+      reverse_lookup: self.reverse_lookup.clone(),
+    }
+  }
+
+  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) {
+    self.symbols = snapshot.symbols;
+    self.mutable_variables = snapshot.mutable_variables;
+    *self.dictionary.borrow_mut() = snapshot.dictionary;
+    self.reverse_lookup = snapshot.reverse_lookup;
+  }
 
 
   pub fn new() -> SymbolTable {
@@ -56,6 +74,35 @@ impl SymbolTable {
     cell.clone()
   }
 
+}
+
+#[cfg(test)]
+mod snapshot_tests {
+  use super::*;
+
+  #[test]
+  fn symbol_table_snapshot_restores_all_indexes_and_identity() {
+    let mut table = SymbolTable::new();
+    let outer = hash_str("outer");
+    let temporary = hash_str("temporary");
+    let outer_ref = table.insert(outer, Value::Index(Ref::new(1)), true);
+    table.dictionary.borrow_mut().insert(outer, "outer".to_string());
+    let outer_addr = outer_ref.addr();
+    let original_snapshot = table.snapshot();
+
+    table.insert(outer, Value::Index(Ref::new(2)), false);
+    table.insert(temporary, Value::Index(Ref::new(3)), false);
+    table.dictionary.borrow_mut().insert(outer, "changed".to_string());
+    table.dictionary.borrow_mut().insert(temporary, "temporary".to_string());
+    assert_ne!(table.snapshot(), original_snapshot);
+
+    table.restore(original_snapshot.clone());
+    assert_eq!(table.snapshot(), original_snapshot);
+    assert!(!table.contains(temporary));
+    assert!(table.get_mutable(outer).is_some());
+    assert_eq!(table.get(outer).unwrap().addr(), outer_addr);
+    assert_eq!(table.get_symbol_name_by_id(outer).as_deref(), Some("outer"));
+  }
 }
 
 #[cfg(feature = "pretty_print")]

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -1,9 +1,12 @@
 use crate::*;
 
-// Symbol Table 
+// Symbol Table
 // ----------------------------------------------------------------------------
 
 pub type SymbolTableRef= Ref<SymbolTable>;
+
+#[derive(Clone, Debug)]
+pub struct SymbolTableSnapshot { symbols: HashMap<u64, ValRef>, mutable_variables: HashMap<u64, ValRef>, dictionary: Dictionary, reverse_lookup: HashMap<*const Ref<Value>, u64> }
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
@@ -14,6 +17,9 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
+  pub fn snapshot(&self) -> SymbolTableSnapshot { SymbolTableSnapshot { symbols:self.symbols.clone(), mutable_variables:self.mutable_variables.clone(), dictionary:self.dictionary.borrow().clone(), reverse_lookup:self.reverse_lookup.clone() } }
+  pub fn restore(&mut self, snapshot: SymbolTableSnapshot) { self.symbols=snapshot.symbols; self.mutable_variables=snapshot.mutable_variables; *self.dictionary.borrow_mut()=snapshot.dictionary; self.reverse_lookup=snapshot.reverse_lookup; }
+
 
   pub fn new() -> SymbolTable {
     Self {

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1254,6 +1254,8 @@ impl Value {
       Value::Set(r) => &*(r as *const Ref<MechSet> as *const Ref<T>),
       #[cfg(feature = "table")]
       Value::Table(r) => &*(r as *const Ref<MechTable> as *const Ref<T>),
+      #[cfg(feature = "tuple")]
+      Value::Tuple(r) => &*(r as *const Ref<MechTuple> as *const Ref<T>),
       x => panic!("Unsupported type for as_unchecked: {:?}.", x),
     }
   }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -16,23 +16,52 @@ activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cel
 #[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
 #[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
 fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
-fn slot(v:&Value)->Option<Value> { match detached(v) {
-  Value::F64(_)=>Some(Value::F64(Ref::new(0.))), Value::F32(_)=>Some(Value::F32(Ref::new(0.))),
-  Value::I64(_)=>Some(Value::I64(Ref::new(0))), Value::I32(_)=>Some(Value::I32(Ref::new(0))), Value::I16(_)=>Some(Value::I16(Ref::new(0))), Value::I8(_)=>Some(Value::I8(Ref::new(0))),
-  Value::U64(_)=>Some(Value::U64(Ref::new(0))), Value::U32(_)=>Some(Value::U32(Ref::new(0))), Value::U16(_)=>Some(Value::U16(Ref::new(0))), Value::U8(_)=>Some(Value::U8(Ref::new(0))),
-  Value::Bool(_)=>Some(Value::Bool(Ref::new(false))), Value::String(_)=>Some(Value::String(Ref::new(String::new()))), Value::Index(_)=>Some(Value::Index(Ref::new(0))), Value::Atom(a)=>Some(Value::Atom(Ref::new(a.borrow().clone()))), _=>None } }
-fn compile(pat:&Pattern, sample:&Value, i:&Interpreter, caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern> { match pat {
- Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}),
- Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash(); if let Some(n)=caps.iter().position(|c|c.id==id){return Ok(CompiledActivationPattern::Capture{capture_index:n})}; let value=slot(sample).ok_or_else(||MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))?; caps.push(Capture{id,kind:sample.kind(),slot:value}); Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})},
- Pattern::Tuple(t)=> {let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; let e=&tv.borrow().elements; if e.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(e.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
- Pattern::TupleStruct(t)=> { let tag=t.name.hash(); let payload=match detached(sample) { Value::Enum(e)=>{let e=e.borrow(); e.variants.iter().find(|(id,_)|*id==tag).and_then(|(_,x)|x.as_ref()).cloned().into_iter().collect::<Vec<_>>()}, Value::Tuple(x)=>{let x=x.borrow(); if x.elements.first().map(|v|matches!(detached(v),Value::Atom(a) if a.borrow().id()==tag)).unwrap_or(false){x.elements.iter().skip(1).map(|v|(**v).clone()).collect()}else{Vec::new()}}, _=>Vec::new()}; if payload.len()!=t.patterns.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::TupleStruct{tag,payload:t.patterns.iter().zip(payload.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
- _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens())) }}
-fn matches_pattern(p:&CompiledActivationPattern,v:&Value, proposed:&mut Vec<Option<Value>>)->bool {match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}},CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false},CompiledActivationPattern::TupleStruct{tag,payload}=>match detached(v){Value::Enum(e)=>{let e=e.borrow();match e.variants.iter().find(|(id,_)|id==tag){Some((_,Some(v))) if payload.len()==1=>matches_pattern(&payload[0],v,proposed),Some((_,None))=>payload.is_empty(),_=>false}},Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==payload.len()+1&&matches!(detached(&t.elements[0]),Value::Atom(a) if a.borrow().id()==*tag)&&payload.iter().zip(t.elements.iter().skip(1)).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}}}
-macro_rules! copy_slot {($s:expr,$v:expr,$($x:ident),*)=>{match ($s,$v){$((Value::$x(a),Value::$x(b))=>{*a.borrow_mut()=*b.borrow();Ok(())},)* _=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}}
-fn commit(s:&Value,v:&Value)->MResult<()> {copy_slot!(s,detached(v),F64,F32,I64,I32,I16,I8,U64,U32,U16,U8,Bool,String,Index,Atom)}
+fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) { let source=source.borrow(); destination.borrow_mut().clone_from(&*source); }
+fn create_capture_slot(sample:&Value)->MResult<Value>{match detached(sample){
+#[cfg(feature="u8")] Value::U8(v)=>Ok(Value::U8(Ref::new(*v.borrow()))),
+#[cfg(feature="u16")] Value::U16(v)=>Ok(Value::U16(Ref::new(*v.borrow()))),
+#[cfg(feature="u32")] Value::U32(v)=>Ok(Value::U32(Ref::new(*v.borrow()))),
+#[cfg(feature="u64")] Value::U64(v)=>Ok(Value::U64(Ref::new(*v.borrow()))),
+#[cfg(feature="u128")] Value::U128(v)=>Ok(Value::U128(Ref::new(*v.borrow()))),
+#[cfg(feature="i8")] Value::I8(v)=>Ok(Value::I8(Ref::new(*v.borrow()))),
+#[cfg(feature="i16")] Value::I16(v)=>Ok(Value::I16(Ref::new(*v.borrow()))),
+#[cfg(feature="i32")] Value::I32(v)=>Ok(Value::I32(Ref::new(*v.borrow()))),
+#[cfg(feature="i64")] Value::I64(v)=>Ok(Value::I64(Ref::new(*v.borrow()))),
+#[cfg(feature="i128")] Value::I128(v)=>Ok(Value::I128(Ref::new(*v.borrow()))),
+#[cfg(feature="f32")] Value::F32(v)=>Ok(Value::F32(Ref::new(*v.borrow()))),
+#[cfg(feature="f64")] Value::F64(v)=>Ok(Value::F64(Ref::new(*v.borrow()))),
+#[cfg(feature="complex")] Value::C64(v)=>Ok(Value::C64(Ref::new(v.borrow().clone()))),
+#[cfg(feature="rational")] Value::R64(v)=>Ok(Value::R64(Ref::new(v.borrow().clone()))),
+#[cfg(any(feature="bool",feature="variable_define"))] Value::Bool(v)=>Ok(Value::Bool(Ref::new(*v.borrow()))),
+#[cfg(any(feature="string",feature="variable_define"))] Value::String(v)=>Ok(Value::String(Ref::new(v.borrow().clone()))),
+Value::Index(v)=>Ok(Value::Index(Ref::new(*v.borrow()))),
+#[cfg(feature="atom")] Value::Atom(v)=>Ok(Value::Atom(Ref::new(v.borrow().clone()))),
+_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
+fn commit_capture_slot(destination:&Value,source:&Value)->MResult<()>{let source=detached(source);match(destination,&source){
+#[cfg(feature="u8")] (Value::U8(a),Value::U8(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u16")] (Value::U16(a),Value::U16(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u32")] (Value::U32(a),Value::U32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u64")] (Value::U64(a),Value::U64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="u128")] (Value::U128(a),Value::U128(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i8")] (Value::I8(a),Value::I8(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i16")] (Value::I16(a),Value::I16(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i32")] (Value::I32(a),Value::I32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i64")] (Value::I64(a),Value::I64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="i128")] (Value::I128(a),Value::I128(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="f32")] (Value::F32(a),Value::F32(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="f64")] (Value::F64(a),Value::F64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="complex")] (Value::C64(a),Value::C64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="rational")] (Value::R64(a),Value::R64(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(any(feature="bool",feature="variable_define"))] (Value::Bool(a),Value::Bool(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(any(feature="string",feature="variable_define"))] (Value::String(a),Value::String(b))=>{clone_ref_value(a,b);Ok(())},
+(Value::Index(a),Value::Index(b))=>{clone_ref_value(a,b);Ok(())},
+#[cfg(feature="atom")] (Value::Atom(a),Value::Atom(b))=>{clone_ref_value(a,b);Ok(())},
+_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
+fn compile(pat:&Pattern,sample:&Value,i:&Interpreter,caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern>{match pat { Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}), Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash();if let Some(n)=caps.iter().position(|c|c.id==id){Ok(CompiledActivationPattern::Capture{capture_index:n})}else{let value=create_capture_slot(sample).map_err(|e|e.with_tokens(pat.tokens()))?;caps.push(Capture{id,kind:sample.kind(),slot:value});Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})}}, #[cfg(feature="tuple")] Pattern::Tuple(t)=>{let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))};let tv=tv.borrow();if tv.elements.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(tv.elements.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})}, _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens()))}}
+fn matches_pattern(p:&CompiledActivationPattern,v:&Value,proposed:&mut Vec<Option<Value>>)->bool{match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}}, #[cfg(feature="tuple")] CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}, CompiledActivationPattern::TupleStruct{..}=>false, #[cfg(not(feature="tuple"))] CompiledActivationPattern::Tuple{..}=>false}}
 fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
 struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
-struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
+struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit_capture_slot(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
 struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
 struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
 struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1214,4 +1214,690 @@ mod tests {
             commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
     }
+
+    type PlanSnapshot = (
+        usize,
+        Vec<(
+            ReactiveNodeId,
+            usize,
+            ReactiveNodeKind,
+            Vec<u64>,
+            Vec<(u64, ReactiveDependencyKind)>,
+        )>,
+        Vec<(u64, Vec<ReactiveNodeId>)>,
+        Vec<(u64, Vec<ReactiveNodeId>)>,
+        Vec<PatternActivationRegistration>,
+        usize,
+    );
+
+    fn interpret(source: &str) -> Interpreter {
+        let tree = mech_syntax::parser::parse(source).unwrap();
+        let mut interpreter = Interpreter::new_with_full_stdlib(0);
+        interpreter.interpret(&tree).unwrap();
+        interpreter
+    }
+
+    fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MResult<Value> {
+        let tree = mech_syntax::parser::parse(source).unwrap();
+        interpreter.interpret(&tree)
+    }
+
+    fn symbol_ref(interpreter: &Interpreter, name: &str) -> ValRef {
+        interpreter
+            .symbols()
+            .borrow()
+            .get(hash_str(name))
+            .unwrap_or_else(|| panic!("missing symbol `{name}`"))
+    }
+    fn symbol(interpreter: &Interpreter, name: &str) -> Value {
+        symbol_ref(interpreter, name).borrow().clone()
+    }
+    fn root_cell(interpreter: &Interpreter, name: &str) -> ReactiveCellId {
+        symbol(interpreter, name).reactive_root_cell_ids()[0]
+    }
+    fn registration(interpreter: &Interpreter) -> PatternActivationRegistration {
+        let plan = interpreter.plan();
+        let registrations = plan.pattern_activation_registrations();
+        assert_eq!(registrations.len(), 1);
+        registrations[0].clone()
+    }
+    fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
+        let plan = interpreter.plan();
+        let depth = plan.activation_registration_depth();
+        let plan = plan.borrow();
+        let nodes = plan
+            .nodes
+            .iter()
+            .map(|node| {
+                (
+                    node.id,
+                    node.plan_index,
+                    node.kind,
+                    node.outputs.iter().map(|cell| cell.get()).collect(),
+                    node.inputs
+                        .iter()
+                        .map(|dependency| (dependency.cell.get(), dependency.kind))
+                        .collect(),
+                )
+            })
+            .collect();
+        let mut reactive = plan
+            .reactive_consumers
+            .iter()
+            .map(|(cell, nodes)| (cell.get(), nodes.clone()))
+            .collect::<Vec<_>>();
+        reactive.sort_by_key(|(cell, _)| *cell);
+        let mut sampled = plan
+            .sampled_consumers
+            .iter()
+            .map(|(cell, nodes)| (cell.get(), nodes.clone()))
+            .collect::<Vec<_>>();
+        sampled.sort_by_key(|(cell, _)| *cell);
+        (
+            plan.len(),
+            nodes,
+            reactive,
+            sampled,
+            plan.pattern_activation_registrations().to_vec(),
+            depth,
+        )
+    }
+    fn turn_executed_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .executed_nodes
+            .iter()
+            .chain(outcome.after_commit.executed_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn turn_changed_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .changed_nodes
+            .iter()
+            .chain(outcome.after_commit.changed_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn turn_unchanged_nodes(outcome: &ReactiveTurnOutcome) -> Vec<ReactiveNodeId> {
+        outcome
+            .before_commit
+            .unchanged_nodes
+            .iter()
+            .chain(outcome.after_commit.unchanged_nodes.iter())
+            .copied()
+            .collect()
+    }
+    fn body_output_f64(interpreter: &Interpreter, arm_index: usize) -> f64 {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm_index];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        for id in (arm.body_node_start..arm.body_node_end).rev() {
+            if let Ok(value) = plan.node(id).unwrap().function.out().as_f64() {
+                return *value.borrow();
+            }
+        }
+        panic!("no f64 output")
+    }
+    fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
+        match symbol(interpreter, "event") {
+            Value::Enum(event) => {
+                let id = event.borrow().id;
+                let names = interpreter
+                    .state
+                    .borrow()
+                    .enums
+                    .get(&id)
+                    .unwrap()
+                    .names
+                    .clone();
+                *event.borrow_mut() = MechEnum {
+                    id,
+                    variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
+                    names,
+                };
+            }
+            Value::Tuple(_) => set_atom_tuple_event(interpreter, variant, payload),
+            _ => panic!("event is neither enum nor tagged tuple"),
+        }
+    }
+    fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
+        let Value::Tuple(event) = symbol(interpreter, "event") else {
+            panic!("event is not tuple")
+        };
+        *event.borrow_mut() = MechTuple::from_vec(vec![
+            Value::Atom(Ref::new(MechAtom::from_name(tag))),
+            Value::F64(Ref::new(payload)),
+        ]);
+    }
+    fn set_tuple_event(interpreter: &Interpreter, values: Vec<Value>) {
+        let Value::Tuple(event) = symbol(interpreter, "event") else {
+            panic!("event is not tuple")
+        };
+        *event.borrow_mut() = MechTuple::from_vec(values);
+    }
+    fn selected_arm_index(
+        registration: &PatternActivationRegistration,
+        outcome: &ReactiveTurnOutcome,
+    ) -> usize {
+        let changed = turn_changed_nodes(outcome);
+        registration
+            .arms
+            .iter()
+            .position(|arm| changed.contains(&arm.gate_node))
+            .expect("no selected gate")
+    }
+    fn assert_dispatch_turn(
+        interpreter: &Interpreter,
+        topology: &PlanSnapshot,
+        outcome: &ReactiveTurnOutcome,
+        expected_arm: usize,
+        output: f64,
+    ) {
+        let registration = registration(interpreter);
+        let executed = turn_executed_nodes(outcome);
+        let changed = turn_changed_nodes(outcome);
+        let unchanged = turn_unchanged_nodes(outcome);
+        assert_eq!(
+            executed
+                .iter()
+                .filter(|id| **id == registration.scope_pulse_node)
+                .count(),
+            1
+        );
+        assert_eq!(
+            executed
+                .iter()
+                .filter(|id| **id == registration.selector_node)
+                .count(),
+            1
+        );
+        assert_eq!(selected_arm_index(&registration, outcome), expected_arm);
+        for (index, arm) in registration.arms.iter().enumerate() {
+            for node in [arm.matcher_node, arm.finalizer_node, arm.gate_node] {
+                assert_eq!(executed.iter().filter(|id| **id == node).count(), 1);
+            }
+            if index == expected_arm {
+                assert!(changed.contains(&arm.gate_node));
+                assert!(!unchanged.contains(&arm.gate_node));
+                for node in arm.body_node_start..arm.body_node_end {
+                    assert_eq!(executed.iter().filter(|id| **id == node).count(), 1);
+                }
+            } else {
+                assert!(unchanged.contains(&arm.gate_node));
+                assert!(!changed.contains(&arm.gate_node));
+                for node in arm.body_node_start..arm.body_node_end {
+                    assert!(!executed.contains(&node));
+                }
+            }
+        }
+        assert_eq!(body_output_f64(interpreter, expected_arm), output);
+        assert_eq!(&plan_snapshot(interpreter), topology);
+    }
+
+    const ENUM_ACTIVATION: &str = r#"event := (:pressed, 0.0)
+
+~> event
+  | :pressed(x) => {
+      selected := x + 0.0
+    }
+  | :released(x) => {
+      selected := x + 1000.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn load_enum_activation() -> (
+        Interpreter,
+        ReactiveCellId,
+        PatternActivationRegistration,
+        PlanSnapshot,
+    ) {
+        let interpreter = interpret(ENUM_ACTIVATION);
+        let trigger = root_cell(&interpreter, "event");
+        let registration = registration(&interpreter);
+        assert_eq!(registration.arms.len(), 3);
+        assert_eq!(registration.arms[0].captures.len(), 1);
+        assert_eq!(registration.arms[1].captures.len(), 1);
+        assert!(registration.arms[2].captures.is_empty());
+        assert!(!interpreter.symbols().borrow().contains(hash_str("x")));
+        assert!(
+            !interpreter
+                .symbols()
+                .borrow()
+                .contains(hash_str("selected"))
+        );
+        let topology = plan_snapshot(&interpreter);
+        (interpreter, trigger, registration, topology)
+    }
+
+    #[test]
+    fn activation_pattern_selects_pressed_released_and_wildcard() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        for (name, payload, arm, output) in [
+            ("pressed", 10., 0, 10.),
+            ("released", 20., 1, 1020.),
+            ("other", 30., 2, -1.),
+        ] {
+            set_enum_event(&i, name, payload);
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, arm, output);
+        }
+    }
+    #[test]
+    fn activation_pattern_enum_arms_compile_independent_of_initial_variant() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        assert_eq!(r.arms[1].captures[0].kind, ValueKind::F64);
+        set_enum_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+    }
+    #[test]
+    fn activation_pattern_enum_payload_capture_is_available() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        let cell = r.arms[0].captures[0].cell;
+        assert!(
+            i.plan().borrow().nodes[r.arms[0].body_node_start..r.arms[0].body_node_end]
+                .iter()
+                .any(|n| n.inputs.iter().any(|d| d.cell == cell))
+        );
+        set_enum_event(&i, "pressed", 10.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 10.);
+    }
+    #[test]
+    fn activation_pattern_equal_packets_dispatch_repeatedly() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        set_enum_event(&i, "pressed", 30.);
+        for _ in 0..2 {
+            let o = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &o, 0, 30.);
+        }
+    }
+    #[test]
+    fn activation_pattern_unselected_arm_nodes_do_not_execute() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        set_enum_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+        let executed = turn_executed_nodes(&o);
+        for arm in [&r.arms[0], &r.arms[2]] {
+            for node in arm.body_node_start..arm.body_node_end {
+                assert!(!executed.contains(&node));
+            }
+        }
+    }
+    #[test]
+    fn activation_pattern_switching_arms_does_not_grow_plan() {
+        let (mut i, trigger, _, topology) = load_enum_activation();
+        for (name, payload) in [
+            ("pressed", 10.),
+            ("released", 20.),
+            ("other", 30.),
+            ("pressed", 30.),
+            ("pressed", 30.),
+        ] {
+            set_enum_event(&i, name, payload);
+            i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+    #[test]
+    fn activation_pattern_capture_storage_identity_is_stable() {
+        let (mut i, trigger, r, topology) = load_enum_activation();
+        let captures = r
+            .arms
+            .iter()
+            .flat_map(|arm| arm.captures.iter())
+            .map(|capture| (capture.id, capture.kind.clone(), capture.cell))
+            .collect::<Vec<_>>();
+        for (name, payload) in [("pressed", 10.), ("released", 20.), ("other", 30.)] {
+            set_enum_event(&i, name, payload);
+            i.advance_reactive_turn(&[trigger]).unwrap();
+            let current = registration(&i)
+                .arms
+                .iter()
+                .flat_map(|arm| arm.captures.iter())
+                .map(|capture| (capture.id, capture.kind.clone(), capture.cell))
+                .collect::<Vec<_>>();
+            assert_eq!(current, captures);
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+
+    const ATOM_TUPLE_ACTIVATION: &str = r#"
+event := (:pressed, 0.0)
+~> event
+  | :pressed(x) => {
+      selected := x + 0.0
+    }
+  | :released(x) => {
+      selected := x + 1000.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn load_atom_tuple_activation() -> (
+        Interpreter,
+        ReactiveCellId,
+        PatternActivationRegistration,
+        PlanSnapshot,
+    ) {
+        let i = interpret(ATOM_TUPLE_ACTIVATION);
+        let trigger = root_cell(&i, "event");
+        let r = registration(&i);
+        let topology = plan_snapshot(&i);
+        (i, trigger, r, topology)
+    }
+    #[test]
+    fn activation_pattern_atom_tagged_tuple_selects_arm() {
+        let (mut i, trigger, _, topology) = load_atom_tuple_activation();
+        for (tag, payload, arm, output) in [
+            ("pressed", 10., 0, 10.),
+            ("released", 20., 1, 1020.),
+            ("other", 30., 2, -1.),
+        ] {
+            set_atom_tuple_event(&i, tag, payload);
+            let o = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &o, arm, output);
+        }
+    }
+    #[test]
+    fn activation_pattern_atom_tagged_tuple_captures_payload() {
+        let (mut i, trigger, r, topology) = load_atom_tuple_activation();
+        assert_eq!(r.arms[0].captures[0].kind, ValueKind::F64);
+        let cell = r.arms[0].captures[0].cell;
+        assert!(
+            i.plan().borrow().nodes[r.arms[0].body_node_start..r.arms[0].body_node_end]
+                .iter()
+                .any(|n| n.inputs.iter().any(|d| d.cell == cell))
+        );
+        set_atom_tuple_event(&i, "pressed", 10.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 10.);
+    }
+    #[test]
+    fn activation_pattern_atom_tuple_arms_compile_independent_of_initial_tag() {
+        let (mut i, trigger, r, topology) = load_atom_tuple_activation();
+        assert_eq!(r.arms[0].captures[0].kind, ValueKind::F64);
+        assert_eq!(r.arms[1].captures[0].kind, ValueKind::F64);
+        set_atom_tuple_event(&i, "released", 20.);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, 1020.);
+    }
+
+    const FLAT_TUPLE_ACTIVATION: &str = r#"
+event := (1.0, 2.0)
+~> event
+  | (x, y) => {
+      selected := x * 10.0 + y
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    const NESTED_TUPLE_ACTIVATION: &str = r#"
+event := ((1.0, 2.0), 3.0)
+~> event
+  | ((x, y), z) => {
+      selected := x * 100.0 + y * 10.0 + z
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    const REPEATED_CAPTURE_ACTIVATION: &str = r#"
+event := (1.0, 1.0)
+~> event
+  | (x, x) => {
+      selected := x
+    }
+  | * => {
+      selected := -1.0
+    }
+"#;
+    fn tuple_fixture(source: &str) -> (Interpreter, ReactiveCellId, PlanSnapshot) {
+        let i = interpret(source);
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        (i, trigger, topology)
+    }
+    #[test]
+    fn activation_pattern_tuple_captures_elements() {
+        let (mut i, trigger, topology) = tuple_fixture(FLAT_TUPLE_ACTIVATION);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 34.);
+    }
+    #[test]
+    fn activation_pattern_nested_tuple_captures_elements() {
+        let (mut i, trigger, topology) = tuple_fixture(NESTED_TUPLE_ACTIVATION);
+        set_tuple_event(
+            &i,
+            vec![
+                Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                    Value::F64(Ref::new(4.)),
+                    Value::F64(Ref::new(5.)),
+                ]))),
+                Value::F64(Ref::new(6.)),
+            ],
+        );
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 456.);
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_requires_equal_values() {
+        let (mut i, trigger, topology) = tuple_fixture(REPEATED_CAPTURE_ACTIVATION);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(2.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 2.);
+        set_tuple_event(&i, vec![Value::F64(Ref::new(2.)), Value::F64(Ref::new(3.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 1, -1.);
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_kind_mismatch_is_structured() {
+        let mut i = interpret("event := (1.0, \"one\")");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, x) => {
+      selected := x
+    }\n  | * => {
+      selected := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("x")));
+        assert!(!i.symbols().borrow().contains(hash_str("selected")));
+    }
+
+    #[test]
+    fn activation_pattern_capture_does_not_leak() {
+        let (mut i, trigger, topology) = tuple_fixture(FLAT_TUPLE_ACTIVATION);
+        for name in ["x", "y", "selected"] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 34.);
+    }
+    #[test]
+    fn activation_pattern_capture_shadows_and_restores_outer_symbol() {
+        let mut i = interpret("event := (1.0, 2.0)\nx := 99.0");
+        let outer = symbol_ref(&i, "x");
+        let address = outer.addr();
+        interpret_more(
+            &mut i,
+            "~> event\n  | (x, y) => {
+      selected := x + y
+    }\n  | * => {
+      selected := -1.0
+    }",
+        )
+        .unwrap();
+        assert_eq!(*symbol(&i, "x").as_f64().unwrap().borrow(), 99.);
+        assert_eq!(symbol_ref(&i, "x").addr(), address);
+        assert!(!i.symbols().borrow().contains(hash_str("y")));
+        assert!(!i.symbols().borrow().contains(hash_str("selected")));
+        let topology = plan_snapshot(&i);
+        let trigger = root_cell(&i, "event");
+        set_tuple_event(&i, vec![Value::F64(Ref::new(3.)), Value::F64(Ref::new(4.))]);
+        let o = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &o, 0, 7.);
+    }
+    #[test]
+    fn activation_pattern_arm_definitions_do_not_leak_between_arms() {
+        let mut i = interpret("event := (1.0, 2.0)");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, y) => {
+      first-local := x + y
+    }\n  | (a, b) => {
+      second-local := first-local + a + b
+    }\n  | * => {
+      fallback := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "UndefinedVariable");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        for name in [
+            "first-local",
+            "second-local",
+            "fallback",
+            "x",
+            "y",
+            "a",
+            "b",
+        ] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+    }
+
+    fn failed_elaboration_fixture() -> (
+        Interpreter,
+        SymbolTableSnapshot,
+        Dictionary,
+        PlanSnapshot,
+        ValRef,
+        usize,
+    ) {
+        let i = interpret("event := (1.0, 2.0)\nouter := 99.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let outer = symbol_ref(&i, "outer");
+        let address = outer.addr();
+        (i, symbols, dictionary, topology, outer, address)
+    }
+    fn assert_failed_elaboration_restored() -> (
+        Interpreter,
+        SymbolTableSnapshot,
+        Dictionary,
+        PlanSnapshot,
+        usize,
+    ) {
+        let (mut i, symbols, dictionary, topology, outer, address) = failed_elaboration_fixture();
+        let error=interpret_more(&mut i,"~> event\n  | (x, y) => {\n      local-atom := :temporary\n      local-first := x + y\n      local-failure := function-that-does-not-exist(local-first)\n    }\n  | * => {
+      fallback := 0.0
+    }").unwrap_err();
+        assert!(error.kind_name().contains("Function"));
+        assert!(!i.dictionary().borrow().contains_key(&hash_str("temporary")));
+        for name in [
+            "local-atom",
+            "local-first",
+            "local-failure",
+            "fallback",
+            "x",
+            "y",
+        ] {
+            assert!(!i.symbols().borrow().contains(hash_str(name)));
+        }
+        assert_eq!(*symbol(&i, "outer").as_f64().unwrap().borrow(), 99.);
+        assert_eq!(symbol_ref(&i, "outer").addr(), address);
+        drop(outer);
+        (i, symbols, dictionary, topology, address)
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_symbol_table() {
+        let (i, symbols, _, _, _) = assert_failed_elaboration_restored();
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_program_dictionary() {
+        let (i, _, dictionary, _, _) = assert_failed_elaboration_restored();
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+    }
+    #[test]
+    fn activation_pattern_elaboration_error_restores_plan() {
+        let (i, _, _, topology, _) = assert_failed_elaboration_restored();
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+    #[test]
+    fn activation_pattern_preflight_error_does_not_modify_plan() {
+        let mut i = interpret("event := (1.0, \"one\")");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | (x, x) => {
+      selected := x
+    }\n  | * => {
+      selected := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+    }
+    #[test]
+    fn activation_pattern_recursive_preflight_rejects_nested_activation() {
+        let mut i = interpret("event := 1.0\ntick := 0.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | 1.0 => {\n      ~> tick {\n        nested := 1.0\n      }\n    }\n  | * => {\n      fallback := 0.0\n    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternDefinitionUnsupported");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("nested")));
+        assert!(!i.symbols().borrow().contains(hash_str("fallback")));
+    }
+    #[test]
+    fn activation_pattern_recursive_preflight_rejects_context_declaration() {
+        let mut i = interpret("event := 1.0");
+        let symbols = i.symbols().borrow().snapshot();
+        let dictionary = i.dictionary().borrow().clone();
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            "~> event\n  | 1.0 => {
+      @temporary := test://resource
+    }\n  | * => {
+      fallback := 0.0
+    }",
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternDefinitionUnsupported");
+        assert_eq!(i.symbols().borrow().snapshot(), symbols);
+        assert_eq!(*i.dictionary().borrow(), dictionary);
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("fallback")));
+    }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,99 +1,59 @@
-#![cfg(all(
-  feature = "functions",
-  feature = "symbol_table",
-))]
-
-//! Static scheduling support for patterned activation scopes.
-//!
-//! The small dispatch nodes in this file deliberately contain no syntax and
-//! are registered once while a source tree is elaborated.  A reactive turn
-//! only moves generation counters through that already-built graph.
-
+#![cfg(all(feature = "functions", feature = "symbol_table"))]
+//! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
 
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternExpressionUnsupported;
-impl MechErrorKind for ActivationPatternExpressionUnsupported { fn name(&self)->&str{"ActivationPatternExpressionUnsupported"} fn message(&self)->String{"This activation pattern is not supported.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternCaptureKindUnsupported;
-impl MechErrorKind for ActivationPatternCaptureKindUnsupported { fn name(&self)->&str{"ActivationPatternCaptureKindUnsupported"} fn message(&self)->String{"The capture kind cannot be inferred from the activation trigger.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternArmsNonExhaustive;
-impl MechErrorKind for ActivationPatternArmsNonExhaustive { fn name(&self)->&str{"ActivationPatternArmsNonExhaustive"} fn message(&self)->String{"Patterned activations require a final unguarded wildcard arm.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternWildcardMustBeLast;
-impl MechErrorKind for ActivationPatternWildcardMustBeLast { fn name(&self)->&str{"ActivationPatternWildcardMustBeLast"} fn message(&self)->String{"The wildcard activation arm must be last.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternGuardMustBePure;
-impl MechErrorKind for ActivationPatternGuardMustBePure { fn name(&self)->&str{"ActivationPatternGuardMustBePure"} fn message(&self)->String{"Patterned activation guards must be pure.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternRegisterWriteUnsupported;
-impl MechErrorKind for ActivationPatternRegisterWriteUnsupported { fn name(&self)->&str{"ActivationPatternRegisterWriteUnsupported"} fn message(&self)->String{"Patterned activation register writes are not supported.".into()} }
-#[derive(Debug, Clone)] pub(crate) struct ActivationPatternContextEffectUnsupported;
-impl MechErrorKind for ActivationPatternContextEffectUnsupported { fn name(&self)->&str{"ActivationPatternContextEffectUnsupported"} fn message(&self)->String{"Patterned activation context effects are not supported.".into()} }
+macro_rules! activation_error {($n:ident,$m:expr)=>{#[derive(Debug,Clone)] pub(crate) struct $n; impl MechErrorKind for $n {fn name(&self)->&str{stringify!($n)} fn message(&self)->String{$m.into()}}};}
+activation_error!(ActivationPatternExpressionUnsupported,"This activation pattern is not supported.");
+activation_error!(ActivationPatternCaptureKindUnsupported,"The capture kind cannot be inferred from the activation trigger.");
+activation_error!(ActivationPatternArmsNonExhaustive,"Patterned activations require a final unguarded wildcard arm.");
+activation_error!(ActivationPatternWildcardMustBeLast,"The wildcard activation arm must be last.");
+activation_error!(ActivationPatternGuardMustBePure,"Patterned activation guards are not supported yet.");
+activation_error!(ActivationPatternRegisterWriteUnsupported,"Patterned activation register writes are not supported.");
+activation_error!(ActivationPatternContextEffectUnsupported,"Patterned activation context effects are not supported.");
+activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cells disagree with the resolved trigger.");
 
-#[derive(Clone, Debug)]
-enum CompiledActivationPattern { Wildcard, Literal(Value) }
+#[derive(Clone,Debug)] enum CompiledActivationPattern { Wildcard, Literal{expected:Value}, Capture{capture_index:usize}, Tuple{elements:Vec<Self>}, TupleStruct{tag:u64,payload:Vec<Self>} }
+#[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
+#[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
+fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
+fn slot(v:&Value)->Option<Value> { match detached(v) {
+  Value::F64(_)=>Some(Value::F64(Ref::new(0.))), Value::F32(_)=>Some(Value::F32(Ref::new(0.))),
+  Value::I64(_)=>Some(Value::I64(Ref::new(0))), Value::I32(_)=>Some(Value::I32(Ref::new(0))), Value::I16(_)=>Some(Value::I16(Ref::new(0))), Value::I8(_)=>Some(Value::I8(Ref::new(0))),
+  Value::U64(_)=>Some(Value::U64(Ref::new(0))), Value::U32(_)=>Some(Value::U32(Ref::new(0))), Value::U16(_)=>Some(Value::U16(Ref::new(0))), Value::U8(_)=>Some(Value::U8(Ref::new(0))),
+  Value::Bool(_)=>Some(Value::Bool(Ref::new(false))), Value::String(_)=>Some(Value::String(Ref::new(String::new()))), Value::Index(_)=>Some(Value::Index(Ref::new(0))), Value::Atom(a)=>Some(Value::Atom(Ref::new(a.borrow().clone()))), _=>None } }
+fn compile(pat:&Pattern, sample:&Value, i:&Interpreter, caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern> { match pat {
+ Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}),
+ Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash(); if let Some(n)=caps.iter().position(|c|c.id==id){return Ok(CompiledActivationPattern::Capture{capture_index:n})}; let value=slot(sample).ok_or_else(||MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))?; caps.push(Capture{id,kind:sample.kind(),slot:value}); Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})},
+ Pattern::Tuple(t)=> {let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; let e=&tv.borrow().elements; if e.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(e.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
+ Pattern::TupleStruct(t)=> { let tag=t.name.hash(); let payload=match detached(sample) { Value::Enum(e)=>{let e=e.borrow(); e.variants.iter().find(|(id,_)|*id==tag).and_then(|(_,x)|x.as_ref()).cloned().into_iter().collect::<Vec<_>>()}, Value::Tuple(x)=>{let x=x.borrow(); if x.elements.first().map(|v|matches!(detached(v),Value::Atom(a) if a.borrow().id()==tag)).unwrap_or(false){x.elements.iter().skip(1).map(|v|(**v).clone()).collect()}else{Vec::new()}}, _=>Vec::new()}; if payload.len()!=t.patterns.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None).with_tokens(pat.tokens()))}; Ok(CompiledActivationPattern::TupleStruct{tag,payload:t.patterns.iter().zip(payload.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})},
+ _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens())) }}
+fn matches_pattern(p:&CompiledActivationPattern,v:&Value, proposed:&mut Vec<Option<Value>>)->bool {match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}},CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false},CompiledActivationPattern::TupleStruct{tag,payload}=>match detached(v){Value::Enum(e)=>{let e=e.borrow();match e.variants.iter().find(|(id,_)|id==tag){Some((_,Some(v))) if payload.len()==1=>matches_pattern(&payload[0],v,proposed),Some((_,None))=>payload.is_empty(),_=>false}},Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==payload.len()+1&&matches!(detached(&t.elements[0]),Value::Atom(a) if a.borrow().id()==*tag)&&payload.iter().zip(t.elements.iter().skip(1)).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}}}
+macro_rules! copy_slot {($s:expr,$v:expr,$($x:ident),*)=>{match ($s,$v){$((Value::$x(a),Value::$x(b))=>{*a.borrow_mut()=*b.borrow();Ok(())},)* _=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}}
+fn commit(s:&Value,v:&Value)->MResult<()> {copy_slot!(s,detached(v),F64,F32,I64,I32,I16,I8,U64,U32,U16,U8,Bool,String,Index,Atom)}
+fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
+struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
+struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
+struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
+struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
+struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}
 
-fn compile_pattern(pattern: &Pattern, interpreter: &Interpreter) -> MResult<CompiledActivationPattern> {
-  match pattern {
-    Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
-    Pattern::Expression(Expression::Literal(literal)) => Ok(CompiledActivationPattern::Literal(crate::literal(literal, interpreter)?)),
-    // A variable is deliberately not treated as a catch-all: doing so loses
-    // the type and stable backing reference required for a capture slot.
-    Pattern::Expression(Expression::Var(_)) => Err(MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(pattern.tokens())),
-    _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None).with_tokens(pattern.tokens())),
-  }
-}
+#[cfg(feature="compiler")] macro_rules! interpreter_only {($t:ty)=>{impl MechFunctionCompiler for $t { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }};}
+#[cfg(feature="compiler")] interpreter_only!(ScopePulse);
+#[cfg(feature="compiler")] interpreter_only!(Matcher);
+#[cfg(feature="compiler")] interpreter_only!(Finalize);
+#[cfg(feature="compiler")] interpreter_only!(Select);
+#[cfg(feature="compiler")] interpreter_only!(Gate);
 
-fn generation() -> (Ref<usize>, Value) { let cell=Ref::new(0usize); let value=Value::Index(cell.clone()); (cell,value) }
-
-struct ScopePulse { out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for ScopePulse { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for ScopePulse {
-  fn solve(&self) {}
-  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
-  fn out(&self)->Value { Value::Index(self.out.clone()) }
-  fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>> { Some(vec![ReactiveDependencyScope::Root]) }
-  fn to_string(&self)->String{"ActivationPatternScopePulse".into()}
-}
-struct Matcher { pattern: CompiledActivationPattern, trigger: Value, matched: Ref<bool>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Matcher { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Matcher {
-  fn solve(&self) {}
-  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.matched.borrow_mut()=match &self.pattern { CompiledActivationPattern::Wildcard=>true, CompiledActivationPattern::Literal(value)=>value==&self.trigger }; *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
-  fn out(&self)->Value{Value::Index(self.out.clone())}
-  fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}
-  fn to_string(&self)->String{"ActivationPatternMatcher".into()}
-}
-struct Finalize { matched: Ref<bool>, eligible: Ref<bool>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Finalize { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Finalize { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmFinalize".into()} }
-struct Select { eligible: Vec<Ref<bool>>, selected: Ref<usize>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Select { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Select { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternSelectArm".into()} }
-struct Gate { arm: usize, selected: Ref<usize>, out: Ref<usize> }
-#[cfg(feature="compiler")] impl MechFunctionCompiler for Gate { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
-impl MechFunctionImpl for Gate { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if *self.selected.borrow()==self.arm {*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} else {Ok(ReactiveSolveStatus::Unchanged)}} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmGate".into()} }
-
-/// Elaborates the static, combinational dispatch graph for literal and
-/// wildcard patterned activation arms.  Unsupported destructuring is rejected
-/// during elaboration rather than deferred to a reactive turn.
-pub(crate) fn elaborate_patterned_activation(scope: &ActivationScope, arms: &[ActivationArm], trigger: Value, trigger_cells: Vec<ReactiveCellId>, interpreter: &Interpreter) -> MResult<Value> {
-  let final_arm=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
-  if !matches!(final_arm.pattern,Pattern::Wildcard) || final_arm.guard.is_some() { return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens())); }
-  if arms[..arms.len()-1].iter().any(|arm|matches!(arm.pattern,Pattern::Wildcard)) { return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens())); }
-  if arms.iter().any(|arm|arm.guard.is_some()) { return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens())); }
-  for arm in arms { if let ActivationArmBody::Block(body)=&arm.body { for (code,_) in body { match code { MechCode::Statement(Statement::VariableAssign(_)) | MechCode::Statement(Statement::OpAssign(_)) => return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())), MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())), _=>{} } } } }
-  let patterns=arms.iter().map(|arm|compile_pattern(&arm.pattern,interpreter)).collect::<MResult<Vec<_>>>()?;
-  let plan=interpreter.plan();
-  let (scope_generation,scope_value)=generation();
-  let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_generation}), &[trigger.clone()])?;
-  let mut matcher_nodes=Vec::new(); let mut completions=Vec::new(); let mut matched=Vec::new();
-  for pattern in patterns { let (complete,complete_value)=generation(); let flag=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Matcher{pattern,trigger:trigger.clone(),matched:flag.clone(),out:complete}), &[scope_value.clone(),trigger.clone()])?; matcher_nodes.push(id); completions.push(complete_value); matched.push(flag); }
-  let mut finalizer_nodes=Vec::new(); let mut eligible=Vec::new(); let mut arm_complete=Vec::new();
-  for (flag, complete) in matched.iter().zip(completions.iter()) { let (done,done_value)=generation(); let ok=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Finalize{matched:flag.clone(),eligible:ok.clone(),out:done}), &[complete.clone()])?; finalizer_nodes.push(id); eligible.push(ok); arm_complete.push(done_value); }
-  let (selection,selection_value)=generation(); let selected=Ref::new(usize::MAX); let selector_node=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:selection}), &arm_complete)?;
-  let mut gate_nodes=Vec::new(); let mut pulses=Vec::new();
-  for arm in 0..arms.len() { let (pulse,pulse_value)=generation(); let id=plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:pulse}), &[selection_value.clone()])?; gate_nodes.push(id); pulses.push(pulse_value); }
-  let mut registrations=Vec::new();
-  for (arm,pulse) in arms.iter().zip(pulses.iter()) { let start=plan.len(); plan.push_activation_registration_scope(pulse.reactive_root_cell_ids()); let result=match &arm.body { ActivationArmBody::Block(body)=>{for (code,_) in body { crate::mech_code(code,interpreter)?; } Ok(())}, ActivationArmBody::Expression(expression)=>{crate::expression(expression,None,interpreter).map(|_|())} }; plan.pop_activation_registration_scope(); result?; registrations.push((start,plan.len())); }
-  let registration=PatternActivationRegistration { scope_pulse_node:scope_node, selector_node, arms:(0..arms.len()).map(|i|PatternActivationArmRegistration{matcher_node:matcher_nodes[i],finalizer_node:finalizer_nodes[i],gate_node:gate_nodes[i],pulse_cell:pulses[i].reactive_root_cell_ids()[0],body_node_start:registrations[i].0,body_node_end:registrations[i].1}).collect() };
-  plan.borrow_mut().register_pattern_activation(registration);
-  let _=trigger_cells; // The scope pulse's Root dependency is the trigger's root storage.
-  Ok(Value::Empty)
+pub(crate) fn elaborate_patterned_activation(scope:&ActivationScope,arms:&[ActivationArm],trigger:Value,trigger_cells:Vec<ReactiveCellId>,i:&Interpreter)->MResult<Value>{
+ let last=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
+ if !matches!(last.pattern,Pattern::Wildcard)||last.guard.is_some(){return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))} if arms[..arms.len()-1].iter().any(|x|matches!(x.pattern,Pattern::Wildcard)){return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens()))} if arms.iter().any(|x|x.guard.is_some()){return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens()))}
+ for arm in arms {if let ActivationArmBody::Block(body)=&arm.body{for(code,_)in body{match code{MechCode::Statement(Statement::VariableAssign(_))|MechCode::Statement(Statement::OpAssign(_))=>return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())),MechCode::Statement(Statement::ContextSend(_))=>return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())),_=>{}}}}}
+ let mut compiled=Vec::new();for arm in arms{let mut captures=Vec::new();let pattern=compile(&arm.pattern,&trigger,i,&mut captures)?;compiled.push(CompiledArm{pattern,captures})}
+ if trigger.reactive_root_cell_ids()!=trigger_cells{return Err(MechError::new(ActivationPatternTriggerInvariant,None).with_tokens(scope.tokens()))}
+ let plan=i.plan();let(scope_gen,scope_v)=generation();let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_gen}),&[trigger.clone()])?;
+ let(mut matcher_nodes,mut completions,mut matched)=(Vec::new(),Vec::new(),Vec::new());for arm in &compiled{let(o,v)=generation();let f=Ref::new(false);let n=plan.borrow_mut().register(Box::new(Matcher{pattern:arm.pattern.clone(),trigger:trigger.clone(),captures:arm.captures.clone(),matched:f.clone(),out:o}),&[scope_v.clone(),trigger.clone()])?;matcher_nodes.push(n);completions.push(v);matched.push(f)}
+ let(mut finalizers,mut eligible,mut done)=(Vec::new(),Vec::new(),Vec::new());for(f,c)in matched.iter().zip(completions.iter()){let(o,v)=generation();let e=Ref::new(false);finalizers.push(plan.borrow_mut().register(Box::new(Finalize{matched:f.clone(),eligible:e.clone(),out:o}),&[c.clone()])?);eligible.push(e);done.push(v)} let(o,selection)=generation();let selected=Ref::new(usize::MAX);let selector=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:o}),&done)?;
+ let(mut gates,mut pulses)=(Vec::new(),Vec::new());for arm in 0..arms.len(){let(o,v)=generation();gates.push(plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:o}),&[selection.clone()])?);pulses.push(v)}
+ let mut ranges=Vec::new();for(arm,compiled_arm)in arms.iter().zip(compiled.iter()){let symbols=i.symbols();let mut s=symbols.borrow_mut();let old=compiled_arm.captures.iter().map(|c|(c.id,s.symbols.get(&c.id).cloned(),s.mutable_variables.get(&c.id).cloned())).collect::<Vec<_>>();for c in &compiled_arm.captures{s.insert(c.id,c.slot.clone(),false);}drop(s);let start=plan.len();plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());let result=match &arm.body{ActivationArmBody::Block(b)=>{for(c,_)in b{crate::mech_code(c,i)?;}Ok(())},ActivationArmBody::Expression(e)=>crate::expression(e,None,i).map(|_|())};plan.pop_activation_registration_scope();let mut s=symbols.borrow_mut();for(id,oldv,oldm)in old{s.symbols.remove(&id);s.mutable_variables.remove(&id);if let Some(v)=oldv{s.symbols.insert(id,v);}if let Some(v)=oldm{s.mutable_variables.insert(id,v);}}drop(s);result?;ranges.push((start,plan.len()))}
+ let registration=PatternActivationRegistration{scope_pulse_node:scope_node,selector_node:selector,arms:(0..arms.len()).map(|n|PatternActivationArmRegistration{matcher_node:matcher_nodes[n],finalizer_node:finalizers[n],gate_node:gates[n],pulse_cell:pulses[n].reactive_root_cell_ids()[0],body_node_start:ranges[n].0,body_node_end:ranges[n].1,captures:compiled[n].captures.iter().map(|c|PatternActivationCaptureRegistration{id:c.id,kind:c.kind.clone(),cell:c.slot.reactive_root_cell_ids()[0]}).collect()}).collect()};plan.borrow_mut().register_pattern_activation(registration);Ok(Value::Empty)
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1127,3 +1127,91 @@ pub(crate) fn elaborate_patterned_activation(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
+        let mut cases = Vec::new();
+        #[cfg(feature = "u8")]
+        cases.push((ValueKind::U8, Value::U8(Ref::new(8))));
+        #[cfg(feature = "u16")]
+        cases.push((ValueKind::U16, Value::U16(Ref::new(16))));
+        #[cfg(feature = "u32")]
+        cases.push((ValueKind::U32, Value::U32(Ref::new(32))));
+        #[cfg(feature = "u64")]
+        cases.push((ValueKind::U64, Value::U64(Ref::new(64))));
+        #[cfg(feature = "u128")]
+        cases.push((ValueKind::U128, Value::U128(Ref::new(128))));
+        #[cfg(feature = "i8")]
+        cases.push((ValueKind::I8, Value::I8(Ref::new(-8))));
+        #[cfg(feature = "i16")]
+        cases.push((ValueKind::I16, Value::I16(Ref::new(-16))));
+        #[cfg(feature = "i32")]
+        cases.push((ValueKind::I32, Value::I32(Ref::new(-32))));
+        #[cfg(feature = "i64")]
+        cases.push((ValueKind::I64, Value::I64(Ref::new(-64))));
+        #[cfg(feature = "i128")]
+        cases.push((ValueKind::I128, Value::I128(Ref::new(-128))));
+        #[cfg(feature = "f32")]
+        cases.push((ValueKind::F32, Value::F32(Ref::new(3.25))));
+        #[cfg(feature = "f64")]
+        cases.push((ValueKind::F64, Value::F64(Ref::new(6.5))));
+        #[cfg(feature = "complex")]
+        cases.push((ValueKind::C64, Value::C64(Ref::new(C64::new(3.0, 4.0)))));
+        #[cfg(feature = "rational")]
+        cases.push((ValueKind::R64, Value::R64(Ref::new(R64::new(3, 4)))));
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        cases.push((ValueKind::Bool, Value::Bool(Ref::new(true))));
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        cases.push((
+            ValueKind::String,
+            Value::String(Ref::new("captured".to_string())),
+        ));
+        cases.push((ValueKind::Index, Value::Index(Ref::new(42))));
+        #[cfg(feature = "atom")]
+        {
+            let atom = MechAtom::from_name("captured");
+            cases.push((
+                ValueKind::Atom(atom.id(), atom.name()),
+                Value::Atom(Ref::new(atom)),
+            ));
+        }
+        cases
+    }
+
+    #[test]
+    fn activation_capture_slot_supports_all_enabled_scalar_kinds() {
+        for (kind, source) in scalar_capture_cases() {
+            let slot = create_capture_slot_for_kind(&kind).unwrap();
+            let cells_before = slot.reactive_root_cell_ids();
+            assert_eq!(cells_before.len(), 1);
+            commit_capture_slot(&slot, &source).unwrap();
+            assert_eq!(slot, source);
+            assert_eq!(slot.reactive_root_cell_ids(), cells_before);
+        }
+    }
+
+    #[cfg(any(feature = "string", feature = "variable_define"))]
+    #[test]
+    fn activation_capture_slot_preserves_identity_across_updates() {
+        let slot = create_capture_slot_for_kind(&ValueKind::String).unwrap();
+        let cells = slot.reactive_root_cell_ids();
+        commit_capture_slot(&slot, &Value::String(Ref::new("first".to_string()))).unwrap();
+        assert_eq!(slot, Value::String(Ref::new("first".to_string())));
+        assert_eq!(slot.reactive_root_cell_ids(), cells);
+        commit_capture_slot(&slot, &Value::String(Ref::new("second".to_string()))).unwrap();
+        assert_eq!(slot, Value::String(Ref::new("second".to_string())));
+        assert_eq!(slot.reactive_root_cell_ids(), cells);
+    }
+
+    #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
+    #[test]
+    fn activation_capture_slot_rejects_kind_mismatch() {
+        let slot = create_capture_slot_for_kind(&ValueKind::F64).unwrap();
+        let error =
+            commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+    }
+}

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1231,14 +1231,14 @@ mod tests {
     );
 
     fn interpret(source: &str) -> Interpreter {
-        let tree = mech_syntax::parser::parse(source).unwrap();
+        let tree = mech_syntax::parser::parse(source.trim_start()).unwrap();
         let mut interpreter = Interpreter::new_with_full_stdlib(0);
         interpreter.interpret(&tree).unwrap();
         interpreter
     }
 
     fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MResult<Value> {
-        let tree = mech_syntax::parser::parse(source).unwrap();
+        let tree = mech_syntax::parser::parse(source.trim_start()).unwrap();
         interpreter.interpret(&tree)
     }
 
@@ -1342,26 +1342,23 @@ mod tests {
         panic!("no f64 output")
     }
     fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
-        match symbol(interpreter, "event") {
-            Value::Enum(event) => {
-                let id = event.borrow().id;
-                let names = interpreter
-                    .state
-                    .borrow()
-                    .enums
-                    .get(&id)
-                    .unwrap()
-                    .names
-                    .clone();
-                *event.borrow_mut() = MechEnum {
-                    id,
-                    variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
-                    names,
-                };
-            }
-            Value::Tuple(_) => set_atom_tuple_event(interpreter, variant, payload),
-            _ => panic!("event is neither enum nor tagged tuple"),
-        }
+        let Value::Enum(event) = symbol(interpreter, "event") else {
+            panic!("event is not an enum");
+        };
+        let enum_id = event.borrow().id;
+        let names = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .expect("event enum definition is missing")
+            .names
+            .clone();
+        *event.borrow_mut() = MechEnum {
+            id: enum_id,
+            variants: vec![(hash_str(variant), Some(Value::F64(Ref::new(payload))))],
+            names,
+        };
     }
     fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
         let Value::Tuple(event) = symbol(interpreter, "event") else {
@@ -1437,7 +1434,12 @@ mod tests {
         assert_eq!(&plan_snapshot(interpreter), topology);
     }
 
-    const ENUM_ACTIVATION: &str = r#"event := (:pressed, 0.0)
+    const ENUM_ACTIVATION: &str = r#"
+<Event> := :pressed(f64)
+  | :released(f64)
+  | :other(f64)
+
+event := :pressed(0.0)
 
 ~> event
   | :pressed(x) => {
@@ -1457,11 +1459,34 @@ mod tests {
         PlanSnapshot,
     ) {
         let interpreter = interpret(ENUM_ACTIVATION);
+        assert!(matches!(symbol(&interpreter, "event"), Value::Enum(_)));
+        let enum_id = match symbol(&interpreter, "event") {
+            Value::Enum(event) => event.borrow().id,
+            value => panic!("expected enum event, found {:?}", value.kind()),
+        };
+        let enum_definition = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .cloned()
+            .expect("event enum definition is missing");
+        for variant in ["pressed", "released", "other"] {
+            assert!(
+                enum_definition
+                    .variants
+                    .iter()
+                    .any(|(variant_id, _)| *variant_id == hash_str(variant)),
+                "missing enum variant `{variant}`"
+            );
+        }
         let trigger = root_cell(&interpreter, "event");
         let registration = registration(&interpreter);
         assert_eq!(registration.arms.len(), 3);
         assert_eq!(registration.arms[0].captures.len(), 1);
         assert_eq!(registration.arms[1].captures.len(), 1);
+        assert_eq!(registration.arms[0].captures[0].kind, ValueKind::F64);
+        assert_eq!(registration.arms[1].captures[0].kind, ValueKind::F64);
         assert!(registration.arms[2].captures.is_empty());
         assert!(!interpreter.symbols().borrow().contains(hash_str("x")));
         assert!(
@@ -1885,6 +1910,7 @@ event := (1.0, 1.0)
         let symbols = i.symbols().borrow().snapshot();
         let dictionary = i.dictionary().borrow().clone();
         let topology = plan_snapshot(&i);
+        let context_bindings = i.context_bindings.borrow().clone();
         let error = interpret_more(
             &mut i,
             "~> event\n  | 1.0 => {
@@ -1898,6 +1924,13 @@ event := (1.0, 1.0)
         assert_eq!(i.symbols().borrow().snapshot(), symbols);
         assert_eq!(*i.dictionary().borrow(), dictionary);
         assert_eq!(plan_snapshot(&i), topology);
+        assert_eq!(*i.context_bindings.borrow(), context_bindings);
+        assert!(
+            !i.context_bindings
+                .borrow()
+                .contains_key(&hash_str("temporary"))
+        );
+        assert!(i.plan().pattern_activation_registrations().is_empty());
         assert!(!i.symbols().borrow().contains(hash_str("fallback")));
     }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1435,11 +1435,11 @@ mod tests {
     }
 
     const ENUM_ACTIVATION: &str = r#"
-<Event> := :pressed(f64)
-  | :released(f64)
-  | :other(f64)
+<event-kind> := :pressed<f64>
+  | :released<f64>
+  | :other<f64>
 
-event := :pressed(0.0)
+event<event-kind> := :pressed(0.0)
 
 ~> event
   | :pressed(x) => {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -109,10 +109,34 @@ fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
 }
 fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
     match kind.deref_kind() {
+        #[cfg(feature = "u8")]
+        ValueKind::U8 => Ok(Value::U8(Ref::new(0))),
+        #[cfg(feature = "u16")]
+        ValueKind::U16 => Ok(Value::U16(Ref::new(0))),
+        #[cfg(feature = "u32")]
+        ValueKind::U32 => Ok(Value::U32(Ref::new(0))),
+        #[cfg(feature = "u64")]
+        ValueKind::U64 => Ok(Value::U64(Ref::new(0))),
+        #[cfg(feature = "u128")]
+        ValueKind::U128 => Ok(Value::U128(Ref::new(0))),
+        #[cfg(feature = "i8")]
+        ValueKind::I8 => Ok(Value::I8(Ref::new(0))),
+        #[cfg(feature = "i16")]
+        ValueKind::I16 => Ok(Value::I16(Ref::new(0))),
+        #[cfg(feature = "i32")]
+        ValueKind::I32 => Ok(Value::I32(Ref::new(0))),
+        #[cfg(feature = "i64")]
+        ValueKind::I64 => Ok(Value::I64(Ref::new(0))),
+        #[cfg(feature = "i128")]
+        ValueKind::I128 => Ok(Value::I128(Ref::new(0))),
         #[cfg(feature = "f64")]
         ValueKind::F64 => Ok(Value::F64(Ref::new(0.0))),
         #[cfg(feature = "f32")]
         ValueKind::F32 => Ok(Value::F32(Ref::new(0.0))),
+        #[cfg(feature = "complex")]
+        ValueKind::C64 => Ok(Value::C64(Ref::new(C64::default()))),
+        #[cfg(feature = "rational")]
+        ValueKind::R64 => Ok(Value::R64(Ref::new(R64::default()))),
         #[cfg(any(feature = "bool", feature = "variable_define"))]
         ValueKind::Bool => Ok(Value::Bool(Ref::new(false))),
         #[cfg(any(feature = "string", feature = "variable_define"))]
@@ -128,6 +152,56 @@ fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
 }
 fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
     match (destination, &detached(source)) {
+        #[cfg(feature = "u8")]
+        (Value::U8(a), Value::U8(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u16")]
+        (Value::U16(a), Value::U16(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u32")]
+        (Value::U32(a), Value::U32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u64")]
+        (Value::U64(a), Value::U64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "u128")]
+        (Value::U128(a), Value::U128(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i8")]
+        (Value::I8(a), Value::I8(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i16")]
+        (Value::I16(a), Value::I16(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i32")]
+        (Value::I32(a), Value::I32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i64")]
+        (Value::I64(a), Value::I64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "i128")]
+        (Value::I128(a), Value::I128(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
         #[cfg(feature = "f64")]
         (Value::F64(a), Value::F64(b)) => {
             clone_ref_value(a, b);
@@ -135,6 +209,16 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
         }
         #[cfg(feature = "f32")]
         (Value::F32(a), Value::F32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "complex")]
+        (Value::C64(a), Value::C64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "rational")]
+        (Value::R64(a), Value::R64(b)) => {
             clone_ref_value(a, b);
             Ok(())
         }
@@ -592,33 +676,8 @@ fn preflight_patterned_activation(
             MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
         );
     }
-    for a in arms {
-        if let ActivationArmBody::Block(body) = &a.body {
-            for (code, _) in body {
-                match code {
-                    MechCode::Statement(Statement::VariableAssign(_))
-                    | MechCode::Statement(Statement::OpAssign(_)) => {
-                        return Err(MechError::new(
-                            ActivationPatternRegisterWriteUnsupported,
-                            None,
-                        )
-                        .with_tokens(code.tokens()));
-                    }
-                    MechCode::Statement(Statement::ContextSend(_)) => {
-                        return Err(MechError::new(
-                            ActivationPatternContextEffectUnsupported,
-                            None,
-                        )
-                        .with_tokens(code.tokens()));
-                    }
-                    MechCode::Statement(Statement::VariableDefine(d)) if d.mutable => {
-                        return Err(MechError::new(ActivationPatternDefinitionUnsupported, None)
-                            .with_tokens(code.tokens()));
-                    }
-                    _ => {}
-                }
-            }
-        }
+    for arm in arms {
+        validate_patterned_arm_body(&arm.body)?;
     }
     if trigger.reactive_root_cell_ids() != trigger_cells {
         return Err(
@@ -638,14 +697,314 @@ fn preflight_patterned_activation(
     })
 }
 
+fn validation_error(kind: impl MechErrorKind + 'static, tokens: Vec<Token>) -> MResult<()> {
+    Err(MechError::new(kind, None).with_tokens(tokens))
+}
+
+fn validate_patterned_arm_body(body: &ActivationArmBody) -> MResult<()> {
+    match body {
+        ActivationArmBody::Block(body) => {
+            for (code, _) in body {
+                validate_patterned_code(code)?;
+            }
+            Ok(())
+        }
+        ActivationArmBody::Expression(expression) => validate_patterned_expression(expression),
+    }
+}
+fn validate_patterned_code(code: &MechCode) -> MResult<()> {
+    match code {
+        MechCode::Comment(_) => Ok(()),
+        MechCode::Expression(expression) => validate_patterned_expression(expression),
+        MechCode::Statement(statement) => validate_patterned_statement(statement),
+        MechCode::ActivationScope(_)
+        | MechCode::FunctionDefine(_)
+        | MechCode::FsmSpecification(_)
+        | MechCode::FsmImplementation(_)
+        | MechCode::Import(_)
+        | MechCode::Error(_, _) => {
+            validation_error(ActivationPatternDefinitionUnsupported, code.tokens())
+        }
+    }
+}
+fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
+    match statement {
+        Statement::VariableDefine(definition)
+            if !definition.mutable && definition.var.context.is_none() =>
+        {
+            validate_patterned_expression(&definition.expression)
+        }
+        Statement::VariableDefine(definition) if definition.var.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                statement.tokens(),
+            )
+        }
+        Statement::VariableDefine(_) => {
+            validation_error(ActivationPatternDefinitionUnsupported, statement.tokens())
+        }
+        Statement::VariableAssign(assignment) if assignment.target.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                statement.tokens(),
+            )
+        }
+        Statement::VariableAssign(_) => validation_error(
+            ActivationPatternRegisterWriteUnsupported,
+            statement.tokens(),
+        ),
+        Statement::OpAssign(assignment) if assignment.target.context.is_some() => validation_error(
+            ActivationPatternContextEffectUnsupported,
+            statement.tokens(),
+        ),
+        Statement::OpAssign(_) => validation_error(
+            ActivationPatternRegisterWriteUnsupported,
+            statement.tokens(),
+        ),
+        Statement::ContextSend(_) => validation_error(
+            ActivationPatternContextEffectUnsupported,
+            statement.tokens(),
+        ),
+        _ => validation_error(ActivationPatternDefinitionUnsupported, statement.tokens()),
+    }
+}
+fn validate_patterned_expression(expression: &Expression) -> MResult<()> {
+    match expression {
+        Expression::Literal(_) | Expression::Var(_) => Ok(()),
+        Expression::Slice(slice) => validate_patterned_slice(slice),
+        Expression::Formula(factor) => validate_patterned_factor(factor),
+        Expression::FunctionCall(call) => {
+            for (_, expression) in &call.args {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Expression::Match(matched) => {
+            validate_patterned_expression(&matched.source)?;
+            for arm in &matched.arms {
+                validate_patterned_pattern(&arm.pattern)?;
+                if let Some(guard) = &arm.guard {
+                    validate_patterned_expression(guard)?;
+                }
+                validate_patterned_expression(&arm.expression)?;
+            }
+            Ok(())
+        }
+        Expression::Range(range) => validate_patterned_range(range),
+        Expression::Structure(structure) => validate_patterned_structure(structure),
+        Expression::SetComprehension(comprehension) => {
+            validate_patterned_expression(&comprehension.expression)?;
+            for qualifier in &comprehension.qualifiers {
+                validate_patterned_qualifier(qualifier)?;
+            }
+            Ok(())
+        }
+        Expression::MatrixComprehension(comprehension) => {
+            validate_patterned_expression(&comprehension.expression)?;
+            for qualifier in &comprehension.qualifiers {
+                validate_patterned_qualifier(qualifier)?;
+            }
+            Ok(())
+        }
+        Expression::FsmPipe(_) => {
+            validation_error(ActivationPatternDefinitionUnsupported, expression.tokens())
+        }
+    }
+}
+fn validate_patterned_pattern(pattern: &Pattern) -> MResult<()> {
+    match pattern {
+        Pattern::Expression(expression) => validate_patterned_expression(expression),
+        Pattern::Tuple(tuple) => {
+            for pattern in &tuple.0 {
+                validate_patterned_pattern(pattern)?;
+            }
+            Ok(())
+        }
+        Pattern::TupleStruct(tuple) => {
+            for pattern in &tuple.patterns {
+                validate_patterned_pattern(pattern)?;
+            }
+            Ok(())
+        }
+        Pattern::Array(array) => {
+            for pattern in array.prefix.iter().chain(&array.suffix) {
+                validate_patterned_pattern(pattern)?;
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    validate_patterned_pattern(binding)?;
+                }
+            }
+            Ok(())
+        }
+        Pattern::Wildcard => Ok(()),
+    }
+}
+fn validate_patterned_factor(factor: &Factor) -> MResult<()> {
+    match factor {
+        Factor::Expression(expression) => validate_patterned_expression(expression),
+        Factor::Negate(factor)
+        | Factor::Not(factor)
+        | Factor::Parenthetical(factor)
+        | Factor::Transpose(factor) => validate_patterned_factor(factor),
+        Factor::Term(term) => {
+            validate_patterned_factor(&term.lhs)?;
+            for (_, factor) in &term.rhs {
+                validate_patterned_factor(factor)?;
+            }
+            Ok(())
+        }
+    }
+}
+fn validate_patterned_range(range: &RangeExpression) -> MResult<()> {
+    validate_patterned_factor(&range.start)?;
+    if let Some((_, increment)) = &range.increment {
+        validate_patterned_factor(increment)?;
+    }
+    validate_patterned_factor(&range.terminal)
+}
+fn validate_patterned_slice(slice: &Slice) -> MResult<()> {
+    for subscript in &slice.subscript {
+        validate_patterned_subscript(subscript)?;
+    }
+    Ok(())
+}
+fn validate_patterned_subscript(subscript: &Subscript) -> MResult<()> {
+    match subscript {
+        Subscript::Brace(subscripts) | Subscript::Bracket(subscripts) => {
+            for subscript in subscripts {
+                validate_patterned_subscript(subscript)?;
+            }
+            Ok(())
+        }
+        Subscript::Formula(factor) => validate_patterned_factor(factor),
+        Subscript::Range(range) => validate_patterned_range(range),
+        Subscript::All | Subscript::Dot(_) | Subscript::DotInt(_) | Subscript::Swizzle(_) => Ok(()),
+    }
+}
+fn validate_patterned_structure(structure: &Structure) -> MResult<()> {
+    match structure {
+        Structure::Empty => Ok(()),
+        Structure::Map(map) => {
+            for mapping in &map.elements {
+                validate_patterned_expression(&mapping.key)?;
+                validate_patterned_expression(&mapping.value)?;
+            }
+            Ok(())
+        }
+        Structure::Matrix(matrix) => {
+            for row in &matrix.rows {
+                for column in &row.columns {
+                    validate_patterned_expression(&column.element)?;
+                }
+            }
+            Ok(())
+        }
+        Structure::Record(record) => {
+            for binding in &record.bindings {
+                validate_patterned_expression(&binding.value)?;
+            }
+            Ok(())
+        }
+        Structure::Set(set) => {
+            for expression in &set.elements {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Structure::Table(table) => {
+            for row in &table.rows {
+                for column in &row.columns {
+                    validate_patterned_expression(&column.element)?;
+                }
+            }
+            Ok(())
+        }
+        Structure::Tuple(tuple) => {
+            for expression in &tuple.elements {
+                validate_patterned_expression(expression)?;
+            }
+            Ok(())
+        }
+        Structure::TupleStruct(tuple) => validate_patterned_expression(&tuple.value),
+    }
+}
+fn validate_patterned_qualifier(qualifier: &ComprehensionQualifier) -> MResult<()> {
+    match qualifier {
+        ComprehensionQualifier::Generator((pattern, expression)) => {
+            validate_patterned_pattern(pattern)?;
+            validate_patterned_expression(expression)
+        }
+        ComprehensionQualifier::Filter(expression) => validate_patterned_expression(expression),
+        ComprehensionQualifier::Let(definition) if definition.mutable => {
+            validation_error(ActivationPatternDefinitionUnsupported, definition.tokens())
+        }
+        ComprehensionQualifier::Let(definition) if definition.var.context.is_some() => {
+            validation_error(
+                ActivationPatternContextEffectUnsupported,
+                definition.tokens(),
+            )
+        }
+        ComprehensionQualifier::Let(definition) => {
+            validate_patterned_expression(&definition.expression)
+        }
+    }
+}
+
+fn elaborate_patterned_arm_body(
+    arm: &ActivationArm,
+    captures: &[ActivationPatternCapture],
+    pulse: &Value,
+    interpreter: &Interpreter,
+) -> MResult<(usize, usize)> {
+    let symbols = interpreter.symbols();
+    let symbol_snapshot = symbols.borrow().snapshot();
+    let plan = interpreter.plan();
+    let original_scope_depth = plan.activation_registration_depth();
+    {
+        let mut symbols = symbols.borrow_mut();
+        for capture in captures {
+            symbols.mutable_variables.remove(&capture.id);
+            symbols.insert(capture.id, capture.slot.clone(), false);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(capture.id, capture.name.clone());
+        }
+    }
+    let body_node_start = plan.len();
+    plan.push_activation_registration_scope(pulse.reactive_root_cell_ids());
+    let body_result = (|| -> MResult<()> {
+        match &arm.body {
+            ActivationArmBody::Block(body) => {
+                for (code, _) in body {
+                    crate::mech_code(code, interpreter)?;
+                }
+                Ok(())
+            }
+            ActivationArmBody::Expression(expression) => {
+                crate::expression(expression, None, interpreter)?;
+                Ok(())
+            }
+        }
+    })();
+    while plan.activation_registration_depth() > original_scope_depth {
+        plan.pop_activation_registration_scope();
+    }
+    symbols.borrow_mut().restore(symbol_snapshot);
+    body_result?;
+    Ok((body_node_start, plan.len()))
+}
+
 fn elaborate_patterned_activation_inner(
-    scope: &ActivationScope,
     arms: &[ActivationArm],
     trigger: Value,
-    trigger_cells: Vec<ReactiveCellId>,
+    preflight: PreflightPatternedActivation,
     i: &Interpreter,
 ) -> MResult<Value> {
-    let preflight = preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, i)?;
+    if trigger.kind().deref_kind() != preflight.trigger_kind {
+        return Err(MechError::new(ActivationPatternTriggerInvariant, None));
+    }
     let compiled = preflight.arms;
     let plan = i.plan();
     let (scope_gen, scope_v) = generation();
@@ -668,7 +1027,7 @@ fn elaborate_patterned_activation_inner(
         )?;
         matcher_nodes.push(n);
         completions.push(v);
-        matched.push(f)
+        matched.push(f);
     }
     let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
     for (f, c) in matched.iter().zip(completions.iter()) {
@@ -683,7 +1042,7 @@ fn elaborate_patterned_activation_inner(
             &[c.clone()],
         )?);
         eligible.push(e);
-        done.push(v)
+        done.push(v);
     }
     let (o, selection) = generation();
     let selected = Ref::new(usize::MAX);
@@ -706,34 +1065,16 @@ fn elaborate_patterned_activation_inner(
             }),
             &[selection.clone()],
         )?);
-        pulses.push(v)
+        pulses.push(v);
     }
     let mut ranges = Vec::new();
-    for (arm, compiled_arm) in arms.iter().zip(compiled.iter()) {
-        let symbols = i.symbols();
-        let snapshot = symbols.borrow().snapshot();
-        {
-            let mut s = symbols.borrow_mut();
-            for c in &compiled_arm.captures {
-                s.insert(c.id, c.slot.clone(), false);
-                s.dictionary.borrow_mut().insert(c.id, c.name.clone());
-            }
-        }
-        let start = plan.len();
-        plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());
-        let result = match &arm.body {
-            ActivationArmBody::Block(b) => {
-                for (c, _) in b {
-                    crate::mech_code(c, i)?;
-                }
-                Ok(())
-            }
-            ActivationArmBody::Expression(e) => crate::expression(e, None, i).map(|_| ()),
-        };
-        plan.pop_activation_registration_scope();
-        symbols.borrow_mut().restore(snapshot);
-        result?;
-        ranges.push((start, plan.len()))
+    for (arm, compiled_arm) in arms.iter().zip(&compiled) {
+        ranges.push(elaborate_patterned_arm_body(
+            arm,
+            &compiled_arm.captures,
+            &pulses[ranges.len()],
+            i,
+        )?);
     }
     let registration = PatternActivationRegistration {
         scope_pulse_node: scope_node,
@@ -769,13 +1110,20 @@ pub(crate) fn elaborate_patterned_activation(
     trigger_cells: Vec<ReactiveCellId>,
     interpreter: &Interpreter,
 ) -> MResult<Value> {
+    let preflight =
+        preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, interpreter)?;
     let plan = interpreter.plan();
     let checkpoint = plan.checkpoint();
-    match elaborate_patterned_activation_inner(scope, arms, trigger, trigger_cells, interpreter) {
+    let program_dictionary = interpreter.state.borrow().dictionary.clone();
+    let dictionary_snapshot = program_dictionary.borrow().clone();
+    match elaborate_patterned_activation_inner(arms, trigger, preflight, interpreter) {
         Ok(value) => Ok(value),
         Err(error) => {
-            plan.rollback(checkpoint)?;
-            Err(error)
+            *program_dictionary.borrow_mut() = dictionary_snapshot;
+            match plan.rollback(checkpoint) {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(rollback_error),
+            }
         }
     }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,3 +1,8 @@
+#![cfg(all(
+  feature = "functions",
+  feature = "symbol_table",
+))]
+
 //! Static scheduling support for patterned activation scopes.
 //!
 //! The small dispatch nodes in this file deliberately contain no syntax and

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -2,87 +2,780 @@
 //! Statically elaborated structural dispatch for patterned activation scopes.
 use crate::*;
 
-macro_rules! activation_error {($n:ident,$m:expr)=>{#[derive(Debug,Clone)] pub(crate) struct $n; impl MechErrorKind for $n {fn name(&self)->&str{stringify!($n)} fn message(&self)->String{$m.into()}}};}
-activation_error!(ActivationPatternExpressionUnsupported,"This activation pattern is not supported.");
-activation_error!(ActivationPatternCaptureKindUnsupported,"The capture kind cannot be inferred from the activation trigger.");
-activation_error!(ActivationPatternArmsNonExhaustive,"Patterned activations require a final unguarded wildcard arm.");
-activation_error!(ActivationPatternWildcardMustBeLast,"The wildcard activation arm must be last.");
-activation_error!(ActivationPatternGuardMustBePure,"Patterned activation guards are not supported yet.");
-activation_error!(ActivationPatternRegisterWriteUnsupported,"Patterned activation register writes are not supported.");
-activation_error!(ActivationPatternContextEffectUnsupported,"Patterned activation context effects are not supported.");
-activation_error!(ActivationPatternTriggerInvariant,"Activation trigger root cells disagree with the resolved trigger.");
+macro_rules! activation_error {
+    ($n:ident,$m:expr) => {
+        #[derive(Debug, Clone)]
+        pub(crate) struct $n;
+        impl MechErrorKind for $n {
+            fn name(&self) -> &str {
+                stringify!($n)
+            }
+            fn message(&self) -> String {
+                $m.into()
+            }
+        }
+    };
+}
+activation_error!(
+    ActivationPatternExpressionUnsupported,
+    "This activation pattern is not supported."
+);
+activation_error!(
+    ActivationPatternCaptureKindUnsupported,
+    "The capture kind cannot be inferred from the activation trigger."
+);
+activation_error!(
+    ActivationPatternArmsNonExhaustive,
+    "Patterned activations require a final unguarded wildcard arm."
+);
+activation_error!(
+    ActivationPatternWildcardMustBeLast,
+    "The wildcard activation arm must be last."
+);
+activation_error!(
+    ActivationPatternGuardMustBePure,
+    "Patterned activation guards are not supported yet."
+);
+activation_error!(
+    ActivationPatternRegisterWriteUnsupported,
+    "Patterned activation register writes are not supported."
+);
+activation_error!(
+    ActivationPatternContextEffectUnsupported,
+    "Patterned activation context effects are not supported."
+);
+activation_error!(
+    ActivationPatternTriggerInvariant,
+    "Activation trigger root cells disagree with the resolved trigger."
+);
 
-#[derive(Clone,Debug)] enum CompiledActivationPattern { Wildcard, Literal{expected:Value}, Capture{capture_index:usize}, Tuple{elements:Vec<Self>}, TupleStruct{tag:u64,payload:Vec<Self>} }
-#[derive(Clone)] struct Capture { id:u64, kind:ValueKind, slot:Value }
-#[derive(Clone)] struct CompiledArm { pattern:CompiledActivationPattern, captures:Vec<Capture> }
-fn detached(v:&Value)->Value { match v {Value::MutableReference(r)=>detached(&r.borrow()), _=>v.clone()} }
-fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) { let source=source.borrow(); destination.borrow_mut().clone_from(&*source); }
-fn create_capture_slot(sample:&Value)->MResult<Value>{match detached(sample){
-#[cfg(feature="u8")] Value::U8(v)=>Ok(Value::U8(Ref::new(*v.borrow()))),
-#[cfg(feature="u16")] Value::U16(v)=>Ok(Value::U16(Ref::new(*v.borrow()))),
-#[cfg(feature="u32")] Value::U32(v)=>Ok(Value::U32(Ref::new(*v.borrow()))),
-#[cfg(feature="u64")] Value::U64(v)=>Ok(Value::U64(Ref::new(*v.borrow()))),
-#[cfg(feature="u128")] Value::U128(v)=>Ok(Value::U128(Ref::new(*v.borrow()))),
-#[cfg(feature="i8")] Value::I8(v)=>Ok(Value::I8(Ref::new(*v.borrow()))),
-#[cfg(feature="i16")] Value::I16(v)=>Ok(Value::I16(Ref::new(*v.borrow()))),
-#[cfg(feature="i32")] Value::I32(v)=>Ok(Value::I32(Ref::new(*v.borrow()))),
-#[cfg(feature="i64")] Value::I64(v)=>Ok(Value::I64(Ref::new(*v.borrow()))),
-#[cfg(feature="i128")] Value::I128(v)=>Ok(Value::I128(Ref::new(*v.borrow()))),
-#[cfg(feature="f32")] Value::F32(v)=>Ok(Value::F32(Ref::new(*v.borrow()))),
-#[cfg(feature="f64")] Value::F64(v)=>Ok(Value::F64(Ref::new(*v.borrow()))),
-#[cfg(feature="complex")] Value::C64(v)=>Ok(Value::C64(Ref::new(v.borrow().clone()))),
-#[cfg(feature="rational")] Value::R64(v)=>Ok(Value::R64(Ref::new(v.borrow().clone()))),
-#[cfg(any(feature="bool",feature="variable_define"))] Value::Bool(v)=>Ok(Value::Bool(Ref::new(*v.borrow()))),
-#[cfg(any(feature="string",feature="variable_define"))] Value::String(v)=>Ok(Value::String(Ref::new(v.borrow().clone()))),
-Value::Index(v)=>Ok(Value::Index(Ref::new(*v.borrow()))),
-#[cfg(feature="atom")] Value::Atom(v)=>Ok(Value::Atom(Ref::new(v.borrow().clone()))),
-_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
-fn commit_capture_slot(destination:&Value,source:&Value)->MResult<()>{let source=detached(source);match(destination,&source){
-#[cfg(feature="u8")] (Value::U8(a),Value::U8(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u16")] (Value::U16(a),Value::U16(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u32")] (Value::U32(a),Value::U32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u64")] (Value::U64(a),Value::U64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="u128")] (Value::U128(a),Value::U128(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i8")] (Value::I8(a),Value::I8(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i16")] (Value::I16(a),Value::I16(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i32")] (Value::I32(a),Value::I32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i64")] (Value::I64(a),Value::I64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="i128")] (Value::I128(a),Value::I128(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="f32")] (Value::F32(a),Value::F32(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="f64")] (Value::F64(a),Value::F64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="complex")] (Value::C64(a),Value::C64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="rational")] (Value::R64(a),Value::R64(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(any(feature="bool",feature="variable_define"))] (Value::Bool(a),Value::Bool(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(any(feature="string",feature="variable_define"))] (Value::String(a),Value::String(b))=>{clone_ref_value(a,b);Ok(())},
-(Value::Index(a),Value::Index(b))=>{clone_ref_value(a,b);Ok(())},
-#[cfg(feature="atom")] (Value::Atom(a),Value::Atom(b))=>{clone_ref_value(a,b);Ok(())},
-_=>Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}}
-fn compile(pat:&Pattern,sample:&Value,i:&Interpreter,caps:&mut Vec<Capture>)->MResult<CompiledActivationPattern>{match pat { Pattern::Wildcard=>Ok(CompiledActivationPattern::Wildcard), Pattern::Expression(Expression::Literal(x))=>Ok(CompiledActivationPattern::Literal{expected:crate::literal(x,i)?}), Pattern::Expression(Expression::Var(v))=>{let id=v.name.hash();if let Some(n)=caps.iter().position(|c|c.id==id){Ok(CompiledActivationPattern::Capture{capture_index:n})}else{let value=create_capture_slot(sample).map_err(|e|e.with_tokens(pat.tokens()))?;caps.push(Capture{id,kind:sample.kind(),slot:value});Ok(CompiledActivationPattern::Capture{capture_index:caps.len()-1})}}, #[cfg(feature="tuple")] Pattern::Tuple(t)=>{let Value::Tuple(tv)=detached(sample) else{return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))};let tv=tv.borrow();if tv.elements.len()!=t.0.len(){return Err(MechError::new(ActivationPatternCaptureKindUnsupported,None))}Ok(CompiledActivationPattern::Tuple{elements:t.0.iter().zip(tv.elements.iter()).map(|(p,v)|compile(p,v,i,caps)).collect::<MResult<_>>()?})}, _=>Err(MechError::new(ActivationPatternExpressionUnsupported,None).with_tokens(pat.tokens()))}}
-fn matches_pattern(p:&CompiledActivationPattern,v:&Value,proposed:&mut Vec<Option<Value>>)->bool{match p {CompiledActivationPattern::Wildcard=>true,CompiledActivationPattern::Literal{expected}=>expected==&detached(v),CompiledActivationPattern::Capture{capture_index}=>{let x=detached(v);match &proposed[*capture_index]{Some(y)=>y==&x,None=>{proposed[*capture_index]=Some(x);true}}}, #[cfg(feature="tuple")] CompiledActivationPattern::Tuple{elements}=>match detached(v){Value::Tuple(t)=>{let t=t.borrow();t.elements.len()==elements.len()&&elements.iter().zip(t.elements.iter()).all(|(p,v)|matches_pattern(p,v,proposed))},_=>false}, CompiledActivationPattern::TupleStruct{..}=>false, #[cfg(not(feature="tuple"))] CompiledActivationPattern::Tuple{..}=>false}}
-fn generation()->(Ref<usize>,Value){let r=Ref::new(0);(r.clone(),Value::Index(r))}
-struct ScopePulse{out:Ref<usize>} impl MechFunctionImpl for ScopePulse{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>>{Some(vec![ReactiveDependencyScope::Root])}fn to_string(&self)->String{"ActivationPatternScopePulse".into()}}
-struct Matcher{pattern:CompiledActivationPattern,trigger:Value,captures:Vec<Capture>,matched:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Matcher{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{let mut p=vec![None;self.captures.len()];let ok=matches_pattern(&self.pattern,&self.trigger,&mut p);if ok{for(c,v)in self.captures.iter().zip(p.iter()){if let Some(v)=v{commit_capture_slot(&c.slot,v)?}}}*self.matched.borrow_mut()=ok;*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}fn to_string(&self)->String{"ActivationPatternMatcher".into()}}
-struct Finalize{matched:Ref<bool>,eligible:Ref<bool>,out:Ref<usize>} impl MechFunctionImpl for Finalize{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmFinalize".into()}}
-struct Select{eligible:Vec<Ref<bool>>,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Select{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternSelectArm".into()}}
-struct Gate{arm:usize,selected:Ref<usize>,out:Ref<usize>} impl MechFunctionImpl for Gate{fn solve(&self){}fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if*self.selected.borrow()==self.arm{*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)}else{Ok(ReactiveSolveStatus::Unchanged)}}fn out(&self)->Value{Value::Index(self.out.clone())}fn to_string(&self)->String{"ActivationPatternArmGate".into()}}
+#[derive(Clone, Debug)]
+enum CompiledActivationPattern {
+    Wildcard,
+    Literal {
+        expected: Value,
+    },
+    Capture {
+        capture_index: usize,
+    },
+    Tuple {
+        elements: Vec<CompiledActivationPattern>,
+    },
+    EnumVariant {
+        enum_id: u64,
+        variant_id: u64,
+        payload: Option<Box<CompiledActivationPattern>>,
+    },
+    AtomTuple {
+        tag_id: u64,
+        payload: Vec<CompiledActivationPattern>,
+    },
+}
+#[derive(Clone)]
+struct ActivationPatternCapture {
+    id: u64,
+    name: String,
+    kind: ValueKind,
+    slot: Value,
+}
+#[derive(Clone)]
+struct PreflightActivationArm {
+    pattern: CompiledActivationPattern,
+    captures: Vec<ActivationPatternCapture>,
+}
+struct PreflightPatternedActivation {
+    trigger_kind: ValueKind,
+    arms: Vec<PreflightActivationArm>,
+}
+#[derive(Debug, Clone)]
+pub(crate) struct ActivationPatternDefinitionUnsupported;
+impl MechErrorKind for ActivationPatternDefinitionUnsupported {
+    fn name(&self) -> &str {
+        "ActivationPatternDefinitionUnsupported"
+    }
+    fn message(&self) -> String {
+        "This definition or declaration is not supported inside a patterned activation arm."
+            .to_string()
+    }
+}
+fn detached(v: &Value) -> Value {
+    match v {
+        Value::MutableReference(r) => detached(&r.borrow()),
+        _ => v.clone(),
+    }
+}
+fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
+    destination.borrow_mut().clone_from(&*source.borrow())
+}
+fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
+    match kind.deref_kind() {
+        #[cfg(feature = "f64")]
+        ValueKind::F64 => Ok(Value::F64(Ref::new(0.0))),
+        #[cfg(feature = "f32")]
+        ValueKind::F32 => Ok(Value::F32(Ref::new(0.0))),
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        ValueKind::Bool => Ok(Value::Bool(Ref::new(false))),
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        ValueKind::String => Ok(Value::String(Ref::new(String::new()))),
+        ValueKind::Index => Ok(Value::Index(Ref::new(0))),
+        #[cfg(feature = "atom")]
+        ValueKind::Atom(id, _) => Ok(Value::Atom(Ref::new(MechAtom::new(id)))),
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
+    match (destination, &detached(source)) {
+        #[cfg(feature = "f64")]
+        (Value::F64(a), Value::F64(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "f32")]
+        (Value::F32(a), Value::F32(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(any(feature = "bool", feature = "variable_define"))]
+        (Value::Bool(a), Value::Bool(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(any(feature = "string", feature = "variable_define"))]
+        (Value::String(a), Value::String(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        (Value::Index(a), Value::Index(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "atom")]
+        (Value::Atom(a), Value::Atom(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+fn compile_activation_literal(l: &Literal, i: &Interpreter) -> MResult<Value> {
+    match l {
+        Literal::Empty(_) => Ok(Value::Empty),
+        #[cfg(feature = "bool")]
+        Literal::Boolean(t) => Ok(crate::boolean(t)),
+        #[cfg(feature = "string")]
+        Literal::String(v) => Ok(crate::string(v)),
+        #[cfg(feature = "atom")]
+        Literal::Atom(a) => Ok(Value::Atom(Ref::new(MechAtom::new(a.name.hash())))),
+        Literal::Number(Number::Real(RealNumber::TypedInteger(_)))
+        | Literal::TypedLiteral(_)
+        | Literal::Kind(_) => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+        Literal::Number(n) => crate::number(n, i),
+        _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+    }
+}
+#[cfg(feature = "enum")]
+fn compile_enum_variant_pattern(
+    t: &PatternTupleStruct,
+    enum_id: u64,
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let variant_id = t.name.hash();
+    let def = i
+        .state
+        .borrow()
+        .enums
+        .get(&enum_id)
+        .cloned()
+        .ok_or_else(|| {
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
+        })?;
+    let declared = def
+        .variants
+        .iter()
+        .find(|(id, _)| *id == variant_id)
+        .map(|(_, p)| p.clone())
+        .ok_or_else(|| {
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
+        })?;
+    let payload = match (t.patterns.as_slice(), declared) {
+        ([], None) => None,
+        ([p], Some(Value::Kind(k))) => Some(Box::new(compile_activation_pattern(p, &k, i, c)?)),
+        _ => {
+            return Err(
+                MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                    .with_tokens(t.tokens()),
+            );
+        }
+    };
+    Ok(CompiledActivationPattern::EnumVariant {
+        enum_id,
+        variant_id,
+        payload,
+    })
+}
+#[cfg(all(feature = "tuple", feature = "atom"))]
+fn compile_atom_tuple_pattern(
+    t: &PatternTupleStruct,
+    kinds: &[ValueKind],
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let Some(first) = kinds.first() else {
+        return Err(
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
+        );
+    };
+    if !matches!(first.deref_kind(), ValueKind::Atom(_, _)) || t.patterns.len() != kinds.len() - 1 {
+        return Err(
+            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
+        );
+    };
+    let payload = t
+        .patterns
+        .iter()
+        .zip(kinds.iter().skip(1))
+        .map(|(p, k)| compile_activation_pattern(p, k, i, c))
+        .collect::<MResult<_>>()?;
+    Ok(CompiledActivationPattern::AtomTuple {
+        tag_id: t.name.hash(),
+        payload,
+    })
+}
+fn compile_activation_pattern(
+    p: &Pattern,
+    kind: &ValueKind,
+    i: &Interpreter,
+    c: &mut Vec<ActivationPatternCapture>,
+) -> MResult<CompiledActivationPattern> {
+    let kind = kind.deref_kind();
+    match p {
+        Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
+        Pattern::Expression(Expression::Literal(l)) => {
+            let expected = compile_activation_literal(l, i)?;
+            if expected.kind().deref_kind() != kind {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            }
+            Ok(CompiledActivationPattern::Literal { expected })
+        }
+        Pattern::Expression(Expression::Var(v)) => {
+            let id = v.name.hash();
+            if let Some(n) = c.iter().position(|x| x.id == id) {
+                if c[n].kind.deref_kind() != kind {
+                    return Err(
+                        MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                            .with_tokens(p.tokens()),
+                    );
+                }
+                return Ok(CompiledActivationPattern::Capture { capture_index: n });
+            }
+            let slot =
+                create_capture_slot_for_kind(&kind).map_err(|e| e.with_tokens(p.tokens()))?;
+            c.push(ActivationPatternCapture {
+                id,
+                name: v.name.to_string(),
+                kind,
+                slot,
+            });
+            Ok(CompiledActivationPattern::Capture {
+                capture_index: c.len() - 1,
+            })
+        }
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(t) => {
+            let ValueKind::Tuple(k) = kind else {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            };
+            if t.0.len() != k.len() {
+                return Err(
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(p.tokens()),
+                );
+            }
+            Ok(CompiledActivationPattern::Tuple {
+                elements: t
+                    .0
+                    .iter()
+                    .zip(k.iter())
+                    .map(|(p, k)| compile_activation_pattern(p, k, i, c))
+                    .collect::<MResult<_>>()?,
+            })
+        }
+        Pattern::TupleStruct(t) => match kind {
+            #[cfg(feature = "enum")]
+            ValueKind::Enum(id, _) => compile_enum_variant_pattern(t, id, i, c),
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            ValueKind::Tuple(k) => compile_atom_tuple_pattern(t, &k, i, c),
+            _ => Err(
+                MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                    .with_tokens(p.tokens()),
+            ),
+        },
+        _ => {
+            Err(MechError::new(ActivationPatternExpressionUnsupported, None)
+                .with_tokens(p.tokens()))
+        }
+    }
+}
+fn matches_pattern(
+    p: &CompiledActivationPattern,
+    v: &Value,
+    proposed: &mut Vec<Option<Value>>,
+) -> bool {
+    match p {
+        CompiledActivationPattern::Wildcard => true,
+        CompiledActivationPattern::Literal { expected } => expected == &detached(v),
+        CompiledActivationPattern::Capture { capture_index } => {
+            let x = detached(v);
+            match &proposed[*capture_index] {
+                Some(y) => y == &x,
+                None => {
+                    proposed[*capture_index] = Some(x);
+                    true
+                }
+            }
+        }
+        #[cfg(feature = "tuple")]
+        CompiledActivationPattern::Tuple { elements } => match detached(v) {
+            Value::Tuple(t) => {
+                let t = t.borrow();
+                t.elements.len() == elements.len()
+                    && elements
+                        .iter()
+                        .zip(t.elements.iter())
+                        .all(|(p, v)| matches_pattern(p, v, proposed))
+            }
+            _ => false,
+        },
+        CompiledActivationPattern::EnumVariant {
+            enum_id,
+            variant_id,
+            payload,
+        } => {
+            #[cfg(feature = "enum")]
+            {
+                let Value::Enum(e) = detached(v) else {
+                    return false;
+                };
+                let e = e.borrow();
+                if e.id != *enum_id || e.variants.len() != 1 {
+                    return false;
+                }
+                let (id, value) = &e.variants[0];
+                id == variant_id
+                    && match (payload, value) {
+                        (None, None) => true,
+                        (Some(p), Some(v)) => matches_pattern(p, v, proposed),
+                        _ => false,
+                    }
+            }
+            #[cfg(not(feature = "enum"))]
+            {
+                false
+            }
+        }
+        CompiledActivationPattern::AtomTuple { tag_id, payload } => {
+            #[cfg(all(feature = "tuple", feature = "atom"))]
+            {
+                let Value::Tuple(t) = detached(v) else {
+                    return false;
+                };
+                let t = t.borrow();
+                if t.elements.len() != payload.len() + 1 {
+                    return false;
+                }
+                let Value::Atom(tag) = detached(&t.elements[0]) else {
+                    return false;
+                };
+                tag.borrow().id() == *tag_id
+                    && payload
+                        .iter()
+                        .zip(t.elements.iter().skip(1))
+                        .all(|(p, v)| matches_pattern(p, v, proposed))
+            }
+            #[cfg(not(all(feature = "tuple", feature = "atom")))]
+            {
+                false
+            }
+        }
+        #[cfg(not(feature = "tuple"))]
+        CompiledActivationPattern::Tuple { .. } => false,
+    }
+}
+fn generation() -> (Ref<usize>, Value) {
+    let r = Ref::new(0);
+    (r.clone(), Value::Index(r))
+}
+struct ScopePulse {
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for ScopePulse {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn reactive_dependency_scopes(&self, _: usize) -> Option<Vec<ReactiveDependencyScope>> {
+        Some(vec![ReactiveDependencyScope::Root])
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternScopePulse".into()
+    }
+}
+struct Matcher {
+    pattern: CompiledActivationPattern,
+    trigger: Value,
+    captures: Vec<ActivationPatternCapture>,
+    matched: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Matcher {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        let mut p = vec![None; self.captures.len()];
+        let ok = matches_pattern(&self.pattern, &self.trigger, &mut p);
+        if ok {
+            for (c, v) in self.captures.iter().zip(p.iter()) {
+                if let Some(v) = v {
+                    commit_capture_slot(&c.slot, v)?
+                }
+            }
+        }
+        *self.matched.borrow_mut() = ok;
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn reactive_dependency_kinds(&self, _: usize) -> Option<Vec<ReactiveDependencyKind>> {
+        Some(vec![
+            ReactiveDependencyKind::Reactive,
+            ReactiveDependencyKind::Sampled,
+        ])
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternMatcher".into()
+    }
+}
+struct Finalize {
+    matched: Ref<bool>,
+    eligible: Ref<bool>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Finalize {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.eligible.borrow_mut() = *self.matched.borrow();
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternArmFinalize".into()
+    }
+}
+struct Select {
+    eligible: Vec<Ref<bool>>,
+    selected: Ref<usize>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Select {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        *self.selected.borrow_mut() = self
+            .eligible
+            .iter()
+            .position(|x| *x.borrow())
+            .unwrap_or(usize::MAX);
+        *self.out.borrow_mut() += 1;
+        Ok(ReactiveSolveStatus::Changed)
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternSelectArm".into()
+    }
+}
+struct Gate {
+    arm: usize,
+    selected: Ref<usize>,
+    out: Ref<usize>,
+}
+impl MechFunctionImpl for Gate {
+    fn solve(&self) {}
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+        if *self.selected.borrow() == self.arm {
+            *self.out.borrow_mut() += 1;
+            Ok(ReactiveSolveStatus::Changed)
+        } else {
+            Ok(ReactiveSolveStatus::Unchanged)
+        }
+    }
+    fn out(&self) -> Value {
+        Value::Index(self.out.clone())
+    }
+    fn to_string(&self) -> String {
+        "ActivationPatternArmGate".into()
+    }
+}
 
-#[cfg(feature="compiler")] macro_rules! interpreter_only {($t:ty)=>{impl MechFunctionCompiler for $t { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }};}
-#[cfg(feature="compiler")] interpreter_only!(ScopePulse);
-#[cfg(feature="compiler")] interpreter_only!(Matcher);
-#[cfg(feature="compiler")] interpreter_only!(Finalize);
-#[cfg(feature="compiler")] interpreter_only!(Select);
-#[cfg(feature="compiler")] interpreter_only!(Gate);
+#[cfg(feature = "compiler")]
+macro_rules! interpreter_only {
+    ($t:ty) => {
+        impl MechFunctionCompiler for $t {
+            fn compile(&self, _: &mut CompileCtx) -> MResult<Register> {
+                Err(MechError::new(
+                    GenericError {
+                        msg: "Activation pattern dispatch is interpreter-only.".into(),
+                    },
+                    None,
+                ))
+            }
+        }
+    };
+}
+#[cfg(feature = "compiler")]
+interpreter_only!(ScopePulse);
+#[cfg(feature = "compiler")]
+interpreter_only!(Matcher);
+#[cfg(feature = "compiler")]
+interpreter_only!(Finalize);
+#[cfg(feature = "compiler")]
+interpreter_only!(Select);
+#[cfg(feature = "compiler")]
+interpreter_only!(Gate);
 
-pub(crate) fn elaborate_patterned_activation(scope:&ActivationScope,arms:&[ActivationArm],trigger:Value,trigger_cells:Vec<ReactiveCellId>,i:&Interpreter)->MResult<Value>{
- let last=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
- if !matches!(last.pattern,Pattern::Wildcard)||last.guard.is_some(){return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))} if arms[..arms.len()-1].iter().any(|x|matches!(x.pattern,Pattern::Wildcard)){return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens()))} if arms.iter().any(|x|x.guard.is_some()){return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens()))}
- for arm in arms {if let ActivationArmBody::Block(body)=&arm.body{for(code,_)in body{match code{MechCode::Statement(Statement::VariableAssign(_))|MechCode::Statement(Statement::OpAssign(_))=>return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())),MechCode::Statement(Statement::ContextSend(_))=>return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())),_=>{}}}}}
- let mut compiled=Vec::new();for arm in arms{let mut captures=Vec::new();let pattern=compile(&arm.pattern,&trigger,i,&mut captures)?;compiled.push(CompiledArm{pattern,captures})}
- if trigger.reactive_root_cell_ids()!=trigger_cells{return Err(MechError::new(ActivationPatternTriggerInvariant,None).with_tokens(scope.tokens()))}
- let plan=i.plan();let(scope_gen,scope_v)=generation();let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_gen}),&[trigger.clone()])?;
- let(mut matcher_nodes,mut completions,mut matched)=(Vec::new(),Vec::new(),Vec::new());for arm in &compiled{let(o,v)=generation();let f=Ref::new(false);let n=plan.borrow_mut().register(Box::new(Matcher{pattern:arm.pattern.clone(),trigger:trigger.clone(),captures:arm.captures.clone(),matched:f.clone(),out:o}),&[scope_v.clone(),trigger.clone()])?;matcher_nodes.push(n);completions.push(v);matched.push(f)}
- let(mut finalizers,mut eligible,mut done)=(Vec::new(),Vec::new(),Vec::new());for(f,c)in matched.iter().zip(completions.iter()){let(o,v)=generation();let e=Ref::new(false);finalizers.push(plan.borrow_mut().register(Box::new(Finalize{matched:f.clone(),eligible:e.clone(),out:o}),&[c.clone()])?);eligible.push(e);done.push(v)} let(o,selection)=generation();let selected=Ref::new(usize::MAX);let selector=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:o}),&done)?;
- let(mut gates,mut pulses)=(Vec::new(),Vec::new());for arm in 0..arms.len(){let(o,v)=generation();gates.push(plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:o}),&[selection.clone()])?);pulses.push(v)}
- let mut ranges=Vec::new();for(arm,compiled_arm)in arms.iter().zip(compiled.iter()){let symbols=i.symbols();let mut s=symbols.borrow_mut();let old=compiled_arm.captures.iter().map(|c|(c.id,s.symbols.get(&c.id).cloned(),s.mutable_variables.get(&c.id).cloned())).collect::<Vec<_>>();for c in &compiled_arm.captures{s.insert(c.id,c.slot.clone(),false);}drop(s);let start=plan.len();plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());let result=match &arm.body{ActivationArmBody::Block(b)=>{for(c,_)in b{crate::mech_code(c,i)?;}Ok(())},ActivationArmBody::Expression(e)=>crate::expression(e,None,i).map(|_|())};plan.pop_activation_registration_scope();let mut s=symbols.borrow_mut();for(id,oldv,oldm)in old{s.symbols.remove(&id);s.mutable_variables.remove(&id);if let Some(v)=oldv{s.symbols.insert(id,v);}if let Some(v)=oldm{s.mutable_variables.insert(id,v);}}drop(s);result?;ranges.push((start,plan.len()))}
- let registration=PatternActivationRegistration{scope_pulse_node:scope_node,selector_node:selector,arms:(0..arms.len()).map(|n|PatternActivationArmRegistration{matcher_node:matcher_nodes[n],finalizer_node:finalizers[n],gate_node:gates[n],pulse_cell:pulses[n].reactive_root_cell_ids()[0],body_node_start:ranges[n].0,body_node_end:ranges[n].1,captures:compiled[n].captures.iter().map(|c|PatternActivationCaptureRegistration{id:c.id,kind:c.kind.clone(),cell:c.slot.reactive_root_cell_ids()[0]}).collect()}).collect()};plan.borrow_mut().register_pattern_activation(registration);Ok(Value::Empty)
+fn preflight_patterned_activation(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: &Value,
+    trigger_cells: &[ReactiveCellId],
+    i: &Interpreter,
+) -> MResult<PreflightPatternedActivation> {
+    let last = arms.last().ok_or_else(|| {
+        MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+    })?;
+    if !matches!(last.pattern, Pattern::Wildcard) || last.guard.is_some() {
+        return Err(
+            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms[..arms.len() - 1]
+        .iter()
+        .any(|a| matches!(a.pattern, Pattern::Wildcard))
+    {
+        return Err(
+            MechError::new(ActivationPatternWildcardMustBeLast, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms.iter().any(|a| a.guard.is_some()) {
+        return Err(
+            MechError::new(ActivationPatternGuardMustBePure, None).with_tokens(scope.tokens())
+        );
+    }
+    for a in arms {
+        if let ActivationArmBody::Block(body) = &a.body {
+            for (code, _) in body {
+                match code {
+                    MechCode::Statement(Statement::VariableAssign(_))
+                    | MechCode::Statement(Statement::OpAssign(_)) => {
+                        return Err(MechError::new(
+                            ActivationPatternRegisterWriteUnsupported,
+                            None,
+                        )
+                        .with_tokens(code.tokens()));
+                    }
+                    MechCode::Statement(Statement::ContextSend(_)) => {
+                        return Err(MechError::new(
+                            ActivationPatternContextEffectUnsupported,
+                            None,
+                        )
+                        .with_tokens(code.tokens()));
+                    }
+                    MechCode::Statement(Statement::VariableDefine(d)) if d.mutable => {
+                        return Err(MechError::new(ActivationPatternDefinitionUnsupported, None)
+                            .with_tokens(code.tokens()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if trigger.reactive_root_cell_ids() != trigger_cells {
+        return Err(
+            MechError::new(ActivationPatternTriggerInvariant, None).with_tokens(scope.tokens())
+        );
+    }
+    let trigger_kind = trigger.kind().deref_kind();
+    let mut compiled = Vec::new();
+    for a in arms {
+        let mut captures = Vec::new();
+        let pattern = compile_activation_pattern(&a.pattern, &trigger_kind, i, &mut captures)?;
+        compiled.push(PreflightActivationArm { pattern, captures });
+    }
+    Ok(PreflightPatternedActivation {
+        trigger_kind,
+        arms: compiled,
+    })
+}
+
+fn elaborate_patterned_activation_inner(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: Value,
+    trigger_cells: Vec<ReactiveCellId>,
+    i: &Interpreter,
+) -> MResult<Value> {
+    let preflight = preflight_patterned_activation(scope, arms, &trigger, &trigger_cells, i)?;
+    let compiled = preflight.arms;
+    let plan = i.plan();
+    let (scope_gen, scope_v) = generation();
+    let scope_node = plan
+        .borrow_mut()
+        .register(Box::new(ScopePulse { out: scope_gen }), &[trigger.clone()])?;
+    let (mut matcher_nodes, mut completions, mut matched) = (Vec::new(), Vec::new(), Vec::new());
+    for arm in &compiled {
+        let (o, v) = generation();
+        let f = Ref::new(false);
+        let n = plan.borrow_mut().register(
+            Box::new(Matcher {
+                pattern: arm.pattern.clone(),
+                trigger: trigger.clone(),
+                captures: arm.captures.clone(),
+                matched: f.clone(),
+                out: o,
+            }),
+            &[scope_v.clone(), trigger.clone()],
+        )?;
+        matcher_nodes.push(n);
+        completions.push(v);
+        matched.push(f)
+    }
+    let (mut finalizers, mut eligible, mut done) = (Vec::new(), Vec::new(), Vec::new());
+    for (f, c) in matched.iter().zip(completions.iter()) {
+        let (o, v) = generation();
+        let e = Ref::new(false);
+        finalizers.push(plan.borrow_mut().register(
+            Box::new(Finalize {
+                matched: f.clone(),
+                eligible: e.clone(),
+                out: o,
+            }),
+            &[c.clone()],
+        )?);
+        eligible.push(e);
+        done.push(v)
+    }
+    let (o, selection) = generation();
+    let selected = Ref::new(usize::MAX);
+    let selector = plan.borrow_mut().register(
+        Box::new(Select {
+            eligible: eligible.clone(),
+            selected: selected.clone(),
+            out: o,
+        }),
+        &done,
+    )?;
+    let (mut gates, mut pulses) = (Vec::new(), Vec::new());
+    for arm in 0..arms.len() {
+        let (o, v) = generation();
+        gates.push(plan.borrow_mut().register(
+            Box::new(Gate {
+                arm,
+                selected: selected.clone(),
+                out: o,
+            }),
+            &[selection.clone()],
+        )?);
+        pulses.push(v)
+    }
+    let mut ranges = Vec::new();
+    for (arm, compiled_arm) in arms.iter().zip(compiled.iter()) {
+        let symbols = i.symbols();
+        let snapshot = symbols.borrow().snapshot();
+        {
+            let mut s = symbols.borrow_mut();
+            for c in &compiled_arm.captures {
+                s.insert(c.id, c.slot.clone(), false);
+                s.dictionary.borrow_mut().insert(c.id, c.name.clone());
+            }
+        }
+        let start = plan.len();
+        plan.push_activation_registration_scope(pulses[ranges.len()].reactive_root_cell_ids());
+        let result = match &arm.body {
+            ActivationArmBody::Block(b) => {
+                for (c, _) in b {
+                    crate::mech_code(c, i)?;
+                }
+                Ok(())
+            }
+            ActivationArmBody::Expression(e) => crate::expression(e, None, i).map(|_| ()),
+        };
+        plan.pop_activation_registration_scope();
+        symbols.borrow_mut().restore(snapshot);
+        result?;
+        ranges.push((start, plan.len()))
+    }
+    let registration = PatternActivationRegistration {
+        scope_pulse_node: scope_node,
+        selector_node: selector,
+        arms: (0..arms.len())
+            .map(|n| PatternActivationArmRegistration {
+                matcher_node: matcher_nodes[n],
+                finalizer_node: finalizers[n],
+                gate_node: gates[n],
+                pulse_cell: pulses[n].reactive_root_cell_ids()[0],
+                body_node_start: ranges[n].0,
+                body_node_end: ranges[n].1,
+                captures: compiled[n]
+                    .captures
+                    .iter()
+                    .map(|c| PatternActivationCaptureRegistration {
+                        id: c.id,
+                        kind: c.kind.clone(),
+                        cell: c.slot.reactive_root_cell_ids()[0],
+                    })
+                    .collect(),
+            })
+            .collect(),
+    };
+    plan.borrow_mut().register_pattern_activation(registration);
+    Ok(Value::Empty)
+}
+
+pub(crate) fn elaborate_patterned_activation(
+    scope: &ActivationScope,
+    arms: &[ActivationArm],
+    trigger: Value,
+    trigger_cells: Vec<ReactiveCellId>,
+    interpreter: &Interpreter,
+) -> MResult<Value> {
+    let plan = interpreter.plan();
+    let checkpoint = plan.checkpoint();
+    match elaborate_patterned_activation_inner(scope, arms, trigger, trigger_cells, interpreter) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            plan.rollback(checkpoint)?;
+            Err(error)
+        }
+    }
 }

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -1,28 +1,94 @@
-//! Patterned activation elaboration.
+//! Static scheduling support for patterned activation scopes.
 //!
-//! This module is deliberately kept separate from `mechdown`: activation
-//! scheduling is interpreter infrastructure rather than syntax dispatch.
-//! Fixed-body scopes continue to use the established registration path while
-//! patterned scopes are elaborated here as the activation graph grows.
+//! The small dispatch nodes in this file deliberately contain no syntax and
+//! are registered once while a source tree is elaborated.  A reactive turn
+//! only moves generation counters through that already-built graph.
 
 use crate::*;
 
-/// Describes the internal generation cells used by a patterned activation.
-///
-/// Keeping this descriptor independent of syntax is important: the reactive
-/// plan owns these cells for the lifetime of the loaded program, so a dispatch
-/// never needs to create or rebuild plan nodes.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PatternActivationGenerations {
-    pub scope: Option<ReactiveCellId>,
-    pub selection: Option<ReactiveCellId>,
-    pub arms: Vec<PatternActivationArmGenerations>,
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternExpressionUnsupported;
+impl MechErrorKind for ActivationPatternExpressionUnsupported { fn name(&self)->&str{"ActivationPatternExpressionUnsupported"} fn message(&self)->String{"This activation pattern is not supported.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternCaptureKindUnsupported;
+impl MechErrorKind for ActivationPatternCaptureKindUnsupported { fn name(&self)->&str{"ActivationPatternCaptureKindUnsupported"} fn message(&self)->String{"The capture kind cannot be inferred from the activation trigger.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternArmsNonExhaustive;
+impl MechErrorKind for ActivationPatternArmsNonExhaustive { fn name(&self)->&str{"ActivationPatternArmsNonExhaustive"} fn message(&self)->String{"Patterned activations require a final unguarded wildcard arm.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternWildcardMustBeLast;
+impl MechErrorKind for ActivationPatternWildcardMustBeLast { fn name(&self)->&str{"ActivationPatternWildcardMustBeLast"} fn message(&self)->String{"The wildcard activation arm must be last.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternGuardMustBePure;
+impl MechErrorKind for ActivationPatternGuardMustBePure { fn name(&self)->&str{"ActivationPatternGuardMustBePure"} fn message(&self)->String{"Patterned activation guards must be pure.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternRegisterWriteUnsupported;
+impl MechErrorKind for ActivationPatternRegisterWriteUnsupported { fn name(&self)->&str{"ActivationPatternRegisterWriteUnsupported"} fn message(&self)->String{"Patterned activation register writes are not supported.".into()} }
+#[derive(Debug, Clone)] pub(crate) struct ActivationPatternContextEffectUnsupported;
+impl MechErrorKind for ActivationPatternContextEffectUnsupported { fn name(&self)->&str{"ActivationPatternContextEffectUnsupported"} fn message(&self)->String{"Patterned activation context effects are not supported.".into()} }
+
+#[derive(Clone, Debug)]
+enum CompiledActivationPattern { Wildcard, Literal(Value) }
+
+fn compile_pattern(pattern: &Pattern, interpreter: &Interpreter) -> MResult<CompiledActivationPattern> {
+  match pattern {
+    Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
+    Pattern::Expression(Expression::Literal(literal)) => Ok(CompiledActivationPattern::Literal(crate::literal(literal, interpreter)?)),
+    // A variable is deliberately not treated as a catch-all: doing so loses
+    // the type and stable backing reference required for a capture slot.
+    Pattern::Expression(Expression::Var(_)) => Err(MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(pattern.tokens())),
+    _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None).with_tokens(pattern.tokens())),
+  }
 }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PatternActivationArmGenerations {
-    pub matched: Option<ReactiveCellId>,
-    pub guard_start: Option<ReactiveCellId>,
-    pub complete: Option<ReactiveCellId>,
-    pub pulse: Option<ReactiveCellId>,
+fn generation() -> (Ref<usize>, Value) { let cell=Ref::new(0usize); let value=Value::Index(cell.clone()); (cell,value) }
+
+struct ScopePulse { out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for ScopePulse { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for ScopePulse {
+  fn solve(&self) {}
+  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
+  fn out(&self)->Value { Value::Index(self.out.clone()) }
+  fn reactive_dependency_scopes(&self,_:usize)->Option<Vec<ReactiveDependencyScope>> { Some(vec![ReactiveDependencyScope::Root]) }
+  fn to_string(&self)->String{"ActivationPatternScopePulse".into()}
+}
+struct Matcher { pattern: CompiledActivationPattern, trigger: Value, matched: Ref<bool>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Matcher { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Matcher {
+  fn solve(&self) {}
+  fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{ *self.matched.borrow_mut()=match &self.pattern { CompiledActivationPattern::Wildcard=>true, CompiledActivationPattern::Literal(value)=>value==&self.trigger }; *self.out.borrow_mut()+=1; Ok(ReactiveSolveStatus::Changed) }
+  fn out(&self)->Value{Value::Index(self.out.clone())}
+  fn reactive_dependency_kinds(&self,_:usize)->Option<Vec<ReactiveDependencyKind>>{Some(vec![ReactiveDependencyKind::Reactive,ReactiveDependencyKind::Sampled])}
+  fn to_string(&self)->String{"ActivationPatternMatcher".into()}
+}
+struct Finalize { matched: Ref<bool>, eligible: Ref<bool>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Finalize { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Finalize { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.eligible.borrow_mut()=*self.matched.borrow();*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmFinalize".into()} }
+struct Select { eligible: Vec<Ref<bool>>, selected: Ref<usize>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Select { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Select { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{*self.selected.borrow_mut()=self.eligible.iter().position(|x|*x.borrow()).unwrap_or(usize::MAX);*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternSelectArm".into()} }
+struct Gate { arm: usize, selected: Ref<usize>, out: Ref<usize> }
+#[cfg(feature="compiler")] impl MechFunctionCompiler for Gate { fn compile(&self,_:&mut CompileCtx)->MResult<Register>{Err(MechError::new(GenericError{msg:"Activation pattern dispatch is interpreter-only.".into()},None))} }
+impl MechFunctionImpl for Gate { fn solve(&self){} fn solve_reactive(&self)->MResult<ReactiveSolveStatus>{if *self.selected.borrow()==self.arm {*self.out.borrow_mut()+=1;Ok(ReactiveSolveStatus::Changed)} else {Ok(ReactiveSolveStatus::Unchanged)}} fn out(&self)->Value{Value::Index(self.out.clone())} fn to_string(&self)->String{"ActivationPatternArmGate".into()} }
+
+/// Elaborates the static, combinational dispatch graph for literal and
+/// wildcard patterned activation arms.  Unsupported destructuring is rejected
+/// during elaboration rather than deferred to a reactive turn.
+pub(crate) fn elaborate_patterned_activation(scope: &ActivationScope, arms: &[ActivationArm], trigger: Value, trigger_cells: Vec<ReactiveCellId>, interpreter: &Interpreter) -> MResult<Value> {
+  let final_arm=arms.last().ok_or_else(||MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens()))?;
+  if !matches!(final_arm.pattern,Pattern::Wildcard) || final_arm.guard.is_some() { return Err(MechError::new(ActivationPatternArmsNonExhaustive,None).with_tokens(scope.tokens())); }
+  if arms[..arms.len()-1].iter().any(|arm|matches!(arm.pattern,Pattern::Wildcard)) { return Err(MechError::new(ActivationPatternWildcardMustBeLast,None).with_tokens(scope.tokens())); }
+  if arms.iter().any(|arm|arm.guard.is_some()) { return Err(MechError::new(ActivationPatternGuardMustBePure,None).with_tokens(scope.tokens())); }
+  for arm in arms { if let ActivationArmBody::Block(body)=&arm.body { for (code,_) in body { match code { MechCode::Statement(Statement::VariableAssign(_)) | MechCode::Statement(Statement::OpAssign(_)) => return Err(MechError::new(ActivationPatternRegisterWriteUnsupported,None).with_tokens(code.tokens())), MechCode::Statement(Statement::ContextSend(_)) => return Err(MechError::new(ActivationPatternContextEffectUnsupported,None).with_tokens(code.tokens())), _=>{} } } } }
+  let patterns=arms.iter().map(|arm|compile_pattern(&arm.pattern,interpreter)).collect::<MResult<Vec<_>>>()?;
+  let plan=interpreter.plan();
+  let (scope_generation,scope_value)=generation();
+  let scope_node=plan.borrow_mut().register(Box::new(ScopePulse{out:scope_generation}), &[trigger.clone()])?;
+  let mut matcher_nodes=Vec::new(); let mut completions=Vec::new(); let mut matched=Vec::new();
+  for pattern in patterns { let (complete,complete_value)=generation(); let flag=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Matcher{pattern,trigger:trigger.clone(),matched:flag.clone(),out:complete}), &[scope_value.clone(),trigger.clone()])?; matcher_nodes.push(id); completions.push(complete_value); matched.push(flag); }
+  let mut finalizer_nodes=Vec::new(); let mut eligible=Vec::new(); let mut arm_complete=Vec::new();
+  for (flag, complete) in matched.iter().zip(completions.iter()) { let (done,done_value)=generation(); let ok=Ref::new(false); let id=plan.borrow_mut().register(Box::new(Finalize{matched:flag.clone(),eligible:ok.clone(),out:done}), &[complete.clone()])?; finalizer_nodes.push(id); eligible.push(ok); arm_complete.push(done_value); }
+  let (selection,selection_value)=generation(); let selected=Ref::new(usize::MAX); let selector_node=plan.borrow_mut().register(Box::new(Select{eligible:eligible.clone(),selected:selected.clone(),out:selection}), &arm_complete)?;
+  let mut gate_nodes=Vec::new(); let mut pulses=Vec::new();
+  for arm in 0..arms.len() { let (pulse,pulse_value)=generation(); let id=plan.borrow_mut().register(Box::new(Gate{arm,selected:selected.clone(),out:pulse}), &[selection_value.clone()])?; gate_nodes.push(id); pulses.push(pulse_value); }
+  let mut registrations=Vec::new();
+  for (arm,pulse) in arms.iter().zip(pulses.iter()) { let start=plan.len(); plan.push_activation_registration_scope(pulse.reactive_root_cell_ids()); let result=match &arm.body { ActivationArmBody::Block(body)=>{for (code,_) in body { crate::mech_code(code,interpreter)?; } Ok(())}, ActivationArmBody::Expression(expression)=>{crate::expression(expression,None,interpreter).map(|_|())} }; plan.pop_activation_registration_scope(); result?; registrations.push((start,plan.len())); }
+  let registration=PatternActivationRegistration { scope_pulse_node:scope_node, selector_node, arms:(0..arms.len()).map(|i|PatternActivationArmRegistration{matcher_node:matcher_nodes[i],finalizer_node:finalizer_nodes[i],gate_node:gate_nodes[i],pulse_cell:pulses[i].reactive_root_cell_ids()[0],body_node_start:registrations[i].0,body_node_end:registrations[i].1}).collect() };
+  plan.borrow_mut().register_pattern_activation(registration);
+  let _=trigger_cells; // The scope pulse's Root dependency is the trigger's root storage.
+  Ok(Value::Empty)
 }

--- a/src/interpreter/src/builtins.rs
+++ b/src/interpreter/src/builtins.rs
@@ -165,6 +165,7 @@ fn is_prelude_name(name: &str) -> bool {
         "SetSize",
         "Set1D",
         "Table",
+        "TupleAccessElement",
     ];
     EXACT.contains(&name) || PREFIXES.iter().any(|prefix| name.starts_with(prefix))
 }

--- a/src/interpreter/src/lib.rs
+++ b/src/interpreter/src/lib.rs
@@ -100,6 +100,10 @@ pub mod builtins;
 #[cfg(feature = "functions")]
 pub mod modules;
 pub mod expressions;
+#[cfg(all(
+  feature = "functions",
+  feature = "symbol_table",
+))]
 pub mod activation;
 #[cfg(feature = "functions")]
 pub mod functions;

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -452,12 +452,20 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 
 #[cfg(all(feature = "functions", feature = "symbol_table"))]
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
-  let ActivationBody::Block(body) = &scope.body else {
-    return Err(MechError::new(ActivationScopeRegistrationUnsupported, None).with_tokens(scope.tokens()));
-  };
-  let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
-  let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
-  plan.pop_activation_registration_scope(); result
+  match &scope.body {
+    ActivationBody::Block(body) => {
+      let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+      let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
+      plan.pop_activation_registration_scope(); result
+    }
+    ActivationBody::PatternArms(arms) => {
+      let trigger = match &scope.trigger {
+        Expression::Var(var) => p.state.borrow().get_symbol(var.name.hash()).map(|value| value.borrow().clone()),
+        _ => None,
+      }.ok_or_else(|| MechError::new(ActivationTriggerMustBeStableReference, None).with_tokens(scope.trigger.tokens()))?;
+      crate::activation::elaborate_patterned_activation(scope, arms, trigger, trigger_cells, p)
+    }
+  }
 }
 #[cfg(not(all(feature = "functions", feature = "symbol_table")))]
 fn elaborate_activation_scope(scope: &ActivationScope, _p: &Interpreter, _trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> { Err(MechError::new(ActivationScopeRegistrationUnsupported,None).with_tokens(scope.tokens())) }

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -84,7 +84,7 @@ mod activation_scope_tests {
     use super::*;
     use std::collections::HashSet;
 
-    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick { left := x - radius\n doubled := left * 2.0 }";
+    const PURE: &str = "tick := 0.0\nx := 10.0\nradius := 2.0\n~> tick {\n left := x - radius\n doubled := left * 2.0\n}";
     const REGISTER: &str =
         "tick := 0.0\n~x := 10.0\n\n~> tick {\n  next-x := x + 1.0\n  x = next-x\n}";
     const TWO_REGISTERS: &str = "tick := 0.0\n\n~x := 0.0\n~y := 0.0\n\n~> tick {\n  next-x := x + 1.0\n  next-y := y + 2.0\n\n  x = next-x\n  y = next-y\n}";
@@ -371,23 +371,31 @@ mod activation_scope_tests {
     }
     #[test]
     fn activation_scope_rejects_whole_assignment_to_trigger() {
-        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick = tick + 1.0 }").unwrap();
         let mut i = Interpreter::new_with_full_stdlib(0);
+        let setup = mech_syntax::parser::parse("~tick := 0.0").unwrap();
+        i.interpret(&setup).unwrap();
+        let before = snapshot(&i);
+        let t = mech_syntax::parser::parse("~> tick {\n tick = tick + 1.0\n}").unwrap();
         assert!(
             format!("{:?}", i.interpret(&t).unwrap_err())
                 .contains("ActivationScopeTriggerWriteUnsupported")
         );
-        assert!(i.plan().borrow().nodes.is_empty());
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.plan().activation_registration_active());
     }
     #[test]
     fn activation_scope_rejects_operator_assignment_to_trigger() {
-        let t = mech_syntax::parser::parse("~tick := 0.0\n~> tick { tick += 1.0 }").unwrap();
         let mut i = Interpreter::new_with_full_stdlib(0);
+        let setup = mech_syntax::parser::parse("~tick := 0.0").unwrap();
+        i.interpret(&setup).unwrap();
+        let before = snapshot(&i);
+        let t = mech_syntax::parser::parse("~> tick {\n tick += 1.0\n}").unwrap();
         assert!(
             format!("{:?}", i.interpret(&t).unwrap_err())
                 .contains("ActivationScopeTriggerWriteUnsupported")
         );
-        assert!(i.plan().borrow().nodes.is_empty());
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.plan().activation_registration_active());
     }
     #[test]
     fn activation_scope_plan_is_stable_across_triggers() {

--- a/src/interpreter/src/stdlib/access/tuple.rs
+++ b/src/interpreter/src/stdlib/access/tuple.rs
@@ -15,6 +15,23 @@ impl MechFunctionImpl for TupleAccessElement {
   fn out(&self) -> Value { self.out.clone() }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
+impl MechFunctionFactory for TupleAccessElement {
+  fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+    match args {
+      FunctionArgs::Nullary(out) => Ok(Box::new(Self { out })),
+      _ => Err(MechError::new(
+        IncorrectNumberOfArguments { expected: 0, found: args.len() },
+        None,
+      ).with_compiler_loc()),
+    }
+  }
+}
+register_descriptor! {
+  FunctionDescriptor {
+    name: "TupleAccessElement",
+    ptr: TupleAccessElement::new,
+  }
+}
 #[cfg(feature = "compiler")]
 impl MechFunctionCompiler for TupleAccessElement {
   fn compile(&self, ctx: &mut CompileCtx) -> MResult<Register> {
@@ -23,7 +40,7 @@ impl MechFunctionCompiler for TupleAccessElement {
     ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Tuple));
     ctx.features.insert(FeatureFlag::Builtin(FeatureKind::Access));
     ctx.emit_nullop(
-      hash_str(stringify!("TupleAccessElement")),
+      hash_str("TupleAccessElement"),
       registers[0],
     );
     return Ok(registers[0]);

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -1297,10 +1297,29 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
         self.flush_direct_execution(program, pending, result)?;
+        // Pure patterned scopes are lowered structurally and then handed to
+        // the interpreter's static patterned-dispatch elaborator.  Effects
+        // remain intentionally unsupported in this path.
+        if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          let mut lowered = scope.clone();
+          lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
+          let mut lowered_arms = Vec::with_capacity(arms.len());
+          for arm in arms {
+            let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
+            let body = match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
+              mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+            };
+            lowered_arms.push(mech_core::ActivationArm { pattern: arm.pattern.clone(), guard, body });
+          }
+          lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
+          program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          return Ok(());
+        }
         let mut lowered = scope.clone();
         lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
         let mut registrations = Vec::new();
-        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => { return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet lowered".to_string() }, None)); } };
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => unreachable!() };
         lowered.body = mech_core::ActivationBody::Block(vec![]);
         let lowered_body = match &mut lowered.body { mech_core::ActivationBody::Block(body) => body, _ => unreachable!() };
         for (body_code, body_comment) in scope_body {
@@ -1482,7 +1501,17 @@ impl MechRuntime {
     match code {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
-        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => return Err(MechError::new(RuntimeAddressedAssignmentUnsupported { target: "patterned activation bodies are not yet supported".to_string() }, None)) };
+        if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          for arm in arms {
+            if let Some(guard) = &arm.guard { self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?; }
+            match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => for (code, _) in body { self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?; },
+              mech_core::ActivationArmBody::Expression(expression) => self.preflight_expression_context_reads(context, registry, expression, addressed_read_preflight)?,
+            }
+          }
+          return Ok(());
+        }
+        let scope_body = match &scope.body { mech_core::ActivationBody::Block(body) => body, mech_core::ActivationBody::PatternArms(_) => unreachable!() };
         let has_send = scope_body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_))));
         // Only writes to local registers conflict with an effectful activation.
         // Context-addressed assignments have their own, operation-specific


### PR DESCRIPTION
### Motivation

- Provide interpreter-side elaboration for patterned activation scopes so patterned arms can be statically registered into the reactive plan rather than rejected at runtime. 
- Establish the static dispatch graph and plan metadata needed to run pure/combinational patterned activations without dynamic plan growth. 
- Permit the runtime to lower and preflight patterned activation bodies/guards for context-read resolution instead of blanket-rejecting them.

### Description

- Replace the lightweight scaffold in `src/interpreter/src/activation.rs` with an interpreter-side patterned-dispatch elaborator that registers a static graph: `ScopePulse`, per-arm `Matcher`, per-arm `Finalize`, a source-ordered `Select`, and per-arm `Gate`, and a minimal `CompiledActivationPattern` supporting literals and wildcards; added structured activation errors for unsupported cases. 
- Add `elaborate_patterned_activation(...)` and route `ActivationBody::PatternArms` from `mechdown` into this entry point, preserving the existing fixed-body activation path unchanged. 
- Register each arm body under its arm pulse (via `push_activation_registration_scope`) and record immutable plan metadata in `PatternActivationRegistration` / `PatternActivationArmRegistration` stored on the `ReactivePlan`. 
- Update runtime lowering and preflight to structurally lower pure patterned activation arms/guards (resolve context reads) and to traverse pattern guards and bodies during preflight instead of rejecting all patterned scopes; explicitly reject effectful constructs (register writes, context sends) inside patterned arms with structured errors.

### Testing

- Ran `cargo check -p mech-interpreter`, which completed successfully after the changes. 
- Triggered `cargo check -p mech-runtime`; the runtime lowering changes were exercised during the build but the CI interaction/long compile was observed and is marked as a follow-up validation item. 
- Performed repository checks (`git diff --check`) and committed the branch `implement-patterned-activation-dispatch` with message `Implement patterned activation dispatch foundation` (commit `c00c9ab54c48d4b9...`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6020b87720832a8e52d71ea57a6547)