### PR TITLE
fix(runtime): harden validation boundaries

### DIFF
--- a/src/cli/commands/repl.rs
+++ b/src/cli/commands/repl.rs
@@ -121,6 +121,7 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
             let config = startup
                 .runtime_config
                 .unwrap_or_else(RuntimeConfig::default);
+            config.validate()?;
             let mut repl_program = MechProgram::new(MechProgramConfig {
                 name: config.name.clone(),
                 environment: MechProgramEnvironment::default(),
@@ -129,7 +130,7 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
                 config.diagnostics.debug_enabled,
                 config.diagnostics.trace_enabled,
                 config.diagnostics.profile_enabled,
-                config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+                config.limits.max_steps_per_turn_as_usize()?,
             );
             MechRepl::from(repl_program)
         }

--- a/src/runtime/examples/dep_cycle.rs
+++ b/src/runtime/examples/dep_cycle.rs
@@ -7,6 +7,7 @@ use mech_runtime::{
   ResolvedSource,
   RuntimeBuilder,
   ModuleBuildOptions,
+  SourceKind,
   SourceRequest,
   SourceResolver,
 };
@@ -18,20 +19,19 @@ struct CycleSourceResolver {
 
 impl CycleSourceResolver {
   fn new() -> Self {
-    let mut a = ResolvedSource::new(
+    let a = ResolvedSource::new(
       "a",
       "memory://cycle/a.mec",
-      MechSourceCode::String("a := 1\na".to_string()),
-    );
+      MechSourceCode::String("+> b.mec\na := 1\na".to_string()),
+    )
+    .with_kind(SourceKind::Mech);
 
-    let mut b = ResolvedSource::new(
+    let b = ResolvedSource::new(
       "b",
       "memory://cycle/b.mec",
-      MechSourceCode::String("b := 2\nb".to_string()),
-    );
-
-    a.dependencies.push(SourceRequest::new("b.mec"));
-    b.dependencies.push(SourceRequest::new("a.mec"));
+      MechSourceCode::String("+> a.mec\nb := 2\nb".to_string()),
+    )
+    .with_kind(SourceKind::Mech);
 
     let mut sources = HashMap::new();
     sources.insert("a.mec".to_string(), a);

--- a/src/runtime/examples/dep_diamond.rs
+++ b/src/runtime/examples/dep_diamond.rs
@@ -8,6 +8,7 @@ use mech_runtime::{
   ResolvedSource,
   RuntimeBuilder,
   ModuleBuildOptions,
+  SourceKind,
   SourceRequest,
   SourceResolver,
 };
@@ -40,56 +41,56 @@ impl DiamondSourceResolver {
   }
 
   fn root_source() -> ResolvedSource {
-    let mut source = ResolvedSource::new(
+    let source = ResolvedSource::new(
       "root",
       "memory://diamond/root.mec",
       MechSourceCode::String(
         r#"
+          +> a.mec
+          +> b.mec
           root := 1
           root
         "#
         .to_string(),
       ),
-    );
-
-    source.dependencies.push(SourceRequest::new("a.mec"));
-    source.dependencies.push(SourceRequest::new("b.mec"));
+    )
+    .with_kind(SourceKind::Mech);
 
     source
   }
 
   fn a_source() -> ResolvedSource {
-    let mut source = ResolvedSource::new(
+    let source = ResolvedSource::new(
       "a",
       "memory://diamond/a.mec",
       MechSourceCode::String(
         r#"
+          +> shared.mec
           a := 10
           a
         "#
         .to_string(),
       ),
-    );
-
-    source.dependencies.push(SourceRequest::new("shared.mec"));
+    )
+    .with_kind(SourceKind::Mech);
 
     source
   }
 
   fn b_source() -> ResolvedSource {
-    let mut source = ResolvedSource::new(
+    let source = ResolvedSource::new(
       "b",
       "memory://diamond/b.mec",
       MechSourceCode::String(
         r#"
+          +> shared.mec
           b := 20
           b
         "#
         .to_string(),
       ),
-    );
-
-    source.dependencies.push(SourceRequest::new("shared.mec"));
+    )
+    .with_kind(SourceKind::Mech);
 
     source
   }
@@ -110,6 +111,7 @@ impl DiamondSourceResolver {
         ),
       ),
     )
+    .with_kind(SourceKind::Mech)
   }
 }
 

