### PR TITLE
Unify pattern matching across dispatch contexts

### DIFF
--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -940,6 +940,31 @@ impl ReactivePlan {
     self.pattern_activation_registrations.push(registration);
   }
 
+  /// Records an input that is read when another reactive cause schedules the
+  /// node. Updating this cell alone must not schedule the node.
+  pub fn add_sampled_dependency(
+    &mut self,
+    node_id: ReactiveNodeId,
+    cell: ReactiveCellId,
+  ) -> bool {
+    let Some(node) = self.nodes.get_mut(node_id) else {
+      return false;
+    };
+    if let Some(existing) = node.inputs.iter().find(|dependency| dependency.cell == cell) {
+      return existing.kind == ReactiveDependencyKind::Sampled
+        || existing.kind == ReactiveDependencyKind::Reactive;
+    }
+    node.inputs.push(ReactiveDependency {
+      cell,
+      kind: ReactiveDependencyKind::Sampled,
+    });
+    let consumers = self.sampled_consumers.entry(cell).or_default();
+    if !consumers.contains(&node_id) {
+      consumers.push(node_id);
+    }
+    true
+  }
+
   pub fn reactive_consumers_for(&self, cell: ReactiveCellId) -> &[ReactiveNodeId] {
     self.reactive_consumers
       .get(&cell)

--- a/src/core/src/nodes.rs
+++ b/src/core/src/nodes.rs
@@ -1982,6 +1982,22 @@ impl Identifier {
   }
 }
 
