### PR TITLE
Fix PR #581 module and browser review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,9 @@ jobs:
       - name: Remove browser release intermediates
         run: rm -rf "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release"
 
+      - name: Build served browser smoke runner
+        run: cargo build --bin mech --no-default-features --features serve
+
       - name: Run headless Chrome WASM tests
         run: |
           wasm-pack test \
@@ -270,6 +273,9 @@ jobs:
             --features browser_project \
             -- \
             --nocapture
+
+      - name: Smoke test served analog clock in headless Chrome
+        run: bash scripts/smoke-analog-clock-browser.sh
 
       - name: Remove generated browser package
         if: always()

--- a/hosts/browser/src/config.rs
+++ b/hosts/browser/src/config.rs
@@ -52,7 +52,7 @@ impl BrowserRuntimeInjectionConfig {
     let mut hosts: Vec<HostInstanceConfig> = document
       .hosts
       .iter()
-      .filter(|host| host.provider == "browser")
+      .filter(|host| browser_runtime_supports_provider(&host.provider))
       .cloned()
       .collect();
     if !hosts.iter().any(|host| host.name == "browser") {
@@ -438,33 +438,45 @@ fn injected_host_context_operations(
   host: &HostInstanceConfig,
   context_name: &str,
 ) -> MResult<Vec<String>> {
-  match host.provider.as_str() {
-    "browser" => {
-      if context_name != "dom" {
-        return Err(invalid_error(
-          "run.grants.target",
-          format!(
-            "browser host instance `{}` does not expose context `{}`; supported browser contexts: dom",
-            host.name,
-            context_name,
-          ),
-        ));
-      }
-      Ok(vec!["read".to_string(), "write".to_string()])
+  let (supported_context, operations): (&str, &[&str]) = match host.provider.as_str() {
+    "browser" => ("dom", &["read", "write"]),
+    "time" => ("clock", &["read"]),
+    "timer" => ("tick", &["read"]),
+    "console" => ("output", &["write"]),
+    "scene" => ("frame", &["write"]),
+    other => {
+      return Err(invalid_error(
+        "hosts.provider",
+        format!(
+          "cannot validate injected host provider `{other}` because no injection validator is registered"
+        ),
+      ));
     }
-
-    other => Err(invalid_error(
-      "hosts.provider",
+  };
+  if context_name != supported_context {
+    return Err(invalid_error(
+      "run.grants.target",
       format!(
-        "cannot validate injected host provider `{other}` because no injection validator is registered"
+        "{} host instance `{}` does not expose context `{}`; supported {} contexts: {}",
+        host.provider,
+        host.name,
+        context_name,
+        host.provider,
+        supported_context,
       ),
-    )),
+    ));
   }
+  Ok(operations.iter().map(|operation| (*operation).to_string()).collect())
+}
+
+fn browser_runtime_supports_provider(provider: &str) -> bool {
+  matches!(provider, "browser" | "time" | "timer" | "console" | "scene")
 }
 
 fn validate_injected_host_settings(host: &HostInstanceConfig) -> MResult<()> {
   match host.provider.as_str() {
     "browser" => browser_config_from_settings(&host.settings).map(|_| ()),
+    // Browser-capable provider factories validate their own opaque settings.
     _ => Ok(()),
   }
 }
@@ -1187,6 +1199,55 @@ config := {
     assert!(injected.hosts.iter().any(|host| host.name == "browser" && host.provider == "browser"));
     assert_eq!(injected.run_grants.len(), 1);
     assert_eq!(injected.run_grants[0].target, "ui/dom");
+  }
+
+  #[test]
+  fn browser_runtime_injection_preserves_standard_browser_capable_hosts_and_grants() {
+    let document = parse_config_document(
+      "test.mcfg",
+      r##"
+config := {
+  hosts: [
+    { name: "clock" provider: "time" settings: { interval-ms: 1000 } }
+    { name: "timer" provider: "timer" settings: { frequency-hz: 60 } }
+    { name: "console" provider: "console" settings: {} }
+    { name: "view" provider: "scene" settings: { selector: "#clock" renderer: "svg" } }
+    { name: "arm" provider: "native-robot" settings: {} }
+  ]
+  run: {
+    grants: [
+      { target: "clock/clock" operations: ["read"] paths: ["second"] }
+      { target: "timer/tick" operations: ["read"] paths: ["tick"] }
+      { target: "console/output" operations: ["write"] paths: ["line"] }
+      { target: "view/frame" operations: ["write"] paths: ["replace"] }
+      { target: "arm/commands" operations: ["write"] paths: ["move"] }
+    ]
+  }
+}
+"##,
+      ConfigProfileOptions::default(),
+    ).unwrap();
+
+    let injected =
+      BrowserRuntimeInjectionConfig::from_document_and_runtime(&document, &RuntimeConfig::default()).unwrap();
+
+    for (name, provider) in [
+      ("browser", "browser"),
+      ("clock", "time"),
+      ("timer", "timer"),
+      ("console", "console"),
+      ("view", "scene"),
+    ] {
+      assert!(
+        injected.hosts.iter().any(|host| host.name == name && host.provider == provider),
+        "missing browser-capable host `{name}` provider `{provider}`",
+      );
+    }
+    assert!(!injected.hosts.iter().any(|host| host.name == "arm"));
+    assert_eq!(
+      injected.run_grants.iter().map(|grant| grant.target.as_str()).collect::<Vec<_>>(),
+      vec!["clock/clock", "timer/tick", "console/output", "view/frame"],
+    );
   }
 
   #[test]

--- a/scripts/smoke-analog-clock-browser.sh
+++ b/scripts/smoke-analog-clock-browser.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+chrome_bin="${CHROME_BIN:-google-chrome}"
+cargo_target_dir="${CARGO_TARGET_DIR:-target}"
+mech_bin="${MECH_BIN:-${cargo_target_dir}/debug/mech}"
+port="${MECH_BROWSER_SMOKE_PORT:-18081}"
+url="http://127.0.0.1:${port}/"
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/mech-browser-smoke.XXXXXX")"
+server_log="$scratch_dir/server.log"
+chrome_log="$scratch_dir/chrome.log"
+rendered_dom="$scratch_dir/rendered.html"
+server_pid=""
+
+cleanup() {
+  status=$?
+  trap - EXIT INT TERM
+  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  if [[ "$status" -ne 0 ]]; then
+    if [[ -s "$server_log" ]]; then
+      echo "mech serve output:" >&2
+      sed -n '1,240p' "$server_log" >&2
+    fi
+    if [[ -s "$chrome_log" ]]; then
+      echo "headless Chrome output:" >&2
+      sed -n '1,240p' "$chrome_log" >&2
+    fi
+    if [[ -s "$rendered_dom" ]]; then
+      echo "rendered DOM:" >&2
+      sed -n '1,80p' "$rendered_dom" >&2
+    fi
+  fi
+  rm -rf -- "$scratch_dir"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+if ! command -v "$chrome_bin" >/dev/null 2>&1; then
+  echo "headless Chrome executable not found: $chrome_bin" >&2
+  exit 1
+fi
+if [[ ! -x "$mech_bin" ]]; then
+  echo "$mech_bin is missing; build the serve-enabled CLI before this smoke test" >&2
+  exit 1
+fi
+if [[ ! -f src/wasm/pkg/mech_wasm.js || ! -f src/wasm/pkg/mech_wasm_bg.wasm ]]; then
+  echo "browser package is missing; run scripts/build-mech-browser.sh before this smoke test" >&2
+  exit 1
+fi
+
+"$mech_bin" serve examples/analog-clock \
+  --address 127.0.0.1 \
+  --port "$port" \
+  --wasm src/wasm/pkg \
+  >"$server_log" 2>&1 &
+server_pid=$!
+
+ready=false
+for _ in {1..120}; do
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    echo "mech serve exited before accepting connections" >&2
+    exit 1
+  fi
+  if curl --fail --silent --output /dev/null "$url"; then
+    ready=true
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$ready" != true ]]; then
+  echo "mech serve did not become ready at $url" >&2
+  exit 1
+fi
+
+chrome_command=(
+  "$chrome_bin"
+  --headless
+  --no-sandbox
+  --no-proxy-server
+  --disable-dev-shm-usage
+  --disable-gpu
+  "--user-data-dir=$scratch_dir/chrome"
+  --run-all-compositor-stages-before-draw
+  --virtual-time-budget=5000
+  --dump-dom
+  "$url"
+)
+if command -v timeout >/dev/null 2>&1; then
+  timeout 30s "${chrome_command[@]}" >"$rendered_dom" 2>"$chrome_log"
+else
+  "${chrome_command[@]}" >"$rendered_dom" 2>"$chrome_log"
+fi
+
+for scene_id in clock-hour-hand clock-minute-hand clock-second-hand clock-center-pin; do
+  if ! grep -F "data-mech-scene-id=\"$scene_id\"" "$rendered_dom" >/dev/null; then
+    echo "served analog clock did not render scene element: $scene_id" >&2
+    exit 1
+  fi
+done
+for hand_id in clock-hour-hand clock-minute-hand clock-second-hand; do
+  if ! grep -E "data-mech-scene-id=\"$hand_id\"[^>]*transform=\"rotate\\(" "$rendered_dom" >/dev/null; then
+    echo "served analog clock did not rotate scene element: $hand_id" >&2
+    exit 1
+  fi
+done

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clap::{Arg, ArgAction, Command};
 use mech_core::*;
-use mech_runtime::{FS_LIST, FS_READ, MECH_TOOL_SUBJECT};
+use mech_runtime::{FS_LIST, FS_READ, MECH_TOOL_SUBJECT, ModuleBuildOptions, SourceKind};
 
 use crate::cli::capabilities;
 use crate::cli::config;
@@ -210,9 +210,56 @@ fn print_run_runtime_events(events: &[RuntimeEvent]) {
     }
 }
 
+fn run_file_target_with_events(
+    runtime: &mut mech_runtime::MechRuntime,
+    target: &Path,
+    fs_kernel: &mech_runtime::SharedCapabilityKernel,
+    profile_enabled: bool,
+) -> MResult<(Value, Vec<RuntimeEvent>)> {
+    if !matches!(SourceKind::from_path(target), SourceKind::Mech) {
+        let source = mech_runtime::read_runtime_source_file_with_capabilities(
+            target,
+            Some(fs_kernel),
+            Some(MECH_TOOL_SUBJECT),
+        )?;
+        return run_cli_source_code_with_events(runtime, &source);
+    }
+
+    let specifier = target.canonicalize()?.to_string_lossy().into_owned();
+    let options = ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "mech-current",
+        "native",
+        &[],
+        &[],
+    );
+    let version = runtime
+        .resolve_and_store_module_source(specifier, options)?
+        .ok_or_else(|| {
+            MechError::new(
+                CliRunError {
+                    operation: "resolve_run_target".to_string(),
+                    reason: format!(
+                        "runtime module resolver could not resolve `{}`",
+                        target.display(),
+                    ),
+                },
+                None,
+            )
+        })?;
+    let started = Instant::now();
+    let mut context = runtime.runtime_context()?;
+    let value = runtime.run_module_in_program_with_context(&mut context, version)?;
+    if profile_enabled {
+        println!("Cycle Time: {:.3}ms", started.elapsed().as_secs_f64() * 1_000.0);
+    }
+    Ok((value, context.events))
+}
+
 fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
     render_config_event(&plan.config_event);
     render_capability_events(&plan.filesystem_access.events);
+    let profile_enabled = plan.runtime_config.diagnostics.profile_enabled;
     #[cfg(feature = "repl")]
     let repl_runtime_config = Some(plan.runtime_config.clone());
     let mut runtime = new_cli_runtime(
@@ -243,12 +290,13 @@ fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
                 let mut last = Value::Empty;
                 for p in &plan.run_paths {
                     for target in collect_run_targets_with_capabilities(Path::new(p), &fs_kernel)? {
-                        let src = mech_runtime::read_runtime_source_file_with_capabilities(
-                            &target,
-                            Some(&fs_kernel),
-                            Some(MECH_TOOL_SUBJECT),
-                        )?;
-                        let (value, events) = run_cli_source_code_with_events(&mut runtime, &src)?;
+                        let (value, events) =
+                            run_file_target_with_events(
+                                &mut runtime,
+                                &target,
+                                &fs_kernel,
+                                profile_enabled,
+                            )?;
                         print_run_runtime_events(&events);
                         last = value;
                     }

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -70,10 +70,12 @@ impl FileSourceResolver {
     &self,
     request: &SourceRequest,
   ) -> MResult<Option<PathBuf>> {
-    let specifier = Path::new(&request.specifier);
+    let Some((specifier, use_referrer)) = normalize_file_specifier(&request.specifier) else {
+      return Ok(None);
+    };
 
     if specifier.is_absolute() {
-      for candidate in absolute_path_candidates(specifier) {
+      for candidate in absolute_path_candidates(&specifier) {
         if candidate.is_file() {
           return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
         }
@@ -81,26 +83,31 @@ impl FileSourceResolver {
       return Ok(None);
     }
 
-    if let Some(referrer) = &request.referrer {
-      let referrer_path = Path::new(referrer);
+    if use_referrer {
+      let referrer_path = request
+        .referrer
+        .as_deref()
+        .and_then(normalize_file_referrer);
 
-      let parent = if referrer_path.is_dir() {
-        Some(referrer_path)
-      } else {
-        referrer_path.parent()
-      };
+      if let Some(referrer_path) = referrer_path {
+        let parent = if referrer_path.is_dir() {
+          Some(referrer_path.as_path())
+        } else {
+          referrer_path.parent()
+        };
 
-      if let Some(parent) = parent {
-        for candidate in path_candidates(parent, specifier) {
-          if candidate.is_file() {
-            return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+        if let Some(parent) = parent {
+          for candidate in path_candidates(parent, &specifier) {
+            if candidate.is_file() {
+              return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+            }
           }
         }
       }
     }
 
     for root in &self.roots {
-      for candidate in path_candidates(root, specifier) {
+      for candidate in path_candidates(root, &specifier) {
         if candidate.is_file() {
           return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
         }
@@ -115,6 +122,66 @@ impl FileSourceResolver {
     if request.referrer.is_some() { self.check(FS_IMPORT, &path)?; }
     Ok(Some(path))
   }
+}
+
+fn normalize_file_specifier(specifier: &str) -> Option<(PathBuf, bool)> {
+  if let Some(path) = specifier.strip_prefix("fs://") {
+    return normalize_fs_path(path).map(|path| (path, false));
+  }
+  if let Some(path) = specifier.strip_prefix("file://") {
+    return absolute_file_uri_path(path).map(|path| (path, false));
+  }
+  if specifier.contains("://") {
+    return None;
+  }
+  Some((PathBuf::from(specifier), true))
+}
+
+fn normalize_file_referrer(referrer: &str) -> Option<PathBuf> {
+  if let Some(path) = referrer.strip_prefix("file://") {
+    return absolute_file_uri_path(path);
+  }
+  if referrer.contains("://") {
+    return None;
+  }
+  Some(PathBuf::from(referrer))
+}
+
+fn normalize_fs_path(path: &str) -> Option<PathBuf> {
+  let path = Path::new(path);
+  if path.as_os_str().is_empty() || path.is_absolute() {
+    return None;
+  }
+  if path.components().any(|component| {
+    matches!(
+      component,
+      std::path::Component::ParentDir
+        | std::path::Component::RootDir
+        | std::path::Component::Prefix(_)
+    )
+  }) {
+    return None;
+  }
+  Some(path.to_path_buf())
+}
+
+#[cfg(not(windows))]
+fn absolute_file_uri_path(path: &str) -> Option<PathBuf> {
+  let path = PathBuf::from(path);
+  path.is_absolute().then_some(path)
+}
+
+#[cfg(windows)]
+fn absolute_file_uri_path(path: &str) -> Option<PathBuf> {
+  if let Some(path) = path.strip_prefix("//?/") {
+    return Some(PathBuf::from(format!(
+      r"\\?\{}",
+      path.replace('/', r"\"),
+    )));
+  }
+  let path = path.strip_prefix('/')?;
+  let path = PathBuf::from(path.replace('/', r"\"));
+  path.is_absolute().then_some(path)
 }
 
 impl SourceResolver for FileSourceResolver {
@@ -511,6 +578,56 @@ mod tests {
     assert_eq!(resolved.name, "math.mec");
   }
 
+  #[test]
+  fn resolves_fs_uri_from_configured_root() {
+    let root = temp_root("resolve-fs-uri");
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(root.join("lib/geometry.mec"), "x := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+
+    let resolved = resolver
+      .resolve(&SourceRequest::new("fs://lib/geometry.mec"))
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(resolved.name, "geometry.mec");
+    assert!(
+      resolver
+        .resolve(&SourceRequest::new("fs://../outside.mec"))
+        .unwrap()
+        .is_none(),
+    );
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn resolves_file_uri_and_relative_import_from_file_uri_referrer() {
+    let root = temp_root("resolve-file-uri");
+    std::fs::create_dir_all(&root).unwrap();
+    let main = root.join("main.mec");
+    let dependency = root.join("dependency.mec");
+    std::fs::write(&main, "+> ./dependency.mec").unwrap();
+    std::fs::write(&dependency, "x := 1").unwrap();
+    let main = main.canonicalize().unwrap();
+    let resolver = FileSourceResolver::empty();
+
+    assert!(
+      resolver
+        .resolve(&SourceRequest::new(file_uri(&main)))
+        .unwrap()
+        .is_some(),
+    );
+    let resolved = resolver
+      .resolve(
+        &SourceRequest::new("./dependency.mec")
+          .with_referrer(file_uri(&main)),
+      )
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(resolved.name, "dependency.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
 
   #[test]
   fn resolves_absolute_file_directory_index_extensionless_and_missing() {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3370,6 +3370,159 @@ impl MechRuntime {
     self.run_module_scope_with_context(context, version, SourceScope::Program)
   }
 
+  /// Executes a resolved module graph while appending the root source to the
+  /// runtime's active program. Dependency modules remain isolated.
+  pub fn run_module_in_program_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    let live_state_before = self.live_state_snapshot();
+    let result = (|| {
+      let scope = SourceScope::Program;
+      let mut preflight_seen = HashSet::new();
+      self.preflight_module_graph_for_scope(
+        context,
+        version,
+        &scope,
+        &mut preflight_seen,
+      )?;
+      context.charge_step()?;
+
+      let Some(record) = self.store.get_module_version(version)? else {
+        return Err(MechError::new(
+          RuntimeRecordNotFoundError {
+            record_type: "module_version",
+            id: version.to_string(),
+          },
+          None,
+        ));
+      };
+      validate_module_import_edges(&record)?;
+      let Some(source) = record.source.clone() else {
+        return Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "run_module_in_program",
+            reason: "module version has no source".to_string(),
+          },
+          None,
+        ));
+      };
+
+      let context_registry = context_registry_for_scope(&record, &scope)?;
+      let mut seen = HashSet::from([(version, scope.clone())]);
+      let mut module_instances = HashMap::new();
+      for edge in &record.import_edges {
+        if edge.scope != scope {
+          continue;
+        }
+        self.execute_module_isolated_for_scope(
+          context,
+          edge.dependency,
+          &SourceScope::Program,
+          &mut seen,
+          &mut module_instances,
+        )?;
+      }
+
+      let mut environment = self.build_import_environment_for_scope(
+        context,
+        &record,
+        &scope,
+        &module_instances,
+      )?;
+      environment.extend(self.build_address_environment_for_scope(
+        context,
+        version,
+        &record,
+        &scope,
+        &context_registry,
+        &mut seen,
+        &mut module_instances,
+      )?);
+
+      {
+        let symbols = self.program.interpreter().symbols();
+        let symbols = symbols.borrow();
+        if let Some(name) = environment
+          .keys()
+          .find(|name| symbols.contains(hash_str(name)))
+        {
+          return Err(MechError::new(
+            RuntimeInvalidOperationError {
+              operation: "run_module_in_program",
+              reason: format!(
+                "imported binding `{name}` is already defined in the active program"
+              ),
+            },
+            None,
+          ));
+        }
+      }
+
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ModuleExecutionStarted {
+          module_version: version,
+        },
+      )?;
+
+      let scoped_source = module_source_for_scope(&source, &scope)?;
+      let program_config = self.program.config.clone();
+      let mut program = std::mem::replace(
+        &mut self.program,
+        MechProgram::new(program_config),
+      );
+      {
+        let symbols = program.interpreter_mut().symbols();
+        let mut symbols = symbols.borrow_mut();
+        for (name, value_ref) in environment {
+          let id = hash_str(&name);
+          symbols.symbols.insert(id, value_ref);
+          symbols.dictionary.borrow_mut().insert(id, name);
+        }
+      }
+
+      let source_result = self.run_module_source_on_program(
+        context,
+        &mut program,
+        &scoped_source,
+        &scope,
+        crate::runtime::LiveRegistrationMode::RetainedRoot,
+      );
+      self.program = program;
+
+      let value = match source_result {
+        Ok(value) => value,
+        Err(error) => {
+          self.emit_event_to_context(
+            context,
+            RuntimeEventKind::ModuleExecutionFailed {
+              module_version: version,
+              message: format!("{error:?}"),
+            },
+          )?;
+          return Err(error);
+        }
+      };
+
+      self.enforce_turn_duration(turn_started)?;
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ModuleExecutionCompleted {
+          module_version: version,
+        },
+      )?;
+      Ok(value)
+    })();
+
+    if result.is_err() {
+      self.restore_live_state(live_state_before);
+    }
+    result
+  }
+
   pub fn run_module_scope_with_context(
     &mut self,
     context: &mut RuntimeContext,
@@ -3581,7 +3734,13 @@ impl MechRuntime {
       RuntimeEventKind::ModuleExecutionStarted { module_version: version },
     )?;
     let scoped_source = module_source_for_scope(&source, scope)?;
-    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
+    let result = self.run_module_source_on_program(
+      context,
+      &mut module_program,
+      &scoped_source,
+      scope,
+      crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+    );
     let result = match result {
       Ok(value) => value,
       Err(error) => {
@@ -3631,6 +3790,7 @@ impl MechRuntime {
     program: &mut MechProgram,
     source: &MechSourceCode,
     scope: &SourceScope,
+    registration_mode: crate::runtime::LiveRegistrationMode,
   ) -> MResult<Value> {
     self.register_runtime_program_host_functions(context, program)?;
 
@@ -3652,7 +3812,7 @@ impl MechRuntime {
     // exports, address environment, and ModuleInstance identity.
     let execution_scope = execution_scope_for_extracted_module_source(scope);
 
-    let result = self.with_live_registration_mode(crate::runtime::LiveRegistrationMode::IsolatedSnapshot, |runtime| {
+    let result = self.with_live_registration_mode(registration_mode, |runtime| {
       match source {
       MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
         Ok(tree) => {
@@ -3686,7 +3846,13 @@ impl MechRuntime {
       MechSourceCode::Program(sources) => {
         let mut result = Ok(Value::Empty);
         for source in sources {
-          result = runtime.run_module_source_on_program(context, program, source, scope);
+          result = runtime.run_module_source_on_program(
+            context,
+            program,
+            source,
+            scope,
+            registration_mode,
+          );
           if result.is_err() {
             break;
           }

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -1005,7 +1005,7 @@ x := @missing/HOME
     .output()
     .unwrap();
 
-  let combined = assert_failure_contains(output, "direct_context_target");
+  let combined = assert_failure_contains(output, "UnknownAddressTarget");
   assert!(
     !combined.contains("must-not-write"),
     "provider wrote before undeclared context read failed preflight:\n{combined}"

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -108,6 +108,36 @@ fn mech_run_subcommand_loads_cli_host_provider() {
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
+fn mech_run_file_resolves_relative_source_import() {
+  let root = temp_root("relative-source-import");
+  std::fs::write(
+    root.join("dep.mec"),
+    "message := \"relative-source-import-ok\"\n<+ message\n",
+  )
+  .unwrap();
+  std::fs::write(
+    root.join("main.mec"),
+    r#"+> ./dep.mec
++> @out := cli/stdout
+
+@out/line <- dep/message
+"#,
+  )
+  .unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--time")
+    .arg("main.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "relative-source-import-ok");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
 fn mech_run_uses_config_run_paths() {
   let root = temp_root("config-run");
   write_cli_host_source(&root);


### PR DESCRIPTION
## Summary

This stacked PR addresses the actionable review feedback on #581 without adding the fixes directly to the release PR branch.

- route Mech file targets through module resolution so relative source imports work
- normalize `fs://` and `file://` resolution behavior
- retain browser-capable time, timer, console, and scene hosts and grants
- add a served analog-clock smoke test using headless Chrome

## Root cause

Direct file execution bypassed module resolution, URI schemes were normalized inconsistently, and browser runtime injection filtered out providers required by browser projects.

## Validation

- resolver tests: 9 passed
- browser host regression: passed
- relative-import CLI regression: passed
- `git diff --check`: passed

## Stack

Base: `v0.3-beta` / #581. After #581 merges, retarget this PR to `main`.