### PR TITLE
fix(runtime): close remaining v0.3.6 review bugs

### DIFF
--- a/include/project.js
+++ b/include/project.js
@@ -33,13 +33,63 @@ async function fetchText(path) {
   return await response.text();
 }
 
+async function readProjectSourceManifest(moduleUrl) {
+  const response = await fetch(
+    new URL('project-sources.json', moduleUrl),
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `failed to fetch project source manifest: ` +
+      `${response.status} ${response.statusText}`,
+    );
+  }
+
+  let manifest;
+
+  try {
+    manifest = await response.json();
+  } catch {
+    throw new Error('invalid project source manifest');
+  }
+
+  if (
+    manifest?.version !== 1 ||
+    !Array.isArray(manifest.sources) ||
+    manifest.sources.some(
+      source =>
+        typeof source?.specifier !== 'string' ||
+        typeof source?.url !== 'string',
+    )
+  ) {
+    throw new Error('invalid project source manifest');
+  }
+
+  return manifest.sources;
+}
+
 async function main() {
   await init();
   const config = await fetchText('mech.mcfg');
-  const paths = WasmProject.requiredPaths(config);
+  const manifestSources =
+    await readProjectSourceManifest(import.meta.url);
+
+  const sourceEntries =
+    manifestSources ??
+    Array.from(WasmProject.requiredPaths(config), path => ({
+      specifier: path,
+      url: path,
+    }));
+
   const sources = {};
-  for (const path of paths) {
-    sources[path] = await fetchText(path);
+
+  for (const source of sourceEntries) {
+    sources[source.specifier] =
+      await fetchText(source.url);
   }
   const hasServedAuthority = Object.prototype.hasOwnProperty.call(window, '__MECH_HOST_CONFIG');
   if (hasServedAuthority) {

--- a/scripts/smoke-served-analog-clock-browser.sh
+++ b/scripts/smoke-served-analog-clock-browser.sh
@@ -37,10 +37,45 @@ cleanup() {
 }
 trap cleanup EXIT
 
+mkdir -p "$project_dir/app"
+
 cp examples/analog-clock/mech.mcfg "$project_dir/mech.mcfg"
-cp examples/analog-clock/clock.mec "$project_dir/clock.mec"
 cp examples/analog-clock/clock.css "$project_dir/clock.css"
 cp examples/analog-clock/index.html "$project_dir/index.html"
+
+{
+  printf '%s\n\n' \
+    '+> ./support.mec' \
+    'module-support-loaded := support/loaded'
+  cat examples/analog-clock/clock.mec
+} > "$project_dir/app/clock.mec"
+
+cat > "$project_dir/app/support.mec" <<'EOF'
+loaded := true
+<+ loaded
+EOF
+
+python3 - "$project_dir/mech.mcfg" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+config = path.read_text()
+expected = '''  run: {
+    paths: ["clock.mec"]'''
+replacement = '''  serve: {
+    paths: ["app"]
+  }
+
+  run: {
+    paths: ["app/clock.mec"]'''
+matches = config.count(expected)
+if matches != 1:
+    raise SystemExit(
+        f"expected exactly one run-path block prefix in temporary mech.mcfg; found {matches}"
+    )
+path.write_text(config.replace(expected, replacement, 1))
+PY
 
 python3 - "$project_dir/index.html" <<'PY'
 from pathlib import Path
@@ -128,6 +163,57 @@ if ! curl --fail --silent --show-error --output /dev/null "$page_url"; then
   sed -n '1,240p' "$server_log" >&2 || true
   exit 1
 fi
+
+manifest_file="$project_dir/project-sources.json"
+
+curl --fail --silent --show-error \
+  "${page_url}_mech/project-sources.json" \
+  > "$manifest_file"
+
+python3 - "$manifest_file" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+try:
+    manifest = json.loads(path.read_text())
+except json.JSONDecodeError as error:
+    raise SystemExit(f"invalid project source manifest JSON: {error}")
+
+def fail(message):
+    raise SystemExit(f"{message}; parsed manifest: {manifest!r}")
+
+if not isinstance(manifest, dict):
+    fail("project source manifest top-level value is not an object")
+if manifest.get("version") != 1:
+    fail("project source manifest version is not 1")
+
+sources = manifest.get("sources")
+if not isinstance(sources, list):
+    fail("project source manifest sources is not a list")
+if len(sources) != 2:
+    fail("project source manifest does not contain exactly two sources")
+
+pairs = set()
+for source in sources:
+    if not isinstance(source, dict):
+        fail("project source manifest source entry is not an object")
+    specifier = source.get("specifier")
+    url = source.get("url")
+    if not isinstance(specifier, str) or not isinstance(url, str):
+        fail("project source manifest source entry fields are not strings")
+    if specifier == "app" or url == "app":
+        fail("project source manifest contains the directory app")
+    pairs.add((specifier, url))
+
+expected_pairs = {
+    ("app/clock.mec", "app/clock.mec"),
+    ("app/support.mec", "app/support.mec"),
+}
+if pairs != expected_pairs:
+    fail("project source manifest has unexpected source pairs")
+PY
 
 google-chrome \
   --headless=new \

--- a/src/runtime/src/config_profile/eval.rs
+++ b/src/runtime/src/config_profile/eval.rs
@@ -143,7 +143,14 @@ impl ConfigEvaluator {
                 self.sub(lhs, rhs)
             }
             ConfigExpr::Negate(inner) => match self.eval_expr(inner, depth)? {
-                ConfigValue::Integer(value) => Ok(ConfigValue::Integer(-value)),
+                ConfigValue::Integer(value) => value
+                    .checked_neg()
+                    .map(ConfigValue::Integer)
+                    .ok_or_else(|| {
+                        ConfigProfileViolation::error(
+                            "integer overflow in Mech config negation",
+                        )
+                    }),
                 ConfigValue::Float(value) => Ok(ConfigValue::Float(-value)),
                 _ => Err(ConfigProfileViolation::error(
                     "cannot negate non-number in Mech config",
@@ -161,7 +168,13 @@ impl ConfigEvaluator {
     fn add(&mut self, lhs: ConfigValue, rhs: ConfigValue) -> MResult<ConfigValue> {
         match (lhs, rhs) {
             (ConfigValue::Integer(lhs), ConfigValue::Integer(rhs)) => {
-                Ok(ConfigValue::Integer(lhs + rhs))
+                lhs.checked_add(rhs)
+                    .map(ConfigValue::Integer)
+                    .ok_or_else(|| {
+                        ConfigProfileViolation::error(
+                            "integer overflow in Mech config addition",
+                        )
+                    })
             }
             (ConfigValue::Float(lhs), ConfigValue::Float(rhs)) => Ok(ConfigValue::Float(lhs + rhs)),
             (ConfigValue::Integer(lhs), ConfigValue::Float(rhs)) => {
@@ -184,7 +197,13 @@ impl ConfigEvaluator {
     fn sub(&self, lhs: ConfigValue, rhs: ConfigValue) -> MResult<ConfigValue> {
         match (lhs, rhs) {
             (ConfigValue::Integer(lhs), ConfigValue::Integer(rhs)) => {
-                Ok(ConfigValue::Integer(lhs - rhs))
+                lhs.checked_sub(rhs)
+                    .map(ConfigValue::Integer)
+                    .ok_or_else(|| {
+                        ConfigProfileViolation::error(
+                            "integer overflow in Mech config subtraction",
+                        )
+                    })
             }
             (ConfigValue::Float(lhs), ConfigValue::Float(rhs)) => Ok(ConfigValue::Float(lhs - rhs)),
             (ConfigValue::Integer(lhs), ConfigValue::Float(rhs)) => {

--- a/src/runtime/src/host/arg.rs
+++ b/src/runtime/src/host/arg.rs
@@ -113,10 +113,14 @@ pub fn host_arg_resolved(
   args: &[Value],
   index: usize,
 ) -> MResult<Value> {
-  match host_arg(function, args, index)? {
-    Value::MutableReference(value) => Ok(value.borrow().clone()),
-    Value::Typed(..) => todo!(),
-    other => Ok(other.clone()),
+  let mut value = host_arg(function, args, index)?.clone();
+
+  loop {
+    value = match value {
+      Value::MutableReference(value) => value.borrow().clone(),
+      Value::Typed(value, _) => *value,
+      other => return Ok(other),
+    };
   }
 }
 
@@ -225,7 +229,12 @@ pub fn expect_no_args(
 }
 
 pub fn is_empty_value(value: &Value) -> bool {
-  matches!(value, Value::Empty)
+  match value {
+    Value::Empty => true,
+    Value::Typed(value, _) => is_empty_value(value),
+    Value::MutableReference(value) => is_empty_value(&value.borrow()),
+    _ => false,
+  }
 }
 
 pub fn host_arg_optional(
@@ -1270,4 +1279,69 @@ where
   let d = D::from_host_value(function, args, 3)?;
 
   Ok(f(a, b, c, d)?.into_host_value())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn typed(value: Value, kind: ValueKind) -> Value {
+    Value::Typed(Box::new(value), kind)
+  }
+
+  #[test]
+  fn resolves_typed_strings_through_scalar_helpers() {
+    let args = vec![typed(
+      Value::String(Ref::new("hello".into())),
+      ValueKind::String,
+    )];
+
+    assert_eq!(host_arg_string("test", &args, 0).unwrap(), "hello");
+  }
+
+  #[cfg(feature = "f64")]
+  #[test]
+  fn resolves_typed_f64_through_scalar_helpers() {
+    let args = vec![typed(Value::F64(Ref::new(42.0)), ValueKind::F64)];
+
+    assert_eq!(host_arg_f64("test", &args, 0).unwrap(), 42.0);
+  }
+
+  #[test]
+  fn resolves_nested_typed_and_mutable_reference_values() {
+    let string = || Value::String(Ref::new("hello".into()));
+    let cases = vec![
+      typed(
+        Value::MutableReference(Ref::new(string())),
+        ValueKind::String,
+      ),
+      Value::MutableReference(Ref::new(typed(string(), ValueKind::String))),
+      Value::MutableReference(Ref::new(Value::MutableReference(Ref::new(typed(
+        string(),
+        ValueKind::String,
+      ))))),
+    ];
+
+    assert_eq!(host_arg_string("test", &cases[..1], 0).unwrap(), "hello");
+    assert_eq!(host_arg_string("test", &cases[1..2], 0).unwrap(), "hello");
+    assert_eq!(host_arg_string("test", &cases[2..], 0).unwrap(), "hello");
+  }
+
+  #[test]
+  fn typed_wrong_type_returns_an_error() {
+    let args = vec![typed(Value::Empty, ValueKind::String)];
+
+    assert!(host_arg_string("test", &args, 0).is_err());
+  }
+
+  #[test]
+  fn optional_helpers_treat_wrapped_empty_as_absent() {
+    let args = vec![
+      typed(Value::Empty, ValueKind::String),
+      Value::MutableReference(Ref::new(typed(Value::Empty, ValueKind::String))),
+    ];
+
+    assert_eq!(host_arg_optional_string("test", &args, 0).unwrap(), None);
+    assert_eq!(host_arg_optional_string("test", &args, 1).unwrap(), None);
+  }
 }

--- a/src/runtime/src/resolver/memory.rs
+++ b/src/runtime/src/resolver/memory.rs
@@ -129,6 +129,32 @@ impl InMemorySourceResolver {
   fn default_canonical_uri(specifier: &str) -> String {
     format!("memory:{}", specifier)
   }
+
+  fn relative_candidate(
+    specifier: &str,
+    referrer: Option<&str>,
+  ) -> Option<String> {
+    if !(specifier.starts_with("./") || specifier.starts_with("../")) {
+      return None;
+    }
+
+    let referrer = referrer?.strip_prefix("memory:")?;
+    let referrer = referrer.strip_prefix("//").unwrap_or(referrer);
+    let base = referrer.rsplit_once('/').map(|(base, _)| base).unwrap_or("");
+    let mut parts = Vec::new();
+
+    for segment in base.split('/').chain(specifier.split('/')) {
+      match segment {
+        "" | "." => {}
+        ".." => {
+          parts.pop()?;
+        }
+        segment => parts.push(segment),
+      }
+    }
+
+    Some(parts.join("/"))
+  }
 }
 
 impl SourceResolver for InMemorySourceResolver {
@@ -137,7 +163,18 @@ impl SourceResolver for InMemorySourceResolver {
 
     let specifier = self.resolve_alias(&request.specifier);
 
-    Ok(self.sources.get(specifier).cloned())
+    if let Some(source) = self.sources.get(specifier) {
+      return Ok(Some(source.clone()));
+    }
+
+    let Some(candidate) = Self::relative_candidate(
+      &request.specifier,
+      request.referrer.as_deref(),
+    ) else {
+      return Ok(None);
+    };
+
+    Ok(self.sources.get(self.resolve_alias(&candidate)).cloned())
   }
 }
 
@@ -211,6 +248,50 @@ mod tests {
 
     assert_eq!(resolved.name, "main.mec");
     assert_eq!(resolved.canonical_uri, "memory:main.mec");
+  }
+
+  #[test]
+  fn resolves_memory_relative_imports() {
+    let resolver = InMemorySourceResolver::new()
+      .with_string("lib.mec", "x := 1")
+      .with_string("app/lib.mec", "x := 1")
+      .with_string("shared/lib.mec", "x := 1")
+      .with_string("shared/deep/lib.mec", "x := 1");
+
+    for (specifier, referrer, expected) in [
+      ("./lib.mec", "memory:main.mec", "lib.mec"),
+      ("./lib.mec", "memory:app/main.mec", "app/lib.mec"),
+      ("../shared/lib.mec", "memory:app/main.mec", "shared/lib.mec"),
+      ("../../shared/deep/lib.mec", "memory:app/nested/main.mec", "shared/deep/lib.mec"),
+    ] {
+      let request = SourceRequest::new(specifier).with_referrer(referrer);
+      assert_eq!(resolver.resolve(&request).unwrap().unwrap().name, expected);
+    }
+  }
+  #[test]
+  fn memory_relative_imports_do_not_escape_or_rebase_other_requests() {
+    let resolver = InMemorySourceResolver::new()
+      .with_string("lib.mec", "x := 1")
+      .with_string("dep.mec", "x := 1");
+
+    for request in [
+      SourceRequest::new("../../lib.mec").with_referrer("memory:main.mec"),
+      SourceRequest::new("./lib.mec").with_referrer("file:///app/main.mec"),
+      SourceRequest::new("other.mec").with_referrer("memory:app/main.mec"),
+    ] {
+      assert!(resolver.resolve(&request).unwrap().is_none());
+    }
+  }
+
+  #[test]
+  fn aliases_apply_to_normalized_memory_relative_imports() {
+    let resolver = InMemorySourceResolver::new()
+      .with_string("lib.mec", "x := 1")
+      .with_alias("app/lib.mec", "lib.mec");
+
+    let request = SourceRequest::new("./lib.mec")
+      .with_referrer("memory:app/main.mec");
+    assert_eq!(resolver.resolve(&request).unwrap().unwrap().name, "lib.mec");
   }
 
   #[test]

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -30,6 +30,26 @@ fn source_index_for_module_record_source(
   }
 }
 
+fn index_unindexed_module_source(
+  resolved: &mut ResolvedSource,
+) -> MResult<()> {
+  if !resolved.scopes.is_empty() {
+    return Ok(());
+  }
+
+  let Some(index) = source_index_for_module_record_source(&resolved.source)? else {
+    return Ok(());
+  };
+
+  index.validate_address_targets()?;
+  resolved.imports = index.all_imports();
+  resolved.exports = index.all_exports();
+  resolved.contexts = index.all_contexts();
+  resolved.address_references = index.all_address_references();
+  resolved.scopes = index.module_scopes();
+  Ok(())
+}
+
 impl MechRuntime {
   pub fn ensure_module(
     &mut self,
@@ -277,6 +297,7 @@ impl MechRuntime {
         .collect::<Vec<_>>();
 
       let mut resolved = resolved;
+      index_unindexed_module_source(&mut resolved)?;
 
       let explicit_capability_requirements = options
         .capability_requirements

--- a/src/runtime/tests/config_profile.rs
+++ b/src/runtime/tests/config_profile.rs
@@ -11,6 +11,43 @@ fn err_text(source: &str) -> String {
     format!("{} {} {:?}", err.kind_name(), err.kind_message(), err)
 }
 
+fn assert_integer_overflow(source: &str, operation: &str) {
+    let error = parse(source).expect_err("expected config evaluation to overflow");
+    assert_eq!(error.kind_name(), "ConfigProfileViolation");
+    assert!(error.kind_message().contains("integer overflow"));
+    assert!(error.kind_message().contains(operation));
+}
+
+#[test]
+fn config_integer_addition_overflow_is_rejected() {
+    assert_integer_overflow(
+        "x := 9223372036854775807 + 1\nconfig := {:}\n",
+        "addition",
+    );
+}
+
+#[test]
+fn config_integer_subtraction_overflow_is_rejected() {
+    assert_integer_overflow(
+        "x := -9223372036854775807 - 2\nconfig := {:}\n",
+        "subtraction",
+    );
+}
+
+#[test]
+fn config_integer_negation_overflow_is_rejected() {
+    assert_integer_overflow(
+        "x := -(-9223372036854775807 - 1)\nconfig := {:}\n",
+        "negation",
+    );
+}
+
+#[test]
+fn config_integer_boundary_values_succeed() {
+    parse("x := 9223372036854775806 + 1\nconfig := {:}\n").unwrap();
+    parse("x := -9223372036854775807 - 1\nconfig := {:}\n").unwrap();
+}
+
 #[test]
 fn shipped_browser_examples_use_hosts_schema() {
     let resource = parse_config_document(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -631,10 +631,16 @@ impl MechServer {
       content_encoding: None,
       backing_paths: project.config_path.clone().into_iter().collect(),
     });
+    let mut source_entries =
+      Vec::with_capacity(project.source_paths.len());
     for source in &project.source_paths {
       check_fs_capability(&mut self.authority.kernel().clone(), &self.serve_subject, FS_READ, source)?;
       let relative = source.strip_prefix(&project.root).map_err(|error| Error::new(ErrorKind::InvalidInput, format!("project source is outside root: {}", error)))?;
       let key = url_key(relative).ok_or_else(|| Error::new(ErrorKind::InvalidInput, "invalid project source URL"))?;
+      source_entries.push(serde_json::json!({
+        "specifier": key.clone(),
+        "url": key.clone(),
+      }));
       registry.insert_user_asset(key, ServerAsset {
         bytes: std::fs::read(source)?,
         content_type: content_type_for_path(source.to_string_lossy().as_ref()),
@@ -662,6 +668,27 @@ impl MechServer {
         backing_paths: Vec::new(),
       });
     }
+    let manifest = serde_json::to_vec(&serde_json::json!({
+      "version": 1,
+      "sources": source_entries,
+    }))
+    .map_err(|error| {
+      Error::new(
+        ErrorKind::InvalidData,
+        format!(
+          "failed to serialize project source manifest: {error}"
+        ),
+      )
+    })?;
+    registry.insert_asset(
+      "_mech/project-sources.json",
+      asset(
+        &manifest,
+        "application/json",
+        None,
+        project.source_paths.clone(),
+      ),
+    );
     drop(registry);
     self.workspace_root = Some(project.root);
     println!("{} Project loaded in {:?}.", self.badge(), started.elapsed());
@@ -1251,6 +1278,112 @@ mod tests {
       served_project_source_paths(&root, &[run_path.clone()], Some(&serve)).unwrap(),
       vec![root.join("app/lib.mec").canonicalize().unwrap(), run_path],
     );
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn served_project_publishes_expanded_source_manifest_after_user_assets() {
+    let root = temp_root("source-manifest");
+    let app = root.join("app");
+    let mech_dir = root.join("_mech");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::create_dir_all(&mech_dir).unwrap();
+
+    let clock_path = app.join("clock.mec");
+    let support_path = app.join("support.mec");
+    std::fs::write(&clock_path, "clock := 1\n").unwrap();
+    std::fs::write(&support_path, "support := 1\n").unwrap();
+    std::fs::write(
+      mech_dir.join("project-sources.json"),
+      r#"{"version":999,"sources":[]}"#,
+    )
+    .unwrap();
+    std::fs::write(root.join("index.html"), "<!doctype html>\n").unwrap();
+    std::fs::write(
+      root.join("mech.mcfg"),
+      r#"config := {
+  hosts: []
+
+  serve: {
+    paths: ["app"]
+  }
+
+  run: {
+    paths: ["app/clock.mec"]
+    grants: []
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let expected_backing_paths = [
+      clock_path.canonicalize().unwrap(),
+      support_path.canonicalize().unwrap(),
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    let guard = CurrentDirGuard::enter(&root);
+    let project = discover_served_project(&[".".to_string()])
+      .unwrap()
+      .unwrap();
+    let mut server = test_server();
+    server.load_served_project(project).unwrap();
+
+    let registry = server.registry.read().unwrap();
+    assert!(registry.user_assets.contains("_mech/project-sources.json"));
+    let manifest_asset = registry
+      .get_route("/_mech/project-sources.json")
+      .expect("generated project source manifest route should exist");
+    assert_eq!(manifest_asset.content_type, "application/json");
+    assert_ne!(
+      manifest_asset.bytes,
+      br#"{"version":999,"sources":[]}"#.to_vec(),
+    );
+
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_asset.bytes).unwrap();
+    assert_eq!(manifest.get("version").and_then(serde_json::Value::as_u64), Some(1));
+    let sources = manifest
+      .get("sources")
+      .and_then(serde_json::Value::as_array)
+      .expect("generated project source manifest should contain sources");
+    assert_eq!(sources.len(), 2);
+    let source_pairs = sources
+      .iter()
+      .map(|source| {
+        let specifier = source
+          .get("specifier")
+          .and_then(serde_json::Value::as_str)
+          .expect("manifest source specifier should be a string")
+          .to_string();
+        let url = source
+          .get("url")
+          .and_then(serde_json::Value::as_str)
+          .expect("manifest source URL should be a string")
+          .to_string();
+        (specifier, url)
+      })
+      .collect::<BTreeSet<_>>();
+    assert_eq!(
+      source_pairs,
+      BTreeSet::from([
+        ("app/clock.mec".to_string(), "app/clock.mec".to_string()),
+        ("app/support.mec".to_string(), "app/support.mec".to_string()),
+      ]),
+    );
+    assert!(sources.iter().all(|source| {
+      source.get("specifier").and_then(serde_json::Value::as_str) != Some("app")
+    }));
+    assert!(sources.iter().all(|source| {
+      source.get("url").and_then(serde_json::Value::as_str) != Some("app")
+    }));
+    assert_eq!(
+      manifest_asset.backing_paths.into_iter().collect::<BTreeSet<_>>(),
+      expected_backing_paths,
+    );
+
+    drop(registry);
+    drop(guard);
     std::fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -631,7 +631,7 @@ impl MechServer {
       content_encoding: None,
       backing_paths: project.config_path.clone().into_iter().collect(),
     });
-    for source in &project.run_paths {
+    for source in &project.source_paths {
       check_fs_capability(&mut self.authority.kernel().clone(), &self.serve_subject, FS_READ, source)?;
       let relative = source.strip_prefix(&project.root).map_err(|error| Error::new(ErrorKind::InvalidInput, format!("project source is outside root: {}", error)))?;
       let key = url_key(relative).ok_or_else(|| Error::new(ErrorKind::InvalidInput, "invalid project source URL"))?;
@@ -872,7 +872,7 @@ struct ServedProject {
   root: PathBuf,
   config_path: Option<PathBuf>,
   config_source: String,
-  run_paths: Vec<PathBuf>,
+  source_paths: Vec<PathBuf>,
   index_path: Option<PathBuf>,
 }
 
@@ -906,17 +906,53 @@ fn discover_served_project(paths: &[String]) -> MResult<Option<ServedProject>> {
       }
       run_paths.push(canonical);
     }
+    let source_paths = served_project_source_paths(&root, &run_paths, document.serve.as_ref())?;
     let index_path = root.join("index.html");
-    return Ok(Some(ServedProject { root, config_path: Some(config_path.canonicalize()?), config_source, run_paths, index_path: index_path.exists().then_some(index_path.canonicalize()?) }));
+    return Ok(Some(ServedProject { root, config_path: Some(config_path.canonicalize()?), config_source, source_paths, index_path: index_path.exists().then_some(index_path.canonicalize()?) }));
   }
   if path.is_file() && is_workspace_target_source(&path) {
     let source = path.canonicalize()?;
     let root = source.parent().ok_or_else(|| Error::new(ErrorKind::InvalidInput, "served source has no parent directory"))?.to_path_buf();
     let file_name = source.file_name().and_then(|name| name.to_str()).ok_or_else(|| Error::new(ErrorKind::InvalidInput, "served source file name is not UTF-8"))?.to_string();
     let config_source = format!("config := {{\n  hosts: []\n  run: {{\n    paths: [\"{}\"]\n    grants: []\n  }}\n}}\n", file_name);
-    return Ok(Some(ServedProject { root, config_path: None, config_source, run_paths: vec![source], index_path: None }));
+    return Ok(Some(ServedProject { root, config_path: None, config_source, source_paths: vec![source], index_path: None }));
   }
   Ok(None)
+}
+
+fn served_project_source_paths(
+  root: &Path,
+  run_paths: &[PathBuf],
+  serve: Option<&mech_runtime::ServeHostConfig>,
+) -> MResult<Vec<PathBuf>> {
+  let mut sources = BTreeSet::new();
+  for path in run_paths {
+    sources.insert(path.clone());
+  }
+  for path in serve.into_iter().flat_map(|serve| &serve.paths) {
+    let candidate = root.join(path).canonicalize()?;
+    if !candidate.starts_with(root) {
+      return Err(Error::new(ErrorKind::InvalidInput, format!("serve path `{}` escapes project root", path.display())).into());
+    }
+    if candidate.is_file() {
+      if is_renderable_mech_text_source(&candidate) {
+        sources.insert(candidate);
+      }
+      continue;
+    }
+    for entry in WalkBuilder::new(candidate).build() {
+      let entry = entry.map_err(|error| Error::new(ErrorKind::Other, error.to_string()))?;
+      if !entry.file_type().map(|kind| kind.is_file()).unwrap_or(false) || !is_renderable_mech_text_source(entry.path()) {
+        continue;
+      }
+      let source = entry.path().canonicalize()?;
+      if !source.starts_with(root) {
+        return Err(Error::new(ErrorKind::InvalidInput, format!("serve source `{}` escapes project root", source.display())).into());
+      }
+      sources.insert(source);
+    }
+  }
+  Ok(sources.into_iter().collect())
 }
 
 fn plan_serve_inputs(paths: &[String]) -> MResult<ServeInputPlan> {
@@ -1196,6 +1232,26 @@ mod tests {
     ));
     std::fs::create_dir_all(&root).unwrap();
     root.canonicalize().unwrap()
+  }
+
+  #[test]
+  fn served_project_sources_include_run_roots_and_serve_inventory() {
+    let root = temp_root("source-inventory");
+    std::fs::create_dir_all(root.join("app")).unwrap();
+    std::fs::write(root.join("main.mec"), "main := 1\n").unwrap();
+    std::fs::write(root.join("app/lib.mec"), "lib := 1\n").unwrap();
+    std::fs::write(root.join("app/ignored.txt"), "ignored\n").unwrap();
+    let run_path = root.join("main.mec").canonicalize().unwrap();
+    let serve = mech_runtime::ServeHostConfig {
+      paths: vec![PathBuf::from("app"), PathBuf::from("main.mec")],
+      ..Default::default()
+    };
+
+    assert_eq!(
+      served_project_source_paths(&root, &[run_path.clone()], Some(&serve)).unwrap(),
+      vec![root.join("app/lib.mec").canonicalize().unwrap(), run_path],
+    );
+    std::fs::remove_dir_all(root).unwrap();
   }
 
   fn snapshot(root: &Path, file: &str) -> RuntimeWorkspaceSnapshot { snapshot_for_sources(root, &[file]) }

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -25,7 +25,8 @@ use mech_host_time::BrowserTimeHostFactory;
 #[cfg(feature = "browser_host_timer")]
 use mech_host_timer::BrowserTimerHostFactory;
 use mech_runtime::{
-    ConfigProfileOptions, MechConfigDocument, MechRuntime, RuntimeBuilder, parse_config_document,
+    ConfigProfileOptions, InMemorySourceResolver, MechConfigDocument, MechRuntime,
+    ModuleBuildOptions, RuntimeBuilder, SourceRequest, parse_config_document,
 };
 
 #[cfg(feature = "browser_host_dom")]
@@ -65,8 +66,9 @@ impl WasmProject {
         validate_compiled_host_providers(&document).map_err(to_js_error)?;
         #[cfg(feature = "browser_host_scene")]
         let scenes = BrowserSceneRegistry::new();
-        let mut runtime = build_runtime(&document, #[cfg(feature = "browser_host_scene")] scenes.clone())?;
-        run_project_sources(&mut runtime, &document, &source_map).map_err(to_js_error)?;
+        let source_resolver = project_source_resolver(&source_map).map_err(to_js_error)?;
+        let mut runtime = build_runtime(&document, source_resolver, #[cfg(feature = "browser_host_scene")] scenes.clone())?;
+        run_project_sources(&mut runtime, &document).map_err(to_js_error)?;
         Ok(Self {
             runtime,
             #[cfg(feature = "browser_host_scene")]
@@ -86,8 +88,9 @@ impl WasmProject {
         validate_compiled_host_providers_for_hosts(&document.hosts).map_err(to_js_error)?;
         #[cfg(feature = "browser_host_scene")]
         let scenes = BrowserSceneRegistry::new();
-        let mut runtime = build_runtime_from_authority(&document, &authority, #[cfg(feature = "browser_host_scene")] scenes.clone())?;
-        run_project_sources(&mut runtime, &document, &source_map).map_err(to_js_error)?;
+        let source_resolver = project_source_resolver(&source_map).map_err(to_js_error)?;
+        let mut runtime = build_runtime_from_authority(&document, &authority, source_resolver, #[cfg(feature = "browser_host_scene")] scenes.clone())?;
+        run_project_sources(&mut runtime, &document).map_err(to_js_error)?;
         Ok(Self {
             runtime,
             #[cfg(feature = "browser_host_scene")]
@@ -183,11 +186,20 @@ fn required_path_strings(source: &str) -> mech_core::MResult<Vec<String>> {
         ConfigProfileOptions::default(),
     )?;
     let run = require_run(&document)?;
-    Ok(run
+    let mut paths = run
         .paths
         .iter()
         .map(|path| path.to_string_lossy().to_string())
-        .collect())
+        .collect::<Vec<_>>();
+    if let Some(serve) = &document.serve {
+        for path in &serve.paths {
+            let path = path.to_string_lossy().to_string();
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+    Ok(paths)
 }
 fn runtime_builder_with_factories(
     #[cfg(feature = "browser_host_scene")] scenes: BrowserSceneRegistry,
@@ -229,9 +241,11 @@ fn runtime_builder_with_factories(
 
 fn build_runtime(
     document: &MechConfigDocument,
+    source_resolver: InMemorySourceResolver,
     #[cfg(feature = "browser_host_scene")] scenes: BrowserSceneRegistry,
 ) -> Result<MechRuntime, JsValue> {
-    let mut builder = runtime_builder_with_factories(#[cfg(feature = "browser_host_scene")] scenes)?;
+    let mut builder = runtime_builder_with_factories(#[cfg(feature = "browser_host_scene")] scenes)?
+        .source_resolver(source_resolver);
     for host in &document.hosts {
         builder = builder.host_instance(host.clone());
     }
@@ -246,10 +260,12 @@ fn build_runtime(
 fn build_runtime_from_authority(
     document: &MechConfigDocument,
     authority: &BrowserRuntimeInjectionConfig,
+    source_resolver: InMemorySourceResolver,
     #[cfg(feature = "browser_host_scene")] scenes: BrowserSceneRegistry,
 ) -> Result<MechRuntime, JsValue> {
     let mut builder = runtime_builder_with_factories(#[cfg(feature = "browser_host_scene")] scenes)?
-        .config(authority.into_runtime_config().map_err(to_js_error)?);
+        .config(authority.into_runtime_config().map_err(to_js_error)?)
+        .source_resolver(source_resolver);
     for required in &document.hosts {
         if let Some(host) = authority.hosts.iter().find(|host| host.name == required.name && host.provider == required.provider) {
             builder = builder.host_instance(host.clone());
@@ -265,6 +281,7 @@ fn build_runtime_from_authority(
 fn build_runtime_from_authority(
     _document: &MechConfigDocument,
     _authority: &(),
+    _source_resolver: InMemorySourceResolver,
     #[cfg(feature = "browser_host_scene")] _scenes: BrowserSceneRegistry,
 ) -> Result<MechRuntime, JsValue> {
     Err(js_error("served project authority support was not compiled into this WASM artifact"))
@@ -494,23 +511,38 @@ fn source_map_from_js(value: JsValue) -> Result<HashMap<String, String>, JsValue
     }
     Ok(out)
 }
+
+fn project_source_resolver(
+    sources: &HashMap<String, String>,
+) -> mech_core::MResult<InMemorySourceResolver> {
+    let mut resolver = InMemorySourceResolver::new();
+    for (specifier, source) in sources {
+        resolver.insert_string(specifier, source)?;
+    }
+    Ok(resolver)
+}
+
+fn browser_module_options() -> ModuleBuildOptions<'static> {
+    ModuleBuildOptions::new(
+        env!("CARGO_PKG_VERSION"),
+        "v0.3",
+        "wasm32-unknown-unknown",
+        &[],
+        &[],
+    )
+}
+
 fn run_project_sources(
     runtime: &mut MechRuntime,
     document: &MechConfigDocument,
-    sources: &HashMap<String, String>,
 ) -> mech_core::MResult<()> {
     let run = require_run(document)?;
     for path in &run.paths {
         let key = path.to_string_lossy().to_string();
-        let source = sources.get(&key).ok_or_else(|| {
-            MechError::new(
-                ProjectError {
-                    message: format!("missing source `{key}`"),
-                },
-                None,
-            )
-        })?;
-        runtime.run_string(source)?;
+        runtime.resolve_and_run_root_module(
+            SourceRequest::new(key),
+            browser_module_options(),
+        )?;
     }
     Ok(())
 }
@@ -580,6 +612,20 @@ mod tests {
     }
 
     #[test]
+    fn required_paths_adds_deduplicated_serve_sources_after_run_roots() {
+        let config = r#"config := {
+  hosts: []
+  run: { paths: ["app/main.mec" "other.mec"] grants: [] }
+  serve: { paths: ["app/main.mec" "app/lib.mec" "other.mec" "shared/lib.mec"] }
+}"#;
+
+        assert_eq!(
+            required_path_strings(config).unwrap(),
+            vec!["app/main.mec", "other.mec", "app/lib.mec", "shared/lib.mec"]
+        );
+    }
+
+    #[test]
     fn required_paths_rejects_missing_run() {
         assert!(required_path_strings("config := { hosts: [] }").is_err());
     }
@@ -592,7 +638,6 @@ mod tests {
 
     #[test]
     fn from_sources_executes_paths_in_order() {
-        let mut runtime = RuntimeBuilder::new().build().unwrap();
         let document = parse_config_document(
             "test.mcfg",
             CONFIG,
@@ -602,7 +647,98 @@ mod tests {
         let mut sources = HashMap::new();
         sources.insert("a.mec".to_string(), "x := 1".to_string());
         sources.insert("b.mec".to_string(), "y := 2".to_string());
-        run_project_sources(&mut runtime, &document, &sources).unwrap();
+        let mut runtime = RuntimeBuilder::new()
+            .source_resolver(project_source_resolver(&sources).unwrap())
+            .build()
+            .unwrap();
+        run_project_sources(&mut runtime, &document).unwrap();
+    }
+
+    fn project_document(paths: &[&str]) -> MechConfigDocument {
+        let paths = paths
+            .iter()
+            .map(|path| format!("\"{path}\""))
+            .collect::<Vec<_>>()
+            .join(" ");
+        parse_config_document(
+            "test.mcfg",
+            &format!("config := {{ hosts: [] run: {{ paths: [{paths}] grants: [] }} }}"),
+            ConfigProfileOptions::default(),
+        )
+        .unwrap()
+    }
+
+    fn assert_f64(value: mech_core::Value, expected: f64) {
+        match value {
+            mech_core::Value::F64(value) => assert_eq!(*value.borrow(), expected),
+            mech_core::Value::MutableReference(value) => match &*value.borrow() {
+                mech_core::Value::F64(value) => assert_eq!(*value.borrow(), expected),
+                other => panic!("expected f64 value, got {other:?}"),
+            },
+            other => panic!("expected f64 value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn project_sources_resolve_sibling_and_parent_modules() {
+        let document = project_document(&["app/main.mec", "nested/main.mec"]);
+        let sources = HashMap::from([
+            (
+                "app/main.mec".to_string(),
+                "+> ./lib.mec\nanswer := lib/value + 1\nanswer\n".to_string(),
+            ),
+            ("app/lib.mec".to_string(), "value := 41\n<+ value\n".to_string()),
+            (
+                "nested/main.mec".to_string(),
+                "+> ../shared/lib.mec\nparent-answer := lib/value + 1\n".to_string(),
+            ),
+            ("shared/lib.mec".to_string(), "value := 41\n<+ value\n".to_string()),
+        ]);
+        let mut runtime = RuntimeBuilder::new()
+            .source_resolver(project_source_resolver(&sources).unwrap())
+            .build()
+            .unwrap();
+
+        run_project_sources(&mut runtime, &document).unwrap();
+
+        assert_f64(runtime.root_symbol_value("answer").unwrap(), 42.0);
+        assert_f64(runtime.root_symbol_value("parent-answer").unwrap(), 42.0);
+    }
+
+    #[test]
+    fn project_sources_report_missing_module_dependencies() {
+        let document = project_document(&["main.mec"]);
+        let sources = HashMap::from([(
+            "main.mec".to_string(),
+            "+> ./missing.mec\nanswer := 1\n".to_string(),
+        )]);
+        let mut runtime = RuntimeBuilder::new()
+            .source_resolver(project_source_resolver(&sources).unwrap())
+            .build()
+            .unwrap();
+
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert!(error
+            .kind_as::<mech_runtime::RuntimeModuleDependencyMissingError>()
+            .is_some());
+    }
+
+    #[test]
+    fn project_sources_only_execute_configured_roots() {
+        let document = project_document(&["first.mec", "second.mec"]);
+        let sources = HashMap::from([
+            ("first.mec".to_string(), "marker := 1\n".to_string()),
+            ("second.mec".to_string(), "answer := marker + 1\n".to_string()),
+            ("unused.mec".to_string(), "this is not valid Mech\n".to_string()),
+        ]);
+        let mut runtime = RuntimeBuilder::new()
+            .source_resolver(project_source_resolver(&sources).unwrap())
+            .build()
+            .unwrap();
+
+        run_project_sources(&mut runtime, &document).unwrap();
+
+        assert_f64(runtime.root_symbol_value("answer").unwrap(), 2.0);
     }
 
 
@@ -739,8 +875,11 @@ rows := |id<string> x<f64>|
   | "row-a" 1 + delta |
   | "row-b" 2 + delta |"#.to_string(),
         );
-        let mut runtime = RuntimeBuilder::new().build().unwrap();
-        run_project_sources(&mut runtime, &document, &sources).unwrap();
+        let mut runtime = RuntimeBuilder::new()
+            .source_resolver(project_source_resolver(&sources).unwrap())
+            .build()
+            .unwrap();
+        run_project_sources(&mut runtime, &document).unwrap();
     }
 
     #[derive(Debug)]
@@ -817,6 +956,7 @@ rows := |id<string> x<f64>|
 
         let scene_backend = mech_host_scene::RecordingSceneBackend::new();
         let mut builder = RuntimeBuilder::new()
+            .source_resolver(project_source_resolver(&generic_fixture_sources()).unwrap())
             .host_input_capacity(16)
             .host_factory(Box::new(TestManualTimerHostFactory::new())).unwrap()
             .host_factory(Box::new(mech_host_scene::SceneHostFactory::with_backend(scene_backend.clone()).unwrap())).unwrap();
@@ -827,7 +967,7 @@ rows := |id<string> x<f64>|
             builder = builder.run_resource_grant(grant.clone());
         }
         let mut runtime = builder.build().unwrap();
-        run_project_sources(&mut runtime, &document, &generic_fixture_sources()).unwrap();
+        run_project_sources(&mut runtime, &document).unwrap();
 
         let initial_scene = scene_backend.latest().unwrap();
         assert_eq!(initial_scene.circles.len(), 2);
@@ -869,8 +1009,7 @@ rows := |id<string> x<f64>|
             ConfigProfileOptions::default(),
         )
         .unwrap();
-        let sources = HashMap::new();
-        assert!(run_project_sources(&mut runtime, &document, &sources).is_err());
+        assert!(run_project_sources(&mut runtime, &document).is_err());
     }
     #[cfg(feature = "served_project_authority")]
     #[test]


### PR DESCRIPTION
## Context

Follow-up to the three unresolved v0.3.6 review findings. This PR deliberately does not reply to or resolve any threads on the original PR; it provides the implementation for separate review.

## 1. Typed host arguments

`host_arg_resolved` now repeatedly unwraps `Value::Typed` and `Value::MutableReference` until it reaches a concrete value. `is_empty_value` follows the same wrappers, so optional host arguments treat wrapped `Empty` as absent.

This keeps the existing scalar host helpers and their error behavior intact, while covering nested typed/reference values rather than adding per-helper special cases.

## 2. Overflowing config integers

Config-profile integer unary negation, addition, and subtraction now use `checked_neg`, `checked_add`, and `checked_sub`. Overflow returns a `ConfigProfileViolation` that identifies the operation; floating-point behavior is unchanged.

Coverage includes all three overflows and both integer boundary-value successes.

## 3. Browser project modules

Browser source maps are installed in `InMemorySourceResolver` and configured `run.paths` execute through `resolve_and_run_root_module`, rather than each source being evaluated with `run_string`.

The resolver supports `./` and `../` imports from `memory:` referrers, normalizes paths lexically without escaping the source-map root, and resolves aliases after normalization. The runtime adds parser/index metadata only for resolver results that do not already provide it, preserving the normal file-resolver path.

`WasmProject.requiredPaths` returns run roots first, then a stable de-duplicated `serve.paths` inventory. The served-project path also exposes run roots plus Mech sources found in its configured serve inventory, which is necessary for the normal served browser flow.

## 4. Served browser source inventory

Configured served projects now publish `/_mech/project-sources.json`, a version-1 source inventory generated directly from the server's concrete `project.source_paths`. Each entry retains distinct `specifier` and `url` fields, allowing a future static bundle to map module identities to different transport locations.

The manifest is registered after configured user assets, so a project file at that internal route cannot override it. The browser bootstrap resolves the manifest relative to `import.meta.url`; only a 404 falls back to `WasmProject.requiredPaths`. Valid manifest URLs continue through the existing `projectBase` source fetch behavior.

The Chrome smoke fixture now uses `serve.paths: ["app"]`, fetches the manifest before browser launch, and gives `app/clock.mec` a real relative `./support.mec` import.

## Validation

Passed:

- `git diff --check`
- `bash -n scripts/smoke-served-analog-clock-browser.sh`
- `cargo test -p mech-runtime --lib host_arg`
- `cargo test -p mech-runtime --test config_profile` (37 tests)
- `cargo test -p mech-runtime resolver::memory` (10 tests)
- `cargo test -p mech-runtime --test module_smoke` (232 tests)
- `cargo test -p mech-wasm --features browser_project` (22 tests)
- `cargo check -p mech-wasm --target wasm32-unknown-unknown --features browser_project`
- `(cd src/wasm && wasm-pack build --target web --dev --features browser_project)`
- `cargo build -p mech --bin mech`
- `cargo test -p mech --lib serve::tests::served_project_publishes_expanded_source_manifest_after_user_assets`
- `scripts/smoke-served-analog-clock-browser.sh`
- runtime and WASM browser feature-boundary checks, including no-default-feature configurations

`cargo test -p mech --lib serve::tests` currently hits the pre-existing `poll_workspace_once_updates_registry_after_manual_refresh` workspace-session failure, which then poisons that module's shared current-directory test lock; no fix for it is included here. `cargo fmt --all -- --check` still reports broad existing formatting drift, so no repository-wide formatting change was applied.