### PR TITLE
[v0.4] Propagate dynamic kernel failures

### DIFF
--- a/scripts/test-dynamic-modules.sh
+++ b/scripts/test-dynamic-modules.sh
@@ -57,18 +57,31 @@ cargo test --manifest-path machines/combinatorics/Cargo.toml --no-default-featur
 echo "building combinatorics dynamic provider"
 cargo build --manifest-path machines/combinatorics/Cargo.toml --no-default-features --features "dynamic-module" --target-dir "${TARGET_DIR}"
 
+echo "building dynamic status test provider"
+cargo build \
+  --manifest-path tests/fixtures/dynamic-status-module/Cargo.toml \
+  --target-dir "${TARGET_DIR}"
+
 echo "staging dynamic modules"
 rm -rf "${MODULE_DIR}"
 mkdir -p "${MODULE_DIR}"
 
 stage_module "mech_math" "mech_module_math"
 stage_module "mech_combinatorics" "mech_module_combinatorics"
+stage_module "mech_dynamic_status_test" "mech_module_status_test"
 
 echo "running dynamic math integration tests"
 MECH_MODULE_PATH="${MODULE_DIR}" cargo test --test dynamic_math --no-default-features --features "base dynamic-modules f64"
 
 echo "running dynamic combinatorics integration tests"
 MECH_MODULE_PATH="${MODULE_DIR}" cargo test --test dynamic_combinatorics --no-default-features --features "base dynamic-modules f64"
