### PR TITLE
[v0.4] Normalize compound host arguments and recover native workers

### DIFF
--- a/hosts/time/src/native.rs
+++ b/hosts/time/src/native.rs
@@ -26,6 +26,14 @@ impl TimeBackend for NativeTimeBackend {
   }
 }
 
+struct WorkerLiveReset(Arc<AtomicBool>);
+
+impl Drop for WorkerLiveReset {
+  fn drop(&mut self) {
+    self.0.store(false, Ordering::SeqCst);
+  }
+}
+
 pub struct NativeTimeInputDriver<B>
 where
   B: TimeBackend + Send + Sync,
@@ -70,6 +78,32 @@ where
       stop_sender: Arc::new(Mutex::new(None)),
     }
   }
+
+  fn prepare_worker_start(&mut self) -> MResult<bool> {
+    let mut stop_sender_guard = self.stop_sender.lock().map_err(|_| time_error("TimeDriverStart", "time stop-signal lock is poisoned"))?;
+    let mut worker_guard = self.worker.lock().map_err(|_| time_error("TimeDriverStart", "time worker lock is poisoned"))?;
+
+    if self.live.load(Ordering::SeqCst) && worker_guard.as_ref().is_some_and(|handle| !handle.is_finished()) {
+      return Ok(true);
+    }
+
+    let stop_sender = stop_sender_guard.take();
+    let worker = worker_guard.take();
+    drop(worker_guard);
+    drop(stop_sender_guard);
+
+    self.live.store(false, Ordering::SeqCst);
+
+    if let Some(sender) = stop_sender {
+      let _ = sender.send(());
+    }
+
+    if let Some(handle) = worker {
+      handle.join().map_err(|_| time_error("TimeDriverStart", "native time worker panicked before restart"))?;
+    }
+
+    Ok(false)
+  }
 }
 
 impl<B> RuntimeHostInputDriver for NativeTimeInputDriver<B>