--- a/src/runtime/examples/runtime_dep_src.rs
+++ b/src/runtime/examples/runtime_dep_src.rs
@@ -8,7 +8,7 @@ use mech_runtime::{
   ResolvedSource,
   RuntimeBuilder,
   ModuleBuildOptions,
-  SourceRequest,
+  SourceKind,
 };
 
 fn short_text(text: &str) -> String {
@@ -58,19 +58,19 @@ fn main() -> MResult<()> {
     .runtime_context()?
     .with_subject("program:runtime-dependency-source");
 
-  let mut resolved = ResolvedSource::new(
+  let resolved = ResolvedSource::new(
     "index",
     "memory://runtime-dependency-source-demo/index.mec",
     MechSourceCode::String(
       r#"
+        +> dep.mec
         x := 41 + 1
         x
       "#
       .to_string(),
     ),
-  );
-
-  resolved.dependencies.push(SourceRequest::new("dep.mec"));
+  )
+  .with_kind(SourceKind::Mech);
 
   let target = runtime_target();
   let options = ModuleBuildOptions::new(

--- a/src/runtime/src/capability/basic.rs
+++ b/src/runtime/src/capability/basic.rs
@@ -261,7 +261,12 @@ impl Capability for BasicCapability {
       return Ok(CapabilityDecision::deny("capability is local-only"));
     }
 
-    if let (Some(max), Some(actual)) = (self.constraints.max_bytes, request.context.bytes) {
+    if let Some(max) = self.constraints.max_bytes {
+      let Some(actual) = request.context.bytes else {
+        return Ok(CapabilityDecision::deny(
+          "byte limit requires request byte count",
+        ));
+      };
       if actual > max {
         return Ok(CapabilityDecision::deny(format!(
           "byte limit exceeded: max {}, actual {}",
@@ -270,7 +275,12 @@ impl Capability for BasicCapability {
       }
     }
 
-    if let (Some(max), Some(actual)) = (self.constraints.max_items, request.context.items) {
+    if let Some(max) = self.constraints.max_items {
+      let Some(actual) = request.context.items else {
+        return Ok(CapabilityDecision::deny(
+          "item limit requires request item count",
+        ));
+      };
       if actual > max {
         return Ok(CapabilityDecision::deny(format!(
           "item limit exceeded: max {}, actual {}",
@@ -279,9 +289,12 @@ impl Capability for BasicCapability {
       }
     }
 
-    if let (Some(max), Some(actual)) =
-      (self.constraints.max_duration_ms, request.context.duration_ms)
-    {
+    if let Some(max) = self.constraints.max_duration_ms {
+      let Some(actual) = request.context.duration_ms else {
+        return Ok(CapabilityDecision::deny(
+          "duration limit requires request duration",
+        ));
+      };
       if actual > max {
         return Ok(CapabilityDecision::deny(format!(
           "duration limit exceeded: max {}ms, actual {}ms",

--- a/src/runtime/src/capability/mod.rs
+++ b/src/runtime/src/capability/mod.rs
@@ -304,6 +304,43 @@ mod tests {
   }
 
   #[test]
+  fn constrained_capability_denies_missing_metrics() {
+    let subject = BasicSubject::new("task://1");
+    let resource = BasicResource::new("db://users");
+    let cap = BasicCapability::new(
+      CapabilityId(1),
+      &subject,
+      &resource,
+      [BasicOperation::read()],
+    )
+    .with_constraints(
+      BasicConstraints::default()
+        .with_max_bytes(10)
+        .with_max_items(2)
+        .with_max_duration_ms(100),
+    );
+
+    let request = CapabilityRequest::new(&subject, &BasicOperation::read(), &resource);
+    assert!(!cap.check(&request).unwrap().allowed);
+
+    let request = request.with_context(CapabilityContext::local().with_bytes(10));
+    assert!(!cap.check(&request).unwrap().allowed);
+
+    let request = request.with_context(
+      CapabilityContext::local().with_bytes(10).with_items(2),
+    );
+    assert!(!cap.check(&request).unwrap().allowed);
+
+    let request = request.with_context(
+      CapabilityContext::local()
+        .with_bytes(10)
+        .with_items(2)
+        .with_duration_ms(100),
+    );
+    assert!(cap.check(&request).unwrap().allowed);
+  }
+
+  #[test]
   fn attenuation_cannot_relax_local_only() {
     let subject = BasicSubject::new("task://1");
     let resource = BasicResource::new("db://users");

--- a/src/runtime/src/config.rs
+++ b/src/runtime/src/config.rs
@@ -207,6 +207,7 @@ impl RuntimeLimits {
 
   pub fn validate(&self) -> MResult<()> {
     require_nonzero_opt("limits.max_steps_per_turn", self.max_steps_per_turn)?;
+    self.max_steps_per_turn_as_usize()?;
     require_nonzero_opt("limits.max_turn_duration_ms", self.max_turn_duration_ms)?;
     require_nonzero_opt("limits.max_memory_bytes", self.max_memory_bytes)?;
     require_nonzero_opt("limits.max_tasks", self.max_tasks)?;
@@ -215,6 +216,24 @@ impl RuntimeLimits {
     require_nonzero_opt("limits.max_source_bytes", self.max_source_bytes)?;
     require_nonzero_opt("limits.max_in_memory_events", self.max_in_memory_events)?;
     Ok(())
+  }
+
+  /// Returns the interpreter step limit in its native counter type.
+  ///
+  /// A missing limit preserves the existing 10,000-round fallback.
+  pub fn max_steps_per_turn_as_usize(&self) -> MResult<usize> {
+    match self.max_steps_per_turn {
+      Some(value) => usize::try_from(value).map_err(|_| {
+        MechError::new(
+          InvalidRuntimeConfigValue {
+            field: "limits.max_steps_per_turn",
+            reason: "must fit the target architecture".to_string(),
+          },
+          None,
+        )
+      }),
+      None => Ok(10_000),
+    }
   }
 }
 
@@ -326,6 +345,28 @@ mod tests {
     config.limits.max_steps_per_turn = Some(0);
 
     assert!(config.validate().is_err());
+  }
+
+  #[test]
+  fn step_limit_must_fit_the_target_architecture() {
+    let mut config = RuntimeConfig::default();
+    let target_max = u64::try_from(usize::MAX).unwrap();
+
+    config.limits.max_steps_per_turn = Some(target_max);
+    assert!(config.validate().is_ok());
+
+    if let Some(too_large) = target_max.checked_add(1) {
+      config.limits.max_steps_per_turn = Some(too_large);
+      assert!(config.validate().is_err());
+    }
+  }
+
+  #[test]
+  fn missing_step_limit_uses_existing_fallback() {
+    let mut limits = RuntimeLimits::default();
+    limits.max_steps_per_turn = None;
+
+    assert_eq!(limits.max_steps_per_turn_as_usize().unwrap(), 10_000);
   }
 
 }

--- a/src/runtime/src/module/builder.rs
+++ b/src/runtime/src/module/builder.rs
@@ -156,3 +156,51 @@ impl MechErrorKind for NonExecutableModuleSource {
     )
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use mech_core::MechSourceCode;
+
+  fn build(resolved: ResolvedSource) -> MResult<RuntimeModuleRecord> {
+    ModuleBuilder::new().build_resolved_source(
+      resolved,
+      "test",
+      "v0.3",
+      "native",
+      &[],
+      &[],
+      &[],
+    )
+  }
+
+  #[test]
+  fn rejects_non_executable_source_kind() {
+    let error = build(
+      ResolvedSource::new(
+        "style.css",
+        "memory://style.css",
+        MechSourceCode::String("body { color: red; }".to_string()),
+      )
+      .with_kind(crate::SourceKind::Css),
+    )
+    .unwrap_err();
+
+    assert!(error.kind_as::<NonExecutableModuleSource>().is_some());
+  }
+
+  #[test]
+  fn rejects_non_executable_source_representation() {
+    let error = build(
+      ResolvedSource::new(
+        "main.mec",
+        "memory://main.mec",
+        MechSourceCode::Html("<p>not Mech code</p>".to_string()),
+      )
+      .with_kind(crate::SourceKind::Mech),
+    )
+    .unwrap_err();
+
+    assert!(error.kind_as::<NonExecutableModuleSource>().is_some());
+  }
+}

--- a/src/runtime/src/resolver/file.rs
+++ b/src/runtime/src/resolver/file.rs
@@ -191,7 +191,12 @@ impl SourceResolver for FileSourceResolver {
     };
 
     let kind = SourceKind::from_path(&path);
-    let source = read_runtime_source_file_with_capabilities(&path, self.capability_kernel.as_ref(), self.capability_subject.as_deref())?;
+    let source = read_runtime_source_file_with_capabilities_and_import_checks(
+      &path,
+      self.capability_kernel.as_ref(),
+      self.capability_subject.as_deref(),
+      request.referrer.is_some(),
+    )?;
     let name = path
       .file_name()
       .and_then(|name| name.to_str())
@@ -472,6 +477,15 @@ pub fn read_runtime_source_file(path: &Path) -> MResult<MechSourceCode> {
 }
 
 pub fn read_runtime_source_file_with_capabilities(path: &Path, kernel: Option<&SharedCapabilityKernel>, subject: Option<&str>) -> MResult<MechSourceCode> {
+  read_runtime_source_file_with_capabilities_and_import_checks(path, kernel, subject, false)
+}
+
+fn read_runtime_source_file_with_capabilities_and_import_checks(
+  path: &Path,
+  kernel: Option<&SharedCapabilityKernel>,
+  subject: Option<&str>,
+  require_import_for_includes: bool,
+) -> MResult<MechSourceCode> {
   check_optional_fs(kernel, subject, FS_READ, path)?;
   let extension = path
     .extension()
@@ -488,7 +502,12 @@ pub fn read_runtime_source_file_with_capabilities(path: &Path, kernel: Option<&S
 
   match extension.as_str() {
     "mec" | "🤖" => {
-      let expanded = expand_mechdown_includes_with_capabilities(path, kernel, subject)?;
+      let expanded = expand_mechdown_includes_with_capabilities_and_import_checks(
+        path,
+        kernel,
+        subject,
+        require_import_for_includes,
+      )?;
       Ok(MechSourceCode::String(expanded))
     }
 
@@ -578,9 +597,24 @@ pub fn read_file_bytes(path: &Path) -> MResult<Vec<u8>> {
 pub fn expand_mechdown_includes(path: &Path) -> MResult<String> { expand_mechdown_includes_with_capabilities(path, None, None) }
 
 pub fn expand_mechdown_includes_with_capabilities(path: &Path, kernel: Option<&SharedCapabilityKernel>, subject: Option<&str>) -> MResult<String> {
+  expand_mechdown_includes_with_capabilities_and_import_checks(path, kernel, subject, false)
+}
+
+fn expand_mechdown_includes_with_capabilities_and_import_checks(
+  path: &Path,
+  kernel: Option<&SharedCapabilityKernel>,
+  subject: Option<&str>,
+  require_import_for_includes: bool,
+) -> MResult<String> {
   let canonical = canonicalize_source_path(path)?;
   let mut active = HashSet::new();
-  expand_mechdown_includes_inner(&canonical, &mut active, kernel, subject)
+  expand_mechdown_includes_inner(
+    &canonical,
+    &mut active,
+    kernel,
+    subject,
+    require_import_for_includes,
+  )
 }
 
 fn expand_mechdown_includes_inner(
@@ -588,6 +622,7 @@ fn expand_mechdown_includes_inner(
   active: &mut HashSet<PathBuf>,
   kernel: Option<&SharedCapabilityKernel>,
   subject: Option<&str>,
+  require_import_for_includes: bool,
 ) -> MResult<String> {
   let canonical = canonicalize_source_path(path)?;
 
@@ -609,6 +644,7 @@ fn expand_mechdown_includes_inner(
     active,
     kernel,
     subject,
+    require_import_for_includes,
   )?;
 
   active.remove(&canonical);
@@ -622,6 +658,7 @@ fn expand_mechdown_include_tokens(
   active: &mut HashSet<PathBuf>,
   kernel: Option<&SharedCapabilityKernel>,
   subject: Option<&str>,
+  require_import_for_includes: bool,
 ) -> MResult<String> {
   let mut result = String::new();
 
@@ -649,8 +686,18 @@ fn expand_mechdown_include_tokens(
             )
           })?;
 
+        if require_import_for_includes {
+          check_optional_fs(kernel, subject, FS_IMPORT, &include_canonical)?;
+        }
+
         let include_source =
-          expand_mechdown_includes_inner(&include_canonical, active, kernel, subject)?;
+          expand_mechdown_includes_inner(
+            &include_canonical,
+            active,
+            kernel,
+            subject,
+            require_import_for_includes,
+          )?;
 
         result.push_str(&include_source);
 
@@ -958,4 +1005,36 @@ mod capability_tests {
 
   #[test]
   fn denies_include_outside_grant() { let root = temp_root("include"); let allowed = root.join("allowed"); let outside = root.join("outside"); std::fs::create_dir_all(&allowed).unwrap(); std::fs::create_dir_all(&outside).unwrap(); std::fs::write(allowed.join("main.mec"), "{../outside/secret.mec}\n").unwrap(); std::fs::write(outside.join("secret.mec"), "x := 2\n").unwrap(); let resolver = resolver(&root, &allowed); assert!(resolver.resolve(&SourceRequest::new("allowed/main.mec")).is_err()); std::fs::remove_dir_all(root).unwrap(); }
+
+  #[test]
+  fn imported_source_requires_import_capability_for_each_include() {
+    let root = temp_root("nested-import-include");
+    let allowed = root.join("allowed");
+    std::fs::create_dir_all(&allowed).unwrap();
+
+    let main = allowed.join("main.mec");
+    let child = allowed.join("child.mec");
+    let grandchild = allowed.join("grandchild.mec");
+    std::fs::write(&main, "{child.mec}\n").unwrap();
+    std::fs::write(&child, "{grandchild.mec}\n").unwrap();
+    std::fs::write(&grandchild, "x := 1\n").unwrap();
+
+    let mut ids = SequentialIdGenerator::new();
+    let mut authority = HostFilesystemAuthority::new(MECH_TOOL_SUBJECT, SharedCapabilityKernel::new());
+    authority.grant_path(&mut ids, &allowed, true, [FS_READ, FS_RESOLVE]).unwrap();
+    authority.grant_path(&mut ids, &main, false, [FS_IMPORT]).unwrap();
+    authority.grant_path(&mut ids, &child, false, [FS_IMPORT]).unwrap();
+    authority.delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &allowed, true, [FS_READ, FS_RESOLVE]).unwrap();
+    authority.delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &main, false, [FS_IMPORT]).unwrap();
+    authority.delegate_path_to(&mut ids, SERVE_HOST_SUBJECT, &child, false, [FS_IMPORT]).unwrap();
+    let resolver = FileSourceResolver::new(&root)
+      .with_capabilities(authority.kernel().clone(), SERVE_HOST_SUBJECT);
+
+    assert!(resolver.resolve(&SourceRequest::new("allowed/main.mec")).is_ok());
+    assert!(resolver
+      .resolve(&SourceRequest::new("allowed/main.mec").with_referrer("memory://parent.mec"))
+      .is_err());
+
+    std::fs::remove_dir_all(root).unwrap();
+  }
 }

--- a/src/runtime/src/resolver/mod.rs
+++ b/src/runtime/src/resolver/mod.rs
@@ -375,7 +375,7 @@ impl ResolvedSource {
   }
 
   pub fn is_executable_mech_source(&self) -> bool {
-    matches!(
+    self.kind.is_executable_mech() && matches!(
       self.source,
       MechSourceCode::String(_)
         | MechSourceCode::Tree(_)
@@ -540,8 +540,20 @@ mod tests {
       "main",
       "memory:main",
       MechSourceCode::String("x := 1".to_string()),
-    );
+    )
+    .with_kind(SourceKind::Mech);
 
     assert!(source.is_executable_mech_source());
+  }
+
+  #[test]
+  fn resolved_source_default_kind_is_not_executable() {
+    let source = ResolvedSource::new(
+      "main",
+      "memory:main",
+      MechSourceCode::String("x := 1".to_string()),
+    );
+
+    assert!(!source.is_executable_mech_source());
   }
 }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3663,7 +3663,7 @@ impl MechRuntime {
         trace_enabled: self.config.diagnostics.trace_enabled,
         debug_enabled: self.config.diagnostics.debug_enabled,
         profile_enabled: self.config.diagnostics.profile_enabled,
-        rounds_per_step: self.config.limits.max_steps_per_turn.unwrap_or(10_000) as usize,
+        rounds_per_step: self.config.limits.max_steps_per_turn_as_usize()?,
       },
     });
 

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -450,11 +450,7 @@ impl RuntimeBuilder {
         trace_enabled: self.config.diagnostics.trace_enabled,
         debug_enabled: self.config.diagnostics.debug_enabled,
         profile_enabled: self.config.diagnostics.profile_enabled,
-        rounds_per_step: self
-          .config
-          .limits
-          .max_steps_per_turn
-          .unwrap_or(10_000) as usize,
+        rounds_per_step: self.config.limits.max_steps_per_turn_as_usize()?,
       },
     };
 

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -15,7 +15,7 @@
 // - `active_module_version`: Retrieves the active version of a module, if any.
 
 use super::*;
-use crate::SourceIndex;
+use crate::{NonExecutableModuleSource, SourceIndex};
 
 fn source_index_for_module_record_source(
   source: &mech_core::MechSourceCode,
@@ -272,6 +272,16 @@ impl MechRuntime {
   ) -> MResult<ModuleVersionId> {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
+
+    if !resolved.is_executable_mech_source() {
+      return Err(MechError::new(
+        NonExecutableModuleSource {
+          canonical_uri: resolved.canonical_uri.clone(),
+        },
+        None,
+      ));
+    }
+
     self.enforce_source_limits(context, &resolved.source)?;
 
     let canonical_uri = resolved.canonical_uri.clone();
@@ -588,7 +598,8 @@ impl MechRuntime {
       name,
       canonical_uri,
       MechSourceCode::String(source.to_string()),
-    );
+    )
+    .with_kind(crate::SourceKind::Mech);
 
     self.build_module_from_resolved_source_with_context(
       context,
@@ -689,5 +700,27 @@ mod tests {
       .unwrap()
       .iter()
       .all(|event| !matches!(event.kind, RuntimeEventKind::ModuleCompiled { .. })));
+  }
+
+  #[test]
+  fn non_executable_module_source_is_rejected_before_indexing() {
+    let mut runtime = MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let resolved = ResolvedSource::new(
+      "style.css",
+      "memory://style.css",
+      MechSourceCode::String("not valid Mech source".to_string()),
+    )
+    .with_kind(SourceKind::Css);
+
+    let error = runtime
+      .build_module_from_resolved_source_with_context(
+        &mut context,
+        resolved,
+        ModuleBuildOptions::new("test", "v0.3", "native", &[], &[]),
+      )
+      .unwrap_err();
+
+    assert!(error.kind_as::<NonExecutableModuleSource>().is_some());
   }
 }

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -4616,6 +4616,7 @@ fn module_function_unknown_address_target_is_preflighted_before_send() {
   let version = runtime
     .store_resolved_module_source(
       ResolvedSource::new("main.mec", "memory://main.mec", MechSourceCode::Tree(tree))
+        .with_kind(SourceKind::Mech)
         .with_imports(index.all_imports())
         .with_exports(index.all_exports())
         .with_contexts(index.all_contexts())


### PR DESCRIPTION
## Summary

Closes four runtime-validation findings from release PR #581:

- fail closed when constrained capability metrics are absent;
- reject max step counts that do not fit the target architecture;
- enforce `FS_IMPORT` on every recursive include edge of an imported source;
- reject non-executable source kinds during module construction.

## Scope

This PR intentionally does not address the remaining dynamic-kernel, host-argument, capability-grant rollback, or worker-restart findings.

## Behavioral decisions

- Missing constrained metrics deny authorization.
- `max_steps_per_turn = None` preserves the existing 10,000-round fallback.
- Recursive include import checks apply when the containing source was resolved as a dependency.
- Root include behavior is unchanged.
- Executability requires both an executable `SourceKind` and an executable `MechSourceCode` representation.
- `ResolvedSource::new` retains its non-executable default kind.

## Validation

- `cargo test -p mech-runtime --test module_smoke` — passed (232 tests).
- Focused regression tests for all four findings — passed.
- `cargo test -p mech-runtime` — 322 passed; 3 pre-existing filesystem-watch failures due to `/var` versus `/private/var` canonicalization.
- `git diff --check` — passed.
- `cargo fmt --check` — reports repository-wide existing formatting drift; no broad formatting changes were applied.