### PR TITLE
Enable state and effects in patterned activations

### DIFF
--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -559,6 +559,7 @@ pub struct ReactivePlan {
   pub reactive_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pub sampled_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>>,
   pattern_activation_registrations: Vec<PatternActivationRegistration>,
+  activation_sampled_cells: Vec<Vec<ReactiveCellId>>,
 }
 
 #[derive(Debug, Clone)]
@@ -769,6 +770,7 @@ impl ReactivePlan {
       reactive_consumers: HashMap::new(),
       sampled_consumers: HashMap::new(),
       pattern_activation_registrations: Vec::new(),
+      activation_sampled_cells: Vec::new(),
     }
   }
 
@@ -785,6 +787,7 @@ impl ReactivePlan {
     self.reactive_consumers.clear();
     self.sampled_consumers.clear();
     self.pattern_activation_registrations.clear();
+    self.activation_sampled_cells.clear();
   }
 
   pub fn iter(&self) -> impl Iterator<Item = &Box<dyn MechFunction>> {
@@ -1236,7 +1239,13 @@ impl Plan {
       }
     }
 
-    self.0.borrow_mut().apply_rollback(checkpoint.reactive);
+    {
+      let mut reactive = self.0.borrow_mut();
+      reactive.apply_rollback(checkpoint.reactive);
+      reactive
+        .activation_sampled_cells
+        .truncate(checkpoint.activation_registration_depth);
+    }
     self
       .1
       .borrow_mut()
@@ -1266,12 +1275,48 @@ impl Plan {
   }
 
   pub fn activation_registration_active(&self) -> bool { !self.1.borrow().is_empty() }
-  pub fn push_activation_registration_scope(&self, trigger_cells: Vec<ReactiveCellId>) { self.1.borrow_mut().push(ActivationRegistrationScope { trigger_cells, local_combinational_cells: Vec::new() }); }
-  pub fn pop_activation_registration_scope(&self) { self.1.borrow_mut().pop(); }
+  pub fn push_activation_registration_scope(&self, trigger_cells: Vec<ReactiveCellId>) {
+    self.push_activation_registration_scope_with_sampled_cells(
+      trigger_cells,
+      Vec::new(),
+    );
+  }
+  pub fn push_activation_registration_scope_with_sampled_cells(&self, trigger_cells: Vec<ReactiveCellId>, sampled_cells: Vec<ReactiveCellId>) {
+    self.1.borrow_mut().push(ActivationRegistrationScope {
+      trigger_cells,
+      local_combinational_cells: Vec::new(),
+    });
+    self
+      .0
+      .borrow_mut()
+      .activation_sampled_cells
+      .push(sampled_cells);
+  }
+  pub fn pop_activation_registration_scope(&self) {
+    self.1.borrow_mut().pop();
+    self.0.borrow_mut().activation_sampled_cells.pop();
+  }
   pub fn register_function(&self, function: Box<dyn MechFunction>, arguments: &[Value]) -> MResult<ReactiveNodeId> {
     let scope = self.1.borrow().last().cloned(); let kind = function.reactive_node_kind(); let outputs = function.reactive_output_cell_ids();
+    let sampled_cells = self
+      .0
+      .borrow()
+      .activation_sampled_cells
+      .last()
+      .cloned()
+      .unwrap_or_default();
     let node = self.0.borrow_mut().register_with_activation(function, arguments, scope.as_ref())?;
-    if scope.is_some() && kind == ReactiveNodeKind::Combinational { if let Some(active) = self.1.borrow_mut().last_mut() { for cell in outputs { if !active.local_combinational_cells.contains(&cell) { active.local_combinational_cells.push(cell); } } } }
+    if scope.is_some() && kind == ReactiveNodeKind::Combinational {
+      if let Some(active) = self.1.borrow_mut().last_mut() {
+        for cell in outputs {
+          if !sampled_cells.contains(&cell)
+            && !active.local_combinational_cells.contains(&cell)
+          {
+            active.local_combinational_cells.push(cell);
+          }
+        }
+      }
+    }
     Ok(node)
   }
 
