### PR TITLE
Fix REPL third Ctrl-C exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,18 @@ jobs:
           cargo check -p mech-runtime -p mech-host-browser -p mech-host-cli
           cargo check -p mech-host-cli --no-default-features
 
+      - name: Run REPL Ctrl-C regression
+        run: |
+          cargo test \
+            --no-default-features \
+            --features repl \
+            --test mech_repl_ctrlc
+
+          cargo test \
+            --no-default-features \
+            --features "repl mika" \
+            --test mech_repl_ctrlc
+
       - name: Disk report at end
         if: always()
         run: bash scripts/ci-disk-report.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,9 @@ matrix_vertcat = ["matrix"]
 [dev-dependencies]
 nalgebra = "0.34.1"
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
 [dependencies]
 mech-core        = { version = "0.3.5", default-features = false }
 mech-syntax      = { version = "0.3.5", default-features = false }

--- a/src/cli/commands/repl.rs
+++ b/src/cli/commands/repl.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "mika")]
 use std::thread;
@@ -65,17 +64,19 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
     println!("{} {}", micromika, intro_message);
 
     let caught_interrupts = Arc::new(Mutex::new(0));
-    let exit_requested = Arc::new(AtomicBool::new(false));
     let ci = caught_interrupts.clone();
-    let exit_requested_for_handler = exit_requested.clone();
     ctrlc::set_handler(move || {
         println!("{}", ctrlc_cmd);
-        let Ok(mut caught_interrupts) = ci.lock() else {
-            exit_requested_for_handler.store(true, Ordering::SeqCst);
-            return;
+        let should_exit = {
+            let mut caught_interrupts = match ci.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+
+            *caught_interrupts += 1;
+            *caught_interrupts >= 3
         };
-        *caught_interrupts += 1;
-        if *caught_interrupts >= 3 {
+        if should_exit {
             #[cfg(feature = "mika")]
             {
                 let final_state = ProgressBar::new_spinner();
@@ -94,8 +95,7 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
             #[cfg(not(feature = "mika"))]
             println!("Okay cya!");
 
-            exit_requested_for_handler.store(true, Ordering::SeqCst);
-            return;
+            std::process::exit(0);
         }
         println!(
             "\n{} {}Enter {} to terminate this REPL session.{}\n",
@@ -142,9 +142,6 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
     }));
 
     loop {
-        if exit_requested.load(Ordering::SeqCst) {
-            return Ok(CliOutcome::exit(0));
-        }
         {
             if let Ok(mut ci) = caught_interrupts.lock() {
                 *ci = 0;

--- a/tests/mech_repl_ctrlc.rs
+++ b/tests/mech_repl_ctrlc.rs
@@ -1,0 +1,261 @@
+#![cfg(all(unix, feature = "repl"))]
+
+use std::fs::{self, File};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+fn unique_temp_dir() -> PathBuf {
+    let temp_root = std::env::temp_dir();
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before the Unix epoch")
+        .as_nanos();
+
+    for attempt in 0..100 {
+        let path = temp_root.join(format!(
+            "mech-repl-ctrlc-{}-{timestamp}-{attempt}",
+            std::process::id()
+        ));
+        match fs::create_dir(&path) {
+            Ok(()) => return path,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => panic!(
+                "failed to create temporary directory {}: {error}",
+                path.display()
+            ),
+        }
+    }
+
+    panic!("failed to create a unique temporary directory")
+}
+
+fn captured_output(stdout_path: &Path, stderr_path: &Path) -> String {
+    let stdout = fs::read_to_string(stdout_path)
+        .unwrap_or_else(|error| format!("<failed to read stdout: {error}>"));
+    let stderr = fs::read_to_string(stderr_path)
+        .unwrap_or_else(|error| format!("<failed to read stderr: {error}>"));
+    format!("stdout:\n{stdout}\nstderr:\n{stderr}")
+}
+
+fn kill_and_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn fail_with_output(
+    child: &mut Child,
+    stdout_path: &Path,
+    stderr_path: &Path,
+    message: impl std::fmt::Display,
+) -> ! {
+    kill_and_reap(child);
+    panic!("{message}\n{}", captured_output(stdout_path, stderr_path),);
+}
+
+fn wait_for_stdout(
+    child: &mut Child,
+    stdout_path: &Path,
+    stderr_path: &Path,
+    timeout: Duration,
+    description: &str,
+    predicate: impl Fn(&str) -> bool,
+) {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let stdout = match fs::read_to_string(stdout_path) {
+            Ok(stdout) => stdout,
+            Err(error) => fail_with_output(
+                child,
+                stdout_path,
+                stderr_path,
+                format!("failed to read stdout while waiting for {description}: {error}"),
+            ),
+        };
+        if predicate(&stdout) {
+            return;
+        }
+
+        match child.try_wait() {
+            Ok(None) => {}
+            Ok(Some(status)) => fail_with_output(
+                child,
+                stdout_path,
+                stderr_path,
+                format!("child exited with {status} while waiting for {description}"),
+            ),
+            Err(error) => fail_with_output(
+                child,
+                stdout_path,
+                stderr_path,
+                format!("failed to poll child while waiting for {description}: {error}"),
+            ),
+        }
+
+        if Instant::now() >= deadline {
+            fail_with_output(
+                child,
+                stdout_path,
+                stderr_path,
+                format!("timed out waiting for {description}"),
+            );
+        }
+
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn wait_for_exit(
+    child: &mut Child,
+    stdout_path: &Path,
+    stderr_path: &Path,
+    timeout: Duration,
+) -> ExitStatus {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status,
+            Ok(None) => {}
+            Err(error) => fail_with_output(
+                child,
+                stdout_path,
+                stderr_path,
+                format!("failed to poll child while waiting for it to exit: {error}"),
+            ),
+        }
+
+        if Instant::now() >= deadline {
+            fail_with_output(
+                child,
+                stdout_path,
+                stderr_path,
+                "timed out waiting for child to exit",
+            );
+        }
+
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn assert_still_running(child: &mut Child, stdout_path: &Path, stderr_path: &Path) {
+    match child.try_wait() {
+        Ok(None) => {}
+        Ok(Some(status)) => fail_with_output(
+            child,
+            stdout_path,
+            stderr_path,
+            format!("child exited unexpectedly with {status}"),
+        ),
+        Err(error) => fail_with_output(
+            child,
+            stdout_path,
+            stderr_path,
+            format!("failed to poll child: {error}"),
+        ),
+    }
+}
+
+fn send_sigint(child: &mut Child, stdout_path: &Path, stderr_path: &Path) {
+    let pid = child.id();
+    // Safety: `pid` belongs to the live child process spawned by this test.
+    let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+    if result != 0 {
+        fail_with_output(
+            child,
+            stdout_path,
+            stderr_path,
+            format!("failed to send SIGINT: {}", io::Error::last_os_error()),
+        );
+    }
+}
+
+#[test]
+fn third_ctrl_c_exits_without_stdin_activity() {
+    let temp_dir = unique_temp_dir();
+    let stdout_path = temp_dir.join("stdout");
+    let stderr_path = temp_dir.join("stderr");
+    let stdout_file = File::create(&stdout_path).expect("failed to create stdout capture file");
+    let stderr_file = File::create(&stderr_path).expect("failed to create stderr capture file");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mech"))
+        .arg("--repl")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .expect("failed to spawn mech REPL");
+    let stdin: ChildStdin = child.stdin.take().expect("child stdin was not piped");
+
+    wait_for_stdout(
+        &mut child,
+        &stdout_path,
+        &stderr_path,
+        Duration::from_secs(5),
+        "the initial REPL prompt",
+        |stdout| stdout.contains(">: "),
+    );
+
+    send_sigint(&mut child, &stdout_path, &stderr_path);
+    wait_for_stdout(
+        &mut child,
+        &stdout_path,
+        &stderr_path,
+        Duration::from_secs(5),
+        "the first Ctrl-C warning",
+        |stdout| stdout.matches("to terminate this REPL session.").count() == 1,
+    );
+    assert_still_running(&mut child, &stdout_path, &stderr_path);
+
+    send_sigint(&mut child, &stdout_path, &stderr_path);
+    wait_for_stdout(
+        &mut child,
+        &stdout_path,
+        &stderr_path,
+        Duration::from_secs(5),
+        "the second Ctrl-C warning",
+        |stdout| stdout.matches("to terminate this REPL session.").count() == 2,
+    );
+    assert_still_running(&mut child, &stdout_path, &stderr_path);
+
+    send_sigint(&mut child, &stdout_path, &stderr_path);
+    let status = wait_for_exit(
+        &mut child,
+        &stdout_path,
+        &stderr_path,
+        Duration::from_secs(10),
+    );
+    drop(stdin);
+
+    let stdout = fs::read_to_string(&stdout_path).expect("failed to read captured stdout");
+    let stderr = fs::read_to_string(&stderr_path).expect("failed to read captured stderr");
+    let combined_output = format!("stdout:\n{stdout}\nstderr:\n{stderr}");
+    let warning_count = stdout.matches("to terminate this REPL session.").count();
+
+    assert!(
+        status.success(),
+        "child did not exit successfully: {status}\n{combined_output}",
+    );
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "child did not exit with code 0\n{combined_output}",
+    );
+    assert_eq!(
+        warning_count, 2,
+        "expected exactly two Ctrl-C warnings\n{combined_output}",
+    );
+
+    #[cfg(not(feature = "mika"))]
+    assert!(
+        combined_output.contains("Okay cya!"),
+        "expected the non-Mika farewell\n{combined_output}",
+    );
+
+    fs::remove_dir_all(temp_dir).expect("failed to remove temporary directory");
+}


### PR DESCRIPTION
## Problem

Pressing Ctrl+C three times in a row should terminate the REPL. Before this change, the third interrupt displayed Mika’s farewell animation (or `Okay cya!` without Mika) but left the `mech` process running whenever it was blocked waiting for stdin.

The failure was a mismatch between the interrupt handler and the REPL loop:

1. The Ctrl+C handler set an `AtomicBool` after the third interrupt.
2. The REPL loop checked that flag only before its next `stdin.read_line` call.
3. With no submitted input, `read_line` remained blocked indefinitely, so the loop never observed the flag.

The visible goodbye therefore succeeded, but control was never returned to the terminal.

## Change

### REPL exit path

- Remove the cooperative `exit_requested` atomic flag and its loop-level check.
- Keep the existing mutex-backed consecutive-interrupt counter and its existing reset behavior after submitted input.
- Recover from a poisoned counter mutex in the Ctrl+C callback, then release the mutex before printing or animating.
- On the third consecutive interrupt, retain the existing Mika animation and non-Mika `Okay cya!` text unchanged, then call `std::process::exit(0)` directly.

This makes termination independent of stdin becoming readable while leaving the first- and second-interrupt guidance, `:quit`, prompt rendering, `CliOutcome`, runtime shutdown behavior, and all other CLI paths unchanged.

### Regression coverage

Add `tests/mech_repl_ctrlc.rs`, gated to Unix REPL builds. The test:

- starts `mech --repl` using `CARGO_BIN_EXE_mech`;
- keeps the piped stdin handle open but never writes a byte or newline;
- waits for the initial prompt before signaling;
- sends SIGINT three times, synchronizing each subsequent signal by waiting for the previous warning text to avoid signal coalescing;
- verifies that the child remains running after the first and second signals;
- verifies that the third signal exits successfully with status code `0`;
- checks that the warning appears exactly twice and that non-Mika output contains `Okay cya!`;
- captures stdout and stderr for timeout/failure diagnostics and cleans up its temporary directory.

The test has fixed five-second output deadlines and a ten-second exit deadline. Any polling failure kills and reaps the test child before reporting captured output.

### CI

Ubuntu CI now runs the regression test in both minimal REPL configurations:

```text
--no-default-features --features repl
--no-default-features --features "repl mika"
```

The Unix signal test is intentionally not added to Windows CI. `libc = "0.2"` is added only as a Unix target-specific development dependency.

## Validation

Passed locally:

- `cargo test --no-default-features --features repl --test mech_repl_ctrlc`
- `cargo test --no-default-features --features "repl mika" --test mech_repl_ctrlc`
- `cargo test --features "run repl pretty_print" --test mech_cli_host` (37 tests)
- `cargo check --bin mech --no-default-features --features repl`
- `cargo check --bin mech --no-default-features --features "repl mika"`
- `git diff --check`

`cargo fmt --all` was run. `cargo fmt --all -- --check` still reports pre-existing repository-wide formatting drift (the baseline uses two-space formatting and missing final newlines); this PR deliberately excludes unrelated formatting changes.

## Scope

This is a REPL-only fix. It does not alter CLI dispatch, `CliOutcome` routing outside the REPL, server shutdown handling, runtime shutdown behavior, prompt text, interrupt thresholds, or Mika animation content/timing.