### PR TITLE
[v0.4] Compensate failed capability grants

### DIFF
--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -16,6 +16,20 @@ use std::collections::{HashMap, HashSet, VecDeque};
 pub trait CapabilityKernel: std::fmt::Debug + Send {
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId>;
 
+  /// Administratively remove a grant that has not committed.
+  ///
+  /// Contract:
+  ///
+  /// - `grant` must not retain grant state when it returns `Err`;
+  /// - `rollback_grant` is called only after `grant` returned `Ok`;
+  /// - `rollback_grant` removes an uncommitted grant administratively;
+  /// - it is not ordinary revocation;
+  /// - it must ignore `Capability::is_revocable`;
+  /// - it must be idempotent;
+  /// - after successful rollback, the kernel must behave as though the grant
+  ///   never occurred.
+  fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()>;
+
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()>;
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId>;
@@ -111,6 +125,26 @@ impl BasicCapabilityKernel {
 
     out
   }
+
+  fn remove_capability_state(&mut self, capability: CapabilityId) {
+    self.capabilities.remove(&capability);
+    self.revoked.remove(&capability);
+    self.uses.remove(&capability);
+
+    self.by_subject.retain(|_, ids| {
+      ids.remove(&capability);
+      !ids.is_empty()
+    });
+
+    self.children.remove(&capability);
+    self.parent.retain(|child, parent| {
+      *child != capability && *parent != capability
+    });
+    self.children.retain(|_, children| {
+      children.remove(&capability);
+      !children.is_empty()
+    });
+  }
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
@@ -128,6 +162,17 @@ impl CapabilityKernel for BasicCapabilityKernel {
     }
 
     Ok(self.index_capability(capability))
+  }
+
+  fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> {
+    let descendants = self.descendants_of(capability);
+
+    for descendant in descendants.into_iter().rev() {
+      self.remove_capability_state(descendant);
+    }
+
+    self.remove_capability_state(capability);
+    Ok(())
   }
 
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
@@ -326,6 +371,7 @@ impl SharedCapabilityKernel {
 
 impl CapabilityKernel for SharedCapabilityKernel {
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
+  fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().check(request) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }

--- a/src/runtime/src/capability/mod.rs
+++ b/src/runtime/src/capability/mod.rs
@@ -304,6 +304,138 @@ mod tests {
   }
 
   #[test]
+  fn rollback_grant_bypasses_non_revocable_policy() {
+    let mut kernel = BasicCapabilityKernel::new();
+    let capability = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task://1",
+      "db://users",
+      [":read"],
+    )
+    .revocable(false);
+    let request = CapabilityRequest::from_keys("task://1", ":read", "db://users");
+    let subject = BasicSubject::new("task://1");
+
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(capability)))
+      .unwrap();
+    assert_eq!(kernel.check(&request).unwrap(), CapabilityId(1));
+
+    kernel.rollback_grant(CapabilityId(1)).unwrap();
+
+    assert!(kernel.get(CapabilityId(1)).unwrap().is_none());
+    assert!(!kernel
+      .list_for_subject(&subject)
+      .unwrap()
+      .contains(&CapabilityId(1)));
+    assert!(kernel.check(&request).is_err());
+  }
+
+  #[test]
+  fn rollback_grant_clears_use_accounting() {
+    let mut kernel = BasicCapabilityKernel::new();
+    let request = CapabilityRequest::from_keys("task://1", ":read", "db://users");
+
+    let capability = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task://1",
+      "db://users",
+      [":read"],
+    )
+    .with_constraints(BasicConstraints::default().with_max_uses(1));
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(capability)))
+      .unwrap();
+    assert_eq!(kernel.check(&request).unwrap(), CapabilityId(1));
+
+    kernel.rollback_grant(CapabilityId(1)).unwrap();
+
+    let replacement = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task://1",
+      "db://users",
+      [":read"],
+    )
+    .with_constraints(BasicConstraints::default().with_max_uses(1));
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(replacement)))
+      .unwrap();
+    assert_eq!(kernel.check(&request).unwrap(), CapabilityId(1));
+  }
+
+  #[test]
+  fn rollback_grant_removes_descendants_and_graph_indexes() {
+    let mut kernel = BasicCapabilityKernel::new();
+    let parent_subject = BasicSubject::new("task://1");
+    let child_subject = BasicSubject::new("task://2");
+
+    let parent = BasicCapability::from_keys(
+      CapabilityId(1),
+      parent_subject.key(),
+      "db://users",
+      [":read"],
+    )
+    .delegable(true);
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(parent)))
+      .unwrap();
+    kernel
+      .derive_capability(CapabilityDerivation::delegate(
+        CapabilityId(1),
+        CapabilityId(2),
+        &parent_subject,
+        &child_subject,
+      ))
+      .unwrap();
+
+    kernel.rollback_grant(CapabilityId(1)).unwrap();
+
+    assert!(kernel.get(CapabilityId(1)).unwrap().is_none());
+    assert!(kernel.get(CapabilityId(2)).unwrap().is_none());
+    assert!(kernel.list_for_subject(&parent_subject).unwrap().is_empty());
+    assert!(kernel.list_for_subject(&child_subject).unwrap().is_empty());
+
+    let replacement = BasicCapability::from_keys(
+      CapabilityId(1),
+      parent_subject.key(),
+      "db://users",
+      [":read"],
+    )
+    .delegable(true);
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(replacement)))
+      .unwrap();
+    assert_eq!(
+      kernel
+        .derive_capability(CapabilityDerivation::delegate(
+          CapabilityId(1),
+          CapabilityId(2),
+          &parent_subject,
+          &child_subject,
+        ))
+        .unwrap(),
+      CapabilityId(2),
+    );
+  }
+
+  #[test]
+  fn rollback_grant_is_idempotent() {
+    let mut kernel = BasicCapabilityKernel::new();
+    let capability = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task://1",
+      "db://users",
+      [":read"],
+    );
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(capability)))
+      .unwrap();
+
+    assert!(kernel.rollback_grant(CapabilityId(1)).is_ok());
+    assert!(kernel.rollback_grant(CapabilityId(1)).is_ok());
+  }
+
+  #[test]
   fn constrained_capability_denies_missing_metrics() {
     let subject = BasicSubject::new("task://1");
     let resource = BasicResource::new("db://users");

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -13,6 +13,32 @@
 
 use super::*;
 
+fn finish_failed_capability_grant(
+  capability: CapabilityId,
+  original: MechError,
+  rollback_failures: Vec<(&'static str, MechError)>,
+) -> MechError {
+  if rollback_failures.is_empty() {
+    return original;
+  }
+
+  let rollback_failures = rollback_failures
+    .into_iter()
+    .map(|(component, error)| {
+      format!("{component}: {}", error.full_chain_message())
+    })
+    .collect();
+
+  MechError::new(
+    RuntimeCapabilityGrantRollbackFailed {
+      capability,
+      rollback_failures,
+    },
+    None,
+  )
+  .with_source(original)
+}
+
 impl MechRuntime {
 
   pub fn grant_capability_with_context(
@@ -26,20 +52,50 @@ impl MechRuntime {
 
     let id = capability.id();
 
-    self
+    self.store.grant_capability(id, capability.clone())?;
+
+    if let Err(error) = self
       .capability_kernel
-      .grant(CapabilityGrant::new(capability.clone()))?;
+      .grant(CapabilityGrant::new(capability))
+    {
+      let rollback_failures = match self.store.rollback_capability_grant(id) {
+        Ok(()) => Vec::new(),
+        Err(rollback_error) => vec![("capability store", rollback_error)],
+      };
 
-    self.store.grant_capability(id, capability)?;
-    context.add_capability(id);
+      return Err(finish_failed_capability_grant(
+        id,
+        error,
+        rollback_failures,
+      ));
+    }
 
-    self.emit_event_to_context(
+    let context_events_before = context.events.clone();
+
+    if let Err(error) = self.emit_event_to_context(
       context,
       RuntimeEventKind::CapabilityGranted {
         capability_id: id,
       },
-    )?;
+    ) {
+      context.events = context_events_before;
 
+      let mut rollback_failures = Vec::new();
+      if let Err(rollback_error) = self.capability_kernel.rollback_grant(id) {
+        rollback_failures.push(("capability kernel", rollback_error));
+      }
+      if let Err(rollback_error) = self.store.rollback_capability_grant(id) {
+        rollback_failures.push(("capability store", rollback_error));
+      }
+
+      return Err(finish_failed_capability_grant(
+        id,
+        error,
+        rollback_failures,
+      ));
+    }
+
+    context.add_capability(id);
     Ok(id)
   }
 
@@ -95,5 +151,423 @@ impl MechRuntime {
     id: CapabilityId,
   ) -> MResult<Option<Arc<dyn Capability>>> {
     self.store.get_capability(id)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use std::collections::VecDeque;
+  use std::sync::atomic::{AtomicBool, Ordering};
+
+  use mech_core::{GenericError, MResult, MechError};
+
+  use crate::capability::{
+    BasicCapability, BasicCapabilityKernel, CapabilityDerivation, CapabilityGrant,
+    CapabilityKernel, Subject,
+  };
+  use crate::id::{
+    ActorId, EventId, IdGenerator, MessageId, NodeId, ObjectId, RuntimeId,
+    SequentialIdGenerator, TaskId, TransactionId,
+  };
+  use crate::store::{InMemoryStore, MechStore};
+
+  fn capability(
+    id: CapabilityId,
+    subject: &str,
+    revocable: bool,
+  ) -> Arc<dyn Capability> {
+    Arc::new(
+      BasicCapability::from_keys(id, subject, "db://users", [":read"])
+        .revocable(revocable),
+    )
+  }
+
+  fn request(subject: &str) -> CapabilityRequest {
+    CapabilityRequest::from_keys(subject, ":read", "db://users")
+  }
+
+  #[derive(Debug)]
+  struct ScriptedEventIdGenerator {
+    next: u128,
+    event_ids: VecDeque<EventId>,
+  }
+
+  impl ScriptedEventIdGenerator {
+    fn new(next: u128, event_ids: impl IntoIterator<Item = EventId>) -> Self {
+      Self {
+        next,
+        event_ids: event_ids.into_iter().collect(),
+      }
+    }
+
+    fn next_id(&mut self) -> u128 {
+      let id = self.next;
+      self.next = self.next.saturating_add(1);
+      id
+    }
+  }
+
+  impl IdGenerator for ScriptedEventIdGenerator {
+    fn runtime_id(&mut self) -> RuntimeId {
+      RuntimeId(self.next_id())
+    }
+
+    fn object_id(&mut self) -> ObjectId {
+      ObjectId(self.next_id())
+    }
+
+    fn actor_id(&mut self) -> ActorId {
+      ActorId(self.next_id())
+    }
+
+    fn task_id(&mut self) -> TaskId {
+      TaskId(self.next_id())
+    }
+
+    fn capability_id(&mut self) -> CapabilityId {
+      CapabilityId(self.next_id())
+    }
+
+    fn transaction_id(&mut self) -> TransactionId {
+      TransactionId(self.next_id())
+    }
+
+    fn event_id(&mut self) -> EventId {
+      self
+        .event_ids
+        .pop_front()
+        .unwrap_or_else(|| EventId(self.next_id()))
+    }
+
+    fn node_id(&mut self) -> NodeId {
+      NodeId(self.next_id())
+    }
+
+    fn message_id(&mut self) -> MessageId {
+      MessageId(self.next_id())
+    }
+  }
+
+  #[derive(Debug)]
+  struct FailingRollbackKernel {
+    inner: BasicCapabilityKernel,
+    rollback_attempted: Arc<AtomicBool>,
+  }
+
+  impl CapabilityKernel for FailingRollbackKernel {
+    fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
+      self.inner.grant(grant)
+    }
+
+    fn rollback_grant(&mut self, _capability: CapabilityId) -> MResult<()> {
+      self.rollback_attempted.store(true, Ordering::SeqCst);
+      Err(MechError::new(
+        GenericError {
+          msg: "test kernel rollback failed".to_string(),
+        },
+        None,
+      ))
+    }
+
+    fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
+      self.inner.revoke(revocation)
+    }
+
+    fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
+      self.inner.check(request)
+    }
+
+    fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
+      self.inner.get(id)
+    }
+
+    fn list_for_subject(
+      &self,
+      subject: &dyn Subject,
+    ) -> MResult<Vec<CapabilityId>> {
+      self.inner.list_for_subject(subject)
+    }
+
+    fn derive_capability(
+      &mut self,
+      derivation: CapabilityDerivation,
+    ) -> MResult<CapabilityId> {
+      self.inner.derive_capability(derivation)
+    }
+
+    fn is_revoked(&self, id: CapabilityId) -> MResult<bool> {
+      self.inner.is_revoked(id)
+    }
+  }
+
+  #[test]
+  fn capability_grant_store_failure_never_grants_kernel_authority() {
+    let mut store = InMemoryStore::new();
+    store
+      .grant_capability(CapabilityId(100), capability(CapabilityId(100), "task:1", true))
+      .unwrap();
+
+    let mut runtime = MechRuntime::builder().store(store).build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let durable_events_before = runtime.list_events(None).unwrap();
+
+    let error = runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(CapabilityId(100), "task:1", true),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "StoreRecordAlreadyExists");
+    assert!(runtime
+      .capability_kernel()
+      .get(CapabilityId(100))
+      .unwrap()
+      .is_none());
+    assert!(!context.has_capability(CapabilityId(100)));
+    assert!(!context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::CapabilityGranted {
+          capability_id: CapabilityId(100),
+        }
+      )
+    }));
+    assert!(runtime.get_capability(CapabilityId(100)).unwrap().is_some());
+    assert_eq!(
+      runtime
+        .store()
+        .list_capabilities_for_subject("task:1")
+        .unwrap(),
+      vec![CapabilityId(100)],
+    );
+    assert_eq!(runtime.list_events(None).unwrap(), durable_events_before);
+  }
+
+  #[test]
+  fn capability_grant_kernel_failure_rolls_back_store() {
+    let mut kernel = BasicCapabilityKernel::new();
+    kernel
+      .grant(CapabilityGrant::new(capability(CapabilityId(100), "task:1", true)))
+      .unwrap();
+
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let context_events_before = context.events.clone();
+    let context_capabilities_before = context.capabilities.clone();
+
+    let error = runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(CapabilityId(100), "task:1", true),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "CapabilityAlreadyExists");
+    assert!(runtime.get_capability(CapabilityId(100)).unwrap().is_none());
+    assert!(runtime
+      .capability_kernel()
+      .get(CapabilityId(100))
+      .unwrap()
+      .is_some());
+    assert_eq!(context.events, context_events_before);
+    assert_eq!(context.capabilities, context_capabilities_before);
+  }
+
+  #[test]
+  fn capability_grant_event_failure_removes_non_revocable_live_authority() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_in_memory_events = Some(1);
+    let mut runtime = MechRuntime::builder()
+      .config(config)
+      .id_generator(ScriptedEventIdGenerator::new(
+        1,
+        [EventId(100), EventId(100)],
+      ))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    context.events.push(RuntimeEvent::new(
+      EventId(999),
+      999,
+      RuntimeEventKind::RuntimeTickStarted,
+    ));
+    let context_events_before = context.events.clone();
+
+    let error = runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(CapabilityId(100), "task:1", false),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "StoreRecordAlreadyExists");
+    assert_eq!(context.events, context_events_before);
+    assert!(!context.has_capability(CapabilityId(100)));
+    assert!(runtime.get_capability(CapabilityId(100)).unwrap().is_none());
+    assert!(runtime
+      .capability_kernel()
+      .get(CapabilityId(100))
+      .unwrap()
+      .is_none());
+    assert!(runtime.check_capability(&request("task:1")).is_err());
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::RuntimeCreated { .. })
+    }));
+    assert!(!runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::CapabilityGranted { .. })
+    }));
+  }
+
+  #[test]
+  fn capability_grant_failed_transactional_event_staging_is_compensated() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(ScriptedEventIdGenerator::new(
+        1,
+        [EventId(100), EventId(101), EventId(0)],
+      ))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let context_events_before = context.events.clone();
+
+    let error = runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(CapabilityId(100), "task:1", true),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "InvalidRuntimeEvent");
+    assert_eq!(context.events, context_events_before);
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(runtime.active_transactions.contains_key(&transaction_id));
+    assert!(!runtime
+      .active_transactions
+      .get(&transaction_id)
+      .unwrap()
+      .staged_events()
+      .any(|event| matches!(event.kind, RuntimeEventKind::CapabilityGranted { .. })));
+    assert!(runtime.get_capability(CapabilityId(100)).unwrap().is_none());
+    assert!(runtime
+      .capability_kernel()
+      .get(CapabilityId(100))
+      .unwrap()
+      .is_none());
+    assert!(!context.has_capability(CapabilityId(100)));
+
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn capability_grant_incomplete_rollback_is_reported_and_continues() {
+    let rollback_attempted = Arc::new(AtomicBool::new(false));
+    let kernel = FailingRollbackKernel {
+      inner: BasicCapabilityKernel::new(),
+      rollback_attempted: rollback_attempted.clone(),
+    };
+    let mut config = RuntimeConfig::default();
+    config.limits.max_in_memory_events = Some(1);
+    let mut runtime = MechRuntime::builder()
+      .config(config)
+      .id_generator(ScriptedEventIdGenerator::new(
+        1,
+        [EventId(100), EventId(100)],
+      ))
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    context.events.push(RuntimeEvent::new(
+      EventId(999),
+      999,
+      RuntimeEventKind::RuntimeTickStarted,
+    ));
+    let context_events_before = context.events.clone();
+
+    let error = runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(CapabilityId(100), "task:1", false),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeCapabilityGrantRollbackFailed");
+    assert_eq!(
+      error.source.as_ref().unwrap().kind_name(),
+      "StoreRecordAlreadyExists",
+    );
+    let rollback = error
+      .kind_as::<RuntimeCapabilityGrantRollbackFailed>()
+      .unwrap();
+    assert!(rollback
+      .rollback_failures
+      .iter()
+      .any(|failure| failure.contains("capability kernel: GenericError")));
+    assert!(rollback_attempted.load(Ordering::SeqCst));
+    assert!(runtime.get_capability(CapabilityId(100)).unwrap().is_none());
+    assert_eq!(context.events, context_events_before);
+    assert!(!context.has_capability(CapabilityId(100)));
+    assert!(runtime
+      .capability_kernel()
+      .get(CapabilityId(100))
+      .unwrap()
+      .is_some());
+  }
+
+  #[test]
+  fn capability_grant_success_updates_every_component_once() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    assert_eq!(
+      runtime
+        .grant_capability_with_context(&mut context, capability(id, "task:1", true))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime.get_capability(id).unwrap().is_some());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_some());
+    assert_eq!(runtime.check_capability(&request("task:1")).unwrap(), id);
+    assert_eq!(context.capabilities.iter().filter(|candidate| **candidate == id).count(), 1);
+    assert_eq!(
+      context
+        .events
+        .iter()
+        .filter(|event| {
+          matches!(
+            event.kind,
+            RuntimeEventKind::CapabilityGranted { capability_id } if capability_id == id
+          )
+        })
+        .count(),
+      1,
+    );
+    assert_eq!(
+      runtime
+        .list_events(None)
+        .unwrap()
+        .iter()
+        .filter(|event| {
+          matches!(
+            event.kind,
+            RuntimeEventKind::CapabilityGranted { capability_id } if capability_id == id
+          )
+        })
+        .count(),
+      1,
+    );
   }
 }

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -9,6 +9,26 @@
 use super::*;
 
 #[derive(Debug, Clone)]