@@ -93,14 +127,12 @@ where
   }
 
   fn start(&mut self) -> MResult<()> {
-    if self.is_live() && self.worker.lock().map_err(|_| time_error("TimeDriverStart", "time worker lock is poisoned"))?.is_some() {
+    if self.prepare_worker_start()? {
       return Ok(());
     }
     let ingress = self.ingress.lock().map_err(|_| time_error("TimeDriverStart", "time ingress lock is poisoned"))?
       .clone()
       .ok_or_else(|| time_error("TimeDriverStart", "native time driver must be attached before start"))?;
-    let mut worker_guard = self.worker.lock().map_err(|_| time_error("TimeDriverStart", "time worker lock is poisoned"))?;
-    if worker_guard.is_some() { return Ok(()); }
     let (stop_sender, stop_receiver) = mpsc::channel();
     *self.stop_sender.lock().map_err(|_| time_error("TimeDriverStart", "time stop-signal lock is poisoned"))? = Some(stop_sender);
     self.live.store(true, Ordering::SeqCst);
@@ -109,7 +141,8 @@ where
     let snapshot = self.snapshot.clone();
     let interval = self.interval;
     let instance = self.instance.clone();
-    *worker_guard = Some(thread::spawn(move || {
+    let worker = thread::spawn(move || {
+      let _live_reset = WorkerLiveReset(live.clone());
       while live.load(Ordering::SeqCst) {
         match backend.snapshot() {
           Ok(next) => {
@@ -142,8 +175,8 @@ where
           Err(RecvTimeoutError::Timeout) => {}
         }
       }
-      live.store(false, Ordering::SeqCst);
-    }));
+    });
+    *self.worker.lock().map_err(|_| time_error("TimeDriverStart", "time worker lock is poisoned"))? = Some(worker);
     Ok(())
   }
 
@@ -168,6 +201,127 @@ where
   B: TimeBackend + Send + Sync,
 {
   fn drop(&mut self) { let _ = self.stop(); }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::atomic::AtomicUsize;
+  use std::time::Instant;
+
+  use super::*;
+
+  fn snapshot() -> TimeSnapshot {
+    TimeSnapshot {
+      unix_ms: 1.0,
+      hour: 2.0,
+      minute: 3.0,
+      second: 4.0,
+      millisecond: 5.0,
+    }
+  }
+
+  fn wait_for_finished_worker<B>(driver: &NativeTimeInputDriver<B>)
+  where
+    B: TimeBackend + Send + Sync,
+  {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+      let finished = driver.worker.lock().unwrap().as_ref().is_some_and(|handle| handle.is_finished());
+      if finished {
+        return;
+      }
+      assert!(Instant::now() < deadline, "timed out waiting for native time worker to finish");
+      thread::sleep(Duration::from_millis(5));
+    }
+  }
+
+  fn wait_for_pending_inputs(runtime: &mech_runtime::MechRuntime, count: usize) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while runtime.pending_host_input_count().unwrap() < count {
+      assert!(Instant::now() < deadline, "timed out waiting for native time input");
+      thread::sleep(Duration::from_millis(5));
+    }
+  }
+
+  #[derive(Clone, Debug)]
+  struct FailingThenWorkingBackend {
+    calls: Arc<AtomicUsize>,
+  }
+
+  impl TimeBackend for FailingThenWorkingBackend {
+    fn snapshot(&self) -> MResult<TimeSnapshot> {
+      if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+        Err(time_error("TimeBackend", "test backend failure"))
+      } else {
+        Ok(snapshot())
+      }
+    }
+  }
+
+  #[derive(Clone, Debug)]
+  struct PanickingThenWorkingBackend {
+    calls: Arc<AtomicUsize>,
+  }
+
+  impl TimeBackend for PanickingThenWorkingBackend {
+    fn snapshot(&self) -> MResult<TimeSnapshot> {
+      if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+        panic!("test time backend panic");
+      }
+      Ok(snapshot())
+    }
+  }
+
+  #[test]
+  fn restart_after_backend_error_replaces_exited_worker() {
+    let runtime = mech_runtime::MechRuntime::builder().host_input_capacity(4).build().unwrap();
+    let backend = FailingThenWorkingBackend { calls: Arc::new(AtomicUsize::new(0)) };
+    let mut driver = NativeTimeInputDriver::new(
+      "clock",
+      backend,
+      new_shared_snapshot(TimeSnapshot::default()),
+      Duration::from_millis(5),
+    );
+    driver.attach(runtime.ingress()).unwrap();
+
+    driver.start().unwrap();
+    wait_for_finished_worker(&driver);
+    assert!(!driver.is_live());
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
+
+    driver.start().unwrap();
+    wait_for_pending_inputs(&runtime, 1);
+    driver.stop().unwrap();
+    assert!(!driver.is_live());
+  }
+
+  #[test]
+  fn panicked_worker_is_reported_once_and_can_restart() {
+    let runtime = mech_runtime::MechRuntime::builder().host_input_capacity(4).build().unwrap();
+    let backend = PanickingThenWorkingBackend { calls: Arc::new(AtomicUsize::new(0)) };
+    let mut driver = NativeTimeInputDriver::new(
+      "clock",
+      backend,
+      new_shared_snapshot(TimeSnapshot::default()),
+      Duration::from_millis(5),
+    );
+    driver.attach(runtime.ingress()).unwrap();
+
+    driver.start().unwrap();
+    wait_for_finished_worker(&driver);
+    assert!(!driver.is_live());
+
+    let error = driver.start().unwrap_err();
+    assert_eq!(error.kind_name(), "TimeDriverStart");
+    assert!(format!("{error:?}").contains("native time worker panicked before restart"));
+    assert!(!driver.is_live());
+    assert!(driver.worker.lock().unwrap().is_none());
+    assert!(driver.stop_sender.lock().unwrap().is_none());
+
+    driver.start().unwrap();
+    wait_for_pending_inputs(&runtime, 1);
+    driver.stop().unwrap();
+  }
 }
 
 #[derive(Debug)]

--- a/hosts/timer/src/native.rs
+++ b/hosts/timer/src/native.rs
@@ -36,6 +36,14 @@ impl MonotonicTimerBackend for NativeMonotonicTimerBackend {
     }
 }
 