+/// Constructs an identifier reserved for sampled runtime pattern values. The
+/// leading NUL cannot be produced by Mech source syntax, so source names always
+/// retain ordinary binding semantics.
+pub fn internal_pattern_value_identifier(name: &str) -> Identifier {
+  let mut chars = Vec::with_capacity(name.chars().count() + 1);
+  chars.push('\0');
+  chars.extend(name.chars());
+  Identifier {
+    name: Token::new(TokenKind::Identifier, SourceRange::default(), chars),
+  }
+}
+
+pub fn is_internal_pattern_value_identifier(identifier: &Identifier) -> bool {
+  identifier.name.chars.first() == Some(&'\0')
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Emoji {

--- a/src/core/src/structures/matrix.rs
+++ b/src/core/src/structures/matrix.rs
@@ -509,9 +509,64 @@ impl<T> Matrix<T> {
   }
 }
 
-impl<T> Matrix<T> 
+impl<T> Matrix<T>
 where T: Debug + Clone + PartialEq + 'static
 {
+
+  /// Returns whether `replace_payload_from` can update this matrix without
+  /// replacing its reactive root.
+  pub fn can_replace_payload_from(&self, source: &Matrix<T>) -> bool {
+    let rows = source.rows();
+    let cols = source.cols();
+    match self {
+      #[cfg(feature = "row_vectord")]
+      Matrix::RowDVector(_) => rows == 1,
+      #[cfg(feature = "vectord")]
+      Matrix::DVector(_) => cols == 1,
+      #[cfg(feature = "matrixd")]
+      Matrix::DMatrix(_) => true,
+      _ => self.shape() == source.shape(),
+    }
+  }
+
+  /// Replaces the payload stored by this matrix without replacing its reactive
+  /// root. Dynamic matrices may change dimensions; fixed matrices require the
+  /// source shape to remain identical.
+  pub fn replace_payload_from(&self, source: &Matrix<T>) -> bool {
+    if !self.can_replace_payload_from(source) {
+      return false;
+    }
+    let rows = source.rows();
+    let cols = source.cols();
+    let elements = source.as_vec();
+    match self {
+      #[cfg(feature = "row_vectord")]
+      Matrix::RowDVector(destination) if rows == 1 => {
+        destination
+          .borrow_mut()
+          .clone_from(&RowDVector::from_vec(elements));
+        true
+      }
+      #[cfg(feature = "vectord")]
+      Matrix::DVector(destination) if cols == 1 => {
+        destination
+          .borrow_mut()
+          .clone_from(&DVector::from_vec(elements));
+        true
+      }
+      #[cfg(feature = "matrixd")]
+      Matrix::DMatrix(destination) => {
+        destination
+          .borrow_mut()
+          .clone_from(&DMatrix::from_vec(rows, cols, elements));
+        true
+      }
+      _ => {
+        self.set(elements);
+        true
+      }
+    }
+  }
 
   pub fn append(&mut self, other: &Matrix<T>) -> MResult<()> {
     match (&self, &other) {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -17,10 +17,6 @@ macro_rules! activation_error {
     };
 }
 activation_error!(
-    ActivationPatternExpressionUnsupported,
-    "This activation pattern is not supported."
-);
-activation_error!(
     ActivationPatternCaptureKindUnsupported,
     "The capture kind cannot be inferred from the activation trigger."
 );
@@ -49,28 +45,6 @@ activation_error!(
     "Activation trigger root cells disagree with the resolved trigger."
 );
 
-#[derive(Clone, Debug)]
-enum CompiledActivationPattern {
-    Wildcard,
-    Literal {
-        expected: Value,
-    },
-    Capture {
-        capture_index: usize,
-    },
-    Tuple {
-        elements: Vec<CompiledActivationPattern>,
-    },
-    EnumVariant {
-        enum_id: u64,
-        variant_id: u64,
-        payload: Option<Box<CompiledActivationPattern>>,
-    },
-    AtomTuple {
-        tag_id: u64,
-        payload: Vec<CompiledActivationPattern>,
-    },
-}
 #[derive(Clone)]
 struct ActivationPatternCapture {
     id: u64,
@@ -80,7 +54,7 @@ struct ActivationPatternCapture {
 }
 #[derive(Clone)]
 struct PreflightActivationArm {
-    pattern: CompiledActivationPattern,
+    pattern: CompiledPattern,
     captures: Vec<ActivationPatternCapture>,
 }
 struct PreflightPatternedActivation {
@@ -247,257 +221,54 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
         )),
     }
 }
-fn compile_activation_literal(l: &Literal, i: &Interpreter) -> MResult<Value> {
-    match l {
-        Literal::Empty(_) => Ok(Value::Empty),
-        #[cfg(feature = "bool")]
-        Literal::Boolean(t) => Ok(crate::boolean(t)),
-        #[cfg(feature = "string")]
-        Literal::String(v) => Ok(crate::string(v)),
-        #[cfg(feature = "atom")]
-        Literal::Atom(a) => Ok(Value::Atom(Ref::new(MechAtom::new(a.name.hash())))),
-        Literal::Number(Number::Real(RealNumber::TypedInteger(_)))
-        | Literal::TypedLiteral(_)
-        | Literal::Kind(_) => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
-        Literal::Number(n) => crate::number(n, i),
-        _ => Err(MechError::new(ActivationPatternExpressionUnsupported, None)),
+
+fn capture_kinds_are_storage_compatible(destination: &ValueKind, source: &ValueKind) -> bool {
+    let destination = destination.deref_kind();
+    let source = source.deref_kind();
+    #[cfg(feature = "atom")]
+    if matches!(
+        (&destination, &source),
+        (ValueKind::Atom(_, _), ValueKind::Atom(_, _))
+    ) {
+        return true;
     }
+    destination == source
 }
-#[cfg(feature = "enum")]
-fn compile_enum_variant_pattern(
-    t: &PatternTupleStruct,
-    enum_id: u64,
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let variant_id = t.name.hash();
-    let def = i
-        .state
-        .borrow()
-        .enums
-        .get(&enum_id)
-        .cloned()
-        .ok_or_else(|| {
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
-        })?;
-    let declared = def
-        .variants
-        .iter()
-        .find(|(id, _)| *id == variant_id)
-        .map(|(_, p)| p.clone())
-        .ok_or_else(|| {
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens())
-        })?;
-    let payload = match (t.patterns.as_slice(), declared) {
-        ([], None) => None,
-        ([p], Some(Value::Kind(k))) => Some(Box::new(compile_activation_pattern(p, &k, i, c)?)),
-        _ => {
-            return Err(
+
+struct ReactiveBindingSink<'a> {
+    captures: &'a [ActivationPatternCapture],
+}
+
+impl PatternBindingSink for ReactiveBindingSink<'_> {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()> {
+        if !pattern_match.matched {
+            return Ok(());
+        }
+
+        // Validate every destination before mutating any stable capture cell.
+        for binding in &pattern_match.bindings {
+            let capture = self.captures.get(binding.index).ok_or_else(|| {
                 MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                    .with_tokens(t.tokens()),
-            );
-        }
-    };
-    Ok(CompiledActivationPattern::EnumVariant {
-        enum_id,
-        variant_id,
-        payload,
-    })
-}
-#[cfg(all(feature = "tuple", feature = "atom"))]
-fn compile_atom_tuple_pattern(
-    t: &PatternTupleStruct,
-    kinds: &[ValueKind],
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let Some(first) = kinds.first() else {
-        return Err(
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
-        );
-    };
-    if !matches!(first.deref_kind(), ValueKind::Atom(_, _)) || t.patterns.len() != kinds.len() - 1 {
-        return Err(
-            MechError::new(ActivationPatternCaptureKindUnsupported, None).with_tokens(t.tokens()),
-        );
-    };
-    let payload = t
-        .patterns
-        .iter()
-        .zip(kinds.iter().skip(1))
-        .map(|(p, k)| compile_activation_pattern(p, k, i, c))
-        .collect::<MResult<_>>()?;
-    Ok(CompiledActivationPattern::AtomTuple {
-        tag_id: t.name.hash(),
-        payload,
-    })
-}
-fn compile_activation_pattern(
-    p: &Pattern,
-    kind: &ValueKind,
-    i: &Interpreter,
-    c: &mut Vec<ActivationPatternCapture>,
-) -> MResult<CompiledActivationPattern> {
-    let kind = kind.deref_kind();
-    match p {
-        Pattern::Wildcard => Ok(CompiledActivationPattern::Wildcard),
-        Pattern::Expression(Expression::Literal(l)) => {
-            let expected = compile_activation_literal(l, i)?;
-            if expected.kind().deref_kind() != kind {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
+            })?;
+            let source = detached(&binding.value);
+            if capture.id != binding.id
+                || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
+                || std::mem::discriminant(&capture.slot) != std::mem::discriminant(&source)
+            {
+                return Err(MechError::new(
+                    ActivationPatternCaptureKindUnsupported,
+                    None,
+                ));
             }
-            Ok(CompiledActivationPattern::Literal { expected })
         }
-        Pattern::Expression(Expression::Var(v)) => {
-            let id = v.name.hash();
-            if let Some(n) = c.iter().position(|x| x.id == id) {
-                if c[n].kind.deref_kind() != kind {
-                    return Err(
-                        MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                            .with_tokens(p.tokens()),
-                    );
-                }
-                return Ok(CompiledActivationPattern::Capture { capture_index: n });
-            }
-            let slot =
-                create_capture_slot_for_kind(&kind).map_err(|e| e.with_tokens(p.tokens()))?;
-            c.push(ActivationPatternCapture {
-                id,
-                name: v.name.to_string(),
-                kind,
-                slot,
-            });
-            Ok(CompiledActivationPattern::Capture {
-                capture_index: c.len() - 1,
-            })
+
+        for binding in &pattern_match.bindings {
+            commit_capture_slot(&self.captures[binding.index].slot, &binding.value)?;
         }
-        #[cfg(feature = "tuple")]
-        Pattern::Tuple(t) => {
-            let ValueKind::Tuple(k) = kind else {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
-            };
-            if t.0.len() != k.len() {
-                return Err(
-                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                        .with_tokens(p.tokens()),
-                );
-            }
-            Ok(CompiledActivationPattern::Tuple {
-                elements: t
-                    .0
-                    .iter()
-                    .zip(k.iter())
-                    .map(|(p, k)| compile_activation_pattern(p, k, i, c))
-                    .collect::<MResult<_>>()?,
-            })
-        }
-        Pattern::TupleStruct(t) => match kind {
-            #[cfg(feature = "enum")]
-            ValueKind::Enum(id, _) => compile_enum_variant_pattern(t, id, i, c),
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            ValueKind::Tuple(k) => compile_atom_tuple_pattern(t, &k, i, c),
-            _ => Err(
-                MechError::new(ActivationPatternCaptureKindUnsupported, None)
-                    .with_tokens(p.tokens()),
-            ),
-        },
-        _ => {
-            Err(MechError::new(ActivationPatternExpressionUnsupported, None)
-                .with_tokens(p.tokens()))
-        }
+        Ok(())
     }
 }
-fn matches_pattern(
-    p: &CompiledActivationPattern,
-    v: &Value,
-    proposed: &mut Vec<Option<Value>>,
-) -> bool {
-    match p {
-        CompiledActivationPattern::Wildcard => true,
-        CompiledActivationPattern::Literal { expected } => expected == &detached(v),
-        CompiledActivationPattern::Capture { capture_index } => {
-            let x = detached(v);
-            match &proposed[*capture_index] {
-                Some(y) => y == &x,
-                None => {
-                    proposed[*capture_index] = Some(x);
-                    true
-                }
-            }
-        }
-        #[cfg(feature = "tuple")]
-        CompiledActivationPattern::Tuple { elements } => match detached(v) {
-            Value::Tuple(t) => {
-                let t = t.borrow();
-                t.elements.len() == elements.len()
-                    && elements
-                        .iter()
-                        .zip(t.elements.iter())
-                        .all(|(p, v)| matches_pattern(p, v, proposed))
-            }
-            _ => false,
-        },
-        CompiledActivationPattern::EnumVariant {
-            enum_id,
-            variant_id,
-            payload,
-        } => {
-            #[cfg(feature = "enum")]
-            {
-                let Value::Enum(e) = detached(v) else {
-                    return false;
-                };
-                let e = e.borrow();
-                if e.id != *enum_id || e.variants.len() != 1 {
-                    return false;
-                }
-                let (id, value) = &e.variants[0];
-                id == variant_id
-                    && match (payload, value) {
-                        (None, None) => true,
-                        (Some(p), Some(v)) => matches_pattern(p, v, proposed),
-                        _ => false,
-                    }
-            }
-            #[cfg(not(feature = "enum"))]
-            {
-                false
-            }
-        }
-        CompiledActivationPattern::AtomTuple { tag_id, payload } => {
-            #[cfg(all(feature = "tuple", feature = "atom"))]
-            {
-                let Value::Tuple(t) = detached(v) else {
-                    return false;
-                };
-                let t = t.borrow();
-                if t.elements.len() != payload.len() + 1 {
-                    return false;
-                }
-                let Value::Atom(tag) = detached(&t.elements[0]) else {
-                    return false;
-                };
-                tag.borrow().id() == *tag_id
-                    && payload
-                        .iter()
-                        .zip(t.elements.iter().skip(1))
-                        .all(|(p, v)| matches_pattern(p, v, proposed))
-            }
-            #[cfg(not(all(feature = "tuple", feature = "atom")))]
-            {
-                false
-            }
-        }
-        #[cfg(not(feature = "tuple"))]
-        CompiledActivationPattern::Tuple { .. } => false,
-    }
-}
+
 fn generation() -> (Ref<usize>, Value) {
     let r = Ref::new(0);
     (r.clone(), Value::Index(r))
@@ -522,8 +293,9 @@ impl MechFunctionImpl for ScopePulse {
     }
 }
 struct Matcher {
-    pattern: CompiledActivationPattern,
+    pattern: CompiledPattern,
     trigger: Value,
+    expression_values: Vec<Value>,
     captures: Vec<ActivationPatternCapture>,
     matched: Ref<bool>,
     out: Ref<usize>,
@@ -531,27 +303,28 @@ struct Matcher {
 impl MechFunctionImpl for Matcher {
     fn solve(&self) {}
     fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
-        let mut p = vec![None; self.captures.len()];
-        let ok = matches_pattern(&self.pattern, &self.trigger, &mut p);
-        if ok {
-            for (c, v) in self.captures.iter().zip(p.iter()) {
-                if let Some(v) = v {
-                    commit_capture_slot(&c.slot, v)?
-                }
-            }
+        let pattern_match = match_compiled_pattern_with_values(
+            &self.pattern,
+            &self.trigger,
+            &self.expression_values,
+        )?;
+        ReactiveBindingSink {
+            captures: &self.captures,
         }
-        *self.matched.borrow_mut() = ok;
+        .commit(&pattern_match)?;
+        *self.matched.borrow_mut() = pattern_match.matched;
         *self.out.borrow_mut() += 1;
         Ok(ReactiveSolveStatus::Changed)
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
     }
-    fn reactive_dependency_kinds(&self, _: usize) -> Option<Vec<ReactiveDependencyKind>> {
-        Some(vec![
-            ReactiveDependencyKind::Reactive,
-            ReactiveDependencyKind::Sampled,
-        ])
+    fn reactive_dependency_kinds(&self, argument_count: usize) -> Option<Vec<ReactiveDependencyKind>> {
+        let mut kinds = vec![ReactiveDependencyKind::Sampled; argument_count];
+        if let Some(scope_pulse) = kinds.first_mut() {
+            *scope_pulse = ReactiveDependencyKind::Reactive;
+        }
+        Some(kinds)
     }
     fn to_string(&self) -> String {
         "ActivationPatternMatcher".into()
@@ -687,8 +460,25 @@ fn preflight_patterned_activation(
     let trigger_kind = trigger.kind().deref_kind();
     let mut compiled = Vec::new();
     for a in arms {
-        let mut captures = Vec::new();
-        let pattern = compile_activation_pattern(&a.pattern, &trigger_kind, i, &mut captures)?;
+        let pattern = compile_pattern(&a.pattern, Some(&trigger_kind), i)?;
+        let captures = pattern
+            .binding_specs()
+            .into_iter()
+            .map(|binding| {
+                let kind = binding.kind.ok_or_else(|| {
+                    MechError::new(ActivationPatternCaptureKindUnsupported, None)
+                        .with_tokens(a.pattern.tokens())
+                })?;
+                let slot = create_capture_slot_for_kind(&kind)
+                    .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
+                Ok(ActivationPatternCapture {
+                    id: binding.id,
+                    name: binding.name,
+                    kind,
+                    slot,
+                })
+            })
+            .collect::<MResult<Vec<_>>>()?;
         compiled.push(PreflightActivationArm { pattern, captures });
     }
     Ok(PreflightPatternedActivation {
@@ -1007,23 +797,38 @@ fn elaborate_patterned_activation_inner(
     }
     let compiled = preflight.arms;
     let plan = i.plan();
+    let pattern_expression_values = compiled
+        .iter()
+        .map(|arm| {
+            arm.pattern
+                .expressions()
+                .iter()
+                .map(|expression| crate::expression(expression, None, i))
+                .collect::<MResult<Vec<_>>>()
+        })
+        .collect::<MResult<Vec<_>>>()?;
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
         .borrow_mut()
         .register(Box::new(ScopePulse { out: scope_gen }), &[trigger.clone()])?;
     let (mut matcher_nodes, mut completions, mut matched) = (Vec::new(), Vec::new(), Vec::new());
-    for arm in &compiled {
+    for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
         let (o, v) = generation();
         let f = Ref::new(false);
+        let mut inputs = Vec::with_capacity(2 + expression_values.len());
+        inputs.push(scope_v.clone());
+        inputs.push(trigger.clone());
+        inputs.extend(expression_values.iter().cloned());
         let n = plan.borrow_mut().register(
             Box::new(Matcher {
                 pattern: arm.pattern.clone(),
                 trigger: trigger.clone(),
+                expression_values: expression_values.clone(),
                 captures: arm.captures.clone(),
                 matched: f.clone(),
                 out: o,
             }),
-            &[scope_v.clone(), trigger.clone()],
+            &inputs,
         )?;
         matcher_nodes.push(n);
         completions.push(v);
@@ -1206,6 +1011,46 @@ mod tests {
         assert_eq!(slot.reactive_root_cell_ids(), cells);
     }
 
+    #[cfg(feature = "atom")]
+    #[test]
+    fn activation_atom_capture_accepts_a_new_atom_value() {
+        let mut interpreter = interpret(
+            r#"
+event := :first
+~> event
+  | captured => {
+      selected := captured
+    }
+  | * => {
+      selected := :fallback
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        let registration = registration(&interpreter);
+        let Value::Atom(event) = symbol(&interpreter, "event") else {
+            panic!("event is not an atom")
+        };
+        *event.borrow_mut() = MechAtom::from_name("second");
+
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&registration, &outcome), 0);
+        let selected_atom = {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            (registration.arms[0].body_node_start..registration.arms[0].body_node_end)
+                .rev()
+                .find_map(|node| match detached(&plan.node(node).unwrap().function.out()) {
+                    Value::Atom(atom) => Some(atom.borrow().id()),
+                    _ => None,
+                })
+                .expect("no atom output in selected arm body")
+        };
+        assert_eq!(selected_atom, hash_str("second"));
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn activation_capture_slot_rejects_kind_mismatch() {
@@ -1360,6 +1205,30 @@ mod tests {
             names,
         };
     }
+    fn set_unit_enum_event(interpreter: &Interpreter, variant: &str) {
+        let event_value = symbol(interpreter, "event");
+        if let Value::Atom(event) = &event_value {
+            *event.borrow_mut() = MechAtom::from_name(variant);
+            return;
+        }
+        let Value::Enum(event) = event_value else {
+            panic!("event is neither an atom nor an enum");
+        };
+        let enum_id = event.borrow().id;
+        let names = interpreter
+            .state
+            .borrow()
+            .enums
+            .get(&enum_id)
+            .expect("event enum definition is missing")
+            .names
+            .clone();
+        *event.borrow_mut() = MechEnum {
+            id: enum_id,
+            variants: vec![(hash_str(variant), None)],
+            names,
+        };
+    }
     fn set_atom_tuple_event(interpreter: &Interpreter, tag: &str, payload: f64) {
         let Value::Tuple(event) = symbol(interpreter, "event") else {
             panic!("event is not tuple")
@@ -1374,6 +1243,13 @@ mod tests {
             panic!("event is not tuple")
         };
         *event.borrow_mut() = MechTuple::from_vec(values);
+    }
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    fn set_f64_matrix_event(interpreter: &Interpreter, values: Vec<f64>) {
+        let Value::MatrixF64(event) = symbol(interpreter, "event") else {
+            panic!("event is not an f64 matrix")
+        };
+        event.set(values);
     }
     fn selected_arm_index(
         registration: &PatternActivationRegistration,
@@ -1570,6 +1446,28 @@ event<event-kind> := :pressed(0.0)
             assert_eq!(plan_snapshot(&i), topology);
         }
     }
+
+    #[test]
+    fn activation_pattern_matches_payload_free_enum_variant() {
+        let mut i = interpret(
+            r#"
+<signal> := :ready | :other
+event<signal> := :other
+~> event
+  | :ready => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        set_unit_enum_event(&i, "ready");
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+    }
     #[test]
     fn activation_pattern_capture_storage_identity_is_stable() {
         let (mut i, trigger, r, topology) = load_enum_activation();
@@ -1724,8 +1622,166 @@ event := (1.0, 1.0)
         let o = i.advance_reactive_turn(&[trigger]).unwrap();
         assert_dispatch_turn(&i, &topology, &o, 1, -1.);
     }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
-    fn activation_pattern_repeated_capture_kind_mismatch_is_structured() {
+    fn activation_array_pattern_samples_expression_only_on_trigger() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 1.0]
+threshold := 2.0
+~> event
+  | [x, threshold + 0.0, x] => {
+      selected := x + 100.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let registration = registration(&i);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let dependency_nodes = turn_executed_nodes(&dependency_turn);
+        assert!(!dependency_nodes.contains(&registration.scope_pulse_node));
+        assert!(!dependency_nodes.contains(&registration.selector_node));
+        for arm in &registration.arms {
+            assert!(!dependency_nodes.contains(&arm.matcher_node));
+            assert!(!dependency_nodes.contains(&arm.finalizer_node));
+            assert!(!dependency_nodes.contains(&arm.gate_node));
+        }
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 104.0);
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 5.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_pattern_supports_prefix_suffix_and_anonymous_spread() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0 1.0]
+~> event
+  | [x, ..., x] => {
+      selected := x + 10.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 11.0);
+
+        set_f64_matrix_event(&i, vec![1.0, 2.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 1, -1.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_rest_segment_accepts_nested_array_pattern() {
+        let mut i = interpret(
+            r#"
+event := [1.0 2.0 3.0 4.0]
+~> event
+  | [head | [second, ..., last]] => {
+      selected := head * 100.0 + second * 10.0 + last
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 124.0);
+    }
+
+    #[cfg(feature = "u64")]
+    #[test]
+    fn activation_typed_literal_pattern_uses_shared_value_matching() {
+        let mut i = interpret(
+            r#"
+event := 1u64
+~> event
+  | 1u64 => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 1.0);
+    }
+
+    #[test]
+    fn activation_whole_composite_capture_fails_before_plan_mutation() {
+        let mut i = interpret("event := (1.0, 2.0)");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | whole => {
+      selected := 1.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("whole")));
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_array_rest_capture_reports_storage_gap_before_plan_mutation() {
+        let mut i = interpret("event := [1.0 2.0 3.0]");
+        let topology = plan_snapshot(&i);
+        let error = interpret_more(
+            &mut i,
+            r#"
+~> event
+  | [head | rest] => {
+      selected := head
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(plan_snapshot(&i), topology);
+        assert!(!i.symbols().borrow().contains(hash_str("head")));
+        assert!(!i.symbols().borrow().contains(hash_str("rest")));
+    }
+    #[test]
+    fn activation_pattern_repeated_capture_kind_mismatch_uses_canonical_error() {
         let mut i = interpret("event := (1.0, \"one\")");
         let topology = plan_snapshot(&i);
         let error = interpret_more(
@@ -1737,7 +1793,7 @@ event := (1.0, 1.0)
     }",
         )
         .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(error.kind_name(), "PatternCompileError");
         assert_eq!(plan_snapshot(&i), topology);
         assert!(!i.symbols().borrow().contains(hash_str("x")));
         assert!(!i.symbols().borrow().contains(hash_str("selected")));
@@ -1883,7 +1939,7 @@ event := (1.0, 1.0)
     }",
         )
         .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(error.kind_name(), "PatternCompileError");
         assert_eq!(plan_snapshot(&i), topology);
     }
     #[test]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -81,7 +81,19 @@ fn detached(v: &Value) -> Value {
 fn clone_ref_value<T: Clone>(destination: &Ref<T>, source: &Ref<T>) {
     destination.borrow_mut().clone_from(&*source.borrow())
 }
-fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
+#[cfg(feature = "matrix")]
+fn capture_matrix_dimensions(shape: &[usize]) -> MResult<(usize, usize)> {
+    match shape {
+        [] => Ok((1, 0)),
+        [rows, cols] => Ok((*rows, *cols)),
+        _ => Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        )),
+    }
+}
+
+fn create_capture_slot_for_kind(kind: &ValueKind, interpreter: &Interpreter) -> MResult<Value> {
     match kind.deref_kind() {
         #[cfg(feature = "u8")]
         ValueKind::U8 => Ok(Value::U8(Ref::new(0))),
@@ -118,13 +130,309 @@ fn create_capture_slot_for_kind(kind: &ValueKind) -> MResult<Value> {
         ValueKind::Index => Ok(Value::Index(Ref::new(0))),
         #[cfg(feature = "atom")]
         ValueKind::Atom(id, _) => Ok(Value::Atom(Ref::new(MechAtom::new(id)))),
+        #[cfg(feature = "tuple")]
+        ValueKind::Tuple(kinds) => Ok(Value::Tuple(Ref::new(MechTuple::from_vec(
+            kinds
+                .iter()
+                .map(|kind| create_capture_slot_for_kind(kind, interpreter))
+                .collect::<MResult<Vec<_>>>()?,
+        )))),
+        #[cfg(feature = "enum")]
+        ValueKind::Enum(id, _) => Ok(Value::Enum(Ref::new(MechEnum {
+            id,
+            variants: Vec::new(),
+            names: interpreter.dictionary(),
+        }))),
+        #[cfg(feature = "record")]
+        ValueKind::Record(fields) => {
+            let values = fields
+                .iter()
+                .map(|(name, kind)| {
+                    Ok(((hash_str(name), name.clone()), create_capture_slot_for_kind(kind, interpreter)?))
+                })
+                .collect::<MResult<Vec<_>>>()?;
+            Ok(Value::Record(Ref::new(MechRecord::from_vec(values))))
+        }
+        #[cfg(feature = "map")]
+        ValueKind::Map(key_kind, value_kind) => Ok(Value::Map(Ref::new(MechMap {
+            key_kind: *key_kind,
+            value_kind: *value_kind,
+            num_elements: 0,
+            map: Default::default(),
+        }))),
+        #[cfg(feature = "set")]
+        ValueKind::Set(element_kind, size) => Ok(Value::Set(Ref::new(MechSet::new(
+            *element_kind,
+            size.unwrap_or(0),
+        )))),
+        #[cfg(feature = "table")]
+        ValueKind::Table(columns, rows) => {
+            let mut names = Vec::with_capacity(columns.len());
+            let mut kinds = Vec::with_capacity(columns.len());
+            let mut values = Vec::with_capacity(columns.len());
+            for (name, kind) in columns {
+                names.push(name);
+                kinds.push(kind.clone());
+                let default = create_capture_slot_for_kind(&kind, interpreter)?;
+                values.push(vec![default; rows]);
+            }
+            Ok(Value::Table(Ref::new(MechTable::new_table(
+                names, kinds, values,
+            ))))
+        }
+        #[cfg(feature = "matrix")]
+        ValueKind::Matrix(element_kind, shape) => {
+            let (rows, cols) = capture_matrix_dimensions(&shape)?;
+            let count = rows.saturating_mul(cols);
+            match *element_kind {
+                ValueKind::Index => Ok(Value::MatrixIndex(Matrix::from_vec(
+                    vec![0; count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "bool")]
+                ValueKind::Bool => Ok(Value::MatrixBool(Matrix::from_vec(
+                    vec![false; count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "u8")]
+                ValueKind::U8 => Ok(Value::MatrixU8(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u16")]
+                ValueKind::U16 => Ok(Value::MatrixU16(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u32")]
+                ValueKind::U32 => Ok(Value::MatrixU32(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u64")]
+                ValueKind::U64 => Ok(Value::MatrixU64(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "u128")]
+                ValueKind::U128 => Ok(Value::MatrixU128(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i8")]
+                ValueKind::I8 => Ok(Value::MatrixI8(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i16")]
+                ValueKind::I16 => Ok(Value::MatrixI16(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i32")]
+                ValueKind::I32 => Ok(Value::MatrixI32(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i64")]
+                ValueKind::I64 => Ok(Value::MatrixI64(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "i128")]
+                ValueKind::I128 => Ok(Value::MatrixI128(Matrix::from_vec(vec![0; count], rows, cols))),
+                #[cfg(feature = "f32")]
+                ValueKind::F32 => Ok(Value::MatrixF32(Matrix::from_vec(vec![0.0; count], rows, cols))),
+                #[cfg(feature = "f64")]
+                ValueKind::F64 => Ok(Value::MatrixF64(Matrix::from_vec(vec![0.0; count], rows, cols))),
+                #[cfg(feature = "string")]
+                ValueKind::String => Ok(Value::MatrixString(Matrix::from_vec(
+                    vec![String::new(); count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "rational")]
+                ValueKind::R64 => Ok(Value::MatrixR64(Matrix::from_vec(
+                    vec![R64::default(); count],
+                    rows,
+                    cols,
+                ))),
+                #[cfg(feature = "complex")]
+                ValueKind::C64 => Ok(Value::MatrixC64(Matrix::from_vec(
+                    vec![C64::default(); count],
+                    rows,
+                    cols,
+                ))),
+                element_kind => {
+                    let default = create_capture_slot_for_kind(&element_kind, interpreter)
+                        .unwrap_or(Value::EmptyKind(element_kind));
+                    Ok(Value::MatrixValue(Matrix::from_vec(
+                        vec![default; count],
+                        rows,
+                        cols,
+                    )))
+                }
+            }
+        }
         _ => Err(MechError::new(
             ActivationPatternCaptureKindUnsupported,
             None,
         )),
     }
 }
+
+fn capture_slot_accepts_payload(destination: &Value, source: &Value) -> bool {
+    let source = detached(source);
+    match (destination, &source) {
+        #[cfg(feature = "tuple")]
+        (Value::Tuple(destination), Value::Tuple(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.elements.len() == source.elements.len()
+                && destination
+                    .elements
+                    .iter()
+                    .zip(&source.elements)
+                    .all(|(destination, source)| {
+                        capture_slot_accepts_payload(destination, source)
+                    })
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(destination), Value::Enum(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            if destination.id != source.id || destination.variants.is_empty() {
+                return destination.id == source.id;
+            }
+            let same_variants = destination.variants.len() == source.variants.len()
+                && destination
+                    .variants
+                    .iter()
+                    .zip(&source.variants)
+                    .all(|((destination_id, _), (source_id, _))| {
+                        destination_id == source_id
+                    });
+            !same_variants
+                || destination.variants.iter().zip(&source.variants).all(
+                    |((_, destination), (_, source))| match (destination, source) {
+                        (Some(destination), Some(source)) => {
+                            capture_slot_accepts_payload(destination, source)
+                        }
+                        (None, None) => true,
+                        _ => false,
+                    },
+                )
+        }
+        #[cfg(feature = "record")]
+        (Value::Record(destination), Value::Record(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.data.len() == source.data.len()
+                && destination.data.iter().zip(&source.data).all(
+                    |((destination_id, destination), (source_id, source))| {
+                        destination_id == source_id
+                            && capture_slot_accepts_payload(destination, source)
+                    },
+                )
+        }
+        #[cfg(feature = "map")]
+        (Value::Map(destination), Value::Map(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            if destination.map.is_empty() || destination.map.len() != source.map.len() {
+                return true;
+            }
+            let same_keys = destination
+                .map
+                .keys()
+                .zip(source.map.keys())
+                .all(|(destination, source)| destination == source);
+            !same_keys
+                || destination
+                    .map
+                    .values()
+                    .zip(source.map.values())
+                    .all(|(destination, source)| {
+                        capture_slot_accepts_payload(destination, source)
+                    })
+        }
+        #[cfg(feature = "table")]
+        (Value::Table(destination), Value::Table(source)) => {
+            let destination = destination.borrow();
+            let source = source.borrow();
+            destination.rows == source.rows
+                && destination.data.len() == source.data.len()
+                && destination.data.iter().zip(&source.data).all(
+                    |(
+                        (destination_id, (destination_kind, destination)),
+                        (source_id, (source_kind, source)),
+                    )| {
+                        destination_id == source_id
+                            && destination_kind == source_kind
+                            && destination.can_replace_payload_from(source)
+                    },
+                )
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixIndex(destination), Value::MatrixIndex(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        (Value::MatrixBool(destination), Value::MatrixBool(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        (Value::MatrixU8(destination), Value::MatrixU8(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        (Value::MatrixU16(destination), Value::MatrixU16(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        (Value::MatrixU32(destination), Value::MatrixU32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        (Value::MatrixU64(destination), Value::MatrixU64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        (Value::MatrixU128(destination), Value::MatrixU128(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        (Value::MatrixI8(destination), Value::MatrixI8(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        (Value::MatrixI16(destination), Value::MatrixI16(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        (Value::MatrixI32(destination), Value::MatrixI32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        (Value::MatrixI64(destination), Value::MatrixI64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        (Value::MatrixI128(destination), Value::MatrixI128(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        (Value::MatrixF32(destination), Value::MatrixF32(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        (Value::MatrixF64(destination), Value::MatrixF64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        (Value::MatrixString(destination), Value::MatrixString(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        (Value::MatrixR64(destination), Value::MatrixR64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        (Value::MatrixC64(destination), Value::MatrixC64(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixValue(destination), Value::MatrixValue(source)) => {
+            destination.can_replace_payload_from(source)
+        }
+        (destination, source) => {
+            std::mem::discriminant(destination) == std::mem::discriminant(source)
+        }
+    }
+}
+
 fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
+    if !capture_slot_accepts_payload(destination, source) {
+        return Err(MechError::new(
+            ActivationPatternCaptureKindUnsupported,
+            None,
+        ));
+    }
     match (destination, &detached(source)) {
         #[cfg(feature = "u8")]
         (Value::U8(a), Value::U8(b)) => {
@@ -215,6 +523,124 @@ fn commit_capture_slot(destination: &Value, source: &Value) -> MResult<()> {
             clone_ref_value(a, b);
             Ok(())
         }
+        #[cfg(feature = "tuple")]
+        (Value::Tuple(a), Value::Tuple(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for (destination, source) in a.elements.iter().zip(&b.elements) {
+                commit_capture_slot(destination, source)?;
+            }
+            Ok(())
+        }
+        #[cfg(feature = "enum")]
+        (Value::Enum(a), Value::Enum(b)) => {
+            let preserve_payload_cells = {
+                let a = a.borrow();
+                let b = b.borrow();
+                !a.variants.is_empty()
+                    && a.variants.len() == b.variants.len()
+                    && a.variants
+                        .iter()
+                        .zip(&b.variants)
+                        .all(|((a, _), (b, _))| a == b)
+            };
+            if preserve_payload_cells {
+                let a = a.borrow();
+                let b = b.borrow();
+                for ((_, destination), (_, source)) in a.variants.iter().zip(&b.variants) {
+                    if let (Some(destination), Some(source)) = (destination, source) {
+                        commit_capture_slot(destination, source)?;
+                    }
+                }
+            } else {
+                clone_ref_value(a, b);
+            }
+            Ok(())
+        }
+        #[cfg(feature = "record")]
+        (Value::Record(a), Value::Record(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for ((_, destination), (_, source)) in a.data.iter().zip(&b.data) {
+                commit_capture_slot(destination, source)?;
+            }
+            Ok(())
+        }
+        #[cfg(feature = "map")]
+        (Value::Map(a), Value::Map(b)) => {
+            let preserve_value_cells = {
+                let a = a.borrow();
+                let b = b.borrow();
+                !a.map.is_empty()
+                    && a.map.len() == b.map.len()
+                    && a.map.keys().zip(b.map.keys()).all(|(a, b)| a == b)
+            };
+            if preserve_value_cells {
+                let a = a.borrow();
+                let b = b.borrow();
+                for ((_, destination), (_, source)) in a.map.iter().zip(&b.map) {
+                    commit_capture_slot(destination, source)?;
+                }
+            } else {
+                clone_ref_value(a, b);
+            }
+            Ok(())
+        }
+        #[cfg(feature = "set")]
+        (Value::Set(a), Value::Set(b)) => {
+            clone_ref_value(a, b);
+            Ok(())
+        }
+        #[cfg(feature = "table")]
+        (Value::Table(a), Value::Table(b)) => {
+            let a = a.borrow();
+            let b = b.borrow();
+            for ((_, (_, destination)), (_, (_, source))) in a.data.iter().zip(&b.data) {
+                if !destination.replace_payload_from(source) {
+                    return Err(MechError::new(
+                        ActivationPatternCaptureKindUnsupported,
+                        None,
+                    ));
+                }
+            }
+            Ok(())
+        }
+        #[cfg(feature = "matrix")]
+        (Value::MatrixIndex(a), Value::MatrixIndex(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        (Value::MatrixBool(a), Value::MatrixBool(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        (Value::MatrixU8(a), Value::MatrixU8(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        (Value::MatrixU16(a), Value::MatrixU16(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        (Value::MatrixU32(a), Value::MatrixU32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        (Value::MatrixU64(a), Value::MatrixU64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        (Value::MatrixU128(a), Value::MatrixU128(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        (Value::MatrixI8(a), Value::MatrixI8(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        (Value::MatrixI16(a), Value::MatrixI16(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        (Value::MatrixI32(a), Value::MatrixI32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        (Value::MatrixI64(a), Value::MatrixI64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        (Value::MatrixI128(a), Value::MatrixI128(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        (Value::MatrixF32(a), Value::MatrixF32(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        (Value::MatrixF64(a), Value::MatrixF64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        (Value::MatrixString(a), Value::MatrixString(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        (Value::MatrixR64(a), Value::MatrixR64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        (Value::MatrixC64(a), Value::MatrixC64(b)) if a.replace_payload_from(b) => Ok(()),
+        #[cfg(feature = "matrix")]
+        (Value::MatrixValue(a), Value::MatrixValue(b)) if a.replace_payload_from(b) => Ok(()),
         _ => Err(MechError::new(
             ActivationPatternCaptureKindUnsupported,
             None,
@@ -229,6 +655,23 @@ fn capture_kinds_are_storage_compatible(destination: &ValueKind, source: &ValueK
     if matches!(
         (&destination, &source),
         (ValueKind::Atom(_, _), ValueKind::Atom(_, _))
+    ) {
+        return true;
+    }
+    #[cfg(feature = "enum")]
+    if matches!(
+        (&destination, &source),
+        (ValueKind::Enum(destination, _), ValueKind::Enum(source, _)) if destination == source
+    ) {
+        return true;
+    }
+    #[cfg(feature = "matrix")]
+    if matches!(
+        (&destination, &source),
+        (
+            ValueKind::Matrix(destination_element, destination_shape),
+            ValueKind::Matrix(source_element, _)
+        ) if destination_shape.is_empty() && destination_element == source_element
     ) {
         return true;
     }
@@ -253,7 +696,7 @@ impl PatternBindingSink for ReactiveBindingSink<'_> {
             let source = detached(&binding.value);
             if capture.id != binding.id
                 || !capture_kinds_are_storage_compatible(&capture.kind, &binding.kind)
-                || std::mem::discriminant(&capture.slot) != std::mem::discriminant(&source)
+                || !capture_slot_accepts_payload(&capture.slot, &source)
             {
                 return Err(MechError::new(
                     ActivationPatternCaptureKindUnsupported,
@@ -469,7 +912,7 @@ fn preflight_patterned_activation(
                     MechError::new(ActivationPatternCaptureKindUnsupported, None)
                         .with_tokens(a.pattern.tokens())
                 })?;
-                let slot = create_capture_slot_for_kind(&kind)
+                let slot = create_capture_slot_for_kind(&kind, i)
                     .map_err(|error| error.with_tokens(a.pattern.tokens()))?;
                 Ok(ActivationPatternCapture {
                     id: binding.id,
@@ -783,7 +1226,17 @@ fn elaborate_patterned_arm_body(
     }
     symbols.borrow_mut().restore(symbol_snapshot);
     body_result?;
-    Ok((body_node_start, plan.len()))
+    let body_node_end = plan.len();
+    {
+        let mut plan = plan.borrow_mut();
+        for node in body_node_start..body_node_end {
+            for capture in captures {
+                let cell = capture.slot.reactive_root_cell_ids()[0];
+                debug_assert!(plan.add_sampled_dependency(node, cell));
+            }
+        }
+    }
+    Ok((body_node_start, body_node_end))
 }
 
 fn elaborate_patterned_activation_inner(
@@ -797,6 +1250,8 @@ fn elaborate_patterned_activation_inner(
     }
     let compiled = preflight.arms;
     let plan = i.plan();
+    let _persistent_user_function_plan =
+        crate::functions::PersistentUserFunctionPlanScope::enter(i);
     let pattern_expression_values = compiled
         .iter()
         .map(|arm| {
@@ -807,6 +1262,15 @@ fn elaborate_patterned_activation_inner(
                 .collect::<MResult<Vec<_>>>()
         })
         .collect::<MResult<Vec<_>>>()?;
+    drop(_persistent_user_function_plan);
+    for (arm, expression_values) in compiled.iter().zip(&pattern_expression_values) {
+        let pattern_match =
+            match_compiled_pattern_with_values(&arm.pattern, &trigger, expression_values)?;
+        ReactiveBindingSink {
+            captures: &arm.captures,
+        }
+        .commit(&pattern_match)?;
+    }
     let (scope_gen, scope_v) = generation();
     let scope_node = plan
         .borrow_mut()
@@ -936,6 +1400,7 @@ pub(crate) fn elaborate_patterned_activation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     fn scalar_capture_cases() -> Vec<(ValueKind, Value)> {
         let mut cases = Vec::new();
@@ -988,8 +1453,9 @@ mod tests {
 
     #[test]
     fn activation_capture_slot_supports_all_enabled_scalar_kinds() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
         for (kind, source) in scalar_capture_cases() {
-            let slot = create_capture_slot_for_kind(&kind).unwrap();
+            let slot = create_capture_slot_for_kind(&kind, &interpreter).unwrap();
             let cells_before = slot.reactive_root_cell_ids();
             assert_eq!(cells_before.len(), 1);
             commit_capture_slot(&slot, &source).unwrap();
@@ -1001,7 +1467,8 @@ mod tests {
     #[cfg(any(feature = "string", feature = "variable_define"))]
     #[test]
     fn activation_capture_slot_preserves_identity_across_updates() {
-        let slot = create_capture_slot_for_kind(&ValueKind::String).unwrap();
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let slot = create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap();
         let cells = slot.reactive_root_cell_ids();
         commit_capture_slot(&slot, &Value::String(Ref::new("first".to_string()))).unwrap();
         assert_eq!(slot, Value::String(Ref::new("first".to_string())));
@@ -1009,6 +1476,108 @@ mod tests {
         commit_capture_slot(&slot, &Value::String(Ref::new("second".to_string()))).unwrap();
         assert_eq!(slot, Value::String(Ref::new("second".to_string())));
         assert_eq!(slot.reactive_root_cell_ids(), cells);
+    }
+
+    #[cfg(all(
+        feature = "tuple",
+        feature = "enum",
+        feature = "record",
+        feature = "map",
+        feature = "set",
+        feature = "table",
+        feature = "string",
+        feature = "f64"
+    ))]
+    #[test]
+    fn activation_capture_slots_support_enabled_composite_value_kinds() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let enum_id = hash_str("capture-enum");
+        let variant_id = hash_str("payload");
+        let names = Ref::new(HashMap::from([
+            (enum_id, "capture-enum".to_string()),
+            (variant_id, "payload".to_string()),
+        ]));
+        let cases = vec![
+            Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+                Value::F64(Ref::new(1.0)),
+                Value::String(Ref::new("tuple".to_string())),
+            ]))),
+            Value::Enum(Ref::new(MechEnum {
+                id: enum_id,
+                variants: vec![(variant_id, Some(Value::F64(Ref::new(2.0))))],
+                names,
+            })),
+            Value::Record(Ref::new(MechRecord::new(vec![
+                ("field", Value::F64(Ref::new(3.0))),
+            ]))),
+            Value::Map(Ref::new(MechMap::from_vec(vec![(
+                Value::String(Ref::new("key".to_string())),
+                Value::F64(Ref::new(4.0)),
+            )]))),
+            Value::Set(Ref::new(MechSet::from_vec(vec![Value::String(Ref::new(
+                "member".to_string(),
+            ))]))),
+            Value::Table(Ref::new(MechTable::new_table(
+                vec!["column".to_string()],
+                vec![ValueKind::F64],
+                vec![vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(6.0))]],
+            ))),
+        ];
+
+        for source in cases {
+            let kind = source.kind();
+            let slot = create_capture_slot_for_kind(&kind, &interpreter).unwrap();
+            let cells = slot.reactive_root_cell_ids();
+            assert_eq!(cells.len(), 1, "missing stable root for {kind}");
+            commit_capture_slot(&slot, &source).unwrap();
+            assert_eq!(slot, source);
+            assert_eq!(slot.reactive_root_cell_ids(), cells);
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "string"))]
+    #[test]
+    fn activation_capture_commit_validates_every_binding_before_mutation() {
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let number = ActivationPatternCapture {
+            id: hash_str("number"),
+            name: "number".to_string(),
+            kind: ValueKind::F64,
+            slot: create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap(),
+        };
+        let text = ActivationPatternCapture {
+            id: hash_str("text"),
+            name: "text".to_string(),
+            kind: ValueKind::String,
+            slot: create_capture_slot_for_kind(&ValueKind::String, &interpreter).unwrap(),
+        };
+        let captures = vec![number, text];
+        let attempted = PatternMatch {
+            matched: true,
+            bindings: vec![
+                PatternBinding {
+                    index: 0,
+                    id: hash_str("number"),
+                    name: "number".to_string(),
+                    kind: ValueKind::F64,
+                    value: Value::F64(Ref::new(9.0)),
+                },
+                PatternBinding {
+                    index: 1,
+                    id: hash_str("text"),
+                    name: "text".to_string(),
+                    kind: ValueKind::F64,
+                    value: Value::F64(Ref::new(10.0)),
+                },
+            ],
+        };
+
+        let error = ReactiveBindingSink { captures: &captures }
+            .commit(&attempted)
+            .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
+        assert_eq!(captures[0].slot, Value::F64(Ref::new(0.0)));
+        assert_eq!(captures[1].slot, Value::String(Ref::new(String::new())));
     }
 
     #[cfg(feature = "atom")]
@@ -1054,7 +1623,8 @@ event := :first
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn activation_capture_slot_rejects_kind_mismatch() {
-        let slot = create_capture_slot_for_kind(&ValueKind::F64).unwrap();
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let slot = create_capture_slot_for_kind(&ValueKind::F64, &interpreter).unwrap();
         let error =
             commit_capture_slot(&slot, &Value::String(Ref::new("wrong".to_string()))).unwrap_err();
         assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
@@ -1185,6 +1755,19 @@ event := :first
             }
         }
         panic!("no f64 output")
+    }
+    fn body_output(interpreter: &Interpreter, arm_index: usize) -> Value {
+        let registration = registration(interpreter);
+        let arm = &registration.arms[arm_index];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        detached(
+            &plan
+                .node(arm.body_node_end - 1)
+                .expect("missing activation body node")
+                .function
+                .out(),
+        )
     }
     fn set_enum_event(interpreter: &Interpreter, variant: &str, payload: f64) {
         let Value::Enum(event) = symbol(interpreter, "event") else {
@@ -1669,6 +2252,49 @@ threshold := 2.0
 
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
+    fn activation_pattern_samples_current_user_function_output_on_trigger() {
+        let mut i = interpret(
+            r#"
+sample(value<f64>) => <f64>
+  | value + 0.0.
+
+event := [1.0 2.0 1.0]
+threshold := 2.0
+~> event
+  | [x, sample(threshold), x] => {
+      selected := x + 100.0
+    }
+  | * => {
+      selected := -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let threshold_cell = root_cell(&i, "threshold");
+        let topology = plan_snapshot(&i);
+        let activation = registration(&i);
+
+        let Value::F64(threshold) = symbol(&i, "threshold") else {
+            panic!("threshold is not f64")
+        };
+        *threshold.borrow_mut() = 3.0;
+        let dependency_turn = i.advance_reactive_turn(&[threshold_cell]).unwrap();
+        let dependency_nodes = turn_executed_nodes(&dependency_turn);
+        assert!(!dependency_nodes.contains(&activation.scope_pulse_node));
+        assert!(!dependency_nodes.contains(&activation.selector_node));
+        for arm in &activation.arms {
+            assert!(!dependency_nodes.contains(&arm.matcher_node));
+            assert!(!dependency_nodes.contains(&arm.finalizer_node));
+            assert!(!dependency_nodes.contains(&arm.gate_node));
+        }
+
+        set_f64_matrix_event(&i, vec![4.0, 3.0, 4.0]);
+        let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&i, &topology, &outcome, 0, 104.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
     fn activation_array_pattern_supports_prefix_suffix_and_anonymous_spread() {
         let mut i = interpret(
             r#"
@@ -1736,49 +2362,142 @@ event := 1u64
     }
 
     #[test]
-    fn activation_whole_composite_capture_fails_before_plan_mutation() {
-        let mut i = interpret("event := (1.0, 2.0)");
-        let topology = plan_snapshot(&i);
-        let error = interpret_more(
-            &mut i,
+    fn activation_whole_composite_capture_is_stable_and_visible_to_the_body() {
+        let mut i = interpret(
             r#"
+event := (1.0, 2.0)
 ~> event
   | whole => {
-      selected := 1.0
+      selected := whole
+    }
+  | * => {
+      selected := (-1.0, -1.0)
+    }
+"#,
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let capture = &activation.arms[0].captures[0];
+        assert_eq!(capture.kind, ValueKind::Tuple(vec![ValueKind::F64, ValueKind::F64]));
+        let body_inputs = i.plan().borrow().nodes
+            [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+            .iter()
+            .flat_map(|node| node.inputs.iter().map(|dependency| dependency.cell))
+            .collect::<Vec<_>>();
+        assert!(
+            body_inputs.contains(&capture.cell),
+            "capture cell {:?} is absent from body inputs {:?}",
+            capture.cell,
+            body_inputs
+        );
+        let topology = plan_snapshot(&i);
+        for values in [[3.0, 4.0], [5.0, 6.0]] {
+            set_tuple_event(
+                &i,
+                values
+                    .into_iter()
+                    .map(|value| Value::F64(Ref::new(value)))
+                    .collect(),
+            );
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            assert_eq!(
+                body_output(&i, 0),
+                Value::Tuple(Ref::new(MechTuple::from_vec(
+                    values
+                        .into_iter()
+                        .map(|value| Value::F64(Ref::new(value)))
+                        .collect(),
+                )))
+            );
+            assert_eq!(registration(&i).arms[0].captures[0].cell, capture.cell);
+            assert_eq!(plan_snapshot(&i), topology);
+        }
+    }
+
+    #[test]
+    fn activation_whole_tuple_capture_keeps_element_access_attached() {
+        let mut i = interpret(
+            r#"
+event := (1.0, 2.0)
+~> event
+  | whole => {
+      selected := whole.1 * 10.0 + whole.2
     }
   | * => {
       selected := -1.0
     }
 "#,
-        )
-        .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(plan_snapshot(&i), topology);
-        assert!(!i.symbols().borrow().contains(hash_str("whole")));
+        );
+        let trigger = root_cell(&i, "event");
+        let topology = plan_snapshot(&i);
+        for (values, expected) in [([3.0, 4.0], 34.0), ([5.0, 6.0], 56.0)] {
+            set_tuple_event(
+                &i,
+                values
+                    .into_iter()
+                    .map(|value| Value::F64(Ref::new(value)))
+                    .collect(),
+            );
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_dispatch_turn(&i, &topology, &outcome, 0, expected);
+        }
     }
 
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
-    fn activation_array_rest_capture_reports_storage_gap_before_plan_mutation() {
-        let mut i = interpret("event := [1.0 2.0 3.0]");
-        let topology = plan_snapshot(&i);
-        let error = interpret_more(
-            &mut i,
+    fn activation_array_rest_capture_preserves_kind_payload_and_identity() {
+        let mut i = interpret(
             r#"
+event := [1.0 2.0 3.0 4.0 5.0]
 ~> event
   | [head | rest] => {
-      selected := head
+      selected := rest
     }
   | * => {
-      selected := -1.0
+      selected := [-1.0]
     }
 "#,
-        )
-        .unwrap_err();
-        assert_eq!(error.kind_name(), "ActivationPatternCaptureKindUnsupported");
-        assert_eq!(plan_snapshot(&i), topology);
-        assert!(!i.symbols().borrow().contains(hash_str("head")));
-        assert!(!i.symbols().borrow().contains(hash_str("rest")));
+        );
+        let trigger = root_cell(&i, "event");
+        let activation = registration(&i);
+        let rest_capture = &activation.arms[0].captures[1];
+        assert_eq!(
+            rest_capture.kind,
+            ValueKind::Matrix(Box::new(ValueKind::F64), Vec::new())
+        );
+        assert!(
+            i.plan().borrow().nodes
+                [activation.arms[0].body_node_start..activation.arms[0].body_node_end]
+                .iter()
+                .any(|node| node
+                    .inputs
+                    .iter()
+                    .any(|dependency| dependency.cell == rest_capture.cell))
+        );
+        let topology = plan_snapshot(&i);
+        let Value::MatrixF64(event) = symbol(&i, "event") else {
+            panic!("event is not an f64 matrix")
+        };
+        for values in [
+            vec![10.0, 20.0, 30.0, 40.0, 50.0],
+            vec![11.0, 21.0, 31.0, 41.0, 51.0, 61.0],
+        ] {
+            let source = Matrix::from_vec(values.clone(), 1, values.len());
+            assert!(event.replace_payload_from(&source));
+            let outcome = i.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            let Value::MatrixF64(rest) = body_output(&i, 0) else {
+                panic!("rest output is not an f64 matrix")
+            };
+            assert_eq!(rest.shape(), vec![1, values.len() - 1]);
+            assert_eq!(rest.as_vec(), values[1..]);
+            assert_eq!(
+                registration(&i).arms[0].captures[1].cell,
+                rest_capture.cell
+            );
+            assert_eq!(plan_snapshot(&i), topology);
+        }
     }
     #[test]
     fn activation_pattern_repeated_capture_kind_mismatch_uses_canonical_error() {

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -1406,19 +1406,21 @@ pub fn match_expression(
         let mut guard_env = base_env.clone();
         let matched = match &arm.pattern {
             Pattern::Wildcard => true,
-            _ => crate::patterns::pattern_matches_value_with_semantics(
+            _ => crate::patterns::pattern_matches_value(
                 &arm.pattern,
                 &detached_source,
                 &mut guard_env,
                 p,
-                crate::patterns::PatternMatchSemantics::OptionGuard,
             )?,
         };
+        if !matched {
+            continue;
+        }
         let passed_guard = match &arm.guard {
             Some(guard) => guard_expression_true(guard, &guard_env, p)?,
             None => true,
         };
-        if matched && passed_guard {
+        if passed_guard {
             #[cfg(feature = "matrix")]
             if value_contains_empty(&detached_source) && is_identity_option_matrix_arm(arm) {
                 if let Some(wildcard_arm) = match_expr
@@ -1561,19 +1563,21 @@ fn match_validate_arm_kinds(
         let mut arm_env = base_env.clone();
         let applicable = match arm.pattern {
             Pattern::Wildcard => true,
-            _ => crate::patterns::pattern_matches_value_with_semantics(
+            _ => crate::patterns::pattern_matches_value(
                 &arm.pattern,
                 source,
                 &mut arm_env,
                 p,
-                crate::patterns::PatternMatchSemantics::OptionGuard,
             )?,
         };
+        if !applicable {
+            continue;
+        }
         let passed_guard = match &arm.guard {
             Some(guard) => guard_expression_true(guard, &arm_env, p)?,
             None => true,
         };
-        if !(applicable && passed_guard) {
+        if !passed_guard {
             continue;
         }
         let arm_value = expression(&arm.expression, Some(&arm_env), p)?;

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -45,7 +45,7 @@ pub fn pattern_match_value(
     match pattern {
         Pattern::Wildcard => Ok(()),
         Pattern::Expression(expr) => match expr {
-            Expression::Var(var) => {
+            Expression::Var(var) if crate::patterns::pattern_var_is_binding(var) => {
                 let id = &var.name.hash();
                 match env.get(id) {
                     Some(existing) if existing == value => Ok(()),

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -36,86 +36,6 @@ pub fn expression(expr: &Expression, env: Option<&Environment>, p: &Interpreter)
 }
 
 #[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
-pub fn pattern_match_value(
-    pattern: &Pattern,
-    value: &Value,
-    env: &mut Environment,
-    p: &Interpreter,
-) -> MResult<()> {
-    match pattern {
-        Pattern::Wildcard => Ok(()),
-        Pattern::Expression(expr) => match expr {
-            Expression::Var(var) if crate::patterns::pattern_var_is_binding(var) => {
-                let id = &var.name.hash();
-                match env.get(id) {
-                    Some(existing) if existing == value => Ok(()),
-                    Some(existing) => Err(MechError::new(
-                        PatternMatchError {
-                            var: var.name.to_string(),
-                            expected: existing.to_string(),
-                            found: value.to_string(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                    None => {
-                        env.insert(id.clone(), value.clone());
-                        Ok(())
-                    }
-                }
-            }
-            _ => {
-                let expected = expression(expr, Some(env), p)?;
-                if detach_comprehension_value(&expected) == detach_comprehension_value(value) {
-                    Ok(())
-                } else {
-                    Err(MechError::new(
-                        PatternMatchError {
-                            var: "<expression>".to_string(),
-                            expected: expected.to_string(),
-                            found: value.to_string(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc())
-                }
-            }
-        },
-        #[cfg(feature = "tuple")]
-        Pattern::Tuple(pat_tuple) => match value {
-            Value::Tuple(values) => {
-                let values_brrw = values.borrow();
-                if pat_tuple.0.len() != values_brrw.elements.len() {
-                    return Err(MechError::new(
-                        ArityMismatchError {
-                            expected: pat_tuple.0.len(),
-                            found: values_brrw.elements.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc());
-                }
-                for (pttrn, val) in pat_tuple.0.iter().zip(values_brrw.elements.iter()) {
-                    pattern_match_value(pttrn, val, env, p)?;
-                }
-                Ok(())
-            }
-            _ => Err(MechError::new(
-                PatternExpectedTupleError {
-                    found: value.kind(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        },
-        Pattern::TupleStruct(pat_struct) => {
-            todo!("Implement tuple struct pattern matching")
-        }
-        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
-    }
-}
-
-#[cfg(any(feature = "set_comprehensions", feature = "matrix_comprehensions"))]
 fn comprehension_environments(
     qualifiers: &[ComprehensionQualifier],
     comprehension_id: u64,
@@ -128,12 +48,19 @@ fn comprehension_environments(
     for qual in qualifiers {
         envs = match qual {
             ComprehensionQualifier::Generator((pttrn, expr)) => {
+                let compiled = crate::patterns::compile_pattern(pttrn, None, &new_p)?;
                 let mut new_envs = Vec::new();
                 for env in &envs {
                     let collection = expression(expr, Some(env), &new_p)?;
                     for elmnt in comprehension_generator_values(&collection)? {
                         let mut new_env = env.clone();
-                        if pattern_match_value(pttrn, &elmnt, &mut new_env, &new_p).is_ok() {
+                        let pattern_match =
+                            crate::patterns::match_compiled_pattern_with_environment_constraints(
+                                &compiled, &elmnt, &new_env, &new_p,
+                            )?;
+                        if pattern_match.matched {
+                            crate::patterns::EnvironmentBindingSink::new(&mut new_env)
+                                .commit(&pattern_match)?;
                             new_envs.push(new_env);
                         }
                     }

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -603,7 +603,7 @@ fn coerce_function_output_kind(
 struct FunctionScope {
   state: Ref<ProgramState>,
   previous_symbols: SymbolTableRef,
-  previous_plan: Plan,
+  previous_plan: Option<Plan>,
   previous_environment: Option<SymbolTableRef>,
 }
 
@@ -617,7 +617,11 @@ impl FunctionScope {
     local_symbols.dictionary = state_brrw.dictionary.clone();
     let local_symbols = Ref::new(local_symbols);
     let previous_symbols = std::mem::replace(&mut state_brrw.symbol_table, local_symbols);
-    let previous_plan = std::mem::replace(&mut state_brrw.plan, Plan::new());
+    let previous_plan = if *p.persistent_user_function_plan_depth.borrow() > 0 {
+      None
+    } else {
+      Some(std::mem::replace(&mut state_brrw.plan, Plan::new()))
+    };
     let previous_environment = state_brrw.environment.take();
     drop(state_brrw);
 
@@ -635,8 +639,30 @@ impl Drop for FunctionScope {
   fn drop(&mut self) {
     let mut state_brrw = self.state.borrow_mut();
     state_brrw.symbol_table = self.previous_symbols.clone();
-    state_brrw.plan = self.previous_plan.clone();
+    if let Some(previous_plan) = &self.previous_plan {
+      state_brrw.plan = previous_plan.clone();
+    }
     state_brrw.environment = self.previous_environment.clone();
+  }
+}
+
+pub(crate) struct PersistentUserFunctionPlanScope {
+  depth: Ref<usize>,
+}
+
+impl PersistentUserFunctionPlanScope {
+  pub(crate) fn enter(interpreter: &Interpreter) -> Self {
+    let depth = interpreter.persistent_user_function_plan_depth.clone();
+    *depth.borrow_mut() += 1;
+    Self { depth }
+  }
+}
+
+impl Drop for PersistentUserFunctionPlanScope {
+  fn drop(&mut self) {
+    let mut depth = self.depth.borrow_mut();
+    debug_assert!(*depth > 0);
+    *depth -= 1;
   }
 }
 

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -41,6 +41,8 @@ pub struct Interpreter {
   #[cfg(feature = "functions")]
   reactive_turn_state: ReactiveTurnState,
   #[cfg(feature = "functions")]
+  pub(crate) persistent_user_function_plan_depth: Ref<usize>,
+  #[cfg(feature = "functions")]
   pub stack: Vec<Frame>,
   registers: Vec<Value>,
   constants: Vec<Value>,
@@ -79,6 +81,8 @@ impl Clone for Interpreter {
       state: Ref::new(self.state.borrow().clone()),
       #[cfg(feature = "functions")]
       reactive_turn_state: self.reactive_turn_state.clone(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: self.persistent_user_function_plan_depth.clone(),
       #[cfg(feature = "functions")]
       stack: self.stack.clone(),
       registers: self.registers.clone(),
@@ -139,6 +143,8 @@ impl Interpreter {
       state: Ref::new(state),
       #[cfg(feature = "functions")]
       reactive_turn_state: ReactiveTurnState::default(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: Ref::new(0),
       #[cfg(feature = "functions")]
       stack: Vec::new(),
       registers: Vec::new(),

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,8 +1,6 @@
 use crate::*;
 use std::collections::HashMap;
 
-const RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX: &str = "mech-internal-context-";
-
 // Patterns
 // ----------------------------------------------------------------------------
 
@@ -795,9 +793,40 @@ pub fn match_compiled_pattern(
     env: &Environment,
     interpreter: &Interpreter,
 ) -> MResult<PatternMatch> {
+    match_compiled_pattern_with_environment(pattern, value, env, interpreter, false)
+}
+
+/// Matches a compiled pattern while treating bindings already present in the
+/// environment as equality constraints. This is used by comprehension
+/// generators, where a later generator may refer to a name introduced by an
+/// earlier qualifier.
+pub fn match_compiled_pattern_with_environment_constraints(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+) -> MResult<PatternMatch> {
+    match_compiled_pattern_with_environment(pattern, value, env, interpreter, true)
+}
+
+fn match_compiled_pattern_with_environment(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+    seed_existing_bindings: bool,
+) -> MResult<PatternMatch> {
     let specs = pattern.binding_specs();
+    let proposed = if seed_existing_bindings {
+        specs
+            .iter()
+            .map(|spec| env.get(&spec.id).map(deep_detach_value))
+            .collect()
+    } else {
+        vec![None; specs.len()]
+    };
     let mut state = PatternMatchState {
-        proposed: vec![None; specs.len()],
+        proposed,
         binding_specs: specs,
         expression_source: PatternExpressionSource::Interpreter { env, interpreter },
     };
@@ -1221,12 +1250,7 @@ fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
 }
 
 pub(crate) fn pattern_var_is_binding(var: &Var) -> bool {
-    var.context.is_none()
-        // Runtime context inputs are sampled pattern values, never captures.
-        && !var
-            .name
-            .to_string()
-            .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX)
+    var.context.is_none() && !is_internal_pattern_value_identifier(&var.name)
 }
 
 fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
@@ -1320,5 +1344,90 @@ mod tests {
             .commit(&pattern_match)
             .unwrap();
         assert_eq!(env.get(&id), Some(&Value::U64(Ref::new(9))));
+    }
+
+    #[test]
+    fn existing_environment_bindings_are_constraints_inside_the_matcher() {
+        let x_id = hash_str("x");
+        let y_id = hash_str("y");
+        let pattern = CompiledPattern::Tuple {
+            elements: vec![
+                CompiledPattern::Binding {
+                    binding_index: 0,
+                    id: x_id,
+                    name: "x".to_string(),
+                    expected_kind: Some(ValueKind::U64),
+                },
+                CompiledPattern::Binding {
+                    binding_index: 1,
+                    id: y_id,
+                    name: "y".to_string(),
+                    expected_kind: Some(ValueKind::U64),
+                },
+            ],
+        };
+        let interpreter = Interpreter::new_with_full_stdlib(0);
+        let mut env = Environment::from([(x_id, Value::U64(Ref::new(1)))]);
+
+        let mismatch = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(2)),
+            Value::U64(Ref::new(3)),
+        ])));
+        let pattern_match = match_compiled_pattern_with_environment_constraints(
+            &pattern,
+            &mismatch,
+            &env,
+            &interpreter,
+        )
+        .unwrap();
+        assert!(!pattern_match.matched);
+        assert!(pattern_match.bindings.is_empty());
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env, Environment::from([(x_id, Value::U64(Ref::new(1)))]));
+
+        let match_value = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(1)),
+            Value::U64(Ref::new(3)),
+        ])));
+        let pattern_match = match_compiled_pattern_with_environment_constraints(
+            &pattern,
+            &match_value,
+            &env,
+            &interpreter,
+        )
+        .unwrap();
+        assert!(pattern_match.matched);
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env.get(&x_id), Some(&Value::U64(Ref::new(1))));
+        assert_eq!(env.get(&y_id), Some(&Value::U64(Ref::new(3))));
+    }
+
+    #[test]
+    fn spellable_internal_looking_name_remains_an_ordinary_binding() {
+        let source_name = "mech-internal-context-user-value";
+        let source_identifier = Identifier {
+            name: Token::new(
+                TokenKind::Identifier,
+                SourceRange::default(),
+                source_name.chars().collect(),
+            ),
+        };
+        let source_var = Var {
+            name: source_identifier,
+            context: None,
+            kind: None,
+        };
+        assert!(pattern_var_is_binding(&source_var));
+
+        let internal_var = Var {
+            name: internal_pattern_value_identifier("context-value"),
+            context: None,
+            kind: None,
+        };
+        assert!(!pattern_var_is_binding(&internal_var));
     }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1,518 +1,1324 @@
 use crate::*;
+use std::collections::HashMap;
+
+const RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX: &str = "mech-internal-context-";
 
 // Patterns
 // ----------------------------------------------------------------------------
 
-// Implements pattern matching. Handles matching runtime Values against 
-// Pattern AST nodes, binding variables into an Environment. 
- 
-// Supports destructuring of tuples, arrays/matrices, and tagged tuple-structs, 
-// and reconstructing values from patterns.
+// Pattern matching is split into two phases. Compilation assigns stable indexes
+// to bindings and value expressions and validates any structure made known by
+// an expected kind. Matching then stages bindings in private storage and only
+// returns them after the complete pattern succeeds.
 
-// Used by functinos, state machines, and option guards.
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PatternMatchSemantics {
-  Standard,     // Standard semantics: pattern expressions are evaluated once and compared to the value.
-  OptionGuard,  // Option guard semantics: pattern expressions are evaluated for each value and must evaluate to true for all to match.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PatternBindingSpec {
+    pub index: usize,
+    pub id: u64,
+    pub name: String,
+    pub kind: Option<ValueKind>,
 }
 
-// Entry point for multi-argument dispatch. When a function is called with 
-// multiple arguments, this wraps them as if they were a tuple and delegates 
-// to pattern_matches_value.
-pub fn pattern_matches_arguments(pattern: &Pattern, args: &Vec<Value>, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
-  if args.is_empty() {
-    return match pattern {
-      Pattern::Wildcard => Ok(true),
-      #[cfg(feature = "tuple")]
-      Pattern::Tuple(pattern_tuple) => Ok(pattern_tuple.0.is_empty()),
-      _ => Ok(false),
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatternBinding {
+    pub index: usize,
+    pub id: u64,
+    pub name: String,
+    pub kind: ValueKind,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PatternMatch {
+    pub matched: bool,
+    pub bindings: Vec<PatternBinding>,
+}
+
+impl PatternMatch {
+    fn no_match() -> Self {
+        Self {
+            matched: false,
+            bindings: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompiledPatternArraySpread {
+    pub kind: PatternArraySpreadKind,
+    pub binding: Option<Box<CompiledPattern>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CompiledPattern {
+    Wildcard,
+    Binding {
+        binding_index: usize,
+        id: u64,
+        name: String,
+        expected_kind: Option<ValueKind>,
+    },
+    ExpressionValue {
+        expression_index: usize,
+        expression: Expression,
+    },
+    Tuple {
+        elements: Vec<CompiledPattern>,
+    },
+    Array {
+        prefix: Vec<CompiledPattern>,
+        spread: Option<CompiledPatternArraySpread>,
+        suffix: Vec<CompiledPattern>,
+    },
+    EnumVariant {
+        enum_id: Option<u64>,
+        variant_id: u64,
+        payload: Option<Box<CompiledPattern>>,
+    },
+    AtomTuple {
+        tag_id: u64,
+        payload: Vec<CompiledPattern>,
+    },
+}
+
+impl CompiledPattern {
+    /// Unique binding slots in stable compiler-assigned order.
+    pub fn binding_specs(&self) -> Vec<PatternBindingSpec> {
+        fn collect(pattern: &CompiledPattern, specs: &mut Vec<Option<PatternBindingSpec>>) {
+            match pattern {
+                CompiledPattern::Binding {
+                    binding_index,
+                    id,
+                    name,
+                    expected_kind,
+                } => {
+                    if specs.len() <= *binding_index {
+                        specs.resize(*binding_index + 1, None);
+                    }
+                    match &mut specs[*binding_index] {
+                        Some(spec) if spec.kind.is_none() && expected_kind.is_some() => {
+                            spec.kind = expected_kind.clone();
+                        }
+                        Some(_) => {}
+                        slot @ None => {
+                            *slot = Some(PatternBindingSpec {
+                                index: *binding_index,
+                                id: *id,
+                                name: name.clone(),
+                                kind: expected_kind.clone(),
+                            });
+                        }
+                    }
+                }
+                CompiledPattern::Tuple { elements } => {
+                    for element in elements {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                } => {
+                    for element in prefix {
+                        collect(element, specs);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        collect(binding, specs);
+                    }
+                    for element in suffix {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::EnumVariant { payload, .. } => {
+                    if let Some(payload) = payload {
+                        collect(payload, specs);
+                    }
+                }
+                CompiledPattern::AtomTuple { payload, .. } => {
+                    for element in payload {
+                        collect(element, specs);
+                    }
+                }
+                CompiledPattern::Wildcard | CompiledPattern::ExpressionValue { .. } => {}
+            }
+        }
+
+        let mut specs = Vec::new();
+        collect(self, &mut specs);
+        specs.into_iter().flatten().collect()
+    }
+
+    /// Non-binding expressions in stable compiler-assigned order.
+    pub fn expressions(&self) -> Vec<Expression> {
+        fn collect(pattern: &CompiledPattern, expressions: &mut Vec<Option<Expression>>) {
+            match pattern {
+                CompiledPattern::ExpressionValue {
+                    expression_index,
+                    expression,
+                } => {
+                    if expressions.len() <= *expression_index {
+                        expressions.resize(*expression_index + 1, None);
+                    }
+                    expressions[*expression_index] = Some(expression.clone());
+                }
+                CompiledPattern::Tuple { elements } => {
+                    for element in elements {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                } => {
+                    for element in prefix {
+                        collect(element, expressions);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        collect(binding, expressions);
+                    }
+                    for element in suffix {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::EnumVariant { payload, .. } => {
+                    if let Some(payload) = payload {
+                        collect(payload, expressions);
+                    }
+                }
+                CompiledPattern::AtomTuple { payload, .. } => {
+                    for element in payload {
+                        collect(element, expressions);
+                    }
+                }
+                CompiledPattern::Wildcard | CompiledPattern::Binding { .. } => {}
+            }
+        }
+
+        let mut expressions = Vec::new();
+        collect(self, &mut expressions);
+        expressions.into_iter().flatten().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternCompileError {
+    pub reason: String,
+}
+
+impl MechErrorKind for PatternCompileError {
+    fn name(&self) -> &str {
+        "PatternCompileError"
+    }
+
+    fn message(&self) -> String {
+        self.reason.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternExpressionValueMissing {
+    pub index: usize,
+}
+
+impl MechErrorKind for PatternExpressionValueMissing {
+    fn name(&self) -> &str {
+        "PatternExpressionValueMissing"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "No sampled value was provided for pattern expression {}.",
+            self.index
+        )
+    }
+}
+
+#[derive(Default)]
+struct PatternCompiler {
+    bindings: Vec<PatternBindingSpec>,
+    binding_ids: HashMap<u64, usize>,
+    next_expression: usize,
+}
+
+impl PatternCompiler {
+    fn error(&self, pattern: &Pattern, reason: impl Into<String>) -> MechError {
+        MechError::new(
+            PatternCompileError {
+                reason: reason.into(),
+            },
+            None,
+        )
+        .with_compiler_loc()
+        .with_tokens(pattern.tokens())
+    }
+
+    fn compile_binding(
+        &mut self,
+        pattern: &Pattern,
+        id: u64,
+        name: String,
+        expected_kind: Option<&ValueKind>,
+    ) -> MResult<CompiledPattern> {
+        let expected_kind = expected_kind.map(ValueKind::deref_kind);
+        if let Some(index) = self.binding_ids.get(&id).copied() {
+            let existing_kind = self.bindings[index].kind.clone();
+            match (&existing_kind, &expected_kind) {
+                (Some(existing), Some(expected)) if existing != expected => {
+                    return Err(self.error(
+                        pattern,
+                        format!(
+                            "Repeated binding '{}' has incompatible kinds '{}' and '{}'.",
+                            name, existing, expected
+                        ),
+                    ));
+                }
+                (None, Some(expected)) => self.bindings[index].kind = Some(expected.clone()),
+                _ => {}
+            }
+            return Ok(CompiledPattern::Binding {
+                binding_index: index,
+                id,
+                name,
+                expected_kind,
+            });
+        }
+
+        let index = self.bindings.len();
+        self.binding_ids.insert(id, index);
+        self.bindings.push(PatternBindingSpec {
+            index,
+            id,
+            name: name.clone(),
+            kind: expected_kind.clone(),
+        });
+        Ok(CompiledPattern::Binding {
+            binding_index: index,
+            id,
+            name,
+            expected_kind,
+        })
+    }
+
+    fn compile_expression(&mut self, expression: &Expression) -> CompiledPattern {
+        let expression_index = self.next_expression;
+        self.next_expression += 1;
+        CompiledPattern::ExpressionValue {
+            expression_index,
+            expression: expression.clone(),
+        }
+    }
+
+    fn compile(
+        &mut self,
+        pattern: &Pattern,
+        expected_kind: Option<&ValueKind>,
+        interpreter: &Interpreter,
+    ) -> MResult<CompiledPattern> {
+        match pattern {
+            Pattern::Wildcard => Ok(CompiledPattern::Wildcard),
+            Pattern::Expression(expression) => {
+                #[cfg(feature = "enum")]
+                if let Expression::Literal(Literal::Atom(atom)) = expression {
+                    if let Some(ValueKind::Enum(enum_id, _)) =
+                        expected_kind.map(ValueKind::deref_kind)
+                    {
+                        let variant_id = atom.name.hash();
+                        let enum_definition = interpreter
+                            .state
+                            .borrow()
+                            .enums
+                            .get(&enum_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!("Enum kind '{}' has no registered definition.", enum_id),
+                                )
+                            })?;
+                        let declared_payload = enum_definition
+                            .variants
+                            .iter()
+                            .find(|(id, _)| *id == variant_id)
+                            .map(|(_, payload)| payload)
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "'{}' is not a variant of the expected enum.",
+                                        atom.name.to_string()
+                                    ),
+                                )
+                            })?;
+                        if declared_payload.is_some() {
+                            return Err(self.error(
+                                pattern,
+                                "Enum variant pattern is missing its payload pattern.",
+                            ));
+                        }
+                        return Ok(CompiledPattern::EnumVariant {
+                            enum_id: Some(enum_id),
+                            variant_id,
+                            payload: None,
+                        });
+                    }
+                }
+                if let Some(var) = extract_pattern_variable(expression) {
+                    self.compile_binding(
+                        pattern,
+                        var.name.hash(),
+                        var.name.to_string(),
+                        expected_kind,
+                    )
+                } else {
+                    Ok(self.compile_expression(expression))
+                }
+            }
+            Pattern::Tuple(tuple) => {
+                let expected_elements = match expected_kind.map(ValueKind::deref_kind) {
+                    Some(ValueKind::Tuple(elements)) => {
+                        if elements.len() != tuple.0.len() {
+                            return Err(self.error(
+                pattern,
+                format!(
+                  "Tuple pattern has arity {}, but the expected tuple kind has arity {}.",
+                  tuple.0.len(),
+                  elements.len()
+                ),
+              ));
+                        }
+                        Some(elements)
+                    }
+                    Some(kind) => {
+                        return Err(self.error(
+                            pattern,
+                            format!("Tuple pattern cannot match expected kind '{}'.", kind),
+                        ));
+                    }
+                    None => None,
+                };
+                let elements = tuple
+                    .0
+                    .iter()
+                    .enumerate()
+                    .map(|(index, element)| {
+                        self.compile(
+                            element,
+                            expected_elements.as_ref().map(|kinds| &kinds[index]),
+                            interpreter,
+                        )
+                    })
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(CompiledPattern::Tuple { elements })
+            }
+            Pattern::Array(array) => {
+                let (element_kind, rest_kind) = match expected_kind.map(ValueKind::deref_kind) {
+                    Some(ValueKind::Matrix(element, _)) => {
+                        let element = *element;
+                        (
+                            Some(element.clone()),
+                            Some(ValueKind::Matrix(Box::new(element), Vec::new())),
+                        )
+                    }
+                    Some(kind) => {
+                        return Err(self.error(
+                            pattern,
+                            format!("Array pattern cannot match expected kind '{}'.", kind),
+                        ));
+                    }
+                    None => (None, None),
+                };
+                let prefix = array
+                    .prefix
+                    .iter()
+                    .map(|element| self.compile(element, element_kind.as_ref(), interpreter))
+                    .collect::<MResult<Vec<_>>>()?;
+                let spread = match &array.spread {
+                    Some(spread) => Some(CompiledPatternArraySpread {
+                        kind: spread.kind.clone(),
+                        binding: match &spread.binding {
+                            Some(binding) => Some(Box::new(self.compile(
+                                binding,
+                                rest_kind.as_ref(),
+                                interpreter,
+                            )?)),
+                            None => None,
+                        },
+                    }),
+                    None => None,
+                };
+                let suffix = array
+                    .suffix
+                    .iter()
+                    .map(|element| self.compile(element, element_kind.as_ref(), interpreter))
+                    .collect::<MResult<Vec<_>>>()?;
+                Ok(CompiledPattern::Array {
+                    prefix,
+                    spread,
+                    suffix,
+                })
+            }
+            Pattern::TupleStruct(tuple_struct) => match expected_kind.map(ValueKind::deref_kind) {
+                Some(ValueKind::Enum(enum_id, _)) => {
+                    #[cfg(feature = "enum")]
+                    {
+                        let enum_definition = interpreter
+                            .state
+                            .borrow()
+                            .enums
+                            .get(&enum_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "Enum kind '{}' has no registered definition.",
+                                        enum_id
+                                    ),
+                                )
+                            })?;
+                        let variant_id = tuple_struct.name.hash();
+                        let declared_payload = enum_definition
+                            .variants
+                            .iter()
+                            .find(|(id, _)| *id == variant_id)
+                            .map(|(_, payload)| payload.clone())
+                            .ok_or_else(|| {
+                                self.error(
+                                    pattern,
+                                    format!(
+                                        "'{}' is not a variant of the expected enum.",
+                                        tuple_struct.name.to_string()
+                                    ),
+                                )
+                            })?;
+                        let payload = match (tuple_struct.patterns.as_slice(), declared_payload) {
+                            ([], None) => None,
+                            ([payload_pattern], Some(Value::Kind(payload_kind))) => Some(Box::new(
+                                self.compile(payload_pattern, Some(&payload_kind), interpreter)?,
+                            )),
+                            _ => {
+                                return Err(self.error(
+                    pattern,
+                    "Enum variant pattern payload arity does not match its definition.",
+                  ));
+                            }
+                        };
+                        return Ok(CompiledPattern::EnumVariant {
+                            enum_id: Some(enum_id),
+                            variant_id,
+                            payload,
+                        });
+                    }
+                    #[cfg(not(feature = "enum"))]
+                    {
+                        return Err(self.error(pattern, "Enum patterns are not enabled."));
+                    }
+                }
+                Some(ValueKind::Tuple(kinds)) => {
+                    if kinds.len() != tuple_struct.patterns.len() + 1
+                        || !matches!(kinds.first(), Some(ValueKind::Atom(_, _)))
+                    {
+                        return Err(self.error(
+                pattern,
+                "Atom-tagged tuple pattern arity does not match the expected tuple kind.",
+              ));
+                    }
+                    let payload = tuple_struct
+                        .patterns
+                        .iter()
+                        .zip(kinds.iter().skip(1))
+                        .map(|(payload, kind)| self.compile(payload, Some(kind), interpreter))
+                        .collect::<MResult<Vec<_>>>()?;
+                    Ok(CompiledPattern::AtomTuple {
+                        tag_id: tuple_struct.name.hash(),
+                        payload,
+                    })
+                }
+                Some(kind) => Err(self.error(
+                    pattern,
+                    format!(
+                        "Tagged tuple pattern cannot match expected kind '{}'.",
+                        kind
+                    ),
+                )),
+                None => self.compile_untyped_tuple_struct(pattern, tuple_struct, interpreter),
+            },
+        }
+    }
+
+    fn compile_untyped_tuple_struct(
+        &mut self,
+        _pattern: &Pattern,
+        tuple_struct: &PatternTupleStruct,
+        interpreter: &Interpreter,
+    ) -> MResult<CompiledPattern> {
+        let payload = tuple_struct
+            .patterns
+            .iter()
+            .map(|payload| self.compile(payload, None, interpreter))
+            .collect::<MResult<Vec<_>>>()?;
+        Ok(CompiledPattern::AtomTuple {
+            tag_id: tuple_struct.name.hash(),
+            payload,
+        })
+    }
+}
+
+pub fn compile_pattern(
+    pattern: &Pattern,
+    expected_kind: Option<&ValueKind>,
+    interpreter: &Interpreter,
+) -> MResult<CompiledPattern> {
+    PatternCompiler::default().compile(pattern, expected_kind, interpreter)
+}
+
+enum PatternExpressionSource<'a> {
+    Interpreter {
+        env: &'a Environment,
+        interpreter: &'a Interpreter,
+    },
+    Sampled(&'a [Value]),
+}
+
+struct PatternMatchState<'a> {
+    binding_specs: Vec<PatternBindingSpec>,
+    proposed: Vec<Option<Value>>,
+    expression_source: PatternExpressionSource<'a>,
+}
+
+impl PatternMatchState<'_> {
+    fn expression_value(
+        &self,
+        expression_index: usize,
+        expression_node: &Expression,
+    ) -> MResult<Value> {
+        match &self.expression_source {
+            PatternExpressionSource::Interpreter { env, interpreter } => {
+                // Expression patterns read the arm's outer environment. Proposed
+                // captures are intentionally invisible; capture-dependent
+                // conditions belong in an explicit arm guard.
+                expression(expression_node, Some(env), interpreter)
+            }
+            PatternExpressionSource::Sampled(values) => {
+                values.get(expression_index).cloned().ok_or_else(|| {
+                    MechError::new(
+                        PatternExpressionValueMissing {
+                            index: expression_index,
+                        },
+                        None,
+                    )
+                    .with_compiler_loc()
+                    .with_tokens(expression_node.tokens())
+                })
+            }
+        }
+    }
+
+    fn matches(&mut self, pattern: &CompiledPattern, value: &Value) -> MResult<bool> {
+        let value = deep_detach_value(value);
+        match pattern {
+            CompiledPattern::Wildcard => Ok(true),
+            CompiledPattern::Binding { binding_index, .. } => {
+                if let Some(existing) = &self.proposed[*binding_index] {
+                    Ok(existing == &value)
+                } else {
+                    self.proposed[*binding_index] = Some(value);
+                    Ok(true)
+                }
+            }
+            CompiledPattern::ExpressionValue {
+                expression_index,
+                expression,
+            } => {
+                let expected =
+                    deep_detach_value(&self.expression_value(*expression_index, expression)?);
+                Ok(values_match(&expected, &value))
+            }
+            CompiledPattern::Tuple { elements } => {
+                #[cfg(feature = "tuple")]
+                if let Value::Tuple(tuple) = value {
+                    let tuple = tuple.borrow();
+                    if tuple.elements.len() != elements.len() {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in elements.iter().zip(tuple.elements.iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            CompiledPattern::Array {
+                prefix,
+                spread,
+                suffix,
+            } => {
+                #[cfg(feature = "matrix")]
+                {
+                    let values = match matrix_like_values(&value) {
+                        Some(values) => values,
+                        None => return Ok(false),
+                    };
+                    if values.len() < prefix.len() + suffix.len() {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in prefix.iter().zip(values.iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    let suffix_start = values.len() - suffix.len();
+                    for (pattern, value) in suffix.iter().zip(values[suffix_start..].iter()) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    if spread.is_none() && values.len() != prefix.len() + suffix.len() {
+                        return Ok(false);
+                    }
+                    if let Some(binding) =
+                        spread.as_ref().and_then(|spread| spread.binding.as_deref())
+                    {
+                        let middle = capture_middle_matrix(&value, prefix.len(), suffix_start);
+                        if !self.matches(binding, &middle)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                #[cfg(not(feature = "matrix"))]
+                Ok(false)
+            }
+            CompiledPattern::EnumVariant {
+                enum_id,
+                variant_id,
+                payload,
+            } => {
+                #[cfg(feature = "enum")]
+                if let Value::Enum(enum_value) = value {
+                    let enum_value = enum_value.borrow();
+                    if enum_id.is_some_and(|expected| expected != enum_value.id)
+                        || enum_value.variants.len() != 1
+                    {
+                        return Ok(false);
+                    }
+                    let (actual_variant, actual_payload) = &enum_value.variants[0];
+                    if actual_variant != variant_id {
+                        return Ok(false);
+                    }
+                    return match (payload, actual_payload) {
+                        (None, None) => Ok(true),
+                        (Some(pattern), Some(value)) => self.matches(pattern, value),
+                        _ => Ok(false),
+                    };
+                }
+                Ok(false)
+            }
+            CompiledPattern::AtomTuple { tag_id, payload } => {
+                #[cfg(feature = "enum")]
+                if let Value::Enum(enum_value) = &value {
+                    let enum_value = enum_value.borrow();
+                    if enum_value.variants.len() != 1 {
+                        return Ok(false);
+                    }
+                    let (actual_variant, actual_payload) = &enum_value.variants[0];
+                    if actual_variant != tag_id {
+                        return Ok(false);
+                    }
+                    return match (payload.as_slice(), actual_payload) {
+                        ([], None) => Ok(true),
+                        ([pattern], Some(value)) => self.matches(pattern, value),
+                        _ => Ok(false),
+                    };
+                }
+                #[cfg(all(feature = "tuple", feature = "atom"))]
+                if let Value::Tuple(tuple) = &value {
+                    let tuple = tuple.borrow();
+                    if tuple.elements.len() != payload.len() + 1 {
+                        return Ok(false);
+                    }
+                    let tag = deep_detach_value(&tuple.elements[0]);
+                    let Value::Atom(tag) = tag else {
+                        return Ok(false);
+                    };
+                    if tag.borrow().id() != *tag_id {
+                        return Ok(false);
+                    }
+                    for (pattern, value) in payload.iter().zip(tuple.elements.iter().skip(1)) {
+                        if !self.matches(pattern, value)? {
+                            return Ok(false);
+                        }
+                    }
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    fn finish(self, matched: bool) -> PatternMatch {
+        if !matched {
+            return PatternMatch::no_match();
+        }
+        let bindings = self
+            .binding_specs
+            .into_iter()
+            .zip(self.proposed)
+            .filter_map(|(spec, value)| {
+                value.map(|value| PatternBinding {
+                    index: spec.index,
+                    id: spec.id,
+                    name: spec.name,
+                    kind: value.kind().deref_kind(),
+                    value,
+                })
+            })
+            .collect();
+        PatternMatch {
+            matched: true,
+            bindings,
+        }
+    }
+}
+
+pub fn match_compiled_pattern(
+    pattern: &CompiledPattern,
+    value: &Value,
+    env: &Environment,
+    interpreter: &Interpreter,
+) -> MResult<PatternMatch> {
+    let specs = pattern.binding_specs();
+    let mut state = PatternMatchState {
+        proposed: vec![None; specs.len()],
+        binding_specs: specs,
+        expression_source: PatternExpressionSource::Interpreter { env, interpreter },
     };
-  }
-  if args.len() == 1 {
-    return pattern_matches_value(pattern, &args[0], env, p);
-  }
-  match pattern {
-    Pattern::Tuple(pattern_tuple) => {
-      if pattern_tuple.0.len() != args.len() {
-        return Ok(false);
-      }
-      for (pat, arg) in pattern_tuple.0.iter().zip(args.iter()) {
-        if !pattern_matches_value(pat, arg, env, p)? {
-          return Ok(false);
-        }
-      }
-      Ok(true)
+    let matched = state.matches(pattern, value)?;
+    Ok(state.finish(matched))
+}
+
+pub fn match_compiled_pattern_with_values(
+    pattern: &CompiledPattern,
+    value: &Value,
+    expression_values: &[Value],
+) -> MResult<PatternMatch> {
+    let specs = pattern.binding_specs();
+    let mut state = PatternMatchState {
+        proposed: vec![None; specs.len()],
+        binding_specs: specs,
+        expression_source: PatternExpressionSource::Sampled(expression_values),
+    };
+    let matched = state.matches(pattern, value)?;
+    Ok(state.finish(matched))
+}
+
+pub trait PatternBindingSink {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()>;
+}
+
+pub struct EnvironmentBindingSink<'a> {
+    env: &'a mut Environment,
+}
+
+impl<'a> EnvironmentBindingSink<'a> {
+    pub fn new(env: &'a mut Environment) -> Self {
+        Self { env }
     }
-    _ => Ok(false),
-  }
 }
 
-pub fn pattern_matches_value(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter) -> MResult<bool> {
-  pattern_matches_value_with_semantics(pattern, value, env, p, PatternMatchSemantics::Standard)
-}
-
-// Takes a semantics mode. Dispatches on pattern kind:
-// Wildcard - always succeeds, binds nothing.
-// - Tuple - recursively matches element-wise against a Value::Tuple, requiring equal arity.
-// - Array - matches prefix and suffix element-wise against any matrix-like value, with optional spread binding (…) for the middle slice.
-// - Expression(Var()) - if the variable is already in the environment, checks equality (used for repeated variable patterns).
-// - Expression(other) - attempts to extract a variable id from more complex expression wrappers (parentheticals, single-term formulas) and handles them like Var.
-// - TupleStruct - matches a tagged tuple
-pub fn pattern_matches_value_with_semantics(pattern: &Pattern, value: &Value, env: &mut Environment, p: &Interpreter, semantics: PatternMatchSemantics) -> MResult<bool> {
-  let detached_value = deep_detach_value(value);
-  match pattern {
-    Pattern::Wildcard => Ok(true),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pattern_tuple) => {
-      match detached_value {
-        Value::Tuple(tuple) => {
-          let tuple_brrw = tuple.borrow();
-          if pattern_tuple.0.len() != tuple_brrw.elements.len() {
-            return Ok(false);
-          }
-          for (pat, val) in pattern_tuple.0.iter().zip(tuple_brrw.elements.iter()) {
-            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-              return Ok(false);
+impl PatternBindingSink for EnvironmentBindingSink<'_> {
+    fn commit(&mut self, pattern_match: &PatternMatch) -> MResult<()> {
+        if pattern_match.matched {
+            for binding in &pattern_match.bindings {
+                self.env.insert(binding.id, binding.value.clone());
             }
-          }
-          return Ok(true);
         }
-        _ => {return Ok(false);},
-      }
-      return Ok(false);
+        Ok(())
     }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(pattern_array) => {
-      let values = match matrix_like_values(&detached_value) {
-        Some(values) => values,
-        None => return Ok(false),
-      };
-      if values.len() < pattern_array.prefix.len() + pattern_array.suffix.len() {
-        return Ok(false);
-      }
-      for (pat, val) in pattern_array.prefix.iter().zip(values.iter()) {
-        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-          return Ok(false);
-        }
-      }
-      let suffix_start = values.len() - pattern_array.suffix.len();
-      for (pat, val) in pattern_array
-          .suffix
-          .iter()
-          .zip(values[suffix_start..].iter())
-      {
-        if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-          return Ok(false);
-        }
-      }
+}
 
-      // If there's no spread, the number of values must match exactly. 
-      // If there is a spread, there can be any number of values in the middle.
-      if pattern_array.spread.is_none() && values.len() != pattern_array.prefix.len() + pattern_array.suffix.len()
-      {
-        return Ok(false);
-      }
-      if let Some(spread) = &pattern_array.spread {
-        if let Some(binding) = &spread.binding {
-          let middle_start = pattern_array.prefix.len();
-          #[cfg(feature = "matrix")]
-          let captured = capture_middle_matrix(&detached_value, middle_start, suffix_start);
-          if !pattern_matches_value_with_semantics(binding, &captured, env, p, semantics)?
-          {
-            return Ok(false);
-          }
-        }
-      }
-      Ok(true)
-    }
-    Pattern::Expression(Expression::Var(var)) => {
-      let var_id = var.name.hash();
-      if let Some(existing) = env.get(&var_id) {
-        Ok(existing == &detached_value)
-      } else {
-        env.insert(var_id, detached_value);
-        Ok(true)
-      }
-    }
-    Pattern::Expression(expr) => {
-      if let Some(var_id) = extract_pattern_variable_id(expr) {
-        if let Some(existing) = env.get(&var_id) {
-          return Ok(existing == &detached_value);
-        }
-        env.insert(var_id, detached_value);
+pub fn pattern_matches_arguments(
+    pattern: &Pattern,
+    args: &Vec<Value>,
+    env: &mut Environment,
+    interpreter: &Interpreter,
+) -> MResult<bool> {
+    if matches!(pattern, Pattern::Wildcard) {
         return Ok(true);
-      }
-      let expected = expression(expr, Some(env), p)?;
-      if semantics == PatternMatchSemantics::OptionGuard {
-        #[cfg(feature = "bool")]
-        if let Value::Bool(flag) = &expected {
-          if matches!(expr, Expression::Literal(Literal::Boolean(_))) {
-            return Ok(values_match(&deep_detach_value(&expected), &detached_value));
-          }
-          return Ok(*flag.borrow());
-        }
-      }
-      Ok(values_match(&deep_detach_value(&expected), &detached_value))
     }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(pat_struct) => {
-      match detached_value {
-        #[cfg(feature = "enum")]
-        Value::Enum(enum_value) => {
-          let enum_brrw = enum_value.borrow();
-          if enum_brrw.variants.len() != 1 {
-            return Ok(false);
-          }
-          let (variant_id, payload) = &enum_brrw.variants[0];
-          let expected_variant_id = pat_struct.name.hash();
-          if *variant_id != expected_variant_id {
-            return Ok(false);
-          }
-          match payload {
-            Some(payload_value) => {
-              if pat_struct.patterns.len() != 1 {
-                return Ok(false);
-              }
-              return pattern_matches_value_with_semantics(
-                &pat_struct.patterns[0],
-                payload_value,
-                env,
-                p,
-                semantics,
-              );
-            }
-            None => {
-              return Ok(pat_struct.patterns.is_empty());
-            }
-          }
-        }
-        Value::Tuple(tuple) => {
-          let tuple_brrw = tuple.borrow();
-          if tuple_brrw.elements.len() != pat_struct.patterns.len() + 1 {
-            return Ok(false);
-          }
-          let expected_state = atom(&Atom {name: pat_struct.name.clone(),},p);
-          if !values_match(&expected_state, &deep_detach_value(&tuple_brrw.elements[0])) {
-            return Ok(false);
-          }
-          for (pat, val) in pat_struct
-              .patterns
-              .iter()
-              .zip(tuple_brrw.elements.iter().skip(1))
-          {
-            if !pattern_matches_value_with_semantics(pat, val, env, p, semantics)? {
-              return Ok(false);
-            }
-          }
-          return Ok(true);
-        }
-        _ => return Ok(false),
-      }
-      return Ok(false);
+    if args.len() == 1 {
+        return pattern_matches_value(pattern, &args[0], env, interpreter);
     }
-    x => Err(MechError::new(FeatureNotEnabledError, Some(format!("Pattern not enabled: {:?}", x))).with_compiler_loc().with_tokens(x.tokens())), 
-  }
+    #[cfg(feature = "tuple")]
+    {
+        let arguments = Value::Tuple(Ref::new(MechTuple::from_vec(args.clone())));
+        return pattern_matches_value(pattern, &arguments, env, interpreter);
+    }
+    #[cfg(not(feature = "tuple"))]
+    {
+        Ok(args.is_empty() && matches!(pattern, Pattern::Wildcard))
+    }
 }
 
+pub fn pattern_matches_value(
+    pattern: &Pattern,
+    value: &Value,
+    env: &mut Environment,
+    interpreter: &Interpreter,
+) -> MResult<bool> {
+    let compiled = compile_pattern(pattern, None, interpreter)?;
+    let pattern_match = match_compiled_pattern(&compiled, value, env, interpreter)?;
+    EnvironmentBindingSink::new(env).commit(&pattern_match)?;
+    Ok(pattern_match.matched)
+}
 
-// Collects all variable ids introduced by a pattern (via 
-// collect_pattern_variable_ids) and removes them from the environment. Used 
+// Collects all variable ids introduced by a pattern (via
+// collect_pattern_variable_ids) and removes them from the environment. Used
 // to undo bindings when a pattern arm fails or needs to be retried.
 pub fn clear_pattern_bindings(pattern: &Pattern, env: &mut Environment) {
-  let mut ids = Vec::new();
-  collect_pattern_variable_ids(pattern, &mut ids);
-  for var_id in ids {
-    env.remove(&var_id);
-  }
+    let mut ids = Vec::new();
+    collect_pattern_variable_ids(pattern, &mut ids);
+    for var_id in ids {
+        env.remove(&var_id);
+    }
 }
-
 
 // Reconstructs a Value from a pattern using the current environment. This is the inverse of matching. used to extract or re-emit bound values.
 pub fn pattern_to_value(pattern: &Pattern, env: &Environment, p: &Interpreter) -> MResult<Value> {
-  match pattern {
-    Pattern::Wildcard => Ok(Value::Empty),
-    Pattern::Expression(expr) => expression(expr, Some(env), p),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(pattern_tuple) => {
-      let mut values = Vec::with_capacity(pattern_tuple.0.len());
-      for inner in &pattern_tuple.0 {
-        values.push(pattern_to_value(inner, env, p)?);
-      }
-      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+    match pattern {
+        Pattern::Wildcard => Ok(Value::Empty),
+        Pattern::Expression(expr) => expression(expr, Some(env), p),
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(pattern_tuple) => {
+            let mut values = Vec::with_capacity(pattern_tuple.0.len());
+            for inner in &pattern_tuple.0 {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+        }
+        #[cfg(feature = "matrix")]
+        Pattern::Array(array) => {
+            let mut values = Vec::new();
+            for inner in &array.prefix {
+                let inner_value = pattern_to_value(inner, env, p)?;
+                if let Some(inner_values) = matrix_like_values(&inner_value) {
+                    values.extend(inner_values);
+                } else {
+                    values.push(inner_value);
+                }
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    let bound = pattern_to_value(binding, env, p)?;
+                    if let Some(bound_values) = matrix_like_values(&bound) {
+                        values.extend(bound_values);
+                    } else {
+                        values.push(bound);
+                    }
+                }
+            }
+            for inner in &array.suffix {
+                let inner_value = pattern_to_value(inner, env, p)?;
+                if let Some(inner_values) = matrix_like_values(&inner_value) {
+                    values.extend(inner_values);
+                } else {
+                    values.push(inner_value);
+                }
+            }
+            return Ok(build_row_matrix_from_values(values));
+        }
+        #[cfg(all(feature = "tuple", feature = "atom"))]
+        Pattern::TupleStruct(pattern_tuple_struct) => {
+            #[cfg(feature = "enum")]
+            {
+                let variant_id = pattern_tuple_struct.name.hash();
+                if let Some((enum_id, enum_def)) = p.state.borrow().enums.iter().find(|(_, enm)| {
+                    enm.variants
+                        .iter()
+                        .any(|(known_variant, _)| *known_variant == variant_id)
+                }) {
+                    let payload = if pattern_tuple_struct.patterns.len() == 1 {
+                        Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
+                    } else if pattern_tuple_struct.patterns.is_empty() {
+                        None
+                    } else {
+                        return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
+                    };
+                    let enm = MechEnum {
+                        id: *enum_id,
+                        variants: vec![(variant_id, payload)],
+                        names: enum_def.names.clone(),
+                    };
+                    return Ok(Value::Enum(Ref::new(enm)));
+                }
+            }
+            let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
+            values.push(atom(
+                &Atom {
+                    name: pattern_tuple_struct.name.clone(),
+                },
+                p,
+            ));
+            for inner in &pattern_tuple_struct.patterns {
+                values.push(pattern_to_value(inner, env, p)?);
+            }
+            return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
+        }
+        _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
     }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(array) => {
-      let mut values = Vec::new();
-      for inner in &array.prefix {
-        let inner_value = pattern_to_value(inner, env, p)?;
-        if let Some(inner_values) = matrix_like_values(&inner_value) {
-          values.extend(inner_values);
-        } else {
-          values.push(inner_value);
-        }
-      }
-      if let Some(spread) = &array.spread {
-        if let Some(binding) = &spread.binding {
-          let bound = pattern_to_value(binding, env, p)?;
-          if let Some(bound_values) = matrix_like_values(&bound) {
-            values.extend(bound_values);
-          } else {
-            values.push(bound);
-          }
-        }
-      }
-      for inner in &array.suffix {
-        let inner_value = pattern_to_value(inner, env, p)?;
-        if let Some(inner_values) = matrix_like_values(&inner_value) {
-          values.extend(inner_values);
-        } else {
-          values.push(inner_value);
-        }
-      }
-      return Ok(build_row_matrix_from_values(values));
-    }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(pattern_tuple_struct) => {
-      #[cfg(feature = "enum")]
-      {
-        let variant_id = pattern_tuple_struct.name.hash();
-        if let Some((enum_id, enum_def)) = p
-          .state
-          .borrow()
-          .enums
-          .iter()
-          .find(|(_, enm)| enm.variants.iter().any(|(known_variant, _)| *known_variant == variant_id))
-        {
-          let payload = if pattern_tuple_struct.patterns.len() == 1 {
-            Some(pattern_to_value(&pattern_tuple_struct.patterns[0], env, p)?)
-          } else if pattern_tuple_struct.patterns.is_empty() {
-            None
-          } else {
-            return Err(MechError::new(FeatureNotEnabledError, Some("Enum tuple-struct patterns currently support zero or one payload value.".to_string())).with_compiler_loc());
-          };
-          let enm = MechEnum {
-            id: *enum_id,
-            variants: vec![(variant_id, payload)],
-            names: enum_def.names.clone(),
-          };
-          return Ok(Value::Enum(Ref::new(enm)));
-        }
-      }
-      let mut values = Vec::with_capacity(pattern_tuple_struct.patterns.len() + 1);
-      values.push(atom(&Atom {name: pattern_tuple_struct.name.clone()}, p));
-      for inner in &pattern_tuple_struct.patterns {
-        values.push(pattern_to_value(inner, env, p)?);
-      }
-      return Ok(Value::Tuple(Ref::new(MechTuple::from_vec(values))));
-    }
-    _ => Err(MechError::new(FeatureNotEnabledError, None).with_compiler_loc()),
-  }
 }
 
-// Mutable reference unwrapper. Recursively follows Value::MutableReference 
-// chains until it reaches a plain value, then clones it. Ensures the pattern 
+// Mutable reference unwrapper. Recursively follows Value::MutableReference
+// chains until it reaches a plain value, then clones it. Ensures the pattern
 // matcher always works on an owned, non-reference value.
 fn deep_detach_value(value: &Value) -> Value {
-  match value {
-    Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
-    _ => value.clone(),
-  }
+    match value {
+        Value::MutableReference(reference) => deep_detach_value(&reference.borrow()),
+        _ => value.clone(),
+    }
 }
 
-// Variable id harvester. Recursively walks a pattern and pushes the hashed ids 
-// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples, 
-// arrays (including spread bindings), and tuple-structs. Used by 
+// Variable id harvester. Recursively walks a pattern and pushes the hashed ids
+// of all bound variable names into a Vec<u64>. Handles Var expressions, tuples,
+// arrays (including spread bindings), and tuple-structs. Used by
 // clear_pattern_bindings.
 fn collect_pattern_variable_ids(pattern: &Pattern, ids: &mut Vec<u64>) {
-  match pattern {
-    Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
-    #[cfg(feature = "tuple")]
-    Pattern::Tuple(tuple) => {
-      for item in &tuple.0 {
-        collect_pattern_variable_ids(item, ids);
-      }
-    }
-    #[cfg(feature = "matrix")]
-    Pattern::Array(array) => {
-      for item in &array.prefix {
-        collect_pattern_variable_ids(item, ids);
-      }
-      if let Some(spread) = &array.spread {
-        if let Some(binding) = &spread.binding {
-          collect_pattern_variable_ids(binding, ids);
+    match pattern {
+        Pattern::Expression(Expression::Var(var)) => ids.push(var.name.hash()),
+        #[cfg(feature = "tuple")]
+        Pattern::Tuple(tuple) => {
+            for item in &tuple.0 {
+                collect_pattern_variable_ids(item, ids);
+            }
         }
-      }
-      for item in &array.suffix {
-        collect_pattern_variable_ids(item, ids);
-      }
+        #[cfg(feature = "matrix")]
+        Pattern::Array(array) => {
+            for item in &array.prefix {
+                collect_pattern_variable_ids(item, ids);
+            }
+            if let Some(spread) = &array.spread {
+                if let Some(binding) = &spread.binding {
+                    collect_pattern_variable_ids(binding, ids);
+                }
+            }
+            for item in &array.suffix {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        #[cfg(all(feature = "tuple", feature = "atom"))]
+        Pattern::TupleStruct(tuple_struct) => {
+            for item in &tuple_struct.patterns {
+                collect_pattern_variable_ids(item, ids);
+            }
+        }
+        _ => {}
     }
-    #[cfg(all(feature = "tuple", feature = "atom"))]
-    Pattern::TupleStruct(tuple_struct) => {
-      for item in &tuple_struct.patterns {
-        collect_pattern_variable_ids(item, ids);
-      }
-    }
-    _ => {}
-  }
 }
 
 #[cfg(feature = "matrix")]
 fn capture_middle_matrix(value: &Value, start: usize, end: usize) -> Value {
-  let cols = end.saturating_sub(start);
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Value::MatrixIndex(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Value::MatrixBool(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Value::MatrixU8(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Value::MatrixU16(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Value::MatrixU32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Value::MatrixU64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Value::MatrixU128(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Value::MatrixI8(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Value::MatrixI16(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Value::MatrixI32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Value::MatrixI64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Value::MatrixI128(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Value::MatrixF32(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Value::MatrixF64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Value::MatrixString(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Value::MatrixR64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Value::MatrixC64(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Value::MatrixValue(Matrix::from_vec(matrix.as_vec()[start..end].to_vec(), 1, cols)),
-    _ => {
-      let values = matrix_like_values(value).unwrap_or_default();
-      Value::MatrixValue(Matrix::from_vec(values[start..end].to_vec(), 1, cols))
+    let cols = end.saturating_sub(start);
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Value::MatrixIndex(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Value::MatrixBool(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Value::MatrixU8(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Value::MatrixU16(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Value::MatrixU32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Value::MatrixU64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Value::MatrixU128(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Value::MatrixI8(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Value::MatrixI16(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Value::MatrixI32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Value::MatrixI64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Value::MatrixI128(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Value::MatrixF32(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Value::MatrixF64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Value::MatrixString(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Value::MatrixR64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Value::MatrixC64(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Value::MatrixValue(Matrix::from_vec(
+            matrix.as_vec()[start..end].to_vec(),
+            1,
+            cols,
+        )),
+        _ => {
+            let values = matrix_like_values(value).unwrap_or_default();
+            Value::MatrixValue(Matrix::from_vec(values[start..end].to_vec(), 1, cols))
+        }
     }
-  }
 }
 
 // Used by the Array pattern arm to get a uniform element list regardless of the matrix's concrete numeric type.
 pub(crate) fn matrix_like_values(value: &Value) -> Option<Vec<Value>> {
-  match value {
-    #[cfg(feature = "matrix")]
-    Value::MatrixIndex(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| Value::Index(Ref::new(value)))
-          .collect(),
-    ),
-    #[cfg(all(feature = "matrix", feature = "bool"))]
-    Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u8"))]
-    Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u16"))]
-    Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u32"))]
-    Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u64"))]
-    Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "u128"))]
-    Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i8"))]
-    Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i16"))]
-    Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i32"))]
-    Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i64"))]
-    Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "i128"))]
-    Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f32"))]
-    Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "f64"))]
-    Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "string"))]
-    Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
-    #[cfg(all(feature = "matrix", feature = "rational"))]
-    Value::MatrixR64(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| value.to_value())
-          .collect(),
-    ),
-    #[cfg(all(feature = "matrix", feature = "complex"))]
-    Value::MatrixC64(matrix) => Some(
-      matrix
-          .as_vec()
-          .into_iter()
-          .map(|value| value.to_value())
-          .collect(),
-    ),
-    #[cfg(feature = "matrix")]
-    Value::MatrixValue(matrix) => Some(matrix.as_vec()),
-    _ => None,
-  }
+    match value {
+        #[cfg(feature = "matrix")]
+        Value::MatrixIndex(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| Value::Index(Ref::new(value)))
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        Value::MatrixBool(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u8"))]
+        Value::MatrixU8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u16"))]
+        Value::MatrixU16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u32"))]
+        Value::MatrixU32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u64"))]
+        Value::MatrixU64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "u128"))]
+        Value::MatrixU128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i8"))]
+        Value::MatrixI8(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i16"))]
+        Value::MatrixI16(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i32"))]
+        Value::MatrixI32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i64"))]
+        Value::MatrixI64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "i128"))]
+        Value::MatrixI128(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f32"))]
+        Value::MatrixF32(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "f64"))]
+        Value::MatrixF64(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "string"))]
+        Value::MatrixString(matrix) => Some(matrix.as_vec().into_iter().map(Value::from).collect()),
+        #[cfg(all(feature = "matrix", feature = "rational"))]
+        Value::MatrixR64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(all(feature = "matrix", feature = "complex"))]
+        Value::MatrixC64(matrix) => Some(
+            matrix
+                .as_vec()
+                .into_iter()
+                .map(|value| value.to_value())
+                .collect(),
+        ),
+        #[cfg(feature = "matrix")]
+        Value::MatrixValue(matrix) => Some(matrix.as_vec()),
+        _ => None,
+    }
 }
 
 #[cfg(feature = "matrix")]
 fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
-  let cols = values.len();
-  #[cfg(feature = "u64")]
-  if values.iter().all(|value| matches!(value, Value::U64(_))) {
-    let data = values
-      .iter()
-      .map(|value| match value {
-        Value::U64(x) => *x.borrow(),
-        _ => unreachable!(),
-      })
-      .collect::<Vec<u64>>();
-    return Value::MatrixU64(Matrix::from_vec(data, 1, cols));
-  }
-  Value::MatrixValue(Matrix::from_vec(values, 1, cols))
+    let cols = values.len();
+    #[cfg(feature = "u64")]
+    if values.iter().all(|value| matches!(value, Value::U64(_))) {
+        let data = values
+            .iter()
+            .map(|value| match value {
+                Value::U64(x) => *x.borrow(),
+                _ => unreachable!(),
+            })
+            .collect::<Vec<u64>>();
+        return Value::MatrixU64(Matrix::from_vec(data, 1, cols));
+    }
+    Value::MatrixValue(Matrix::from_vec(values, 1, cols))
 }
 
-fn extract_pattern_variable_id(expr: &Expression) -> Option<u64> {
-  match expr {
-    Expression::Var(var) => Some(var.name.hash()),
-    Expression::Formula(factor) => match factor {
-      Factor::Expression(inner_expr) => extract_pattern_variable_id(inner_expr),
-      Factor::Term(term) if term.rhs.is_empty() => extract_pattern_variable_id_from_term(&term.lhs),
-      _ => None,
-    },
-    _ => None,
-  }
+fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
+    match expr {
+        Expression::Var(var)
+            if var.context.is_none()
+                // Runtime context inputs are sampled pattern values, never captures.
+                && !var
+                    .name
+                    .to_string()
+                    .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX) =>
+        {
+            Some(var)
+        }
+        Expression::Var(_) => None,
+        Expression::Formula(factor) => match factor {
+            Factor::Expression(inner_expr) => extract_pattern_variable(inner_expr),
+            Factor::Term(term) if term.rhs.is_empty() => {
+                extract_pattern_variable_from_term(&term.lhs)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
-fn extract_pattern_variable_id_from_term(factor: &Factor) -> Option<u64> {
-  match factor {
-    Factor::Expression(expr) => extract_pattern_variable_id(expr),
-    Factor::Parenthetical(inner) => extract_pattern_variable_id_from_term(inner),
-    _ => None,
-  }
+fn extract_pattern_variable_from_term(factor: &Factor) -> Option<&Var> {
+    match factor {
+        Factor::Expression(expr) => extract_pattern_variable(expr),
+        Factor::Parenthetical(inner) => extract_pattern_variable_from_term(inner),
+        _ => None,
+    }
 }
 
 // TODO: This needs to be expanded to handle all types.
 fn values_match(expected: &Value, actual: &Value) -> bool {
-  if expected == actual {
-    return true;
-  }
-  match (expected, actual) {
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    (Value::F64(x), Value::U64(y)) => return (*x.borrow() as u64) == *y.borrow(),
-    #[cfg(all(feature = "u64", feature = "f64"))]
-    (Value::U64(x), Value::F64(y)) => return *x.borrow() == (*y.borrow() as u64),
-    _ => {}
-  }
-  false
+    if expected == actual {
+        return true;
+    }
+    match (expected, actual) {
+        #[cfg(all(feature = "atom", feature = "enum"))]
+        (Value::Atom(atom), Value::Enum(enum_value))
+        | (Value::Enum(enum_value), Value::Atom(atom)) => {
+            let enum_value = enum_value.borrow();
+            return enum_value.variants.len() == 1
+                && enum_value.variants[0].0 == atom.borrow().id()
+                && enum_value.variants[0].1.is_none();
+        }
+        #[cfg(all(feature = "u64", feature = "f64"))]
+        (Value::F64(x), Value::U64(y)) => {
+            let x = *x.borrow();
+            return x.is_finite()
+                && x >= 0.0
+                && x.fract() == 0.0
+                && x < 18_446_744_073_709_551_616.0
+                && (x as u64) == *y.borrow();
+        }
+        #[cfg(all(feature = "u64", feature = "f64"))]
+        (Value::U64(x), Value::F64(y)) => {
+            let y = *y.borrow();
+            return y.is_finite()
+                && y >= 0.0
+                && y.fract() == 0.0
+                && y < 18_446_744_073_709_551_616.0
+                && *x.borrow() == (y as u64);
+        }
+        _ => {}
+    }
+    false
+}
+
+#[cfg(all(test, feature = "tuple", feature = "u64"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_compiled_match_returns_no_bindings_and_cannot_mutate_sink() {
+        let id = hash_str("x");
+        let binding = CompiledPattern::Binding {
+            binding_index: 0,
+            id,
+            name: "x".to_string(),
+            expected_kind: Some(ValueKind::U64),
+        };
+        let pattern = CompiledPattern::Tuple {
+            elements: vec![binding.clone(), binding],
+        };
+        let value = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+            Value::U64(Ref::new(1)),
+            Value::U64(Ref::new(2)),
+        ])));
+
+        let pattern_match = match_compiled_pattern_with_values(&pattern, &value, &[]).unwrap();
+        assert!(!pattern_match.matched);
+        assert!(pattern_match.bindings.is_empty());
+
+        let mut env = Environment::new();
+        env.insert(id, Value::U64(Ref::new(9)));
+        EnvironmentBindingSink::new(&mut env)
+            .commit(&pattern_match)
+            .unwrap();
+        assert_eq!(env.get(&id), Some(&Value::U64(Ref::new(9))));
+    }
 }

--- a/src/interpreter/src/patterns.rs
+++ b/src/interpreter/src/patterns.rs
@@ -1220,18 +1220,18 @@ fn build_row_matrix_from_values(values: Vec<Value>) -> Value {
     Value::MatrixValue(Matrix::from_vec(values, 1, cols))
 }
 
+pub(crate) fn pattern_var_is_binding(var: &Var) -> bool {
+    var.context.is_none()
+        // Runtime context inputs are sampled pattern values, never captures.
+        && !var
+            .name
+            .to_string()
+            .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX)
+}
+
 fn extract_pattern_variable(expr: &Expression) -> Option<&Var> {
     match expr {
-        Expression::Var(var)
-            if var.context.is_none()
-                // Runtime context inputs are sampled pattern values, never captures.
-                && !var
-                    .name
-                    .to_string()
-                    .starts_with(RUNTIME_CONTEXT_PATTERN_VALUE_PREFIX) =>
-        {
-            Some(var)
-        }
+        Expression::Var(var) if pattern_var_is_binding(var) => Some(var),
         Expression::Var(_) => None,
         Expression::Formula(factor) => match factor {
             Factor::Expression(inner_expr) => extract_pattern_variable(inner_expr),

--- a/src/interpreter/src/state_machines.rs
+++ b/src/interpreter/src/state_machines.rs
@@ -137,6 +137,16 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       )
     )
   );
+  let compiled_arm_patterns = fsm
+    .arms
+    .iter()
+    .map(|arm| match arm {
+      FsmArm::Guard(pattern, _) | FsmArm::Transition(pattern, _) => {
+        compile_pattern(pattern, None, p).map(Some)
+      }
+      FsmArm::Comment(_) => Ok(None),
+    })
+    .collect::<MResult<Vec<_>>>()?;
   // Step through the FSM, applying transitions until we hit a terminal state (no applicable transitions) or exceed the step limit.
   for step in 0..p.max_steps {
     trace_println!(
@@ -152,9 +162,14 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
       match arm {
         FsmArm::Comment(_) => continue,
         FsmArm::Transition(pattern, transitions) => {
-          let mut arm_env = call_env.clone();
-          clear_pattern_bindings(pattern, &mut arm_env);
-          let matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          let base_env = call_env.clone();
+          let compiled_pattern = compiled_arm_patterns[arm_idx]
+            .as_ref()
+            .expect("transition arm pattern was not compiled");
+          let pattern_match = match_compiled_pattern(compiled_pattern, state, &base_env, p)?;
+          let matched = pattern_match.matched;
+          let mut arm_env = base_env.clone();
+          EnvironmentBindingSink::new(&mut arm_env).commit(&pattern_match)?;
           trace_println!(
             p,
             "{}",
@@ -170,6 +185,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
           if matched {
             let previous_state = summarize_value(state);
             let out = apply_transitions(transitions, state, &mut arm_env, p)?;
+            restore_arm_local_bindings(&pattern_match, &base_env, &mut arm_env);
             *call_env = arm_env;
             if let Some(value) = out {
               trace_println!(
@@ -199,9 +215,14 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
           }
         }
         FsmArm::Guard(pattern, guards) => {
-          let mut arm_env = call_env.clone();
-          clear_pattern_bindings(pattern, &mut arm_env);
-          let pattern_matched = pattern_matches_value(pattern, state, &mut arm_env, p)?;
+          let base_env = call_env.clone();
+          let compiled_pattern = compiled_arm_patterns[arm_idx]
+            .as_ref()
+            .expect("guard arm pattern was not compiled");
+          let pattern_match = match_compiled_pattern(compiled_pattern, state, &base_env, p)?;
+          let pattern_matched = pattern_match.matched;
+          let mut arm_env = base_env.clone();
+          EnvironmentBindingSink::new(&mut arm_env).commit(&pattern_match)?;
           trace_println!(
             p,
             "{}",
@@ -255,6 +276,7 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
             }
             let previous_state = summarize_value(state);
             let out = apply_transitions(&guard.transitions, state, &mut arm_env, p)?;
+            restore_arm_local_bindings(&pattern_match, &base_env, &mut arm_env);
             *call_env = arm_env;
             if let Some(value) = out {
               trace_println!(
@@ -304,6 +326,20 @@ fn execute_fsm_pipe_impl(fsm: &FsmImplementation, state: &mut Value, call_env: &
     None,
   )
   .with_compiler_loc())
+}
+
+fn restore_arm_local_bindings(
+  pattern_match: &PatternMatch,
+  base_env: &Environment,
+  arm_env: &mut Environment,
+) {
+  for binding in &pattern_match.bindings {
+    if let Some(original) = base_env.get(&binding.id) {
+      arm_env.insert(binding.id, original.clone());
+    } else {
+      arm_env.remove(&binding.id);
+    }
+  }
 }
 
 fn validate_fsm_state_coverage(fsm: &FsmImplementation, fsm_pipe: &FsmPipe) -> MResult<()> {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -542,6 +542,8 @@ impl MechRuntime {
     value: Value,
   ) -> MResult<mech_core::Expression> {
     self.validate_live_context_candidate(context)?;
+    // The interpreter recognizes this prefix as a sampled pattern value rather
+    // than a source-level capture name.
     let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
     let symbol_id = hash_str(&name);
     let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
@@ -949,92 +951,53 @@ impl MechRuntime {
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<mech_core::Expression> {
-    if let Some(expression) = self.literalize_match_pattern_context_read_expression(
-      context,
+    if let Some(expression) = self.resolve_interpreter_address_pattern_expression(
       program,
       registry,
       expression,
     )? {
       return Ok(expression);
     }
-
     self.resolve_context_reads_in_expression(context, program, registry, expression)
   }
 
-  fn literalize_match_pattern_context_read_expression(
+  fn resolve_interpreter_address_pattern_expression(
     &mut self,
-    context: &RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     expression: &mech_core::Expression,
   ) -> MResult<Option<mech_core::Expression>> {
     match expression {
       mech_core::Expression::Var(var) => {
-        self.literalize_match_pattern_context_read_var(context, program, registry, var)
+        let Some(var_context) = &var.context else {
+          return Ok(None);
+        };
+        let target = var_context.to_string();
+        if registry.get(&target).is_some() {
+          return Ok(None);
+        }
+
+        let address = format!("@{target}/{}", var.name.to_string());
+        let value = {
+          let symbols = program.interpreter().symbols();
+          let symbols = symbols.borrow();
+          symbols
+            .get(hash_str(&address))
+            .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
+        };
+        match value {
+          Some(value) => self.resolved_pattern_value_expression(value).map(Some),
+          None => Ok(None),
+        }
       }
       mech_core::Expression::Formula(factor) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, factor)
+        self.resolve_interpreter_address_pattern_factor(program, registry, factor)
       }
       _ => Ok(None),
     }
   }
 
-  fn literalize_match_pattern_context_read_factor(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    factor: &mech_core::Factor,
-  ) -> MResult<Option<mech_core::Expression>> {
-    match factor {
-      mech_core::Factor::Expression(expression) => {
-        self.literalize_match_pattern_context_read_expression(context, program, registry, expression)
-      }
-      mech_core::Factor::Parenthetical(inner) => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, inner)
-      }
-      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
-        self.literalize_match_pattern_context_read_factor(context, program, registry, &term.lhs)
-      }
-      _ => Ok(None),
-    }
-  }
-
-  fn literalize_match_pattern_context_read_var(
-    &mut self,
-    context: &RuntimeContext,
-    program: &mut MechProgram,
-    registry: &RuntimeContextRegistry,
-    var: &mech_core::Var,
-  ) -> MResult<Option<mech_core::Expression>> {
-    let Some(var_context) = &var.context else {
-      return Ok(None);
-    };
-
-    let target = var_context.to_string();
-    let path = var.name.to_string();
-    if let Some(binding) = registry.get(&target) {
-      let value = self.read_context_resource(context, binding, &path)?;
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    let address_key = format!("@{target}/{path}");
-    let value = {
-      let symbols = program.interpreter().symbols();
-      let symbols = symbols.borrow();
-      symbols
-        .get(hash_str(&address_key))
-        .map(|value_ref| resolve_runtime_value(value_ref.borrow().clone()))
-    };
-
-    if let Some(value) = value {
-      return Ok(Some(self.context_pattern_value_expression(value)?));
-    }
-
-    Ok(None)
-  }
-
-  fn context_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
+  fn resolved_pattern_value_expression(&self, value: Value) -> MResult<mech_core::Expression> {
     let value = resolve_runtime_value(value);
     match value {
       Value::String(value) => {
@@ -1062,9 +1025,31 @@ impl MechRuntime {
         vec!['_'],
       )))),
       other => Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "context_match_pattern",
-        reason: format!("context match patterns currently support string, bool, and empty values; got {other:?}"),
+        operation: "interpreter_address_pattern",
+        reason: format!(
+          "interpreter-address patterns currently support string, bool, and empty values; got {other:?}",
+        ),
       }, None)),
+    }
+  }
+
+  fn resolve_interpreter_address_pattern_factor(
+    &mut self,
+    program: &mut MechProgram,
+    registry: &RuntimeContextRegistry,
+    factor: &mech_core::Factor,
+  ) -> MResult<Option<mech_core::Expression>> {
+    match factor {
+      mech_core::Factor::Expression(expression) => {
+        self.resolve_interpreter_address_pattern_expression(program, registry, expression)
+      }
+      mech_core::Factor::Parenthetical(inner) => {
+        self.resolve_interpreter_address_pattern_factor(program, registry, inner)
+      }
+      mech_core::Factor::Term(term) if term.rhs.is_empty() => {
+        self.resolve_interpreter_address_pattern_factor(program, registry, &term.lhs)
+      }
+      _ => Ok(None),
     }
   }
 
@@ -1305,12 +1290,18 @@ impl MechRuntime {
           lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
           let mut lowered_arms = Vec::with_capacity(arms.len());
           for arm in arms {
+            let pattern = self.resolve_context_reads_in_match_pattern(
+              context,
+              program,
+              registry,
+              &arm.pattern,
+            )?;
             let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
             let body = match &arm.body {
               mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
               mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
             };
-            lowered_arms.push(mech_core::ActivationArm { pattern: arm.pattern.clone(), guard, body });
+            lowered_arms.push(mech_core::ActivationArm { pattern, guard, body });
           }
           lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
@@ -1503,6 +1494,12 @@ impl MechRuntime {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
           for arm in arms {
+            self.preflight_pattern_context_reads(
+              context,
+              registry,
+              &arm.pattern,
+              addressed_read_preflight,
+            )?;
             if let Some(guard) = &arm.guard { self.preflight_expression_context_reads(context, registry, guard, addressed_read_preflight)?; }
             match &arm.body {
               mech_core::ActivationArmBody::Block(body) => for (code, _) in body { self.preflight_code_context_capabilities(context, registry, code, DirectContextEffectPlacement::ActivationScope, addressed_read_preflight)?; },

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -542,10 +542,13 @@ impl MechRuntime {
     value: Value,
   ) -> MResult<mech_core::Expression> {
     self.validate_live_context_candidate(context)?;
-    // The interpreter recognizes this prefix as a sampled pattern value rather
-    // than a source-level capture name.
-    let name = format!("mech-internal-context-{}-{}", hash_str(source.base_uri()), hash_str(source.path()));
-    let symbol_id = hash_str(&name);
+    let identifier = mech_core::internal_pattern_value_identifier(&format!(
+      "context-{}-{}",
+      hash_str(source.base_uri()),
+      hash_str(source.path())
+    ));
+    let name = identifier.to_string();
+    let symbol_id = identifier.hash();
     let input = program.ensure_input(program.interpreter().id, symbol_id, &name, resolve_runtime_value(value))?;
     if self.live_registration_mode == crate::runtime::LiveRegistrationMode::RetainedRoot {
       let bindings = self.live_input_bindings.entry(source).or_default();
@@ -555,7 +558,7 @@ impl MechRuntime {
       self.commit_live_context_candidate(context);
     }
     let var = mech_core::Var {
-      name: identifier_from_str(&name),
+      name: identifier,
       context: None,
       kind: None,
     };

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3360,6 +3360,126 @@ result := \"x\"?
 }
 
 #[test]
+fn activation_arm_pattern_context_read_fails_preflight_before_stdout_write() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+
+  let result = runtime.run_string(
+    "@out := cli://stdout{:write(line)}
+@env := cli://env{:read(HOME)}
+@out/line <- \"must-not-write\"
+event := \"x\"
+~> event
+  | (@env/HOME) => {
+      selected := true
+    }
+  | * => {
+      selected := false
+    }
+",
+  );
+
+  assert!(result.is_err(), "activation arm context read should fail in preflight");
+  let error = format!("{:?}", result.err().unwrap());
+  assert!(
+    error.contains("RuntimeCapabilityGrantDenied") || error.contains("context_read"),
+    "expected context read preflight error, got {error}",
+  );
+  assert!(
+    state.lock().unwrap().stdout.is_empty(),
+    "preflight failed after stdout write: {:?}",
+    state.lock().unwrap().stdout,
+  );
+}
+
+#[test]
+fn activation_arm_context_read_pattern_is_lowered_when_allowed() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  state.lock().unwrap().env.insert(
+    "MECH_ACTIVATION_PATTERN".to_string(),
+    "expected".to_string(),
+  );
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime.grant_capability(RuntimeCapabilityGrant {
+    subject,
+    resource: "cli://cli/env".to_string(),
+    operations: vec![RuntimeCapabilityOperation::Read],
+    paths: vec!["MECH_ACTIVATION_PATTERN".to_string()],
+  }).unwrap();
+
+  let result = runtime.run_string(
+    "@env := cli://env{:read(MECH_ACTIVATION_PATTERN)}
+event := \"expected\"
+~> event
+  | (@env/MECH_ACTIVATION_PATTERN) => {
+      selected := true
+    }
+  | * => {
+      selected := false
+    }
+",
+  );
+
+  assert!(result.is_ok(), "allowed activation context pattern failed: {result:?}");
+  assert_eq!(runtime.live_input_binding_count(), 1);
+  let registration = {
+    let plan = runtime.program().interpreter().plan();
+    let registrations = plan.pattern_activation_registrations();
+    assert_eq!(registrations.len(), 1);
+    registrations[0].clone()
+  };
+
+  let update = runtime.apply_host_input(RuntimeHostInput::single(
+    RuntimeHostInputSource::new("cli://env", "MECH_ACTIVATION_PATTERN").unwrap(),
+    RuntimeHostInputValue::String("next".to_string()),
+  )).unwrap();
+  assert_eq!(update.binding_count, 1);
+  assert_eq!(update.ignored_update_count, 0);
+  if let Some(turn) = &update.turn {
+    for interpreter_turn in &turn.interpreter_turns {
+      let executed_nodes = interpreter_turn
+        .turn
+        .before_commit
+        .executed_nodes
+        .iter()
+        .chain(interpreter_turn.turn.after_commit.executed_nodes.iter())
+        .copied()
+        .collect::<Vec<_>>();
+      assert!(!executed_nodes.contains(&registration.scope_pulse_node));
+      assert!(!executed_nodes.contains(&registration.selector_node));
+      for arm in &registration.arms {
+        assert!(!executed_nodes.contains(&arm.matcher_node));
+        assert!(!executed_nodes.contains(&arm.finalizer_node));
+        assert!(!executed_nodes.contains(&arm.gate_node));
+      }
+    }
+  }
+
+  let trigger = {
+    let symbols = runtime.program().interpreter().symbols();
+    let event = symbols.borrow().get(hash_str("event")).unwrap().borrow().clone();
+    event.reactive_root_cell_ids()[0]
+  };
+  let trigger_turn = runtime
+    .program_mut()
+    .interpreter_mut()
+    .advance_reactive_turn(&[trigger])
+    .unwrap();
+  let changed_nodes = trigger_turn
+    .before_commit
+    .changed_nodes
+    .iter()
+    .chain(trigger_turn.after_commit.changed_nodes.iter())
+    .copied()
+    .collect::<Vec<_>>();
+  assert!(!changed_nodes.contains(&registration.arms[0].gate_node));
+  assert!(
+    changed_nodes.contains(&registration.arms[1].gate_node),
+    "the trigger did not sample the updated pattern value",
+  );
+}
+
+#[test]
 fn fsm_pipe_transition_context_read_fails_preflight_before_stdout_write() {
   let (mut runtime, state) = runtime_with_recording_cli();
   grant_runtime_stdout_line(&mut runtime);

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -45,6 +45,6 @@ mod tests {
   #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
   #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
   #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
-  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); assert!(matches!(p.body.sections[0].elements[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
+  #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); let SectionElement::MechCode(code) = &p.body.sections[0].elements[0] else { panic!("expected Mech code") }; assert!(matches!(&code[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
   #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/patterns.rs
+++ b/src/syntax/src/patterns.rs
@@ -54,11 +54,7 @@ fn spread_operator(input: ParseString) -> ParseResult<()> {
 }
 
 fn pattern_array_item(input: ParseString) -> ParseResult<Pattern> {
-  if let Ok((input, _)) = wildcard(input.clone()) {
-    return Ok((input, Pattern::Wildcard));
-  }
-  let (input, expr) = expression(input)?;
-  Ok((input, Pattern::Expression(expr)))
+  pattern(input)
 }
 
 #[derive(Clone)]
@@ -256,4 +252,76 @@ pub fn pattern_tuple(input: ParseString) -> ParseResult<PatternTuple> {
   let (input, _) = whitespace0(input)?;
   let (input, _) = right_parenthesis(input)?;
   Ok((input, PatternTuple(patterns)))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn parse_array_pattern(source: &str) -> PatternArray {
+    let graphemes = crate::graphemes::init_tag(source);
+    let input = ParseString::new(&graphemes);
+    let (remaining, parsed) = pattern(input).expect("expected array pattern to parse");
+    assert!(remaining.is_empty(), "expected the whole array pattern to be consumed");
+    match parsed {
+      Pattern::Array(array) => array,
+      other => panic!("expected Pattern::Array, got {:?}", other),
+    }
+  }
+
+  #[test]
+  fn array_items_accept_recursive_patterns_around_spread() {
+    let array = parse_array_pattern("[(left, right), ..., :some((payload, nested))]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Tuple(_)]));
+    assert!(matches!(
+      array.spread,
+      Some(PatternArraySpread {
+        kind: PatternArraySpreadKind::Spread,
+        binding: None,
+      })
+    ));
+    let [Pattern::TupleStruct(variant)] = array.suffix.as_slice() else {
+      panic!("expected a tagged suffix pattern");
+    };
+    assert_eq!(variant.patterns.len(), 1);
+    assert!(matches!(variant.patterns[0], Pattern::Tuple(_)));
+  }
+
+  #[test]
+  fn array_rest_binding_accepts_recursive_pattern() {
+    let array = parse_array_pattern("[(:head(value), other) | :tail((left, right))]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Tuple(_)]));
+    let Some(PatternArraySpread {
+      kind: PatternArraySpreadKind::Rest,
+      binding: Some(binding),
+    }) = array.spread else {
+      panic!("expected a recursively patterned rest binding");
+    };
+    assert!(matches!(*binding, Pattern::TupleStruct(_)));
+    assert!(array.suffix.is_empty());
+  }
+
+  #[test]
+  fn array_rest_binding_accepts_nested_array_pattern() {
+    let array = parse_array_pattern("[head | [second, ..., last]]");
+    assert!(matches!(array.prefix.as_slice(), [Pattern::Expression(_)]));
+    let Some(PatternArraySpread {
+      kind: PatternArraySpreadKind::Rest,
+      binding: Some(binding),
+    }) = array.spread else {
+      panic!("expected an array-patterned rest binding");
+    };
+    let Pattern::Array(nested) = *binding else {
+      panic!("expected the rest binding to be an array pattern");
+    };
+    assert_eq!(nested.prefix.len(), 1);
+    assert!(matches!(
+      nested.spread,
+      Some(PatternArraySpread {
+        kind: PatternArraySpreadKind::Spread,
+        binding: None,
+      })
+    ));
+    assert_eq!(nested.suffix.len(), 1);
+  }
 }

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -407,6 +407,66 @@ test_interpreter!(
   Value::U64(Ref::new(42))
 );
 test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_recursive_rest_across_function_fsm_match_and_comprehension,
+  r#"
+probe(xs<[u64]>) => <u64>
+  | [head | [second, ..., last]] => head + second + last
+  | * => 0u64.
+
+#Probe(xs<[u64]>) => <u64>
+  ├ :Scan(xs<[u64]>)
+  └ :Done(out<u64>).
+
+#Probe(xs) -> :Scan(xs)
+  :Scan([head | [second, ..., last]]) -> :Done(head + second + last)
+  :Scan(*) -> :Done(0u64)
+  :Done(out) => out.
+
+value := [1u64 2u64 3u64 4u64]
+function-result := probe(value)
+fsm-result := #Probe(value)
+match-result := value?
+  | [head | [second, ..., last]] => head + second + last
+  | * => 0u64.
+comprehension-result := [head + second + last | [head | [second, ..., last]] <- {value}]
+function-result + fsm-result + match-result + comprehension-result[1]
+"#,
+  Value::U64(Ref::new(28))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_repeated_binding_and_first_arm_across_dispatch_contexts,
+  r#"
+probe(xs<[u64]>) => <u64>
+  | [x, x] => x
+  | [x, ...] => 99u64
+  | * => 0u64.
+
+#Probe(xs<[u64]>) => <u64>
+  ├ :Scan(xs<[u64]>)
+  └ :Done(out<u64>).
+
+#Probe(xs) -> :Scan(xs)
+  :Scan([x, x]) -> :Done(x)
+  :Scan([x, ...]) -> :Done(99u64)
+  :Scan(*) -> :Done(0u64)
+  :Done(out) => out.
+
+equal := [3u64 3u64]
+unequal := [3u64 4u64]
+function-result := probe(equal)
+fsm-result := #Probe(equal)
+match-equal := equal? | [x, x] => x | [x, ...] => 99u64 | * => 0u64.
+match-unequal := unequal? | [x, x] => x | [x, ...] => 99u64 | * => 0u64.
+generated := [x | [x, x] <- {equal, unequal}]
+function-result + fsm-result + match-equal + match-unequal + generated[1]
+"#,
+  Value::U64(Ref::new(111))
+);
 test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>
   ├ :Start(arr<[u64]>)
@@ -1635,6 +1695,65 @@ test_interpreter!(interpret_set_comprehension, r#"{ x * x | x <- {1,2,3,4}, y :=
 test_interpreter!(interpret_set_comprehension_variable, r#"qq := {1,2,3,4}; { x * x | x <- qq, y := 2, (x % 2) != 0 }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0))]))));
 test_interpreter!(interpret_set_comprehension_tuple, r#"qq := {(1,2),(3,4),(5,6),(7,8)}; { x * x | (x, *) <- qq }"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(1.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(25.0)), Value::F64(Ref::new(49.0))]))));
 test_interpreter!(interpret_set_comprehension_fof, r#"pairs:= {(1,2), (1,3), (2,8), (3,5), (3,9)}; user := 1; {fof | ( u, f ) <- pairs, ( f, fof ) <- pairs, u ⩵ user}"#, Value::Set(Ref::new(MechSet::from_vec(vec![Value::F64(Ref::new(5.0)), Value::F64(Ref::new(9.0)), Value::F64(Ref::new(8.0))]))));
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_repeated_binding,
+  r#"pairs := {(1u64, 1u64), (1u64, 2u64), (3u64, 3u64)}; {x | (x, x) <- pairs}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(1)), Value::U64(Ref::new(3))])))
+);
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_typed_and_expression_values,
+  r#"pairs := {(1u64, 10u64), (2u64, 20u64)}; expected := 1u64; {x | (expected + 0u64, x) <- pairs}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(10))])))
+);
+
+#[cfg(feature = "u64")]
+test_interpreter!(
+  pattern_conformance_comprehension_nested_tuple,
+  r#"values := {((1u64, 2u64), 3u64), ((4u64, 5u64), 6u64)}; {a + b + c | ((a, b), c) <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(6)), Value::U64(Ref::new(15))])))
+);
+
+#[cfg(all(feature = "u64", feature = "atom"))]
+test_interpreter!(
+  pattern_conformance_comprehension_atom_tuple,
+  r#"events := {(:ready, 7u64), (:ready, 9u64)}; {x | :ready(x) <- events}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(7)), Value::U64(Ref::new(9))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_exact_array,
+  r#"values := {[1u64 2u64], [3u64 4u64]}; {a + b | [a, b] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(3)), Value::U64(Ref::new(7))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_prefix_suffix_spread,
+  r#"values := {[1u64 2u64 3u64 4u64], [5u64 6u64 7u64 8u64]}; {head + last | [head, ..., last] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(5)), Value::U64(Ref::new(13))])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_bound_rest,
+  r#"values := {[1u64 2u64 3u64], [4u64 5u64 6u64]}; {tail | [head | tail] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![
+    Value::MatrixU64(Matrix::from_vec(vec![2, 3], 1, 2)),
+    Value::MatrixU64(Matrix::from_vec(vec![5, 6], 1, 2)),
+  ])))
+);
+
+#[cfg(all(feature = "u64", feature = "matrix"))]
+test_interpreter!(
+  pattern_conformance_comprehension_recursive_rest_pattern,
+  r#"values := {[1u64 2u64 3u64 4u64], [5u64 6u64 7u64 8u64]}; {head + second + last | [head | [second, ..., last]] <- values}"#,
+  Value::Set(Ref::new(MechSet::from_vec(vec![Value::U64(Ref::new(7)), Value::U64(Ref::new(19))])))
+);
 
 test_interpreter!(interpret_matrix_comprehension, r#"[ x * x | x <- [1 2 3 4], y := 2, (x % 2) == 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![4.0, 16.0], 1, 2)));
 test_interpreter!(interpret_matrix_comprehension_variable, r#"qq := [1 2 3 4]; [ x * x | x <- qq, y := 2, (x % 2) != 0 ]"#, Value::MatrixF64(Matrix::from_vec(vec![1.0, 9.0], 1, 2)));

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -118,7 +118,7 @@ test_interpreter!(
 #[cfg(feature = "u64")]
 test_interpreter!(
   interpret_option_match_scalar_some,
-  "x<u64?> := 4u64; x? | x > 3u64 => x | * => 0u64.",
+  "x<u64?> := 4u64; x? | value, value > 3u64 => value | * => 0u64.",
   Value::U64(Ref::new(4))
 );
 #[cfg(feature = "u64")]
@@ -353,6 +353,20 @@ test_interpreter!(
   Value::U64(Ref::new(3))
 );
 
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_match_structural_failure_skips_guard,
+  "pair := (1u64, 2u64)\nresult := pair?\n  | (x, 0u64), missing-capture > 0u64 => x\n  | * => 9u64.\nresult + 0u64",
+  Value::U64(Ref::new(9))
+);
+
+#[cfg(all(feature = "u64", feature = "f64"))]
+test_interpreter!(
+  interpret_match_fractional_f64_literal_does_not_equal_u64,
+  "value := 1u64\nresult := value?\n  | 1.5 => 99u64\n  | * => 7u64.\nresult + 0u64",
+  Value::U64(Ref::new(7))
+);
+
 test_interpreter!(interpret_option_match_tuple_struct_pattern, "state := (:Done, 9u64); y := state? | :Done(x) => x | * => 0u64.; y + 0u64", Value::U64(Ref::new(9)));
 #[test]
 fn interpret_tagged_union_match_requires_exhaustive_arms() {
@@ -377,9 +391,21 @@ test_interpreter!(
   "add-one(x<f64>) => <f64>\n  | x + 1.\n\nadd-one([1 2 3])",
   Value::MatrixF64(Matrix::from_vec(vec![2.0, 3.0, 4.0], 1, 3))
 );
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_function_multi_argument_wildcard_arm_matches,
+  "multi-default(left<u64>, right<u64>) => <u64>\n  | * => 9u64.\n\nmulti-default(1u64, 2u64)",
+  Value::U64(Ref::new(9))
+);
 test_interpreter!(interpret_function_array_pattern_arms, "head(xs<[u64]:1,3>) => <u64>\n  | [x …] => x\n  | * => 0u64.\nhead([10u64 20u64 30u64]) + 0u64", Value::U64(Ref::new(10)));
 test_interpreter!(interpret_fsm_array_pattern_state_arguments, "#VecFsm(n<u64>) => <u64>\n  ├ :Scan(xs<[u64]:1,3>)\n  └ :Done(out<u64>).\n\n#VecFsm(n<u64>) -> :Scan([1u64 2u64 3u64])\n  :Scan([x … y]) -> :Done(x + y)\n  :Done(out) => out.\n\n#VecFsm(0u64)", Value::U64(Ref::new(4)));
 test_interpreter!(interpret_fsm_accepts_unsized_vector_input, "#Echo(xs<[u64]>) => <u64>\n  ├ :Start(xs<[u64]>)\n  └ :Done(out<u64>).\n\n#Echo(xs<[u64]>) -> :Start(xs)\n  :Start([x ...]) -> :Done(x)\n  :Done(out) => out.\n\n#Echo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(5)));
+#[cfg(feature = "u64")]
+test_interpreter!(
+  interpret_fsm_pattern_binding_does_not_replace_input,
+  "#RestoreInput(input<u64>) => <u64>\n  ├ :Start(value<u64>)\n  └ :Done(value<u64>).\n\n#RestoreInput(input<u64>) -> :Start(7u64)\n  :Start(input) -> :Done(0u64)\n  :Done(*) => input.\n\n#RestoreInput(42u64)",
+  Value::U64(Ref::new(42))
+);
 test_interpreter!(interpret_fsm_array_spread_reconstruction_keeps_scalar_guards, "#Demo(arr<[u64]>) => <u64>\n  ├ :Pass(arr<[u64]>)\n  └ :Done(out<u64>).\n\n#Demo(arr<[u64]>) -> :Pass(arr)\n  :Pass([a, b | tail])\n    ├ a > b -> :Pass([a tail])\n    └ * -> :Done(0u64)\n  :Pass([x …]) -> :Done(x)\n  :Done(out) => out.\n\n#Demo([5u64 3u64 8u64 1u64])", Value::U64(Ref::new(0)));
 test_interpreter!(interpret_fsm_bubble_sort_returns_typed_u64_matrix, "#bubble-sort(arr<[u64]>) => <[u64]>\n  ├ :Start(arr<[u64]>)\n  ├ :Pass(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  ├ :Next(arr<[u64]>, swaps<u64>)\n  ├ :Reverse(arr<[u64]>, acc<[u64]>, swaps<u64>)\n  └ :Done(arr<[u64]>).\n\n#bubble-sort(arr) -> :Start(arr)\n  :Start(arr) -> :Pass(arr, [], 0u64)\n  :Pass([a, b | tail], acc, swaps)\n    ├ a > b -> :Pass([a tail], [b acc], swaps + 1u64)\n    └ *     -> :Pass([b tail], [a acc], swaps)\n  :Pass([x], acc, swaps) -> :Next([x acc], swaps)\n  :Pass([], acc, swaps)  -> :Next(acc, swaps)\n  :Next(arr, swaps) -> :Reverse(arr, [], swaps)\n  :Reverse([x | tail], acc, swaps) -> :Reverse(tail, [x acc], swaps)\n  :Reverse([], acc, 0u64)     -> :Done(acc)\n  :Reverse([], acc, swaps) -> :Pass(acc, [], 0u64)\n  :Done(arr) => arr.\n\n#bubble-sort([5u64 3u64 8u64 1u64])", Value::MatrixU64(Matrix::from_vec(vec![1, 3, 5, 8], 1, 4)));
 test_interpreter!(interpret_fsm_bubble_sort_assigns_matrix_value, "#bubble-sort(arr<[u64]>) => <[u64]>

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -912,6 +912,47 @@ ys := { x | (x, @env/MECH_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop"
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
+fn mech_run_matrix_generator_context_pattern_is_literal_filter() {
+  let root = temp_root("matrix-generator-pattern-literal");
+  let source = root.join("matrix_generator_pattern_literal.mec");
+
+  std::fs::write(
+    &source,
+    r#"+> @env := cli/env
++> @out := cli/stdout
+
+ys := [ x | (x, @env/MECH_MATRIX_GENERATOR_PATTERN_TEST) <- [("keep", "secret") ("drop", "other")] ]
+@out/line <- ys
+"done"
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg(&source)
+    .current_dir(&root)
+    .env("MECH_MATRIX_GENERATOR_PATTERN_TEST", "secret")
+    .output()
+    .unwrap();
+
+  let combined = combined_output(&output);
+  assert!(
+    output.status.success(),
+    "matrix generator context-pattern program failed:\n{combined}"
+  );
+  assert!(
+    combined.contains("keep"),
+    "matrix generator context pattern should retain matching tuple:\n{combined}"
+  );
+  assert!(
+    !combined.contains("drop"),
+    "matrix generator context pattern should reject nonmatching tuple:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
 fn mech_run_undeclared_context_read_is_preflighted_before_send() {
   let root = temp_root("undeclared-context-read");
   let source = root.join("undeclared_context_read.mec");


### PR DESCRIPTION
## Motivation

Pattern support currently forks at activations: functions, FSMs, and `match` use the shared matcher, while patterned activations compile and execute a smaller pattern subset through a separate implementation. That causes the same source pattern to behave differently depending on context.

This PR is stacked on `implement-patterned-activation-bodies` and establishes one structural matching foundation before composite reactive captures and activation guards are added.

## What changed

- Introduced a shared `CompiledPattern` representation for wildcard, binding, expression-value, tuple, array, enum-variant, and atom-tagged tuple patterns.
- Added transactional `PatternMatch` results: failed matches return no bindings, repeated names require equality, and sinks commit only after the complete pattern succeeds.
- Added environment and reactive binding sinks, then migrated functions, FSMs, `match`, and patterned activations to the shared matcher.
- Added exact, prefix/suffix, anonymous-spread, and bound-rest array matching with recursive nested patterns and preservation of concrete matrix kinds where possible.
- Changed activation expression patterns to sampled inputs: expression dependencies do not dispatch an activation independently, while the next trigger pulse samples their latest values.
- Lowered activation-arm runtime context reads into live sampled inputs and retained constant handling for module interpreter-address patterns.
- Removed ordinary Boolean-predicate behavior from match pattern expressions; capture-dependent predicates remain explicit arm guards.
- Preserved FSM inputs when arm-local capture names shadow them and fixed scalar atom capture updates across atom values.
- Made array pattern parsing recursive in every array position.
- Reused the canonical binding classifier in comprehension generators so lowered runtime-context values remain equality filters; added set and matrix CLI regressions.

## Root cause and impact

The activation-specific matcher duplicated only part of the shared pattern language and coupled structural matching to scalar reactive capture storage. Moving structural semantics into the pattern module gives all four dispatch contexts the same matching rules and keeps activation scheduling policy outside the matcher.

Activation composite/rest capture storage and activation guards remain explicit preflight errors in this PR. They require stable general reactive capture cells and guard scheduling, respectively, and are intentionally left for follow-up work.

## Validation

- `cargo check -p mech-interpreter`
- `cargo check -p mech-runtime`
- `cargo test -p mech-interpreter --lib -- --test-threads=1` — 97 passed
- `cargo test --test interpreter -- --test-threads=1` — 573 passed
- `cargo test -p mech-runtime --test module_smoke -- --test-threads=1` — 222 passed
- `cargo test -p mech-interpreter --lib --no-default-features --features base activation::tests -- --test-threads=1` — 33 passed
- `cargo test -p mech-syntax patterns::tests -- --test-threads=1` — 3 passed
- `cargo test --features "run repl pretty_print" --test mech_cli_host` — 32 passed
- `cargo test --features "run cli_host time_host_native timer_host_native console_host_native scene_host_native" --test mech_cli_host` — 32 passed