+pub struct RuntimeCapabilityGrantRollbackFailed {
+  pub capability: CapabilityId,
+  pub rollback_failures: Vec<String>,
+}
+
+impl MechErrorKind for RuntimeCapabilityGrantRollbackFailed {
+  fn name(&self) -> &str {
+    "RuntimeCapabilityGrantRollbackFailed"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "capability grant {} failed and compensation was incomplete: {}",
+      self.capability,
+      self.rollback_failures.join("; "),
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
 pub struct RuntimeModuleDependencyCycleError {
   pub cycle: Vec<String>,
 }

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -125,6 +125,19 @@ pub trait MechStore: std::fmt::Debug + Send {
     capability: Arc<dyn Capability>,
   ) -> MResult<CapabilityId>;
 
+  /// Administratively remove a capability grant that has not committed.
+  ///
+  /// Contract:
+  ///
+  /// - `grant_capability` must not retain grant state when it returns `Err`;
+  /// - `rollback_capability_grant` is called only after `grant_capability`
+  ///   returned `Ok`;
+  /// - it administratively removes an uncommitted record;
+  /// - it ignores the capability's revocable policy;
+  /// - it is idempotent;
+  /// - it removes subject and revocation indexes as well as the primary record.
+  fn rollback_capability_grant(&mut self, id: CapabilityId) -> MResult<()>;
+
   fn get_capability(
     &self,
     id: CapabilityId,
@@ -1269,6 +1282,18 @@ impl MechStore for InMemoryStore {
     Ok(id)
   }
 
+  fn rollback_capability_grant(&mut self, id: CapabilityId) -> MResult<()> {
+    self.capabilities.remove(&id);
+    self.revoked_capabilities.remove(&id);
+
+    self.capabilities_by_subject.retain(|_, ids| {
+      ids.retain(|candidate| *candidate != id);
+      !ids.is_empty()
+    });
+
+    Ok(())
+  }
+
   fn get_capability(
     &self,
     id: CapabilityId,
@@ -1737,6 +1762,63 @@ mod tests {
     store.revoke_capability(CapabilityId(1)).unwrap();
 
     assert!(store.is_capability_revoked(CapabilityId(1)).unwrap());
+  }
+
+  #[test]
+  fn capability_grant_rollback_removes_non_revocable_capability() {
+    let mut store = InMemoryStore::new();
+    let capability = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task:1",
+      "db:users",
+      [":read"],
+    )
+    .revocable(false);
+
+    store
+      .grant_capability(CapabilityId(1), Arc::new(capability))
+      .unwrap();
+    store.rollback_capability_grant(CapabilityId(1)).unwrap();
+
+    assert!(store.get_capability(CapabilityId(1)).unwrap().is_none());
+    assert!(store
+      .list_capabilities_for_subject("task:1")
+      .unwrap()
+      .is_empty());
+
+    let replacement = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task:1",
+      "db:users",
+      [":read"],
+    )
+    .revocable(false);
+    assert_eq!(
+      store
+        .grant_capability(CapabilityId(1), Arc::new(replacement))
+        .unwrap(),
+      CapabilityId(1),
+    );
+  }
+
+  #[test]
+  fn capability_grant_rollback_is_idempotent() {
+    let mut store = InMemoryStore::new();
+
+    assert!(store.rollback_capability_grant(CapabilityId(1)).is_ok());
+
+    let capability = BasicCapability::from_keys(
+      CapabilityId(1),
+      "task:1",
+      "db:users",
+      [":read"],
+    );
+    store
+      .grant_capability(CapabilityId(1), Arc::new(capability))
+      .unwrap();
+
+    assert!(store.rollback_capability_grant(CapabilityId(1)).is_ok());
+    assert!(store.rollback_capability_grant(CapabilityId(1)).is_ok());
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Closes the failed-capability-grant finding from release PR #581.

- persist capability records before exposing live kernel authority;
- add explicit administrative rollback operations to the kernel and store;
- compensate successful store and kernel mutations when later grant steps fail;
- restore the complete context event state after failed event emission;
- surface incomplete compensation with a structured error and the original
  failure as its source.

## Behavioral decisions

- Store grant occurs before kernel grant.
- Context authority is added only after all fallible work succeeds.
- Administrative rollback is distinct from revocation and ignores
  `is_revocable`.
- Grant and rollback operations are idempotent according to their documented
  contracts.
- Kernel compensation is attempted before store compensation after an event
  failure.
- Every compensation step is attempted even when an earlier rollback fails.
- Successful compensation returns the original operation error.
- Incomplete compensation returns
  `RuntimeCapabilityGrantRollbackFailed` with the original error as its cause.
- Event rollback restores the complete prior context event vector rather than
  truncating by length.

## Scope

This PR does not add a general kernel/store transaction, stage capability
mutations in RuntimeTransaction, change revocation behavior, implement
two-phase commit, or make later transaction aborts undo successful capability
grants.

## Validation

- `cargo test -p mech-runtime --lib rollback_grant -- --nocapture` — passed (4 tests).
- `cargo test -p mech-runtime --lib capability_grant -- --nocapture` — passed (9 tests).
- `cargo test -p mech-runtime --lib store::tests -- --nocapture` — passed (15 tests).
- `cargo test -p mech-runtime --lib --tests` — 340 passed; 3 known macOS workspace-watch failures involving `/var` versus `/private/var`.
- `cargo check -p mech-runtime --no-default-features` — passed (one pre-existing dead-code warning).
- `cargo check -p mech-runtime --no-default-features --features program` — passed (one pre-existing dead-code warning).
- `cargo check -p mech-runtime --no-default-features --features compiler` — passed (one pre-existing dead-code warning).
- `cargo check -p mech-runtime` — passed.
- `cargo check -p mech-wasm --target wasm32-unknown-unknown --no-default-features --features browser_project_runner` — passed (existing dylib/dead-code warnings).
- `git diff --check` — passed.