@@ -1974,6 +2019,70 @@ mod reactive_plan_tests {
     let node = plan.node(node_id).unwrap();
     assert_eq!(node.kind, ReactiveNodeKind::Register);
     assert!(node.outputs.contains(&output_cell));
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn activation_registration_does_not_promote_preexisting_alias_cells() {
+    let trigger = Value::F64(Ref::new(0.0));
+    let sampled = Value::F64(Ref::new(1.0));
+    let local = Value::F64(Ref::new(2.0));
+    let trigger_cell = trigger.reactive_root_cell_ids()[0];
+    let sampled_cell = sampled.reactive_root_cell_ids()[0];
+    let local_cell = local.reactive_root_cell_ids()[0];
+    let plan = Plan::new();
+
+    plan.push_activation_registration_scope_with_sampled_cells(
+      vec![trigger_cell],
+      sampled.reactive_cell_ids(),
+    );
+    plan
+      .register_function(
+        Box::new(TestFunction::with_output("sampled alias", sampled.clone())),
+        &[],
+      )
+      .unwrap();
+    let sampled_consumer = plan
+      .register_function(
+        Box::new(TestFunction::new("sampled consumer")),
+        &[sampled],
+      )
+      .unwrap();
+    plan
+      .register_function(
+        Box::new(TestFunction::with_output("local producer", local.clone())),
+        &[],
+      )
+      .unwrap();
+    let local_consumer = plan
+      .register_function(
+        Box::new(TestFunction::new("local consumer")),
+        &[local],
+      )
+      .unwrap();
+    plan.pop_activation_registration_scope();
+
+    let plan = plan.borrow();
+    assert_eq!(
+      plan.node(sampled_consumer)
+        .unwrap()
+        .inputs
+        .iter()
+        .find(|dependency| dependency.cell == sampled_cell)
+        .unwrap()
+        .kind,
+      ReactiveDependencyKind::Sampled,
+    );
+    assert_eq!(
+      plan.node(local_consumer)
+        .unwrap()
+        .inputs
+        .iter()
+        .find(|dependency| dependency.cell == local_cell)
+        .unwrap()
+        .kind,
+      ReactiveDependencyKind::Reactive,
+    );
   }
 
   #[cfg(feature = "f64")]

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1062,6 +1062,250 @@ pub fn val_ref_reactive_cell_ids(value: &ValRef) -> Vec<ReactiveCellId> {
   ids
 }
 impl Value {
+  /// Recursively snapshots this value into storage that is detached from the
+  /// source's reactive cells.
+  ///
+  /// Mutable references are unwrapped, while typed values retain their kind
+  /// annotation. Container metadata is preserved and nested values are
+  /// detached recursively.
+  pub fn deep_snapshot(&self) -> Value {
+    match self {
+      #[cfg(feature = "u8")]
+      Value::U8(value) => Value::U8(Ref::new(*value.borrow())),
+      #[cfg(feature = "u16")]
+      Value::U16(value) => Value::U16(Ref::new(*value.borrow())),
+      #[cfg(feature = "u32")]
+      Value::U32(value) => Value::U32(Ref::new(*value.borrow())),
+      #[cfg(feature = "u64")]
+      Value::U64(value) => Value::U64(Ref::new(*value.borrow())),
+      #[cfg(feature = "u128")]
+      Value::U128(value) => Value::U128(Ref::new(*value.borrow())),
+      #[cfg(feature = "i8")]
+      Value::I8(value) => Value::I8(Ref::new(*value.borrow())),
+      #[cfg(feature = "i16")]
+      Value::I16(value) => Value::I16(Ref::new(*value.borrow())),
+      #[cfg(feature = "i32")]
+      Value::I32(value) => Value::I32(Ref::new(*value.borrow())),
+      #[cfg(feature = "i64")]
+      Value::I64(value) => Value::I64(Ref::new(*value.borrow())),
+      #[cfg(feature = "i128")]
+      Value::I128(value) => Value::I128(Ref::new(*value.borrow())),
+      #[cfg(feature = "f32")]
+      Value::F32(value) => Value::F32(Ref::new(*value.borrow())),
+      #[cfg(feature = "f64")]
+      Value::F64(value) => Value::F64(Ref::new(*value.borrow())),
+      #[cfg(feature = "complex")]
+      Value::C64(value) => Value::C64(Ref::new(value.borrow().clone())),
+      #[cfg(feature = "rational")]
+      Value::R64(value) => Value::R64(Ref::new(value.borrow().clone())),
+      #[cfg(any(feature = "string", feature = "variable_define"))]
+      Value::String(value) => Value::String(Ref::new(value.borrow().clone())),
+      #[cfg(any(feature = "bool", feature = "variable_define"))]
+      Value::Bool(value) => Value::Bool(Ref::new(*value.borrow())),
+      #[cfg(feature = "atom")]
+      Value::Atom(value) => Value::Atom(Ref::new(value.borrow().clone())),
+      #[cfg(feature = "matrix")]
+      Value::MatrixIndex(value) => Value::MatrixIndex(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "bool"))]
+      Value::MatrixBool(value) => Value::MatrixBool(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u8"))]
+      Value::MatrixU8(value) => Value::MatrixU8(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u16"))]
+      Value::MatrixU16(value) => Value::MatrixU16(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u32"))]
+      Value::MatrixU32(value) => Value::MatrixU32(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u64"))]
+      Value::MatrixU64(value) => Value::MatrixU64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "u128"))]
+      Value::MatrixU128(value) => Value::MatrixU128(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i8"))]
+      Value::MatrixI8(value) => Value::MatrixI8(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i16"))]
+      Value::MatrixI16(value) => Value::MatrixI16(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i32"))]
+      Value::MatrixI32(value) => Value::MatrixI32(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i64"))]
+      Value::MatrixI64(value) => Value::MatrixI64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "i128"))]
+      Value::MatrixI128(value) => Value::MatrixI128(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "f32"))]
+      Value::MatrixF32(value) => Value::MatrixF32(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "f64"))]
+      Value::MatrixF64(value) => Value::MatrixF64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "string"))]
+      Value::MatrixString(value) => Value::MatrixString(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "rational"))]
+      Value::MatrixR64(value) => Value::MatrixR64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(all(feature = "matrix", feature = "complex"))]
+      Value::MatrixC64(value) => Value::MatrixC64(Matrix::from_vec(
+        value.as_vec(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(feature = "matrix")]
+      Value::MatrixValue(value) => Value::MatrixValue(Matrix::from_vec(
+        value
+          .as_vec()
+          .iter()
+          .map(Value::deep_snapshot)
+          .collect(),
+        value.rows(),
+        value.cols(),
+      )),
+      #[cfg(feature = "set")]
+      Value::Set(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.set = snapshot
+          .set
+          .iter()
+          .map(Value::deep_snapshot)
+          .collect();
+        Value::Set(Ref::new(snapshot))
+      }
+      #[cfg(feature = "map")]
+      Value::Map(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.map = snapshot
+          .map
+          .iter()
+          .map(|(key, value)| (key.deep_snapshot(), value.deep_snapshot()))
+          .collect();
+        Value::Map(Ref::new(snapshot))
+      }
+      #[cfg(feature = "record")]
+      Value::Record(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.data = snapshot
+          .data
+          .iter()
+          .map(|(id, value)| (*id, value.deep_snapshot()))
+          .collect();
+        Value::Record(Ref::new(snapshot))
+      }
+      #[cfg(feature = "table")]
+      Value::Table(value) => {
+        let mut snapshot = value.borrow().clone();
+        snapshot.data = snapshot
+          .data
+          .iter()
+          .map(|(id, (kind, values))| {
+            let values = Matrix::from_vec(
+              values
+                .as_vec()
+                .iter()
+                .map(Value::deep_snapshot)
+                .collect(),
+              values.rows(),
+              values.cols(),
+            );
+            (*id, (kind.clone(), values))
+          })
+          .collect();
+        Value::Table(Ref::new(snapshot))
+      }
+      #[cfg(feature = "tuple")]
+      Value::Tuple(value) => Value::Tuple(Ref::new(
+        MechTuple::from_vec(
+          value
+            .borrow()
+            .elements
+            .iter()
+            .map(|value| value.deep_snapshot())
+            .collect(),
+        ),
+      )),
+      #[cfg(feature = "enum")]
+      Value::Enum(value) => {
+        let value = value.borrow();
+        Value::Enum(Ref::new(MechEnum {
+          id: value.id,
+          variants: value
+            .variants
+            .iter()
+            .map(|(id, payload)| {
+              (*id, payload.as_ref().map(Value::deep_snapshot))
+            })
+            .collect(),
+          names: value.names.clone(),
+        }))
+      }
+      Value::Id(value) => Value::Id(*value),
+      Value::Index(value) => Value::Index(Ref::new(*value.borrow())),
+      Value::MutableReference(value) => value.borrow().deep_snapshot(),
+      Value::Typed(value, kind) => {
+        Value::Typed(Box::new(value.deep_snapshot()), kind.clone())
+      }
+      Value::Kind(kind) => Value::Kind(kind.clone()),
+      Value::IndexAll => Value::IndexAll,
+      Value::EmptyKind(kind) => Value::EmptyKind(kind.clone()),
+      Value::Empty => Value::Empty,
+    }
+  }
+
   #[cfg(feature = "matrix")]
   fn infer_matrix_value_kind(matrix: &Matrix<Value>) -> ValueKind {
     let mut base_kind: Option<ValueKind> = None;
@@ -3156,6 +3400,39 @@ mod reactive_cell_tests {
     let record = Ref::new(MechRecord { cols: 1, kinds: vec![ValueKind::Tuple(vec![ValueKind::F64, ValueKind::F64])], data, field_names: HashMap::new() });
 
     assert_eq!(Value::Record(record.clone()).reactive_cell_ids(), cell_ids(&[record.id(), tuple.id(), a.id(), b.id()]));
+  }
+
+  #[cfg(all(feature = "record", feature = "tuple", feature = "f64"))]
+  #[test]
+  fn deep_snapshot_detaches_nested_record_and_tuple_cells() {
+    let live = Ref::new(1.0);
+    let value = Value::Record(Ref::new(MechRecord::new(vec![(
+      "position",
+      Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+        Value::F64(live.clone()),
+        Value::F64(Ref::new(2.0)),
+      ]))),
+    )])));
+
+    let snapshot = value.deep_snapshot();
+    *live.borrow_mut() = 9.0;
+
+    let Value::Record(snapshot) = snapshot else {
+      panic!("expected record snapshot");
+    };
+    let position = {
+      let snapshot = snapshot.borrow();
+      let Value::Tuple(position) = snapshot.data.get(&hash_str("position")).unwrap() else {
+        panic!("expected tuple field");
+      };
+      position.clone()
+    };
+    let position = position.borrow();
+    let Value::F64(x) = position.elements[0].as_ref() else {
+      panic!("expected scalar tuple element");
+    };
+    assert_eq!(*x.borrow(), 1.0);
+    assert_ne!(x.as_ptr(), live.as_ptr());
   }
 
   #[cfg(all(feature = "map", feature = "set", feature = "f64"))]

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -23,11 +23,11 @@ activation_error!(
 );
 activation_error!(
     ActivationPatternArmsNonExhaustive,
-    "Patterned activations require a final unguarded wildcard arm."
+    "Patterned activations require a final unguarded irrefutable arm."
 );
 activation_error!(
     ActivationPatternWildcardMustBeLast,
-    "The wildcard activation arm must be last."
+    "An unguarded wildcard activation arm must be last."
 );
 activation_error!(
     ActivationPatternGuardMustBePure,
@@ -43,7 +43,11 @@ activation_error!(
 );
 activation_error!(
     ActivationPatternRegisterWriteUnsupported,
-    "Patterned activation register writes are not supported."
+    "Patterned activation register writes must target a whole local register."
+);
+activation_error!(
+    ActivationScopeTriggerWriteUnsupported,
+    "An activation scope cannot assign to its own trigger."
 );
 activation_error!(
     ActivationPatternContextEffectUnsupported,
@@ -980,6 +984,74 @@ interpreter_only!(Select);
 #[cfg(feature = "compiler")]
 interpreter_only!(Gate);
 
+fn pattern_is_irrefutable(pattern: &CompiledPattern, trigger_kind: &ValueKind) -> bool {
+    fn check(
+        pattern: &CompiledPattern,
+        trigger_kind: &ValueKind,
+        bindings: &mut HashSet<usize>,
+    ) -> bool {
+        match pattern {
+            CompiledPattern::Wildcard => true,
+            CompiledPattern::Binding { binding_index, .. } => {
+                bindings.insert(*binding_index)
+            }
+            CompiledPattern::ExpressionValue { .. }
+            | CompiledPattern::EnumVariant { .. }
+            | CompiledPattern::AtomTuple { .. } => false,
+            CompiledPattern::Tuple { elements } => {
+                let ValueKind::Tuple(kinds) = trigger_kind.deref_kind() else {
+                    return false;
+                };
+                elements.len() == kinds.len()
+                    && elements
+                        .iter()
+                        .zip(&kinds)
+                        .all(|(element, kind)| check(element, kind, bindings))
+            }
+            CompiledPattern::Array {
+                prefix,
+                spread,
+                suffix,
+            } => {
+                let ValueKind::Matrix(element_kind, shape) = trigger_kind.deref_kind() else {
+                    return false;
+                };
+                let minimum_len = prefix.len() + suffix.len();
+                let known_len = (!shape.is_empty()).then(|| shape.iter().product::<usize>());
+                match (known_len, spread) {
+                    (Some(len), None) if len != minimum_len => return false,
+                    (Some(len), Some(_)) if len < minimum_len => return false,
+                    (None, None) => return false,
+                    (None, Some(_)) if minimum_len != 0 => return false,
+                    _ => {}
+                }
+                if !prefix
+                    .iter()
+                    .chain(suffix)
+                    .all(|element| check(element, &element_kind, bindings))
+                {
+                    return false;
+                }
+                spread
+                    .as_ref()
+                    .and_then(|spread| spread.binding.as_deref())
+                    .map_or(true, |binding| {
+                        let middle_shape = known_len
+                            .map(|len| vec![1, len - minimum_len])
+                            .unwrap_or_default();
+                        check(
+                            binding,
+                            &ValueKind::Matrix(element_kind, middle_shape),
+                            bindings,
+                        )
+                    })
+            }
+        }
+    }
+
+    check(pattern, trigger_kind, &mut HashSet::new())
+}
+
 fn preflight_patterned_activation(
     scope: &ActivationScope,
     arms: &[ActivationArm],
@@ -987,27 +1059,23 @@ fn preflight_patterned_activation(
     trigger_cells: &[ReactiveCellId],
     i: &Interpreter,
 ) -> MResult<PreflightPatternedActivation> {
-    let last = arms.last().ok_or_else(|| {
+    arms.last().ok_or_else(|| {
         MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
     })?;
-    if !matches!(last.pattern, Pattern::Wildcard) || last.guard.is_some() {
-        return Err(
-            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
-        );
-    }
-    if arms[..arms.len() - 1]
-        .iter()
-        .any(|a| matches!(a.pattern, Pattern::Wildcard))
-    {
-        return Err(
-            MechError::new(ActivationPatternWildcardMustBeLast, None).with_tokens(scope.tokens())
-        );
-    }
+    let trigger_id = match &scope.trigger {
+        Expression::Var(var) => var.name.hash(),
+        _ => {
+            return Err(
+                MechError::new(ActivationPatternTriggerInvariant, None)
+                    .with_tokens(scope.trigger.tokens()),
+            );
+        }
+    };
     for arm in arms {
         if let Some(guard) = &arm.guard {
             validate_patterned_guard_expression(guard, i)?;
         }
-        validate_patterned_arm_body(&arm.body)?;
+        validate_patterned_arm_body(&arm.body, trigger_id, trigger_cells, i)?;
     }
     if trigger.reactive_root_cell_ids() != trigger_cells {
         return Err(
@@ -1041,6 +1109,23 @@ fn preflight_patterned_activation(
             .collect::<MResult<Vec<_>>>()?;
         compiled.push(PreflightActivationArm { pattern, captures });
     }
+    let last = arms.last().unwrap();
+    if last.guard.is_some()
+        || !pattern_is_irrefutable(&compiled.last().unwrap().pattern, &trigger_kind)
+    {
+        return Err(
+            MechError::new(ActivationPatternArmsNonExhaustive, None).with_tokens(scope.tokens())
+        );
+    }
+    if arms[..arms.len() - 1]
+        .iter()
+        .any(|arm| arm.guard.is_none() && matches!(arm.pattern, Pattern::Wildcard))
+    {
+        return Err(
+            MechError::new(ActivationPatternWildcardMustBeLast, None)
+                .with_tokens(scope.tokens()),
+        );
+    }
     Ok(PreflightPatternedActivation {
         trigger_kind,
         arms: compiled,
@@ -1051,22 +1136,34 @@ fn validation_error(kind: impl MechErrorKind + 'static, tokens: Vec<Token>) -> M
     Err(MechError::new(kind, None).with_tokens(tokens))
 }
 
-fn validate_patterned_arm_body(body: &ActivationArmBody) -> MResult<()> {
+fn validate_patterned_arm_body(
+    body: &ActivationArmBody,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+) -> MResult<()> {
     match body {
         ActivationArmBody::Block(body) => {
             for (code, _) in body {
-                validate_patterned_code(code)?;
+                validate_patterned_code(code, trigger_id, trigger_cells, interpreter)?;
             }
             Ok(())
         }
         ActivationArmBody::Expression(expression) => validate_patterned_expression(expression),
     }
 }
-fn validate_patterned_code(code: &MechCode) -> MResult<()> {
+fn validate_patterned_code(
+    code: &MechCode,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+) -> MResult<()> {
     match code {
         MechCode::Comment(_) => Ok(()),
         MechCode::Expression(expression) => validate_patterned_expression(expression),
-        MechCode::Statement(statement) => validate_patterned_statement(statement),
+        MechCode::Statement(statement) => {
+            validate_patterned_statement(statement, trigger_id, trigger_cells, interpreter)
+        }
         MechCode::ActivationScope(_)
         | MechCode::FunctionDefine(_)
         | MechCode::FsmSpecification(_)
@@ -1077,7 +1174,46 @@ fn validate_patterned_code(code: &MechCode) -> MResult<()> {
         }
     }
 }
-fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
+fn validate_patterned_register_write(
+    target: &SliceRef,
+    expression: &Expression,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+    tokens: Vec<Token>,
+) -> MResult<()> {
+    if target.context.is_some() {
+        return validation_error(ActivationPatternContextEffectUnsupported, tokens);
+    }
+    let target_id = target.name.hash();
+    let aliases_trigger = interpreter
+        .symbols()
+        .borrow()
+        .get(target_id)
+        .is_some_and(|value| {
+            value
+                .borrow()
+                .reactive_root_cell_ids()
+                .iter()
+                .any(|cell| trigger_cells.contains(cell))
+        });
+    if target_id == trigger_id || aliases_trigger {
+        return validation_error(ActivationScopeTriggerWriteUnsupported, tokens);
+    }
+    // Indexed assignment implementations still mutate eagerly and do not
+    // implement the reactive-register staging contract.
+    if target.subscript.is_some() {
+        return validation_error(ActivationPatternRegisterWriteUnsupported, tokens);
+    }
+    validate_patterned_expression(expression)
+}
+
+fn validate_patterned_statement(
+    statement: &Statement,
+    trigger_id: u64,
+    trigger_cells: &[ReactiveCellId],
+    interpreter: &Interpreter,
+) -> MResult<()> {
     match statement {
         Statement::VariableDefine(definition)
             if !definition.mutable && definition.var.context.is_none() =>
@@ -1093,22 +1229,20 @@ fn validate_patterned_statement(statement: &Statement) -> MResult<()> {
         Statement::VariableDefine(_) => {
             validation_error(ActivationPatternDefinitionUnsupported, statement.tokens())
         }
-        Statement::VariableAssign(assignment) if assignment.target.context.is_some() => {
-            validation_error(
-                ActivationPatternContextEffectUnsupported,
-                statement.tokens(),
-            )
-        }
-        Statement::VariableAssign(_) => validation_error(
-            ActivationPatternRegisterWriteUnsupported,
+        Statement::VariableAssign(assignment) => validate_patterned_register_write(
+            &assignment.target,
+            &assignment.expression,
+            trigger_id,
+            trigger_cells,
+            interpreter,
             statement.tokens(),
         ),
-        Statement::OpAssign(assignment) if assignment.target.context.is_some() => validation_error(
-            ActivationPatternContextEffectUnsupported,
-            statement.tokens(),
-        ),
-        Statement::OpAssign(_) => validation_error(
-            ActivationPatternRegisterWriteUnsupported,
+        Statement::OpAssign(assignment) => validate_patterned_register_write(
+            &assignment.target,
+            &assignment.expression,
+            trigger_id,
+            trigger_cells,
+            interpreter,
             statement.tokens(),
         ),
         Statement::ContextSend(_) => validation_error(
@@ -1562,6 +1696,22 @@ struct ElaboratedPatternGuard {
     node_end: usize,
 }
 
+pub(crate) fn activation_scope_entry_cells(
+    interpreter: &Interpreter,
+) -> Vec<ReactiveCellId> {
+    let symbols = interpreter.symbols();
+    let symbols = symbols.borrow();
+    let mut cells = Vec::new();
+    for symbol in symbols.symbols.values() {
+        for cell in symbol.borrow().reactive_cell_ids() {
+            if !cells.contains(&cell) {
+                cells.push(cell);
+            }
+        }
+    }
+    cells
+}
+
 fn elaborate_patterned_arm_guard(
     guard: &Expression,
     captures: &[ActivationPatternCapture],
@@ -1587,7 +1737,10 @@ fn elaborate_patterned_arm_guard(
     }
     let node_start = plan.len();
     let pulse_cells = pulse.reactive_root_cell_ids();
-    plan.push_activation_registration_scope(pulse_cells.clone());
+    plan.push_activation_registration_scope_with_sampled_cells(
+        pulse_cells.clone(),
+        activation_scope_entry_cells(interpreter),
+    );
     let result = (|| -> MResult<ElaboratedPatternGuard> {
         let _deferred_expression_solves =
             crate::expressions::DeferredExpressionSolveScope::enter(interpreter);
@@ -1680,7 +1833,10 @@ fn elaborate_patterned_arm_body(
         }
     }
     let body_node_start = plan.len();
-    plan.push_activation_registration_scope(pulse.reactive_root_cell_ids());
+    plan.push_activation_registration_scope_with_sampled_cells(
+        pulse.reactive_root_cell_ids(),
+        activation_scope_entry_cells(interpreter),
+    );
     let body_result = (|| -> MResult<()> {
         match &arm.body {
             ActivationArmBody::Block(body) => {
@@ -1946,6 +2102,63 @@ mod tests {
         fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
             self.compile_calls.fetch_add(1, Ordering::SeqCst);
             panic!("unsupported guard compiler must not run during preflight")
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct PatternRegisterStageFailure;
+    impl MechErrorKind for PatternRegisterStageFailure {
+        fn name(&self) -> &str {
+            "PatternRegisterStageFailure"
+        }
+        fn message(&self) -> String {
+            "intentional patterned register staging failure".to_string()
+        }
+    }
+
+    struct FailingPatternRegister {
+        sink: Ref<f64>,
+        solve_calls: Arc<AtomicUsize>,
+        stage_calls: Arc<AtomicUsize>,
+    }
+    impl MechFunctionImpl for FailingPatternRegister {
+        fn solve(&self) {
+            self.solve_calls.fetch_add(1, Ordering::SeqCst);
+            *self.sink.borrow_mut() = -999.0;
+        }
+        fn stage_register(&self) -> MResult<Box<dyn ReactiveRegisterCommit>> {
+            self.stage_calls.fetch_add(1, Ordering::SeqCst);
+            Err(MechError::new(PatternRegisterStageFailure, None))
+        }
+        fn out(&self) -> Value {
+            Value::F64(self.sink.clone())
+        }
+        fn reactive_node_kind(&self) -> ReactiveNodeKind {
+            ReactiveNodeKind::Register
+        }
+        fn to_string(&self) -> String {
+            "FailingPatternRegister".to_string()
+        }
+    }
+    #[cfg(feature = "compiler")]
+    impl MechFunctionCompiler for FailingPatternRegister {
+        fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+            Err(MechError::new(PatternRegisterStageFailure, None))
+        }
+    }
+
+    struct FailingPatternRegisterCompiler {
+        sink: Ref<f64>,
+        solve_calls: Arc<AtomicUsize>,
+        stage_calls: Arc<AtomicUsize>,
+    }
+    impl NativeFunctionCompiler for FailingPatternRegisterCompiler {
+        fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+            Ok(Box::new(FailingPatternRegister {
+                sink: self.sink.clone(),
+                solve_calls: self.solve_calls.clone(),
+                stage_calls: self.stage_calls.clone(),
+            }))
         }
     }
 
@@ -2268,6 +2481,18 @@ event := :first
     fn root_cell(interpreter: &Interpreter, name: &str) -> ReactiveCellId {
         symbol(interpreter, name).reactive_root_cell_ids()[0]
     }
+    fn f64_symbol(interpreter: &Interpreter, name: &str) -> f64 {
+        *symbol(interpreter, name)
+            .as_f64()
+            .unwrap_or_else(|_| panic!("symbol `{name}` is not f64"))
+            .borrow()
+    }
+    fn set_f64_symbol(interpreter: &Interpreter, name: &str, value: f64) {
+        *symbol(interpreter, name)
+            .as_f64()
+            .unwrap_or_else(|_| panic!("symbol `{name}` is not f64"))
+            .borrow_mut() = value;
+    }
     fn registration(interpreter: &Interpreter) -> PatternActivationRegistration {
         let plan = interpreter.plan();
         let registrations = plan.pattern_activation_registrations();
@@ -2321,6 +2546,20 @@ event := :first
         };
         let value = *generation.borrow();
         value
+    }
+    fn arm_register_nodes(
+        interpreter: &Interpreter,
+        registration: &PatternActivationRegistration,
+        arm: usize,
+    ) -> Vec<ReactiveNodeId> {
+        let arm = &registration.arms[arm];
+        let plan = interpreter.plan();
+        let plan = plan.borrow();
+        plan.nodes[arm.body_node_start..arm.body_node_end]
+            .iter()
+            .filter(|node| node.kind == ReactiveNodeKind::Register)
+            .map(|node| node.id)
+            .collect()
     }
     fn plan_snapshot(interpreter: &Interpreter) -> PlanSnapshot {
         let plan = interpreter.plan();
@@ -2537,6 +2776,564 @@ event := :first
         }
         assert_eq!(body_output_f64(interpreter, expected_arm), output);
         assert_eq!(&plan_snapshot(interpreter), topology);
+    }
+
+    #[test]
+    fn activation_final_binding_is_exhaustive_and_guarded_binding_falls_through_to_it() {
+        let mut interpreter = interpret(
+            r#"
+physics-tick := 0.25
+~position-y := -1.0
+~velocity-y := 0.0
+floor := 0.0
+restitution := 0.5
+gravity := 4.0
+
+~> physics-tick
+  | dt, position-y >= floor => {
+      velocity-y = -velocity-y * restitution
+      position-y = floor
+    }
+  | dt => {
+      velocity-y = velocity-y + gravity * dt
+      position-y = position-y + velocity-y * dt
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "physics-tick");
+        let activation = registration(&interpreter);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(activation.arms.len(), 2);
+        assert!(activation.arms[0].guard.is_some());
+        assert!(activation.arms[1].guard.is_none());
+        assert_eq!(activation.arms[0].captures.len(), 1);
+        assert_eq!(activation.arms[1].captures.len(), 1);
+        let arm_registers = (0..activation.arms.len())
+            .map(|arm| arm_register_nodes(&interpreter, &activation, arm))
+            .collect::<Vec<_>>();
+        assert!(arm_registers.iter().all(|registers| registers.len() == 2));
+        assert_eq!(
+            (
+                f64_symbol(&interpreter, "position-y"),
+                f64_symbol(&interpreter, "velocity-y"),
+            ),
+            (-1.0, 0.0),
+        );
+
+        let fallback = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &fallback), 1);
+        assert_eq!(fallback.register_commit.committed_nodes, arm_registers[1]);
+        assert_eq!(
+            (
+                f64_symbol(&interpreter, "position-y"),
+                f64_symbol(&interpreter, "velocity-y"),
+            ),
+            (-1.0, 1.0),
+        );
+        assert_eq!(
+            committed_capture_value(&interpreter, 1, 0),
+            Value::F64(Ref::new(0.25)),
+        );
+        assert_eq!(plan_snapshot(&interpreter), topology);
+
+        set_f64_symbol(&interpreter, "position-y", 1.0);
+        let guarded = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &guarded), 0);
+        assert_eq!(guarded.register_commit.committed_nodes, arm_registers[0]);
+        assert_eq!(
+            (
+                f64_symbol(&interpreter, "position-y"),
+                f64_symbol(&interpreter, "velocity-y"),
+            ),
+            (0.0, -0.5),
+        );
+        assert_eq!(
+            committed_capture_value(&interpreter, 0, 0),
+            Value::F64(Ref::new(0.25)),
+        );
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_guarded_wildcard_may_precede_an_exhaustive_binding() {
+        let mut interpreter = interpret(
+            r#"
+event := 2.0
+ready := false
+
+~> event
+  | *, ready == true => {
+      selected := -1.0
+    }
+  | value => {
+      selected := value
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&interpreter, &topology, &outcome, 1, 2.0);
+    }
+
+    #[test]
+    fn activation_final_irrefutable_tuple_is_exhaustive() {
+        let mut interpreter = interpret(
+            r#"
+event := (1.0, 2.0)
+~> event
+  | (tick, dt) => {
+      selected := tick * 10.0 + dt
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        set_tuple_event(
+            &interpreter,
+            vec![Value::F64(Ref::new(3.0)), Value::F64(Ref::new(4.0))],
+        );
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&interpreter, &topology, &outcome, 0, 34.0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_final_irrefutable_fixed_matrix_pattern_is_exhaustive() {
+        let mut interpreter = interpret(
+            r#"
+event := [1.0 2.0]
+~> event
+  | [left, right] => {
+      selected := left * 10.0 + right
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let topology = plan_snapshot(&interpreter);
+        set_f64_matrix_event(&interpreter, vec![3.0, 4.0]);
+        let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_dispatch_turn(&interpreter, &topology, &outcome, 0, 34.0);
+    }
+
+    #[test]
+    fn activation_final_refutable_pattern_is_non_exhaustive() {
+        for pattern in ["1.0", "(x, x)"] {
+            let mut interpreter = if pattern == "1.0" {
+                interpret("event := 1.0")
+            } else {
+                interpret("event := (1.0, 1.0)")
+            };
+            let topology = plan_snapshot(&interpreter);
+            let error = interpret_more(
+                &mut interpreter,
+                &format!(
+                    "~> event\n  | {pattern} => {{\n      selected := 1.0\n    }}"
+                ),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind_name(), "ActivationPatternArmsNonExhaustive");
+            assert_eq!(plan_snapshot(&interpreter), topology);
+        }
+
+        let mut interpreter = interpret("event := 1.0");
+        let topology = plan_snapshot(&interpreter);
+        let error = interpret_more(
+            &mut interpreter,
+            r#"
+~> event
+  | value, value > 0.0 => {
+      selected := value
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternArmsNonExhaustive");
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_unguarded_wildcard_before_the_final_arm_is_rejected() {
+        let mut interpreter = interpret("event := 1.0");
+        let topology = plan_snapshot(&interpreter);
+        let error = interpret_more(
+            &mut interpreter,
+            r#"
+~> event
+  | * => {
+      selected := 1.0
+    }
+  | value => {
+      selected := value
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationPatternWildcardMustBeLast");
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_selected_arm_commits_register_batch_and_other_arms_schedule_nothing() {
+        let mut interpreter = interpret(
+            r#"
+event := 0.0
+~x := 1.0
+~y := 10.0
+
+~> event
+  | first, first > 10.0 => {
+      x = first
+      y += first
+    }
+  | second, second > 0.0 => {
+      x = second * 2.0
+      y = second + 1.0
+    }
+  | * => {
+      x = -1.0
+      y = -1.0
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let activation = registration(&interpreter);
+        let topology = plan_snapshot(&interpreter);
+        let arm_registers = (0..activation.arms.len())
+            .map(|arm| arm_register_nodes(&interpreter, &activation, arm))
+            .collect::<Vec<_>>();
+        assert!(arm_registers.iter().all(|registers| registers.len() == 2));
+        {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            for (arm_index, registers) in arm_registers.iter().enumerate() {
+                for register in registers {
+                    let node = plan.node(*register).unwrap();
+                    assert!(node.inputs.iter().any(|dependency| {
+                        dependency.cell == activation.arms[arm_index].pulse_cell
+                            && dependency.kind == ReactiveDependencyKind::Reactive
+                    }));
+                    for (other_arm, registration) in activation.arms.iter().enumerate() {
+                        if other_arm != arm_index {
+                            assert!(!node.inputs.iter().any(|dependency| {
+                                dependency.cell == registration.pulse_cell
+                                    && dependency.kind == ReactiveDependencyKind::Reactive
+                            }));
+                        }
+                    }
+                    for capture in &activation.arms[arm_index].captures {
+                        assert!(node.inputs.iter().any(|dependency| {
+                            dependency.cell == capture.cell
+                                && dependency.kind == ReactiveDependencyKind::Sampled
+                        }));
+                    }
+                }
+            }
+        }
+
+        // Initial dispatch selects the fallback only to seed captures. No arm
+        // body is pulsed while the static graph is being registered.
+        assert_eq!(
+            (f64_symbol(&interpreter, "x"), f64_symbol(&interpreter, "y")),
+            (1.0, 10.0)
+        );
+        assert!(!interpreter.has_pending_reactive_registers());
+        for arm in 0..activation.arms.len() {
+            assert_eq!(arm_pulse_generation(&interpreter, arm), 0);
+        }
+
+        // Both guarded arms are eligible, so source order selects arm zero.
+        // The matching-but-losing arm must not schedule either register.
+        set_f64_symbol(&interpreter, "event", 20.0);
+        let first = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &first), 0);
+        assert_eq!(first.before_commit.pending_register_nodes, arm_registers[0]);
+        assert_eq!(first.register_commit.staged_nodes, arm_registers[0]);
+        assert_eq!(first.register_commit.committed_nodes, arm_registers[0]);
+        assert_eq!(
+            (f64_symbol(&interpreter, "x"), f64_symbol(&interpreter, "y")),
+            (20.0, 30.0)
+        );
+        for register in arm_registers[1].iter().chain(&arm_registers[2]) {
+            assert!(!first.before_commit.pending_register_nodes.contains(register));
+            assert!(!first.register_commit.staged_nodes.contains(register));
+            assert!(!first.register_commit.committed_nodes.contains(register));
+            assert!(!first.after_commit.pending_register_nodes.contains(register));
+        }
+
+        // Arm zero still matches, but its false guard must leave its register
+        // nodes dormant. Arm one's capture is consumed by both writes from
+        // this same trigger.
+        set_f64_symbol(&interpreter, "event", 5.0);
+        let second = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &second), 1);
+        assert_eq!(second.before_commit.pending_register_nodes, arm_registers[1]);
+        assert_eq!(second.register_commit.staged_nodes, arm_registers[1]);
+        assert_eq!(second.register_commit.committed_nodes, arm_registers[1]);
+        assert_eq!(
+            (f64_symbol(&interpreter, "x"), f64_symbol(&interpreter, "y")),
+            (10.0, 6.0)
+        );
+        assert_eq!(
+            committed_capture_value(&interpreter, 1, 0),
+            Value::F64(Ref::new(5.0))
+        );
+        for register in arm_registers[0].iter().chain(&arm_registers[2]) {
+            assert!(!second.before_commit.pending_register_nodes.contains(register));
+            assert!(!second.register_commit.staged_nodes.contains(register));
+            assert!(!second.register_commit.committed_nodes.contains(register));
+            assert!(!second.after_commit.pending_register_nodes.contains(register));
+        }
+        assert!(!interpreter.has_pending_reactive_registers());
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_equal_trigger_packets_produce_distinct_register_transitions_without_plan_growth() {
+        let mut interpreter = interpret(
+            r#"
+event := 2.0
+~count := 0.0
+
+~> event
+  | amount => {
+      count += amount
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#,
+        );
+        let trigger = root_cell(&interpreter, "event");
+        let activation = registration(&interpreter);
+        let registers = arm_register_nodes(&interpreter, &activation, 0);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(registers.len(), 1);
+        assert_eq!(f64_symbol(&interpreter, "count"), 0.0);
+
+        for (expected_count, expected_pulse) in [(2.0, 1usize), (4.0, 2usize)] {
+            let outcome = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+            assert_eq!(selected_arm_index(&activation, &outcome), 0);
+            assert_eq!(outcome.before_commit.pending_register_nodes, registers);
+            assert_eq!(outcome.register_commit.staged_nodes, registers);
+            assert_eq!(outcome.register_commit.committed_nodes, registers);
+            assert_eq!(f64_symbol(&interpreter, "count"), expected_count);
+            assert_eq!(arm_pulse_generation(&interpreter, 0), expected_pulse);
+            assert_eq!(plan_snapshot(&interpreter), topology);
+        }
+    }
+
+    #[test]
+    fn activation_arm_alias_of_live_input_remains_sampled_until_trigger() {
+        let mut interpreter = Interpreter::new_with_full_stdlib(0);
+        let outer_id = hash_str("outer");
+        {
+            let symbols = interpreter.symbols();
+            let mut symbols = symbols.borrow_mut();
+            symbols.insert(outer_id, Value::F64(Ref::new(1.0)), true);
+            symbols
+                .dictionary
+                .borrow_mut()
+                .insert(outer_id, "outer".to_string());
+        }
+        interpreter
+            .dictionary()
+            .borrow_mut()
+            .insert(outer_id, "outer".to_string());
+        interpret_more(
+            &mut interpreter,
+            r#"
+event := 0.0
+~state := 0.0
+
+~> event
+  | tick => {
+      sampled := outer
+      state = sampled
+    }
+"#,
+        )
+        .unwrap();
+
+        let trigger = root_cell(&interpreter, "event");
+        let outer = root_cell(&interpreter, "outer");
+        let activation = registration(&interpreter);
+        let registers = arm_register_nodes(&interpreter, &activation, 0);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(registers.len(), 1);
+        assert_eq!(f64_symbol(&interpreter, "state"), 0.0);
+        {
+            let plan = interpreter.plan();
+            let plan = plan.borrow();
+            let register = plan.node(registers[0]).unwrap();
+            assert!(register.inputs.iter().any(|dependency| {
+                dependency.cell == outer
+                    && dependency.kind == ReactiveDependencyKind::Sampled
+            }));
+            assert!(register.inputs.iter().any(|dependency| {
+                dependency.cell == activation.arms[0].pulse_cell
+                    && dependency.kind == ReactiveDependencyKind::Reactive
+            }));
+        }
+
+        set_f64_symbol(&interpreter, "outer", 5.0);
+        let sampled_only = interpreter.advance_reactive_turn(&[outer]).unwrap();
+        assert!(!sampled_only
+            .before_commit
+            .pending_register_nodes
+            .contains(&registers[0]));
+        assert!(!sampled_only
+            .register_commit
+            .committed_nodes
+            .contains(&registers[0]));
+        assert_eq!(f64_symbol(&interpreter, "state"), 0.0);
+
+        let tick = interpreter.advance_reactive_turn(&[trigger]).unwrap();
+        assert_eq!(selected_arm_index(&activation, &tick), 0);
+        assert_eq!(tick.register_commit.committed_nodes, registers);
+        assert_eq!(f64_symbol(&interpreter, "state"), 5.0);
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_failed_multi_register_staging_mutates_nothing() {
+        let mut interpreter = interpret(
+            r#"
+event := 0.0
+~first := 1.0
+~second := 2.0
+"#,
+        );
+        let second_sink = symbol(&interpreter, "second").as_f64().unwrap().clone();
+        let solve_calls = Arc::new(AtomicUsize::new(0));
+        let stage_calls = Arc::new(AtomicUsize::new(0));
+        interpreter
+            .functions()
+            .borrow_mut()
+            .insert_function_compiler(
+                "test/failing-pattern-register",
+                Arc::new(FailingPatternRegisterCompiler {
+                    sink: second_sink,
+                    solve_calls: solve_calls.clone(),
+                    stage_calls: stage_calls.clone(),
+                }),
+            );
+        interpret_more(
+            &mut interpreter,
+            r#"
+~> event
+  | value => {
+      first = value
+      test/failing-pattern-register()
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#,
+        )
+        .unwrap();
+
+        let trigger = root_cell(&interpreter, "event");
+        let activation = registration(&interpreter);
+        let registers = arm_register_nodes(&interpreter, &activation, 0);
+        let topology = plan_snapshot(&interpreter);
+        assert_eq!(registers.len(), 2);
+        assert_eq!(
+            (f64_symbol(&interpreter, "first"), f64_symbol(&interpreter, "second")),
+            (1.0, 2.0)
+        );
+        assert_eq!(solve_calls.load(Ordering::SeqCst), 0);
+
+        set_f64_symbol(&interpreter, "event", 9.0);
+        let error = interpreter.advance_reactive_turn(&[trigger]).unwrap_err();
+        assert_eq!(error.kind_name(), "PatternRegisterStageFailure");
+        assert_eq!(stage_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(solve_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            (f64_symbol(&interpreter, "first"), f64_symbol(&interpreter, "second")),
+            (1.0, 2.0)
+        );
+        assert_eq!(plan_snapshot(&interpreter), topology);
+    }
+
+    #[test]
+    fn activation_patterned_body_rejects_writes_to_its_trigger() {
+        for assignment in ["event = event + 1.0", "event += 1.0"] {
+            let mut interpreter = interpret("~event := 1.0");
+            let topology = plan_snapshot(&interpreter);
+            let error = interpret_more(
+                &mut interpreter,
+                &format!(
+                    r#"
+~> event
+  | * => {{
+      {assignment}
+    }}
+"#
+                ),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind_name(), "ActivationScopeTriggerWriteUnsupported");
+            assert_eq!(f64_symbol(&interpreter, "event"), 1.0);
+            assert_eq!(plan_snapshot(&interpreter), topology);
+            assert_eq!(interpreter.plan().activation_registration_depth(), 0);
+        }
+    }
+
+    #[test]
+    fn activation_patterned_body_rejects_writes_through_a_trigger_alias() {
+        let mut interpreter = interpret(
+            r#"
+~event := 1.0
+alias := event
+"#,
+        );
+        let topology = plan_snapshot(&interpreter);
+        let error = interpret_more(
+            &mut interpreter,
+            r#"
+~> alias
+  | * => {
+      event += 1.0
+    }
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind_name(), "ActivationScopeTriggerWriteUnsupported");
+        assert_eq!(f64_symbol(&interpreter, "event"), 1.0);
+        assert_eq!(plan_snapshot(&interpreter), topology);
+        assert_eq!(interpreter.plan().activation_registration_depth(), 0);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    #[test]
+    fn activation_patterned_body_rejects_eager_subscript_writes() {
+        for assignment in ["values[1] = 3.0", "values[1] += 3.0"] {
+            let mut interpreter = interpret(
+                r#"
+event := 0.0
+~values := [1.0 2.0]
+"#,
+            );
+            let topology = plan_snapshot(&interpreter);
+            let values_before = symbol(&interpreter, "values");
+            let error = interpret_more(
+                &mut interpreter,
+                &format!(
+                    r#"
+~> event
+  | * => {{
+      {assignment}
+    }}
+"#
+                ),
+            )
+            .unwrap_err();
+            assert_eq!(error.kind_name(), "ActivationPatternRegisterWriteUnsupported");
+            assert_eq!(symbol(&interpreter, "values"), values_before);
+            assert_eq!(plan_snapshot(&interpreter), topology);
+            assert_eq!(interpreter.plan().activation_registration_depth(), 0);
+        }
     }
 
     const ENUM_ACTIVATION: &str = r#"

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -454,9 +454,29 @@ fn activation_trigger_cells(scope: &ActivationScope, _var: &Var, _p: &Interprete
 fn elaborate_activation_scope(scope: &ActivationScope, p: &Interpreter, trigger_cells: Vec<ReactiveCellId>) -> MResult<Value> {
   match &scope.body {
     ActivationBody::Block(body) => {
-      let plan=p.plan(); plan.push_activation_registration_scope(trigger_cells);
+      let plan = p.plan();
+      let checkpoint = plan.checkpoint();
+      let symbols = p.symbols();
+      let symbol_snapshot = symbols.borrow().snapshot();
+      let program_dictionary = p.state.borrow().dictionary.clone();
+      let dictionary_snapshot = program_dictionary.borrow().clone();
+      plan.push_activation_registration_scope_with_sampled_cells(
+        trigger_cells,
+        crate::activation::activation_scope_entry_cells(p),
+      );
       let result=(|| -> MResult<Value> { for (code,_) in body { mech_code(code,p)?; } Ok(Value::Empty) })();
-      plan.pop_activation_registration_scope(); result
+      plan.pop_activation_registration_scope();
+      match result {
+        Ok(value) => Ok(value),
+        Err(error) => {
+          symbols.borrow_mut().restore(symbol_snapshot);
+          *program_dictionary.borrow_mut() = dictionary_snapshot;
+          match plan.rollback(checkpoint) {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(rollback_error),
+          }
+        }
+      }
     }
     ActivationBody::PatternArms(arms) => {
       let trigger = match &scope.trigger {

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -346,15 +346,14 @@ mod activation_scope_tests {
     }
     #[test]
     fn activation_scope_failed_elaboration_clears_registration_state() {
-        let mut i = Interpreter::new_with_full_stdlib(0);
-        let failing=mech_syntax::parser::parse("tick := 0.0\nx := 1.0\n\n~> tick {\n  registered-first := x + 1.0\n  fails-later := function-that-does-not-exist(registered-first)\n}").unwrap();
+        let mut i = interpret("tick := 0.0\nx := 1.0");
+        let before = snapshot(&i);
+        let failing=mech_syntax::parser::parse("~> tick {\n  registered-first := x + 1.0\n  fails-later := function-that-does-not-exist(registered-first)\n}").unwrap();
         let error = i.interpret(&failing).unwrap_err();
         assert!(format!("{error:?}").contains("Function"));
-        assert!(
-            i.plan()
-                .borrow()
-                .nodes.iter().any(|node|node.kind==ReactiveNodeKind::Combinational&&node.outputs.contains(&cell(&i,"registered-first")))
-        );
+        assert_eq!(snapshot(&i), before);
+        assert!(!i.symbols().borrow().contains(hash_str("registered-first")));
+        assert!(!i.symbols().borrow().contains(hash_str("fails-later")));
         assert!(!i.plan().activation_registration_active());
         let ordinary = mech_syntax::parser::parse("ordinary := x + 2.0").unwrap();
         i.interpret(&ordinary).unwrap();

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -101,14 +101,21 @@ struct ResolvedContextResourceRequest {
 // Keeping the compiler registered on the program is therefore not a public
 // source-level API.
 pub(super) const ACTIVATION_EFFECT_BARRIER_NAME: &str = "\0mech/runtime/activation-effect-barrier";
-const ACTIVATION_SEND_PAYLOAD_NAME_PREFIX: &str =
-  "\0mech/runtime/activation-send-payload/";
+pub(super) const ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME: &str =
+  "\0mech/runtime/activation-effect-payload-capture";
 
 #[derive(Clone, Debug)]
 pub(super) struct ActivationEffectBarrierCompiler;
 impl NativeFunctionCompiler for ActivationEffectBarrierCompiler {
   fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
-    if !arguments.is_empty() { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier accepts no arguments".into() }, None)); }
+    if !arguments.is_empty() {
+      return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+        reason: format!(
+          "activation effect barrier expected no payloads, found {}",
+          arguments.len()
+        ),
+      }, None));
+    }
     Ok(Box::new(ActivationEffectBarrier))
   }
 }
@@ -120,10 +127,62 @@ impl MechFunctionImpl for ActivationEffectBarrier {
   // The barrier is a scheduling node, not a value producer.  Its node id and
   // reactive execution record are the observable state used by send replay.
   fn out(&self) -> Value { Value::Empty }
+  fn reactive_output_values(&self) -> Vec<Value> { Vec::new() }
   fn to_string(&self) -> String { ACTIVATION_EFFECT_BARRIER_NAME.to_string() }
 }
 impl MechFunctionCompiler for ActivationEffectBarrier {
   fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation effect barrier cannot be bytecode compiled".into() }, None)) }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ActivationEffectPayloadCaptureCompiler;
+impl NativeFunctionCompiler for ActivationEffectPayloadCaptureCompiler {
+  fn compile(&self, arguments: &Vec<Value>) -> MResult<Box<dyn mech_core::MechFunction>> {
+    let [payload] = arguments.as_slice() else {
+      return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+        reason: format!(
+          "activation effect payload capture expected one payload, found {}",
+          arguments.len()
+        ),
+      }, None));
+    };
+    Ok(Box::new(ActivationEffectPayloadCapture {
+      payload: payload.clone(),
+      snapshot: mech_core::Ref::new(snapshot_runtime_value(payload)),
+    }))
+  }
+}
+
+#[derive(Clone, Debug)]
+struct ActivationEffectPayloadCapture {
+  payload: Value,
+  snapshot: mech_core::ValRef,
+}
+
+impl MechFunctionImpl for ActivationEffectPayloadCapture {
+  fn solve(&self) {
+    *self.snapshot.borrow_mut() = snapshot_runtime_value(&self.payload);
+  }
+  fn solve_reactive(&self) -> MResult<mech_core::ReactiveSolveStatus> {
+    self.solve();
+    Ok(mech_core::ReactiveSolveStatus::Unchanged)
+  }
+  fn out(&self) -> Value { Value::MutableReference(self.snapshot.clone()) }
+  // Payloads are sampled only when the activation pulse schedules this node.
+  // Their own changes must never dispatch an activation effect.
+  fn reactive_dependency_scopes(&self, argument_count: usize) -> Option<Vec<mech_core::ReactiveDependencyScope>> {
+    Some(vec![mech_core::ReactiveDependencyScope::None; argument_count])
+  }
+  fn reactive_output_values(&self) -> Vec<Value> { Vec::new() }
+  fn to_string(&self) -> String { ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME.to_string() }
+}
+
+impl MechFunctionCompiler for ActivationEffectPayloadCapture {
+  fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+    Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+      reason: "activation effect payload capture cannot be bytecode compiled".into(),
+    }, None))
+  }
 }
 
 fn identifier_from_str(name: &str) -> mech_core::Identifier {
@@ -328,6 +387,13 @@ fn resolve_runtime_value(value: Value) -> Value {
     Value::MutableReference(value) => value.borrow().clone(),
     other => other,
   }
+}
+
+// Activation effects are released after the reactive turn succeeds. Keep the
+// body-time payload separate from any live source cells so a register commit
+// cannot change the value that the selected arm staged for its send.
+fn snapshot_runtime_value(value: &Value) -> Value {
+  value.deep_snapshot()
 }
 
 
@@ -1285,13 +1351,12 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         if !pending_codes.is_empty() { pending.push(mech_core::SectionElement::MechCode(std::mem::take(pending_codes))); }
         self.flush_direct_execution(program, pending, result)?;
-        // Pure patterned scopes are lowered structurally and then handed to
-        // the interpreter's static patterned-dispatch elaborator.  Effects
-        // remain intentionally unsupported in this path.
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
           let mut lowered = scope.clone();
           lowered.trigger = self.resolve_context_reads_in_expression(context, program, registry, &scope.trigger)?;
           let mut lowered_arms = Vec::with_capacity(arms.len());
+          let mut arm_registrations = Vec::with_capacity(arms.len());
+          let mut registration_count = 0usize;
           for arm in arms {
             let pattern = self.resolve_context_reads_in_match_pattern(
               context,
@@ -1300,14 +1365,144 @@ impl MechRuntime {
               &arm.pattern,
             )?;
             let guard = arm.guard.as_ref().map(|guard| self.resolve_context_reads_in_expression(context, program, registry, guard)).transpose()?;
-            let body = match &arm.body {
-              mech_core::ActivationArmBody::Block(body) => mech_core::ActivationArmBody::Block(body.iter().map(|(code, comment)| Ok((self.resolve_context_reads_in_mech_code(context, program, registry, code)?, comment.clone()))).collect::<MResult<_>>()?),
-              mech_core::ActivationArmBody::Expression(expression) => mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+            let (body, registrations) = match &arm.body {
+              mech_core::ActivationArmBody::Block(body) => {
+                let mut lowered_body = Vec::with_capacity(body.len() + 1);
+                let mut registrations = Vec::new();
+                for (body_code, body_comment) in body {
+                  match body_code {
+                    mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
+                      let context_name = send.target.context.as_ref().unwrap().to_string();
+                      let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
+                      registration_count += 1;
+                      let payload = self.resolve_context_reads_in_expression(
+                        context,
+                        program,
+                        registry,
+                        &send.expression,
+                      )?;
+                      lowered_body.push((
+                        mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(
+                          mech_core::FunctionCall {
+                            name: identifier_from_str(ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME),
+                            args: vec![(None, payload)],
+                          },
+                        )),
+                        body_comment.clone(),
+                      ));
+                      registrations.push((binding, send.target.name.to_string()));
+                    }
+                    _ => lowered_body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
+                  }
+                }
+                if !registrations.is_empty() {
+                  // The payload captures remain at their source positions, but
+                  // a single final barrier releases the complete arm effect
+                  // batch only after every body node has succeeded.
+                  lowered_body.push((
+                    mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(mech_core::FunctionCall {
+                      name: identifier_from_str(ACTIVATION_EFFECT_BARRIER_NAME),
+                      args: vec![],
+                    })),
+                    None,
+                  ));
+                }
+                (mech_core::ActivationArmBody::Block(lowered_body), registrations)
+              }
+              mech_core::ActivationArmBody::Expression(expression) => (
+                mech_core::ActivationArmBody::Expression(self.resolve_context_reads_in_expression(context, program, registry, expression)?),
+                Vec::new(),
+              ),
             };
+            arm_registrations.push(registrations);
             lowered_arms.push(mech_core::ActivationArm { pattern, guard, body });
           }
           lowered.body = mech_core::ActivationBody::PatternArms(lowered_arms);
+          if registration_count > 0 {
+            if self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot {
+              return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None));
+            }
+            self.validate_live_context_candidate(context)?;
+          }
+          let pattern_registration_start = program.interpreter().plan().pattern_activation_registrations().len();
           program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
+          if registration_count == 0 { return Ok(()); }
+          let interpreter_id = program.interpreter().id;
+          let pattern_registration = {
+            let plan = program.interpreter().plan();
+            let registrations = plan.pattern_activation_registrations();
+            if registrations.len() != pattern_registration_start + 1 {
+              return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                reason: format!("expected one patterned activation registration, found {}", registrations.len().saturating_sub(pattern_registration_start)),
+              }, None));
+            }
+            registrations[pattern_registration_start].clone()
+          };
+          if pattern_registration.arms.len() != arm_registrations.len() {
+            return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+              reason: format!("patterned activation arm registration mismatch: expected {}, found {}", arm_registrations.len(), pattern_registration.arms.len()),
+            }, None));
+          }
+          let mut sends = Vec::with_capacity(registration_count);
+          {
+            let plan = program.interpreter().plan();
+            let plan = plan.borrow();
+            for (arm, registrations) in pattern_registration.arms.iter().zip(arm_registrations) {
+              if registrations.is_empty() { continue; }
+              let captures = plan.nodes[arm.body_node_start..arm.body_node_end].iter().filter(|node| {
+                node.kind == mech_core::ReactiveNodeKind::Combinational
+                  && node.function.to_string() == ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME
+                  && node.outputs.is_empty()
+              }).collect::<Vec<_>>();
+              let barriers = plan.nodes[arm.body_node_start..arm.body_node_end].iter().filter(|node| {
+                node.kind == mech_core::ReactiveNodeKind::Combinational
+                  && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+                  && node.outputs.is_empty()
+              }).collect::<Vec<_>>();
+              if captures.len() != registrations.len() {
+                return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                  reason: format!(
+                    "expected {} patterned-arm activation effect payload captures, found {}",
+                    registrations.len(),
+                    captures.len()
+                  ),
+                }, None));
+              }
+              if barriers.len() != 1 {
+                return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                  reason: format!(
+                    "expected one patterned-arm activation effect barrier, found {}",
+                    barriers.len()
+                  ),
+                }, None));
+              }
+              let barrier_node_id = barriers[0].id;
+              for ((binding, path), capture) in registrations.into_iter().zip(captures) {
+                let snapshot = match capture.function.out() {
+                  Value::MutableReference(snapshot) => snapshot,
+                  other => return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+                    reason: format!(
+                      "patterned-arm activation effect payload capture returned {}, expected a snapshot",
+                      other.kind()
+                    ),
+                  }, None)),
+                };
+                sends.push(RuntimePersistentSend {
+                  binding,
+                  path,
+                  value: snapshot,
+                  schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id },
+                });
+              }
+            }
+          }
+          if sends.len() != registration_count {
+            return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+              reason: format!("patterned activation send registration mismatch: expected {}, found {}", registration_count, sends.len()),
+            }, None));
+          }
+          self.persistent_sends.extend(sends);
+          self.commit_live_context_candidate(context);
           return Ok(());
         }
         let mut lowered = scope.clone();
@@ -1321,11 +1516,22 @@ impl MechRuntime {
             mech_core::MechCode::Statement(mech_core::Statement::ContextSend(send)) => {
               let context_name = send.target.context.as_ref().unwrap().to_string();
               let binding = registry.get(&context_name).cloned().ok_or_else(|| MechError::new(RuntimeAddressedAssignmentUnsupported { target: context_name.clone() }, None))?;
-              let index = self.persistent_sends.len() + registrations.len();
-              let value_name = format!("{ACTIVATION_SEND_PAYLOAD_NAME_PREFIX}{index}");
-              let value = mech_core::VariableDefine { mutable: false, var: mech_core::Var { name: identifier_from_str(&value_name), context: None, kind: None }, expression: self.resolve_context_reads_in_expression(context, program, registry, &send.expression)? };
-              lowered_body.push((mech_core::MechCode::Statement(mech_core::Statement::VariableDefine(value)), body_comment.clone()));
-              registrations.push((binding, send.target.name.to_string(), hash_str(&value_name)));
+              let payload = self.resolve_context_reads_in_expression(
+                context,
+                program,
+                registry,
+                &send.expression,
+              )?;
+              lowered_body.push((
+                mech_core::MechCode::Expression(mech_core::Expression::FunctionCall(
+                  mech_core::FunctionCall {
+                    name: identifier_from_str(ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME),
+                    args: vec![(None, payload)],
+                  },
+                )),
+                body_comment.clone(),
+              ));
+              registrations.push((binding, send.target.name.to_string()));
             }
             _ => lowered_body.push((self.resolve_context_reads_in_mech_code(context, program, registry, body_code)?, body_comment.clone())),
           }
@@ -1339,16 +1545,52 @@ impl MechRuntime {
         let plan_start = program.interpreter().plan().borrow().nodes.len();
         program.run_tree(&single_code_program(mech_core::MechCode::ActivationScope(lowered), comment.clone()))?;
         let interpreter_id = program.interpreter().id;
-        let trigger_cells = match &scope.trigger { mech_core::Expression::Var(var) => program.interpreter().symbols().borrow().get(var.name.hash()).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "activation trigger disappeared".into() }, None))?.borrow().reactive_root_cell_ids(), _ => vec![] };
-        let barrier_ids: Vec<_> = program.interpreter().plan().borrow().nodes[plan_start..].iter().filter(|node| node.kind == mech_core::ReactiveNodeKind::Combinational && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME && trigger_cells.iter().all(|cell| node.inputs.iter().any(|dependency| dependency.cell == *cell && dependency.kind == mech_core::ReactiveDependencyKind::Reactive))).map(|node| node.id).collect();
-        if barrier_ids.len() != 1 { return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: format!("expected exactly one activation effect barrier, found {}", barrier_ids.len()) }, None)); }
-        let barrier_node_id = barrier_ids[0];
-        let symbols = program.interpreter().symbols();
-        let mut sends = Vec::new();
-        for (binding, path, value_id) in registrations {
-          let value = symbols.borrow().get(value_id).ok_or_else(|| MechError::new(RuntimeActivationEffectBarrierInvariantError { reason: "missing lowered activation payload".into() }, None))?;
-          sends.push(RuntimePersistentSend { binding, path, value, schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id } });
+        let plan = program.interpreter().plan();
+        let plan = plan.borrow();
+        let captures = plan.nodes[plan_start..].iter().filter(|node| {
+          node.kind == mech_core::ReactiveNodeKind::Combinational
+            && node.function.to_string() == ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME
+            && node.outputs.is_empty()
+        }).collect::<Vec<_>>();
+        let barriers = plan.nodes[plan_start..].iter().filter(|node| {
+          node.kind == mech_core::ReactiveNodeKind::Combinational
+            && node.function.to_string() == ACTIVATION_EFFECT_BARRIER_NAME
+            && node.outputs.is_empty()
+        }).collect::<Vec<_>>();
+        if captures.len() != registrations.len() {
+          return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+            reason: format!(
+              "expected {} activation effect payload captures, found {}",
+              registrations.len(),
+              captures.len()
+            ),
+          }, None));
         }
+        if barriers.len() != 1 {
+          return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+            reason: format!("expected one activation effect barrier, found {}", barriers.len()),
+          }, None));
+        }
+        let barrier_node_id = barriers[0].id;
+        let mut sends = Vec::with_capacity(registrations.len());
+        for ((binding, path), capture) in registrations.into_iter().zip(captures) {
+          let snapshot = match capture.function.out() {
+            Value::MutableReference(snapshot) => snapshot,
+            other => return Err(MechError::new(RuntimeActivationEffectBarrierInvariantError {
+              reason: format!(
+                "activation effect payload capture returned {}, expected a snapshot",
+                other.kind()
+              ),
+            }, None)),
+          };
+          sends.push(RuntimePersistentSend {
+            binding,
+            path,
+            value: snapshot,
+            schedule: RuntimePersistentSendSchedule::Activation { interpreter_id, barrier_node_id },
+          });
+        }
+        drop(plan);
         self.persistent_sends.extend(sends);
         self.commit_live_context_candidate(context);
         Ok(())