+
+echo "running dynamic status failure tests"
+MECH_MODULE_PATH="${MODULE_DIR}" \
+  cargo test \
+    --test dynamic_status_failures \
+    --no-default-features \
+    --features "base dynamic-modules f64"
 
 echo "running dynamic module smoke tests"
 MECH_MODULE_PATH="${MODULE_DIR}" cargo test --test dynamic_modules --no-default-features --features "base dynamic-modules f64"

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -166,7 +166,7 @@ pub fn execute_native_function_compiler(
 ) -> MResult<Value> {
   let plan = p.plan();
   match fxn_compiler.compile(input_arg_values) {
-    Ok(mut new_fxn) => {
+    Ok(new_fxn) => {
       trace_println!(
         p,
         "{}",
@@ -183,7 +183,7 @@ pub fn execute_native_function_compiler(
           ),
         )
       );
-      if !plan.activation_registration_active() { new_fxn.solve(); }
+      if !plan.activation_registration_active() { new_fxn.solve_result()?; }
       let result = new_fxn.out();
       trace_println!(
         p,
@@ -1143,11 +1143,20 @@ mod native_dependency_tests {
     let input_cell = ReactiveCellId::new(input.id());
     let arguments = vec![Value::F64(input)];
     let solve_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    assert!(execute_native_function_compiler(Arc::new(DeferredNativeSolveCompiler { solve_calls: solve_calls.clone() }), &arguments, &interpreter).is_ok());
-    assert_eq!(solve_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
     let plan = interpreter.plan();
+    plan.push_activation_registration_scope(vec![input_cell]);
+    let result = execute_native_function_compiler(
+      Arc::new(DeferredNativeSolveCompiler {
+        solve_calls: solve_calls.clone(),
+      }),
+      &arguments,
+      &interpreter,
+    );
+    plan.pop_activation_registration_scope();
+
+    assert!(result.is_ok());
+    assert_eq!(solve_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
     let plan = plan.borrow();
-    let node = plan.last().unwrap();
     assert!(plan.nodes.last().unwrap().inputs.iter().any(|dependency| dependency.cell == input_cell));
     assert!(plan.nodes.last().unwrap().function.solve_result().unwrap_err().kind_name().contains("DeferredNativeSolveError"));
     assert_eq!(plan.len(), 1);
@@ -1194,5 +1203,118 @@ mod native_dependency_tests {
       &[node.id],
     );
     assert!(node.outputs.contains(&output_cell));
+  }
+}
+
+#[cfg(all(test, feature = "functions", feature = "f64"))]
+mod native_initialization_failure_tests {
+  use super::*;
+  use std::sync::atomic::{AtomicUsize, Ordering};
+
+  struct FailingInitializationCompiler {
+    solve_calls: Arc<AtomicUsize>,
+    solve_result_calls: Arc<AtomicUsize>,
+  }
+
+  struct FailingInitializationFunction {
+    solve_calls: Arc<AtomicUsize>,
+    solve_result_calls: Arc<AtomicUsize>,
+    output: Ref<f64>,
+  }
+
+  impl NativeFunctionCompiler for FailingInitializationCompiler {
+    fn compile(&self, _arguments: &Vec<Value>) -> MResult<Box<dyn MechFunction>> {
+      Ok(Box::new(FailingInitializationFunction {
+        solve_calls: self.solve_calls.clone(),
+        solve_result_calls: self.solve_result_calls.clone(),
+        output: Ref::new(123.0),
+      }))
+    }
+  }
+
+  impl MechFunctionImpl for FailingInitializationFunction {
+    fn solve(&self) {
+      self.solve_calls.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn solve_result(&self) -> MResult<()> {
+      self.solve_result_calls.fetch_add(1, Ordering::SeqCst);
+      Err(MechError::new(
+        GenericError {
+          msg: "test native initialization failed".to_string(),
+        },
+        None,
+      ))
+    }
+
+    fn out(&self) -> Value {
+      Value::F64(self.output.clone())
+    }
+
+    fn to_string(&self) -> String {
+      "failing-initialization-test".to_string()
+    }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for FailingInitializationFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+      panic!("failing initialization test function must not be bytecode compiled")
+    }
+  }
+
+  fn failing_compiler(
+    solve_calls: Arc<AtomicUsize>,
+    solve_result_calls: Arc<AtomicUsize>,
+  ) -> Arc<dyn NativeFunctionCompiler> {
+    Arc::new(FailingInitializationCompiler {
+      solve_calls,
+      solve_result_calls,
+    })
+  }
+
+  #[test]
+  fn eager_initialization_uses_solve_result() {
+    let interpreter = Interpreter::new(0, 100);
+    let arguments = vec![Value::F64(Ref::new(1.0))];
+    let solve_calls = Arc::new(AtomicUsize::new(0));
+    let solve_result_calls = Arc::new(AtomicUsize::new(0));
+    let plan_len = interpreter.plan().len();
+
+    let error = execute_native_function_compiler(
+      failing_compiler(solve_calls.clone(), solve_result_calls.clone()),
+      &arguments,
+      &interpreter,
+    )
+    .expect_err("eager initialization must return the native solve error");
+
+    assert!(error.full_chain_message().contains("test native initialization failed"));
+    assert_eq!(solve_result_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(solve_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(interpreter.plan().len(), plan_len);
+  }
+
+  #[test]
+  fn activation_registration_defers_initialization_solving() {
+    let interpreter = Interpreter::new(0, 100);
+    let input = Ref::new(1.0);
+    let arguments = vec![Value::F64(input.clone())];
+    let solve_calls = Arc::new(AtomicUsize::new(0));
+    let solve_result_calls = Arc::new(AtomicUsize::new(0));
+    let plan = interpreter.plan();
+    let plan_len = plan.len();
+
+    plan.push_activation_registration_scope(vec![ReactiveCellId::new(input.id())]);
+    let result = execute_native_function_compiler(
+      failing_compiler(solve_calls.clone(), solve_result_calls.clone()),
+      &arguments,
+      &interpreter,
+    );
+    plan.pop_activation_registration_scope();
+
+    assert!(result.is_ok());
+    assert_eq!(solve_result_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(solve_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(plan.len(), plan_len + 1);
   }
 }

--- a/src/interpreter/src/modules.rs
+++ b/src/interpreter/src/modules.rs
@@ -424,6 +424,34 @@ fn dynamic_trace(message: impl AsRef<str>) {
 }
 
 #[cfg(feature = "dynamic-modules")]
+fn dynamic_status_name(status: mech_abi::MechStatusV1) -> &'static str {
+    match status.0 {
+        0 => "Ok",
+        1 => "InvalidIndex",
+        2 => "NullPointer",
+        3 => "WrongType",
+        4 => "WrongShape",
+        5 => "Unsupported",
+        6 => "Panic",
+        _ => "Unknown",
+    }
+}
+
+#[cfg(feature = "dynamic-modules")]
+fn check_dynamic_kernel_status(function: &str, status: mech_abi::MechStatusV1) -> MResult<()> {
+    if status == mech_abi::MechStatusV1::Ok {
+        return Ok(());
+    }
+
+    Err(DynamicModuleLoader::dynamic_error(format!(
+        "dynamic kernel `{}` returned {} (status {})",
+        function,
+        dynamic_status_name(status),
+        status.0,
+    )))
+}
+
+#[cfg(feature = "dynamic-modules")]
 struct DynamicOverloadedCompiler {
     name: String,
     compilers: Vec<Arc<dyn NativeFunctionCompiler>>,
@@ -930,17 +958,30 @@ struct DynamicBinaryF64F64ToF64Function {
 }
 
 #[cfg(feature = "dynamic-modules")]
+fn solve_dynamic_binary_scalar(
+    n: &Ref<f64>,
+    k: &Ref<f64>,
+    out: &Ref<f64>,
+    kernel: mech_abi::MechBinaryF64F64ToF64KernelV1,
+    name: &str,
+) -> MResult<()> {
+    let mut next = *out.borrow();
+    let status = unsafe { (kernel)(*n.borrow(), *k.borrow(), &mut next as *mut f64) };
+    check_dynamic_kernel_status(name, status)?;
+    *out.borrow_mut() = next;
+    Ok(())
+}
+
+#[cfg(feature = "dynamic-modules")]
 impl MechFunctionImpl for DynamicBinaryF64F64ToF64Function {
     fn solve(&self) {
-        let status =
-            unsafe { (self.kernel)(*self.n.as_ptr(), *self.k.as_ptr(), self.out.as_mut_ptr()) };
-
-        if status != mech_abi::MechStatusV1::Ok {
-            dynamic_trace(format!(
-                "dynamic kernel `{}` returned status {:?}",
-                self.name, status
-            ));
+        if let Err(error) = self.solve_result() {
+            dynamic_trace(error.full_chain_message());
         }
+    }
+
+    fn solve_result(&self) -> MResult<()> {
+        solve_dynamic_binary_scalar(&self.n, &self.k, &self.out, self.kernel, &self.name)
     }
 
     fn out(&self) -> Value {
@@ -997,15 +1038,7 @@ fn solve_dynamic_binary_broadcast(
                 &mut value as *mut f64,
             )
         };
-        if status != mech_abi::MechStatusV1::Ok {
-            return Err(MechError::new(
-                GenericError {
-                    msg: format!("dynamic kernel `{}` returned status {:?}", name, status),
-                },
-                None,
-            )
-            .with_compiler_loc());
-        }
+        check_dynamic_kernel_status(name, status)?;
         out_vec.push(value);
     }
     replace_dynamic_matrix_output(out, plan.rows, plan.cols, out_vec, name)
@@ -1014,11 +1047,13 @@ fn solve_dynamic_binary_broadcast(
 #[cfg(feature = "dynamic-modules")]
 impl MechFunctionImpl for DynamicBinaryF64F64BroadcastFunction {
     fn solve(&self) {
-        if let Err(err) =
-            solve_dynamic_binary_broadcast(&self.lhs, &self.rhs, &self.out, self.kernel, &self.name)
-        {
-            dynamic_trace(err.full_chain_message());
+        if let Err(error) = self.solve_result() {
+            dynamic_trace(error.full_chain_message());
         }
+    }
+
+    fn solve_result(&self) -> MResult<()> {
+        solve_dynamic_binary_broadcast(&self.lhs, &self.rhs, &self.out, self.kernel, &self.name)
     }
 
     fn out(&self) -> Value {
@@ -1056,16 +1091,29 @@ struct DynamicUnaryF64ToF64Function {
 }
 
 #[cfg(feature = "dynamic-modules")]
+fn solve_dynamic_unary_scalar(
+    input: &Ref<f64>,
+    out: &Ref<f64>,
+    kernel: mech_abi::MechUnaryF64ToF64KernelV1,
+    name: &str,
+) -> MResult<()> {
+    let mut next = *out.borrow();
+    let status = unsafe { (kernel)(*input.borrow(), &mut next as *mut f64) };
+    check_dynamic_kernel_status(name, status)?;
+    *out.borrow_mut() = next;
+    Ok(())
+}
+
+#[cfg(feature = "dynamic-modules")]
 impl MechFunctionImpl for DynamicUnaryF64ToF64Function {
     fn solve(&self) {
-        let status = unsafe { (self.kernel)(*self.input.as_ptr(), self.out.as_mut_ptr()) };
-
-        if status != mech_abi::MechStatusV1::Ok {
-            dynamic_trace(format!(
-                "dynamic kernel `{}` returned status {:?}",
-                self.name, status
-            ));
+        if let Err(error) = self.solve_result() {
+            dynamic_trace(error.full_chain_message());
         }
+    }
+
+    fn solve_result(&self) -> MResult<()> {
+        solve_dynamic_unary_scalar(&self.input, &self.out, self.kernel, &self.name)
     }
 
     fn out(&self) -> Value {
@@ -1141,25 +1189,20 @@ fn solve_dynamic_unary_view(
             },
         )
     };
-    if status != mech_abi::MechStatusV1::Ok {
-        return Err(MechError::new(
-            GenericError {
-                msg: format!("dynamic kernel `{}` returned status {:?}", name, status),
-            },
-            None,
-        )
-        .with_compiler_loc());
-    }
+    check_dynamic_kernel_status(name, status)?;
     replace_dynamic_matrix_output(out, rows, cols, out_vec, name)
 }
 
 #[cfg(feature = "dynamic-modules")]
 impl MechFunctionImpl for DynamicUnaryF64ViewToF64ViewFunction {
     fn solve(&self) {
-        if let Err(err) = solve_dynamic_unary_view(&self.input, &self.out, self.kernel, &self.name)
-        {
-            dynamic_trace(err.full_chain_message());
+        if let Err(error) = self.solve_result() {
+            dynamic_trace(error.full_chain_message());
         }
+    }
+
+    fn solve_result(&self) -> MResult<()> {
+        solve_dynamic_unary_view(&self.input, &self.out, self.kernel, &self.name)
     }
 
     fn out(&self) -> Value {

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -591,7 +591,7 @@ fn live_host_output_kind_change_preserves_previous_output() {
   let host_calls = calls.clone();
   runtime.register_mech_host_function(ClosureHostFunction::new("demo/kind-change", move |_services, _context, args| {
     let call = host_calls.fetch_add(1, Ordering::SeqCst);
-    if call == 0 {
+    if call < 2 {
       let value = match &args[0] {
         Value::F64(value) => *value.borrow(),
         Value::MutableReference(value) => match &*value.borrow() {

--- a/tests/dynamic_status_failures.rs
+++ b/tests/dynamic_status_failures.rs
@@ -1,0 +1,245 @@
+#![cfg(feature = "dynamic-modules")]
+
+use mech::program::{MechProgram, MechProgramConfig, ProgramInputId, ProgramInputUpdate};
+use mech_core::{Ref, Value, hash_str, structures::matrix::Matrix};
+
+fn unwrap_value(value: Value) -> Value {
+    match value {
+        Value::MutableReference(reference) => unwrap_value(reference.borrow().clone()),
+        Value::Typed(value, _) => unwrap_value(*value),
+        value => value,
+    }
+}
+
+fn f64_output(value: Value) -> f64 {
+    match unwrap_value(value) {
+        Value::F64(value) => *value.borrow(),
+        value => panic!("expected f64 output, got {value:?}"),
+    }
+}
+
+fn assert_matrix_output(value: Value, expected: &[f64], rows: usize, cols: usize) {
+    let Value::MatrixF64(matrix) = unwrap_value(value) else {
+        panic!("expected f64 matrix output");
+    };
+
+    assert_eq!((matrix.rows(), matrix.cols()), (rows, cols));
+    assert_eq!(
+        (1..=rows * cols)
+            .map(|index| matrix.index1d(index))
+            .collect::<Vec<_>>(),
+        expected,
+    );
+}
+
+fn matrix_value(values: Vec<f64>, rows: usize, cols: usize) -> Value {
+    Value::MatrixF64(Matrix::from_vec(values, rows, cols))
+}
+
+fn ensure_input(program: &mut MechProgram, name: &str, value: Value) -> ProgramInputId {
+    program
+        .ensure_input(program.interpreter().id, hash_str(name), name, value)
+        .unwrap()
+}
+
+fn symbol_value(program: &MechProgram, name: &str) -> Value {
+    let symbols = program.interpreter().symbols();
+    let value = symbols
+        .borrow()
+        .get(hash_str(name))
+        .unwrap_or_else(|| panic!("missing symbol `{name}`"));
+    value.borrow().clone()
+}
+
+fn assert_status_error(message: &str, function: &str, status: &str, code: i32) {
+    assert!(message.contains(function), "missing function in {message}");
+    assert!(message.contains(status), "missing status in {message}");
+    assert!(
+        message.contains(&format!("status {code}")),
+        "missing numeric status in {message}"
+    );
+}
+
+fn assert_no_dynamic_node(program: &MechProgram, function: &str) {
+    let plan = program.interpreter().plan();
+    assert!(
+        !plan
+            .borrow()
+            .nodes
+            .iter()
+            .any(|node| node.function.to_string() == format!("dynamic {function}")),
+        "failed dynamic function `{function}` remained registered"
+    );
+}
+
+#[test]
+fn unary_status_failure_reaches_the_caller() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let plan_len = program.interpreter().plan_len();
+    let error = program
+        .run_string(
+            "+> status-test/unary
+y := unary(2.0)
+y",
+        )
+        .expect_err("a dynamic unary status failure must abort eager execution");
+
+    assert_status_error(
+        &error.full_chain_message(),
+        "status-test/unary",
+        "WrongShape",
+        4,
+    );
+    assert_eq!(program.interpreter().plan_len(), plan_len);
+}
+
+#[test]
+fn scalar_binary_status_failure_reaches_the_caller() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let plan_len = program.interpreter().plan_len();
+    let error = program
+        .run_string(
+            "+> status-test/binary
+y := binary(2.0, 3.0)
+y",
+        )
+        .expect_err("a dynamic binary status failure must abort eager execution");
+
+    assert_status_error(
+        &error.full_chain_message(),
+        "status-test/binary",
+        "Unsupported",
+        5,
+    );
+    assert_eq!(program.interpreter().plan_len(), plan_len);
+}
+
+#[test]
+fn view_status_failure_reaches_the_caller() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let error = program
+        .run_string(
+            "+> status-test/view
+y := view([1.0 2.0])
+y",
+        )
+        .expect_err("a dynamic view status failure must abort eager execution");
+
+    assert_status_error(&error.full_chain_message(), "status-test/view", "Panic", 6);
+    assert_no_dynamic_node(&program, "status-test/view");
+}
+
+#[test]
+fn unary_scalar_output_survives_failure() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let input = ensure_input(&mut program, "x", Value::F64(Ref::new(1.0)));
+    program
+        .run_string(
+            "+> status-test/unary
+y := unary(x)
+y",
+        )
+        .unwrap();
+    assert_eq!(f64_output(symbol_value(&program, "y")), 10.0);
+
+    let error = program
+        .update_inputs_and_advance_turn(&[ProgramInputUpdate {
+            input,
+            value: Value::F64(Ref::new(2.0)),
+        }])
+        .expect_err("a failed reactive unary kernel must return an error");
+
+    assert_status_error(
+        &error.full_chain_message(),
+        "status-test/unary",
+        "WrongShape",
+        4,
+    );
+    assert_eq!(f64_output(symbol_value(&program, "x")), 2.0);
+    assert_eq!(f64_output(symbol_value(&program, "y")), 10.0);
+}
+
+#[test]
+fn binary_scalar_output_survives_failure() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let input = ensure_input(&mut program, "x", Value::F64(Ref::new(1.0)));
+    program
+        .run_string(
+            "+> status-test/binary
+y := binary(x, 3.0)
+y",
+        )
+        .unwrap();
+    assert_eq!(f64_output(symbol_value(&program, "y")), 4.0);
+
+    let error = program
+        .update_inputs_and_advance_turn(&[ProgramInputUpdate {
+            input,
+            value: Value::F64(Ref::new(2.0)),
+        }])
+        .expect_err("a failed reactive binary kernel must return an error");
+
+    assert_status_error(
+        &error.full_chain_message(),
+        "status-test/binary",
+        "Unsupported",
+        5,
+    );
+    assert_eq!(f64_output(symbol_value(&program, "x")), 2.0);
+    assert_eq!(f64_output(symbol_value(&program, "y")), 4.0);
+}
+
+#[test]
+fn broadcast_output_is_all_or_nothing() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let input = ensure_input(&mut program, "x", matrix_value(vec![1.0, 1.0], 1, 2));
+    program
+        .run_string(
+            "+> status-test/binary
+y := binary(x, 3.0)
+y",
+        )
+        .unwrap();
+    assert_matrix_output(symbol_value(&program, "y"), &[4.0, 4.0], 1, 2);
+
+    let error = program
+        .update_inputs_and_advance_turn(&[ProgramInputUpdate {
+            input,
+            value: matrix_value(vec![1.0, 2.0], 1, 2),
+        }])
+        .expect_err("a failed reactive broadcast kernel must return an error");
+
+    assert_status_error(
+        &error.full_chain_message(),
+        "status-test/binary",
+        "Unsupported",
+        5,
+    );
+    assert_matrix_output(symbol_value(&program, "x"), &[1.0, 2.0], 1, 2);
+    assert_matrix_output(symbol_value(&program, "y"), &[4.0, 4.0], 1, 2);
+}
+
+#[test]
+fn view_output_is_all_or_nothing() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let input = ensure_input(&mut program, "x", matrix_value(vec![1.0, 1.0], 1, 2));
+    program
+        .run_string(
+            "+> status-test/view
+y := view(x)
+y",
+        )
+        .unwrap();
+    assert_matrix_output(symbol_value(&program, "y"), &[10.0, 10.0], 1, 2);
+
+    let error = program
+        .update_inputs_and_advance_turn(&[ProgramInputUpdate {
+            input,
+            value: matrix_value(vec![1.0, 2.0], 1, 2),
+        }])
+        .expect_err("a failed reactive view kernel must return an error");
+
+    assert_status_error(&error.full_chain_message(), "status-test/view", "Panic", 6);
+    assert_matrix_output(symbol_value(&program, "x"), &[1.0, 2.0], 1, 2);
+    assert_matrix_output(symbol_value(&program, "y"), &[10.0, 10.0], 1, 2);
+}

--- a/tests/fixtures/dynamic-status-module/Cargo.toml
+++ b/tests/fixtures/dynamic-status-module/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mech-dynamic-status-test"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "mech_dynamic_status_test"
+crate-type = ["cdylib"]
+
+[dependencies]
+mech-abi = { path = "../../../src/abi" }
+
+[workspace]

--- a/tests/fixtures/dynamic-status-module/src/lib.rs
+++ b/tests/fixtures/dynamic-status-module/src/lib.rs
@@ -1,0 +1,93 @@
+use mech_abi::{MechF64ViewMutV1, MechF64ViewV1, MechStatusV1};
+
+mech_abi::mech_dynamic_module_v1! {
+    module: b"status-test",
+    exports: [
+        unary_f64_to_f64 {
+            name: b"status-test/unary",
+            function: status_test_unary,
+        },
+        binary_f64_f64_to_f64 {
+            name: b"status-test/binary",
+            function: status_test_binary,
+        },
+        unary_f64_view_to_f64_view {
+            name: b"status-test/view",
+            function: status_test_view,
+        },
+    ],
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn status_test_unary(input: f64, out: *mut f64) -> MechStatusV1 {
+    if out.is_null() {
+        return MechStatusV1::NullPointer;
+    }
+
+    unsafe {
+        *out = if input == 2.0 { 999.0 } else { input * 10.0 };
+    }
+
+    if input == 2.0 {
+        MechStatusV1::WrongShape
+    } else {
+        MechStatusV1::Ok
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn status_test_binary(lhs: f64, rhs: f64, out: *mut f64) -> MechStatusV1 {
+    if out.is_null() {
+        return MechStatusV1::NullPointer;
+    }
+
+    unsafe {
+        *out = if lhs == 2.0 { 999.0 } else { lhs + rhs };
+    }
+
+    if lhs == 2.0 {
+        MechStatusV1::Unsupported
+    } else {
+        MechStatusV1::Ok
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn status_test_view(
+    input: MechF64ViewV1,
+    out: MechF64ViewMutV1,
+) -> MechStatusV1 {
+    let Some(expected_len) = input.rows.checked_mul(input.cols) else {
+        return MechStatusV1::WrongShape;
+    };
+
+    if input.len != out.len
+        || input.rows != out.rows
+        || input.cols != out.cols
+        || input.len != expected_len
+    {
+        return MechStatusV1::WrongShape;
+    }
+
+    if input.len > 0 && (input.ptr.is_null() || out.ptr.is_null()) {
+        return MechStatusV1::NullPointer;
+    }
+
+    if input.len == 0 {
+        return MechStatusV1::Ok;
+    }
+
+    let input_values = unsafe { std::slice::from_raw_parts(input.ptr, input.len) };
+    let output_values = unsafe { std::slice::from_raw_parts_mut(out.ptr, out.len) };
+    let should_fail = input_values.iter().any(|value| *value == 2.0);
+
+    for (output, value) in output_values.iter_mut().zip(input_values) {
+        *output = if should_fail { 999.0 } else { value * 10.0 };
+    }
+
+    if should_fail {
+        MechStatusV1::Panic
+    } else {
+        MechStatusV1::Ok
+    }
+}


### PR DESCRIPTION
## Summary

Closes the dynamic-kernel failure finding from release PR #581.

- eager native-function initialization now propagates `solve_result`;
- scalar dynamic kernels stage outputs before committing;
- broadcast and view adapters return kernel failures instead of tracing and
  suppressing them;
- reactive failures preserve the last successful output;
- a dedicated ABI fixture exercises WrongShape, Unsupported, and Panic
  statuses through the real dynamic loader.

## Behavioral decisions

- Any non-OK kernel status is an execution error.
- Status errors include the function name, symbolic status, and numeric
  status code.
- Failed eager functions are not registered in the reactive plan.
- Failed reactive outputs retain their last successful value.
- Triggering input writes are not rolled back.
- Broadcast and view outputs are all-or-nothing.
- Activation registration remains solve-deferred.
- `solve()` remains an infallible compatibility wrapper; error-aware paths
  use `solve_result()`.

## Scope

This PR does not change the ABI, add kernel kinds, add bytecode support,
modify production dynamic providers, or address the remaining capability
grant finding.

## Validation

Passed:

- `rustfmt --edition 2024 src/interpreter/src/functions.rs src/interpreter/src/modules.rs tests/dynamic_status_failures.rs tests/fixtures/dynamic-status-module/src/lib.rs`
- `bash -n scripts/test-dynamic-modules.sh`
- `cargo test -p mech-interpreter --lib --no-default-features --features "base dynamic-modules f64"`
- `cargo check -p mech-interpreter --no-default-features --features "base dynamic-modules f64"`
- `cargo build --manifest-path tests/fixtures/dynamic-status-module/Cargo.toml --target-dir target/dynamic-modules`
- `bash scripts/test-dynamic-modules.sh` (math, combinatorics, new status fixture, and smoke tests)
- `cargo test -p mech-interpreter --lib`
- `cargo test -p mech-program --lib`
- `cargo test -p mech-runtime --lib live_host_output_kind_change_preserves_previous_output`
- `git diff --check`

`cargo test -p mech-runtime --lib` passed the corrected host-output test but has three unrelated local failures in `workspace::watch` path tests:
`nonrecursive_directory_watch_allows_directory_and_direct_children_only`,
`recursive_directory_watch_still_allows_descendants`, and
`target_watch_falls_back_to_existing_parent_when_target_is_deleted`.

The initial restricted-network attempts to fetch missing Cargo dependencies failed DNS resolution; each was rerun with registry access and passed.