### PR TITLE
[v0.4] Add retained program checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,7 @@ version = "0.3.5"
 dependencies = [
  "bincode",
  "colored",
+ "criterion",
  "crossbeam-channel",
  "csv",
  "mech-core",

--- a/docs/design/retained-program-checkpoint-function-state-audit.md
+++ b/docs/design/retained-program-checkpoint-function-state-audit.md
@@ -1,0 +1,74 @@
+# Retained program checkpoint function-state audit
+
+`MechFunctionImpl::transaction_state_values` is the checkpoint contract for
+mutable state retained inside a plan node. The default is correct when all
+semantic mutation is reachable from `reactive_output_values`. Implementations
+with hidden cells must return those cells explicitly, and implementations whose
+state cannot be represented by journaled `Value` cells must return
+`TransactionStateUnsupported`.
+
+The Round 2 audit covered every production `MechFunctionImpl` under `src/`,
+`machines/`, and `hosts/`.
+
+## Explicit retained-state discovery
+
+- `UserFunction`: result cell, symbols, and nested plan state.
+- Activation state: `Matcher`, `Finalize`, `UnmatchedFinalize`,
+  `GuardFinalize`, and `Select`.
+- Outer `Ref<Value>` outputs: `ConvertSEmpty`, `ConvertMatPassthrough`,
+  `ValueMatrixComprehension`, `VariableDefineEmpty`,
+  and `MatrixAccessScalarValueF`.
+- Non-reactive activation payload state is retained by the plan collector's
+  empty-output fallback through `ActivationEffectPayloadCapture::out`.
+
+## Structured unsupported state
+
+- `NChooseKMatrix<T>` retains `Ref<Matrix<T>>` and can replace the outer matrix
+  enum. That outer topology is not a journalable `Value` cell, so checkpoint
+  creation returns `TransactionStateUnsupported` before mutation.
+- `RuntimeHostNativeFunction` owns an outer output cell in the runtime layer.
+  Retaining that topology requires the runtime transaction coordinator, so
+  Round 2 rejects it before inspection or mutation.
+
+## Implementations covered by the default
+
+- Core unary, binary, and register families.
+- Remaining interpreter conversion, access, assignment, definition,
+  concatenation, table, set, string, and matrix functions.
+- `ScopePulse`, `MatchGate`, and `Gate`; committed gate captures are reactive
+  outputs.
+- Dynamic-module functions and `ClosureNativeFunction`; their executable
+  handles are immutable and their semantic mutation is output-backed.
+- Remaining machine functions in stats, matrix, range, compare, logic, math,
+  string, set, and scalar combinatorics.
+- I/O print functions and `ActivationEffectBarrier`, which retain no mutable
+  semantic state.
+
+No host crate directly implements `MechFunctionImpl`; runtime host calls are
+represented by the structured unsupported boundary above.
+
+Out-of-tree implementations are responsible for honoring this trait contract.
+Hidden mutable state must never inherit the permissive output-backed default.
+
+## Checkpoint architecture guardrails
+
+- `ValueStateJournal` is the only layer that knows how current cell payloads
+  are physically captured and restored. Structural checkpoints coordinate its
+  preflight and apply API without reaching through a value handle.
+- `MechProgramCheckpoint` keeps the journal behind the opaque
+  `InterpreterCheckpoint`; program code never inspects journal entries or
+  performs physical cell restoration.
+- These checkpoints are explicit, process-local savepoints. They are not
+  durable history, and runtime transaction identity must never be derived from
+  pointer addresses.
+- `ReactiveCellId` remains a process-local scheduler identity. Durable history
+  requires an explicit stable logical cell ID before it is introduced.
+- Journal capture and restoration occur only through explicit checkpoint APIs,
+  never in the reactive solver inner loop.
+- The current benchmark suite measures capture and restore separately across
+  the required retained structures. A value-arena rewrite must be justified by
+  additional representative, real Mech workload measurements rather than
+  these structural microbenchmarks alone.
+- `Ref<T>` hides its current `Rc<RefCell<T>>` backing and exposes handle,
+  borrowing, and identity operations through its own API so future value
+  storage changes remain localized.

--- a/docs/design/retained-program-checkpoint-function-state-audit.md
+++ b/docs/design/retained-program-checkpoint-function-state-audit.md
@@ -27,8 +27,9 @@ The Round 2 audit covered every production `MechFunctionImpl` under `src/`,
   enum. That outer topology is not a journalable `Value` cell, so checkpoint
   creation returns `TransactionStateUnsupported` before mutation.
 - `RuntimeHostNativeFunction` owns an outer output cell in the runtime layer.
-  Retaining that topology requires the runtime transaction coordinator, so
-  Round 2 rejects it before inspection or mutation.
+  Retaining that topology requires the runtime transaction coordinator. The
+  function itself therefore returns `TransactionStateUnsupported` before
+  ordinary program checkpointing can inspect or mutate its state.
 
 ## Implementations covered by the default
 
@@ -44,11 +45,36 @@ The Round 2 audit covered every production `MechFunctionImpl` under `src/`,
 - I/O print functions and `ActivationEffectBarrier`, which retain no mutable
   semantic state.
 
-No host crate directly implements `MechFunctionImpl`; runtime host calls are
-represented by the structured unsupported boundary above.
+`RuntimeHostNativeFunction` declares the runtime-layer unsupported boundary
+itself. Provider crates under `hosts/` do not directly implement
+`MechFunctionImpl`.
 
 Out-of-tree implementations are responsible for honoring this trait contract.
 Hidden mutable state must never inherit the permissive output-backed default.
+
+## Plan function-object lifetime constraint
+
+A plan checkpoint retains the identity of every function object that existed
+when the checkpoint was created. It does not clone or take secondary ownership
+of `Box<dyn MechFunction>`. The retained identity is a process-local preflight
+token only, not a durable cell or runtime transaction identity.
+
+Supported structural changes include:
+
+- appending new plan nodes;
+- changing metadata on pre-existing nodes;
+- changing value-backed state owned by pre-existing functions;
+- adding activation registrations and scopes.
+
+Restoration removes appended nodes, restores metadata and registrations, and
+restores value-backed function state.
+
+Removing or replacing a pre-existing function object invalidates the
+checkpoint. Restore detects the missing or changed function identity during
+preflight, returns a structured error, and performs no partial restoration.
+
+Runtime transaction coordination must treat failure to restore a checkpoint as
+a runtime-poisoning condition.
 
 ## Checkpoint architecture guardrails
 

--- a/machines/combinatorics/src/n_choose_k.rs
+++ b/machines/combinatorics/src/n_choose_k.rs
@@ -147,6 +147,15 @@ where
       *self.out.borrow_mut() = result;
   }
   fn out(&self) -> Value { (*self.out.borrow()).to_value() }
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: format!("NChooseKMatrix<{}>", core::any::type_name::<T>()),
+        reason: "the retained outer matrix enum is not a Value-backed cell".to_string(),
+      },
+      None,
+    ).with_compiler_loc())
+  }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
 #[cfg(all(feature = "matrix", feature = "compiler"))]
@@ -160,6 +169,26 @@ where
   }
 }
 register_fxn_descriptor!(NChooseKMatrix, u8, "u8", i8, "i8", u16, "u16", i16, "i16", u32, "u32", i32, "i32", u64, "u64", i64, "i64", u128, "u128", i128, "i128", f32, "f32", f64, "f64", R64, "r64", C64, "c64");