+struct WorkerLiveReset(Arc<AtomicBool>);
+
+impl Drop for WorkerLiveReset {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
 pub struct NativeTimerInputDriver<B: MonotonicTimerBackend + Send + Sync> {
     instance: String,
     backend: B,
@@ -74,6 +82,52 @@ impl<B: MonotonicTimerBackend + Send + Sync> NativeTimerInputDriver<B> {
             stop_sender: Arc::new(Mutex::new(None)),
         }
     }
+
+    fn prepare_worker_start(&mut self) -> MResult<bool> {
+        let mut stop_sender_guard = self
+            .stop_sender
+            .lock()
+            .map_err(|_| timer_error("TimerDriverStart", "timer stop-signal lock is poisoned"))?;
+        let mut worker_guard = self
+            .worker
+            .lock()
+            .map_err(|_| timer_error("TimerDriverStart", "timer worker lock is poisoned"))?;
+
+        if self.live.load(Ordering::SeqCst)
+            && worker_guard
+                .as_ref()
+                .is_some_and(|handle| !handle.is_finished())
+        {
+            return Ok(true);
+        }
+
+        let stop_sender = stop_sender_guard.take();
+        let worker = worker_guard.take();
+        drop(worker_guard);
+        drop(stop_sender_guard);
+
+        self.live.store(false, Ordering::SeqCst);
+
+        if let Some(sender) = stop_sender {
+            let _ = sender.send(());
+        }
+
+        let worker_panicked = worker.is_some_and(|handle| handle.join().is_err());
+
+        self.scheduler
+            .lock()
+            .map_err(|_| timer_error("TimerDriverStart", "timer scheduler lock is poisoned"))?
+            .pause();
+
+        if worker_panicked {
+            return Err(timer_error(
+                "TimerDriverStart",
+                "native timer worker panicked before restart",
+            ));
+        }
+
+        Ok(false)
+    }
 }
 impl<B: MonotonicTimerBackend + Send + Sync> RuntimeHostInputDriver for NativeTimerInputDriver<B> {
     fn drives(&self, source: &RuntimeHostInputSource) -> bool {
@@ -101,7 +155,7 @@ impl<B: MonotonicTimerBackend + Send + Sync> RuntimeHostInputDriver for NativeTi
         Ok(())
     }
     fn start(&mut self) -> MResult<()> {
-        if self.is_live() {
+        if self.prepare_worker_start()? {
             return Ok(());
         }
         let ingress = self
@@ -115,13 +169,6 @@ impl<B: MonotonicTimerBackend + Send + Sync> RuntimeHostInputDriver for NativeTi
                     "native timer driver must be attached before start",
                 )
             })?;
-        let mut worker_guard = self
-            .worker
-            .lock()
-            .map_err(|_| timer_error("TimerDriverStart", "timer worker lock is poisoned"))?;
-        if worker_guard.is_some() {
-            return Ok(());
-        }
         let now = self.backend.now_ms()?;
         self.scheduler
             .lock()
@@ -140,7 +187,8 @@ impl<B: MonotonicTimerBackend + Send + Sync> RuntimeHostInputDriver for NativeTi
         let snapshot = self.snapshot.clone();
         let pending = self.pending.clone();
         let instance = self.instance.clone();