@@ -1496,6 +1738,13 @@ impl MechRuntime {
       mech_core::MechCode::ActivationScope(scope) => {
         self.preflight_expression_context_reads(context, registry, &scope.trigger, addressed_read_preflight)?;
         if let mech_core::ActivationBody::PatternArms(arms) = &scope.body {
+          let has_send = arms.iter().any(|arm| match &arm.body {
+            mech_core::ActivationArmBody::Block(body) => body.iter().any(|(code, _)| matches!(code, mech_core::MechCode::Statement(mech_core::Statement::ContextSend(_)))),
+            mech_core::ActivationArmBody::Expression(_) => false,
+          });
+          if has_send && self.live_registration_mode == crate::runtime::LiveRegistrationMode::IsolatedSnapshot {
+            return Err(MechError::new(RuntimeIsolatedActivationSendUnsupported, None));
+          }
           for arm in arms {
             self.preflight_pattern_context_reads(
               context,
@@ -3746,6 +3995,38 @@ mod tests {
     atomic::{AtomicUsize, Ordering},
   };
 
+  #[cfg(all(feature = "record", feature = "tuple", feature = "f64"))]
+  #[test]
+  fn activation_effect_payload_snapshot_deeply_detaches_scene_values() {
+    let live = Ref::new(1.0);
+    let scene = Value::Record(Ref::new(mech_core::MechRecord::new(vec![(
+      "position",
+      Value::Tuple(Ref::new(mech_core::MechTuple::from_vec(vec![
+        Value::F64(live.clone()),
+        Value::F64(Ref::new(2.0)),
+      ]))),
+    )])));
+    let snapshot = snapshot_runtime_value(&scene);
+    *live.borrow_mut() = 9.0;
+
+    let Value::Record(snapshot) = snapshot else {
+      panic!("expected record snapshot");
+    };
+    let position = {
+      let snapshot = snapshot.borrow();
+      let Value::Tuple(position) = snapshot.data.get(&hash_str("position")).unwrap() else {
+        panic!("expected tuple field");
+      };
+      position.clone()
+    };
+    let position = position.borrow();
+    let Value::F64(x) = position.elements[0].as_ref() else {
+      panic!("expected scalar tuple element");
+    };
+    assert_eq!(*x.borrow(), 1.0);
+    assert_ne!(x.as_ptr(), live.as_ptr());
+  }
+
   #[test]
   fn runtime_has_interpreter_finds_root_interpreter() {
     let runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
@@ -4116,8 +4397,8 @@ impl MechRuntime {
         program.update_inputs_and_advance_turn(
           &target_updates,
         )?;
-      self.execute_persistent_sends(&context, &turn)?;
       self.enforce_turn_duration(turn_started)?;
+      self.execute_persistent_sends(&context, &turn)?;
 
       Ok(crate::RuntimeHostInputOutcome {
         update_count: input.updates.len(),

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -34,7 +34,12 @@
 
 
 use super::*;
-use super::execution::{ACTIVATION_EFFECT_BARRIER_NAME, ActivationEffectBarrierCompiler};
+use super::execution::{
+  ACTIVATION_EFFECT_BARRIER_NAME,
+  ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME,
+  ActivationEffectBarrierCompiler,
+  ActivationEffectPayloadCaptureCompiler,
+};
 use mech_core::{GuardFunctionSafety, Ref, ValueKind};
 
 impl MechRuntime {
@@ -47,6 +52,10 @@ impl MechRuntime {
     program.register_native_function_compiler(
       ACTIVATION_EFFECT_BARRIER_NAME,
       Arc::new(ActivationEffectBarrierCompiler),
+    );
+    program.register_native_function_compiler(
+      ACTIVATION_EFFECT_PAYLOAD_CAPTURE_NAME,
+      Arc::new(ActivationEffectPayloadCaptureCompiler),
     );
     for name in self.host_registry.list_functions()? {
       program.register_native_function_compiler(

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
 use std::thread;
@@ -1486,6 +1486,478 @@ render-tick := @clock/hour
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     publish(&mut runtime, &driver, snapshot(5.0, 2.0, 3.0, 4.0));
     assert_eq!(console.lines(), vec!["\"first\"", "\"second\"", "\"third\"", "\"first\"", "\"second\"", "\"third\""]);
+  }
+
+  #[test]
+  fn activation_send_snapshots_fixed_payloads_before_same_trigger_register_commit() {
+    let provider = TestResourceProvider::new().with_value(
+      "test://render/timer",
+      "tick",
+      Value::F64(Ref::new(0.0)),
+    );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~state := 0.0
+
+~> render-tick {
+  state = state + 1.0
+}
+
+~> render-tick {
+  @out/line <- state
+  @out/line <- state + 0.0
+}
+"#).unwrap();
+
+    let plan = activation_plan_snapshot(&runtime);
+    let register = register_node_for_symbol(&runtime, "state");
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 0.0);
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_send_count(&runtime), 2);
+
+    let first = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(
+      only_reactive_turn(&first).register_commit.committed_nodes,
+      vec![register]
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 1.0);
+    assert_eq!(output.lines(), vec!["0", "0"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let equal = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(
+      only_reactive_turn(&equal).register_commit.committed_nodes,
+      vec![register]
+    );
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 2.0);
+    assert_eq!(output.lines(), vec!["0", "0", "1", "1"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+  }
+
+  #[test]
+  fn activation_send_registration_is_atomic_on_fixed_elaboration_failure() {
+    let (mut runtime, output) = activation_rejection_runtime();
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+render-tick := @tick/tick
+"#).unwrap();
+    let plan = activation_plan_snapshot(&runtime);
+    let sends = runtime.persistent_sends.len();
+    let bindings = runtime.live_input_bindings.clone();
+
+    let error = runtime.run_string(r#"@out := test://effects/output{:write(line)}
+~> render-tick {
+  @out/line <- render-tick
+  registered-first := render-tick + 1.0
+  failure :=
+    function-that-does-not-exist(registered-first)
+}
+"#).unwrap_err();
+
+    assert!(
+      error.kind_name().contains("Function"),
+      "unexpected elaboration error: {error:?}"
+    );
+    assert_rejected_activation_left_no_state(
+      &runtime,
+      &output,
+      &plan,
+      sends,
+      &bindings,
+    );
+    assert!(
+      !runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .contains(hash_str("registered-first"))
+    );
+    assert!(
+      !runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .contains(hash_str("failure"))
+    );
+  }
+
+  #[test]
+  fn activation_send_duration_failure_does_not_release_fixed_or_patterned_effects() {
+    let provider = TestResourceProvider::new().with_value(
+      "test://render/timer",
+      "tick",
+      Value::F64(Ref::new(0.0)),
+    );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    let subject = runtime.runtime_context().unwrap().subject;
+    grant_host_call(
+      &mut runtime,
+      &subject,
+      195,
+      "host:demo/activation-duration-sleep",
+    );
+    register_sleep_host(
+      &mut runtime,
+      "demo/activation-duration-sleep",
+    );
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+
+~> render-tick {
+  @out/line <-
+    demo/activation-duration-sleep(render-tick)
+}
+
+~> render-tick
+  | selected => {
+      @out/line <- selected + 10.0
+    }
+"#).unwrap();
+
+    let plan = activation_plan_snapshot(&runtime);
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_send_count(&runtime), 2);
+
+    runtime.config.limits.max_turn_duration_ms = Some(1);
+    let error = runtime.apply_host_input(RuntimeHostInput::single(
+      RuntimeHostInputSource::new(
+        "test://render/timer",
+        "tick",
+      ).unwrap(),
+      RuntimeHostInputValue::F64(1.0),
+    )).unwrap_err();
+    let error = format!("{error:?}");
+    assert!(
+      error.contains("turn_duration_ms")
+        || error.contains("ResourceBudgetExceeded"),
+      "{error}"
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+
+    runtime.config.limits.max_turn_duration_ms = None;
+    let retry = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert!(retry.turn.is_some());
+    assert_eq!(output.lines(), vec!["1", "11"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+  }
+
+  #[test]
+  fn patterned_activation_sends_only_from_the_selected_arm() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick
+  | 99.0 => {
+      @out/line <- 99.0
+    }
+  | selected, selected > 0.0 => {
+      @out/line <- selected
+    }
+  | * => {
+      @out/line <- -1.0
+    }
+"#).unwrap();
+    assert!(output.lines().is_empty(),"patterned effects ran during load");assert_eq!(activation_send_count(&runtime),3);
+    let barriers=runtime.persistent_sends.iter().map(|send|match send.schedule{RuntimePersistentSendSchedule::Activation{barrier_node_id,..}=>barrier_node_id,RuntimePersistentSendSchedule::EveryAcceptedTurn=>panic!("patterned activation send used top-level schedule")}).collect::<Vec<_>>();
+    assert_eq!(barriers.iter().copied().collect::<HashSet<_>>().len(),3,"each effectful arm must own a distinct barrier");
+    let plan=activation_plan_snapshot(&runtime);
+    let first=apply_f64_input(&mut runtime,"test://render/timer","tick",5.0);let turn=only_reactive_turn(&first);assert_eq!(output.lines(),vec!["5"]);assert_eq!((executed_count(turn,barriers[0]),executed_count(turn,barriers[1]),executed_count(turn,barriers[2])),(0,1,0));assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let equal=apply_f64_input(&mut runtime,"test://render/timer","tick",5.0);let turn=only_reactive_turn(&equal);assert_eq!(output.lines(),vec!["5","5"]);assert_eq!((executed_count(turn,barriers[0]),executed_count(turn,barriers[1]),executed_count(turn,barriers[2])),(0,1,0));assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let fallback=apply_f64_input(&mut runtime,"test://render/timer","tick",-5.0);let turn=only_reactive_turn(&fallback);assert_eq!(output.lines(),vec!["5","5","-1"]);assert_eq!((executed_count(turn,barriers[0]),executed_count(turn,barriers[1]),executed_count(turn,barriers[2])),(0,0,1));assert_eq!(activation_plan_snapshot(&runtime),plan);assert_eq!(activation_send_count(&runtime),3);
+  }
+
+  #[test]
+  fn patterned_activation_samples_outer_effect_values_only_on_its_trigger() {
+    let provider = TestResourceProvider::new()
+      .with_value(
+        "test://render/timer",
+        "tick",
+        Value::F64(Ref::new(0.0)),
+      )
+      .with_value(
+        TEST_SIGNALS_BASE_URI,
+        "value",
+        Value::F64(Ref::new(1.0)),
+      );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_read(&mut runtime, TEST_SIGNALS_BASE_URI, "value");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@signals := test://signals/inputs{:read(value)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+scene := @signals/value
+~> render-tick
+  | *, scene > 0.0 => {
+      @out/line <- scene
+    }
+  | * => {}
+"#).unwrap();
+
+    assert!(output.lines().is_empty());
+    assert_eq!(activation_send_count(&runtime), 1);
+    let barrier = runtime
+      .persistent_sends
+      .iter()
+      .find_map(|send| match send.schedule {
+        RuntimePersistentSendSchedule::Activation { barrier_node_id, .. } => {
+          Some(barrier_node_id)
+        }
+        RuntimePersistentSendSchedule::EveryAcceptedTurn => None,
+      })
+      .unwrap();
+    let plan = activation_plan_snapshot(&runtime);
+
+    let scene_only = apply_f64_input(
+      &mut runtime,
+      TEST_SIGNALS_BASE_URI,
+      "value",
+      -1.0,
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(executed_count(only_reactive_turn(&scene_only), barrier), 0);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let guard_false = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(executed_count(only_reactive_turn(&guard_false), barrier), 0);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let scene_only = apply_f64_input(
+      &mut runtime,
+      TEST_SIGNALS_BASE_URI,
+      "value",
+      10.0,
+    );
+    assert!(output.lines().is_empty());
+    assert_eq!(executed_count(only_reactive_turn(&scene_only), barrier), 0);
+
+    let render = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(output.lines(), vec!["10"]);
+    assert_eq!(executed_count(only_reactive_turn(&render), barrier), 1);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let scene_only = apply_f64_input(
+      &mut runtime,
+      TEST_SIGNALS_BASE_URI,
+      "value",
+      20.0,
+    );
+    assert_eq!(output.lines(), vec!["10"]);
+    assert_eq!(executed_count(only_reactive_turn(&scene_only), barrier), 0);
+
+    let equal_render = apply_f64_input(
+      &mut runtime,
+      "test://render/timer",
+      "tick",
+      1.0,
+    );
+    assert_eq!(output.lines(), vec!["10", "20"]);
+    assert_eq!(executed_count(only_reactive_turn(&equal_render), barrier), 1);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 1);
+  }
+
+  #[test]
+  fn patterned_activation_send_registration_is_atomic_on_elaboration_failure() {
+    let(mut runtime,output)=activation_rejection_runtime();
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+render-tick := @tick/tick
+"#).unwrap();
+    let plan=activation_plan_snapshot(&runtime);let sends=runtime.persistent_sends.len();let bindings=runtime.live_input_bindings.clone();
+    let error=runtime.run_string(r#"@out := test://effects/output{:write(line)}
+~> render-tick
+  | selected => {
+      @out/line <- selected
+    }
+  | * => {
+      failure := function-that-does-not-exist(1.0)
+    }
+"#).unwrap_err();
+    assert!(error.kind_name().contains("Function"),"unexpected elaboration error: {error:?}");
+    assert_rejected_activation_left_no_state(&runtime,&output,&plan,sends,&bindings);
+  }
+
+  #[test]
+  fn patterned_activation_send_rejects_isolated_registration() {
+    let(mut runtime,output)=activation_rejection_runtime();let plan=activation_plan_snapshot(&runtime);let sends=runtime.persistent_sends.len();let bindings=runtime.live_input_bindings.clone();let mut context=runtime.runtime_context().unwrap();
+    let error=runtime.run_string_with_isolated_registration_for_test(&mut context,r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick
+  | selected, selected > 0.0 => {
+      @out/line <- selected
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap_err();
+    assert!(error.kind_as::<RuntimeIsolatedActivationSendUnsupported>().is_some(),"unexpected error: {error:?}");
+    assert_rejected_activation_left_no_state(&runtime,&output,&plan,sends,&bindings);
+  }
+
+  #[test]
+  fn patterned_activation_send_preserves_custom_live_authority() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);let default_subject=runtime.runtime_context().unwrap().subject;let custom_subject="task:patterned-activation-send-custom";grant_read_to(&mut runtime,custom_subject,"test://render/timer","tick");grant_write_to(&mut runtime,custom_subject,TEST_OUTPUT_BASE_URI,"line");
+    assert!(!runtime.has_capability_grant(&default_subject,"test://render/timer",&RuntimeCapabilityOperation::Read,"tick"));assert!(!runtime.has_capability_grant(&default_subject,TEST_OUTPUT_BASE_URI,&RuntimeCapabilityOperation::Write,"line"));
+    let mut context=runtime.runtime_context().unwrap().with_subject(custom_subject);
+    runtime.run_string_with_context(&mut context,r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~> render-tick
+  | selected, selected > 0.0 => {
+      @out/line <- selected
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap();
+    assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let outcome=apply_f64_input(&mut runtime,"test://render/timer","tick",9.0);assert!(outcome.turn.is_some());assert_eq!(output.lines(),vec!["9"]);assert_eq!(activation_send_count(&runtime),1);
+  }
+
+  #[test]
+  fn patterned_activation_snapshots_effects_before_commit_and_releases_after_success() {
+    let provider = TestResourceProvider::new().with_value(
+      "test://render/timer",
+      "tick",
+      Value::F64(Ref::new(0.0)),
+    );
+    let (mut runtime, output) = test_runtime_with_output(provider);
+    grant_read(&mut runtime, "test://render/timer", "tick");
+    grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+~state := 0.0
+~> render-tick
+  | amount, amount > 0.0 => {
+      state = state + amount
+      @out/line <- state
+      @out/line <- state + 0.0
+    }
+  | ignored => {
+      fallback := ignored
+    }
+"#).unwrap();
+    let plan = activation_plan_snapshot(&runtime);
+    let register = register_node_for_symbol(&runtime, "state");
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 0.0);
+    assert!(output.lines().is_empty());
+
+    let first = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+    let first_turn = only_reactive_turn(&first);
+    assert_eq!(
+      first_turn.register_commit.committed_nodes,
+      vec![register]
+    );
+    assert!(first_turn.after_commit.pending_register_nodes.is_empty());
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 1.0);
+    assert_eq!(output.lines(), vec!["0", "0"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+
+    let equal = apply_f64_input(&mut runtime, "test://render/timer", "tick", 1.0);
+    let equal_turn = only_reactive_turn(&equal);
+    assert_eq!(
+      equal_turn.register_commit.committed_nodes,
+      vec![register]
+    );
+    assert!(equal_turn.after_commit.pending_register_nodes.is_empty());
+    assert_eq!(f64_value(&symbol_value(&runtime, "state")), 2.0);
+    assert_eq!(output.lines(), vec!["0", "0", "1", "1"]);
+    assert_eq!(activation_plan_snapshot(&runtime), plan);
+    assert_eq!(activation_send_count(&runtime), 2);
+  }
+
+  #[test]
+  fn patterned_activation_register_batch_failure_does_not_leak_or_replay_send() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_read(&mut runtime,"test://other/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@other := test://other/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+other-tick := @other/tick
+other-value := other-tick + 1.0
+~state := 0.0
+~> render-tick
+  | amount, amount > 0.0 => {
+      state = state + amount
+      state = state + amount + 1.0
+      @out/line <- state
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap();
+    let plan=activation_plan_snapshot(&runtime);assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let error=runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://render/timer","tick").unwrap(),RuntimeHostInputValue::F64(1.0))).unwrap_err();assert!(format!("{error:?}").contains("ReactiveRegisterOutputConflict"),"unexpected error: {error:?}");assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let unrelated_error=runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://other/timer","tick").unwrap(),RuntimeHostInputValue::F64(7.0))).unwrap_err();assert!(format!("{unrelated_error:?}").contains("ReactiveRegisterOutputConflict"),"unexpected carried-batch error: {unrelated_error:?}");assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);assert_eq!(activation_send_count(&runtime),1);
+  }
+
+  #[test]
+  fn failed_patterned_body_does_not_replay_send_on_unrelated_turn() {
+    let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_read(&mut runtime,"test://other/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
+    let subject=runtime.runtime_context().unwrap().subject;grant_host_call(&mut runtime,&subject,194,"host:demo/patterned-body-fail-second");let calls=Arc::new(AtomicUsize::new(0));let host_calls=calls.clone();
+    runtime.register_mech_host_function(ClosureHostFunction::new("demo/patterned-body-fail-second",move |_services,_context,args|{let call=host_calls.fetch_add(1,Ordering::SeqCst)+1;if call==2{return Err(MechError::new(DeliberateHostCallError,None));}Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))})).unwrap();
+    runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
+@other := test://other/timer{:read(tick)}
+@out := test://effects/output{:write(line)}
+render-tick := @tick/tick
+other-tick := @other/tick
+other-value := other-tick + 1.0
+~state := 0.0
+~> render-tick
+  | amount, amount > 0.0 => {
+      state = demo/patterned-body-fail-second(state + amount)
+      @out/line <- state
+    }
+  | * => {
+      fallback := 0.0
+    }
+"#).unwrap();
+    let plan=activation_plan_snapshot(&runtime);assert_eq!(calls.load(Ordering::SeqCst),1);assert!(output.lines().is_empty());assert_eq!(activation_send_count(&runtime),1);
+    let error=runtime.apply_host_input(RuntimeHostInput::single(RuntimeHostInputSource::new("test://render/timer","tick").unwrap(),RuntimeHostInputValue::F64(1.0))).unwrap_err();assert!(error.kind_as::<DeliberateHostCallError>().is_some());assert_eq!(calls.load(Ordering::SeqCst),2);assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let unrelated=apply_f64_input(&mut runtime,"test://other/timer","tick",7.0);assert!(unrelated.turn.is_some());assert_eq!(f64_value(&symbol_value(&runtime,"state")),0.0);assert!(output.lines().is_empty());assert_eq!(activation_plan_snapshot(&runtime),plan);
+    let retry=apply_f64_input(&mut runtime,"test://render/timer","tick",1.0);assert!(retry.turn.is_some());assert_eq!(calls.load(Ordering::SeqCst),3);assert_eq!(f64_value(&symbol_value(&runtime,"state")),1.0);assert_eq!(output.lines(),vec!["0"]);assert_eq!(activation_plan_snapshot(&runtime),plan);assert_eq!(activation_send_count(&runtime),1);
   }
 
   #[test]

--- a/src/syntax/src/activation.rs
+++ b/src/syntax/src/activation.rs
@@ -10,9 +10,13 @@ pub fn activation_scope(input: ParseString) -> ParseResult<ActivationScope> {
   let (input, _) = whitespace0(input)?;
   let (input, body) = if let Ok((input, _)) = left_brace(input.clone()) {
     let (input, _) = whitespace0(input)?;
-    let (input, parsed) = mech_code(input)?;
-    let (input, _) = cut(right_brace)(input)?;
-    (input, ActivationBody::Block(parsed.code))
+    if let Ok((input, _)) = right_brace(input.clone()) {
+      (input, ActivationBody::Block(Vec::new()))
+    } else {
+      let (input, parsed) = mech_code(input)?;
+      let (input, _) = cut(right_brace)(input)?;
+      (input, ActivationBody::Block(parsed.code))
+    }
   } else {
     let (input, arms) = cut(many1(activation_arm))(input)?;
     let (input, _) = opt(period)(input)?;
@@ -29,9 +33,13 @@ fn activation_arm(input: ParseString) -> ParseResult<ActivationArm> {
   let (input, _) = whitespace0(input)?;
   if let Ok((input, _)) = left_brace(input.clone()) {
     let (input, _) = whitespace0(input)?;
-    let (input, parsed) = mech_code(input)?;
-    let (input, _) = cut(right_brace)(input)?;
-    Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(parsed.code) }))
+    if let Ok((input, _)) = right_brace(input.clone()) {
+      Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(Vec::new()) }))
+    } else {
+      let (input, parsed) = mech_code(input)?;
+      let (input, _) = cut(right_brace)(input)?;
+      Ok((input, ActivationArm { pattern, guard, body: ActivationArmBody::Block(parsed.code) }))
+    }
   } else {
     let (input, expression) = expression(input)?;
     let (input, _) = opt(alt((whitespace1, statement_separator)))(input)?;
@@ -45,6 +53,29 @@ mod tests {
   #[test] fn activation_scope_parses_fixed_block_body() { assert!(parse("~> tick {\n output := x + 1\n}").is_ok()); }
   #[test] fn activation_scope_parses_pattern_block_and_expression_arms() { assert!(parse("~> event\n | :pressed(x) => {\n output := x\n }\n | * => 0.").is_ok()); }
   #[test] fn activation_scope_parses_pattern_guard() { assert!(parse("~> event\n | (x, y), x > y => { output := x }\n | * => { output := 0 }").is_ok()); }
+  #[test] fn activation_scope_parses_empty_fixed_and_pattern_blocks() {
+    let fixed = parse("~> tick {}").unwrap();
+    let SectionElement::MechCode(fixed) = &fixed.body.sections[0].elements[0] else {
+      panic!("expected fixed activation code");
+    };
+    assert!(matches!(
+      &fixed[0].0,
+      MechCode::ActivationScope(ActivationScope { body: ActivationBody::Block(body), .. })
+        if body.is_empty()
+    ));
+
+    let patterned = parse("~> tick\n | value, value > 0 => {\n output := value\n }\n | * => {}").unwrap();
+    let SectionElement::MechCode(patterned) = &patterned.body.sections[0].elements[0] else {
+      panic!("expected patterned activation code");
+    };
+    let MechCode::ActivationScope(ActivationScope {
+      body: ActivationBody::PatternArms(arms),
+      ..
+    }) = &patterned[0].0 else {
+      panic!("expected patterned activation");
+    };
+    assert!(matches!(&arms[1].body, ActivationArmBody::Block(body) if body.is_empty()));
+  }
   #[test] fn activation_scope_pattern_body_does_not_parse_as_match_expression() { let p=parse("~> event | * => 0.").unwrap(); let SectionElement::MechCode(code) = &p.body.sections[0].elements[0] else { panic!("expected Mech code") }; assert!(matches!(&code[0].0, MechCode::ActivationScope(ActivationScope { body: ActivationBody::PatternArms(_), .. }))); }
   #[test] fn activation_scope_does_not_conflict_with_mutable_definition() { assert!(parse("~x := 10\n~> tick {\n output := x + 1\n}").is_ok()); }
 }

--- a/src/syntax/src/parser.rs
+++ b/src/syntax/src/parser.rs
@@ -342,11 +342,11 @@ pub fn mech_code_alt(input: ParseString) -> ParseResult<MechCode> {
 
 }
 
-/// code-terminal := *space-tab, ?(?semicolon, *space-tab, comment), (new-line | ";" | eof), *whitespace ;
+/// code-terminal := *space-tab, ?(?semicolon, *space-tab, comment), (new-line | ";" | right-brace | eof), *whitespace ;
 pub fn code_terminal(input: ParseString) -> ParseResult<Option<Comment>> {
   let (input, _) = many0(space_tab)(input)?;
   let (input, cmmnt) = opt(tuple((opt(semicolon), many0(space_tab), comment)))(input)?;
-  let (input, _) = alt((null(new_line), null(semicolon), null(eof), null(peek(mika_section_close))))(input)?;
+  let (input, _) = alt((null(new_line), null(semicolon), null(peek(right_brace)), null(eof), null(peek(mika_section_close))))(input)?;
   let (input, _) = whitespace0(input)?;
   let cmmt = match cmmnt {
     Some((_, _, cmnt)) => Some(cmnt),


### PR DESCRIPTION
## Motivation

Patterned activation arms could match triggers and evaluate guards, but their bodies could not yet update registers or emit activation-scoped context sends. That forced stateful collision logic into fixed activation bodies and left patterned activations short of the v0.3.6 runtime model.

## What changed

- Allow only the selected patterned arm to stage whole-register writes through the existing reactive-register machinery.
- Preserve the turn order: match and guard, select, commit captures, evaluate the selected body, stage and atomically commit registers, then release effects.
- Ensure unmatched, losing, guard-false, and failed arms cannot mutate registers or leak sends.
- Lower patterned-body sends through deep-snapshot payload captures and the existing activation effect barrier.
- Reuse the same payload snapshot and barrier model for fixed activation sends so direct and formula-derived payloads observe the same pre-commit body state.
- Validate duration limits before releasing fixed or patterned activation effects.
- Preserve activation authority and isolation rules for persistent sends.
- Make failed fixed activation elaboration transactional, rolling back plan topology, symbols, dictionary entries, registration state, and lowered sends.
- Track activation-entry sampled cells so aliases of outer live inputs remain sampled until the next trigger.
- Accept a final unguarded irrefutable pattern as exhaustive instead of requiring a literal wildcard. Bindings are irrefutable, and known-shape tuple, array, and matrix patterns are checked recursively against the trigger kind.
- Accept empty fixed and patterned bodies and inline closing braces in activation syntax.

The natural two-arm collision form is therefore exhaustive:

```mech
~> physics-tick
  | dt, position-y >= floor => {
      velocity-y = -velocity-y * restitution
      position-y = floor
    }
  | dt => {
      velocity-y = velocity-y + gravity * dt
      position-y = position-y + velocity-y * dt
    }
```

Both arms structurally match the trigger. Source order and the first guard select the body, and only the selected arm commits its private `dt` capture.

## Runtime guarantees

A successful patterned activation turn executes as:

1. Match and evaluate guards.
2. Select the first eligible arm.
3. Commit only the selected arm's captures.
4. Evaluate the selected body and snapshot effect payloads.
5. Stage and atomically commit its register batch.
6. Release the selected arm's effects.

Equal-valued trigger packets remain distinct turns, plans do not grow across triggers, and activation bodies neither update registers nor send effects during initial elaboration.

## Validation

- `cargo test -p mech-interpreter --lib` — 133 passed.
- `cargo test -p mech-runtime persistent_send_tests --lib` — 32 passed.
- `cargo test -p mech-runtime --lib` with three pre-existing Windows watcher path tests filtered — 290 passed.
- `cargo test -p mech-core --lib` — 96 passed.
- `cargo test -p mech-syntax --lib` — 14 passed.
- `cargo check -p mech-runtime --no-default-features` — passed.
- `cargo check -p mech-runtime --no-default-features --features program` — passed.
- `git diff --check` and `git diff --cached --check` — clean.

The three filtered runtime cases are existing Windows path-canonicalization watcher failures; this PR does not modify workspace watcher code.