+
+#[cfg(all(test, feature = "matrix", feature = "f64"))]
+mod transaction_state_tests {
+  use super::*;
+
+  #[test]
+  fn matrix_combinations_decline_unsupported_outer_state_without_borrowing_it() {
+    let function = NChooseKMatrix {
+      n: Ref::new(f64::to_matrix(vec![1.0, 2.0], 2, 1)),
+      k: Ref::new(1.0),
+      out: Ref::new(f64::to_matrix(vec![1.0], 1, 1)),
+    };
+    let held = function.out.borrow();
+
+    let error = function.transaction_state_values().unwrap_err();
+
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+    drop(held);
+  }
+}
 
 
 fn impl_combinatorics_n_choose_k_fxn(n: Value, k: Value) -> MResult<Box<dyn MechFunction>> {

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -168,6 +168,12 @@ pub trait MechFunctionImpl {
   /// cells must override this method, while functions whose retained state
   /// cannot be represented by `Value` must return
   /// [`TransactionStateUnsupportedError`].
+  ///
+  /// The function implementation itself owns this checkpoint contract.
+  /// Callers must not infer checkpoint support from [`Self::to_string`],
+  /// [`Debug`] output, type names, module names, or other display metadata. A
+  /// function that requires participation from a higher-level transaction
+  /// coordinator must return [`TransactionStateUnsupportedError`] directly.
   fn transaction_state_values(&self) -> MResult<Vec<Value>> {
     Ok(self.reactive_output_values())
   }
@@ -1031,6 +1037,11 @@ impl ReactivePlanCheckpoint {
   pub fn node_len(&self) -> usize { self.nodes.len() }
 }
 
+/// A process-local structural checkpoint for a [`Plan`].
+///
+/// This checkpoint supports append-only plan elaboration. Removing or
+/// replacing a function object that existed at capture time invalidates
+/// restoration.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlanCheckpoint {
   reactive: ReactivePlanCheckpoint,
@@ -1405,16 +1416,6 @@ impl ReactivePlan {
   pub fn transaction_state_values(&self) -> MResult<Vec<Value>> {
     let mut values = Vec::new();
     for node in &self.nodes {
-      let function_name = node.function.to_string();
-      if function_name.starts_with("RuntimeHostNativeFunction::") {
-        return Err(MechError::new(
-          TransactionStateUnsupportedError {
-            function: function_name,
-            reason: "runtime host output topology requires runtime transaction participation".to_string(),
-          },
-          None,
-        ).with_compiler_loc());
-      }
       let mut function_values = node.function.transaction_state_values()?;
       if function_values.is_empty() {
         function_values.push(node.function.out());
@@ -3202,28 +3203,37 @@ mod reactive_plan_tests {
     assert_eq!(error.kind_name(), "TransactionStateUnsupported");
   }
 
-  struct RuntimeHostBoundaryFunction;
-  impl MechFunctionImpl for RuntimeHostBoundaryFunction {
+  struct MisleadingRuntimeHostNameFunction {
+    output: ValRef,
+  }
+  impl MechFunctionImpl for MisleadingRuntimeHostNameFunction {
     fn solve(&self) {}
-    fn out(&self) -> Value { Value::Empty }
+    fn out(&self) -> Value { Value::MutableReference(self.output.clone()) }
     fn to_string(&self) -> String {
-      "RuntimeHostNativeFunction::test".to_string()
+      "RuntimeHostNativeFunction::misleading-name".to_string()
     }
   }
   #[cfg(feature = "compiler")]
-  impl MechFunctionCompiler for RuntimeHostBoundaryFunction {
+  impl MechFunctionCompiler for MisleadingRuntimeHostNameFunction {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Ok(0) }
   }
 
   #[test]
-  fn plan_checkpoint_declines_runtime_host_state_before_inspection() {
+  fn host_like_display_name_does_not_change_checkpoint_behavior() {
     let plan = Plan::new();
-    plan.add_function(Box::new(RuntimeHostBoundaryFunction));
+    let output = Ref::new(Value::Index(Ref::new(42)));
+    plan.add_function(Box::new(MisleadingRuntimeHostNameFunction {
+      output: output.clone(),
+    }));
 
-    let error = plan.transaction_state_values().unwrap_err();
+    let values = plan.transaction_state_values().unwrap();
 
-    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
-    assert!(error.kind_message().contains("runtime transaction participation"));
+    assert!(values.iter().any(
+      |value| matches!(
+        value,
+        Value::MutableReference(cell) if cell.same_handle(&output)
+      ),
+    ));
   }
 
   struct UnschedulableOutputFunction {

--- a/src/core/src/functions.rs
+++ b/src/core/src/functions.rs
@@ -161,6 +161,16 @@ pub trait MechFunctionImpl {
   fn reactive_output_values(&self) -> Vec<Value> {
     vec![self.out()]
   }
+  /// Returns every `Value`-backed cell that contains retained mutable state
+  /// owned by this function.
+  ///
+  /// Reactive outputs cover the common case. Functions with hidden retained
+  /// cells must override this method, while functions whose retained state
+  /// cannot be represented by `Value` must return
+  /// [`TransactionStateUnsupportedError`].
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Ok(self.reactive_output_values())
+  }
   fn reactive_output_cell_ids(&self) -> Vec<ReactiveCellId> {
     let mut cells = Vec::new();
 
@@ -277,6 +287,294 @@ pub struct Functions {
   pub function_compilers: FunctionCompilerTable,
   pub user_functions: UserFunctionTable,
   pub dictionary: Ref<Dictionary>,
+}
+
+#[derive(Clone)]
+pub struct FunctionsSnapshot {
+  target: FunctionsRef,
+  functions: FunctionTable,
+  function_compilers: FunctionCompilerTable,
+  user_functions: UserFunctionTable,
+  dictionary_target: Ref<Dictionary>,
+  dictionary: Dictionary,
+  user_function_snapshots: Vec<FunctionDefinitionSnapshot>,
+}
+
+#[derive(Clone)]
+struct FunctionDefinitionSnapshot {
+  symbols_target: SymbolTableRef,
+  symbols: SymbolTableSnapshot,
+  symbol_dictionary_target: Ref<Dictionary>,
+  out_target: Ref<Value>,
+  plan_target: Plan,
+  plan: PlanCheckpoint,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionStateUnsupportedError {
+  pub function: String,
+  pub reason: String,
+}
+
+impl MechErrorKind for TransactionStateUnsupportedError {
+  fn name(&self) -> &str { "TransactionStateUnsupported" }
+  fn message(&self) -> String {
+    format!(
+      "Cannot checkpoint retained transaction state for function '{}': {}.",
+      self.function,
+      self.reason,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionStateBorrowConflictError {
+  pub function: String,
+  pub component: &'static str,
+  pub address: usize,
+}
+
+impl MechErrorKind for TransactionStateBorrowConflictError {
+  fn name(&self) -> &str { "TransactionStateBorrowConflict" }
+  fn message(&self) -> String {
+    format!(
+      "Cannot inspect retained transaction state for function '{}' because {} at 0x{:x} is already borrowed.",
+      self.function,
+      self.component,
+      self.address,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionsSnapshotBorrowConflictError {
+  pub phase: &'static str,
+  pub component: &'static str,
+  pub address: usize,
+}
+
+impl MechErrorKind for FunctionsSnapshotBorrowConflictError {
+  fn name(&self) -> &str { "FunctionsSnapshotBorrowConflict" }
+  fn message(&self) -> String {
+    format!(
+      "Cannot borrow functions {} at 0x{:x} during {}.",
+      self.component,
+      self.address,
+      self.phase,
+    )
+  }
+}
+
+impl FunctionsSnapshot {
+  fn borrow_conflict(
+    phase: &'static str,
+    component: &'static str,
+    address: usize,
+  ) -> MechError {
+    MechError::new(
+      FunctionsSnapshotBorrowConflictError {
+        phase,
+        component,
+        address,
+      },
+      None,
+    ).with_compiler_loc()
+  }
+
+  /// Captures all function tables and the contents and identity of their
+  /// dictionary. The original [`FunctionsRef`] is retained as the restore
+  /// target so restoration never substitutes the outer container.
+  pub fn capture(target: &FunctionsRef) -> MResult<Self> {
+    let functions = target.try_borrow().map_err(|_| {
+      Self::borrow_conflict("capture", "table", target.addr())
+    })?;
+    let dictionary_target = functions.dictionary.clone();
+    let dictionary = dictionary_target.try_borrow().map_err(|_| {
+      Self::borrow_conflict("capture", "dictionary", dictionary_target.addr())
+    })?.clone();
+    let mut user_function_snapshots = Vec::with_capacity(functions.user_functions.len());
+    for definition in functions.user_functions.values() {
+      let symbols = definition.symbols.try_borrow().map_err(|_| {
+        Self::borrow_conflict(
+          "capture",
+          "user symbol table",
+          definition.symbols.addr(),
+        )
+      })?;
+      let symbol_dictionary_target = symbols.dictionary.clone();
+      let _symbol_dictionary =
+        symbol_dictionary_target.try_borrow().map_err(|_| {
+          Self::borrow_conflict(
+            "capture",
+            "user symbol dictionary",
+            symbol_dictionary_target.addr(),
+          )
+        })?;
+      let symbol_snapshot = symbols.snapshot();
+      drop(_symbol_dictionary);
+      drop(symbols);
+
+      let reactive = definition.plan.0.try_borrow().map_err(|_| {
+        Self::borrow_conflict(
+          "capture",
+          "user reactive plan",
+          definition.plan.0.addr(),
+        )
+      })?;
+      let scopes = definition.plan.1.try_borrow().map_err(|_| {
+        Self::borrow_conflict(
+          "capture",
+          "user activation scopes",
+          definition.plan.1.addr(),
+        )
+      })?;
+      reactive.validate_checkpoint_invariants(scopes.len())?;
+      let plan = PlanCheckpoint {
+        reactive: reactive.checkpoint(),
+        activation_registration_scopes: scopes.clone(),
+      };
+      drop(scopes);
+      drop(reactive);
+
+      user_function_snapshots.push(FunctionDefinitionSnapshot {
+        symbols_target: definition.symbols.clone(),
+        symbols: symbol_snapshot,
+        symbol_dictionary_target,
+        out_target: definition.out.clone(),
+        plan_target: definition.plan.clone(),
+        plan,
+      });
+    }
+    let snapshot = Self {
+      target: target.clone(),
+      functions: functions.functions.clone(),
+      function_compilers: functions.function_compilers.clone(),
+      user_functions: functions.user_functions.clone(),
+      dictionary_target,
+      dictionary,
+      user_function_snapshots,
+    };
+    Ok(snapshot)
+  }
+
+  /// Verifies that both original containers can be restored without changing
+  /// either one.
+  pub fn preflight_restore(&self) -> MResult<()> {
+    {
+      let _functions = self.target.try_borrow_mut().map_err(|_| {
+        Self::borrow_conflict("restore", "table", self.target.addr())
+      })?;
+      let _dictionary = self.dictionary_target.try_borrow_mut().map_err(|_| {
+        Self::borrow_conflict(
+          "restore",
+          "dictionary",
+          self.dictionary_target.addr(),
+        )
+      })?;
+    }
+    for definition in &self.user_function_snapshots {
+      {
+        let _symbols = definition.symbols_target.try_borrow_mut().map_err(|_| {
+          Self::borrow_conflict(
+            "restore",
+            "user symbol table",
+            definition.symbols_target.addr(),
+          )
+        })?;
+        let _dictionary =
+          definition.symbol_dictionary_target.try_borrow_mut().map_err(|_| {
+            Self::borrow_conflict(
+              "restore",
+              "user symbol dictionary",
+              definition.symbol_dictionary_target.addr(),
+            )
+          })?;
+      }
+      definition.plan_target.preflight_rollback(&definition.plan)?;
+    }
+    Ok(())
+  }
+
+  /// Restores captured registry and plan structure after successful preflight.
+  ///
+  /// Consumer indexes are finalized separately so a coordinating checkpoint
+  /// can restore journal payloads before rebuilding derived state.
+  pub fn apply_restore_structure(&self) {
+    for definition in &self.user_function_snapshots {
+      {
+        let mut symbols = definition.symbols_target.borrow_mut();
+        symbols.dictionary = definition.symbol_dictionary_target.clone();
+        symbols.restore(definition.symbols.clone());
+      }
+      definition
+        .plan_target
+        .apply_rollback_structure(&definition.plan);
+    }
+
+    let mut functions = self.target.borrow_mut();
+    let mut dictionary = self.dictionary_target.borrow_mut();
+    functions.functions = self.functions.clone();
+    functions.function_compilers = self.function_compilers.clone();
+    functions.user_functions = self.user_functions.clone();
+    functions.dictionary = self.dictionary_target.clone();
+    *dictionary = self.dictionary.clone();
+  }
+
+  pub fn rebuild_checkpoint_indexes(&self) {
+    for definition in &self.user_function_snapshots {
+      definition.plan_target.rebuild_checkpoint_indexes();
+    }
+  }
+
+  pub fn validate_checkpoint_invariants(&self) -> MResult<()> {
+    for definition in &self.user_function_snapshots {
+      definition.plan_target.validate_checkpoint_invariants()?;
+    }
+    Ok(())
+  }
+
+  /// Restores the captured tables and dictionary after successful preflight.
+  ///
+  /// No function compiler, callback, or user function is invoked.
+  pub fn apply_restore(&self) {
+    self.apply_restore_structure();
+    self.rebuild_checkpoint_indexes();
+  }
+
+  /// Returns the `Value` roots retained by captured user definitions.
+  ///
+  /// This includes each outer result cell, all symbol cells, and every nested
+  /// reactive-plan function. [`ValueStateJournal`] deduplicates aliases.
+  pub fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    let mut values = Vec::new();
+    let mut seen_refs = HashSet::new();
+    for definition in &self.user_function_snapshots {
+      if seen_refs.insert(definition.out_target.addr()) {
+        values.push(Value::MutableReference(definition.out_target.clone()));
+      }
+      let symbols = definition.symbols_target.try_borrow().map_err(|_| {
+        Self::borrow_conflict(
+          "transaction-state",
+          "user symbol table",
+          definition.symbols_target.addr(),
+        )
+      })?;
+      for value in symbols.symbols.values().chain(symbols.mutable_variables.values()) {
+        if seen_refs.insert(value.addr()) {
+          values.push(Value::MutableReference(value.clone()));
+        }
+      }
+      drop(symbols);
+      values.extend(definition.plan_target.transaction_state_values()?);
+    }
+    Ok(values)
+  }
+
+  pub fn restore(&self) -> MResult<()> {
+    self.preflight_restore()?;
+    self.apply_restore();
+    Ok(())
+  }
 }
 
 impl Functions {
@@ -416,6 +714,29 @@ impl MechFunctionImpl for UserFunction {
   fn out(&self) -> Value {
     self.fxn.out.borrow().clone()
   }
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    let mut values = vec![Value::MutableReference(self.fxn.out.clone())];
+    let mut seen_refs = HashSet::new();
+    seen_refs.insert(self.fxn.out.addr());
+    let symbols = self.fxn.symbols.try_borrow().map_err(|_| {
+      MechError::new(
+        TransactionStateBorrowConflictError {
+          function: self.to_string(),
+          component: "user symbol table",
+          address: self.fxn.symbols.addr(),
+        },
+        None,
+      ).with_compiler_loc()
+    })?;
+    for value in symbols.symbols.values().chain(symbols.mutable_variables.values()) {
+      if seen_refs.insert(value.addr()) {
+        values.push(Value::MutableReference(value.clone()));
+      }
+    }
+    drop(symbols);
+    values.extend(self.fxn.plan.transaction_state_values()?);
+    Ok(values)
+  }
   fn to_string(&self) -> String { format!("UserFxn::{:?}", self.fxn.name) }
 }
 #[cfg(feature = "compiler")]
@@ -533,7 +854,7 @@ pub struct ReactiveTurnOutcome {
   pub after_commit: ReactivePlanSolveOutcome,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ActivationRegistrationScope {
   pub trigger_cells: Vec<ReactiveCellId>,
   pub local_combinational_cells: Vec<ReactiveCellId>,
@@ -545,10 +866,42 @@ pub struct ReactiveDependency {
   pub kind: ReactiveDependencyKind,
 }
 
+pub struct ReactivePlanFunction {
+  function: Box<dyn MechFunction>,
+  identity: Rc<()>,
+}
+
+impl ReactivePlanFunction {
+  fn new(function: Box<dyn MechFunction>) -> Self {
+    Self {
+      function,
+      identity: Rc::new(()),
+    }
+  }
+
+  pub fn as_ref(&self) -> &dyn MechFunction {
+    self.function.as_ref()
+  }
+}
+
+impl core::ops::Deref for ReactivePlanFunction {
+  type Target = dyn MechFunction;
+
+  fn deref(&self) -> &Self::Target {
+    self.function.as_ref()
+  }
+}
+
+impl core::ops::DerefMut for ReactivePlanFunction {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    self.function.as_mut()
+  }
+}
+
 pub struct ReactivePlanNode {
   pub id: ReactiveNodeId,
   pub plan_index: usize,
-  pub function: Box<dyn MechFunction>,
+  pub function: ReactivePlanFunction,
   pub inputs: Vec<ReactiveDependency>,
   pub outputs: Vec<ReactiveCellId>,
   pub kind: ReactiveNodeKind,
@@ -657,16 +1010,35 @@ impl MechErrorKind for ReactiveDependencyKindConflictError {
   }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ReactivePlanCheckpoint {
-  node_len: usize,
-  pattern_activation_registration_len: usize,
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReactivePlanNodeCheckpoint {
+  id: ReactiveNodeId,
+  plan_index: usize,
+  inputs: Vec<ReactiveDependency>,
+  outputs: Vec<ReactiveCellId>,
+  kind: ReactiveNodeKind,
+  function_identity: ReactiveFunctionIdentity,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReactivePlanCheckpoint {
+  nodes: Vec<ReactivePlanNodeCheckpoint>,
+  pattern_activation_registrations: Vec<PatternActivationRegistration>,
+  activation_sampled_cells: Vec<Vec<ReactiveCellId>>,
+}
+
+impl ReactivePlanCheckpoint {
+  pub fn node_len(&self) -> usize { self.nodes.len() }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlanCheckpoint {
   reactive: ReactivePlanCheckpoint,
-  activation_registration_depth: usize,
+  activation_registration_scopes: Vec<ActivationRegistrationScope>,
+}
+
+impl PlanCheckpoint {
+  pub fn node_len(&self) -> usize { self.reactive.node_len() }
 }
 
 #[derive(Debug, Clone)]
@@ -681,6 +1053,25 @@ impl MechErrorKind for ReactivePlanRollbackInvariantError {
   fn name(&self) -> &str { "ReactivePlanRollbackInvariant" }
   fn message(&self) -> String {
     format!("Cannot roll the reactive plan back from {} nodes and {} patterned registrations to {} nodes and {} patterned registrations.", self.current_nodes, self.current_registrations, self.checkpoint_nodes, self.checkpoint_registrations)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactivePlanFunctionIdentityError {
+  pub node_id: ReactiveNodeId,
+  pub checkpoint_identity: usize,
+  pub current_identity: usize,
+}
+
+impl MechErrorKind for ReactivePlanFunctionIdentityError {
+  fn name(&self) -> &str { "ReactivePlanFunctionIdentity" }
+  fn message(&self) -> String {
+    format!(
+      "Cannot restore reactive node {} because its function identity changed (checkpoint address 0x{:x}, current address 0x{:x}).",
+      self.node_id,
+      self.checkpoint_identity,
+      self.current_identity,
+    )
   }
 }
 
@@ -701,6 +1092,93 @@ impl MechErrorKind for ActivationRegistrationRollbackInvariantError {
       self.current_depth,
       self.checkpoint_depth,
     )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct PlanCheckpointBorrowConflictError {
+  pub phase: &'static str,
+  pub component: &'static str,
+  pub address: usize,
+}
+
+impl MechErrorKind for PlanCheckpointBorrowConflictError {
+  fn name(&self) -> &str { "PlanCheckpointBorrowConflict" }
+  fn message(&self) -> String {
+    format!(
+      "Cannot borrow plan {} at 0x{:x} during {}.",
+      self.component,
+      self.address,
+      self.phase,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactivePlanCheckpointInvariantError {
+  pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactiveTurnCheckpointInvariantError {
+  pub node_id: ReactiveNodeId,
+  pub reason: String,
+}
+
+impl MechErrorKind for ReactiveTurnCheckpointInvariantError {
+  fn name(&self) -> &str {
+    "ReactiveTurnCheckpointInvariant"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Cannot checkpoint pending reactive node {}: {}.",
+      self.node_id,
+      self.reason,
+    )
+  }
+}
+
+impl MechErrorKind for ReactivePlanCheckpointInvariantError {
+  fn name(&self) -> &str {
+    "ReactivePlanCheckpointInvariant"
+  }
+
+  fn message(&self) -> String {
+    format!("Cannot checkpoint an invalid reactive plan: {}.", self.reason)
+  }
+}
+
+#[derive(Clone)]
+struct ReactiveFunctionIdentity {
+  owner: Rc<()>,
+}
+
+impl ReactiveFunctionIdentity {
+  fn owner_address(&self) -> usize {
+    Rc::as_ptr(&self.owner) as usize
+  }
+}
+
+impl Debug for ReactiveFunctionIdentity {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("ReactiveFunctionIdentity")
+      .field("owner_address", &self.owner_address())
+      .finish()
+  }
+}
+
+impl PartialEq for ReactiveFunctionIdentity {
+  fn eq(&self, other: &Self) -> bool {
+    Rc::ptr_eq(&self.owner, &other.owner)
+  }
+}
+
+impl Eq for ReactiveFunctionIdentity {}
+
+fn reactive_function_identity(function: &ReactivePlanFunction) -> ReactiveFunctionIdentity {
+  ReactiveFunctionIdentity {
+    owner: function.identity.clone(),
   }
 }
 
@@ -725,42 +1203,168 @@ impl ReactivePlan {
     }
   }
 
-  fn validate_rollback(&self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
-    if checkpoint.node_len > self.nodes.len()
-      || checkpoint.pattern_activation_registration_len > self.pattern_activation_registrations.len()
+  pub fn validate_checkpoint_invariants(
+    &self,
+    activation_scope_count: usize,
+  ) -> MResult<()> {
+    let invalid = |reason: String| {
+      MechError::new(
+        ReactivePlanCheckpointInvariantError { reason },
+        None,
+      )
+      .with_compiler_loc()
+    };
+    let node_len = self.nodes.len();
+
+    for (index, node) in self.nodes.iter().enumerate() {
+      if node.id != index {
+        return Err(invalid(format!(
+          "node at index {} has id {}",
+          index,
+          node.id,
+        )));
+      }
+      if node.plan_index != index {
+        return Err(invalid(format!(
+          "node {} has plan index {}",
+          node.id,
+          node.plan_index,
+        )));
+      }
+    }
+
+    let mut reactive_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>> =
+      HashMap::new();
+    let mut sampled_consumers: HashMap<ReactiveCellId, Vec<ReactiveNodeId>> =
+      HashMap::new();
+    for node in &self.nodes {
+      for dependency in &node.inputs {
+        let consumers = match dependency.kind {
+          ReactiveDependencyKind::Reactive => &mut reactive_consumers,
+          ReactiveDependencyKind::Sampled => &mut sampled_consumers,
+        };
+        let consumers = consumers.entry(dependency.cell).or_insert_with(Vec::new);
+        if !consumers.contains(&node.id) {
+          consumers.push(node.id);
+        }
+      }
+    }
+    if reactive_consumers != self.reactive_consumers
+      || sampled_consumers != self.sampled_consumers
     {
+      return Err(invalid("consumer indexes do not match node dependencies".into()));
+    }
+
+    let valid_node = |node: ReactiveNodeId| node < node_len;
+    for registration in &self.pattern_activation_registrations {
+      if !valid_node(registration.scope_pulse_node)
+        || !valid_node(registration.selector_node)
+      {
+        return Err(invalid("pattern activation references a missing root node".into()));
+      }
+      for arm in &registration.arms {
+        if !valid_node(arm.matcher_node)
+          || !valid_node(arm.finalizer_node)
+          || !valid_node(arm.gate_node)
+          || arm.body_node_start > arm.body_node_end
+          || arm.body_node_end > node_len
+        {
+          return Err(invalid("pattern activation arm topology is invalid".into()));
+        }
+        if let Some(guard) = &arm.guard {
+          if !valid_node(guard.match_gate_node)
+            || !valid_node(guard.guard_finalizer_node)
+            || guard.guard_node_start > guard.guard_node_end
+            || guard.guard_node_end > node_len
+          {
+            return Err(invalid("pattern activation guard topology is invalid".into()));
+          }
+        }
+      }
+    }
+
+    if self.activation_sampled_cells.len() != activation_scope_count {
+      return Err(invalid(format!(
+        "sampled-cell stack depth {} differs from activation-scope depth {}",
+        self.activation_sampled_cells.len(),
+        activation_scope_count,
+      )));
+    }
+
+    Ok(())
+  }
+
+  pub fn preflight_rollback(&self, checkpoint: &ReactivePlanCheckpoint) -> MResult<()> {
+    if checkpoint.nodes.len() > self.nodes.len() {
       return Err(MechError::new(
         ReactivePlanRollbackInvariantError {
-          checkpoint_nodes: checkpoint.node_len,
+          checkpoint_nodes: checkpoint.nodes.len(),
           current_nodes: self.nodes.len(),
-          checkpoint_registrations: checkpoint.pattern_activation_registration_len,
+          checkpoint_registrations: checkpoint.pattern_activation_registrations.len(),
           current_registrations: self.pattern_activation_registrations.len(),
         },
         None,
       ));
     }
 
+    for (node, saved) in self.nodes.iter().zip(checkpoint.nodes.iter()) {
+      let current_identity = reactive_function_identity(&node.function);
+      if current_identity != saved.function_identity {
+        return Err(MechError::new(
+          ReactivePlanFunctionIdentityError {
+            node_id: saved.id,
+            checkpoint_identity: saved.function_identity.owner_address(),
+            current_identity: current_identity.owner_address(),
+          },
+          None,
+        ));
+      }
+    }
+
     Ok(())
   }
 
-  fn apply_rollback(&mut self, checkpoint: ReactivePlanCheckpoint) {
-    self.nodes.truncate(checkpoint.node_len);
-    self
-      .pattern_activation_registrations
-      .truncate(checkpoint.pattern_activation_registration_len);
+  pub fn apply_rollback_structure(&mut self, checkpoint: &ReactivePlanCheckpoint) {
+    self.nodes.truncate(checkpoint.nodes.len());
+    for (node, saved) in self.nodes.iter_mut().zip(checkpoint.nodes.iter()) {
+      node.id = saved.id;
+      node.plan_index = saved.plan_index;
+      node.inputs = saved.inputs.clone();
+      node.outputs = saved.outputs.clone();
+      node.kind = saved.kind;
+    }
+    self.pattern_activation_registrations =
+      checkpoint.pattern_activation_registrations.clone();
+    self.activation_sampled_cells = checkpoint.activation_sampled_cells.clone();
+  }
+
+  pub fn rebuild_checkpoint_indexes(&mut self) {
     self.rebuild_consumer_indexes();
+  }
+
+  pub fn apply_rollback(&mut self, checkpoint: &ReactivePlanCheckpoint) {
+    self.apply_rollback_structure(checkpoint);
+    self.rebuild_checkpoint_indexes();
   }
 
   pub fn checkpoint(&self) -> ReactivePlanCheckpoint {
     ReactivePlanCheckpoint {
-      node_len: self.nodes.len(),
-      pattern_activation_registration_len: self.pattern_activation_registrations.len(),
+      nodes: self.nodes.iter().map(|node| ReactivePlanNodeCheckpoint {
+        id: node.id,
+        plan_index: node.plan_index,
+        inputs: node.inputs.clone(),
+        outputs: node.outputs.clone(),
+        kind: node.kind,
+        function_identity: reactive_function_identity(&node.function),
+      }).collect(),
+      pattern_activation_registrations: self.pattern_activation_registrations.clone(),
+      activation_sampled_cells: self.activation_sampled_cells.clone(),
     }
   }
 
   pub fn rollback(&mut self, checkpoint: ReactivePlanCheckpoint) -> MResult<()> {
-    self.validate_rollback(checkpoint)?;
-    self.apply_rollback(checkpoint);
+    self.preflight_rollback(&checkpoint)?;
+    self.apply_rollback(&checkpoint);
     Ok(())
   }
 
@@ -790,15 +1394,37 @@ impl ReactivePlan {
     self.activation_sampled_cells.clear();
   }
 
-  pub fn iter(&self) -> impl Iterator<Item = &Box<dyn MechFunction>> {
+  pub fn iter(&self) -> impl Iterator<Item = &ReactivePlanFunction> {
     self.nodes.iter().map(|node| &node.function)
   }
 
-  pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Box<dyn MechFunction>> {
+  pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ReactivePlanFunction> {
     self.nodes.iter_mut().map(|node| &mut node.function)
   }
 
-  pub fn last(&self) -> Option<&Box<dyn MechFunction>> {
+  pub fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    let mut values = Vec::new();
+    for node in &self.nodes {
+      let function_name = node.function.to_string();
+      if function_name.starts_with("RuntimeHostNativeFunction::") {
+        return Err(MechError::new(
+          TransactionStateUnsupportedError {
+            function: function_name,
+            reason: "runtime host output topology requires runtime transaction participation".to_string(),
+          },
+          None,
+        ).with_compiler_loc());
+      }
+      let mut function_values = node.function.transaction_state_values()?;
+      if function_values.is_empty() {
+        function_values.push(node.function.out());
+      }
+      values.extend(function_values);
+    }
+    Ok(values)
+  }
+
+  pub fn last(&self) -> Option<&ReactivePlanFunction> {
     self.nodes.last().map(|node| &node.function)
   }
 
@@ -817,7 +1443,7 @@ impl ReactivePlan {
       inputs: Vec::new(),
       outputs,
       kind: function.reactive_node_kind(),
-      function,
+      function: ReactivePlanFunction::new(function),
     };
 
     self.nodes.push(node);
@@ -941,7 +1567,7 @@ impl ReactivePlan {
       inputs,
       outputs,
       kind: node_kind,
-      function,
+      function: ReactivePlanFunction::new(function),
     };
 
     self.nodes.push(node);
@@ -1182,7 +1808,7 @@ impl ReactivePlan {
 }
 
 impl core::ops::Index<usize> for ReactivePlan {
-  type Output = Box<dyn MechFunction>;
+  type Output = ReactivePlanFunction;
 
   fn index(&self, index: usize) -> &Self::Output {
     &self.nodes[index].function
@@ -1211,47 +1837,131 @@ impl fmt::Debug for Plan {
 }
 
 impl Plan {
+  fn checkpoint_borrow_conflict(
+    phase: &'static str,
+    component: &'static str,
+    address: usize,
+  ) -> MechError {
+    MechError::new(
+      PlanCheckpointBorrowConflictError {
+        phase,
+        component,
+        address,
+      },
+      None,
+    ).with_compiler_loc()
+  }
+
   pub fn checkpoint(&self) -> PlanCheckpoint {
     PlanCheckpoint {
       reactive: self.0.borrow().checkpoint(),
-      activation_registration_depth: self.1.borrow().len(),
+      activation_registration_scopes: self.1.borrow().clone(),
     }
   }
 
-  pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
-    {
-      let reactive = self.0.borrow();
-      reactive.validate_rollback(checkpoint.reactive)?;
-    }
+  pub fn validate_checkpoint_invariants(&self) -> MResult<()> {
+    let reactive = self.0.try_borrow().map_err(|_| {
+      Self::checkpoint_borrow_conflict(
+        "checkpoint-validation",
+        "reactive graph",
+        self.0.addr(),
+      )
+    })?;
+    let scopes = self.1.try_borrow().map_err(|_| {
+      Self::checkpoint_borrow_conflict(
+        "checkpoint-validation",
+        "activation scopes",
+        self.1.addr(),
+      )
+    })?;
+    reactive.validate_checkpoint_invariants(scopes.len())
+  }
 
-    {
-      let scopes = self.1.borrow();
-      let current_depth = scopes.len();
-
-      if checkpoint.activation_registration_depth > current_depth {
+  pub fn validate_checkpoint_turn_state(
+    &self,
+    state: &ReactiveTurnState,
+  ) -> MResult<()> {
+    let reactive = self.0.try_borrow().map_err(|_| {
+      Self::checkpoint_borrow_conflict(
+        "checkpoint-validation",
+        "reactive graph",
+        self.0.addr(),
+      )
+    })?;
+    for node_id in &state.pending_register_nodes {
+      let Some(node) = reactive.nodes.get(*node_id) else {
         return Err(MechError::new(
-          ActivationRegistrationRollbackInvariantError {
-            checkpoint_depth: checkpoint.activation_registration_depth,
-            current_depth,
+          ReactiveTurnCheckpointInvariantError {
+            node_id: *node_id,
+            reason: "the node does not exist".into(),
           },
           None,
-        ));
+        )
+        .with_compiler_loc());
+      };
+      if node.kind != ReactiveNodeKind::Register {
+        return Err(MechError::new(
+          ReactiveTurnCheckpointInvariantError {
+            node_id: *node_id,
+            reason: "the node is not a register".into(),
+          },
+          None,
+        )
+        .with_compiler_loc());
       }
     }
-
-    {
-      let mut reactive = self.0.borrow_mut();
-      reactive.apply_rollback(checkpoint.reactive);
-      reactive
-        .activation_sampled_cells
-        .truncate(checkpoint.activation_registration_depth);
-    }
-    self
-      .1
-      .borrow_mut()
-      .truncate(checkpoint.activation_registration_depth);
-
     Ok(())
+  }
+
+  pub fn preflight_rollback(&self, checkpoint: &PlanCheckpoint) -> MResult<()> {
+    let reactive = self.0.try_borrow_mut().map_err(|_| {
+      Self::checkpoint_borrow_conflict(
+        "restore",
+        "reactive graph",
+        self.0.addr(),
+      )
+    })?;
+    let _scopes = self.1.try_borrow_mut().map_err(|_| {
+      Self::checkpoint_borrow_conflict(
+        "restore",
+        "activation scopes",
+        self.1.addr(),
+      )
+    })?;
+    reactive.preflight_rollback(&checkpoint.reactive)
+  }
+
+  pub fn apply_rollback_structure(&self, checkpoint: &PlanCheckpoint) {
+    let mut reactive = self.0.borrow_mut();
+    let mut scopes = self.1.borrow_mut();
+    reactive.apply_rollback_structure(&checkpoint.reactive);
+    *scopes = checkpoint.activation_registration_scopes.clone();
+  }
+
+  pub fn rebuild_checkpoint_indexes(&self) {
+    self.0.borrow_mut().rebuild_checkpoint_indexes();
+  }
+
+  pub fn apply_rollback(&self, checkpoint: &PlanCheckpoint) {
+    self.apply_rollback_structure(checkpoint);
+    self.rebuild_checkpoint_indexes();
+  }
+
+  pub fn rollback(&self, checkpoint: PlanCheckpoint) -> MResult<()> {
+    self.preflight_rollback(&checkpoint)?;
+    self.apply_rollback(&checkpoint);
+    Ok(())
+  }
+
+  pub fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    let reactive = self.0.try_borrow().map_err(|_| {
+      Self::checkpoint_borrow_conflict(
+        "transaction-state",
+        "reactive graph",
+        self.0.addr(),
+      )
+    })?;
+    reactive.transaction_state_values()
   }
 
   pub fn activation_registration_depth(&self) -> usize {
@@ -1532,6 +2242,19 @@ mod reactive_plan_tests {
     fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
       Ok(0)
     }
+  }
+
+  struct RetainedZstFunction;
+
+  impl MechFunctionImpl for RetainedZstFunction {
+    fn solve(&self) {}
+    fn out(&self) -> Value { Value::Empty }
+    fn to_string(&self) -> String { "retained-zst".into() }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for RetainedZstFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Ok(0) }
   }
 
   #[test]
@@ -2167,23 +2890,377 @@ mod reactive_plan_tests {
     assert!(plan.sampled_consumers.values().all(|nodes| !nodes.contains(&tail)));
   }
   #[test]
-  fn reactive_plan_rollback_truncates_pattern_registrations() {
-    let mut plan = ReactivePlan::new(); let checkpoint = plan.checkpoint(); plan.register_pattern_activation(PatternActivationRegistration { scope_pulse_node: 0, selector_node: 0, arms: Vec::new() }); assert_eq!(plan.pattern_activation_registrations().len(), 1); plan.rollback(checkpoint).unwrap(); assert!(plan.pattern_activation_registrations().is_empty());
+  fn plan_rollback_restores_full_structure_and_rebuilds_consumers() {
+    let input = Value::Index(Ref::new(1));
+    let original_cell = input.reactive_root_cell_ids()[0];
+    let replacement_cell = ReactiveCellId::new(99);
+    let sampled_cell = ReactiveCellId::new(100);
+    let plan = Plan::new();
+    let base = plan
+      .borrow_mut()
+      .register(Box::new(TestFunction::new("base")), &[input])
+      .unwrap();
+    plan.push_activation_registration_scope_with_sampled_cells(
+      vec![original_cell],
+      vec![sampled_cell],
+    );
+    {
+      let mut reactive = plan.borrow_mut();
+      reactive.register_pattern_activation(PatternActivationRegistration {
+        scope_pulse_node: base,
+        selector_node: base,
+        arms: Vec::new(),
+      });
+    }
+    let checkpoint = plan.checkpoint();
+    let function_identity = {
+      let reactive = plan.borrow();
+      reactive_function_identity(&reactive.nodes[base].function)
+    };
+
+    {
+      let mut reactive = plan.borrow_mut();
+      let node = &mut reactive.nodes[base];
+      node.id = 42;
+      node.plan_index = 77;
+      node.inputs = vec![ReactiveDependency {
+        cell: replacement_cell,
+        kind: ReactiveDependencyKind::Sampled,
+      }];
+      node.outputs = vec![replacement_cell];
+      node.kind = ReactiveNodeKind::Register;
+      reactive.pattern_activation_registrations.clear();
+      reactive.activation_sampled_cells = vec![vec![replacement_cell]];
+      reactive.push(Box::new(TestFunction::new("tail")));
+    }
+    {
+      let mut scopes = plan.1.borrow_mut();
+      scopes[0].trigger_cells = vec![replacement_cell];
+      scopes[0].local_combinational_cells = vec![replacement_cell];
+      scopes.push(ActivationRegistrationScope {
+        trigger_cells: vec![replacement_cell],
+        local_combinational_cells: Vec::new(),
+      });
+    }
+
+    plan.preflight_rollback(&checkpoint).unwrap();
+    plan.apply_rollback(&checkpoint);
+
+    assert_eq!(plan.checkpoint(), checkpoint);
+    let reactive = plan.borrow();
+    assert_eq!(reactive.len(), 1);
+    assert_eq!(
+      reactive_function_identity(&reactive.nodes[base].function),
+      function_identity,
+    );
+    assert_eq!(reactive.reactive_consumers_for(original_cell), &[base]);
+    assert!(reactive.sampled_consumers_for(replacement_cell).is_empty());
+    assert_eq!(
+      reactive.activation_sampled_cells,
+      vec![vec![sampled_cell]],
+    );
   }
+
   #[test]
   fn plan_rollback_restores_activation_registration_depth() {
     let plan = Plan::new(); let checkpoint = plan.checkpoint(); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]); plan.push_activation_registration_scope(vec![ReactiveCellId::new(2)]); assert_eq!(plan.activation_registration_depth(), 2); plan.rollback(checkpoint).unwrap(); assert_eq!(plan.activation_registration_depth(), 0);
   }
+
   #[test]
-  fn plan_rollback_invalid_checkpoint_is_atomic() {
-    let plan = Plan::new(); plan.add_function(Box::new(TestFunction::new("retained"))); plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
-    let nodes_before = plan.len(); let reactive_before = plan.borrow().reactive_consumers.clone(); let sampled_before = plan.borrow().sampled_consumers.clone(); let registrations_before = plan.pattern_activation_registrations().clone(); let depth_before = plan.activation_registration_depth();
-    let error = plan.rollback(PlanCheckpoint { reactive: ReactivePlanCheckpoint { node_len: nodes_before + 1, pattern_activation_registration_len: registrations_before.len() }, activation_registration_depth: depth_before }).unwrap_err(); assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
-    let valid_reactive_checkpoint = { let reactive_plan = plan.borrow(); reactive_plan.checkpoint() };
-    let invalid_scope_checkpoint = PlanCheckpoint { reactive: valid_reactive_checkpoint, activation_registration_depth: depth_before + 1 };
-    let error = plan.rollback(invalid_scope_checkpoint).unwrap_err(); assert_eq!(error.kind_name(), "ActivationRegistrationRollbackInvariant");
-    assert_eq!(plan.len(), nodes_before); assert_eq!(plan.borrow().reactive_consumers, reactive_before); assert_eq!(plan.borrow().sampled_consumers, sampled_before); assert_eq!(*plan.pattern_activation_registrations(), registrations_before); assert_eq!(plan.activation_registration_depth(), depth_before);
+  fn plan_rollback_rejects_removed_node_without_partial_restore() {
+    let plan = Plan::new();
+    plan.add_function(Box::new(TestFunction::new("retained")));
+    let checkpoint = plan.checkpoint();
+    plan.borrow_mut().nodes.pop();
+    plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+
+    let error = plan.rollback(checkpoint).unwrap_err();
+
+    assert_eq!(error.kind_name(), "ReactivePlanRollbackInvariant");
+    assert_eq!(plan.len(), 0);
+    assert_eq!(plan.activation_registration_depth(), 1);
+  }
+
+  #[test]
+  fn plan_rollback_rejects_replaced_function_without_partial_restore() {
+    let plan = Plan::new();
+    let node_id = plan.add_function(Box::new(TestFunction::new("retained")));
+    let checkpoint = plan.checkpoint();
+    {
+      let mut reactive = plan.borrow_mut();
+      reactive.nodes[node_id].plan_index = 123;
+      reactive.nodes[node_id].function =
+        ReactivePlanFunction::new(Box::new(TestFunction::new("replacement")));
+    }
+    plan.push_activation_registration_scope(vec![ReactiveCellId::new(1)]);
+
+    let error = plan.rollback(checkpoint).unwrap_err();
+
+    assert_eq!(error.kind_name(), "ReactivePlanFunctionIdentity");
+    assert_eq!(plan.borrow().nodes[node_id].plan_index, 123);
+    assert_eq!(plan.activation_registration_depth(), 1);
+  }
+
+  #[test]
+  fn plan_rollback_rejects_replaced_zero_sized_function_box() {
+    let plan = Plan::new();
+    let node_id = plan.add_function(Box::new(RetainedZstFunction));
+    let checkpoint = plan.checkpoint();
+    let saved_identity = {
+      let reactive = plan.borrow();
+      reactive_function_identity(&reactive.nodes[node_id].function)
+    };
+    {
+      let mut reactive = plan.borrow_mut();
+      reactive.nodes[node_id].function =
+        ReactivePlanFunction::new(Box::new(RetainedZstFunction));
+    }
+    let replacement_identity = {
+      let reactive = plan.borrow();
+      reactive_function_identity(&reactive.nodes[node_id].function)
+    };
+
+    assert_ne!(saved_identity, replacement_identity);
+    let error = plan.rollback(checkpoint).unwrap_err();
+
+    assert_eq!(error.kind_name(), "ReactivePlanFunctionIdentity");
+  }
+
+  fn original_test_factory(
+    _arguments: FunctionArgs,
+  ) -> MResult<Box<dyn MechFunction>> {
+    Ok(Box::new(TestFunction::new("original factory")))
+  }
+
+  fn replacement_test_factory(
+    _arguments: FunctionArgs,
+  ) -> MResult<Box<dyn MechFunction>> {
+    Ok(Box::new(TestFunction::new("replacement factory")))
+  }
+
+  fn empty_function_definition(id: u64, name: &str) -> FunctionDefinition {
+    FunctionDefinition::new(
+      id,
+      name.to_string(),
+      FunctionDefine {
+        name: internal_pattern_value_identifier(name),
+        input: Vec::new(),
+        output: Vec::new(),
+        statements: Vec::new(),
+        match_arms: Vec::new(),
+      },
+    )
+  }
+
+  #[test]
+  fn functions_snapshot_restores_containers_and_nested_user_structure() {
+    let target = Ref::new(Functions::new());
+    let original_dictionary = target.borrow().dictionary.clone();
+    let original_compiler: Arc<dyn NativeFunctionCompiler> =
+      Arc::new(PureStaticTestCompiler);
+    let function_id = 1;
+    let compiler_id = 2;
+    let user_id = 3;
+    let symbol_id = 4;
+    let mut definition = empty_function_definition(user_id, "user");
+    *definition.out.borrow_mut() = Value::Index(Ref::new(10));
+    let symbol = definition
+      .symbols
+      .borrow_mut()
+      .insert(symbol_id, Value::Index(Ref::new(20)), true);
+    let original_symbol_dictionary =
+      definition.symbols.borrow().dictionary.clone();
+    original_symbol_dictionary
+      .borrow_mut()
+      .insert(symbol_id, "symbol".to_string());
+    definition
+      .plan
+      .add_function(Box::new(TestFunction::new("nested")));
+    let original_symbols = definition.symbols.clone();
+    let original_out = definition.out.clone();
+    let original_plan = definition.plan.clone();
+    let original_plan_checkpoint = original_plan.checkpoint();
+    {
+      let mut functions = target.borrow_mut();
+      functions.functions.insert(function_id, original_test_factory);
+      functions
+        .function_compilers
+        .insert(compiler_id, original_compiler.clone());
+      functions.user_functions.insert(user_id, definition);
+      functions
+        .dictionary
+        .borrow_mut()
+        .insert(function_id, "original".to_string());
+    }
+
+    let snapshot = FunctionsSnapshot::capture(&target).unwrap();
+    let mut journal = ValueStateJournal::new();
+    for value in snapshot.transaction_state_values().unwrap() {
+      journal.capture_value(&value).unwrap();
+    }
+
+    *original_out.borrow_mut() = Value::Index(Ref::new(99));
+    *symbol.borrow_mut() = Value::Index(Ref::new(98));
+    {
+      let mut symbols = original_symbols.borrow_mut();
+      symbols.symbols.clear();
+      symbols.mutable_variables.clear();
+      symbols.dictionary = Ref::new(Dictionary::new());
+    }
+    {
+      let mut nested = original_plan.borrow_mut();
+      nested.nodes[0].plan_index = 88;
+      nested.push(Box::new(TestFunction::new("nested tail")));
+    }
+    let replacement_dictionary = Ref::new(Dictionary::new());
+    {
+      let mut functions = target.borrow_mut();
+      functions.functions.clear();
+      functions
+        .functions
+        .insert(function_id, replacement_test_factory);
+      functions.function_compilers.clear();
+      functions.user_functions.clear();
+      functions.dictionary = replacement_dictionary;
+    }
+
+    snapshot.preflight_restore().unwrap();
+    journal.preflight_restore_before().unwrap();
+    snapshot.apply_restore();
+    journal.apply_restore_before();
+
+    assert_eq!(target.borrow().dictionary.addr(), original_dictionary.addr());
+    assert_eq!(
+      target.borrow().dictionary.borrow().get(&function_id),
+      Some(&"original".to_string()),
+    );
+    assert_eq!(
+      *target.borrow().functions.get(&function_id).unwrap() as usize,
+      original_test_factory as usize,
+    );
+    let restored_compiler =
+      target.borrow().function_compilers.get(&compiler_id).unwrap().clone();
+    assert!(Arc::ptr_eq(&restored_compiler, &original_compiler));
+    let functions = target.borrow();
+    let restored = functions.user_functions.get(&user_id).unwrap();
+    assert_eq!(restored.symbols.addr(), original_symbols.addr());
+    assert_eq!(restored.out.addr(), original_out.addr());
+    assert_eq!(restored.plan.0.addr(), original_plan.0.addr());
+    assert_eq!(
+      restored.symbols.borrow().dictionary.addr(),
+      original_symbol_dictionary.addr(),
+    );
+    assert_eq!(restored.plan.checkpoint(), original_plan_checkpoint);
+    assert_eq!(
+      restored.symbols.borrow().symbols.get(&symbol_id).unwrap().addr(),
+      symbol.addr(),
+    );
+  }
+
+  #[test]
+  fn functions_snapshot_preflight_failure_is_atomic() {
+    let target = Ref::new(Functions::new());
+    target
+      .borrow_mut()
+      .functions
+      .insert(1, original_test_factory);
+    let snapshot = FunctionsSnapshot::capture(&target).unwrap();
+    target.borrow_mut().functions.clear();
+    let dictionary = snapshot.dictionary_target.borrow();
+
+    let error = snapshot.preflight_restore().unwrap_err();
+
+    assert_eq!(error.kind_name(), "FunctionsSnapshotBorrowConflict");
+    assert!(target.borrow().functions.is_empty());
+    drop(dictionary);
+  }
+
+  struct UnsupportedStateFunction;
+  impl MechFunctionImpl for UnsupportedStateFunction {
+    fn solve(&self) {}
+    fn out(&self) -> Value { Value::Empty }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+      Err(MechError::new(
+        TransactionStateUnsupportedError {
+          function: self.to_string(),
+          reason: "test-only opaque state".to_string(),
+        },
+        None,
+      ))
+    }
+    fn to_string(&self) -> String { "unsupported".to_string() }
+  }
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for UnsupportedStateFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Ok(0) }
+  }
+
+  #[test]
+  fn transaction_state_unsupported_error_is_structured() {
+    let function = UnsupportedStateFunction;
+    let error = function.transaction_state_values().unwrap_err();
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+  }
+
+  struct RuntimeHostBoundaryFunction;
+  impl MechFunctionImpl for RuntimeHostBoundaryFunction {
+    fn solve(&self) {}
+    fn out(&self) -> Value { Value::Empty }
+    fn to_string(&self) -> String {
+      "RuntimeHostNativeFunction::test".to_string()
+    }
+  }
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for RuntimeHostBoundaryFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> { Ok(0) }
+  }
+
+  #[test]
+  fn plan_checkpoint_declines_runtime_host_state_before_inspection() {
+    let plan = Plan::new();
+    plan.add_function(Box::new(RuntimeHostBoundaryFunction));
+
+    let error = plan.transaction_state_values().unwrap_err();
+
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+    assert!(error.kind_message().contains("runtime transaction participation"));
+  }
+
+  struct UnschedulableOutputFunction {
+    state: ValRef,
+  }
+  impl MechFunctionImpl for UnschedulableOutputFunction {
+    fn solve(&self) {}
+    fn out(&self) -> Value {
+      Value::MutableReference(self.state.clone())
+    }
+    fn reactive_output_values(&self) -> Vec<Value> {
+      Vec::new()
+    }
+    fn to_string(&self) -> String {
+      "unschedulable-output".to_string()
+    }
+  }
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for UnschedulableOutputFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+      Ok(0)
+    }
+  }
+
+  #[test]
+  fn plan_transaction_state_retains_outputs_excluded_from_scheduling() {
+    let state = Ref::new(Value::Index(Ref::new(1)));
+    let plan = Plan::new();
+    plan.add_function(Box::new(UnschedulableOutputFunction {
+      state: state.clone(),
+    }));
+
+    let values = plan.transaction_state_values().unwrap();
+
+    assert!(values.iter().any(
+      |value| matches!(value, Value::MutableReference(cell) if cell.addr() == state.addr())
+    ));
   }
 }
 
@@ -2229,6 +3306,26 @@ mod reactive_turn_tests {
   #[test] fn reactive_turn_combinational_only_has_empty_commit() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let a=Ref::new(2.);let b=Ref::new(3.);let(na,_)=comb(&mut p,input.clone(),a.clone(),false);let(nb,_)=comb(&mut p,a.clone(),b.clone(),false);*input.borrow_mut()=10.;let mut s=ReactiveTurnState::default();let o=p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap();assert_eq!(o.before_commit.executed_nodes,vec![na,nb]);assert_eq!(o.register_commit,ReactiveRegisterCommitOutcome::default());assert_eq!(o.after_commit,ReactivePlanSolveOutcome::default());assert_eq!(*b.borrow(),12.); }
   #[test] fn reactive_turn_empty_is_noop() { let mut p=ReactivePlan::new();let mut s=ReactiveTurnState::default();assert_eq!(p.advance_reactive_turn(&mut s,&[]).unwrap(),ReactiveTurnOutcome::default());assert_eq!(s,ReactiveTurnState::default()); }
   #[test] fn reactive_turn_commit_failure_skips_post_commit_propagation() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);let(r,solve,stage,commit)=reg(&mut p,input.clone(),sink.clone(),true);let(_,down)=comb(&mut p,sink.clone(),Ref::new(2.),false);let mut s=ReactiveTurnState::default();let e=p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).unwrap_err();assert!(e.kind_message().contains("stage failure"));assert_eq!((*solve.borrow(),*stage.borrow(),*commit.borrow(),*down.borrow(),*sink.borrow()),(0,1,0,0,1.));assert_eq!(s.pending_register_nodes,vec![r]); }
+  #[test]
+  fn checkpoint_validation_accepts_duplicate_registers_from_retried_failed_turn() {
+    let plan = Plan::new();
+    let input = Ref::new(1.);
+    let sink = Ref::new(1.);
+    let (register, _, stage, _) = {
+      let mut reactive = plan.borrow_mut();
+      reg(&mut reactive, input.clone(), sink, true)
+    };
+    let dirty = input.to_value().reactive_root_cell_ids();
+    let mut state = ReactiveTurnState::default();
+
+    assert!(plan.advance_reactive_turn(&mut state, &dirty).is_err());
+    assert_eq!(state.pending_register_nodes, vec![register]);
+    assert!(plan.advance_reactive_turn(&mut state, &dirty).is_err());
+    assert_eq!(state.pending_register_nodes, vec![register, register]);
+    assert_eq!(*stage.borrow(), 2);
+
+    plan.validate_checkpoint_turn_state(&state).unwrap();
+  }
   #[test] fn reactive_turn_post_commit_failure_does_not_requeue_committed_registers() { let mut p=ReactivePlan::new();let input=Ref::new(1.);let sink=Ref::new(1.);let(_,_,_,commit)=reg(&mut p,input.clone(),sink.clone(),false);let(_,down)=comb(&mut p,sink.clone(),Ref::new(2.),true);*input.borrow_mut()=10.;let mut s=ReactiveTurnState::default();assert!(p.advance_reactive_turn(&mut s,&input.to_value().reactive_root_cell_ids()).is_err());assert_eq!((*sink.borrow(),*commit.borrow(),*down.borrow()),(10.,1,1));assert!(s.pending_register_nodes.is_empty()); }
   #[test]
   fn reactive_turn_post_commit_failure_preserves_deferred_registers() {

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -9,7 +9,8 @@ pub type SymbolTableRef= Ref<SymbolTable>;
 pub struct SymbolTableSnapshot {
   symbols: HashMap<u64, ValRef>,
   mutable_variables: HashMap<u64, ValRef>,
-  dictionary: Dictionary,
+  dictionary: Ref<Dictionary>,
+  dictionary_contents: Dictionary,
   reverse_lookup: HashMap<*const Ref<Value>, u64>,
 }
 
@@ -26,16 +27,40 @@ impl SymbolTable {
     SymbolTableSnapshot {
       symbols: self.symbols.clone(),
       mutable_variables: self.mutable_variables.clone(),
-      dictionary: self.dictionary.borrow().clone(),
+      dictionary: self.dictionary.clone(),
+      dictionary_contents: self.dictionary.borrow().clone(),
       reverse_lookup: self.reverse_lookup.clone(),
     }
   }
 
+  pub fn preflight_restore(&self, snapshot: &SymbolTableSnapshot) -> MResult<()> {
+    snapshot
+      .dictionary
+      .try_borrow_mut()
+      .map(|_| ())
+      .map_err(|_| {
+        MechError::new(
+          ValueStateBorrowConflict {
+            phase: "restore-before",
+            type_name: core::any::type_name::<Dictionary>(),
+            address: snapshot.dictionary.addr(),
+          },
+          None,
+        )
+        .with_compiler_loc()
+      })
+  }
+
+  pub fn apply_restore(&mut self, snapshot: &SymbolTableSnapshot) {
+    self.symbols = snapshot.symbols.clone();
+    self.mutable_variables = snapshot.mutable_variables.clone();
+    self.dictionary = snapshot.dictionary.clone();
+    *self.dictionary.borrow_mut() = snapshot.dictionary_contents.clone();
+    self.reverse_lookup = snapshot.reverse_lookup.clone();
+  }
+
   pub fn restore(&mut self, snapshot: SymbolTableSnapshot) {
-    self.symbols = snapshot.symbols;
-    self.mutable_variables = snapshot.mutable_variables;
-    *self.dictionary.borrow_mut() = snapshot.dictionary;
-    self.reverse_lookup = snapshot.reverse_lookup;
+    self.apply_restore(&snapshot);
   }
 
 
@@ -88,12 +113,14 @@ mod snapshot_tests {
     let outer_ref = table.insert(outer, Value::Index(Ref::new(1)), true);
     table.dictionary.borrow_mut().insert(outer, "outer".to_string());
     let outer_addr = outer_ref.addr();
+    let dictionary_addr = table.dictionary.addr();
     let original_snapshot = table.snapshot();
 
     table.insert(outer, Value::Index(Ref::new(2)), false);
     table.insert(temporary, Value::Index(Ref::new(3)), false);
     table.dictionary.borrow_mut().insert(outer, "changed".to_string());
     table.dictionary.borrow_mut().insert(temporary, "temporary".to_string());
+    table.dictionary = Ref::new(Dictionary::new());
     assert_ne!(table.snapshot(), original_snapshot);
 
     table.restore(original_snapshot.clone());
@@ -101,6 +128,7 @@ mod snapshot_tests {
     assert!(!table.contains(temporary));
     assert!(table.get_mutable(outer).is_some());
     assert_eq!(table.get(outer).unwrap().addr(), outer_addr);
+    assert_eq!(table.dictionary.addr(), dictionary_addr);
     assert_eq!(table.get_symbol_name_by_id(outer).as_deref(), Some("outer"));
   }
 }

--- a/src/core/src/state_journal.rs
+++ b/src/core/src/state_journal.rs
@@ -183,7 +183,6 @@ where
             return Ok(());
         }
         self.target
-            .0
             .try_borrow_mut()
             .map(|_| ())
             .map_err(|_| self.borrow_conflict("restore-before"))
@@ -194,7 +193,6 @@ where
             return Ok(());
         }
         self.target
-            .0
             .try_borrow_mut()
             .map(|_| ())
             .map_err(|_| self.borrow_conflict("restore-after"))
@@ -223,6 +221,10 @@ where
 /// The journal stores shallow payload clones alongside the original cell
 /// handles. Nested cells are journaled separately, preserving addresses,
 /// sharing, cycles, and reactive identities when state is restored.
+///
+/// This is the only checkpoint layer that knows how physical cell payloads are
+/// captured and restored. Higher-level checkpoints coordinate its opaque
+/// preflight and apply operations without reaching into cell storage.
 pub struct ValueStateJournal {
     entries: Vec<Box<dyn ErasedValueStateEntry>>,
     entry_indices: HashMap<ValueStateKey, usize>,
@@ -283,13 +285,32 @@ impl ValueStateJournal {
     ///
     /// Every target is preflighted before the first payload is changed.
     pub fn restore_before(&self) -> MResult<()> {
+        self.preflight_restore_before()?;
+        self.apply_restore_before();
+        Ok(())
+    }
+
+    /// Verifies that every captured before-state target can be mutably borrowed.
+    ///
+    /// Transaction coordinators can call this before mutating any other
+    /// checkpointed subsystem, then call [`Self::apply_restore_before`] after
+    /// all participating checkpoints have passed their own preflight.
+    pub fn preflight_restore_before(&self) -> MResult<()> {
         for entry in &self.entries {
             entry.preflight_restore_before()?;
         }
+        Ok(())
+    }
+
+    /// Restores all captured before-state after a successful preflight.
+    ///
+    /// This method deliberately performs no fallible work. Callers must not
+    /// retain or acquire borrows of captured cells between
+    /// [`Self::preflight_restore_before`] and this method.
+    pub fn apply_restore_before(&self) {
         for entry in &self.entries {
             entry.restore_before_unchecked();
         }
-        Ok(())
     }
 
     /// Records the complete state currently reachable from all saved roots.
@@ -415,7 +436,7 @@ impl ValueStateJournal {
         if !seen.insert(key) {
             return Ok(());
         }
-        let payload = target.0.try_borrow().map_err(|_| {
+        let payload = target.try_borrow().map_err(|_| {
             MechError::new(
                 ValueStateBorrowConflict {
                     phase: side.phase(),
@@ -467,7 +488,7 @@ impl ValueStateJournal {
         if !seen.insert(key) {
             return Ok(());
         }
-        let payload = target.0.try_borrow().map_err(|_| {
+        let payload = target.try_borrow().map_err(|_| {
             MechError::new(
                 ValueStateBorrowConflict {
                     phase: side.phase(),
@@ -1266,6 +1287,24 @@ mod tests {
         assert_eq!(*cell.borrow(), 1.0);
         assert_eq!(cell.addr(), address);
         assert_eq!(value.reactive_root_cell_ids(), vec![identity]);
+    }
+
+    #[test]
+    fn state_journal_split_restore_preflights_before_apply() {
+        let cell = scalar(1.0);
+        let mut journal = ValueStateJournal::new();
+        journal.capture_value(&scalar_value(&cell)).unwrap();
+        *cell.borrow_mut() = 2.0;
+
+        let held_borrow = cell.borrow();
+        let error = journal.preflight_restore_before().unwrap_err();
+        assert_eq!(error.kind_name(), "ValueStateBorrowConflict");
+        assert_eq!(*held_borrow, 2.0);
+        drop(held_borrow);
+
+        journal.preflight_restore_before().unwrap();
+        journal.apply_restore_before();
+        assert_eq!(*cell.borrow(), 1.0);
     }
 
     #[test]

--- a/src/core/src/types/mod.rs
+++ b/src/core/src/types/mod.rs
@@ -57,7 +57,7 @@ pub use self::rational_numbers::*;
 /// Callers use this API rather than depending on the current backing store so
 /// the representation can change without leaking into checkpoint or runtime
 /// coordination code.
-pub struct Ref<T>(pub Rc<RefCell<T>>);
+pub struct Ref<T>(Rc<RefCell<T>>);
 
 impl<T: Debug> Debug for Ref<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/core/src/types/mod.rs
+++ b/src/core/src/types/mod.rs
@@ -52,6 +52,11 @@ pub use self::rational_numbers::*;
 // Ref
 // ----------------------------------------------------------------------------
 
+/// An opaque shared handle to a Mech value payload.
+///
+/// Callers use this API rather than depending on the current backing store so
+/// the representation can change without leaking into checkpoint or runtime
+/// coordination code.
 pub struct Ref<T>(pub Rc<RefCell<T>>);
 
 impl<T: Debug> Debug for Ref<T> {
@@ -87,6 +92,15 @@ impl<T> Ref<T> {
     }
     pub fn borrow_mut(&self) -> cell::RefMut<'_, T> {
         self.0.borrow_mut()
+    }
+    pub fn try_borrow(&self) -> Result<cell::Ref<'_, T>, cell::BorrowError> {
+        self.0.try_borrow()
+    }
+    pub fn try_borrow_mut(&self) -> Result<cell::RefMut<'_, T>, cell::BorrowMutError> {
+        self.0.try_borrow_mut()
+    }
+    pub fn same_handle(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
     }
     pub fn addr(&self) -> usize {
         Rc::as_ptr(&self.0) as *const () as usize

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -647,6 +647,11 @@ pub enum Value {
 impl Eq for Value {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// A process-local identity used by the reactive scheduler.
+///
+/// This is not a durable cell identity and must not be persisted as transaction
+/// history. Durable history requires a stable logical cell ID that is
+/// independent of the current [`Ref`] backing representation.
 pub struct ReactiveCellId(u64);
 
 impl ReactiveCellId {

--- a/src/interpreter/src/activation.rs
+++ b/src/interpreter/src/activation.rs
@@ -57,6 +57,25 @@ activation_error!(
     ActivationPatternTriggerInvariant,
     "Activation trigger root cells disagree with the resolved trigger."
 );
+activation_error!(
+    ActivationPatternTransactionBoolStateUnsupported,
+    "Patterned activation transaction state requires boolean values."
+);
+
+fn transaction_bool_state(value: &Ref<bool>) -> MResult<Value> {
+    #[cfg(any(feature = "bool", feature = "variable_define"))]
+    {
+        Ok(Value::Bool(value.clone()))
+    }
+    #[cfg(not(any(feature = "bool", feature = "variable_define")))]
+    {
+        let _ = value;
+        Err(MechError::new(
+            ActivationPatternTransactionBoolStateUnsupported,
+            None,
+        ))
+    }
+}
 
 #[derive(Clone)]
 struct ActivationPatternCapture {
@@ -802,6 +821,11 @@ impl MechFunctionImpl for Matcher {
         outputs.extend(self.captures.iter().map(|capture| capture.proposed.clone()));
         outputs
     }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        let mut values = self.reactive_output_values();
+        values.push(transaction_bool_state(&self.matched)?);
+        Ok(values)
+    }
     fn reactive_dependency_kinds(&self, argument_count: usize) -> Option<Vec<ReactiveDependencyKind>> {
         let mut kinds = vec![ReactiveDependencyKind::Sampled; argument_count];
         if let Some(scope_pulse) = kinds.first_mut() {
@@ -827,6 +851,11 @@ impl MechFunctionImpl for Finalize {
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
+    }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        let mut values = self.reactive_output_values();
+        values.push(transaction_bool_state(&self.eligible)?);
+        Ok(values)
     }
     fn to_string(&self) -> String {
         "ActivationPatternArmFinalize".into()
@@ -872,6 +901,11 @@ impl MechFunctionImpl for UnmatchedFinalize {
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
     }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        let mut values = self.reactive_output_values();
+        values.push(transaction_bool_state(&self.eligible)?);
+        Ok(values)
+    }
     fn to_string(&self) -> String {
         "ActivationPatternGuardUnmatchedFinalize".into()
     }
@@ -890,6 +924,11 @@ impl MechFunctionImpl for GuardFinalize {
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
+    }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        let mut values = self.reactive_output_values();
+        values.push(transaction_bool_state(&self.eligible)?);
+        Ok(values)
     }
     fn to_string(&self) -> String {
         "ActivationPatternGuardFinalize".into()
@@ -913,6 +952,11 @@ impl MechFunctionImpl for Select {
     }
     fn out(&self) -> Value {
         Value::Index(self.out.clone())
+    }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        let mut values = self.reactive_output_values();
+        values.push(Value::Index(self.selected.clone()));
+        Ok(values)
     }
     fn to_string(&self) -> String {
         "ActivationPatternSelectArm".into()
@@ -2093,6 +2137,74 @@ mod tests {
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
+
+    #[cfg(any(feature = "bool", feature = "variable_define"))]
+    #[test]
+    fn activation_transaction_state_exposes_hidden_mutable_cells() {
+        fn contains_bool(values: &[Value], target: &Ref<bool>) -> bool {
+            values.iter().any(|value| {
+                matches!(value, Value::Bool(cell) if cell.addr() == target.addr())
+            })
+        }
+        fn contains_index(values: &[Value], target: &Ref<usize>) -> bool {
+            values.iter().any(|value| {
+                matches!(value, Value::Index(cell) if cell.addr() == target.addr())
+            })
+        }
+
+        let matched = Ref::new(false);
+        let matcher = Matcher {
+            pattern: CompiledPattern::Wildcard,
+            trigger: Value::Empty,
+            expression_values: Vec::new(),
+            captures: Vec::new(),
+            matched: matched.clone(),
+            out: Ref::new(0),
+        };
+        let matcher_values = matcher.transaction_state_values().unwrap();
+        assert_eq!(matcher_values.len(), 2);
+        assert!(contains_bool(&matcher_values, &matched));
+
+        let eligible = Ref::new(false);
+        let finalize = Finalize {
+            matched: matched.clone(),
+            eligible: eligible.clone(),
+            out: Ref::new(0),
+        };
+        let finalize_values = finalize.transaction_state_values().unwrap();
+        assert_eq!(finalize_values.len(), 2);
+        assert!(contains_bool(&finalize_values, &eligible));
+
+        let unmatched_eligible = Ref::new(false);
+        let unmatched = UnmatchedFinalize {
+            matched: matched.clone(),
+            eligible: unmatched_eligible.clone(),
+            out: Ref::new(0),
+        };
+        let unmatched_values = unmatched.transaction_state_values().unwrap();
+        assert_eq!(unmatched_values.len(), 2);
+        assert!(contains_bool(&unmatched_values, &unmatched_eligible));
+
+        let guard_eligible = Ref::new(false);
+        let guard = GuardFinalize {
+            guard: Ref::new(false),
+            eligible: guard_eligible.clone(),
+            out: Ref::new(0),
+        };
+        let guard_values = guard.transaction_state_values().unwrap();
+        assert_eq!(guard_values.len(), 2);
+        assert!(contains_bool(&guard_values, &guard_eligible));
+
+        let selected = Ref::new(usize::MAX);
+        let select = Select {
+            eligible: vec![eligible],
+            selected: selected.clone(),
+            out: Ref::new(0),
+        };
+        let select_values = select.transaction_state_values().unwrap();
+        assert_eq!(select_values.len(), 2);
+        assert!(contains_index(&select_values, &selected));
+    }
 
     struct EagerGuardTestCompiler {
         compile_calls: Arc<AtomicUsize>,

--- a/src/interpreter/src/expressions.rs
+++ b/src/interpreter/src/expressions.rs
@@ -294,10 +294,35 @@ impl MechFunctionImpl for ValueMatrixComprehension {
     fn out(&self) -> Value {
         self.out.borrow().clone()
     }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        Ok(vec![Value::MutableReference(self.out.clone())])
+    }
     fn to_string(&self) -> String {
         format!("{:#?}", self)
     }
 }
+
+#[cfg(all(test, feature = "matrix_comprehensions", feature = "functions"))]
+mod matrix_comprehension_transaction_tests {
+    use super::*;
+
+    #[test]
+    fn transaction_state_retains_matrix_comprehension_outer_output_ref() {
+        let out = Ref::new(Value::Empty);
+        let function = ValueMatrixComprehension {
+            arguments: Vec::new(),
+            out: out.clone(),
+        };
+
+        let values = function.transaction_state_values().unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            Value::MutableReference(root) => assert_eq!(root.addr(), out.addr()),
+            other => panic!("expected mutable-reference transaction root, got {other:?}"),
+        }
+    }
+}
+
 #[cfg(all(feature = "matrix_comprehensions", feature = "functions"))]
 impl MechFunctionFactory for ValueMatrixComprehension {
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
@@ -848,7 +873,7 @@ fn mutable_reference_is_mutable_symbol(reference: &MutableReference, p: &Interpr
     symbols_brrw
         .mutable_variables
         .values()
-        .any(|symbol| std::rc::Rc::ptr_eq(&symbol.0, &reference.0))
+        .any(|symbol| symbol.same_handle(reference))
 }
 
 #[cfg(feature = "subscript_formula")]

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -36,6 +36,20 @@ pub struct Frame {
   state: FrameState,      // Running / Suspended / Completed
 }
 
+impl Frame {
+  pub(crate) fn checkpoint_plan(&self) -> Plan {
+    self.plan.clone()
+  }
+
+  pub(crate) fn checkpoint_locals(&self) -> SymbolTableRef {
+    self.locals.clone()
+  }
+
+  pub(crate) fn checkpoint_out(&self) -> Option<Value> {
+    self.out.clone()
+  }
+}
+
 // The call stack is a simple growable list of frames; the last entry is current.
 #[derive(Clone)]
 pub struct Stack {

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -26,8 +26,11 @@ pub struct RuntimeContextBinding {
   pub base_uri: String,
 }
 
+pub type InterpreterRef = Ref<Box<Interpreter>>;
+
 pub struct Interpreter {
   pub id: u64,
+  checkpoint_owner: Rc<()>,
   pub profile: bool,
   pub max_steps: usize,
   #[cfg(feature = "trace")]
@@ -63,13 +66,887 @@ pub struct Interpreter {
   pub user_state_machines: Ref<HashMap<u64, FsmImplementation>>,
   #[cfg(feature = "state_machines")]
   pub user_state_machine_specs: Ref<HashMap<u64, FsmSpecification>>,
-  pub sub_interpreters: Ref<HashMap<u64, Box<Interpreter>>>,
+  pub sub_interpreters: Ref<HashMap<u64, InterpreterRef>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterpreterCheckpointUnsupportedCompilerContext {
+  pub interpreter_id: u64,
+}
+
+impl MechErrorKind for InterpreterCheckpointUnsupportedCompilerContext {
+  fn name(&self) -> &str {
+    "InterpreterCheckpointUnsupportedCompilerContext"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Interpreter {} has a retained compiler context that cannot be checkpointed safely.",
+      self.interpreter_id,
+    )
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterpreterCheckpointBorrowConflict {
+  pub phase: &'static str,
+  pub interpreter_id: u64,
+  pub type_name: &'static str,
+  pub address: usize,
+}
+
+impl MechErrorKind for InterpreterCheckpointBorrowConflict {
+  fn name(&self) -> &str {
+    "InterpreterCheckpointBorrowConflict"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Cannot borrow {} checkpoint target at 0x{:x} for interpreter {} during {}.",
+      self.type_name,
+      self.address,
+      self.interpreter_id,
+      self.phase,
+    )
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterpreterCheckpointHierarchyAlias {
+  pub interpreter_id: u64,
+  pub address: usize,
+}
+
+impl MechErrorKind for InterpreterCheckpointHierarchyAlias {
+  fn name(&self) -> &str {
+    "InterpreterCheckpointHierarchyAlias"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Interpreter {} contains a repeated or cyclic child handle at 0x{:x}.",
+      self.interpreter_id,
+      self.address,
+    )
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterpreterCheckpointOwnerMismatch {
+  pub interpreter_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterpreterCheckpointChildKeyMismatch {
+  pub parent_id: u64,
+  pub key: u64,
+  pub child_id: u64,
+}
+
+impl MechErrorKind for InterpreterCheckpointChildKeyMismatch {
+  fn name(&self) -> &str {
+    "InterpreterCheckpointChildKeyMismatch"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Interpreter {} stores child {} under mismatched key {}.",
+      self.parent_id,
+      self.child_id,
+      self.key,
+    )
+  }
+}
+
+impl MechErrorKind for InterpreterCheckpointOwnerMismatch {
+  fn name(&self) -> &str {
+    "InterpreterCheckpointOwnerMismatch"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "The checkpoint belongs to a different interpreter than interpreter {}.",
+      self.interpreter_id,
+    )
+  }
+}
+
+fn checkpoint_borrow_error<T: 'static>(
+  phase: &'static str,
+  interpreter_id: u64,
+  target: &Ref<T>,
+) -> MechError {
+  MechError::new(
+    InterpreterCheckpointBorrowConflict {
+      phase,
+      interpreter_id,
+      type_name: core::any::type_name::<T>(),
+      address: target.addr(),
+    },
+    None,
+  )
+  .with_compiler_loc()
+}
+
+fn checkpoint_clone_ref<T: Clone + 'static>(
+  target: &Ref<T>,
+  interpreter_id: u64,
+) -> MResult<T> {
+  target
+    .try_borrow()
+    .map(|value| value.clone())
+    .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter_id, target))
+}
+
+fn checkpoint_preflight_ref<T: 'static>(
+  target: &Ref<T>,
+  interpreter_id: u64,
+) -> MResult<()> {
+  target
+    .try_borrow_mut()
+    .map(|_| ())
+    .map_err(|_| checkpoint_borrow_error("checkpoint-restore", interpreter_id, target))
+}
+
+#[cfg(feature = "functions")]
+fn checkpoint_preflight_plan_capture(
+  plan: &Plan,
+  interpreter_id: u64,
+) -> MResult<()> {
+  plan
+    .0
+    .try_borrow()
+    .map(|_| ())
+    .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter_id, &plan.0))?;
+  plan
+    .1
+    .try_borrow()
+    .map(|_| ())
+    .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter_id, &plan.1))?;
+  plan.validate_checkpoint_invariants()
+}
+
+struct RefPayloadCheckpoint<T: Clone + 'static> {
+  target: Ref<T>,
+  payload: T,
+}
+
+impl<T: Clone + 'static> RefPayloadCheckpoint<T> {
+  fn capture(target: &Ref<T>, interpreter_id: u64) -> MResult<Self> {
+    Ok(Self {
+      target: target.clone(),
+      payload: checkpoint_clone_ref(target, interpreter_id)?,
+    })
+  }
+
+  fn preflight(&self, interpreter_id: u64) -> MResult<()> {
+    checkpoint_preflight_ref(&self.target, interpreter_id)
+  }
+
+  fn apply(&self) {
+    *self.target.borrow_mut() = self.payload.clone();
+  }
+}
+
+#[cfg(feature = "symbol_table")]
+struct SymbolTableCellCheckpoint {
+  target: SymbolTableRef,
+  snapshot: SymbolTableSnapshot,
+}
+
+#[cfg(feature = "symbol_table")]
+impl SymbolTableCellCheckpoint {
+  fn capture(
+    target: &SymbolTableRef,
+    interpreter_id: u64,
+    journal: &mut ValueStateJournal,
+  ) -> MResult<Self> {
+    let snapshot = {
+      let table = target
+        .try_borrow()
+        .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter_id, target))?;
+      table
+        .dictionary
+        .try_borrow()
+        .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter_id, &table.dictionary))?;
+      let snapshot = table.snapshot();
+      for value in table.symbols.values() {
+        journal.capture_val_ref(value)?;
+      }
+      for value in table.mutable_variables.values() {
+        journal.capture_val_ref(value)?;
+      }
+      snapshot
+    };
+    Ok(Self {
+      target: target.clone(),
+      snapshot,
+    })
+  }
+
+  fn preflight(&self, interpreter_id: u64) -> MResult<()> {
+    checkpoint_preflight_ref(&self.target, interpreter_id)?;
+    let table = self
+      .target
+      .try_borrow()
+      .map_err(|_| checkpoint_borrow_error("checkpoint-restore", interpreter_id, &self.target))?;
+    table.preflight_restore(&self.snapshot)
+  }
+
+  fn apply(&self) {
+    self.target.borrow_mut().apply_restore(&self.snapshot);
+  }
+}
+
+#[cfg(feature = "functions")]
+struct FrameCellCheckpoint {
+  locals: SymbolTableCellCheckpoint,
+  plan: Plan,
+  plan_checkpoint: PlanCheckpoint,
+}
+
+#[cfg(feature = "functions")]
+impl FrameCellCheckpoint {
+  fn capture(
+    frame: &Frame,
+    interpreter_id: u64,
+    journal: &mut ValueStateJournal,
+  ) -> MResult<Self> {
+    let plan = frame.checkpoint_plan();
+    checkpoint_preflight_plan_capture(&plan, interpreter_id)?;
+    for value in plan.transaction_state_values()? {
+      journal.capture_value(&value)?;
+    }
+    if let Some(value) = frame.checkpoint_out() {
+      journal.capture_value(&value)?;
+    }
+    Ok(Self {
+      locals: SymbolTableCellCheckpoint::capture(
+        &frame.checkpoint_locals(),
+        interpreter_id,
+        journal,
+      )?,
+      plan_checkpoint: plan.checkpoint(),
+      plan,
+    })
+  }
+
+  fn preflight(&self, interpreter_id: u64) -> MResult<()> {
+    self.locals.preflight(interpreter_id)?;
+    self.plan.preflight_rollback(&self.plan_checkpoint)
+  }
+
+  fn apply_structure(&self) {
+    self.locals.apply();
+    self.plan.apply_rollback_structure(&self.plan_checkpoint);
+  }
+
+  fn rebuild_checkpoint_indexes(&self) {
+    self.plan.rebuild_checkpoint_indexes();
+    self
+      .plan
+      .validate_checkpoint_invariants()
+      .expect("frame checkpoint preflight guarantees restored plan invariants");
+  }
+}
+
+struct ProgramStateCheckpoint {
+  target: Ref<ProgramState>,
+  #[cfg(feature = "symbol_table")]
+  symbol_table: SymbolTableCellCheckpoint,
+  #[cfg(feature = "symbol_table")]
+  environment: Option<SymbolTableCellCheckpoint>,
+  #[cfg(feature = "functions")]
+  functions: FunctionsRef,
+  #[cfg(feature = "functions")]
+  functions_snapshot: FunctionsSnapshot,
+  #[cfg(feature = "functions")]
+  plan: Plan,
+  #[cfg(feature = "functions")]
+  plan_checkpoint: PlanCheckpoint,
+  kinds: KindTable,
+  #[cfg(feature = "enum")]
+  enums: EnumTable,
+  #[cfg(feature = "enum")]
+  enum_dictionaries: Vec<RefPayloadCheckpoint<Dictionary>>,
+  #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
+  invariants: InvariantTable,
+  #[cfg(feature = "invariant_define")]
+  invariant_violations: Vec<InvariantViolation>,
+  #[cfg(feature = "invariant_define")]
+  invariant_expressions: InvariantExpressionTable,
+  #[cfg(feature = "invariant_define")]
+  invariant_evaluations: InvariantEvaluationTable,
+  dictionary: RefPayloadCheckpoint<Dictionary>,
+}
+
+impl ProgramStateCheckpoint {
+  fn capture(
+    target: &Ref<ProgramState>,
+    interpreter_id: u64,
+    journal: &mut ValueStateJournal,
+  ) -> MResult<Self> {
+    let state = target
+      .try_borrow()
+      .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter_id, target))?;
+
+    #[cfg(feature = "symbol_table")]
+    let symbol_table = SymbolTableCellCheckpoint::capture(
+      &state.symbol_table,
+      interpreter_id,
+      journal,
+    )?;
+    #[cfg(feature = "symbol_table")]
+    let environment = match &state.environment {
+      Some(environment) => Some(SymbolTableCellCheckpoint::capture(
+        environment,
+        interpreter_id,
+        journal,
+      )?),
+      None => None,
+    };
+
+    #[cfg(feature = "functions")]
+    let functions = state.functions.clone();
+    #[cfg(feature = "functions")]
+    let functions_snapshot = FunctionsSnapshot::capture(&functions)?;
+    #[cfg(feature = "functions")]
+    for value in functions_snapshot.transaction_state_values()? {
+      journal.capture_value(&value)?;
+    }
+
+    #[cfg(feature = "functions")]
+    let plan = state.plan.clone();
+    #[cfg(feature = "functions")]
+    checkpoint_preflight_plan_capture(&plan, interpreter_id)?;
+    #[cfg(feature = "functions")]
+    for value in plan.transaction_state_values()? {
+      journal.capture_value(&value)?;
+    }
+    #[cfg(feature = "functions")]
+    let plan_checkpoint = plan.checkpoint();
+
+    #[cfg(feature = "enum")]
+    let enums = state.enums.clone();
+    #[cfg(feature = "enum")]
+    let mut enum_dictionaries = Vec::new();
+    #[cfg(feature = "enum")]
+    for enum_value in enums.values() {
+      enum_dictionaries.push(RefPayloadCheckpoint::capture(
+        &enum_value.names,
+        interpreter_id,
+      )?);
+      for (_, payload) in &enum_value.variants {
+        if let Some(payload) = payload {
+          journal.capture_value(payload)?;
+        }
+      }
+    }
+
+    #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
+    for (_, value) in state.invariants.values() {
+      journal.capture_val_ref(value)?;
+    }
+
+    Ok(Self {
+      target: target.clone(),
+      #[cfg(feature = "symbol_table")]
+      symbol_table,
+      #[cfg(feature = "symbol_table")]
+      environment,
+      #[cfg(feature = "functions")]
+      functions,
+      #[cfg(feature = "functions")]
+      functions_snapshot,
+      #[cfg(feature = "functions")]
+      plan,
+      #[cfg(feature = "functions")]
+      plan_checkpoint,
+      kinds: state.kinds.clone(),
+      #[cfg(feature = "enum")]
+      enums,
+      #[cfg(feature = "enum")]
+      enum_dictionaries,
+      #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
+      invariants: state.invariants.clone(),
+      #[cfg(feature = "invariant_define")]
+      invariant_violations: state.invariant_violations.clone(),
+      #[cfg(feature = "invariant_define")]
+      invariant_expressions: state.invariant_expressions.clone(),
+      #[cfg(feature = "invariant_define")]
+      invariant_evaluations: state.invariant_evaluations.clone(),
+      dictionary: RefPayloadCheckpoint::capture(&state.dictionary, interpreter_id)?,
+    })
+  }
+
+  fn preflight(&self, interpreter_id: u64) -> MResult<()> {
+    checkpoint_preflight_ref(&self.target, interpreter_id)?;
+    #[cfg(feature = "symbol_table")]
+    self.symbol_table.preflight(interpreter_id)?;
+    #[cfg(feature = "symbol_table")]
+    if let Some(environment) = &self.environment {
+      environment.preflight(interpreter_id)?;
+    }
+    #[cfg(feature = "functions")]
+    self.functions_snapshot.preflight_restore()?;
+    #[cfg(feature = "functions")]
+    self.plan.preflight_rollback(&self.plan_checkpoint)?;
+    #[cfg(feature = "enum")]
+    for dictionary in &self.enum_dictionaries {
+      dictionary.preflight(interpreter_id)?;
+    }
+    self.dictionary.preflight(interpreter_id)
+  }
+
+  fn apply_structure(&self) {
+    {
+      let mut state = self.target.borrow_mut();
+      #[cfg(feature = "symbol_table")]
+      {
+        state.symbol_table = self.symbol_table.target.clone();
+        state.environment = self
+          .environment
+          .as_ref()
+          .map(|environment| environment.target.clone());
+      }
+      #[cfg(feature = "functions")]
+      {
+        state.functions = self.functions.clone();
+        state.plan = self.plan.clone();
+      }
+      state.kinds = self.kinds.clone();
+      #[cfg(feature = "enum")]
+      {
+        state.enums = self.enums.clone();
+      }
+      #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
+      {
+        state.invariants = self.invariants.clone();
+      }
+      #[cfg(feature = "invariant_define")]
+      {
+        state.invariant_violations = self.invariant_violations.clone();
+        state.invariant_expressions = self.invariant_expressions.clone();
+        state.invariant_evaluations = self.invariant_evaluations.clone();
+      }
+      state.dictionary = self.dictionary.target.clone();
+    }
+
+    #[cfg(feature = "symbol_table")]
+    self.symbol_table.apply();
+    #[cfg(feature = "symbol_table")]
+    if let Some(environment) = &self.environment {
+      environment.apply();
+    }
+    #[cfg(feature = "functions")]
+    self.functions_snapshot.apply_restore_structure();
+    #[cfg(feature = "functions")]
+    self.plan.apply_rollback_structure(&self.plan_checkpoint);
+    #[cfg(feature = "enum")]
+    for dictionary in &self.enum_dictionaries {
+      dictionary.apply();
+    }
+    self.dictionary.apply();
+  }
+
+  #[cfg(feature = "functions")]
+  fn rebuild_checkpoint_indexes(&self, turn_state: &ReactiveTurnState) {
+    self.functions_snapshot.rebuild_checkpoint_indexes();
+    self.plan.rebuild_checkpoint_indexes();
+    self
+      .functions_snapshot
+      .validate_checkpoint_invariants()
+      .expect("function checkpoint preflight guarantees restored plan invariants");
+    self
+      .plan
+      .validate_checkpoint_invariants()
+      .expect("program checkpoint preflight guarantees restored plan invariants");
+    self
+      .plan
+      .validate_checkpoint_turn_state(turn_state)
+      .expect("program checkpoint preflight guarantees restored turn invariants");
+  }
+}
+
+struct ChildInterpreterCheckpoint {
+  target: InterpreterRef,
+  checkpoint: Box<InterpreterStructureCheckpoint>,
+}
+
+struct InterpreterStructureCheckpoint {
+  owner: Rc<()>,
+  id: u64,
+  profile: bool,
+  max_steps: usize,
+  ip: usize,
+  #[cfg(feature = "trace")]
+  trace: bool,
+  #[cfg(feature = "trace")]
+  trace_to_stdout: bool,
+  #[cfg(feature = "trace")]
+  trace_events: RefPayloadCheckpoint<Vec<TraceEvent>>,
+  state: ProgramStateCheckpoint,
+  #[cfg(feature = "functions")]
+  reactive_turn_state: ReactiveTurnState,
+  #[cfg(feature = "functions")]
+  persistent_user_function_plan_depth: RefPayloadCheckpoint<usize>,
+  deferred_expression_solve_depth: RefPayloadCheckpoint<usize>,
+  #[cfg(feature = "functions")]
+  stack: Vec<Frame>,
+  #[cfg(feature = "functions")]
+  frame_checkpoints: Vec<FrameCellCheckpoint>,
+  registers: Vec<Value>,
+  constants: Vec<Value>,
+  code: Vec<MechSourceCode>,
+  out: Value,
+  out_values: RefPayloadCheckpoint<HashMap<u64, Value>>,
+  #[cfg(feature = "subscript_formula")]
+  string_access_live_values: RefPayloadCheckpoint<std::collections::BTreeSet<usize>>,
+  #[cfg(feature = "subscript_formula")]
+  current_string_access_expression_live: RefPayloadCheckpoint<bool>,
+  inline_eval_counter: RefPayloadCheckpoint<u64>,
+  context_bindings: RefPayloadCheckpoint<HashMap<u64, RuntimeContextBinding>>,
+  module_manifests: RefPayloadCheckpoint<ModuleManifestCatalog>,
+  #[cfg(feature = "state_machines")]
+  user_state_machines: RefPayloadCheckpoint<HashMap<u64, FsmImplementation>>,
+  #[cfg(feature = "state_machines")]
+  user_state_machine_specs: RefPayloadCheckpoint<HashMap<u64, FsmSpecification>>,
+  sub_interpreters: Ref<HashMap<u64, InterpreterRef>>,
+  sub_interpreter_entries: HashMap<u64, InterpreterRef>,
+  children: Vec<ChildInterpreterCheckpoint>,
+}
+
+impl InterpreterStructureCheckpoint {
+  fn capture(
+    interpreter: &Interpreter,
+    journal: &mut ValueStateJournal,
+    seen_children: &mut Vec<InterpreterRef>,
+  ) -> MResult<Self> {
+    #[cfg(feature = "compiler")]
+    if interpreter.context.is_some() {
+      return Err(MechError::new(
+        InterpreterCheckpointUnsupportedCompilerContext {
+          interpreter_id: interpreter.id,
+        },
+        None,
+      )
+      .with_compiler_loc());
+    }
+
+    let state = ProgramStateCheckpoint::capture(
+      &interpreter.state,
+      interpreter.id,
+      journal,
+    )?;
+    #[cfg(feature = "functions")]
+    state
+      .plan
+      .validate_checkpoint_turn_state(&interpreter.reactive_turn_state)?;
+
+    for value in &interpreter.registers {
+      journal.capture_value(value)?;
+    }
+    for value in &interpreter.constants {
+      journal.capture_value(value)?;
+    }
+    journal.capture_value(&interpreter.out)?;
+
+    let out_values = RefPayloadCheckpoint::capture(
+      &interpreter.out_values,
+      interpreter.id,
+    )?;
+    for value in out_values.payload.values() {
+      journal.capture_value(value)?;
+    }
+
+    #[cfg(feature = "functions")]
+    let mut frame_checkpoints = Vec::with_capacity(interpreter.stack.len());
+    #[cfg(feature = "functions")]
+    for frame in &interpreter.stack {
+      frame_checkpoints.push(FrameCellCheckpoint::capture(
+        frame,
+        interpreter.id,
+        journal,
+      )?);
+    }
+
+    let sub_interpreter_entries = checkpoint_clone_ref(
+      &interpreter.sub_interpreters,
+      interpreter.id,
+    )?;
+    let mut children = Vec::with_capacity(sub_interpreter_entries.len());
+    for (child_id, child) in &sub_interpreter_entries {
+      if seen_children.iter().any(|seen| seen.same_handle(child)) {
+        return Err(MechError::new(
+          InterpreterCheckpointHierarchyAlias {
+            interpreter_id: interpreter.id,
+            address: child.addr(),
+          },
+          None,
+        )
+        .with_compiler_loc());
+      }
+      seen_children.push(child.clone());
+      let child_borrow = child
+        .try_borrow()
+        .map_err(|_| checkpoint_borrow_error("checkpoint-capture", interpreter.id, child))?;
+      if child_borrow.id != *child_id {
+        return Err(MechError::new(
+          InterpreterCheckpointChildKeyMismatch {
+            parent_id: interpreter.id,
+            key: *child_id,
+            child_id: child_borrow.id,
+          },
+          None,
+        )
+        .with_compiler_loc());
+      }
+      let checkpoint = Self::capture(
+        child_borrow.as_ref(),
+        journal,
+        seen_children,
+      )?;
+      children.push(ChildInterpreterCheckpoint {
+        target: child.clone(),
+        checkpoint: Box::new(checkpoint),
+      });
+    }
+
+    Ok(Self {
+      owner: interpreter.checkpoint_owner.clone(),
+      id: interpreter.id,
+      profile: interpreter.profile,
+      max_steps: interpreter.max_steps,
+      ip: interpreter.ip,
+      #[cfg(feature = "trace")]
+      trace: interpreter.trace,
+      #[cfg(feature = "trace")]
+      trace_to_stdout: interpreter.trace_to_stdout,
+      #[cfg(feature = "trace")]
+      trace_events: RefPayloadCheckpoint::capture(
+        &interpreter.trace_events,
+        interpreter.id,
+      )?,
+      state,
+      #[cfg(feature = "functions")]
+      reactive_turn_state: interpreter.reactive_turn_state.clone(),
+      #[cfg(feature = "functions")]
+      persistent_user_function_plan_depth: RefPayloadCheckpoint::capture(
+        &interpreter.persistent_user_function_plan_depth,
+        interpreter.id,
+      )?,
+      deferred_expression_solve_depth: RefPayloadCheckpoint::capture(
+        &interpreter.deferred_expression_solve_depth,
+        interpreter.id,
+      )?,
+      #[cfg(feature = "functions")]
+      stack: interpreter.stack.clone(),
+      #[cfg(feature = "functions")]
+      frame_checkpoints,
+      registers: interpreter.registers.clone(),
+      constants: interpreter.constants.clone(),
+      code: interpreter.code.clone(),
+      out: interpreter.out.clone(),
+      out_values,
+      #[cfg(feature = "subscript_formula")]
+      string_access_live_values: RefPayloadCheckpoint::capture(
+        &interpreter.string_access_live_values,
+        interpreter.id,
+      )?,
+      #[cfg(feature = "subscript_formula")]
+      current_string_access_expression_live: RefPayloadCheckpoint::capture(
+        &interpreter.current_string_access_expression_live,
+        interpreter.id,
+      )?,
+      inline_eval_counter: RefPayloadCheckpoint::capture(
+        &interpreter.inline_eval_counter,
+        interpreter.id,
+      )?,
+      context_bindings: RefPayloadCheckpoint::capture(
+        &interpreter.context_bindings,
+        interpreter.id,
+      )?,
+      module_manifests: RefPayloadCheckpoint::capture(
+        &interpreter.module_manifests,
+        interpreter.id,
+      )?,
+      #[cfg(feature = "state_machines")]
+      user_state_machines: RefPayloadCheckpoint::capture(
+        &interpreter.user_state_machines,
+        interpreter.id,
+      )?,
+      #[cfg(feature = "state_machines")]
+      user_state_machine_specs: RefPayloadCheckpoint::capture(
+        &interpreter.user_state_machine_specs,
+        interpreter.id,
+      )?,
+      sub_interpreters: interpreter.sub_interpreters.clone(),
+      sub_interpreter_entries,
+      children,
+    })
+  }
+
+  fn preflight(&self) -> MResult<()> {
+    self.state.preflight(self.id)?;
+    #[cfg(feature = "trace")]
+    self.trace_events.preflight(self.id)?;
+    #[cfg(feature = "functions")]
+    self.persistent_user_function_plan_depth.preflight(self.id)?;
+    self.deferred_expression_solve_depth.preflight(self.id)?;
+    self.out_values.preflight(self.id)?;
+    #[cfg(feature = "subscript_formula")]
+    self.string_access_live_values.preflight(self.id)?;
+    #[cfg(feature = "subscript_formula")]
+    self.current_string_access_expression_live.preflight(self.id)?;
+    self.inline_eval_counter.preflight(self.id)?;
+    self.context_bindings.preflight(self.id)?;
+    self.module_manifests.preflight(self.id)?;
+    #[cfg(feature = "state_machines")]
+    self.user_state_machines.preflight(self.id)?;
+    #[cfg(feature = "state_machines")]
+    self.user_state_machine_specs.preflight(self.id)?;
+    checkpoint_preflight_ref(&self.sub_interpreters, self.id)?;
+    #[cfg(feature = "functions")]
+    for frame in &self.frame_checkpoints {
+      frame.preflight(self.id)?;
+    }
+    for child in &self.children {
+      checkpoint_preflight_ref(&child.target, self.id)?;
+      let child_borrow = child
+        .target
+        .try_borrow()
+        .map_err(|_| checkpoint_borrow_error("checkpoint-restore", self.id, &child.target))?;
+      child.checkpoint.preflight_owner(child_borrow.as_ref())?;
+      child.checkpoint.preflight()?;
+    }
+    Ok(())
+  }
+
+  fn preflight_owner(&self, interpreter: &Interpreter) -> MResult<()> {
+    if Rc::ptr_eq(&self.owner, &interpreter.checkpoint_owner) {
+      Ok(())
+    } else {
+      Err(MechError::new(
+        InterpreterCheckpointOwnerMismatch {
+          interpreter_id: interpreter.id,
+        },
+        None,
+      )
+      .with_compiler_loc())
+    }
+  }
+
+  fn apply_structure(&self, interpreter: &mut Interpreter) {
+    interpreter.id = self.id;
+    interpreter.profile = self.profile;
+    interpreter.max_steps = self.max_steps;
+    interpreter.ip = self.ip;
+    #[cfg(feature = "trace")]
+    {
+      interpreter.trace = self.trace;
+      interpreter.trace_to_stdout = self.trace_to_stdout;
+      interpreter.trace_events = self.trace_events.target.clone();
+    }
+    interpreter.state = self.state.target.clone();
+    #[cfg(feature = "functions")]
+    {
+      interpreter.reactive_turn_state = self.reactive_turn_state.clone();
+      interpreter.persistent_user_function_plan_depth =
+        self.persistent_user_function_plan_depth.target.clone();
+      interpreter.stack = self.stack.clone();
+    }
+    interpreter.deferred_expression_solve_depth =
+      self.deferred_expression_solve_depth.target.clone();
+    interpreter.registers = self.registers.clone();
+    interpreter.constants = self.constants.clone();
+    #[cfg(feature = "compiler")]
+    {
+      interpreter.context = None;
+    }
+    interpreter.code = self.code.clone();
+    interpreter.out = self.out.clone();
+    interpreter.out_values = self.out_values.target.clone();
+    #[cfg(feature = "subscript_formula")]
+    {
+      interpreter.string_access_live_values = self.string_access_live_values.target.clone();
+      interpreter.current_string_access_expression_live =
+        self.current_string_access_expression_live.target.clone();
+    }
+    interpreter.inline_eval_counter = self.inline_eval_counter.target.clone();
+    interpreter.context_bindings = self.context_bindings.target.clone();
+    interpreter.module_manifests = self.module_manifests.target.clone();
+    #[cfg(feature = "state_machines")]
+    {
+      interpreter.user_state_machines = self.user_state_machines.target.clone();
+      interpreter.user_state_machine_specs = self.user_state_machine_specs.target.clone();
+    }
+    interpreter.sub_interpreters = self.sub_interpreters.clone();
+
+    self.state.apply_structure();
+    #[cfg(feature = "trace")]
+    self.trace_events.apply();
+    #[cfg(feature = "functions")]
+    self.persistent_user_function_plan_depth.apply();
+    self.deferred_expression_solve_depth.apply();
+    self.out_values.apply();
+    #[cfg(feature = "subscript_formula")]
+    self.string_access_live_values.apply();
+    #[cfg(feature = "subscript_formula")]
+    self.current_string_access_expression_live.apply();
+    self.inline_eval_counter.apply();
+    self.context_bindings.apply();
+    self.module_manifests.apply();
+    #[cfg(feature = "state_machines")]
+    self.user_state_machines.apply();
+    #[cfg(feature = "state_machines")]
+    self.user_state_machine_specs.apply();
+    #[cfg(feature = "functions")]
+    for frame in &self.frame_checkpoints {
+      frame.apply_structure();
+    }
+
+    *self.sub_interpreters.borrow_mut() = self.sub_interpreter_entries.clone();
+    for child in &self.children {
+      let mut child_borrow = child.target.borrow_mut();
+      child.checkpoint.apply_structure(child_borrow.as_mut());
+    }
+  }
+
+  fn rebuild_checkpoint_indexes(&self) {
+    #[cfg(feature = "functions")]
+    {
+      self
+        .state
+        .rebuild_checkpoint_indexes(&self.reactive_turn_state);
+      for frame in &self.frame_checkpoints {
+        frame.rebuild_checkpoint_indexes();
+      }
+    }
+    for child in &self.children {
+      child.checkpoint.rebuild_checkpoint_indexes();
+    }
+  }
+}
+
+struct InterpreterCheckpointData {
+  structure: InterpreterStructureCheckpoint,
+  journal: ValueStateJournal,
+}
+
+/// A process-local explicit savepoint for retained interpreter state.
+///
+/// This type is intentionally opaque and is not a serializable history record
+/// or a source of durable transaction identities.
+#[derive(Clone)]
+pub struct InterpreterCheckpoint {
+  data: Rc<InterpreterCheckpointData>,
 }
 
 impl Clone for Interpreter {
   fn clone(&self) -> Self {
     Self {
       id: self.id,
+      checkpoint_owner: Rc::new(()),
       ip: self.ip,
       profile: false,
       max_steps: self.max_steps,
@@ -111,6 +988,32 @@ impl Clone for Interpreter {
 }
 
 impl Interpreter {
+  pub fn checkpoint(&self) -> MResult<InterpreterCheckpoint> {
+    let mut journal = ValueStateJournal::new();
+    let mut seen_children = Vec::new();
+    let structure = InterpreterStructureCheckpoint::capture(
+      self,
+      &mut journal,
+      &mut seen_children,
+    )?;
+    Ok(InterpreterCheckpoint {
+      data: Rc::new(InterpreterCheckpointData {
+        structure,
+        journal,
+      }),
+    })
+  }
+
+  pub fn restore(&mut self, checkpoint: InterpreterCheckpoint) -> MResult<()> {
+    checkpoint.data.structure.preflight_owner(self)?;
+    checkpoint.data.structure.preflight()?;
+    checkpoint.data.journal.preflight_restore_before()?;
+    checkpoint.data.structure.apply_structure(self);
+    checkpoint.data.journal.apply_restore_before();
+    checkpoint.data.structure.rebuild_checkpoint_indexes();
+    Ok(())
+  }
+
   pub fn new(id: u64, max_steps: usize) -> Self {
     let mut state = ProgramState::new();
     load_stdkinds(&mut state.kinds);
@@ -133,6 +1036,7 @@ impl Interpreter {
     load_prelude(&mut state.functions.borrow_mut());
     Self {
       id,
+      checkpoint_owner: Rc::new(()),
       ip: 0,
       profile: false,
       max_steps, // Default maximum steps
@@ -260,7 +1164,9 @@ impl Interpreter {
 
   pub fn clear(&mut self) {
     let id = self.id;
+    let checkpoint_owner = self.checkpoint_owner.clone();
     *self = Interpreter::new(id, self.max_steps);
+    self.checkpoint_owner = checkpoint_owner;
   }
 
   pub fn set_trace_enabled(&mut self, enabled: bool) {
@@ -749,6 +1655,370 @@ fn register_bytecode_function(
   state.plan.register_function(function, &input_values)?;
 
   Ok(output)
+}
+
+#[cfg(all(
+  test,
+  feature = "functions",
+  feature = "symbol_table",
+  feature = "f64"
+))]
+mod checkpoint_tests {
+  use super::*;
+
+  fn f64_value(value: &Ref<f64>) -> Value {
+    Value::F64(value.clone())
+  }
+
+  fn install_scalar(
+    interpreter: &Interpreter,
+    name: &str,
+    value: f64,
+  ) -> (ValRef, Ref<f64>) {
+    let backing = Ref::new(value);
+    let id = hash_str(name);
+    let symbols = interpreter.symbols();
+    let cell = symbols
+      .borrow_mut()
+      .insert(id, f64_value(&backing), true);
+    symbols
+      .borrow()
+      .dictionary
+      .borrow_mut()
+      .insert(id, name.to_string());
+    (cell, backing)
+  }
+
+  fn child_box_address(child: &InterpreterRef) -> usize {
+    let child = child.borrow();
+    child.as_ref() as *const Interpreter as usize
+  }
+
+  #[test]
+  fn interpreter_checkpoint_restores_private_state_and_recursive_child_identity() {
+    let mut root = Interpreter::new(1, 100);
+    root.ip = 7;
+    root.profile = true;
+    let (symbol_cell, symbol_backing) = install_scalar(&root, "kept", 1.0);
+    let symbol_cell_address = symbol_cell.addr();
+    let symbol_backing_address = symbol_backing.addr();
+    let symbol_backing_identity = ReactiveCellId::new(symbol_backing.id());
+    root.registers = vec![f64_value(&symbol_backing)];
+    root.constants = vec![f64_value(&Ref::new(2.0))];
+    root.out = f64_value(&symbol_backing);
+    root.code.push(MechSourceCode::String("before".to_string()));
+    root
+      .out_values
+      .borrow_mut()
+      .insert(hash_str("out"), f64_value(&symbol_backing));
+    *root.inline_eval_counter.borrow_mut() = 4;
+    *root.persistent_user_function_plan_depth.borrow_mut() = 2;
+    *root.deferred_expression_solve_depth.borrow_mut() = 3;
+    let context_binding_id = hash_str("checkpoint-context");
+    root.context_bindings.borrow_mut().insert(
+      context_binding_id,
+      RuntimeContextBinding {
+        name: "checkpoint-context".to_string(),
+        base_uri: "test://checkpoint".to_string(),
+      },
+    );
+    let original_manifests = root.module_manifests.borrow().clone();
+    #[cfg(feature = "trace")]
+    {
+      root.trace = true;
+      root.trace_to_stdout = false;
+    }
+    #[cfg(feature = "state_machines")]
+    {
+      let name = internal_pattern_value_identifier("checkpoint-fsm");
+      root.user_state_machines.borrow_mut().insert(
+        hash_str("checkpoint-fsm"),
+        FsmImplementation {
+          name: name.clone(),
+          input: Vec::new(),
+          start: Pattern::Wildcard,
+          arms: Vec::new(),
+        },
+      );
+      root.user_state_machine_specs.borrow_mut().insert(
+        hash_str("checkpoint-fsm"),
+        FsmSpecification {
+          name,
+          input: Vec::new(),
+          output: None,
+          states: Vec::new(),
+        },
+      );
+    }
+    #[cfg(feature = "invariant_define")]
+    {
+      let invariant_id = hash_str("checkpoint-invariant");
+      let invariant_value = Ref::new(Value::Bool(Ref::new(true)));
+      let mut state = root.state.borrow_mut();
+      state
+        .invariants
+        .insert(invariant_id, ("checkpoint invariant".to_string(), invariant_value));
+      state
+        .invariant_expressions
+        .insert(invariant_id, "value == true".to_string());
+      state.invariant_evaluations.insert(
+        invariant_id,
+        InvariantEvaluation {
+          reason: "checkpoint reason".to_string(),
+          evaluated_kind: "bool".to_string(),
+          actual: "true".to_string(),
+          expected: "true".to_string(),
+        },
+      );
+      state.invariant_violations.push(InvariantViolation {
+        id: invariant_id,
+        error: MechError::new(
+          GenericError {
+            msg: "checkpoint violation".to_string(),
+          },
+          None,
+        ),
+      });
+    }
+
+    let state_address = root.state.addr();
+    let symbols_address = root.symbols().addr();
+    let symbol_dictionary_address = root.symbols().borrow().dictionary.addr();
+    let out_values_address = root.out_values.addr();
+    let inline_counter_address = root.inline_eval_counter.addr();
+    let context_bindings_address = root.context_bindings.addr();
+    let module_manifests_address = root.module_manifests.addr();
+    #[cfg(feature = "trace")]
+    let trace_events_address = root.trace_events.addr();
+    #[cfg(feature = "state_machines")]
+    let user_state_machines_address = root.user_state_machines.addr();
+    #[cfg(feature = "state_machines")]
+    let user_state_machine_specs_address = root.user_state_machine_specs.addr();
+    let sub_interpreters_address = root.sub_interpreters.addr();
+
+    let child_id = 2;
+    let grandchild_id = 3;
+    let mut child = Interpreter::new(child_id, 200);
+    child.ip = 8;
+    let (_child_cell, child_backing) = install_scalar(&child, "child", 20.0);
+    let mut grandchild = Interpreter::new(grandchild_id, 300);
+    grandchild.ip = 9;
+    let (_grandchild_cell, grandchild_backing) =
+      install_scalar(&grandchild, "grandchild", 30.0);
+    let grandchild_ref = Ref::new(Box::new(grandchild));
+    let grandchild_handle_address = grandchild_ref.addr();
+    let expected_grandchild_box_address = child_box_address(&grandchild_ref);
+    child
+      .sub_interpreters
+      .borrow_mut()
+      .insert(grandchild_id, grandchild_ref);
+    let child_ref = Ref::new(Box::new(child));
+    let child_handle_address = child_ref.addr();
+    let expected_child_box_address = child_box_address(&child_ref);
+    root
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, child_ref);
+
+    let checkpoint = root.checkpoint().unwrap();
+
+    root.id = 99;
+    root.ip = 99;
+    root.profile = false;
+    root.max_steps = 999;
+    root.registers.clear();
+    root.constants.clear();
+    root.code.push(MechSourceCode::String("after".to_string()));
+    root.out = Value::Empty;
+    root.state = Ref::new(ProgramState::new());
+    root.out_values = Ref::new(HashMap::new());
+    root.inline_eval_counter = Ref::new(99);
+    root.persistent_user_function_plan_depth = Ref::new(99);
+    root.deferred_expression_solve_depth = Ref::new(99);
+    root.context_bindings = Ref::new(HashMap::new());
+    root.module_manifests = Ref::new(ModuleManifestCatalog::new());
+    #[cfg(feature = "trace")]
+    {
+      root.trace = false;
+      root.trace_to_stdout = true;
+      root.trace_events = Ref::new(Vec::new());
+    }
+    #[cfg(feature = "state_machines")]
+    {
+      root.user_state_machines = Ref::new(HashMap::new());
+      root.user_state_machine_specs = Ref::new(HashMap::new());
+    }
+    *symbol_backing.borrow_mut() = 11.0;
+    *child_backing.borrow_mut() = 21.0;
+    *grandchild_backing.borrow_mut() = 31.0;
+
+    let removed_child = root
+      .sub_interpreters
+      .borrow_mut()
+      .remove(&child_id)
+      .unwrap();
+    {
+      let mut child = removed_child.borrow_mut();
+      child.id = 22;
+      child.ip = 88;
+      let removed_grandchild = child
+        .sub_interpreters
+        .borrow_mut()
+        .remove(&grandchild_id)
+        .unwrap();
+      drop(removed_grandchild);
+    }
+    drop(removed_child);
+    root
+      .sub_interpreters
+      .borrow_mut()
+      .insert(999, Ref::new(Box::new(Interpreter::new(999, 10))));
+
+    let held = symbol_backing.borrow();
+    let error = root.restore(checkpoint.clone()).unwrap_err();
+    assert_eq!(
+      error.kind_as::<ValueStateBorrowConflict>().unwrap().phase,
+      "restore-before"
+    );
+    assert_eq!(root.id, 99);
+    assert_eq!(root.ip, 99);
+    assert_ne!(root.state.addr(), state_address);
+    assert!(root.sub_interpreters.borrow().contains_key(&999));
+    assert!(!root.sub_interpreters.borrow().contains_key(&child_id));
+    assert_eq!(*held, 11.0);
+    drop(held);
+
+    root.restore(checkpoint).unwrap();
+
+    assert_eq!(root.id, 1);
+    assert_eq!(root.ip, 7);
+    assert!(root.profile);
+    assert_eq!(root.max_steps, 100);
+    assert_eq!(root.state.addr(), state_address);
+    assert_eq!(root.symbols().addr(), symbols_address);
+    assert_eq!(
+      root.symbols().borrow().dictionary.addr(),
+      symbol_dictionary_address
+    );
+    assert_eq!(root.out_values.addr(), out_values_address);
+    assert_eq!(root.inline_eval_counter.addr(), inline_counter_address);
+    assert_eq!(root.context_bindings.addr(), context_bindings_address);
+    assert_eq!(root.module_manifests.addr(), module_manifests_address);
+    assert_eq!(*root.module_manifests.borrow(), original_manifests);
+    assert_eq!(
+      root.context_bindings
+        .borrow()
+        .get(&context_binding_id)
+        .unwrap()
+        .base_uri,
+      "test://checkpoint",
+    );
+    #[cfg(feature = "trace")]
+    {
+      assert!(root.trace);
+      assert!(!root.trace_to_stdout);
+      assert_eq!(root.trace_events.addr(), trace_events_address);
+    }
+    #[cfg(feature = "state_machines")]
+    {
+      assert_eq!(root.user_state_machines.addr(), user_state_machines_address);
+      assert_eq!(
+        root.user_state_machine_specs.addr(),
+        user_state_machine_specs_address,
+      );
+      assert!(root
+        .user_state_machines
+        .borrow()
+        .contains_key(&hash_str("checkpoint-fsm")));
+      assert!(root
+        .user_state_machine_specs
+        .borrow()
+        .contains_key(&hash_str("checkpoint-fsm")));
+    }
+    #[cfg(feature = "invariant_define")]
+    {
+      let state = root.state.borrow();
+      let invariant_id = hash_str("checkpoint-invariant");
+      assert!(state.invariants.contains_key(&invariant_id));
+      assert_eq!(
+        state.invariant_expressions.get(&invariant_id).unwrap(),
+        "value == true",
+      );
+      assert_eq!(
+        state
+          .invariant_evaluations
+          .get(&invariant_id)
+          .unwrap()
+          .reason,
+        "checkpoint reason",
+      );
+      assert_eq!(state.invariant_violations.len(), 1);
+      assert_eq!(state.invariant_violations[0].id, invariant_id);
+    }
+    assert_eq!(root.sub_interpreters.addr(), sub_interpreters_address);
+    assert_eq!(root.registers.len(), 1);
+    assert_eq!(root.constants.len(), 1);
+    assert_eq!(root.code, vec![MechSourceCode::String("before".to_string())]);
+    assert_eq!(*root.inline_eval_counter.borrow(), 4);
+    assert_eq!(*root.persistent_user_function_plan_depth.borrow(), 2);
+    assert_eq!(*root.deferred_expression_solve_depth.borrow(), 3);
+    assert_eq!(symbol_cell.addr(), symbol_cell_address);
+    assert_eq!(symbol_backing.addr(), symbol_backing_address);
+    assert_eq!(
+      ReactiveCellId::new(symbol_backing.id()),
+      symbol_backing_identity
+    );
+    assert_eq!(*symbol_backing.borrow(), 1.0);
+    assert!(root.sub_interpreters.borrow().get(&999).is_none());
+
+    let restored_child = root
+      .sub_interpreters
+      .borrow()
+      .get(&child_id)
+      .cloned()
+      .unwrap();
+    assert_eq!(restored_child.addr(), child_handle_address);
+    assert_eq!(
+      child_box_address(&restored_child),
+      expected_child_box_address
+    );
+    let restored_grandchild = {
+      let child = restored_child.borrow();
+      assert_eq!(child.id, child_id);
+      assert_eq!(child.ip, 8);
+      assert_eq!(*child_backing.borrow(), 20.0);
+      child
+        .sub_interpreters
+        .borrow()
+        .get(&grandchild_id)
+        .cloned()
+        .unwrap()
+    };
+    assert_eq!(restored_grandchild.addr(), grandchild_handle_address);
+    assert_eq!(
+      child_box_address(&restored_grandchild),
+      expected_grandchild_box_address
+    );
+    let grandchild = restored_grandchild.borrow();
+    assert_eq!(grandchild.id, grandchild_id);
+    assert_eq!(grandchild.ip, 9);
+    assert_eq!(*grandchild_backing.borrow(), 30.0);
+  }
+
+  #[cfg(feature = "compiler")]
+  #[test]
+  fn interpreter_checkpoint_rejects_retained_compiler_context() {
+    let mut interpreter = Interpreter::new(41, 100);
+    interpreter.context = Some(CompileCtx::new());
+    let error = match interpreter.checkpoint() {
+      Ok(_) => panic!("retained compiler context checkpoint unexpectedly succeeded"),
+      Err(error) => error,
+    };
+    let unsupported = error
+      .kind_as::<InterpreterCheckpointUnsupportedCompilerContext>()
+      .unwrap();
+    assert_eq!(unsupported.interpreter_id, 41);
+  }
 }
 
 #[cfg(all(test, feature = "program", feature = "functions", feature = "symbol_table", feature = "f64"))]

--- a/src/interpreter/src/mechdown.rs
+++ b/src/interpreter/src/mechdown.rs
@@ -92,11 +92,13 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
         let mut new_sub_interpreter =  Interpreter::new(code_id, 10_000);
         new_sub_interpreter.set_functions(p.functions().clone());
 
-        let mut pp = sub_interpreters
+        let pp = sub_interpreters
           .entry(code_id)
-          .or_insert(Box::new(new_sub_interpreter))
-          .as_mut();
-        out = eval_fenced_code_block(&block.code, pp, true)?;
+          .or_insert(Ref::new(Box::new(new_sub_interpreter)))
+          .clone();
+        drop(sub_interpreters);
+        let pp = pp.borrow();
+        out = eval_fenced_code_block(&block.code, pp.as_ref(), true)?;
         // Save the output of the last code block in the parent interpreter
         // so we can reference it later.
         let (last_code,_) = block.code.last().unwrap();
@@ -173,9 +175,11 @@ pub fn section_element(element: &SectionElement, p: &Interpreter) -> MResult<Val
         new_sub_interpreter.set_functions(p.functions().clone());
         let pp = sub_interpreters
           .entry(mika_interp_id)
-          .or_insert(Box::new(new_sub_interpreter))
-          .as_mut();
-        let _ = section(&mika_section.elements, pp)?;
+          .or_insert(Ref::new(Box::new(new_sub_interpreter)))
+          .clone();
+        drop(sub_interpreters);
+        let pp = pp.borrow();
+        let _ = section(&mika_section.elements, pp.as_ref())?;
       }
       return Ok(Value::Atom(Ref::new(MechAtom::from_name(&m.to_string()))));
     },

--- a/src/interpreter/src/stdlib/access/matrix.rs
+++ b/src/interpreter/src/stdlib/access/matrix.rs
@@ -836,7 +836,33 @@ impl MechFunctionImpl for MatrixAccessScalarValueF {
     };
   }
   fn out(&self) -> Value { self.out.borrow().clone() }
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Ok(vec![Value::MutableReference(self.out.clone())])
+  }
   fn to_string(&self) -> String { format!("{:#?}", self) }
+}
+
+#[cfg(all(test, feature = "functions", feature = "matrixd"))]
+mod matrix_access_scalar_value_transaction_tests {
+  use super::*;
+
+  #[test]
+  fn transaction_state_retains_scalar_value_access_outer_output_ref() {
+    let out = Ref::new(Value::Empty);
+    let function = MatrixAccessScalarValueF {
+      source: Matrix::from_vec(vec![Value::Empty], 1, 1),
+      ix: Ref::new(1),
+      out: out.clone(),
+      element_kind: ValueKind::Any,
+    };
+
+    let values = function.transaction_state_values().unwrap();
+    assert_eq!(values.len(), 1);
+    match &values[0] {
+      Value::MutableReference(root) => assert_eq!(root.addr(), out.addr()),
+      other => panic!("expected mutable-reference transaction root, got {other:?}"),
+    }
+  }
 }
 
 #[cfg(feature = "compiler")]

--- a/src/interpreter/src/stdlib/convert/mat_to_mat.rs
+++ b/src/interpreter/src/stdlib/convert/mat_to_mat.rs
@@ -16,8 +16,28 @@ impl MechFunctionImpl for ConvertMatPassthrough {
     fn out(&self) -> Value {
         self.out.borrow().clone()
     }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+        Ok(vec![Value::MutableReference(self.out.clone())])
+    }
     fn to_string(&self) -> String {
         format!("{:#?}", self)
+    }
+}
+
+#[cfg(test)]
+mod passthrough_transaction_state_tests {
+    use super::*;
+
+    #[test]
+    fn matrix_passthrough_exposes_original_outer_value_cell() {
+        let out = Ref::new(Value::Empty);
+        let function = ConvertMatPassthrough { out: out.clone() };
+        let values = function.transaction_state_values().unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            Value::MutableReference(value) => assert_eq!(value.addr(), out.addr()),
+            value => panic!("expected mutable-reference transaction state, got {value:?}"),
+        }
     }
 }
 #[cfg(feature = "compiler")]

--- a/src/interpreter/src/stdlib/convert/scalar.rs
+++ b/src/interpreter/src/stdlib/convert/scalar.rs
@@ -54,6 +54,9 @@ struct ConvertSEmpty {
 impl MechFunctionImpl for ConvertSEmpty {
   fn solve(&self) { }
   fn out(&self) -> Value { self.out.borrow().clone() }
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Ok(vec![Value::MutableReference(self.out.clone())])
+  }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
 #[cfg(feature = "compiler")]
@@ -79,6 +82,23 @@ register_descriptor! {
         ),
       }
     },
+  }
+}
+
+#[cfg(test)]
+mod empty_transaction_state_tests {
+  use super::*;
+
+  #[test]
+  fn convert_scalar_empty_exposes_original_outer_value_cell() {
+    let out = Ref::new(Value::Empty);
+    let function = ConvertSEmpty { out: out.clone() };
+    let values = function.transaction_state_values().unwrap();
+    assert_eq!(values.len(), 1);
+    match &values[0] {
+      Value::MutableReference(value) => assert_eq!(value.addr(), out.addr()),
+      value => panic!("expected mutable-reference transaction state, got {value:?}"),
+    }
   }
 }
 

--- a/src/interpreter/src/stdlib/define.rs
+++ b/src/interpreter/src/stdlib/define.rs
@@ -188,6 +188,9 @@ pub struct VariableDefineEmpty {
 impl MechFunctionImpl for VariableDefineEmpty {
   fn solve(&self) {}
   fn out(&self) -> Value { self.var.borrow().clone() }
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Ok(vec![Value::MutableReference(self.var.clone())])
+  }
   fn to_string(&self) -> String { format!("{:#?}", self) }
 }
 #[cfg(feature = "compiler")]
@@ -219,6 +222,28 @@ register_descriptor! {
         ).with_compiler_loc()),
       }
     },
+  }
+}
+
+#[cfg(test)]
+mod empty_transaction_state_tests {
+  use super::*;
+
+  #[test]
+  fn variable_define_empty_exposes_original_outer_value_cell() {
+    let var = Ref::new(Value::Empty);
+    let function = VariableDefineEmpty {
+      id: 1,
+      name: Ref::new("value".to_string()),
+      mutable: Ref::new(true),
+      var: var.clone(),
+    };
+    let values = function.transaction_state_values().unwrap();
+    assert_eq!(values.len(), 1);
+    match &values[0] {
+      Value::MutableReference(value) => assert_eq!(value.addr(), var.addr()),
+      value => panic!("expected mutable-reference transaction state, got {value:?}"),
+    }
   }
 }
 

--- a/src/program/Cargo.toml
+++ b/src/program/Cargo.toml
@@ -189,3 +189,11 @@ reqwest = { version = "0.13.2", features = ["blocking"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 web-time = "1.1.0"
+
+[dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "program_checkpoint"
+harness = false
+required-features = ["baselib", "program", "compiler"]

--- a/src/program/benches/program_checkpoint.rs
+++ b/src/program/benches/program_checkpoint.rs
@@ -1,0 +1,346 @@
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use mech_core::{
+  MechFunctionImpl, MechMap, MechRecord, MechSet, MechTuple, Ref, ToMatrix, Value,
+  hash_str,
+};
+use mech_interpreter::Interpreter;
+use mech_program::{MechProgram, MechProgramConfig};
+use std::hint::black_box;
+
+const NESTED_MATRIX_SIDE: usize = 8;
+const MUTATION_MATRIX_SIDE: usize = 64;
+
+struct BenchNode {
+  out: Ref<f64>,
+}
+
+impl MechFunctionImpl for BenchNode {
+  fn solve(&self) {}
+  fn out(&self) -> Value { Value::F64(self.out.clone()) }
+  fn to_string(&self) -> String { "ProgramCheckpointBenchNode".to_string() }
+}
+
+#[cfg(feature = "compiler")]
+impl mech_core::MechFunctionCompiler for BenchNode {
+  fn compile(&self, _ctx: &mut mech_core::CompileCtx) -> mech_core::MResult<mech_core::Register> {
+    Ok(0)
+  }
+}
+
+fn insert_symbol(interpreter: &Interpreter, name: &str, value: Value) {
+  let id = hash_str(name);
+  let symbols = interpreter.symbols();
+  {
+    let mut symbols = symbols.borrow_mut();
+    symbols.insert(id, value, true);
+    symbols.dictionary.borrow_mut().insert(id, name.to_string());
+  }
+  interpreter.dictionary().borrow_mut().insert(id, name.to_string());
+}
+
+fn append_plan_nodes(interpreter: &Interpreter, count: usize) {
+  let plan = interpreter.plan();
+  let mut plan = plan.borrow_mut();
+  for index in 0..count {
+    plan.push(Box::new(BenchNode {
+      out: Ref::new(index as f64),
+    }));
+  }
+}
+
+fn empty_program() -> MechProgram {
+  MechProgram::new(MechProgramConfig::default())
+}
+
+fn small_scalar_program() -> MechProgram {
+  let mut program = empty_program();
+  program
+    .run_string(
+      "x := 1.0
+y := x + 2.0",
+    )
+    .unwrap();
+  program
+}
+
+fn plan_program(node_count: usize) -> MechProgram {
+  let program = empty_program();
+  append_plan_nodes(program.interpreter(), node_count);
+  program
+}
+
+fn plan_100_program() -> MechProgram {
+  plan_program(100)
+}
+
+fn plan_1000_program() -> MechProgram {
+  plan_program(1_000)
+}
+
+fn nested_containers_program() -> MechProgram {
+  let program = empty_program();
+  let shared = Ref::new(1.0);
+  let map = Value::Map(Ref::new(MechMap::from_vec(vec![
+    (Value::Id(1), Value::F64(shared.clone())),
+    (Value::Id(2), Value::F64(Ref::new(2.0))),
+  ])));
+  let set = Value::Set(Ref::new(MechSet::from_vec(vec![
+    Value::Id(10),
+    Value::Id(20),
+    Value::Id(30),
+  ])));
+  let tuple = Value::Tuple(Ref::new(MechTuple::from_vec(vec![
+    Value::F64(shared.clone()),
+    map,
+    set,
+  ])));
+  let matrix_elements = (0..NESTED_MATRIX_SIDE * NESTED_MATRIX_SIDE)
+    .map(|index| {
+      if index % 8 == 0 {
+        Value::F64(shared.clone())
+      } else {
+        Value::F64(Ref::new(index as f64))
+      }
+    })
+    .collect();
+  let value_matrix = Value::MatrixValue(<Value as ToMatrix>::to_matrixd(
+    matrix_elements,
+    NESTED_MATRIX_SIDE,
+    NESTED_MATRIX_SIDE,
+  ));
+  let root = Value::Record(Ref::new(MechRecord::new(vec![
+    ("shared", Value::F64(shared)),
+    ("tuple", tuple),
+    ("matrix", value_matrix),
+  ])));
+  insert_symbol(program.interpreter(), "nested", root);
+  program
+}
+
+fn recursive_interpreters_program() -> MechProgram {
+  let program = empty_program();
+  let child = Interpreter::new(101, 10_000);
+  let grandchild = Interpreter::new(202, 10_000);
+
+  insert_symbol(&child, "child_value", Value::F64(Ref::new(101.0)));
+  insert_symbol(
+    &grandchild,
+    "grandchild_value",
+    Value::F64(Ref::new(202.0)),
+  );
+  append_plan_nodes(&child, 8);
+  append_plan_nodes(&grandchild, 8);
+
+  child
+    .sub_interpreters
+    .borrow_mut()
+    .insert(grandchild.id, Ref::new(Box::new(grandchild)));
+  program
+    .interpreter()
+    .sub_interpreters
+    .borrow_mut()
+    .insert(child.id, Ref::new(Box::new(child)));
+  program
+}
+
+fn structural_additions_program() -> MechProgram {
+  let program = empty_program();
+  append_plan_nodes(program.interpreter(), 16);
+  insert_symbol(
+    program.interpreter(),
+    "retained",
+    Value::F64(Ref::new(1.0)),
+  );
+  program
+}
+
+fn scalar_matrix_program() -> MechProgram {
+  let program = empty_program();
+  insert_symbol(
+    program.interpreter(),
+    "checkpoint_scalar",
+    Value::F64(Ref::new(1.0)),
+  );
+  insert_symbol(
+    program.interpreter(),
+    "checkpoint_matrix",
+    Value::MatrixF64(<f64 as ToMatrix>::to_matrixd(
+      vec![1.0; MUTATION_MATRIX_SIDE * MUTATION_MATRIX_SIDE],
+      MUTATION_MATRIX_SIDE,
+      MUTATION_MATRIX_SIDE,
+    )),
+  );
+  program
+}
+
+fn no_mutation(_program: &mut MechProgram) {}
+
+fn add_structures(program: &mut MechProgram) {
+  append_plan_nodes(program.interpreter(), 64);
+  insert_symbol(
+    program.interpreter(),
+    "temporary",
+    Value::F64(Ref::new(99.0)),
+  );
+  program
+    .interpreter()
+    .out_values
+    .borrow_mut()
+    .insert(hash_str("temporary-output"), Value::F64(Ref::new(100.0)));
+  let child = Interpreter::new(303, 10_000);
+  program
+    .interpreter()
+    .sub_interpreters
+    .borrow_mut()
+    .insert(child.id, Ref::new(Box::new(child)));
+  program.config.name = "mutated-after-checkpoint".to_string();
+}
+
+fn mutate_scalar_and_matrix(program: &mut MechProgram) {
+  let symbols = program.interpreter().symbols();
+  let scalar = symbols
+    .borrow()
+    .get(hash_str("checkpoint_scalar"))
+    .unwrap()
+    .clone();
+  let matrix = symbols
+    .borrow()
+    .get(hash_str("checkpoint_matrix"))
+    .unwrap()
+    .clone();
+
+  match &*scalar.borrow() {
+    Value::F64(value) => *value.borrow_mut() = 10_000.0,
+    other => panic!("expected scalar benchmark value, got {other:?}"),
+  }
+  match &*matrix.borrow() {
+    Value::MatrixF64(value) => {
+      value.set(vec![
+        10_000.0;
+        MUTATION_MATRIX_SIDE * MUTATION_MATRIX_SIDE
+      ]);
+    }
+    other => panic!("expected matrix benchmark value, got {other:?}"),
+  }
+}
+
+type ProgramFixture = fn() -> MechProgram;
+type ProgramMutation = fn(&mut MechProgram);
+
+fn batch_size(large_input: bool) -> BatchSize {
+  if large_input {
+    BatchSize::LargeInput
+  } else {
+    BatchSize::SmallInput
+  }
+}
+
+fn benchmark_family(
+  c: &mut Criterion,
+  name: &str,
+  fixture: ProgramFixture,
+  mutation: ProgramMutation,
+  large_input: bool,
+  throughput: Option<u64>,
+) {
+  let mut group = c.benchmark_group(format!("program_checkpoint/{name}"));
+  if let Some(elements) = throughput {
+    group.throughput(Throughput::Elements(elements));
+  }
+
+  group.bench_function("capture", |b| {
+    b.iter_batched(
+      fixture,
+      |program| black_box(program.checkpoint().unwrap()),
+      batch_size(large_input),
+    )
+  });
+
+  group.bench_function("restore", |b| {
+    b.iter_batched(
+      || {
+        let mut program = fixture();
+        let checkpoint = program.checkpoint().unwrap();
+        mutation(&mut program);
+        (program, checkpoint)
+      },
+      |(mut program, checkpoint)| {
+        program.restore(checkpoint).unwrap();
+        black_box(program)
+      },
+      batch_size(large_input),
+    )
+  });
+
+  group.finish();
+}
+
+fn program_checkpoint_benchmarks(c: &mut Criterion) {
+  benchmark_family(
+    c,
+    "empty_program",
+    empty_program,
+    no_mutation,
+    false,
+    None,
+  );
+  benchmark_family(
+    c,
+    "small_scalar",
+    small_scalar_program,
+    no_mutation,
+    false,
+    None,
+  );
+  benchmark_family(
+    c,
+    "plan_100_nodes",
+    plan_100_program,
+    no_mutation,
+    false,
+    Some(100),
+  );
+  benchmark_family(
+    c,
+    "plan_1000_nodes",
+    plan_1000_program,
+    no_mutation,
+    true,
+    Some(1_000),
+  );
+  benchmark_family(
+    c,
+    "nested_containers",
+    nested_containers_program,
+    no_mutation,
+    false,
+    None,
+  );
+  benchmark_family(
+    c,
+    "recursive_interpreters",
+    recursive_interpreters_program,
+    no_mutation,
+    false,
+    None,
+  );
+  benchmark_family(
+    c,
+    "structural_additions",
+    structural_additions_program,
+    add_structures,
+    false,
+    None,
+  );
+  benchmark_family(
+    c,
+    "scalar_matrix_mutation",
+    scalar_matrix_program,
+    mutate_scalar_and_matrix,
+    true,
+    None,
+  );
+}
+
+criterion_group!(benches, program_checkpoint_benchmarks);
+criterion_main!(benches);

--- a/src/program/benches/program_checkpoint.rs
+++ b/src/program/benches/program_checkpoint.rs
@@ -249,7 +249,7 @@ fn benchmark_family(
   }
 
   group.bench_function("capture", |b| {
-    b.iter_batched(
+    b.iter_batched_ref(
       fixture,
       |program| black_box(program.checkpoint().unwrap()),
       batch_size(large_input),

--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -20,7 +20,7 @@ use mech_core::{
   val_ref_reactive_cell_ids, ReactiveCellId, ReactiveTurnOutcome,
 };
 
-use mech_interpreter::Interpreter;
+use mech_interpreter::{Interpreter, InterpreterCheckpoint};
 use mech_syntax::parser;
 
 use crate::ClosureNativeFunctionCompiler;
@@ -301,6 +301,18 @@ pub struct MechProgram {
   interpreter: Interpreter,
 }
 
+/// An explicit, retained snapshot of a complete [`MechProgram`].
+///
+/// The checkpoint is intentionally opaque: it can only be created by
+/// [`MechProgram::checkpoint`] and consumed by [`MechProgram::restore`].
+/// It is a process-local savepoint, not a serializable durable-history record
+/// or a source of stable transaction identities.
+#[derive(Clone)]
+pub struct MechProgramCheckpoint {
+  config: MechProgramConfig,
+  interpreter: InterpreterCheckpoint,
+}
+
 impl MechProgram {
   pub fn new(config: MechProgramConfig) -> Self {
     let id = hash_str(&format!("program/{}", config.name));
@@ -312,6 +324,25 @@ impl MechProgram {
       config,
       interpreter,
     }
+  }
+
+  /// Captures the complete structural and value state of this program.
+  ///
+  /// Capture is explicit and has no effect on ordinary interpretation or
+  /// reactive turns.
+  pub fn checkpoint(&self) -> MResult<MechProgramCheckpoint> {
+    Ok(MechProgramCheckpoint {
+      config: self.config.clone(),
+      interpreter: self.interpreter.checkpoint()?,
+    })
+  }
+
+  /// Restores a retained checkpoint without executing program functions,
+  /// callbacks, solvers, or providers.
+  pub fn restore(&mut self, checkpoint: MechProgramCheckpoint) -> MResult<()> {
+    self.interpreter.restore(checkpoint.interpreter)?;
+    self.config = checkpoint.config;
+    Ok(())
   }
 
   #[cfg(feature = "functions")]
@@ -750,8 +781,9 @@ fn with_interpreter_mut<T>(
   }
   let child_ids = interpreter.sub_interpreters.borrow().keys().copied().collect::<Vec<_>>();
   for child_id in child_ids {
-    let mut sub_interpreters = interpreter.sub_interpreters.borrow_mut();
-    let Some(child) = sub_interpreters.get_mut(&child_id) else { continue; };
+    let child = interpreter.sub_interpreters.borrow().get(&child_id).cloned();
+    let Some(child) = child else { continue; };
+    let mut child = child.borrow_mut();
     if let Some(result) = with_interpreter_mut(child.as_mut(), interpreter_id, f) { return Some(result); }
   }
   None
@@ -788,8 +820,14 @@ fn with_interpreter<T>(
     return Some(f(interpreter));
   }
 
-  let sub_interpreters = interpreter.sub_interpreters.borrow();
-  for sub_interpreter in sub_interpreters.values() {
+  let sub_interpreters = interpreter
+    .sub_interpreters
+    .borrow()
+    .values()
+    .cloned()
+    .collect::<Vec<_>>();
+  for sub_interpreter in sub_interpreters {
+    let sub_interpreter = sub_interpreter.borrow();
     if let Some(result) = with_interpreter(sub_interpreter.as_ref(), interpreter_id, f) {
       return Some(result);
     }
@@ -814,10 +852,11 @@ fn bind_ans_recursive(
   };
 
   for child_id in child_ids {
-    let mut sub_interpreters = interpreter.sub_interpreters.borrow_mut();
-    let Some(child) = sub_interpreters.get_mut(&child_id) else {
+    let child = interpreter.sub_interpreters.borrow().get(&child_id).cloned();
+    let Some(child) = child else {
       continue;
     };
+    let mut child = child.borrow_mut();
     if bind_ans_recursive(child.as_mut(), interpreter_id, value) {
       return true;
     }
@@ -888,6 +927,7 @@ impl MechErrorKind for UnsupportedProgramSourceError {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use mech_core::Ref;
 
   fn program_with_nested_interpreter(nested_id: u64, child_id: u64) -> MechProgram {
     let mut program = MechProgram::new(MechProgramConfig::default());
@@ -900,12 +940,12 @@ mod tests {
     child
       .sub_interpreters
       .borrow_mut()
-      .insert(nested_id, Box::new(nested));
+      .insert(nested_id, Ref::new(Box::new(nested)));
     program
       .interpreter_mut()
       .sub_interpreters
       .borrow_mut()
-      .insert(child_id, Box::new(child));
+      .insert(child_id, Ref::new(Box::new(child)));
     program
   }
 
@@ -923,10 +963,20 @@ mod tests {
     let mut program = program_with_nested_interpreter(nested_id, child_id);
     {
       let root = program.interpreter_mut();
-      let mut sub_interpreters = root.sub_interpreters.borrow_mut();
-      let child = sub_interpreters.get_mut(&child_id).unwrap();
-      let mut child_sub_interpreters = child.sub_interpreters.borrow_mut();
-      let nested = child_sub_interpreters.get_mut(&nested_id).unwrap();
+      let child = root
+        .sub_interpreters
+        .borrow()
+        .get(&child_id)
+        .unwrap()
+        .clone();
+      let child = child.borrow();
+      let nested = child
+        .sub_interpreters
+        .borrow()
+        .get(&nested_id)
+        .unwrap()
+        .clone();
+      let nested = nested.borrow();
       nested
         .out_values
         .borrow_mut()
@@ -1541,6 +1591,492 @@ mod program_reactive_turn_tests {
   #[cfg(feature="string")] #[test] fn program_reactive_turn_preflight_failure_mutates_nothing(){let mut p=MechProgram::new(MechProgramConfig::default());let(a,b)=(input(&mut p,"a",1.),input(&mut p,"b",2.));p.run_string("output := a + b").unwrap();let id=p.interpreter().id;let s=snapshot(&p,id);let q=p.update_inputs_and_advance_turn(&[ProgramInputUpdate{input:a,value:f64_value(10.)},ProgramInputUpdate{input:b,value:Value::String(Ref::new("bad".into()))}]).unwrap_err();assert!(format!("{q:?}").contains("StableValueUpdateKindMismatch"));assert_eq!((value(&p,id,"a"),value(&p,id,"b"),value(&p,id,"output")),(1.,2.,3.));assert_eq!(snapshot(&p,id),s);assert!(!pending(&p,id));}
   #[test] fn program_reactive_turn_rejects_root_alias_duplicate(){let mut p=MechProgram::new(MechProgramConfig::default());let x=input(&mut p,"input",1.);let id=p.interpreter().id;let e=p.update_inputs_and_advance_turn(&[ProgramInputUpdate{input:ProgramInputId{interpreter_id:0,symbol_id:x.symbol_id},value:f64_value(2.)},ProgramInputUpdate{input:x,value:f64_value(3.)}]).unwrap_err();assert!(format!("{e:?}").contains("ProgramInputDuplicateTarget"));assert_eq!(value(&p,id,"input"),1.);assert!(!pending(&p,id));}
   #[test] fn program_reactive_turn_empty_batch_is_noop(){let mut p=MechProgram::new(MechProgramConfig::default());let id=p.interpreter().id;let s=snapshot(&p,id);assert_eq!(p.update_inputs_and_advance_turn(&[]).unwrap(),ProgramInputTurnOutcome::default());assert_eq!(snapshot(&p,id),s);assert!(!pending(&p,id));}
-  #[test] fn program_reactive_turn_orders_nested_interpreters_deterministically(){let mut p=MechProgram::new(MechProgramConfig::default());let mut c1=Interpreter::new_with_full_stdlib(101);let mut c2=Interpreter::new_with_full_stdlib(202);for(i,src) in [(&mut c1,"input := 1.0\n~a := 0.0\n~b := 0.0\na = input\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0"),(&mut c2,"input := 1.0\noutput := input + 1.0")]{i.interpret(&parser::parse(src).unwrap()).unwrap();}p.interpreter_mut().sub_interpreters.borrow_mut().insert(101,Box::new(c1));p.interpreter_mut().sub_interpreters.borrow_mut().insert(202,Box::new(c2));let(a,b)=(ProgramInputId{interpreter_id:101,symbol_id:hash_str("input")},ProgramInputId{interpreter_id:202,symbol_id:hash_str("input")});let root=snapshot(&p,p.interpreter().id);let o=p.update_inputs_and_advance_turn(&[ProgramInputUpdate{input:b,value:f64_value(20.)},ProgramInputUpdate{input:a,value:f64_value(10.)}]).unwrap();assert_eq!(o.updated_count,2);assert_eq!(o.interpreter_turns.iter().map(|x|x.interpreter_id).collect::<Vec<_>>(),vec![101,202]);assert!(!o.interpreter_turns[0].dirty_cells.is_empty());assert!(!o.interpreter_turns[1].dirty_cells.is_empty());assert_ne!(o.interpreter_turns[0].dirty_cells,o.interpreter_turns[1].dirty_cells);assert_eq!((value(&p,101,"a"),value(&p,101,"middle"),value(&p,101,"b")),(10.,11.,2.));assert!(pending(&p,101));assert_eq!(value(&p,202,"output"),21.);assert!(!pending(&p,202));assert!(!pending(&p,p.interpreter().id));assert_eq!(snapshot(&p,p.interpreter().id),root);p.advance_reactive_turn(101,&[]).unwrap();assert_eq!((value(&p,101,"b"),value(&p,101,"output"),value(&p,202,"output")),(11.,12.,21.));assert!(!pending(&p,101));assert!(!pending(&p,202));}
+  #[test] fn program_reactive_turn_orders_nested_interpreters_deterministically(){let mut p=MechProgram::new(MechProgramConfig::default());let mut c1=Interpreter::new_with_full_stdlib(101);let mut c2=Interpreter::new_with_full_stdlib(202);for(i,src) in [(&mut c1,"input := 1.0\n~a := 0.0\n~b := 0.0\na = input\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0"),(&mut c2,"input := 1.0\noutput := input + 1.0")]{i.interpret(&parser::parse(src).unwrap()).unwrap();}p.interpreter_mut().sub_interpreters.borrow_mut().insert(101,Ref::new(Box::new(c1)));p.interpreter_mut().sub_interpreters.borrow_mut().insert(202,Ref::new(Box::new(c2)));let(a,b)=(ProgramInputId{interpreter_id:101,symbol_id:hash_str("input")},ProgramInputId{interpreter_id:202,symbol_id:hash_str("input")});let root=snapshot(&p,p.interpreter().id);let o=p.update_inputs_and_advance_turn(&[ProgramInputUpdate{input:b,value:f64_value(20.)},ProgramInputUpdate{input:a,value:f64_value(10.)}]).unwrap();assert_eq!(o.updated_count,2);assert_eq!(o.interpreter_turns.iter().map(|x|x.interpreter_id).collect::<Vec<_>>(),vec![101,202]);assert!(!o.interpreter_turns[0].dirty_cells.is_empty());assert!(!o.interpreter_turns[1].dirty_cells.is_empty());assert_ne!(o.interpreter_turns[0].dirty_cells,o.interpreter_turns[1].dirty_cells);assert_eq!((value(&p,101,"a"),value(&p,101,"middle"),value(&p,101,"b")),(10.,11.,2.));assert!(pending(&p,101));assert_eq!(value(&p,202,"output"),21.);assert!(!pending(&p,202));assert!(!pending(&p,p.interpreter().id));assert_eq!(snapshot(&p,p.interpreter().id),root);p.advance_reactive_turn(101,&[]).unwrap();assert_eq!((value(&p,101,"b"),value(&p,101,"output"),value(&p,202,"output")),(11.,12.,21.));assert!(!pending(&p,101));assert!(!pending(&p,202));}
   #[cfg(feature="compiler")] #[test] fn program_reactive_turn_decoded_plan_reuses_identity(){let mut source=MechProgram::new(MechProgramConfig::default());source.load_full_stdlib();source.run_string("input := 1.0\n~a := 0.0\n~b := 0.0\na = input\nmiddle := a + 1.0\nb = middle\noutput := b + 1.0\noutput").unwrap();let bytes=source.compile_bytecode().unwrap();let mut p=MechProgram::new(MechProgramConfig::default());p.load_full_stdlib();p.run_bytecode(&bytes).unwrap();let id=p.interpreter().id;let x=p.ensure_input(id,hash_str("input"),"input",f64_value(1.)).unwrap();let s=snapshot(&p,id);let(a,b)=(register_node_for_output(&p,id,cell(&p,id,"a")),register_node_for_output(&p,id,cell(&p,id,"b")));let o=p.update_inputs_and_advance_turn(&[ProgramInputUpdate{input:x,value:f64_value(10.)}]).unwrap();assert_eq!(o.interpreter_turns[0].turn.register_commit.committed_nodes,vec![a]);assert_eq!(o.interpreter_turns[0].turn.after_commit.pending_register_nodes,vec![b]);let o=p.advance_reactive_turn(id,&[]).unwrap();assert_eq!(o.register_commit.committed_nodes,vec![b]);assert_eq!(value(&p,id,"output"),12.);assert!(!pending(&p,id));assert_eq!(snapshot(&p,id),s);}
+}
+
+#[cfg(all(
+  test,
+  feature = "program",
+  feature = "functions",
+  feature = "f64",
+  feature = "variable_define",
+))]
+mod retained_checkpoint_tests {
+  use super::*;
+  use mech_core::{MechRecord, MechTuple, Ref, ToMatrix};
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  struct RestoreProbe {
+    output: Ref<f64>,
+    solve_count: Rc<RefCell<usize>>,
+  }
+
+  impl MechFunctionImpl for RestoreProbe {
+    fn solve(&self) {
+      *self.solve_count.borrow_mut() += 1;
+    }
+    fn out(&self) -> Value {
+      Value::F64(self.output.clone())
+    }
+    fn to_string(&self) -> String {
+      "RestoreProbe".into()
+    }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl mech_core::MechFunctionCompiler for RestoreProbe {
+    fn compile(&self, _context: &mut CompileCtx) -> MResult<mech_core::Register> {
+      Ok(0)
+    }
+  }
+
+  struct UnsupportedCheckpointFunction;
+
+  impl MechFunctionImpl for UnsupportedCheckpointFunction {
+    fn solve(&self) {}
+    fn out(&self) -> Value {
+      Value::Empty
+    }
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+      Err(MechError::new(
+        mech_core::TransactionStateUnsupportedError {
+          function: self.to_string(),
+          reason: "opaque test state".into(),
+        },
+        None,
+      ))
+    }
+    fn to_string(&self) -> String {
+      "UnsupportedCheckpointFunction".into()
+    }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl mech_core::MechFunctionCompiler for UnsupportedCheckpointFunction {
+    fn compile(&self, _context: &mut CompileCtx) -> MResult<mech_core::Register> {
+      Ok(0)
+    }
+  }
+
+  fn scalar_cell(program: &MechProgram, name: &str) -> (ValRef, Ref<f64>) {
+    let outer = program
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(hash_str(name))
+      .expect("symbol");
+    let inner = match &*outer.borrow() {
+      Value::F64(value) => value.clone(),
+      other => panic!("expected f64 symbol, got {other:?}"),
+    };
+    (outer, inner)
+  }
+
+  fn activation_capture(
+    program: &MechProgram,
+    arm_index: usize,
+    capture_index: usize,
+  ) -> (ReactiveCellId, Value) {
+    let plan = program.interpreter().plan();
+    let registration = {
+      let registrations = plan.pattern_activation_registrations();
+      assert_eq!(registrations.len(), 1);
+      registrations[0].clone()
+    };
+    let arm = registration.arms.get(arm_index).expect("activation arm");
+    let capture = arm.captures.get(capture_index).expect("activation capture");
+    let capture_cell = capture.cell;
+    let capture_value = plan
+      .borrow()
+      .node(arm.gate_node)
+      .expect("activation gate")
+      .function
+      .reactive_output_values()
+      .into_iter()
+      .find(|value| value.reactive_root_cell_ids().contains(&capture_cell))
+      .expect("committed activation capture");
+    (capture_cell, capture_value)
+  }
+
+  fn tuple_f64_backing(tuple: &Ref<MechTuple>, index: usize) -> Ref<f64> {
+    let tuple = tuple.borrow();
+    match tuple.elements.get(index).map(|element| element.as_ref()) {
+      Some(Value::F64(backing)) => backing.clone(),
+      other => panic!("expected tuple f64 backing, got {other:?}"),
+    }
+  }
+
+  fn insert_interpreter_scalar(
+    interpreter: &Interpreter,
+    name: &str,
+    value: f64,
+  ) -> (ValRef, Ref<f64>) {
+    let id = hash_str(name);
+    let inner = Ref::new(value);
+    let outer = interpreter
+      .symbols()
+      .borrow_mut()
+      .insert(id, Value::F64(inner.clone()), true);
+    interpreter
+      .symbols()
+      .borrow()
+      .dictionary
+      .borrow_mut()
+      .insert(id, name.to_string());
+    interpreter
+      .dictionary()
+      .borrow_mut()
+      .insert(id, name.to_string());
+    (outer, inner)
+  }
+
+  fn interpreter_box_address(interpreter: &mech_interpreter::InterpreterRef) -> usize {
+    interpreter.borrow().as_ref() as *const Interpreter as usize
+  }
+
+  #[test]
+  fn program_checkpoint_restores_config_structure_values_and_identity() {
+    let mut program = MechProgram::new(MechProgramConfig {
+      name: "retained".into(),
+      environment: MechProgramEnvironment::default(),
+    });
+    program.run_string("x := 1.0\ny := x + 1.0").unwrap();
+
+    let symbols_addr = program.interpreter().symbols().addr();
+    let functions_addr = program.interpreter().functions().addr();
+    let original_plan = program.interpreter().plan();
+    let plan_addr = original_plan.0.addr();
+    let original_plan_len = original_plan.borrow().len();
+    let (x_outer, x_inner) = scalar_cell(&program, "x");
+    let x_outer_addr = x_outer.addr();
+    let x_inner_addr = x_inner.addr();
+    let checkpoint = program.checkpoint().unwrap();
+
+    program.config.name = "changed".into();
+    program.config.environment.rounds_per_step = 17;
+    *x_inner.borrow_mut() = 99.0;
+    program.run_string("temporary := x + 10.0").unwrap();
+    assert!(program.interpreter().plan_len() > original_plan_len);
+
+    program.restore(checkpoint).unwrap();
+
+    assert_eq!(program.config.name, "retained");
+    assert_eq!(program.config.environment.rounds_per_step, 10_000);
+    assert_eq!(program.interpreter().symbols().addr(), symbols_addr);
+    assert_eq!(program.interpreter().functions().addr(), functions_addr);
+    assert_eq!(program.interpreter().plan().0.addr(), plan_addr);
+    assert_eq!(program.interpreter().plan_len(), original_plan_len);
+    assert!(
+      program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("temporary"))
+        .is_none()
+    );
+    let (restored_outer, restored_inner) = scalar_cell(&program, "x");
+    assert_eq!(restored_outer.addr(), x_outer_addr);
+    assert_eq!(restored_inner.addr(), x_inner_addr);
+    assert_eq!(*restored_inner.borrow(), 1.0);
+  }
+
+  #[test]
+  fn program_checkpoint_restores_activation_capture_identity_and_payload() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program
+      .run_string(
+        r#"
+event := (1.0, 2.0)
+~> event
+  | whole => {
+      selected := whole
+    }
+  | * => {
+      selected := (-1.0, -1.0)
+    }
+"#,
+      )
+      .unwrap();
+
+    let (capture_cell, capture_value) = activation_capture(&program, 0, 0);
+    let Value::Tuple(capture_outer) = capture_value else {
+      panic!("expected tuple activation capture")
+    };
+    let first_backing = tuple_f64_backing(&capture_outer, 0);
+    let second_backing = tuple_f64_backing(&capture_outer, 1);
+    let outer_addr = capture_outer.addr();
+    let first_backing_addr = first_backing.addr();
+    let second_backing_addr = second_backing.addr();
+    assert_eq!(capture_cell, ReactiveCellId::new(capture_outer.id()));
+    assert_eq!(*first_backing.borrow(), 1.0);
+    assert_eq!(*second_backing.borrow(), 2.0);
+    let checkpoint = program.checkpoint().unwrap();
+
+    *first_backing.borrow_mut() = 99.0;
+    *second_backing.borrow_mut() = 100.0;
+    *capture_outer.borrow_mut() = MechTuple::from_vec(vec![
+      Value::F64(Ref::new(101.0)),
+      Value::F64(Ref::new(102.0)),
+    ]);
+
+    program.restore(checkpoint).unwrap();
+
+    let (restored_cell, restored_value) = activation_capture(&program, 0, 0);
+    let Value::Tuple(restored_outer) = restored_value else {
+      panic!("expected restored tuple activation capture")
+    };
+    let restored_first = tuple_f64_backing(&restored_outer, 0);
+    let restored_second = tuple_f64_backing(&restored_outer, 1);
+    assert_eq!(restored_cell, capture_cell);
+    assert_eq!(restored_outer.addr(), outer_addr);
+    assert_eq!(restored_first.addr(), first_backing_addr);
+    assert_eq!(restored_second.addr(), second_backing_addr);
+    assert_eq!(*restored_first.borrow(), 1.0);
+    assert_eq!(*restored_second.borrow(), 2.0);
+  }
+
+  #[test]
+  fn program_checkpoint_restore_preflights_everything_before_mutation() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program.run_string("x := 1.0").unwrap();
+    let (x_outer, x_inner) = scalar_cell(&program, "x");
+    let checkpoint = program.checkpoint().unwrap();
+
+    *x_inner.borrow_mut() = 42.0;
+    program.config.name = "still-mutated-on-error".into();
+    program.run_string("temporary := 2.0").unwrap();
+    let held_late_borrow = x_outer.borrow();
+
+    let error = program.restore(checkpoint.clone()).unwrap_err();
+    assert_eq!(error.kind_name(), "ValueStateBorrowConflict");
+    assert_eq!(program.config.name, "still-mutated-on-error");
+    assert_eq!(*x_inner.borrow(), 42.0);
+    assert!(
+      program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("temporary"))
+        .is_some()
+    );
+
+    drop(held_late_borrow);
+    program.restore(checkpoint).unwrap();
+    assert_eq!(program.config.name, "program");
+    let (_, restored_inner) = scalar_cell(&program, "x");
+    assert_eq!(*restored_inner.borrow(), 1.0);
+    assert!(
+      program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("temporary"))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn program_checkpoint_restores_removed_recursive_interpreters_with_identity() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let child_id = 101;
+    let grandchild_id = 202;
+
+    let child = Interpreter::new(child_id, 10_000);
+    let (child_outer, child_inner) =
+      insert_interpreter_scalar(&child, "child-value", 1.0);
+    let grandchild = Interpreter::new(grandchild_id, 10_000);
+    let (grandchild_outer, grandchild_inner) =
+      insert_interpreter_scalar(&grandchild, "grandchild-value", 2.0);
+    let grandchild_ref = Ref::new(Box::new(grandchild));
+    let grandchild_handle_addr = grandchild_ref.addr();
+    let grandchild_box_addr = interpreter_box_address(&grandchild_ref);
+    child
+      .sub_interpreters
+      .borrow_mut()
+      .insert(grandchild_id, grandchild_ref.clone());
+    let child_ref = Ref::new(Box::new(child));
+    let child_handle_addr = child_ref.addr();
+    let child_box_addr = interpreter_box_address(&child_ref);
+    program
+      .interpreter()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, child_ref.clone());
+
+    let checkpoint = program.checkpoint().unwrap();
+
+    let removed_child = program
+      .interpreter()
+      .sub_interpreters
+      .borrow_mut()
+      .remove(&child_id)
+      .unwrap();
+    removed_child
+      .borrow()
+      .sub_interpreters
+      .borrow_mut()
+      .remove(&grandchild_id);
+    *child_inner.borrow_mut() = 10.0;
+    *grandchild_inner.borrow_mut() = 20.0;
+    program
+      .interpreter()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, Ref::new(Box::new(Interpreter::new(child_id, 10_000))));
+    program
+      .interpreter()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(303, Ref::new(Box::new(Interpreter::new(303, 10_000))));
+
+    program.restore(checkpoint).unwrap();
+
+    let restored_child = program
+      .interpreter()
+      .sub_interpreters
+      .borrow()
+      .get(&child_id)
+      .unwrap()
+      .clone();
+    assert_eq!(program.interpreter().sub_interpreters.borrow().len(), 1);
+    assert_eq!(restored_child.addr(), child_handle_addr);
+    assert_eq!(interpreter_box_address(&restored_child), child_box_addr);
+    assert_eq!(child_outer.addr(), restored_child.borrow().symbols().borrow().get(hash_str("child-value")).unwrap().addr());
+    assert_eq!(*child_inner.borrow(), 1.0);
+
+    let restored_grandchild = restored_child
+      .borrow()
+      .sub_interpreters
+      .borrow()
+      .get(&grandchild_id)
+      .unwrap()
+      .clone();
+    assert_eq!(restored_grandchild.addr(), grandchild_handle_addr);
+    assert_eq!(
+      interpreter_box_address(&restored_grandchild),
+      grandchild_box_addr,
+    );
+    assert_eq!(
+      grandchild_outer.addr(),
+      restored_grandchild
+        .borrow()
+        .symbols()
+        .borrow()
+        .get(hash_str("grandchild-value"))
+        .unwrap()
+        .addr(),
+    );
+    assert_eq!(*grandchild_inner.borrow(), 2.0);
+  }
+
+  #[test]
+  fn program_restore_does_not_execute_functions_and_preserves_output_identity() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let output = Ref::new(1.0);
+    let solve_count = Rc::new(RefCell::new(0));
+    program.interpreter().plan().add_function(Box::new(RestoreProbe {
+      output: output.clone(),
+      solve_count: solve_count.clone(),
+    }));
+    let function_address = {
+      let plan = program.interpreter().plan();
+      let plan = plan.borrow();
+      plan.nodes[0].function.as_ref() as *const dyn MechFunction as *const () as usize
+    };
+    let checkpoint = program.checkpoint().unwrap();
+    *output.borrow_mut() = 99.0;
+
+    program.restore(checkpoint).unwrap();
+
+    assert_eq!(*solve_count.borrow(), 0);
+    assert_eq!(*output.borrow(), 1.0);
+    let restored_function_address = {
+      let plan = program.interpreter().plan();
+      let plan = plan.borrow();
+      plan.nodes[0].function.as_ref() as *const dyn MechFunction as *const () as usize
+    };
+    assert_eq!(restored_function_address, function_address);
+  }
+
+  #[test]
+  fn unsupported_function_state_fails_checkpoint_creation_without_changes() {
+    let program = MechProgram::new(MechProgramConfig::default());
+    let plan = program.interpreter().plan();
+    plan.add_function(Box::new(UnsupportedCheckpointFunction));
+    let plan_len = plan.len();
+
+    let error = match program.checkpoint() {
+      Ok(_) => panic!("unsupported checkpoint unexpectedly succeeded"),
+      Err(error) => error,
+    };
+
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+    assert_eq!(program.interpreter().plan_len(), plan_len);
+  }
+
+  #[test]
+  fn program_checkpoint_restores_nested_container_and_matrix_topology() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let shared = Ref::new(1.0);
+    let matrix = <f64 as ToMatrix>::to_matrixd(vec![1.0, 2.0, 3.0, 4.0], 2, 2);
+    let record = Ref::new(MechRecord::new(vec![
+      ("shared", Value::F64(shared.clone())),
+      ("matrix", Value::MatrixF64(matrix.clone())),
+    ]));
+    let record_addr = record.addr();
+    let matrix_cells = Value::MatrixF64(matrix.clone()).reactive_cell_ids();
+    let record_outer = program
+      .interpreter()
+      .symbols()
+      .borrow_mut()
+      .insert(
+        hash_str("nested"),
+        Value::Record(record.clone()),
+        true,
+      );
+    let checkpoint = program.checkpoint().unwrap();
+
+    *shared.borrow_mut() = 10.0;
+    matrix.set(vec![10.0, 20.0, 30.0, 40.0]);
+    *record.borrow_mut() = MechRecord::new(vec![
+      ("replacement", Value::F64(Ref::new(99.0))),
+    ]);
+
+    program.restore(checkpoint).unwrap();
+
+    assert_eq!(record.addr(), record_addr);
+    assert_eq!(*shared.borrow(), 1.0);
+    assert_eq!(matrix.as_vec(), vec![1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(
+      Value::MatrixF64(matrix.clone()).reactive_cell_ids(),
+      matrix_cells,
+    );
+    assert_eq!(record.borrow().cols, 2);
+    assert_eq!(
+      record_outer.borrow().reactive_cell_ids(),
+      Value::Record(record).reactive_cell_ids(),
+    );
+  }
+
+  #[test]
+  fn program_checkpoint_rejects_cross_program_restore_before_mutation() {
+    let source = MechProgram::new(MechProgramConfig {
+      name: "source".into(),
+      environment: MechProgramEnvironment::default(),
+    });
+    let checkpoint = source.checkpoint().unwrap();
+    let mut target = MechProgram::new(MechProgramConfig {
+      name: "target".into(),
+      environment: MechProgramEnvironment::default(),
+    });
+    let target_state_addr = target.interpreter().state.addr();
+
+    let error = target.restore(checkpoint).unwrap_err();
+
+    assert_eq!(error.kind_name(), "InterpreterCheckpointOwnerMismatch");
+    assert_eq!(target.config.name, "target");
+    assert_eq!(target.interpreter().state.addr(), target_state_addr);
+  }
 }

--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -307,6 +307,10 @@ pub struct MechProgram {
 /// [`MechProgram::checkpoint`] and consumed by [`MechProgram::restore`].
 /// It is a process-local savepoint, not a serializable durable-history record
 /// or a source of stable transaction identities.
+///
+/// This checkpoint supports append-only plan elaboration. Removing or
+/// replacing a function object that existed at capture time invalidates
+/// restoration.
 #[derive(Clone)]
 pub struct MechProgramCheckpoint {
   config: MechProgramConfig,

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -40,7 +40,9 @@ use super::execution::{
   ActivationEffectBarrierCompiler,
   ActivationEffectPayloadCaptureCompiler,
 };
-use mech_core::{GuardFunctionSafety, Ref, ValueKind};
+use mech_core::{
+  GuardFunctionSafety, Ref, TransactionStateUnsupportedError, ValueKind,
+};
 
 impl MechRuntime {
 
@@ -332,6 +334,21 @@ impl MechFunctionImpl for RuntimeHostNativeFunction {
     self.value.borrow().clone()
   }
 
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Err(
+      MechError::new(
+        TransactionStateUnsupportedError {
+          function: self.to_string(),
+          reason:
+            "ordinary retained-program checkpoints cannot own complete runtime host output topology; runtime transaction participation is required"
+              .to_string(),
+        },
+        None,
+      )
+      .with_compiler_loc(),
+    )
+  }
+
   fn to_string(&self) -> String {
     format!("RuntimeHostNativeFunction::{}", self.name)
   }
@@ -348,5 +365,38 @@ impl MechFunctionCompiler for RuntimeHostNativeFunction {
       },
       None,
     ))
+  }
+}
+
+#[cfg(test)]
+mod checkpoint_tests {
+  use super::*;
+
+  #[test]
+  fn runtime_host_native_function_requires_runtime_checkpoint_participation() {
+    let program = MechProgram::new(MechProgramConfig::default());
+    let plan = program.interpreter().plan();
+    let value = Ref::new(Value::Empty);
+    plan.add_function(Box::new(RuntimeHostNativeFunction {
+      name: "test/host".to_string(),
+      host_name: "test/host".to_string(),
+      arguments: Vec::new(),
+      value: value.clone(),
+    }));
+    let plan_before = plan.checkpoint();
+
+    let error = match program.checkpoint() {
+      Ok(_) => panic!("runtime host program checkpoint unexpectedly succeeded"),
+      Err(error) => error,
+    };
+
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+    assert!(
+      error
+        .kind_message()
+        .contains("runtime transaction participation"),
+    );
+    assert_eq!(plan.checkpoint(), plan_before);
+    assert_eq!(*value.borrow(), Value::Empty);
   }
 }


### PR DESCRIPTION
## Summary

Stacked on #651 (`fix/581-program-transactions`).

- Add complete function-registry and reactive-plan structural checkpoints with atomic preflight, derived-index rebuilding, pending-turn restoration, and retained function-object identity.
- Add recursive, identity-preserving interpreter checkpoints covering program state, frames, registries, plans, traces, contexts, manifests, FSMs, and named child interpreters.
- Expose opaque `MechProgram::checkpoint` / `restore` savepoints backed by the Round 1 `ValueStateJournal`.
- Audit every production `MechFunctionImpl`, add hidden-state discovery overrides, and return structured unsupported errors where state cannot be represented by journaled `Value` cells.
- Add separate capture and restore benchmarks for all eight required retained-program scenarios.
- Make `Ref<T>` backing storage private and route borrowing/handle identity through its API.

## Architectural boundaries

- `ValueStateJournal` is the only layer that knows how physical cell payloads are restored; `MechProgramCheckpoint` keeps it opaque behind `InterpreterCheckpoint`.
- Checkpoints are explicit process-local savepoints, not durable history or transaction IDs.
- Runtime transaction identity does not use pointer addresses. Durable history requires explicit stable logical cell IDs first.
- No journal work enters the reactive inner loop.
- The structural benchmarks are baselines only; any arena rewrite must be justified with representative real Mech workloads.
- Runtime changes are limited to declaring the existing host function's checkpoint-support contract and its regression test. No runtime transaction or effect-staging behavior is implemented.

## Stage 2 follow-up

- Removed runtime-host checkpoint detection based on `MechFunctionImpl::to_string()`.
- `RuntimeHostNativeFunction` now explicitly returns `TransactionStateUnsupported` until the runtime transaction coordinator can participate.
- Added a regression proving host-like display names have no semantic effect.
- Added a program-level regression using the real runtime host function; it fails before plan or output mutation.
- Documented that checkpoints support append-only plan elaboration and reject deletion or replacement of pre-existing function objects.
- Corrected the capture benchmark to keep fixture destruction outside the measured routine, then executed and recorded all program-checkpoint benchmark families.

Corrective commit: `7060bc4cc2187d97c24a701a9bfe6cc5733dde8e` (`fix(runtime): declare host checkpoint participation explicitly`).

### Criterion medians

| Scenario | Capture | Restore |
| --- | ---: | ---: |
| Empty program | 147.853 µs | 395.670 µs |
| Small scalar | 155.111 µs | 404.145 µs |
| 100-node plan | 168.790 µs | 399.889 µs |
| 1,000-node plan | 318.394 µs | 429.988 µs |
| Nested containers | 175.000 µs | 395.332 µs |
| Recursive interpreters | 461.162 µs | 1.160 ms |
| Structural additions | 156.217 µs | 517.454 µs |
| Scalar and matrix mutation | 163.149 µs | 395.157 µs |

- Empty fixed cost: 147.853 µs capture; 395.670 µs restore.
- Capture increment over empty: 0.209 µs/node at 100 nodes; 0.171 µs/node at 1,000 nodes.
- Restore after structural additions: 517.454 µs (+121.783 µs / 30.8% over empty).
- Recursive interpreters: 461.162 µs capture; 1.160 ms restore.
- Scalar and matrix mutation restore: 395.157 µs (within 0.513 µs of empty restore).

## Verification

- `cargo bench -p mech-program --bench program_checkpoint --no-run` — passed
- `cargo bench -p mech-program --bench program_checkpoint -- --test` — 16/16 smoke cases passed
- `cargo bench -p mech-program --bench program_checkpoint` — all 16 Criterion measurements completed
- `cargo test -p mech-core --lib` — 135 passed
- `cargo test -p mech-interpreter --lib` — 143 passed
- `cargo test -p mech-program --lib` — 49 passed
- Focused runtime-host checkpoint test — 1 passed
- `cargo test -p mech-runtime --lib` — 341 passed; 3 existing macOS watch-path failures
- Runtime suite with those three known watch tests skipped — 341 passed
- `cargo test --lib --no-default-features --features 'n_choose_k,matrixd,f64,compiler' matrix_combinations_decline_unsupported_outer_state_without_borrowing_it` — passed
- `cargo check -p mech-interpreter --no-default-features --features base` — passed
- `cargo check -p mech-program --bench program_checkpoint` — passed
- `cargo test -p mech-program --doc` — passed
- `git diff --check` — clean
- `rustfmt --edition 2024 --check` on the changed Rust files — reports the repository's pre-existing broad formatting divergence; no reformatting was performed.

The unfiltered runtime suite has the three pre-existing `/var` versus `/private/var` workspace-watch failures on macOS. CI result: all eight checks passed (Cargo language tests, Cargo runtime and host tests, Dynamic modules, Project browser, Project native, Run-only CLI, Windows CLI, and cargo).