-        *worker_guard = Some(thread::spawn(move || {
+        let worker = thread::spawn(move || {
+            let _live_reset = WorkerLiveReset(live.clone());
             while live.load(Ordering::SeqCst) {
                 let state = pending
                     .lock()
@@ -158,10 +206,15 @@ impl<B: MonotonicTimerBackend + Send + Sync> RuntimeHostInputDriver for NativeTi
                 match state {
                     Ok(TimerSubmitState::Drained) => {}
                     Ok(TimerSubmitState::Full) => {
-                        let wait = scheduler
-                            .lock()
+                        let wait = backend
+                            .now_ms()
                             .ok()
-                            .and_then(|s| backend.now_ms().ok().map(|now| native_wait_duration(&s, now)))
+                            .and_then(|now| {
+                                scheduler
+                                    .lock()
+                                    .ok()
+                                    .map(|scheduler| native_wait_duration(&scheduler, now))
+                            })
                             .unwrap_or_else(|| Duration::from_millis(1));
                         match stop_receiver.recv_timeout(wait) {
                             Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
@@ -223,8 +276,12 @@ impl<B: MonotonicTimerBackend + Send + Sync> RuntimeHostInputDriver for NativeTi
                     Err(RecvTimeoutError::Timeout) => {}
                 }
             }
-            live.store(false, Ordering::SeqCst);
-        }));
+        });
+        *self
+            .worker
+            .lock()
+            .map_err(|_| timer_error("TimerDriverStart", "timer worker lock is poisoned"))? =
+            Some(worker);
         Ok(())
     }
     fn stop(&mut self) -> MResult<()> {
@@ -267,6 +324,232 @@ pub fn native_wait_duration(scheduler: &FixedStepScheduler, now_ms: f64) -> Dura
 impl<B: MonotonicTimerBackend + Send + Sync> Drop for NativeTimerInputDriver<B> {
     fn drop(&mut self) {
         let _ = self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+
+    fn wait_for_finished_worker<B>(driver: &NativeTimerInputDriver<B>)
+    where
+        B: MonotonicTimerBackend + Send + Sync,
+    {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let finished = driver
+                .worker
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|handle| handle.is_finished());
+            if finished {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for native timer worker to finish"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn wait_for_pending_inputs(runtime: &mech_runtime::MechRuntime, count: usize) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while runtime.pending_host_input_count().unwrap() < count {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for native timer input"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ControlledBackend {
+        calls: Arc<AtomicUsize>,
+        panic_on_worker_call: bool,
+    }
+
+    impl MonotonicTimerBackend for ControlledBackend {
+        fn now_ms(&self) -> MResult<f64> {
+            match self.calls.fetch_add(1, Ordering::SeqCst) {
+                0 => Ok(0.0),
+                1 if self.panic_on_worker_call => panic!("test timer backend panic"),
+                1 => Err(timer_error("TimerBackend", "test backend failure")),
+                2 => Ok(10_000.0),
+                3 => Ok(10_010.0),
+                _ => Ok(10_010.0),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct WorkingBackend {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl MonotonicTimerBackend for WorkingBackend {
+        fn now_ms(&self) -> MResult<f64> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(0.0)
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct FullIngressPanickingBackend {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl MonotonicTimerBackend for FullIngressPanickingBackend {
+        fn now_ms(&self) -> MResult<f64> {
+            match self.calls.fetch_add(1, Ordering::SeqCst) {
+                0 => Ok(0.0),
+                1 => Ok(10.0),
+                2 => panic!("test timer backend panic while ingress is full"),
+                _ => Ok(10_000.0),
+            }
+        }
+    }
+
+    fn snapshot() -> SharedTimerSnapshot {
+        new_shared_snapshot(TimerSnapshot::new(0, 100, 0))
+    }
+
+    #[test]
+    fn restart_after_backend_error_rebases_scheduler() {
+        let runtime = mech_runtime::MechRuntime::builder()
+            .host_input_capacity(4)
+            .build()
+            .unwrap();
+        let shared_snapshot = snapshot();
+        let backend = ControlledBackend {
+            calls: Arc::new(AtomicUsize::new(0)),
+            panic_on_worker_call: false,
+        };
+        let mut driver = NativeTimerInputDriver::new(
+            "physics",
+            backend,
+            FixedStepScheduler::new(100, 8),
+            shared_snapshot.clone(),
+        );
+        driver.attach(runtime.ingress()).unwrap();
+
+        driver.start().unwrap();
+        wait_for_finished_worker(&driver);
+        assert!(!driver.is_live());
+
+        driver.start().unwrap();
+        wait_for_pending_inputs(&runtime, 1);
+        assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+        let snapshot = *shared_snapshot.lock().unwrap();
+        assert_eq!(snapshot.tick, 1);
+        assert_eq!(snapshot.skipped_steps, 0);
+        driver.stop().unwrap();
+    }
+
+    #[test]
+    fn panicked_worker_is_reported_once_and_can_restart() {
+        let runtime = mech_runtime::MechRuntime::builder()
+            .host_input_capacity(4)
+            .build()
+            .unwrap();
+        let shared_snapshot = snapshot();
+        let backend = ControlledBackend {
+            calls: Arc::new(AtomicUsize::new(0)),
+            panic_on_worker_call: true,
+        };
+        let mut driver = NativeTimerInputDriver::new(
+            "physics",
+            backend,
+            FixedStepScheduler::new(100, 8),
+            shared_snapshot.clone(),
+        );
+        driver.attach(runtime.ingress()).unwrap();
+
+        driver.start().unwrap();
+        wait_for_finished_worker(&driver);
+        assert!(!driver.is_live());
+
+        let error = driver.start().unwrap_err();
+        assert_eq!(error.kind_name(), "TimerDriverStart");
+        assert!(format!("{error:?}").contains("native timer worker panicked before restart"));
+        assert!(!driver.is_live());
+        assert!(driver.worker.lock().unwrap().is_none());
+        assert!(driver.stop_sender.lock().unwrap().is_none());
+        assert_eq!(driver.scheduler.lock().unwrap().time_until_next_boundary(10_000.0), 0.0);
+
+        driver.start().unwrap();
+        wait_for_pending_inputs(&runtime, 1);
+        let snapshot = *shared_snapshot.lock().unwrap();
+        assert_eq!(snapshot.tick, 1);
+        assert_eq!(snapshot.skipped_steps, 0);
+        driver.stop().unwrap();
+    }
+
+    #[test]
+    fn full_ingress_panic_leaves_scheduler_recoverable() {
+        let mut runtime = mech_runtime::MechRuntime::builder()
+            .host_input_capacity(1)
+            .build()
+            .unwrap();
+        let shared_snapshot = snapshot();
+        let backend = FullIngressPanickingBackend {
+            calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let mut driver = NativeTimerInputDriver::new(
+            "physics",
+            backend,
+            FixedStepScheduler::new(100, 8),
+            shared_snapshot.clone(),
+        );
+        driver.attach(runtime.ingress()).unwrap();
+        runtime
+            .ingress()
+            .submit(TimerSnapshot::new(0, 100, 0).into_host_input("filler").unwrap())
+            .unwrap();
+
+        driver.start().unwrap();
+        wait_for_finished_worker(&driver);
+        assert!(!driver.is_live());
+
+        let error = driver.start().unwrap_err();
+        assert_eq!(error.kind_name(), "TimerDriverStart");
+        assert!(format!("{error:?}").contains("native timer worker panicked before restart"));
+        assert!(driver.scheduler.lock().is_ok());
+
+        runtime.drain_host_inputs(1).unwrap();
+        driver.start().unwrap();
+        wait_for_pending_inputs(&runtime, 1);
+        assert_eq!(shared_snapshot.lock().unwrap().tick, 1);
+        driver.stop().unwrap();
+    }
+
+    #[test]
+    fn native_start_is_idempotent_while_worker_is_live() {
+        let runtime = mech_runtime::MechRuntime::builder()
+            .host_input_capacity(4)
+            .build()
+            .unwrap();
+        let backend = WorkingBackend {
+            calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let mut driver = NativeTimerInputDriver::new(
+            "physics",
+            backend,
+            FixedStepScheduler::new(100, 8),
+            snapshot(),
+        );
+        driver.attach(runtime.ingress()).unwrap();
+
+        driver.start().unwrap();
+        let first_thread = driver.worker.lock().unwrap().as_ref().unwrap().thread().id();
+        driver.start().unwrap();
+        let second_thread = driver.worker.lock().unwrap().as_ref().unwrap().thread().id();
+        assert_eq!(first_thread, second_thread);
+        driver.stop().unwrap();
     }
 }
 

--- a/src/runtime/src/host/arg.rs
+++ b/src/runtime/src/host/arg.rs
@@ -563,9 +563,9 @@ pub fn host_arg_tuple(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechTuple> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::Tuple(value) => Ok(value.borrow().clone()),
-    other => Err(wrong_type_error(function, index, "tuple", other)),
+    other => Err(wrong_type_error(function, index, "tuple", &other)),
   }
 }
 
@@ -575,9 +575,9 @@ pub fn host_arg_record(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechRecord> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::Record(value) => Ok(value.borrow().clone()),
-    other => Err(wrong_type_error(function, index, "record", other)),
+    other => Err(wrong_type_error(function, index, "record", &other)),
   }
 }
 
@@ -587,9 +587,9 @@ pub fn host_arg_table(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechTable> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::Table(value) => Ok(value.borrow().clone()),
-    other => Err(wrong_type_error(function, index, "table", other)),
+    other => Err(wrong_type_error(function, index, "table", &other)),
   }
 }
 
@@ -599,9 +599,9 @@ pub fn host_arg_map(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMap> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::Map(value) => Ok(value.borrow().clone()),
-    other => Err(wrong_type_error(function, index, "map", other)),
+    other => Err(wrong_type_error(function, index, "map", &other)),
   }
 }
 
@@ -611,9 +611,9 @@ pub fn host_arg_set(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechSet> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::Set(value) => Ok(value.borrow().clone()),
-    other => Err(wrong_type_error(function, index, "set", other)),
+    other => Err(wrong_type_error(function, index, "set", &other)),
   }
 }
 
@@ -623,9 +623,9 @@ pub fn host_arg_matrix_index(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<usize>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixIndex(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<index>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<index>", &other)),
   }
 }
 
@@ -635,9 +635,9 @@ pub fn host_arg_matrix_bool(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<bool>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixBool(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<bool>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<bool>", &other)),
   }
 }
 
@@ -647,9 +647,9 @@ pub fn host_arg_matrix_u8(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<u8>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixU8(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<u8>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<u8>", &other)),
   }
 }
 
@@ -659,9 +659,9 @@ pub fn host_arg_matrix_u16(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<u16>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixU16(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<u16>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<u16>", &other)),
   }
 }
 
@@ -671,9 +671,9 @@ pub fn host_arg_matrix_u32(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<u32>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixU32(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<u32>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<u32>", &other)),
   }
 }
 
@@ -683,9 +683,9 @@ pub fn host_arg_matrix_u64(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<u64>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixU64(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<u64>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<u64>", &other)),
   }
 }
 
@@ -695,9 +695,9 @@ pub fn host_arg_matrix_u128(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<u128>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixU128(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<u128>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<u128>", &other)),
   }
 }
 
@@ -707,9 +707,9 @@ pub fn host_arg_matrix_i8(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<i8>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixI8(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<i8>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<i8>", &other)),
   }
 }
 
@@ -719,9 +719,9 @@ pub fn host_arg_matrix_i16(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<i16>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixI16(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<i16>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<i16>", &other)),
   }
 }
 
@@ -731,9 +731,9 @@ pub fn host_arg_matrix_i32(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<i32>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixI32(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<i32>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<i32>", &other)),
   }
 }
 
@@ -743,9 +743,9 @@ pub fn host_arg_matrix_i64(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<i64>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixI64(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<i64>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<i64>", &other)),
   }
 }
 
@@ -755,9 +755,9 @@ pub fn host_arg_matrix_i128(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<i128>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixI128(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<i128>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<i128>", &other)),
   }
 }
 
@@ -767,9 +767,9 @@ pub fn host_arg_matrix_f32(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<f32>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixF32(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<f32>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<f32>", &other)),
   }
 }
 
@@ -791,9 +791,9 @@ pub fn host_arg_matrix_string(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<String>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixString(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<string>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<string>", &other)),
   }
 }
 
@@ -803,9 +803,9 @@ pub fn host_arg_matrix_value_matrix(
   args: &[Value],
   index: usize,
 ) -> MResult<mech_core::MechMatrix<Value>> {
-  match host_arg(function, args, index)? {
+  match host_arg_resolved(function, args, index)? {
     Value::MatrixValue(value) => Ok(value.clone()),
-    other => Err(wrong_type_error(function, index, "matrix<value>", other)),
+    other => Err(wrong_type_error(function, index, "matrix<value>", &other)),
   }
 }
 
@@ -1289,6 +1289,11 @@ mod tests {
     Value::Typed(Box::new(value), kind)
   }
 
+  fn typed_reference(value: Value) -> Value {
+    let kind = value.kind();
+    Value::MutableReference(Ref::new(Value::Typed(Box::new(value), kind)))
+  }
+
   #[test]
   fn resolves_typed_strings_through_scalar_helpers() {
     let args = vec![typed(
@@ -1332,6 +1337,72 @@ mod tests {
     let args = vec![typed(Value::Empty, ValueKind::String)];
 
     assert!(host_arg_string("test", &args, 0).is_err());
+  }
+
+  #[cfg(feature = "tuple")]
+  #[test]
+  fn resolves_typed_tuples_through_compound_helpers() {
+    let tuple = mech_core::MechTuple::from_vec(vec![Value::Empty]);
+    let value = Value::Tuple(Ref::new(tuple.clone()));
+    let args = vec![typed(value.clone(), value.kind())];
+
+    assert_eq!(host_arg_tuple("test", &args, 0).unwrap(), tuple);
+  }
+
+  #[cfg(feature = "record")]
+  #[test]
+  fn resolves_typed_records_behind_mutable_references() {
+    let record = mech_core::MechRecord::new(vec![("field", Value::Empty)]);
+    let args = vec![typed_reference(Value::Record(Ref::new(record.clone())))];
+
+    assert_eq!(host_arg_record("test", &args, 0).unwrap(), record);
+  }
+
+  #[cfg(all(feature = "matrix", feature = "u8"))]
+  #[test]
+  fn resolves_typed_u8_matrices_behind_mutable_references() {
+    let matrix = mech_core::MechMatrix::from_vec(vec![1, 2], 1, 2);
+    let args = vec![typed_reference(Value::MatrixU8(matrix.clone()))];
+    let actual = host_arg_matrix_u8("test", &args, 0).unwrap();
+
+    assert_eq!(actual.shape(), matrix.shape());
+    assert_eq!(actual.as_vec(), matrix.as_vec());
+  }
+
+  #[cfg(feature = "tuple")]
+  #[test]
+  fn typed_non_tuple_returns_a_host_argument_error() {
+    let args = vec![typed(Value::Empty, ValueKind::Empty)];
+    let error = host_arg_tuple("test", &args, 0).unwrap_err();
+
+    assert!(error.kind_as::<HostArgumentError>().is_some());
+  }
+
+  #[test]
+  fn raw_and_reference_helpers_preserve_typed_wrappers() {
+    let typed_string = typed(
+      Value::String(Ref::new("hello".into())),
+      ValueKind::String,
+    );
+    let args = vec![typed_string.clone()];
+
+    assert!(matches!(host_arg_raw("test", &args, 0).unwrap(), Value::Typed(..)));
+    assert_eq!(
+      host_arg_optional_value("test", &args, 0).unwrap(),
+      Some(typed_string.clone())
+    );
+
+    let referenced = Value::MutableReference(Ref::new(typed_string.clone()));
+    assert_eq!(
+      host_arg_reference_value("test", &[referenced.clone()], 0).unwrap(),
+      typed_string
+    );
+
+    let nested_reference = Value::MutableReference(Ref::new(referenced.clone()));
+    assert_eq!(
+      host_arg_deref_cloned("test", &[nested_reference], 0).unwrap(),
+      referenced
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Closes two host-boundary findings from release PR #581:

- resolve typed and mutable-reference wrappers consistently in compound
  host argument helpers;
- reap exited native time and timer worker handles before restart.

## Behavioral decisions

- Semantic compound extractors use `host_arg_resolved`.
- Raw and reference-oriented helpers preserve their existing representation
  behavior.
- `start()` is idempotent only when a worker handle exists, the live flag is
  true, and the handle is not finished.
- Exited workers are signaled, joined, and removed before replacement.
- A worker panic is surfaced once through `start()` and leaves reusable state.
- Timer restart pauses and rebases the scheduler without resetting ticks,
  skipped-step counts, pending packets, or snapshots.
- Drivers do not auto-restart from their worker threads.

## Scope

This PR does not address dynamic module kernel failures, capability grant
atomicity, or the runtime-validation findings assigned to the other focused
PRs.

## Validation

- `git fetch origin` — passed.
- `git switch v0.3-beta` — passed.
- `git pull --ff-only origin v0.3-beta` — passed.
- `git switch -c fix/581-host-boundaries` — passed.
- `rustfmt --edition 2024 src/runtime/src/host/arg.rs hosts/time/src/native.rs hosts/timer/src/native.rs` — completed; no formatter-only baseline rewrite retained.
- `git diff --check` — passed.
- `cargo test -p mech-runtime --lib host_arg -- --nocapture` — passed.
- `cargo test -p mech-runtime --lib --tests` — 328 passed; 3 unrelated workspace-watch tests failed because macOS temporary paths appear as both `/var` and `/private/var`.
- `cargo test -p mech-host-time --no-default-features --features native -- --test-threads=1` — passed (21 tests).
- `cargo test -p mech-host-timer --no-default-features --features native -- --test-threads=1` — passed (45 tests across unit and integration suites).
- `cargo check -p mech-runtime --no-default-features` — passed.
- `cargo check -p mech-runtime` — passed.
- `cargo check -p mech-host-time --no-default-features --features native` — passed.
- `cargo check -p mech-host-timer --no-default-features --features native` — passed.
- Final `rg` audits, `git diff --stat`, `git diff --check`, and `git status --short` — passed; only the three scoped files changed.