### PR TITLE
Fix CLI file module resolution and filesystem URI imports

### DIFF
--- a/examples/analog-clock/mech.mcfg
+++ b/examples/analog-clock/mech.mcfg
@@ -1,4 +1,10 @@
 config := {
+  runtime: {
+    limits: {
+      max-turn-duration-ms: 2000
+    }
+  }
+
   hosts: [
     {
       name: "clock"

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -10,14 +10,15 @@ use crate::cli::capabilities;
 use crate::cli::config;
 use crate::cli::outcome::CliOutcome;
 use crate::cli::run::{
-    RunInputMode, new_cli_runtime, run_cli_source_code_with_events, run_cli_source_with_events,
+    RunInputMode, cli_module_options, new_cli_runtime, run_cli_root_module_with_events,
+    run_cli_source_code_with_events, run_cli_source_with_events,
 };
 use crate::cli::runtime_plan::RunExecutionPlan;
 use crate::source_discovery::{
     DedupePolicy, DiscoveryOptions, MissingPathPolicy, SkipReason, SourceDiscoveryEvent,
     collect_sources_with_events,
 };
-use mech_runtime::{RuntimeEvent, RuntimeEventKind};
+use mech_runtime::{RuntimeEvent, RuntimeEventKind, SourceKind, SourceRequest};
 
 #[derive(Debug, Clone)]
 struct CliRunError {
@@ -243,12 +244,29 @@ fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
                 let mut last = Value::Empty;
                 for p in &plan.run_paths {
                     for target in collect_run_targets_with_capabilities(Path::new(p), &fs_kernel)? {
-                        let src = mech_runtime::read_runtime_source_file_with_capabilities(
-                            &target,
-                            Some(&fs_kernel),
-                            Some(MECH_TOOL_SUBJECT),
-                        )?;
-                        let (value, events) = run_cli_source_code_with_events(&mut runtime, &src)?;
+                        let (value, events) = if SourceKind::from_path(&target) == SourceKind::Mech {
+                            let canonical_target = target.canonicalize().map_err(|error| {
+                                MechError::new(
+                                    CliRunError {
+                                        operation: "canonicalize_run_target".to_string(),
+                                        reason: format!("{}: {}", target.display(), error),
+                                    },
+                                    None,
+                                )
+                            })?;
+                            run_cli_root_module_with_events(
+                                &mut runtime,
+                                SourceRequest::new(canonical_target.to_string_lossy().to_string()),
+                                cli_module_options(),
+                            )?
+                        } else {
+                            let src = mech_runtime::read_runtime_source_file_with_capabilities(
+                                &target,
+                                Some(&fs_kernel),
+                                Some(MECH_TOOL_SUBJECT),
+                            )?;
+                            run_cli_source_code_with_events(&mut runtime, &src)?
+                        };
                         print_run_runtime_events(&events);
                         last = value;
                     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,8 +1,8 @@
 use clap::{Arg, ArgAction};
 use mech_core::*;
 use mech_runtime::{
-    ConfigValue, HostInstanceConfig, MechRuntime, RunResourceGrantConfig, RuntimeBuilder,
-    RuntimeConfig, RuntimeEvent, parse_host_context_target,
+    ConfigValue, HostInstanceConfig, MechRuntime, ModuleBuildOptions, RunResourceGrantConfig,
+    RuntimeBuilder, RuntimeConfig, RuntimeEvent, SourceRequest, parse_host_context_target,
 };
 use std::collections::BTreeSet;
 use std::ffi::OsStr;
@@ -591,6 +591,26 @@ pub fn run_cli_source_code_with_events(
 ) -> MResult<(Value, Vec<RuntimeEvent>)> {
     let mut context = runtime.runtime_context()?;
     let result = runtime.run_source_with_context(&mut context, source)?;
+    Ok((result, context.events))
+}
+
+pub fn cli_module_options() -> ModuleBuildOptions<'static> {
+    ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "v0.3",
+        "native",
+        &[],
+        &[],
+    )
+}
+
+pub fn run_cli_root_module_with_events(
+    runtime: &mut MechRuntime,
+    request: SourceRequest,
+    options: ModuleBuildOptions<'_>,
+) -> MResult<(Value, Vec<RuntimeEvent>)> {
+    let mut context = runtime.runtime_context()?;
+    let result = runtime.resolve_and_run_root_module_with_context(&mut context, request, options)?;
     Ok((result, context.events))
 }
 

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
-use mech_core::{MResult, MechError, MechSourceCode};
+use mech_core::{MResult, MechError, MechErrorKind, MechSourceCode};
 
 use crate::{check_fs_capability, SharedCapabilityKernel, FS_IMPORT, FS_READ, FS_RESOLVE};
 use crate::resolver::{
@@ -15,6 +15,28 @@ use super::{
   SourceIncludeCycle, SourceIncludeReadFailed, SourceKind,
   SourceUnknownFileExtension,
 };
+
+#[derive(Debug, Clone)]
+pub struct SourceFilesystemSpecifierInvalid {
+  pub specifier: String,
+  pub reason: String,
+}
+
+impl MechErrorKind for SourceFilesystemSpecifierInvalid {
+  fn name(&self) -> &str { "SourceFilesystemSpecifierInvalid" }
+
+  fn message(&self) -> String {
+    format!("Invalid filesystem source specifier `{}`: {}", self.specifier, self.reason)
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FilesystemSourceSpecifier {
+  Ordinary(PathBuf),
+  RootRelative(PathBuf),
+  Absolute(PathBuf),
+  OtherScheme,
+}
 
 #[derive(Clone, Debug)]
 pub struct FileSourceResolver {
@@ -70,44 +92,84 @@ impl FileSourceResolver {
     &self,
     request: &SourceRequest,
   ) -> MResult<Option<PathBuf>> {
-    let specifier = Path::new(&request.specifier);
-
-    if specifier.is_absolute() {
-      for candidate in absolute_path_candidates(specifier) {
-        if candidate.is_file() {
-          return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
-        }
-      }
-      return Ok(None);
-    }
-
-    if let Some(referrer) = &request.referrer {
-      let referrer_path = Path::new(referrer);
-
-      let parent = if referrer_path.is_dir() {
-        Some(referrer_path)
-      } else {
-        referrer_path.parent()
-      };
-
-      if let Some(parent) = parent {
-        for candidate in path_candidates(parent, specifier) {
+    match parse_filesystem_source_specifier(&request.specifier)? {
+      FilesystemSourceSpecifier::OtherScheme => Ok(None),
+      FilesystemSourceSpecifier::Absolute(specifier) => {
+        for candidate in absolute_path_candidates(&specifier) {
           if candidate.is_file() {
             return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
           }
         }
+        Ok(None)
       }
-    }
-
-    for root in &self.roots {
-      for candidate in path_candidates(root, specifier) {
-        if candidate.is_file() {
-          return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+      FilesystemSourceSpecifier::RootRelative(specifier) => {
+        for root in &self.roots {
+          for candidate in path_candidates(root, &specifier) {
+            if candidate.is_file() {
+              return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+            }
+          }
         }
+        Ok(None)
+      }
+      FilesystemSourceSpecifier::Ordinary(specifier) => {
+        if specifier.is_absolute() {
+          for candidate in absolute_path_candidates(&specifier) {
+            if candidate.is_file() {
+              return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+            }
+          }
+          return Ok(None);
+        }
+
+        if let Some(referrer) = &request.referrer {
+          if let Some(referrer_path) = self.normalize_referrer_path(referrer)? {
+            let parent = if referrer_path.is_dir() {
+              Some(referrer_path.as_path())
+            } else {
+              referrer_path.parent()
+            };
+
+            if let Some(parent) = parent {
+              for candidate in path_candidates(parent, &specifier) {
+                if candidate.is_file() {
+                  return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+                }
+              }
+            }
+          }
+        }
+
+        for root in &self.roots {
+          for candidate in path_candidates(root, &specifier) {
+            if candidate.is_file() {
+              return self.authorize_resolved(request, canonicalize_source_path(&candidate)?);
+            }
+          }
+        }
+
+        Ok(None)
       }
     }
+  }
 
-    Ok(None)
+  fn normalize_referrer_path(&self, referrer: &str) -> MResult<Option<PathBuf>> {
+    match parse_filesystem_source_specifier(referrer)? {
+      FilesystemSourceSpecifier::OtherScheme => Ok(None),
+      FilesystemSourceSpecifier::Ordinary(path) | FilesystemSourceSpecifier::Absolute(path) => {
+        Ok(Some(path))
+      }
+      FilesystemSourceSpecifier::RootRelative(path) => {
+        for root in &self.roots {
+          for candidate in path_candidates(root, &path) {
+            if candidate.is_file() {
+              return Ok(Some(canonicalize_source_path(&candidate)?));
+            }
+          }
+        }
+        Ok(None)
+      }
+    }
   }
 
   fn authorize_resolved(&self, request: &SourceRequest, path: PathBuf) -> MResult<Option<PathBuf>> {
@@ -136,12 +198,13 @@ impl SourceResolver for FileSourceResolver {
       .unwrap_or("source")
       .to_string();
 
-    let mut resolved = ResolvedSource::new(name, file_uri(&path), source).with_kind(kind);
+    let canonical_uri = path_to_file_uri(&path)?;
+    let mut resolved = ResolvedSource::new(name, canonical_uri.clone(), source).with_kind(kind);
 
     if resolved.kind == SourceKind::Mech {
       if let MechSourceCode::String(source_text) = &resolved.source {
         let tree = mech_syntax::parser::parse(source_text.trim())?;
-        let referrer = path.to_string_lossy().to_string();
+        let referrer = canonical_uri.clone();
         let index = SourceIndex::from_program(&tree);
         index.validate_address_targets()?;
         let imports = index.all_imports();
@@ -165,6 +228,212 @@ impl SourceResolver for FileSourceResolver {
     }
 
     Ok(Some(resolved))
+  }
+}
+
+fn parse_filesystem_source_specifier(specifier: &str) -> MResult<FilesystemSourceSpecifier> {
+  let Some((scheme, rest)) = split_uri_scheme(specifier) else {
+    return Ok(FilesystemSourceSpecifier::Ordinary(PathBuf::from(specifier)));
+  };
+  match scheme {
+    "fs" => parse_fs_uri(specifier, rest),
+    "file" => file_uri_to_path(specifier).map(FilesystemSourceSpecifier::Absolute),
+    _ => Ok(FilesystemSourceSpecifier::OtherScheme),
+  }
+}
+
+fn split_uri_scheme(specifier: &str) -> Option<(&str, &str)> {
+  let (prefix, rest) = specifier.split_once("://")?;
+  if valid_uri_scheme(prefix) { Some((prefix, rest)) } else { None }
+}
+
+fn valid_uri_scheme(prefix: &str) -> bool {
+  let mut chars = prefix.chars();
+  let Some(first) = chars.next() else { return false; };
+  first.is_ascii_alphabetic()
+    && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '+' || ch == '.' || ch == '-')
+}
+
+fn filesystem_specifier_error(specifier: impl Into<String>, reason: impl Into<String>) -> MechError {
+  MechError::new(SourceFilesystemSpecifierInvalid { specifier: specifier.into(), reason: reason.into() }, None)
+}
+
+fn parse_fs_uri(specifier: &str, rest: &str) -> MResult<FilesystemSourceSpecifier> {
+  reject_query_or_fragment(specifier, rest)?;
+  let raw_path = rest.trim_start_matches('/');
+  if raw_path.is_empty() {
+    return Err(filesystem_specifier_error(specifier, "fs:// path must not be empty"));
+  }
+  let decoded = percent_decode_to_string(specifier, raw_path)?;
+  Ok(FilesystemSourceSpecifier::RootRelative(normalize_root_relative_path(specifier, &decoded)?))
+}
+
+fn reject_query_or_fragment(specifier: &str, rest: &str) -> MResult<()> {
+  if rest.contains('?') {
+    return Err(filesystem_specifier_error(specifier, "query strings are not supported"));
+  }
+  if rest.contains('#') {
+    return Err(filesystem_specifier_error(specifier, "fragments are not supported"));
+  }
+  Ok(())
+}
+
+fn normalize_root_relative_path(specifier: &str, decoded: &str) -> MResult<PathBuf> {
+  if decoded.trim().is_empty() {
+    return Err(filesystem_specifier_error(specifier, "path must not be empty"));
+  }
+  if looks_like_windows_drive_path(decoded) {
+    return Err(filesystem_specifier_error(specifier, "Windows drive prefixes are not permitted in fs:// paths"));
+  }
+  let path = Path::new(decoded);
+  if path.is_absolute() {
+    return Err(filesystem_specifier_error(specifier, "absolute paths are not permitted in fs:// paths"));
+  }
+
+  let mut normalized = PathBuf::new();
+  for component in path.components() {
+    match component {
+      Component::Normal(part) => normalized.push(part),
+      Component::CurDir => {}
+      Component::ParentDir => return Err(filesystem_specifier_error(specifier, "parent traversal is not permitted in fs:// paths")),
+      Component::RootDir => return Err(filesystem_specifier_error(specifier, "root components are not permitted in fs:// paths")),
+      Component::Prefix(_) => return Err(filesystem_specifier_error(specifier, "path prefixes are not permitted in fs:// paths")),
+    }
+  }
+  if normalized.as_os_str().is_empty() {
+    return Err(filesystem_specifier_error(specifier, "path must not be empty"));
+  }
+  Ok(normalized)
+}
+
+fn looks_like_windows_drive_path(text: &str) -> bool {
+  let bytes = text.as_bytes();
+  bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn file_uri_to_path(uri: &str) -> MResult<PathBuf> {
+  let Some(rest) = uri.strip_prefix("file://") else {
+    return Err(filesystem_specifier_error(uri, "file URI must start with file://"));
+  };
+  reject_query_or_fragment(uri, rest)?;
+  let (authority, raw_path) = if rest.starts_with('/') {
+    ("", rest)
+  } else if let Some(path_start) = rest.find('/') {
+    (&rest[..path_start], &rest[path_start..])
+  } else {
+    return Err(filesystem_specifier_error(uri, "file URI must include an absolute path"));
+  };
+  let decoded_path = percent_decode_to_string(uri, raw_path)?;
+  local_file_uri_to_path(uri, authority, &decoded_path)
+}
+
+#[cfg(not(windows))]
+fn local_file_uri_to_path(uri: &str, authority: &str, decoded_path: &str) -> MResult<PathBuf> {
+  if !(authority.is_empty() || authority.eq_ignore_ascii_case("localhost")) {
+    return Err(filesystem_specifier_error(uri, "non-local file URI authorities are not supported on this platform"));
+  }
+  if !decoded_path.starts_with('/') {
+    return Err(filesystem_specifier_error(uri, "file URI path must be absolute"));
+  }
+  Ok(PathBuf::from(decoded_path))
+}
+
+#[cfg(windows)]
+fn local_file_uri_to_path(uri: &str, authority: &str, decoded_path: &str) -> MResult<PathBuf> {
+  if authority.is_empty() || authority.eq_ignore_ascii_case("localhost") {
+    let local_path = if decoded_path.len() >= 4
+      && decoded_path.as_bytes()[0] == b'/'
+      && decoded_path.as_bytes()[1].is_ascii_alphabetic()
+      && decoded_path.as_bytes()[2] == b':'
+      && decoded_path.as_bytes()[3] == b'/'
+    {
+      decoded_path[1..].replace('/', "\\")
+    } else {
+      return Err(filesystem_specifier_error(uri, "local Windows file URI path must include a drive prefix"));
+    };
+    return Ok(PathBuf::from(local_path));
+  }
+  let path = decoded_path.trim_start_matches('/').replace('/', "\\");
+  if path.is_empty() {
+    return Err(filesystem_specifier_error(uri, "UNC file URI must include a share path"));
+  }
+  Ok(PathBuf::from(format!("\\\\{}\\{}", authority, path)))
+}
+
+fn percent_decode_to_string(specifier: &str, text: &str) -> MResult<String> {
+  let bytes = text.as_bytes();
+  let mut out = Vec::with_capacity(bytes.len());
+  let mut index = 0;
+  while index < bytes.len() {
+    if bytes[index] == b'%' {
+      if index + 2 >= bytes.len() {
+        return Err(filesystem_specifier_error(specifier, "malformed percent escape"));
+      }
+      let high = hex_value(bytes[index + 1]).ok_or_else(|| filesystem_specifier_error(specifier, "malformed percent escape"))?;
+      let low = hex_value(bytes[index + 2]).ok_or_else(|| filesystem_specifier_error(specifier, "malformed percent escape"))?;
+      out.push((high << 4) | low);
+      index += 3;
+    } else {
+      out.push(bytes[index]);
+      index += 1;
+    }
+  }
+  String::from_utf8(out).map_err(|error| filesystem_specifier_error(specifier, format!("percent-decoded path is not valid UTF-8: {}", error)))
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+  match byte {
+    b'0'..=b'9' => Some(byte - b'0'),
+    b'a'..=b'f' => Some(byte - b'a' + 10),
+    b'A'..=b'F' => Some(byte - b'A' + 10),
+    _ => None,
+  }
+}
+
+fn path_to_file_uri(path: &Path) -> MResult<String> {
+  #[cfg(windows)]
+  {
+    let text = path.display().to_string().replace('\\', "/");
+    if let Some(unc) = text.strip_prefix("//") {
+      return Ok(format!("file://{}", percent_encode_path(unc.as_bytes())));
+    }
+    let path_text = if text.starts_with('/') { text } else { format!("/{}", text) };
+    return Ok(format!("file://{}", percent_encode_path(path_text.as_bytes())));
+  }
+
+  #[cfg(not(windows))]
+  {
+    use std::os::unix::ffi::OsStrExt;
+    if !path.is_absolute() {
+      return Err(filesystem_specifier_error(path.display().to_string(), "file URI source path must be absolute"));
+    }
+    Ok(format!("file://{}", percent_encode_path(path.as_os_str().as_bytes())))
+  }
+}
+
+fn percent_encode_path(bytes: &[u8]) -> String {
+  let mut out = String::new();
+  for &byte in bytes {
+    if is_file_uri_path_byte_unreserved(byte) {
+      out.push(byte as char);
+    } else {
+      out.push('%');
+      out.push(hex_char(byte >> 4));
+      out.push(hex_char(byte & 0x0f));
+    }
+  }
+  out
+}
+
+fn is_file_uri_path_byte_unreserved(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/' | b':')
+}
+
+fn hex_char(value: u8) -> char {
+  match value {
+    0..=9 => (b'0' + value) as char,
+    10..=15 => (b'A' + value - 10) as char,
+    _ => unreachable!(),
   }
 }
 
@@ -415,16 +684,6 @@ fn canonicalize_source_path(path: &Path) -> MResult<PathBuf> {
   })
 }
 
-fn file_uri(path: &Path) -> String {
-  let mut text = path.display().to_string();
-
-  if cfg!(windows) {
-    text = text.replace('\\', "/");
-  }
-
-  format!("file://{}", text)
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -509,6 +768,142 @@ mod tests {
     let request = SourceRequest::new("./math.mec").with_referrer(referrer.to_string_lossy().to_string());
     let resolved = resolver.resolve(&request).unwrap().unwrap();
     assert_eq!(resolved.name, "math.mec");
+  }
+
+  #[test]
+  fn resolves_fs_uri_beneath_configured_root() {
+    let root = temp_root("resolve-fs-root");
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(root.join("lib/dep.mec"), "value := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let resolved = resolver.resolve(&SourceRequest::new("fs://lib/dep.mec")).unwrap().unwrap();
+    assert_eq!(resolved.name, "dep.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn resolves_fs_uri_with_empty_authority_beneath_configured_root() {
+    let root = temp_root("resolve-fs-root-empty-authority");
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(root.join("lib/dep.mec"), "value := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let resolved = resolver.resolve(&SourceRequest::new("fs:///lib/dep.mec")).unwrap().unwrap();
+    assert_eq!(resolved.name, "dep.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn rejects_fs_uri_parent_traversal_before_filesystem_probe() {
+    let root = temp_root("reject-fs-parent");
+    std::fs::create_dir_all(&root).unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let error = resolver.resolve(&SourceRequest::new("fs://../dep.mec")).unwrap_err();
+    assert!(error.kind_as::<SourceFilesystemSpecifierInvalid>().is_some());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn resolves_percent_encoded_fs_uri_path() {
+    let root = temp_root("resolve-fs-percent");
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(root.join("lib/space dep.mec"), "value := 1").unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let resolved = resolver.resolve(&SourceRequest::new("fs://lib/space%20dep.mec")).unwrap().unwrap();
+    assert_eq!(resolved.name, "space dep.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn resolves_file_uri_absolute_path() {
+    let root = temp_root("resolve-file-absolute");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("main.mec");
+    std::fs::write(&path, "value := 1").unwrap();
+    let uri = path_to_file_uri(&path.canonicalize().unwrap()).unwrap();
+    let resolver = FileSourceResolver::empty();
+    let resolved = resolver.resolve(&SourceRequest::new(uri)).unwrap().unwrap();
+    assert_eq!(resolved.name, "main.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn resolves_file_uri_localhost_path() {
+    let root = temp_root("resolve-file-localhost");
+    std::fs::create_dir_all(&root).unwrap();
+    let path = root.join("main.mec");
+    std::fs::write(&path, "value := 1").unwrap();
+    let uri = path_to_file_uri(&path.canonicalize().unwrap()).unwrap().replacen("file://", "file://localhost", 1);
+    let resolver = FileSourceResolver::empty();
+    let resolved = resolver.resolve(&SourceRequest::new(uri)).unwrap().unwrap();
+    assert_eq!(resolved.name, "main.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn resolves_percent_encoded_file_uri_path() {
+    let root = temp_root("resolve-file-percent");
+    std::fs::create_dir_all(root.join("space dir")).unwrap();
+    let path = root.join("space dir/dep #1.mec");
+    std::fs::write(&path, "value := 1").unwrap();
+    let uri = path_to_file_uri(&path.canonicalize().unwrap()).unwrap();
+    assert!(uri.contains("%20"));
+    assert!(uri.contains("%23"));
+    let resolver = FileSourceResolver::empty();
+    let resolved = resolver.resolve(&SourceRequest::new(uri)).unwrap().unwrap();
+    assert_eq!(resolved.name, "dep #1.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn file_uri_referrer_resolves_relative_import_from_parent() {
+    let root = temp_root("resolve-file-referrer");
+    std::fs::create_dir_all(root.join("sub")).unwrap();
+    let referrer = root.join("sub/main.mec");
+    let dep = root.join("sub/dep.mec");
+    std::fs::write(&referrer, "+> ./dep.mec").unwrap();
+    std::fs::write(&dep, "value := 1").unwrap();
+    let referrer_uri = path_to_file_uri(&referrer.canonicalize().unwrap()).unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    let request = SourceRequest::new("./dep.mec").with_referrer(referrer_uri);
+    let resolved = resolver.resolve(&request).unwrap().unwrap();
+    assert_eq!(resolved.name, "dep.mec");
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn other_uri_schemes_are_ignored_by_file_resolver() {
+    let root = temp_root("resolve-other-schemes");
+    std::fs::create_dir_all(&root).unwrap();
+    let resolver = FileSourceResolver::new(&root);
+    assert!(resolver.resolve(&SourceRequest::new("https://example.com/main.mec")).unwrap().is_none());
+    assert!(resolver.resolve(&SourceRequest::new("memory://main.mec")).unwrap().is_none());
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn file_uri_helpers_round_trip_supported_local_path() {
+    let root = temp_root("file-uri-round-trip");
+    std::fs::create_dir_all(root.join("space dir")).unwrap();
+    let path = root.join("space dir/dep #1%.mec");
+    std::fs::write(&path, "value := 1").unwrap();
+    let canonical = path.canonicalize().unwrap();
+    let uri = path_to_file_uri(&canonical).unwrap();
+    assert_eq!(file_uri_to_path(&uri).unwrap(), canonical);
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(not(windows))]
+  #[test]
+  fn rejects_nonlocal_file_uri_authority_on_non_windows() {
+    let error = file_uri_to_path("file://server/share/project/main.mec").unwrap_err();
+    assert!(error.kind_as::<SourceFilesystemSpecifierInvalid>().is_some());
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn supports_windows_drive_and_unc_file_uri_forms() {
+    assert_eq!(file_uri_to_path("file:///C:/project/main.mec").unwrap(), PathBuf::from("C:\\project\\main.mec"));
+    assert_eq!(file_uri_to_path("file://server/share/project/main.mec").unwrap(), PathBuf::from("\\\\server\\share\\project\\main.mec"));
   }
 
 

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -401,13 +401,27 @@ fn path_to_file_uri(path: &Path) -> MResult<String> {
     return Ok(format!("file://{}", percent_encode_path(path_text.as_bytes())));
   }
 
-  #[cfg(not(windows))]
+  #[cfg(unix)]
   {
     use std::os::unix::ffi::OsStrExt;
     if !path.is_absolute() {
       return Err(filesystem_specifier_error(path.display().to_string(), "file URI source path must be absolute"));
     }
     Ok(format!("file://{}", percent_encode_path(path.as_os_str().as_bytes())))
+  }
+
+  #[cfg(not(any(unix, windows)))]
+  {
+    if !path.is_absolute() {
+      return Err(filesystem_specifier_error(path.display().to_string(), "file URI source path must be absolute"));
+    }
+    let text = path.to_str().ok_or_else(|| {
+      filesystem_specifier_error(
+        path.display().to_string(),
+        "file URI source path must be valid UTF-8 on this target",
+      )
+    })?;
+    Ok(format!("file://{}", percent_encode_path(text.as_bytes())))
   }
 }
 

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -158,6 +158,21 @@ impl MechErrorKind for RuntimeModuleDependencyMissingError {
   }
 }
 
+#[derive(Debug, Clone)]
+pub struct RuntimeRootModuleSourceNotFound {
+  pub specifier: String,
+}
+
+impl MechErrorKind for RuntimeRootModuleSourceNotFound {
+  fn name(&self) -> &str {
+    "RuntimeRootModuleSourceNotFound"
+  }
+
+  fn message(&self) -> String {
+    format!("root module source `{}` could not be resolved", self.specifier)
+  }
+}
+
 
 #[derive(Debug, Clone)]
 pub struct RuntimeProgramHostNotActiveError {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -36,6 +36,81 @@ enum AddressedReadPreflight {
   AllowModuleAddressTargets,
 }
 
+struct PreparedModuleScopeExecution {
+  record: ModuleVersionRecord,
+  source: MechSourceCode,
+  environment: HashMap<String, ValRef>,
+}
+
+struct ProgramEnvironmentOverlay {
+  entries: Vec<ProgramEnvironmentOverlayEntry>,
+}
+
+struct ProgramEnvironmentOverlayEntry {
+  id: u64,
+  previous_symbol: Option<ValRef>,
+  previous_dictionary: Option<String>,
+}
+
+impl ProgramEnvironmentOverlay {
+  fn install(program: &mut MechProgram, environment: &HashMap<String, ValRef>) -> MResult<Self> {
+    let mut ids = HashMap::new();
+    for name in environment.keys() {
+      let id = hash_str(name);
+      if let Some(first) = ids.insert(id, name.clone()) {
+        if first != *name {
+          return Err(MechError::new(RuntimeModuleImportConflict {
+            binding: name.clone(),
+            first_import: first,
+            second_import: name.clone(),
+          }, None));
+        }
+      }
+    }
+
+    let mut entries = Vec::with_capacity(environment.len());
+    let symbols = program.interpreter_mut().symbols();
+    let mut symbols_brrw = symbols.borrow_mut();
+    for (name, value_ref) in environment {
+      let id = hash_str(name);
+      let previous_symbol = symbols_brrw.symbols.get(&id).cloned();
+      let previous_dictionary = symbols_brrw.dictionary.borrow().get(&id).cloned();
+      if let Some(previous_name) = &previous_dictionary {
+        if previous_name != name && !environment.contains_key(previous_name) {
+          return Err(MechError::new(RuntimeModuleImportConflict {
+            binding: name.clone(),
+            first_import: previous_name.clone(),
+            second_import: name.clone(),
+          }, None));
+        }
+      }
+      entries.push(ProgramEnvironmentOverlayEntry { id, previous_symbol, previous_dictionary });
+      symbols_brrw.symbols.insert(id, value_ref.clone());
+      symbols_brrw.dictionary.borrow_mut().insert(id, name.clone());
+    }
+
+    Ok(Self { entries })
+  }
+
+  fn restore(self, program: &mut MechProgram) {
+    let symbols = program.interpreter_mut().symbols();
+    let mut symbols_brrw = symbols.borrow_mut();
+    for entry in self.entries.into_iter().rev() {
+      if let Some(previous_symbol) = entry.previous_symbol {
+        symbols_brrw.symbols.insert(entry.id, previous_symbol);
+      } else {
+        symbols_brrw.symbols.remove(&entry.id);
+      }
+
+      if let Some(previous_dictionary) = entry.previous_dictionary {
+        symbols_brrw.dictionary.borrow_mut().insert(entry.id, previous_dictionary);
+      } else {
+        symbols_brrw.dictionary.borrow_mut().remove(&entry.id);
+      }
+    }
+  }
+}
+
 impl AddressedReadPreflight {
   fn requires_context_binding(self) -> bool {
     matches!(self, AddressedReadPreflight::RequireContextBinding)
@@ -3395,7 +3470,7 @@ impl MechRuntime {
     Ok(instance.result)
   }
 
-  fn preflight_module_graph_for_scope(
+  pub(super) fn preflight_module_graph_for_scope(
     &self,
     context: &RuntimeContext,
     version: ModuleVersionId,
@@ -3493,28 +3568,14 @@ impl MechRuntime {
     }
   }
 
-  fn execute_module_isolated_for_scope(
+  fn prepare_module_scope_execution(
     &mut self,
     context: &mut RuntimeContext,
     version: ModuleVersionId,
     scope: &SourceScope,
     seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
     module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
-  ) -> MResult<ModuleInstance> {
-    self.validate_context_for_runtime(context)?;
-    context.charge_step()?;
-
-    let instance_key = (version, scope.clone());
-
-    if let Some(instance) = module_instances.get(&instance_key).cloned() {
-      return Ok(instance);
-    }
-
-    if seen.contains(&instance_key) {
-      return Ok(ModuleInstance { version, exports: HashMap::new(), result: Value::Empty });
-    }
-    seen.insert(instance_key.clone());
-
+  ) -> MResult<PreparedModuleScopeExecution> {
     let Some(record) = self.store.get_module_version(version)? else {
       return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
     };
@@ -3539,7 +3600,7 @@ impl MechRuntime {
       )?;
     }
 
-    let mut import_environment = self.build_import_environment_for_scope(
+    let mut environment = self.build_import_environment_for_scope(
       context,
       &record,
       scope,
@@ -3555,7 +3616,47 @@ impl MechRuntime {
       seen,
       module_instances,
     )?;
-    import_environment.extend(address_environment);
+    merge_module_environment(
+      &mut environment,
+      address_environment,
+      "import environment",
+      "address environment",
+    )?;
+
+    let scoped_source = module_source_for_scope(&source, scope)?;
+
+    Ok(PreparedModuleScopeExecution { record, source: scoped_source, environment })
+  }
+
+  fn execute_module_isolated_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    scope: &SourceScope,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+  ) -> MResult<ModuleInstance> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+
+    let instance_key = (version, scope.clone());
+
+    if let Some(instance) = module_instances.get(&instance_key).cloned() {
+      return Ok(instance);
+    }
+
+    if seen.contains(&instance_key) {
+      return Ok(ModuleInstance { version, exports: HashMap::new(), result: Value::Empty });
+    }
+    seen.insert(instance_key.clone());
+
+    let prepared = self.prepare_module_scope_execution(
+      context,
+      version,
+      scope,
+      seen,
+      module_instances,
+    )?;
     let mut module_program = MechProgram::new(MechProgramConfig {
       name: self.config.name.clone(),
       environment: MechProgramEnvironment {
@@ -3569,10 +3670,10 @@ impl MechRuntime {
     {
       let symbols = module_program.interpreter_mut().symbols();
       let mut symbols_brrw = symbols.borrow_mut();
-      for (name, value_ref) in import_environment {
+      for (name, value_ref) in &prepared.environment {
         let id = hash_str(&name);
-        symbols_brrw.symbols.insert(id, value_ref);
-        symbols_brrw.dictionary.borrow_mut().insert(id, name);
+        symbols_brrw.symbols.insert(id, value_ref.clone());
+        symbols_brrw.dictionary.borrow_mut().insert(id, name.clone());
       }
     }
 
@@ -3580,8 +3681,13 @@ impl MechRuntime {
       context,
       RuntimeEventKind::ModuleExecutionStarted { module_version: version },
     )?;
-    let scoped_source = module_source_for_scope(&source, scope)?;
-    let result = self.run_module_source_on_program(context, &mut module_program, &scoped_source, scope);
+    let result = self.run_module_source_on_program(
+      context,
+      &mut module_program,
+      &prepared.source,
+      scope,
+      crate::runtime::LiveRegistrationMode::IsolatedSnapshot,
+    );
     let result = match result {
       Ok(value) => value,
       Err(error) => {
@@ -3599,10 +3705,10 @@ impl MechRuntime {
     {
       let symbols = module_program.interpreter_mut().symbols();
       let symbols_brrw = symbols.borrow();
-      for export in exports_for_scope(&record, scope) {
+      for export in exports_for_scope(&prepared.record, scope) {
         let id = hash_str(&export.name);
         let Some(value_ref) = symbols_brrw.get(id) else {
-          let error = MechError::new(RuntimeModuleExportNotFound { dependency: record.id.to_string(), export: export.name.clone() }, None);
+          let error = MechError::new(RuntimeModuleExportNotFound { dependency: prepared.record.id.to_string(), export: export.name.clone() }, None);
           self.emit_event_to_context(
             context,
             RuntimeEventKind::ModuleExecutionFailed {
@@ -3625,12 +3731,107 @@ impl MechRuntime {
     Ok(instance)
   }
 
+  pub(super) fn execute_module_retained_root_for_scope(
+    &mut self,
+    context: &mut RuntimeContext,
+    version: ModuleVersionId,
+    scope: &SourceScope,
+    seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
+    module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
+    turn_started: Instant,
+  ) -> MResult<Value> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+
+    if !matches!(scope, SourceScope::Program) {
+      return Err(MechError::new(RuntimeInvalidOperationError {
+        operation: "run_root_module",
+        reason: "retained root module execution only supports program scope".to_string(),
+      }, None));
+    }
+
+    let instance_key = (version, scope.clone());
+    if seen.contains(&instance_key) {
+      return Ok(Value::Empty);
+    }
+    seen.insert(instance_key);
+
+    let prepared = self.prepare_module_scope_execution(
+      context,
+      version,
+      scope,
+      seen,
+      module_instances,
+    )?;
+
+    let program_config = self.program.config.clone();
+    let mut root_program = std::mem::replace(
+      &mut self.program,
+      MechProgram::new(program_config),
+    );
+
+    let result = (|| -> MResult<Value> {
+      let overlay = ProgramEnvironmentOverlay::install(&mut root_program, &prepared.environment)?;
+      let live_state_before = self.live_state_snapshot();
+
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ModuleExecutionStarted { module_version: version },
+      )?;
+
+      let result = self
+        .run_module_source_on_program(
+          context,
+          &mut root_program,
+          &prepared.source,
+          scope,
+          crate::runtime::LiveRegistrationMode::RetainedRoot,
+        )
+        .and_then(|value| {
+          self.enforce_turn_duration(turn_started)?;
+          Ok(value)
+        });
+
+      match result {
+        Ok(value) => Ok(value),
+        Err(error) => {
+          self.restore_live_state(live_state_before);
+          overlay.restore(&mut root_program);
+          Err(error)
+        }
+      }
+    })();
+
+    self.program = root_program;
+
+    match result {
+      Ok(value) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ModuleExecutionCompleted { module_version: version },
+        )?;
+        Ok(value)
+      }
+      Err(error) => {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ModuleExecutionFailed {
+            module_version: version,
+            message: format!("{:?}", error),
+          },
+        )?;
+        Err(error)
+      }
+    }
+  }
+
   fn run_module_source_on_program(
     &mut self,
     context: &mut RuntimeContext,
     program: &mut MechProgram,
     source: &MechSourceCode,
     scope: &SourceScope,
+    registration_mode: crate::runtime::LiveRegistrationMode,
   ) -> MResult<Value> {
     self.register_runtime_program_host_functions(context, program)?;
 
@@ -3652,7 +3853,7 @@ impl MechRuntime {
     // exports, address environment, and ModuleInstance identity.
     let execution_scope = execution_scope_for_extracted_module_source(scope);
 
-    let result = self.with_live_registration_mode(crate::runtime::LiveRegistrationMode::IsolatedSnapshot, |runtime| {
+    let result = self.with_live_registration_mode(registration_mode, |runtime| {
       match source {
       MechSourceCode::String(source) => match mech_syntax::parser::parse(source.trim()) {
         Ok(tree) => {
@@ -3686,7 +3887,13 @@ impl MechRuntime {
       MechSourceCode::Program(sources) => {
         let mut result = Ok(Value::Empty);
         for source in sources {
-          result = runtime.run_module_source_on_program(context, program, source, scope);
+          result = runtime.run_module_source_on_program(
+            context,
+            program,
+            source,
+            scope,
+            registration_mode,
+          );
           if result.is_err() {
             break;
           }
@@ -3978,6 +4185,25 @@ fn exports_for_scope<'a>(
     .find(|metadata| &metadata.scope == scope)
     .map(|metadata| metadata.exports.as_slice())
     .unwrap_or(&[])
+}
+
+fn merge_module_environment(
+  target: &mut HashMap<String, ValRef>,
+  source: HashMap<String, ValRef>,
+  first_import: &str,
+  second_import: &str,
+) -> MResult<()> {
+  for (binding, value) in source {
+    if target.contains_key(&binding) {
+      return Err(MechError::new(RuntimeModuleImportConflict {
+        binding,
+        first_import: first_import.to_string(),
+        second_import: second_import.to_string(),
+      }, None));
+    }
+    target.insert(binding, value);
+  }
+  Ok(())
 }
 
 

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -32,7 +32,7 @@ mod transaction;
 #[cfg(test)]
 mod input_tests;
 
-use crate::runtime::errors::*;
+pub use self::errors::*;
 use crate::runtime::host::*;
 
 use std::sync::Arc;

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -475,6 +475,68 @@ impl MechRuntime {
     )
   }
 
+  pub fn resolve_and_run_root_module(
+    &mut self,
+    request: impl Into<SourceRequest>,
+    options: ModuleBuildOptions<'_>,
+  ) -> MResult<Value> {
+    let mut context = self.runtime_context()?;
+    self.resolve_and_run_root_module_with_context(&mut context, request, options)
+  }
+
+  pub fn resolve_and_run_root_module_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    request: impl Into<SourceRequest>,
+    options: ModuleBuildOptions<'_>,
+  ) -> MResult<Value> {
+    let turn_started = Instant::now();
+    self.validate_context_for_runtime(context)?;
+
+    let request = request.into();
+    request.validate()?;
+    let root_specifier = request.specifier.clone();
+    let previous_module_version = context.module_version;
+
+    let result = (|| -> MResult<Value> {
+      let Some(root_version) = self.build_module_from_request_with_context(
+        context,
+        request,
+        options,
+      )? else {
+        return Err(MechError::new(
+          RuntimeRootModuleSourceNotFound { specifier: root_specifier },
+          None,
+        ));
+      };
+
+      context.module_version = Some(root_version);
+
+      let mut preflight_seen = HashSet::new();
+      self.preflight_module_graph_for_scope(
+        context,
+        root_version,
+        &SourceScope::Program,
+        &mut preflight_seen,
+      )?;
+
+      let mut seen = HashSet::new();
+      let mut module_instances = HashMap::new();
+      let value = self.execute_module_retained_root_for_scope(
+        context,
+        root_version,
+        &SourceScope::Program,
+        &mut seen,
+        &mut module_instances,
+        turn_started,
+      )?;
+      Ok(value)
+    })();
+
+    context.module_version = previous_module_version;
+    result
+  }
+
   pub fn put_source_module(
     &mut self,
     name: &str,

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -6,6 +6,12 @@ use mech_program::{MechProgram, MechProgramConfig};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::*;
 
+fn temp_root(name: &str) -> std::path::PathBuf {
+  let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{name}-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
+  std::fs::create_dir_all(&root).unwrap();
+  root
+}
+
 fn setup_modules(main_source: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
   std::fs::create_dir_all(&root).unwrap();
@@ -201,6 +207,17 @@ fn assert_bool_false(result: Value, label: &str) {
   }
 }
 
+fn assert_f64(result: Value, expected: f64, label: &str) {
+  match result {
+    Value::F64(value) => assert_eq!(*value.borrow(), expected, "{label}"),
+    Value::MutableReference(value) => match &*value.borrow() {
+      Value::F64(value) => assert_eq!(*value.borrow(), expected, "{label}"),
+      other => panic!("expected f64 mutable reference result from {label}, got {:?}", other),
+    },
+    other => panic!("expected f64 result from {label}, got {:?}", other),
+  }
+}
+
 
 
 #[test]
@@ -220,6 +237,135 @@ ok := math/tau > 6.0
   let result = runtime.run_module(version).unwrap();
 
   assert_bool_true(result, "direct run_string normal import");
+}
+
+#[test]
+fn resolved_retained_root_imports_sibling_module() {
+  let root = setup_main_only_module("retained-root-sibling", "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n");
+  std::fs::write(root.join("dep.mec"), "value := 41\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap();
+  assert_f64(result, 42.0, "retained root sibling import");
+  assert_f64(runtime.root_symbol_value("answer").unwrap(), 42.0, "retained root answer");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn resolved_retained_root_imports_parent_relative_module() {
+  let root = temp_root("retained-root-parent-relative");
+  std::fs::create_dir_all(root.join("app")).unwrap();
+  std::fs::create_dir_all(root.join("shared")).unwrap();
+  std::fs::write(root.join("shared/dep.mec"), "value := 41\n<+ value\n").unwrap();
+  std::fs::write(root.join("app/main.mec"), "+> ../shared/dep.mec\nanswer := dep/value + 1\nanswer\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_run_root_module("app/main.mec", module_options()).unwrap();
+  assert_f64(result, 42.0, "retained root parent-relative import");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn resolved_retained_root_import_namespace_exports_are_visible() {
+  let root = setup_main_only_module("retained-root-namespace", "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n");
+  std::fs::write(root.join("dep.mec"), "value := 41\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap();
+  assert_f64(runtime.root_symbol_value("dep/value").unwrap(), 41.0, "retained root namespace export");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn resolved_retained_root_wildcard_source_import_works() {
+  let root = setup_main_only_module("retained-root-wildcard", "+> ./dep.mec/*\nanswer := value + 1\nanswer\n");
+  std::fs::write(root.join("dep.mec"), "value := 41\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let result = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap();
+  assert_f64(result, 42.0, "retained root wildcard import");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn resolved_retained_root_missing_dependency_reports_dependency_error() {
+  let root = setup_main_only_module("retained-root-missing-dependency", "+> ./missing.mec\nanswer := 1\n");
+  let mut runtime = runtime_with_root(&root);
+  let error = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap_err();
+  assert!(error.kind_as::<RuntimeModuleDependencyMissingError>().is_some(), "expected dependency missing error, got {error:?}");
+  assert!(format!("{error:?}").contains("./missing.mec"));
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn resolved_retained_root_missing_source_reports_root_error() {
+  let root = temp_root("retained-root-missing-source");
+  let mut runtime = runtime_with_root(&root);
+  let error = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap_err();
+  assert!(error.kind_as::<RuntimeRootModuleSourceNotFound>().is_some(), "expected root source not found, got {error:?}");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn resolved_retained_root_dependency_cycle_reports_existing_cycle_error() {
+  let root = setup_main_only_module("retained-root-cycle", "+> ./dep.mec\nanswer := 1\n");
+  std::fs::write(root.join("dep.mec"), "+> ./main.mec\nvalue := 1\n<+ value\n").unwrap();
+  let mut runtime = runtime_with_root(&root);
+  let error = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap_err();
+  assert!(error.kind_as::<RuntimeModuleDependencyCycleError>().is_some(), "expected dependency cycle, got {error:?}");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn retained_root_dependency_context_read_does_not_create_live_binding() {
+  let root = setup_main_only_module("retained-root-dependency-isolated", "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n");
+  std::fs::write(root.join("dep.mec"), "@numbers := docs://numbers{:read(increment)}\nvalue := @numbers/increment\n<+ value\n").unwrap();
+  let provider = docs_provider_with("docs://numbers", "increment", Value::F64(Ref::new(41.0)));
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(provider).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://numbers", "increment")).unwrap();
+  let result = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap();
+  assert_f64(result, 42.0, "dependency context read result");
+  assert!(!runtime.has_live_input_bindings(), "dependency context reads must remain isolated");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn retained_root_context_read_creates_live_binding_and_recomputes() {
+  let root = setup_main_only_module(
+    "retained-root-live",
+    "@numbers := docs://numbers{:read(increment)}\noutput := @numbers/increment + 1\noutput\n",
+  );
+  let provider = docs_provider_with("docs://numbers", "increment", Value::F64(Ref::new(2.0)));
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(provider).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://numbers", "increment")).unwrap();
+  let result = runtime.resolve_and_run_root_module("main.mec", module_options()).unwrap();
+  assert_f64(result, 3.0, "root context read initial result");
+  assert!(runtime.has_live_input_bindings(), "root context read should retain live binding");
+  runtime.apply_host_input(RuntimeHostInput::single(
+    RuntimeHostInputSource::new("docs://numbers", "increment").unwrap(),
+    RuntimeHostInputValue::F64(10.0),
+  )).unwrap();
+  assert_f64(runtime.root_symbol_value("output").unwrap(), 11.0, "root recompute after host input");
+  std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn failed_retained_root_restores_live_state_and_imported_environment() {
+  let root = temp_root("retained-root-failure-rollback");
+  std::fs::write(root.join("dep.mec"), "value := 41\n<+ value\n").unwrap();
+  std::fs::write(root.join("ok.mec"), "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n").unwrap();
+  let provider = docs_provider_with("docs://numbers", "increment", Value::F64(Ref::new(1.0)));
+  let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).in_memory_docs(provider).build().unwrap();
+  runtime.grant_capability(runtime_context_read_grant(&runtime, "docs://numbers", "increment")).unwrap();
+  runtime.resolve_and_run_root_module("ok.mec", module_options()).unwrap();
+  assert_f64(runtime.root_symbol_value("dep/value").unwrap(), 41.0, "initial imported environment");
+
+  std::fs::write(root.join("dep.mec"), "value := 99\n<+ value\n").unwrap();
+  std::fs::write(
+    root.join("bad.mec"),
+    "+> ./dep.mec\n@numbers := docs://numbers{:read(increment)}\nsample := @numbers/increment\nbroken := missing + sample\n",
+  ).unwrap();
+  let error = runtime.resolve_and_run_root_module("bad.mec", module_options()).unwrap_err();
+  assert!(format!("{error:?}").contains("missing"), "expected root execution failure, got {error:?}");
+  assert!(!runtime.has_live_input_bindings(), "failed root must restore live input bindings");
+  assert_f64(runtime.root_symbol_value("dep/value").unwrap(), 41.0, "restored imported environment");
+  std::fs::remove_dir_all(root).unwrap();
 }
 
 #[test]

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -290,6 +290,101 @@ fn mech_run_directory_ignores_non_mech_assets() {
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
 #[test]
+fn mech_run_file_resolves_relative_sibling_import() {
+  let root = temp_root("run-file-sibling-import");
+  std::fs::write(root.join("dep.mec"), "value := 41\n<+ value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n").unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("main.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "42");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_file_resolves_parent_relative_import() {
+  let root = temp_root("run-file-parent-import");
+  std::fs::create_dir_all(root.join("app")).unwrap();
+  std::fs::create_dir_all(root.join("shared")).unwrap();
+  std::fs::write(root.join("shared/dep.mec"), "value := 41\n<+ value\n").unwrap();
+  std::fs::write(root.join("app/main.mec"), "+> ../shared/dep.mec\nanswer := dep/value + 1\nanswer\n").unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("app/main.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "42");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_file_resolves_fs_uri_import() {
+  let root = temp_root("run-file-fs-import");
+  std::fs::create_dir_all(root.join("lib")).unwrap();
+  std::fs::write(root.join("lib/dep.mec"), "value := 41\n<+ value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> fs://lib/dep.mec\nanswer := dep/value + 1\nanswer\n").unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("main.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  assert_success_contains(output, "42");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_file_missing_import_reports_dependency() {
+  let root = temp_root("run-file-missing-import");
+  std::fs::write(root.join("main.mec"), "+> ./missing.mec\nanswer := 1\n").unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("main.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "RuntimeModuleDependencyMissing");
+  assert!(combined.contains("./missing.mec"), "missing specifier should appear in output:\n{combined}");
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
+fn mech_run_file_dependency_denied_by_filesystem_capability() {
+  let root = temp_root("run-file-dependency-denied");
+  std::fs::write(root.join("dep.mec"), "value := 41\n<+ value\n").unwrap();
+  std::fs::write(root.join("main.mec"), "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n").unwrap();
+
+  let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
+    .arg("run")
+    .arg("--no-default-capabilities")
+    .arg("--allow-read")
+    .arg("main.mec")
+    .arg("main.mec")
+    .current_dir(&root)
+    .output()
+    .unwrap();
+
+  let combined = assert_failure_contains(output, "Capability");
+  assert!(
+    combined.contains("resolve") || combined.contains("import"),
+    "expected filesystem resolve/import capability denial, got:\n{combined}"
+  );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host"))]
+#[test]
 fn mech_run_explicit_loader_supported_text_file_still_runs() {
   let root = temp_root("run-explicit-js");
   let source = root.join("script.js");
@@ -975,7 +1070,7 @@ x := @missing/HOME
     .output()
     .unwrap();
 
-  let combined = assert_failure_contains(output, "direct_context_target");
+  let combined = assert_failure_contains(output, "UnknownAddressTarget");
   assert!(
     !combined.contains("must-not-write"),
     "provider wrote before undeclared context read failed preflight:\n{combined}"


### PR DESCRIPTION
## Summary

Addresses the two filesystem/module-resolution findings from PR 581 without touching PR 581 directly:

- Normalize filesystem source specifiers in `FileSourceResolver`, including `fs://`, local `file://`, canonical file URI referrers, percent encoding/decoding, and pass-through behavior for non-filesystem schemes.
- Add retained root-module execution so CLI file entrypoints build the runtime module graph, execute dependencies in isolated module programs, and execute the root program scope against the retained runtime program.
- Route CLI `.mec` and `.🤖` targets through the new root-module API while keeping inline source and non-Mech file handling on the existing direct path.
- Keep the analog-clock live project smoke stable under retained root execution by setting its project turn-duration limit above its 1s timer interval.

## Root Cause

CLI file execution was pre-reading Mech files and running them as direct source, which bypassed module construction and left relative source imports unresolved. Separately, the file resolver treated URI-looking filesystem specifiers as literal paths, so `fs://...` and canonical `file://...` referrers could not participate in normal relative import resolution.

## Validation

- `cargo test -p mech-runtime --lib --tests` fails in existing workspace watch tests unrelated to this change:
  - `workspace::watch::tests::nonrecursive_directory_watch_allows_directory_and_direct_children_only`
  - `workspace::watch::tests::recursive_directory_watch_still_allows_descendants`
  - `workspace::watch::tests::target_watch_falls_back_to_existing_parent_when_target_is_deleted`
  - failure shape is the existing macOS `/var` vs `/private/var` temp-path mismatch; resolver/module/CLI tests in this run pass.
- `cargo test -p mech-runtime --lib resolver::file::tests` passes.
- `cargo test -p mech-runtime --test module_smoke` passes.
- `cargo test --features "run repl pretty_print" --test mech_cli_host` passes.
- `cargo test --features "run repl pretty_print" cli::run::tests` passes.
- `cargo test --features "run repl pretty_print time_host_native timer_host_native console_host_native scene_host_native" --test mech_cli_host` passes.
- `cargo build --bin mech` passes.
- `cargo check -p mech-wasm --target wasm32-unknown-unknown --no-default-features --features browser_project_runner` passes.
- `cargo check -p mech-wasm --target wasm32-unknown-unknown --no-default-features --features "browser_project_runner,browser_host_time,browser_host_console,browser_host_scene,statements_default,compare_default,logic_default,subscript_default,math_default,matrix_default,f64,bool,string,record,tuple,table,atom,enum,variables"` passes.
- `target/debug/mech run examples/analog-clock` stayed live, emitted multiple clock values, and exited 0 after interrupt.

## Hosted CI

The first hosted run on this PR had 6 passing jobs and 2 failing jobs:

- `Project browser` failed because the file URI helper used Unix-only `OsStrExt` on `wasm32-unknown-unknown`.
- `Project native` failed because the analog-clock smoke crossed the default 1000ms turn-duration limit on the Linux runner.

Both failure causes are addressed in the latest pushed commit; the new hosted run should verify that on the updated head.