### PR TITLE
[v0.4] Transact retained runtime execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ name = "mech-runtime"
 version = "0.3.5"
 dependencies = [
  "blake3",
+ "criterion",
  "ed25519-dalek",
  "ignore",
  "mech-core",

--- a/docs/design/retained-program-checkpoint-function-state-audit.md
+++ b/docs/design/retained-program-checkpoint-function-state-audit.md
@@ -26,10 +26,17 @@ The Round 2 audit covered every production `MechFunctionImpl` under `src/`,
 - `NChooseKMatrix<T>` retains `Ref<Matrix<T>>` and can replace the outer matrix
   enum. That outer topology is not a journalable `Value` cell, so checkpoint
   creation returns `TransactionStateUnsupported` before mutation.
-- `RuntimeHostNativeFunction` owns an outer output cell in the runtime layer.
-  Retaining that topology requires the runtime transaction coordinator. The
-  function itself therefore returns `TransactionStateUnsupported` before
-  ordinary program checkpointing can inspect or mutate its state.
+
+## Round 3 runtime-host output state
+
+`RuntimeHostNativeFunction` exposes its outer `Ref<Value>` and complete
+reachable output graph to `ValueStateJournal`. The runtime-owned program
+transaction coordinator now restores this output state when a retained
+operation or explicit transaction rolls back.
+
+Round 3 does not undo arbitrary external effects performed by the host call.
+Host effect preparation, commit, suppression, and compensation belong to
+Round 4.
 
 ## Implementations covered by the default
 
@@ -45,9 +52,7 @@ The Round 2 audit covered every production `MechFunctionImpl` under `src/`,
 - I/O print functions and `ActivationEffectBarrier`, which retain no mutable
   semantic state.
 
-`RuntimeHostNativeFunction` declares the runtime-layer unsupported boundary
-itself. Provider crates under `hosts/` do not directly implement
-`MechFunctionImpl`.
+Provider crates under `hosts/` do not directly implement `MechFunctionImpl`.
 
 Out-of-tree implementations are responsible for honoring this trait contract.
 Hidden mutable state must never inherit the permissive output-backed default.

--- a/docs/design/runtime-program-transactions.md
+++ b/docs/design/runtime-program-transactions.md
@@ -126,3 +126,22 @@ Pointer addresses and `ReactiveCellId` are not durable history keys. Durable
 history requires an explicit stable logical cell ID first. This separation
 allows future values to use storage other than `Rc<RefCell<T>>` without
 teaching transaction coordination about the current representation.
+
+## macOS CLI serve-test classification
+
+The first serial CLI failure was
+`serve::tests::poll_workspace_once_updates_registry_after_manual_refresh`.
+It failed identically in three of three runs at both the Round 3 parent
+`7a5b0895771de0d5aeda0885ae4c8ae68cb3390b` and corrective head
+`da384fe619e769dba0ab720348b08ab1733638bd`.
+
+The test expected `server.workspace_session` to be `Some` after loading
+`main.mec`, but the actual value was `None`. A single existing Mech source is
+classified as a configured served project, which does not create a workspace
+session. The assertion failed before the later `source/main.mec` route lookup.
+
+Every run used a canonical temporary root under
+`/private/var/folders/.../T/mech-serve-refresh-*`; no `/var` versus
+`/private/var` comparison was reached. The remaining eleven serial failures
+were follow-on failures from the poisoned current-directory test lock. This is
+a pre-existing CLI fixture failure, not a Round 3 runtime regression.

--- a/docs/design/runtime-program-transactions.md
+++ b/docs/design/runtime-program-transactions.md
@@ -1,0 +1,128 @@
+# Runtime-owned program transactions
+
+Round 3 gives every runtime-owned retained-program operation one atomic
+internal boundary. The runtime coordinates four existing mechanisms rather
+than teaching any one of them about the others:
+
+- `MechProgramCheckpoint` owns structural program rollback and treats its
+  value-state journal as opaque.
+- `RuntimeTransaction` stages store records and runtime events.
+- `RuntimeLiveStateSnapshot` captures live input bindings, persistent sends,
+  the live context template, and registration mode.
+- `RuntimeContextCheckpoint` captures operation context.
+
+Arbitrary provider and host effects are outside this boundary.
+
+## Implicit retained operations
+
+A retained source operation without an explicit transaction receives a normal
+runtime transaction ID. A successful operation commits its program, live state,
+staged store changes, success events, and a durable `TransactionRecord`.
+
+A failed operation restores program, live, store-staging, and context state,
+then aborts the hidden transaction. `TransactionStarted` and
+`TransactionAborted` remain observable, but there is no durable transaction
+record. The failure audit is emitted after restoration, so rolled-back success
+events do not survive.
+
+Runtime event sequence numbers and generated IDs are never rewound. Gaps after
+rollback are expected.
+
+## Explicit ownership and savepoints
+
+Program ownership is lazy. Beginning an explicit store-only transaction does
+not checkpoint or lock the retained program. Its first successful retained
+operation captures the outer program and live baseline and claims the single
+program-writer slot.
+
+While transaction A owns that slot:
+
+- retained operations from A are allowed;
+- retained operations from transaction B are rejected;
+- implicit retained operations are rejected;
+- store-only work in B remains allowed.
+
+Each retained operation inside A has its own savepoint. If a later operation
+fails, its program, live, staged-store, event, and context changes are removed
+while earlier successful operations remain provisional. Outer commit keeps the
+provisional program. Outer abort restores the original program and live
+baseline and discards all staged store state.
+
+A store commit failure does not discard the program baseline. The transaction
+remains active, retains ownership, and may be retried or aborted.
+
+## Context identity and rollback
+
+An active transaction is bound to the exact runtime, subject, task, actor,
+actor message, and actor-state identity captured at begin. A same-subject
+context with a different execution identity cannot drive that transaction.
+
+Operation rollback restores module binding, capabilities, access, events,
+identity fields, and budget maxima. It does not refund resource use:
+
+- steps;
+- bytes;
+- items;
+- messages.
+
+For each counter, restored use is the greater of current and checkpoint use.
+Elapsed time and generated transaction, event, object, task, actor, and message
+IDs are also monotonic.
+
+Only access added after the outer context baseline enters the durable
+transaction read and write sets.
+
+## Rollback failure and health
+
+Ordinary parsing, preflight, execution, or store-commit failures do not poison
+the runtime. Poisoning is reserved for an incomplete restoration or a broken
+coordinator invariant.
+
+A poisoned runtime preserves the original operation error and every rollback
+failure for diagnostics. It rejects new retained execution, begin, and commit.
+Read-only inspection, abort cleanup, and shutdown remain available. Round 3
+does not provide an unpoison operation.
+
+## Host output and external effects
+
+Runtime-host plan nodes expose their outer output cell and reachable value
+graph to the checkpoint journal. Rollback therefore restores the output cell's
+identity, topology, and payload.
+
+Round 3 does not undo an arbitrary external effect already performed by a host
+function, provider write, or capability-kernel mutation. Host-effect
+preparation, suppression, commit, and compensation belong to Round 4. No
+provider transaction protocol is introduced here.
+
+## Reactive and module boundaries
+
+Whole-program checkpoint work does not run in the reactive inner loop.
+Transactional `step_with_context` and host-input turns are rejected while a
+transaction is active or owns the program. Nontransactional reactive turns
+retain their existing behavior. Compact reactive-turn deltas belong to Round 6.
+
+Retained root-module installation and execution are coordinated after a root
+module version has been built. Module source resolution, compilation,
+module-record persistence, dependency invariant reporting, and the complete
+module-graph store handoff are not included in the program savepoint. Those
+become atomic in Round 5.
+
+One-shot bytecode execution and isolated dependency-module programs continue
+to use temporary programs and are not retained-operation transactions.
+
+`program_mut` and `take_program` remain low-level compatibility escape hatches.
+They are outside runtime-owned atomic guarantees, runtime internals must not
+use them to bypass the coordinator, and callers must not use them while a
+transaction owns the retained program.
+
+## Value storage guardrails
+
+`ValueStateJournal` remains the only layer that knows how current cells are
+physically restored. Program checkpoints and the runtime coordinator only
+compose opaque checkpoint APIs.
+
+Checkpoint identity is process-local and never becomes transaction identity.
+Pointer addresses and `ReactiveCellId` are not durable history keys. Durable
+history requires an explicit stable logical cell ID first. This separation
+allows future values to use storage other than `Rc<RefCell<T>>` without
+teaching transaction coordination about the current representation.

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -154,6 +154,7 @@ host_delegation = ["serde"]
 host_delegation_signing = ["host_delegation", "dep:ed25519-dalek", "dep:rand_core"]
 
 [dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 mech-host-cli = { path = "../../hosts/cli", features = ["provider"] }
 serde_json = "1.0.150"
 
@@ -274,3 +275,8 @@ required-features = ["program"]
 name = "module_smoke"
 path = "tests/module_smoke.rs"
 required-features = ["program"]
+
+[[bench]]
+name = "program_transaction"
+harness = false
+required-features = ["baselib"]

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,0 +1,200 @@
+use criterion::{
+  BatchSize, Criterion, criterion_group, criterion_main,
+};
+use mech_core::MechSourceCode;
+use mech_runtime::{
+  MechRuntime, RuntimeContext, SequentialIdGenerator,
+};
+use std::hint::black_box;
+
+struct ExplicitFixture {
+  runtime: MechRuntime,
+  context: RuntimeContext,
+}
+
+fn retained_runtime() -> MechRuntime {
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .build()
+    .unwrap();
+  runtime.run_string("bench-anchor := 1").unwrap();
+  runtime
+}
+
+fn explicit_fixture() -> ExplicitFixture {
+  let mut runtime = retained_runtime();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+  ExplicitFixture { runtime, context }
+}
+
+fn subsequent_explicit_fixture() -> ExplicitFixture {
+  let mut fixture = explicit_fixture();
+  fixture
+    .runtime
+    .run_string_with_context(
+      &mut fixture.context,
+      "bench-explicit-a := bench-anchor + 1",
+    )
+    .unwrap();
+  fixture
+}
+
+fn implicit_failure_source() -> MechSourceCode {
+  MechSourceCode::Program(vec![
+    MechSourceCode::String(
+      "bench-implicit-partial := bench-anchor + 1".to_string(),
+    ),
+    MechSourceCode::String(
+      "bench-implicit-error := missing-bench-value + 1".to_string(),
+    ),
+  ])
+}
+
+fn explicit_failure_source() -> MechSourceCode {
+  MechSourceCode::Program(vec![
+    MechSourceCode::String(
+      "bench-explicit-partial := bench-explicit-a + 1".to_string(),
+    ),
+    MechSourceCode::String(
+      "bench-explicit-error := missing-bench-value + 1".to_string(),
+    ),
+  ])
+}
+
+fn program_transaction_benchmarks(c: &mut Criterion) {
+  let mut group = c.benchmark_group("runtime_program_transaction");
+
+  group.bench_function("implicit_successful_retained_operation", |b| {
+    b.iter_batched(
+      || {
+        let runtime = retained_runtime();
+        let context = runtime.runtime_context().unwrap();
+        (runtime, context)
+      },
+      |(mut runtime, mut context)| {
+        let value = runtime
+          .run_string_with_context(
+            &mut context,
+            "bench-implicit-success := bench-anchor + 1",
+          )
+          .unwrap();
+        black_box(value);
+        black_box((runtime, context))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("explicit_first_operation_and_ownership", |b| {
+    b.iter_batched(
+      explicit_fixture,
+      |mut fixture| {
+        let value = fixture
+          .runtime
+          .run_string_with_context(
+            &mut fixture.context,
+            "bench-explicit-first := bench-anchor + 1",
+          )
+          .unwrap();
+        black_box(value);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("explicit_subsequent_savepoint_operation", |b| {
+    b.iter_batched(
+      subsequent_explicit_fixture,
+      |mut fixture| {
+        let value = fixture
+          .runtime
+          .run_string_with_context(
+            &mut fixture.context,
+            "bench-explicit-b := bench-explicit-a + 1",
+          )
+          .unwrap();
+        black_box(value);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("failed_implicit_operation_with_rollback", |b| {
+    b.iter_batched(
+      || {
+        let runtime = retained_runtime();
+        let context = runtime.runtime_context().unwrap();
+        (runtime, context, implicit_failure_source())
+      },
+      |(mut runtime, mut context, source)| {
+        let error = runtime
+          .run_source_with_context(&mut context, &source)
+          .unwrap_err();
+        black_box(error);
+        black_box((runtime, context, source))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("failed_explicit_subsequent_operation_with_rollback", |b| {
+    b.iter_batched(
+      || (subsequent_explicit_fixture(), explicit_failure_source()),
+      |(mut fixture, source)| {
+        let error = fixture
+          .runtime
+          .run_source_with_context(&mut fixture.context, &source)
+          .unwrap_err();
+        black_box(error);
+        black_box((fixture, source))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("explicit_outer_abort_after_program_changes", |b| {
+    b.iter_batched(
+      subsequent_explicit_fixture,
+      |mut fixture| {
+        fixture
+          .runtime
+          .abort_runtime_transaction(
+            &mut fixture.context,
+            "benchmark outer abort",
+          )
+          .unwrap();
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("implicit_transaction_store_commit", |b| {
+    b.iter_batched(
+      || {
+        let runtime = retained_runtime();
+        let context = runtime.runtime_context().unwrap();
+        (runtime, context)
+      },
+      |(mut runtime, mut context)| {
+        let value = runtime
+          .run_string_with_context(
+            &mut context,
+            "bench-implicit-store-commit := 1",
+          )
+          .unwrap();
+        black_box(value);
+        black_box((runtime, context))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.finish();
+}
+
+criterion_group!(benches, program_transaction_benchmarks);
+criterion_main!(benches);

--- a/src/runtime/src/runtime/actor.rs
+++ b/src/runtime/src/runtime/actor.rs
@@ -29,7 +29,7 @@ impl MechRuntime {
 
     for message in self.store.list_mailbox(actor)? {
       let acknowledged =
-        transaction.staged_message_ack_occurrences(actor, message.id);
+        transaction.store.staged_message_ack_occurrences(actor, message.id);
       let skipped = skipped_occurrences.entry(message.id).or_insert(0);
 
       if *skipped < acknowledged {
@@ -41,6 +41,7 @@ impl MechRuntime {
     }
 
     Ok(transaction
+      .store
       .peek_staged_enqueued_message(actor)
       .map(VisibleTransactionMessage::Staged))
   }
@@ -134,7 +135,7 @@ impl MechRuntime {
 
     if let Some(transaction_id) = context.transaction {
       if let Some(transaction) = self.active_transactions.get(&transaction_id) {
-        if let Some(actor) = transaction.get_staged_actor(id) {
+        if let Some(actor) = transaction.store.get_staged_actor(id) {
           return Ok(Some(actor));
         }
       }
@@ -247,7 +248,7 @@ impl MechRuntime {
 
     if let Some(transaction_id) = context.transaction {
       if let Some(transaction) = self.active_transactions.get(&transaction_id) {
-        let ack_count = transaction.staged_message_ack_count(actor)?;
+        let ack_count = transaction.store.staged_message_ack_count(actor)?;
         effective_len = effective_len.checked_sub(ack_count).ok_or_else(|| {
           MechError::new(
             RuntimeInvalidOperationError {
@@ -258,7 +259,7 @@ impl MechRuntime {
           )
         })?;
         effective_len = effective_len
-          .checked_add(transaction.staged_message_enqueue_count(actor)?)
+          .checked_add(transaction.store.staged_message_enqueue_count(actor)?)
           .ok_or_else(|| {
             MechError::new(
               ResourceBudgetExceededError {
@@ -555,11 +556,13 @@ mod tests {
       .active_transactions
       .get(&transaction_id)
       .unwrap()
+      .store
       .staged_event_ids();
     let staged_put_count_before = runtime
       .active_transactions
       .get(&transaction_id)
       .unwrap()
+      .store
       .staged_puts()
       .count();
 
@@ -582,6 +585,7 @@ mod tests {
         .active_transactions
         .get(&transaction_id)
         .unwrap()
+        .store
         .staged_event_ids(),
       staged_event_ids_before,
     );
@@ -590,6 +594,7 @@ mod tests {
         .active_transactions
         .get(&transaction_id)
         .unwrap()
+        .store
         .staged_puts()
         .count(),
       staged_put_count_before,
@@ -858,6 +863,7 @@ mod tests {
         .active_transactions
         .get(&transaction_id)
         .unwrap()
+        .store
         .staged_message_ack_occurrences(ActorId(1), MessageId(5)),
       2,
     );

--- a/src/runtime/src/runtime/actor.rs
+++ b/src/runtime/src/runtime/actor.rs
@@ -608,12 +608,11 @@ mod tests {
   fn transactional_actor_turn_succeeds_when_subject_matches_owner() {
     let mut runtime = MechRuntime::builder().build().unwrap();
     let mut context = runtime.runtime_context().unwrap();
-    context.subject = "owner".to_string();
-    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
-
     let actor = ActorRecord::new(ActorId(1), "owner");
     let message = MessageRecord::new(MessageId(1), ActorId(1), "ping", Vec::new());
     let turn = ActorTurn::new(actor, message).unwrap();
+    context.bind_actor_turn(&turn);
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
 
     runtime.run_actor_turn_envelope(&mut context, &turn).unwrap();
 

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -452,6 +452,7 @@ mod tests {
       .active_transactions
       .get(&transaction_id)
       .unwrap()
+      .store
       .staged_events()
       .any(|event| matches!(event.kind, RuntimeEventKind::CapabilityGranted { .. })));
     assert!(runtime.get_capability(CapabilityId(100)).unwrap().is_none());

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -9,6 +9,159 @@
 use super::*;
 
 #[derive(Debug, Clone)]
+pub struct RuntimeTransactionContextMismatch {
+  pub transaction_id: TransactionId,
+  pub reason: String,
+}
+
+impl MechErrorKind for RuntimeTransactionContextMismatch {
+  fn name(&self) -> &str {
+    "RuntimeTransactionContextMismatch"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "runtime transaction {} context identity mismatch: {}",
+      self.transaction_id,
+      self.reason,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeProgramBusy {
+  pub operation: &'static str,
+  pub owner: TransactionId,
+  pub requester: Option<TransactionId>,
+}
+
+impl MechErrorKind for RuntimeProgramBusy {
+  fn name(&self) -> &str {
+    "RuntimeProgramBusy"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "retained program operation `{}` is owned by transaction {}; requester is {:?}",
+      self.operation,
+      self.owner,
+      self.requester,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeProgramOperationReentrant {
+  pub active_operation: &'static str,
+  pub requested_operation: &'static str,
+  pub transaction_id: TransactionId,
+}
+
+impl MechErrorKind for RuntimeProgramOperationReentrant {
+  fn name(&self) -> &str {
+    "RuntimeProgramOperationReentrant"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "retained program operation `{}` cannot enter `{}` recursively in transaction {}",
+      self.active_operation,
+      self.requested_operation,
+      self.transaction_id,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeTransactionalReactiveTurnUnsupported {
+  pub operation: &'static str,
+  pub transaction_id: Option<TransactionId>,
+  pub owner: Option<TransactionId>,
+}
+
+impl MechErrorKind for RuntimeTransactionalReactiveTurnUnsupported {
+  fn name(&self) -> &str {
+    "RuntimeTransactionalReactiveTurnUnsupported"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "reactive operation `{}` cannot run transactionally yet (transaction {:?}, program owner {:?})",
+      self.operation,
+      self.transaction_id,
+      self.owner,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeTransactionalLiveRegistrationUnsupported {
+  pub transaction_id: TransactionId,
+  pub owner: Option<TransactionId>,
+  pub active_operation: Option<&'static str>,
+}
+
+impl MechErrorKind for RuntimeTransactionalLiveRegistrationUnsupported {
+  fn name(&self) -> &str {
+    "RuntimeTransactionalLiveRegistrationUnsupported"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "transaction {} may register retained live state only inside its coordinated program operation (owner {:?}, active operation {:?})",
+      self.transaction_id,
+      self.owner,
+      self.active_operation,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimePoisoned {
+  pub operation: &'static str,
+  pub poison: RuntimePoisonRecord,
+}
+
+impl MechErrorKind for RuntimePoisoned {
+  fn name(&self) -> &str {
+    "RuntimePoisoned"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "runtime operation `{}` rejected because `{}` rollback poisoned the runtime: {}",
+      self.operation,
+      self.poison.operation,
+      self.poison.rollback_failures.join("; "),
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeProgramRollbackFailed {
+  pub operation: &'static str,
+  pub transaction_id: Option<TransactionId>,
+  pub original_error: String,
+  pub rollback_failures: Vec<String>,
+}
+
+impl MechErrorKind for RuntimeProgramRollbackFailed {
+  fn name(&self) -> &str {
+    "RuntimeProgramRollbackFailed"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "retained program operation `{}` failed ({}) and rollback was incomplete for transaction {:?}: {}",
+      self.operation,
+      self.original_error,
+      self.transaction_id,
+      self.rollback_failures.join("; "),
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
 pub struct RuntimeCapabilityGrantRollbackFailed {
   pub capability: CapabilityId,
   pub rollback_failures: Vec<String>,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -42,15 +42,7 @@ struct PreparedModuleScopeExecution {
   environment: HashMap<String, ValRef>,
 }
 
-struct ProgramEnvironmentOverlay {
-  entries: Vec<ProgramEnvironmentOverlayEntry>,
-}
-
-struct ProgramEnvironmentOverlayEntry {
-  id: u64,
-  previous_symbol: Option<ValRef>,
-  previous_dictionary: Option<String>,
-}
+struct ProgramEnvironmentOverlay;
 
 fn imports_for_scope<'a>(
   record: &'a ModuleVersionRecord,
@@ -151,7 +143,7 @@ fn materialize_function_imports_for_scope(
 }
 
 impl ProgramEnvironmentOverlay {
-  fn install(program: &mut MechProgram, environment: &HashMap<String, ValRef>) -> MResult<Self> {
+  fn install(program: &mut MechProgram, environment: &HashMap<String, ValRef>) -> MResult<()> {
     let mut ids = HashMap::new();
     for name in environment.keys() {
       let id = hash_str(name);
@@ -166,12 +158,10 @@ impl ProgramEnvironmentOverlay {
       }
     }
 
-    let mut entries = Vec::with_capacity(environment.len());
     let symbols = program.interpreter_mut().symbols();
     let mut symbols_brrw = symbols.borrow_mut();
     for (name, value_ref) in environment {
       let id = hash_str(name);
-      let previous_symbol = symbols_brrw.symbols.get(&id).cloned();
       let previous_dictionary = symbols_brrw.dictionary.borrow().get(&id).cloned();
       if let Some(previous_name) = &previous_dictionary {
         if previous_name != name && !environment.contains_key(previous_name) {
@@ -182,30 +172,11 @@ impl ProgramEnvironmentOverlay {
           }, None));
         }
       }
-      entries.push(ProgramEnvironmentOverlayEntry { id, previous_symbol, previous_dictionary });
       symbols_brrw.symbols.insert(id, value_ref.clone());
       symbols_brrw.dictionary.borrow_mut().insert(id, name.clone());
     }
 
-    Ok(Self { entries })
-  }
-
-  fn restore(self, program: &mut MechProgram) {
-    let symbols = program.interpreter_mut().symbols();
-    let mut symbols_brrw = symbols.borrow_mut();
-    for entry in self.entries.into_iter().rev() {
-      if let Some(previous_symbol) = entry.previous_symbol {
-        symbols_brrw.symbols.insert(entry.id, previous_symbol);
-      } else {
-        symbols_brrw.symbols.remove(&entry.id);
-      }
-
-      if let Some(previous_dictionary) = entry.previous_dictionary {
-        symbols_brrw.dictionary.borrow_mut().insert(entry.id, previous_dictionary);
-      } else {
-        symbols_brrw.dictionary.borrow_mut().remove(&entry.id);
-      }
-    }
+    Ok(())
   }
 }
 
@@ -3892,8 +3863,7 @@ impl MechRuntime {
 
     let result = (|| -> MResult<Value> {
       materialize_function_imports_for_scope(&mut root_program, &prepared.record, scope)?;
-      let overlay = ProgramEnvironmentOverlay::install(&mut root_program, &prepared.environment)?;
-      let live_state_before = self.live_state_snapshot();
+      ProgramEnvironmentOverlay::install(&mut root_program, &prepared.environment)?;
 
       self.emit_event_to_context(
         context,
@@ -3913,14 +3883,7 @@ impl MechRuntime {
           Ok(value)
         });
 
-      match result {
-        Ok(value) => Ok(value),
-        Err(error) => {
-          self.restore_live_state(live_state_before);
-          overlay.restore(&mut root_program);
-          Err(error)
-        }
-      }
+      result
     })();
 
     self.program = root_program;
@@ -3933,16 +3896,7 @@ impl MechRuntime {
         )?;
         Ok(value)
       }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ModuleExecutionFailed {
-            module_version: version,
-            message: format!("{:?}", error),
-          },
-        )?;
-        Err(error)
-      }
+      Err(error) => Err(error),
     }
   }
 
@@ -4029,24 +3983,13 @@ impl MechRuntime {
       }
     });
 
-    match &result {
-      Ok(_) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramCompleted {
-            task_id: context.task,
-          },
-        )?;
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-      }
+    if result.is_ok() {
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ProgramCompleted {
+          task_id: context.task,
+        },
+      )?;
     }
 
     result

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3064,23 +3064,37 @@ impl MechRuntime {
     source: &str,
   ) -> MResult<Value> {
     let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    let source_bytes = u64::try_from(source.as_bytes().len()).map_err(|_| {
-      MechError::new(
-        ResourceBudgetExceededError {
-          resource: "source_bytes",
-          used: u64::MAX,
-          requested: 1,
-          max: None,
-        },
-        None,
-      )
-    })?;
-    self.enforce_source_byte_count(context, source_bytes)?;
-    self.run_string_with_context_inner(context, source, turn_started)
+    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+    let result = self.with_atomic_program_operation(
+      context,
+      "run_string_with_context",
+      |runtime, context| {
+        let source_bytes = u64::try_from(source.as_bytes().len()).map_err(|_| {
+          MechError::new(
+            ResourceBudgetExceededError {
+              resource: "source_bytes",
+              used: u64::MAX,
+              requested: 1,
+              max: None,
+            },
+            None,
+          )
+        })?;
+        runtime.enforce_source_byte_count(context, source_bytes)?;
+        runtime.run_string_operation(context, source, turn_started)
+      },
+    );
+    if let Err(error) = &result {
+      self.emit_program_failure_audit(
+        context,
+        error,
+        profile_started,
+      );
+    }
+    result
   }
 
-  fn run_string_with_context_inner(
+  fn run_string_operation(
     &mut self,
     context: &mut RuntimeContext,
     source: &str,
@@ -3096,8 +3110,6 @@ impl MechRuntime {
         task_id: context.task,
       },
     )?;
-
-    let live_state_before = self.live_state_snapshot();
 
     let result = match mech_syntax::parser::parse(source.trim()) {
       Ok(tree) => match self.preflight_context_capabilities(context, &tree, &SourceScope::Program) {
@@ -3130,48 +3142,49 @@ impl MechRuntime {
     };
 
     let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
-    if result.is_err() {
-      self.restore_live_state(live_state_before);
-    }
-    match &result {
-      Ok(_) => {
+    if result.is_ok() {
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ProgramCompleted {
+          task_id: context.task,
+        },
+      )?;
+      if let Some(started) = profile_started {
         self.emit_event_to_context(
           context,
-          RuntimeEventKind::ProgramCompleted {
+          RuntimeEventKind::ProgramProfiled {
             task_id: context.task,
+            duration_ns: started.elapsed().as_nanos(),
           },
         )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
       }
     }
 
     result
+  }
+
+  fn emit_program_failure_audit(
+    &mut self,
+    context: &mut RuntimeContext,
+    error: &MechError,
+    profile_started: Option<Instant>,
+  ) {
+    let _ = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::ProgramFailed {
+        task_id: context.task,
+        message: format!("{:?}", error),
+      },
+    );
+    if let Some(started) = profile_started {
+      let _ = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ProgramProfiled {
+          task_id: context.task,
+          duration_ns: started.elapsed().as_nanos(),
+        },
+      );
+    }
   }
 
   /// Evaluates bytecode in an isolated temporary program. It returns the
@@ -3290,25 +3303,43 @@ impl MechRuntime {
     source: &MechSourceCode,
   ) -> MResult<Value> {
     let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    self.enforce_source_limits(context, source)?;
-    self.run_source_with_context_inner(context, source, turn_started)
+    if let MechSourceCode::ByteCode(bytes) = source {
+      return self.run_bytecode_with_context(context, bytes);
+    }
+
+    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+    let result = self.with_atomic_program_operation(
+      context,
+      "run_source_with_context",
+      |runtime, context| {
+        runtime.enforce_source_limits(context, source)?;
+        runtime.run_source_operation(context, source, turn_started)
+      },
+    );
+    if let Err(error) = &result {
+      self.emit_program_failure_audit(
+        context,
+        error,
+        profile_started,
+      );
+    }
+    result
   }
 
-  fn run_source_with_context_inner(
+  fn run_source_operation(
     &mut self,
     context: &mut RuntimeContext,
     source: &MechSourceCode,
     turn_started: Instant,
   ) -> MResult<Value> {
     match source {
-      MechSourceCode::String(source) => self.run_string_with_context_inner(context, source, turn_started),
-      MechSourceCode::Tree(tree) => self.run_tree_with_context_timed(context, tree, turn_started),
+      MechSourceCode::String(source) => self.run_string_operation(context, source, turn_started),
+      MechSourceCode::Tree(tree) => self.run_tree_operation(context, tree, turn_started),
       MechSourceCode::ByteCode(bytes) => self.run_bytecode_with_context_inner(context, bytes, turn_started),
       MechSourceCode::Program(sources) => {
         let mut value = Value::Empty;
         for source in sources {
-          value = self.run_source_with_context_inner(context, source, turn_started)?;
+          value = self.run_source_operation(context, source, turn_started)?;
         }
         Ok(value)
       }
@@ -3327,10 +3358,23 @@ impl MechRuntime {
     tree: &mech_core::Program,
   ) -> MResult<Value> {
     let turn_started = Instant::now();
-    self.run_tree_with_context_timed(context, tree, turn_started)
+    let profile_started = self.config.diagnostics.profile_enabled.then(Instant::now);
+    let result = self.with_atomic_program_operation(
+      context,
+      "run_tree_with_context",
+      |runtime, context| runtime.run_tree_operation(context, tree, turn_started),
+    );
+    if let Err(error) = &result {
+      self.emit_program_failure_audit(
+        context,
+        error,
+        profile_started,
+      );
+    }
+    result
   }
 
-  fn run_tree_with_context_timed(
+  fn run_tree_operation(
     &mut self,
     context: &mut RuntimeContext,
     tree: &mech_core::Program,
@@ -3346,8 +3390,6 @@ impl MechRuntime {
         task_id: context.task,
       },
     )?;
-
-    let live_state_before = self.live_state_snapshot();
 
     let result = match self.preflight_context_capabilities(context, tree, &SourceScope::Program) {
       Ok(()) => {
@@ -3377,44 +3419,21 @@ impl MechRuntime {
     };
 
     let result = result.and_then(|value| { self.enforce_turn_duration(turn_started)?; Ok(value) });
-    if result.is_err() {
-      self.restore_live_state(live_state_before);
-    }
-    match &result {
-      Ok(_) => {
+    if result.is_ok() {
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ProgramCompleted {
+          task_id: context.task,
+        },
+      )?;
+      if let Some(started) = profile_started {
         self.emit_event_to_context(
           context,
-          RuntimeEventKind::ProgramCompleted {
+          RuntimeEventKind::ProgramProfiled {
             task_id: context.task,
+            duration_ns: started.elapsed().as_nanos(),
           },
         )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
-      }
-      Err(error) => {
-        self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ProgramFailed {
-            task_id: context.task,
-            message: format!("{:?}", error),
-          },
-        )?;
-        if let Some(started) = profile_started {
-          self.emit_event_to_context(
-            context,
-            RuntimeEventKind::ProgramProfiled {
-              task_id: context.task,
-              duration_ns: started.elapsed().as_nanos(),
-            },
-          )?;
-        }
       }
     }
 

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3411,6 +3411,10 @@ impl MechRuntime {
     result
   }
 
+  /// Low-level manual escape hatch outside runtime-owned atomic execution.
+  ///
+  /// Taking the program bypasses runtime transaction coordination. Callers
+  /// must not use it while a transaction owns the retained program.
   pub fn take_program(&mut self) -> MechProgram {
     let program_config = self.program.config.clone();
     std::mem::replace(&mut self.program, MechProgram::new(program_config))
@@ -3461,6 +3465,17 @@ impl MechRuntime {
     interpreter_id: u64,
     value: &Value,
   ) -> MResult<()> {
+    if let Some(owner) = self.program_transaction_owner {
+      return Err(MechError::new(
+        RuntimeProgramBusy {
+          operation: "bind_ans_for_interpreter",
+          owner,
+          requester: None,
+        },
+        None,
+      ));
+    }
+
     if self.program.bind_ans_for_interpreter(interpreter_id, value) {
       return Ok(());
     }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3498,6 +3498,7 @@ impl MechRuntime {
   ) -> MResult<()> {
     let turn_started = Instant::now();
     self.validate_context_for_runtime(context)?;
+    self.reject_transactional_reactive_turn(context, "step_with_context")?;
     context.charge_step()?;
 
     let program_config = self.program.config.clone();
@@ -4668,6 +4669,16 @@ impl MechRuntime {
 
   pub fn apply_host_input(&mut self, input: crate::RuntimeHostInput) -> MResult<crate::RuntimeHostInputOutcome> {
     input.validate()?;
+    if self.program_transaction_owner.is_some() {
+      return Err(MechError::new(
+        RuntimeTransactionalReactiveTurnUnsupported {
+          operation: "apply_host_input",
+          transaction_id: None,
+          owner: self.program_transaction_owner,
+        },
+        None,
+      ));
+    }
     let mut target_updates = Vec::new();
     let mut seen_targets = std::collections::HashSet::new();
     let mut ignored_update_count = 0;

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -41,7 +41,7 @@ use super::execution::{
   ActivationEffectPayloadCaptureCompiler,
 };
 use mech_core::{
-  GuardFunctionSafety, Ref, TransactionStateUnsupportedError, ValueKind,
+  GuardFunctionSafety, Ref, ValueKind,
 };
 
 impl MechRuntime {
@@ -335,18 +335,9 @@ impl MechFunctionImpl for RuntimeHostNativeFunction {
   }
 
   fn transaction_state_values(&self) -> MResult<Vec<Value>> {
-    Err(
-      MechError::new(
-        TransactionStateUnsupportedError {
-          function: self.to_string(),
-          reason:
-            "ordinary retained-program checkpoints cannot own complete runtime host output topology; runtime transaction participation is required"
-              .to_string(),
-        },
-        None,
-      )
-      .with_compiler_loc(),
-    )
+    Ok(vec![
+      Value::MutableReference(self.value.clone()),
+    ])
   }
 
   fn to_string(&self) -> String {
@@ -373,30 +364,25 @@ mod checkpoint_tests {
   use super::*;
 
   #[test]
-  fn runtime_host_native_function_requires_runtime_checkpoint_participation() {
-    let program = MechProgram::new(MechProgramConfig::default());
+  fn runtime_host_native_function_output_round_trips_through_program_checkpoint() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
     let plan = program.interpreter().plan();
     let value = Ref::new(Value::Empty);
+    let value_address = value.addr();
     plan.add_function(Box::new(RuntimeHostNativeFunction {
       name: "test/host".to_string(),
       host_name: "test/host".to_string(),
       arguments: Vec::new(),
       value: value.clone(),
     }));
-    let plan_before = plan.checkpoint();
+    let checkpoint = program.checkpoint().unwrap();
+    let replacement = Ref::new(Value::Index(Ref::new(99)));
+    *value.borrow_mut() = Value::MutableReference(replacement);
 
-    let error = match program.checkpoint() {
-      Ok(_) => panic!("runtime host program checkpoint unexpectedly succeeded"),
-      Err(error) => error,
-    };
+    program.restore(checkpoint).unwrap();
 
-    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
-    assert!(
-      error
-        .kind_message()
-        .contains("runtime transaction participation"),
-    );
-    assert_eq!(plan.checkpoint(), plan_before);
+    assert_eq!(value.addr(), value_address);
     assert_eq!(*value.borrow(), Value::Empty);
+    assert!(program.checkpoint().is_ok());
   }
 }

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -676,25 +676,55 @@ fn runtime_reactive_host_input_preflight_failure_mutates_nothing() {
 }
 
 #[test]
-fn transactional_context_cannot_arm_live_program() {
+fn transactional_live_program_is_provisional_until_outer_commit() {
   let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
   let mut context = runtime.runtime_context().unwrap();
   grant_read_to(&mut runtime, &context.subject, "test://clock/ticks", "value");
-  runtime.begin_transaction(&mut context).unwrap();
-  let error = format!("{:?}", runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value").unwrap_err());
-  assert!(error.contains("RuntimeTransactionalLiveProgramUnsupported"), "{error}");
+  let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+    )
+    .unwrap();
+
+  assert!(runtime.live_context_template.is_some());
+  assert!(!runtime.live_input_bindings.is_empty());
+  assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+  assert!(runtime.program.root_symbol_value("output").is_ok());
+
+  runtime
+    .abort_runtime_transaction(&mut context, "discard live program")
+    .unwrap();
+
+  assert_eq!(context.transaction, None);
   assert!(runtime.live_context_template.is_none());
   assert!(runtime.live_input_bindings.is_empty());
   assert!(runtime.persistent_sends.is_empty());
+  assert!(runtime.program.root_symbol_value("output").is_err());
 }
 
 #[test]
 fn failed_source_does_not_leave_live_state_armed() {
-  let mut runtime = test_runtime(test_provider_with("test://clock/ticks", "value", 1.0));
+  let (mut runtime, output) = test_runtime_with_output(
+    test_provider_with("test://clock/ticks", "value", 1.0),
+  );
   let mut context_a = runtime.runtime_context().unwrap().with_subject("subject-a");
   grant_read_to(&mut runtime, "subject-a", "test://clock/ticks", "value");
-  let error = runtime.run_string_with_context(&mut context_a, "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\nmissing := @pulse/missing");
+  runtime
+    .grant_capability(RuntimeCapabilityGrant {
+      subject: "subject-a".to_string(),
+      resource: TEST_OUTPUT_BASE_URI.to_string(),
+      operations: vec![RuntimeCapabilityOperation::Write],
+      paths: vec!["line".to_string()],
+    })
+    .unwrap();
+  let error = runtime.run_string_with_context(
+    &mut context_a,
+    "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\n@out/line <- output\nmissing := missing-live-value + 1",
+  );
   assert!(error.is_err());
+  assert!(!output.lines().is_empty());
   assert!(runtime.live_context_template.is_none());
   assert!(runtime.live_input_bindings.is_empty());
   assert!(runtime.persistent_sends.is_empty());

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -24,6 +24,7 @@ mod host;
 mod id;
 mod module;
 mod object;
+mod program_transaction;
 mod schedule;
 mod service;
 mod task;
@@ -33,6 +34,17 @@ mod transaction;
 mod input_tests;
 
 pub use self::errors::*;
+pub use self::program_transaction::{
+  RuntimeHealth,
+  RuntimePoisonRecord,
+};
+use self::program_transaction::{
+  ActiveRuntimeProgramOperation,
+  RuntimeContextCheckpoint,
+  RuntimeExecutionTransaction,
+  RuntimeExecutionTransactionMode,
+  RuntimeTransactionContextIdentity,
+};
 use crate::runtime::host::*;
 
 use std::sync::Arc;
@@ -57,7 +69,7 @@ use mech_core::{
 };
 
 use mech_program::{
-  MechProgram, MechProgramConfig, MechProgramEnvironment, ProgramInputId
+  MechProgram, MechProgramCheckpoint, MechProgramConfig, MechProgramEnvironment, ProgramInputId
 };
 
 
@@ -142,6 +154,7 @@ struct RuntimeLiveStateSnapshot {
   context_template: Option<RuntimeLiveContextTemplate>,
   input_bindings: HashMap<crate::RuntimeHostInputSource, Vec<ProgramInputId>>,
   persistent_sends: Vec<RuntimePersistentSend>,
+  registration_mode: LiveRegistrationMode,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -480,6 +493,9 @@ impl RuntimeBuilder {
       scheduler: self.scheduler,
       scheduler_policy: self.scheduler_policy,
       active_transactions: HashMap::new(),
+      program_transaction_owner: None,
+      active_program_operation: None,
+      health: RuntimeHealth::Healthy,
       actor_behavior_driver: self.actor_behavior_driver,
       module_builder: self.module_builder,
       resources: RuntimeResourceRegistry::new(),
@@ -555,7 +571,10 @@ pub struct MechRuntime {
   host_policy: Box<dyn HostCallPolicy>,
   scheduler: Box<dyn Scheduler>,
   scheduler_policy: SchedulerPolicy,
-  active_transactions: HashMap<TransactionId, RuntimeTransaction>,
+  active_transactions: HashMap<TransactionId, RuntimeExecutionTransaction>,
+  program_transaction_owner: Option<TransactionId>,
+  active_program_operation: Option<ActiveRuntimeProgramOperation>,
+  health: RuntimeHealth,
   actor_behavior_driver: Box<dyn ActorBehaviorDriver>,
   module_builder: ModuleBuilder,
   resources: RuntimeResourceRegistry,
@@ -675,8 +694,20 @@ impl MechRuntime {
     &self.program
   }
 
+  /// Low-level manual escape hatch outside runtime-owned atomic execution.
+  ///
+  /// Callers must not use it while a transaction owns the retained program.
+  /// Runtime internals must not use it to bypass the program coordinator.
   pub fn program_mut(&mut self) -> &mut MechProgram {
     &mut self.program
+  }
+
+  pub fn health(&self) -> &RuntimeHealth {
+    &self.health
+  }
+
+  pub fn is_poisoned(&self) -> bool {
+    matches!(self.health, RuntimeHealth::Poisoned(_))
   }
 
   pub fn bind_context_export(
@@ -1117,11 +1148,20 @@ impl MechRuntime {
   }
 
   fn validate_live_context_candidate(&self, context: &RuntimeContext) -> MResult<()> {
-    if context.transaction.is_some() {
-      return Err(MechError::new(RuntimeInvalidOperationError {
-        operation: "RuntimeTransactionalLiveProgramUnsupported",
-        reason: "live context reads and persistent sends cannot be armed under an active transaction".to_string(),
-      }, None));
+    if let Some(transaction_id) = context.transaction {
+      let active_operation = self.active_program_operation.as_ref();
+      if self.program_transaction_owner != Some(transaction_id)
+        || active_operation.map(|active| active.transaction_id) != Some(transaction_id)
+      {
+        return Err(MechError::new(
+          RuntimeTransactionalLiveRegistrationUnsupported {
+            transaction_id,
+            owner: self.program_transaction_owner,
+            active_operation: active_operation.map(|active| active.operation),
+          },
+          None,
+        ));
+      }
     }
     match &self.live_context_template {
       Some(template) if template.matches_context(context) => Ok(()),
@@ -1144,6 +1184,7 @@ impl MechRuntime {
       context_template: self.live_context_template.clone(),
       input_bindings: self.live_input_bindings.clone(),
       persistent_sends: self.persistent_sends.clone(),
+      registration_mode: self.live_registration_mode,
     }
   }
 
@@ -1151,6 +1192,7 @@ impl MechRuntime {
     self.live_context_template = snapshot.context_template;
     self.live_input_bindings = snapshot.input_bindings;
     self.persistent_sends = snapshot.persistent_sends;
+    self.live_registration_mode = snapshot.registration_mode;
   }
 
   fn live_turn_context(&self) -> MResult<RuntimeContext> {
@@ -1226,24 +1268,13 @@ impl MechRuntime {
     }
 
     if let Some(transaction_id) = context.transaction {
-      let transaction = self
-        .active_transactions
-        .get(&transaction_id)
-        .ok_or_else(|| {
-          MechError::new(
-            RuntimeTransactionNotFoundError { transaction_id },
-            None,
-          )
-        })?;
+      let transaction = self.active_execution_transaction(transaction_id)?;
 
-      if transaction.subject != context.subject {
+      if let Some(reason) = transaction.context_identity.mismatch_reason(context) {
         return Err(MechError::new(
-          RuntimeInvalidOperationError {
-            operation: "validate_context_for_runtime",
-            reason: format!(
-              "transaction {} subject mismatch: transaction owner subject `{}`, supplied context subject `{}`",
-              transaction_id, transaction.subject, context.subject,
-            ),
+          RuntimeTransactionContextMismatch {
+            transaction_id,
+            reason,
           },
           None,
         ));
@@ -1285,7 +1316,7 @@ impl MechRuntime {
     self.trim_events_to_retention(&mut context.events);
     if let Some(transaction_id) = context.transaction {
       if let Some(transaction) = self.active_transactions.get_mut(&transaction_id) {
-        transaction.stage_event(event)?;
+        transaction.store.stage_event(event)?;
         return Ok(id);
       }
     }

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -522,7 +522,10 @@ impl MechRuntime {
     options: ModuleBuildOptions<'_>,
   ) -> MResult<Value> {
     let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
+    self.preflight_atomic_program_operation(
+      context,
+      "resolve_and_run_root_module_with_context",
+    )?;
 
     let request = request.into();
     request.validate()?;

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -527,44 +527,60 @@ impl MechRuntime {
     let request = request.into();
     request.validate()?;
     let root_specifier = request.specifier.clone();
-    let previous_module_version = context.module_version;
+    let Some(root_version) = self.build_module_from_request_with_context(
+      context,
+      request,
+      options,
+    )? else {
+      return Err(MechError::new(
+        RuntimeRootModuleSourceNotFound { specifier: root_specifier },
+        None,
+      ));
+    };
 
-    let result = (|| -> MResult<Value> {
-      let Some(root_version) = self.build_module_from_request_with_context(
+    let result = self.with_atomic_program_operation(
+      context,
+      "resolve_and_run_root_module_with_context",
+      |runtime, context| {
+        context.module_version = Some(root_version);
+
+        let mut preflight_seen = HashSet::new();
+        runtime.preflight_module_graph_for_scope(
+          context,
+          root_version,
+          &SourceScope::Program,
+          &mut preflight_seen,
+        )?;
+
+        let mut seen = HashSet::new();
+        let mut module_instances = HashMap::new();
+        runtime.execute_module_retained_root_for_scope(
+          context,
+          root_version,
+          &SourceScope::Program,
+          &mut seen,
+          &mut module_instances,
+          turn_started,
+        )
+      },
+    );
+
+    if let Err(error) = &result {
+      let _ = self.emit_event_to_context(
         context,
-        request,
-        options,
-      )? else {
-        return Err(MechError::new(
-          RuntimeRootModuleSourceNotFound { specifier: root_specifier },
-          None,
-        ));
-      };
-
-      context.module_version = Some(root_version);
-
-      let mut preflight_seen = HashSet::new();
-      self.preflight_module_graph_for_scope(
+        RuntimeEventKind::ModuleExecutionFailed {
+          module_version: root_version,
+          message: format!("{:?}", error),
+        },
+      );
+      let _ = self.emit_event_to_context(
         context,
-        root_version,
-        &SourceScope::Program,
-        &mut preflight_seen,
-      )?;
-
-      let mut seen = HashSet::new();
-      let mut module_instances = HashMap::new();
-      let value = self.execute_module_retained_root_for_scope(
-        context,
-        root_version,
-        &SourceScope::Program,
-        &mut seen,
-        &mut module_instances,
-        turn_started,
-      )?;
-      Ok(value)
-    })();
-
-    context.module_version = previous_module_version;
+        RuntimeEventKind::ProgramFailed {
+          task_id: context.task,
+          message: format!("{:?}", error),
+        },
+      );
+    }
     result
   }
 

--- a/src/runtime/src/runtime/object.rs
+++ b/src/runtime/src/runtime/object.rs
@@ -72,7 +72,7 @@ impl MechRuntime {
 
     if let Some(transaction_id) = context.transaction {
       if let Some(transaction) = self.active_transactions.get(&transaction_id) {
-        if let Some(object) = transaction.get_staged_object(id) {
+        if let Some(object) = transaction.store.get_staged_object(id) {
           return Ok(Some(object));
         }
       }

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -207,6 +207,35 @@ pub(super) struct ActiveRuntimeProgramOperation {
   pub(super) operation: &'static str,
 }
 
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProgramTransactionTestFault {
+  RemoveImplicitEnvelopeBeforeCleanup,
+  FailImplicitStoreAbort,
+}
+
+#[cfg(test)]
+thread_local! {
+  static PROGRAM_TRANSACTION_TEST_FAULT:
+    std::cell::RefCell<Option<ProgramTransactionTestFault>> =
+      const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn set_program_transaction_test_fault(fault: ProgramTransactionTestFault) {
+  PROGRAM_TRANSACTION_TEST_FAULT.with(|slot| {
+    assert!(
+      slot.replace(Some(fault)).is_none(),
+      "program transaction test fault was already armed",
+    );
+  });
+}
+
+#[cfg(test)]
+fn take_program_transaction_test_fault() -> Option<ProgramTransactionTestFault> {
+  PROGRAM_TRANSACTION_TEST_FAULT.with(|slot| slot.replace(None))
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimeHealth {
   Healthy,
@@ -348,6 +377,169 @@ impl MechRuntime {
     failures
   }
 
+  fn validate_implicit_cleanup_complete(
+    &self,
+    context: &RuntimeContext,
+    transaction_id: TransactionId,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    if self.active_transactions.contains_key(&transaction_id) {
+      failures.push(format!(
+        "active implicit transaction envelope {} still exists after cleanup",
+        transaction_id,
+      ));
+    }
+    if self.program_transaction_owner == Some(transaction_id) {
+      failures.push(format!(
+        "program owner still references implicit transaction {} after cleanup",
+        transaction_id,
+      ));
+    }
+    if context.transaction == Some(transaction_id) {
+      failures.push(format!(
+        "runtime context still references implicit transaction {} after cleanup",
+        transaction_id,
+      ));
+    }
+    if self
+      .active_program_operation
+      .as_ref()
+      .is_some_and(|active| active.transaction_id == transaction_id)
+    {
+      failures.push(format!(
+        "active program operation still references implicit transaction {} after cleanup",
+        transaction_id,
+      ));
+    }
+
+    failures
+  }
+
+  fn finish_implicit_cleanup_best_effort(
+    &mut self,
+    context: &mut RuntimeContext,
+    transaction_id: TransactionId,
+    reason: &str,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    if let Some(transaction) = self.active_transactions.remove(&transaction_id) {
+      if let Err(error) = transaction.store.abort(reason) {
+        failures.push(format!(
+          "best-effort staged store discard failed: {:?}",
+          error,
+        ));
+      }
+    }
+    if self.program_transaction_owner == Some(transaction_id) {
+      self.program_transaction_owner = None;
+    }
+    if context.transaction == Some(transaction_id) {
+      context.transaction = None;
+    }
+    if self
+      .active_program_operation
+      .as_ref()
+      .is_some_and(|active| active.transaction_id == transaction_id)
+    {
+      self.active_program_operation = None;
+    }
+
+    failures
+  }
+
+  #[cfg(test)]
+  fn apply_program_transaction_test_fault(
+    &mut self,
+    transaction_id: TransactionId,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    match take_program_transaction_test_fault() {
+      Some(ProgramTransactionTestFault::RemoveImplicitEnvelopeBeforeCleanup) => {
+        self.active_transactions.remove(&transaction_id);
+      }
+      Some(ProgramTransactionTestFault::FailImplicitStoreAbort) => {
+        match self.active_transactions.get_mut(&transaction_id) {
+          Some(transaction) => {
+            transaction.store.status =
+              crate::transaction::TransactionStatus::Committed;
+          }
+          None => failures.push(format!(
+            "could not arm staged-store abort failure for missing implicit transaction {}",
+            transaction_id,
+          )),
+        }
+      }
+      None => {}
+    }
+
+    failures
+  }
+
+  fn cleanup_failed_implicit_operation(
+    &mut self,
+    context: &mut RuntimeContext,
+    operation: &'static str,
+    transaction_id: TransactionId,
+    reason: &str,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    #[cfg(test)]
+    failures.extend(
+      self.apply_program_transaction_test_fault(transaction_id),
+    );
+
+    match self.abort_runtime_transaction_cleanup(
+      context,
+      reason,
+      false,
+    ) {
+      Ok((cleaned_transaction_id, cleanup_failures)) => {
+        failures.extend(cleanup_failures);
+        if cleaned_transaction_id != transaction_id {
+          failures.push(format!(
+            "implicit cleanup targeted transaction {}, expected {}",
+            cleaned_transaction_id,
+            transaction_id,
+          ));
+        }
+      }
+      Err(error) => failures.push(format!(
+        "implicit transaction cleanup for `{}` transaction {} could not start: {:?}",
+        operation,
+        transaction_id,
+        error,
+      )),
+    }
+
+    let invariant_failures =
+      self.validate_implicit_cleanup_complete(context, transaction_id);
+    if !invariant_failures.is_empty() {
+      failures.extend(invariant_failures);
+      failures.extend(self.finish_implicit_cleanup_best_effort(
+        context,
+        transaction_id,
+        reason,
+      ));
+      failures.extend(
+        self
+          .validate_implicit_cleanup_complete(context, transaction_id)
+          .into_iter()
+          .map(|failure| {
+            format!(
+              "implicit cleanup invariant remained unsatisfied: {}",
+              failure,
+            )
+          }),
+      );
+    }
+
+    failures
+  }
+
   pub(super) fn preflight_atomic_program_operation(
     &self,
     context: &RuntimeContext,
@@ -467,11 +659,21 @@ impl MechRuntime {
 
     if rollback_failures.is_empty() {
       if implicit {
-        let _ = self.abort_runtime_transaction_internal(
+        let cleanup_failures = self.cleanup_failed_implicit_operation(
           context,
-          format!("retained program operation `{}` failed", operation),
-          false,
+          operation,
+          transaction_id,
+          &format!("retained program operation `{}` failed", operation),
         );
+        if cleanup_failures.is_empty() {
+          return Err(original_error);
+        }
+        return Err(self.poison_program_operation(
+          operation,
+          Some(transaction_id),
+          original_error_text,
+          cleanup_failures,
+        ));
       } else if first_explicit_operation {
         self.program_transaction_owner = None;
         if let Ok(transaction) =
@@ -483,13 +685,17 @@ impl MechRuntime {
       return Err(original_error);
     }
 
+    let mut rollback_failures = rollback_failures;
     if implicit {
-      let _ = self.abort_runtime_transaction_internal(
+      rollback_failures.extend(self.cleanup_failed_implicit_operation(
         context,
-        format!("retained program operation `{}` rollback failed", operation),
-        false,
-      );
-      self.program_transaction_owner = None;
+        operation,
+        transaction_id,
+        &format!(
+          "retained program operation `{}` rollback failed",
+          operation,
+        ),
+      ));
     }
 
     Err(self.poison_program_operation(
@@ -684,7 +890,7 @@ mod tests {
 
     let error = runtime.run_source_with_context(&mut context, &source);
 
-    assert!(error.is_err());
+    assert_eq!(error.unwrap_err().kind_name(), "UndefinedVariable");
     assert!(runtime.program.root_symbol_value("round3-partial").is_err());
     assert_eq!(runtime.program.interpreter().plan_len(), plan_len_before);
     assert_eq!(
@@ -741,6 +947,108 @@ mod tests {
         RuntimeEventKind::ProgramCompleted { .. }
       )
     }));
+  }
+
+  #[test]
+  fn implicit_cleanup_failure_returns_rollback_error_and_poisons_runtime() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let mut implicit_transaction_id = None;
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "implicit_cleanup_failure_test",
+      |_runtime, context| {
+        implicit_transaction_id = context.transaction;
+        set_program_transaction_test_fault(
+          ProgramTransactionTestFault::FailImplicitStoreAbort,
+        );
+        Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "implicit_cleanup_failure_test",
+            reason: "deliberate implicit execution failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    let transaction_id =
+      implicit_transaction_id.expect("implicit transaction should be active");
+    let error = result.unwrap_err();
+    assert_eq!(error.kind_name(), "RuntimeProgramRollbackFailed");
+    assert!(runtime.is_poisoned());
+    let poison = match runtime.health() {
+      RuntimeHealth::Healthy => panic!("runtime should be poisoned"),
+      RuntimeHealth::Poisoned(poison) => poison,
+    };
+    assert!(
+      poison
+        .original_error
+        .contains("deliberate implicit execution failure"),
+    );
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("staged store discard invariant failed")
+        && failure.contains("transaction is not open")
+    }));
+    assert!(!runtime.active_transactions.contains_key(&transaction_id));
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert!(runtime.active_program_operation.is_none());
+  }
+
+  #[test]
+  fn missing_implicit_envelope_during_cleanup_is_not_hidden() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let mut implicit_transaction_id = None;
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "missing_implicit_envelope_test",
+      |_runtime, context| {
+        implicit_transaction_id = context.transaction;
+        set_program_transaction_test_fault(
+          ProgramTransactionTestFault::RemoveImplicitEnvelopeBeforeCleanup,
+        );
+        Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "missing_implicit_envelope_test",
+            reason: "deliberate implicit execution failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    let transaction_id =
+      implicit_transaction_id.expect("implicit transaction should be active");
+    let error = result.unwrap_err();
+    assert_eq!(error.kind_name(), "RuntimeProgramRollbackFailed");
+    assert!(runtime.is_poisoned());
+    let poison = match runtime.health() {
+      RuntimeHealth::Healthy => panic!("runtime should be poisoned"),
+      RuntimeHealth::Poisoned(poison) => poison,
+    };
+    assert!(
+      poison
+        .original_error
+        .contains("deliberate implicit execution failure"),
+    );
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("implicit transaction cleanup")
+        && failure.contains("could not start")
+    }));
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("program owner still references implicit transaction")
+    }));
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("runtime context still references implicit transaction")
+    }));
+    assert!(!runtime.active_transactions.contains_key(&transaction_id));
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert!(runtime.active_program_operation.is_none());
   }
 
   #[test]

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -1,0 +1,492 @@
+//! Runtime-owned execution transaction coordination.
+//!
+//! [`RuntimeTransaction`] remains the staged-store component. The private
+//! execution envelope in this module coordinates it with retained-program,
+//! live-runtime, and context state.
+
+use super::*;
+use crate::AccessSet;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RuntimeExecutionTransactionMode {
+  Explicit,
+  ImplicitProgramOperation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct RuntimeTransactionContextIdentity {
+  runtime: RuntimeId,
+  subject: String,
+  task: Option<TaskId>,
+  actor: Option<ActorId>,
+  actor_message: Option<MessageRecord>,
+  actor_state: Option<ObjectId>,
+}
+
+impl RuntimeTransactionContextIdentity {
+  pub(super) fn capture(context: &RuntimeContext) -> Self {
+    Self {
+      runtime: context.runtime,
+      subject: context.subject.clone(),
+      task: context.task,
+      actor: context.actor,
+      actor_message: context.actor_message.clone(),
+      actor_state: context.actor_state,
+    }
+  }
+
+  pub(super) fn mismatch_reason(&self, context: &RuntimeContext) -> Option<String> {
+    if self.runtime != context.runtime {
+      return Some(format!(
+        "runtime changed from {} to {}",
+        self.runtime,
+        context.runtime,
+      ));
+    }
+    if self.subject != context.subject {
+      return Some(format!(
+        "subject changed from `{}` to `{}`",
+        self.subject,
+        context.subject,
+      ));
+    }
+    if self.task != context.task {
+      return Some(format!(
+        "task changed from {:?} to {:?}",
+        self.task,
+        context.task,
+      ));
+    }
+    if self.actor != context.actor {
+      return Some(format!(
+        "actor changed from {:?} to {:?}",
+        self.actor,
+        context.actor,
+      ));
+    }
+    if self.actor_message != context.actor_message {
+      return Some("actor message changed".to_string());
+    }
+    if self.actor_state != context.actor_state {
+      return Some(format!(
+        "actor state changed from {:?} to {:?}",
+        self.actor_state,
+        context.actor_state,
+      ));
+    }
+    None
+  }
+}
+
+#[derive(Clone)]
+pub(super) struct RuntimeContextCheckpoint {
+  runtime: RuntimeId,
+  subject: String,
+  task: Option<TaskId>,
+  actor: Option<ActorId>,
+  access: AccessSet,
+  module_version: Option<ModuleVersionId>,
+  transaction: Option<TransactionId>,
+  capabilities: Vec<CapabilityId>,
+  budget: ResourceBudget,
+  events: Vec<RuntimeEvent>,
+  actor_message: Option<MessageRecord>,
+  actor_state: Option<ObjectId>,
+}
+
+impl RuntimeContextCheckpoint {
+  pub(super) fn capture(context: &RuntimeContext) -> Self {
+    Self {
+      runtime: context.runtime,
+      subject: context.subject.clone(),
+      task: context.task,
+      actor: context.actor,
+      access: context.access.clone(),
+      module_version: context.module_version,
+      transaction: context.transaction,
+      capabilities: context.capabilities.clone(),
+      budget: context.budget.clone(),
+      events: context.events.clone(),
+      actor_message: context.actor_message.clone(),
+      actor_state: context.actor_state,
+    }
+  }
+
+  pub(super) fn restore_preserving_consumption(&self, context: &mut RuntimeContext) {
+    let used_steps = context.budget.used_steps.max(self.budget.used_steps);
+    let used_bytes = context.budget.used_bytes.max(self.budget.used_bytes);
+    let used_items = context.budget.used_items.max(self.budget.used_items);
+    let used_messages = context.budget.used_messages.max(self.budget.used_messages);
+
+    context.runtime = self.runtime;
+    context.subject = self.subject.clone();
+    context.task = self.task;
+    context.actor = self.actor;
+    context.access = self.access.clone();
+    context.module_version = self.module_version;
+    context.transaction = self.transaction;
+    context.capabilities = self.capabilities.clone();
+    context.budget = ResourceBudget {
+      max_steps: self.budget.max_steps,
+      used_steps,
+      max_bytes: self.budget.max_bytes,
+      used_bytes,
+      max_items: self.budget.max_items,
+      used_items,
+      max_messages: self.budget.max_messages,
+      used_messages,
+    };
+    context.events = self.events.clone();
+    context.actor_message = self.actor_message.clone();
+    context.actor_state = self.actor_state;
+  }
+
+  pub(super) fn access_delta(&self, context: &RuntimeContext) -> AccessSet {
+    AccessSet {
+      reads: context
+        .access
+        .reads
+        .iter()
+        .copied()
+        .filter(|object| !self.access.reads.contains(object))
+        .collect(),
+      writes: context
+        .access
+        .writes
+        .iter()
+        .copied()
+        .filter(|object| !self.access.writes.contains(object))
+        .collect(),
+    }
+  }
+}
+
+#[derive(Clone)]
+pub(super) struct RuntimeProgramBaseline {
+  pub(super) program: MechProgramCheckpoint,
+  pub(super) live: RuntimeLiveStateSnapshot,
+}
+
+#[derive(Clone)]
+pub(super) struct RuntimeExecutionTransaction {
+  pub(super) store: RuntimeTransaction,
+  pub(super) mode: RuntimeExecutionTransactionMode,
+  pub(super) context_identity: RuntimeTransactionContextIdentity,
+  pub(super) context_baseline: RuntimeContextCheckpoint,
+  pub(super) program: Option<RuntimeProgramBaseline>,
+}
+
+impl RuntimeExecutionTransaction {
+  pub(super) fn new(
+    store: RuntimeTransaction,
+    mode: RuntimeExecutionTransactionMode,
+    context_identity: RuntimeTransactionContextIdentity,
+    context_baseline: RuntimeContextCheckpoint,
+  ) -> Self {
+    Self {
+      store,
+      mode,
+      context_identity,
+      context_baseline,
+      program: None,
+    }
+  }
+}
+
+#[derive(Clone)]
+pub(super) struct RuntimeProgramOperationSavepoint {
+  pub(super) program: MechProgramCheckpoint,
+  pub(super) live: RuntimeLiveStateSnapshot,
+  pub(super) transaction: RuntimeExecutionTransaction,
+  pub(super) context: RuntimeContextCheckpoint,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ActiveRuntimeProgramOperation {
+  pub(super) transaction_id: TransactionId,
+  pub(super) operation: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeHealth {
+  Healthy,
+  Poisoned(RuntimePoisonRecord),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimePoisonRecord {
+  pub operation: String,
+  pub transaction_id: Option<TransactionId>,
+  pub original_error: String,
+  pub rollback_failures: Vec<String>,
+}
+
+impl MechRuntime {
+  pub(super) fn ensure_runtime_healthy(
+    &self,
+    operation: &'static str,
+  ) -> MResult<()> {
+    match &self.health {
+      RuntimeHealth::Healthy => Ok(()),
+      RuntimeHealth::Poisoned(poison) => Err(MechError::new(
+        RuntimePoisoned {
+          operation,
+          poison: poison.clone(),
+        },
+        None,
+      )),
+    }
+  }
+
+  pub(super) fn reject_program_operation_reentrancy(
+    &self,
+    requested_operation: &'static str,
+  ) -> MResult<()> {
+    let Some(active) = &self.active_program_operation else {
+      return Ok(());
+    };
+    Err(MechError::new(
+      RuntimeProgramOperationReentrant {
+        active_operation: active.operation,
+        requested_operation,
+        transaction_id: active.transaction_id,
+      },
+      None,
+    ))
+  }
+
+  pub(super) fn reject_transactional_reactive_turn(
+    &self,
+    context: &RuntimeContext,
+    operation: &'static str,
+  ) -> MResult<()> {
+    if context.transaction.is_none() && self.program_transaction_owner.is_none() {
+      return Ok(());
+    }
+    Err(MechError::new(
+      RuntimeTransactionalReactiveTurnUnsupported {
+        operation,
+        transaction_id: context.transaction,
+        owner: self.program_transaction_owner,
+      },
+      None,
+    ))
+  }
+
+  pub(super) fn poison_program_operation(
+    &mut self,
+    operation: &'static str,
+    transaction_id: Option<TransactionId>,
+    original_error: String,
+    rollback_failures: Vec<String>,
+  ) -> MechError {
+    self.health = RuntimeHealth::Poisoned(RuntimePoisonRecord {
+      operation: operation.to_string(),
+      transaction_id,
+      original_error: original_error.clone(),
+      rollback_failures: rollback_failures.clone(),
+    });
+    MechError::new(
+      RuntimeProgramRollbackFailed {
+        operation,
+        transaction_id,
+        original_error,
+        rollback_failures,
+      },
+      None,
+    )
+  }
+
+  fn coordinator_invariant_failure<T>(
+    &mut self,
+    operation: &'static str,
+    transaction_id: Option<TransactionId>,
+    reason: impl Into<String>,
+  ) -> MResult<T> {
+    let reason = reason.into();
+    Err(self.poison_program_operation(
+      operation,
+      transaction_id,
+      "runtime program coordinator preflight failed".to_string(),
+      vec![reason],
+    ))
+  }
+
+  fn rollback_program_operation(
+    &mut self,
+    context: &mut RuntimeContext,
+    transaction_id: TransactionId,
+    savepoint: &RuntimeProgramOperationSavepoint,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    if let Err(error) = self.program.restore(savepoint.program.clone()) {
+      failures.push(format!("program restore failed: {:?}", error));
+    }
+
+    self.restore_live_state(savepoint.live.clone());
+
+    if !self.active_transactions.contains_key(&transaction_id) {
+      failures.push(format!(
+        "active execution transaction {} disappeared before operation rollback",
+        transaction_id,
+      ));
+    }
+    self.active_transactions.insert(
+      transaction_id,
+      savepoint.transaction.clone(),
+    );
+
+    savepoint
+      .context
+      .restore_preserving_consumption(context);
+
+    if let Err(error) = self.validate_context_for_runtime(context) {
+      failures.push(format!("context restore invariant failed: {:?}", error));
+    }
+
+    failures
+  }
+
+  pub(super) fn with_atomic_program_operation<T>(
+    &mut self,
+    context: &mut RuntimeContext,
+    operation: &'static str,
+    execute: impl FnOnce(
+      &mut MechRuntime,
+      &mut RuntimeContext,
+    ) -> MResult<T>,
+  ) -> MResult<T> {
+    self.ensure_runtime_healthy(operation)?;
+    self.validate_context_for_runtime(context)?;
+    self.reject_program_operation_reentrancy(operation)?;
+
+    let requested_transaction = context.transaction;
+    if let Some(owner) = self.program_transaction_owner {
+      if requested_transaction != Some(owner) {
+        return Err(MechError::new(
+          RuntimeProgramBusy {
+            operation,
+            owner,
+            requester: requested_transaction,
+          },
+          None,
+        ));
+      }
+    }
+
+    let implicit = requested_transaction.is_none();
+    let mut first_explicit_operation = false;
+
+    let (transaction_id, program_checkpoint, live_checkpoint) = if implicit {
+      let program_checkpoint = self.program.checkpoint()?;
+      let live_checkpoint = self.live_state_snapshot();
+      let transaction_id = self.begin_runtime_transaction_internal(
+        context,
+        RuntimeExecutionTransactionMode::ImplicitProgramOperation,
+      )?;
+      self.active_execution_transaction_mut(transaction_id)?.program =
+        Some(RuntimeProgramBaseline {
+          program: program_checkpoint.clone(),
+          live: live_checkpoint.clone(),
+        });
+      self.program_transaction_owner = Some(transaction_id);
+      (transaction_id, program_checkpoint, live_checkpoint)
+    } else {
+      let transaction_id = requested_transaction.unwrap();
+      let mode = self.active_execution_transaction(transaction_id)?.mode;
+      if mode != RuntimeExecutionTransactionMode::Explicit {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "a public retained operation entered an implicit execution transaction without reentrancy detection",
+        );
+      }
+
+      let program_checkpoint = self.program.checkpoint()?;
+      let live_checkpoint = self.live_state_snapshot();
+      if self.program_transaction_owner.is_none() {
+        self.active_execution_transaction_mut(transaction_id)?.program =
+          Some(RuntimeProgramBaseline {
+            program: program_checkpoint.clone(),
+            live: live_checkpoint.clone(),
+          });
+        self.program_transaction_owner = Some(transaction_id);
+        first_explicit_operation = true;
+      } else if self.active_execution_transaction(transaction_id)?.program.is_none() {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "program ownership exists without a transaction program baseline",
+        );
+      }
+      (transaction_id, program_checkpoint, live_checkpoint)
+    };
+
+    let savepoint = RuntimeProgramOperationSavepoint {
+      program: program_checkpoint,
+      live: live_checkpoint,
+      transaction: self
+        .active_execution_transaction(transaction_id)?
+        .clone(),
+      context: RuntimeContextCheckpoint::capture(context),
+    };
+
+    self.active_program_operation = Some(ActiveRuntimeProgramOperation {
+      transaction_id,
+      operation,
+    });
+    let execution_result = execute(self, context);
+    self.active_program_operation = None;
+
+    let original_error = match execution_result {
+      Ok(value) if implicit => match self.commit_runtime_transaction_internal(context) {
+        Ok(_) => return Ok(value),
+        Err(error) => error,
+      },
+      Ok(value) => return Ok(value),
+      Err(error) => error,
+    };
+
+    let original_error_text = format!("{:?}", original_error);
+    let rollback_failures = self.rollback_program_operation(
+      context,
+      transaction_id,
+      &savepoint,
+    );
+
+    if rollback_failures.is_empty() {
+      if implicit {
+        let _ = self.abort_runtime_transaction_internal(
+          context,
+          format!("retained program operation `{}` failed", operation),
+          false,
+        );
+      } else if first_explicit_operation {
+        self.program_transaction_owner = None;
+        if let Ok(transaction) =
+          self.active_execution_transaction_mut(transaction_id)
+        {
+          transaction.program = None;
+        }
+      }
+      return Err(original_error);
+    }
+
+    if implicit {
+      let _ = self.abort_runtime_transaction_internal(
+        context,
+        format!("retained program operation `{}` rollback failed", operation),
+        false,
+      );
+      self.program_transaction_owner = None;
+    }
+
+    Err(self.poison_program_operation(
+      operation,
+      Some(transaction_id),
+      original_error_text,
+      rollback_failures,
+    ))
+  }
+}

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -534,4 +534,131 @@ mod tests {
     assert_eq!(runtime.program.interpreter().plan_len(), plan_len_before);
     assert!(runtime.program.root_symbol_value("round3-owned").is_err());
   }
+
+  #[test]
+  fn program_transaction_implicit_success_commits_program_store_and_events() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "round3-implicit-success := 7",
+      )
+      .unwrap();
+
+    assert!(
+      runtime
+        .program
+        .root_symbol_value("round3-implicit-success")
+        .is_ok(),
+    );
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert_eq!(runtime.list_transactions(None).unwrap().len(), 1);
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramCompleted { .. }
+      )
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::TransactionCommitted { .. }
+      )
+    }));
+  }
+
+  #[test]
+  fn program_transaction_implicit_partial_failure_restores_everything() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    runtime
+      .run_string("round3-anchor := 1")
+      .unwrap();
+    let anchor = runtime
+      .program
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(hash_str("round3-anchor"))
+      .unwrap()
+      .clone();
+    let anchor_address = anchor.addr();
+    let plan_len_before = runtime.program.interpreter().plan_len();
+    let live_before = runtime.live_state_snapshot();
+    let transactions_before = runtime.list_transactions(None).unwrap().len();
+    let events_before = runtime.list_events(None).unwrap().len();
+    let mut context = runtime.runtime_context().unwrap();
+    let source = MechSourceCode::Program(vec![
+      MechSourceCode::String(
+        "round3-partial := round3-anchor + 1".to_string(),
+      ),
+      MechSourceCode::String(
+        "round3-failure := missing-round3-value + 1".to_string(),
+      ),
+    ]);
+
+    let error = runtime.run_source_with_context(&mut context, &source);
+
+    assert!(error.is_err());
+    assert!(runtime.program.root_symbol_value("round3-partial").is_err());
+    assert_eq!(runtime.program.interpreter().plan_len(), plan_len_before);
+    assert_eq!(
+      runtime
+        .program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("round3-anchor"))
+        .unwrap()
+        .addr(),
+      anchor_address,
+    );
+    assert_eq!(
+      runtime.live_state_snapshot().context_template.is_some(),
+      live_before.context_template.is_some(),
+    );
+    assert_eq!(
+      runtime.live_state_snapshot().input_bindings,
+      live_before.input_bindings,
+    );
+    assert_eq!(
+      runtime.live_state_snapshot().persistent_sends.len(),
+      live_before.persistent_sends.len(),
+    );
+    assert_eq!(
+      runtime.live_state_snapshot().registration_mode,
+      live_before.registration_mode,
+    );
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert_eq!(
+      runtime.list_transactions(None).unwrap().len(),
+      transactions_before,
+    );
+    let events = runtime.list_events(None).unwrap();
+    let new_events = &events[events_before..];
+    assert!(new_events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::TransactionAborted { .. }
+      )
+    }));
+    assert!(new_events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramFailed { .. }
+      )
+    }));
+    assert!(!new_events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ProgramCompleted { .. }
+      )
+    }));
+  }
 }

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -348,6 +348,31 @@ impl MechRuntime {
     failures
   }
 
+  pub(super) fn preflight_atomic_program_operation(
+    &self,
+    context: &RuntimeContext,
+    operation: &'static str,
+  ) -> MResult<()> {
+    self.ensure_runtime_healthy(operation)?;
+    self.validate_context_for_runtime(context)?;
+    self.reject_program_operation_reentrancy(operation)?;
+
+    if let Some(owner) = self.program_transaction_owner {
+      if context.transaction != Some(owner) {
+        return Err(MechError::new(
+          RuntimeProgramBusy {
+            operation,
+            owner,
+            requester: context.transaction,
+          },
+          None,
+        ));
+      }
+    }
+
+    Ok(())
+  }
+
   pub(super) fn with_atomic_program_operation<T>(
     &mut self,
     context: &mut RuntimeContext,
@@ -357,24 +382,9 @@ impl MechRuntime {
       &mut RuntimeContext,
     ) -> MResult<T>,
   ) -> MResult<T> {
-    self.ensure_runtime_healthy(operation)?;
-    self.validate_context_for_runtime(context)?;
-    self.reject_program_operation_reentrancy(operation)?;
+    self.preflight_atomic_program_operation(context, operation)?;
 
     let requested_transaction = context.transaction;
-    if let Some(owner) = self.program_transaction_owner {
-      if requested_transaction != Some(owner) {
-        return Err(MechError::new(
-          RuntimeProgramBusy {
-            operation,
-            owner,
-            requester: requested_transaction,
-          },
-          None,
-        ));
-      }
-    }
-
     let implicit = requested_transaction.is_none();
     let mut first_explicit_operation = false;
 
@@ -494,6 +504,77 @@ impl MechRuntime {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::collections::VecDeque;
+  use std::sync::Mutex;
+
+  use crate::capability::{
+    BasicCapability, BasicOperation, BasicResource, BasicSubject,
+  };
+  use crate::{
+    ClosureHostFunction, NodeId,
+  };
+
+  #[derive(Debug)]
+  struct ScriptedEventIdGenerator {
+    next: u128,
+    event_ids: VecDeque<EventId>,
+  }
+
+  impl ScriptedEventIdGenerator {
+    fn new(next: u128, event_ids: impl IntoIterator<Item = EventId>) -> Self {
+      Self {
+        next,
+        event_ids: event_ids.into_iter().collect(),
+      }
+    }
+
+    fn next_id(&mut self) -> u128 {
+      let id = self.next;
+      self.next = self.next.saturating_add(1);
+      id
+    }
+  }
+
+  impl IdGenerator for ScriptedEventIdGenerator {
+    fn runtime_id(&mut self) -> RuntimeId {
+      RuntimeId(self.next_id())
+    }
+
+    fn object_id(&mut self) -> ObjectId {
+      ObjectId(self.next_id())
+    }
+
+    fn actor_id(&mut self) -> ActorId {
+      ActorId(self.next_id())
+    }
+
+    fn task_id(&mut self) -> TaskId {
+      TaskId(self.next_id())
+    }
+
+    fn capability_id(&mut self) -> CapabilityId {
+      CapabilityId(self.next_id())
+    }
+
+    fn transaction_id(&mut self) -> TransactionId {
+      TransactionId(self.next_id())
+    }
+
+    fn event_id(&mut self) -> EventId {
+      self
+        .event_ids
+        .pop_front()
+        .unwrap_or_else(|| EventId(self.next_id()))
+    }
+
+    fn node_id(&mut self) -> NodeId {
+      NodeId(self.next_id())
+    }
+
+    fn message_id(&mut self) -> MessageId {
+      MessageId(self.next_id())
+    }
+  }
 
   #[test]
   fn program_transaction_outer_abort_restores_program_baseline() {
@@ -660,5 +741,563 @@ mod tests {
         RuntimeEventKind::ProgramCompleted { .. }
       )
     }));
+  }
+
+  #[test]
+  fn explicit_program_operations_use_savepoints_before_outer_abort() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .run_string_with_context(&mut context, "round3-a := 1")
+      .unwrap();
+    let plan_len_after_a = runtime.program.interpreter().plan_len();
+    let events_after_a = context.events.clone();
+    let access_after_a = context.access.clone();
+    let staged_events_after_a = runtime
+      .active_transaction_mut(transaction_id)
+      .unwrap()
+      .staged_event_ids();
+
+    let failure: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "explicit_b_test",
+      |runtime, context| {
+        runtime.program.run_source(&MechSourceCode::String(
+          "round3-b := round3-a + 1".to_string(),
+        ))?;
+        runtime
+          .active_transaction_mut(transaction_id)?
+          .stage_put_object(ObjectRecord::text(
+            ObjectId(350),
+            "note",
+            "B provisional",
+          ))?;
+        context.record_write(ObjectId(350));
+        runtime.emit_event_to_context(
+          context,
+          RuntimeEventKind::ObjectCreated {
+            object_id: ObjectId(350),
+          },
+        )?;
+        Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "explicit_b_test",
+            reason: "deliberate B failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    assert!(failure.is_err());
+    assert!(runtime.program.root_symbol_value("round3-a").is_ok());
+    assert!(runtime.program.root_symbol_value("round3-b").is_err());
+    assert_eq!(runtime.program.interpreter().plan_len(), plan_len_after_a);
+    assert_eq!(context.events, events_after_a);
+    assert_eq!(context.access, access_after_a);
+    let transaction = runtime.active_transaction_mut(transaction_id).unwrap();
+    assert_eq!(transaction.staged_puts().count(), 0);
+    assert_eq!(transaction.staged_event_ids(), staged_events_after_a);
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "round3-c := round3-a + 2",
+      )
+      .unwrap();
+    assert!(runtime.program.root_symbol_value("round3-c").is_ok());
+
+    runtime
+      .abort_runtime_transaction(&mut context, "discard A and C")
+      .unwrap();
+
+    assert!(runtime.program.root_symbol_value("round3-a").is_err());
+    assert!(runtime.program.root_symbol_value("round3-b").is_err());
+    assert!(runtime.program.root_symbol_value("round3-c").is_err());
+    assert!(runtime.get_object(ObjectId(350)).unwrap().is_none());
+    assert_eq!(runtime.program_transaction_owner, None);
+  }
+
+  #[test]
+  fn explicit_program_commit_keeps_program_and_commits_access_delta() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    context.record_read(ObjectId(70));
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "round3-committed := 41 + 1",
+      )
+      .unwrap();
+    context.record_read(ObjectId(71));
+    context.record_write(ObjectId(72));
+
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+
+    assert!(runtime
+      .program
+      .root_symbol_value("round3-committed")
+      .is_ok());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    let record = runtime.get_transaction(transaction_id).unwrap().unwrap();
+    assert!(!record.read_set.contains(&ObjectId(70)));
+    assert!(record.read_set.contains(&ObjectId(71)));
+    assert!(record.write_set.contains(&ObjectId(72)));
+  }
+
+  #[test]
+  fn explicit_commit_failure_keeps_program_provisional_until_abort() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "round3-provisional := 42",
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(200), "note", "missing"),
+      )
+      .unwrap();
+
+    assert!(runtime.commit_runtime_transaction(&mut context).is_err());
+    assert!(runtime
+      .program
+      .root_symbol_value("round3-provisional")
+      .is_ok());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+    assert!(runtime.active_transactions.contains_key(&transaction_id));
+
+    runtime
+      .abort_runtime_transaction(&mut context, "failed commit")
+      .unwrap();
+
+    assert!(runtime
+      .program
+      .root_symbol_value("round3-provisional")
+      .is_err());
+    assert_eq!(runtime.program_transaction_owner, None);
+  }
+
+  #[test]
+  fn one_transaction_owns_program_while_other_store_work_remains_allowed() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context_a = runtime.runtime_context().unwrap();
+    let transaction_a = runtime.begin_transaction(&mut context_a).unwrap();
+    runtime
+      .run_string_with_context(&mut context_a, "round3-owner-a := 1")
+      .unwrap();
+
+    let mut context_b = runtime.runtime_context().unwrap();
+    let transaction_b = runtime.begin_transaction(&mut context_b).unwrap();
+    runtime
+      .put_object_with_context(
+        &mut context_b,
+        ObjectRecord::text(ObjectId(300), "note", "B store-only"),
+      )
+      .unwrap();
+
+    let b_error = runtime
+      .run_string_with_context(&mut context_b, "round3-owner-b := 2")
+      .unwrap_err();
+    assert_eq!(b_error.kind_name(), "RuntimeProgramBusy");
+
+    let mut unowned_context = runtime.runtime_context().unwrap();
+    let implicit_error = runtime
+      .run_string_with_context(
+        &mut unowned_context,
+        "round3-unowned := 3",
+      )
+      .unwrap_err();
+    assert_eq!(implicit_error.kind_name(), "RuntimeProgramBusy");
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_a));
+
+    runtime
+      .abort_runtime_transaction(&mut context_a, "release A")
+      .unwrap();
+    runtime
+      .run_string_with_context(&mut context_b, "round3-owner-b := 2")
+      .unwrap();
+
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_b));
+    assert!(runtime.program.root_symbol_value("round3-owner-b").is_ok());
+    assert!(runtime.get_object(ObjectId(300)).unwrap().is_none());
+
+    runtime
+      .abort_runtime_transaction(&mut context_b, "release B")
+      .unwrap();
+    assert!(runtime.program.root_symbol_value("round3-owner-b").is_err());
+    assert!(runtime.get_object(ObjectId(300)).unwrap().is_none());
+  }
+
+  #[test]
+  fn failed_first_explicit_operation_releases_program_ownership() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context_a = runtime.runtime_context().unwrap();
+    let transaction_a = runtime.begin_transaction(&mut context_a).unwrap();
+
+    assert!(runtime
+      .run_string_with_context(
+        &mut context_a,
+        "round3-first-fails := missing-round3-first + 1",
+      )
+      .is_err());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(runtime.active_transactions.contains_key(&transaction_a));
+    assert!(runtime
+      .active_execution_transaction(transaction_a)
+      .unwrap()
+      .program
+      .is_none());
+
+    let mut context_b = runtime.runtime_context().unwrap();
+    let transaction_b = runtime.begin_transaction(&mut context_b).unwrap();
+    runtime
+      .run_string_with_context(&mut context_b, "round3-after-failure := 2")
+      .unwrap();
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_b));
+
+    runtime
+      .abort_runtime_transaction(&mut context_b, "release B")
+      .unwrap();
+    runtime
+      .abort_runtime_transaction(&mut context_a, "release A")
+      .unwrap();
+  }
+
+  #[test]
+  fn failed_operation_restores_context_and_staging_but_keeps_budget_usage() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    context.capabilities = vec![CapabilityId(10)];
+    context.budget = ResourceBudget::default()
+      .with_max_steps(100)
+      .with_max_bytes(100)
+      .with_max_items(100)
+      .with_max_messages(100);
+    context.charge_step().unwrap();
+    context.record_read(ObjectId(10));
+    let baseline = context.clone();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let operation_events = context.events.clone();
+    let staged_events = runtime
+      .active_transaction_mut(transaction_id)
+      .unwrap()
+      .staged_event_ids();
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "context_rollback_test",
+      |runtime, context| {
+        context.charge_steps(3)?;
+        context.charge_bytes(4)?;
+        context.charge_items(5)?;
+        context.charge_messages(6)?;
+        context.record_read(ObjectId(11));
+        context.record_write(ObjectId(12));
+        runtime
+          .active_transaction_mut(transaction_id)?
+          .stage_put_object(ObjectRecord::text(
+            ObjectId(400),
+            "note",
+            "provisional",
+          ))?;
+        runtime.emit_event_to_context(
+          context,
+          RuntimeEventKind::ObjectCreated {
+            object_id: ObjectId(400),
+          },
+        )?;
+
+        context.runtime = RuntimeId(999);
+        context.subject = "mutated-subject".to_string();
+        context.task = Some(TaskId(20));
+        context.actor = Some(ActorId(21));
+        context.module_version = Some(ModuleVersionId(22));
+        context.transaction = None;
+        context.capabilities = vec![CapabilityId(23)];
+        context.budget.max_steps = Some(4);
+        context.budget.max_bytes = Some(5);
+        context.budget.max_items = Some(6);
+        context.budget.max_messages = Some(7);
+        context.actor_message = Some(MessageRecord::new(
+          MessageId(24),
+          ActorId(21),
+          "mutated",
+          Vec::new(),
+        ));
+        context.actor_state = Some(ObjectId(25));
+
+        Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "context_rollback_test",
+            reason: "deliberate failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    assert!(result.is_err());
+    assert_eq!(context.runtime, baseline.runtime);
+    assert_eq!(context.subject, baseline.subject);
+    assert_eq!(context.task, baseline.task);
+    assert_eq!(context.actor, baseline.actor);
+    assert_eq!(context.module_version, baseline.module_version);
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(context.capabilities, baseline.capabilities);
+    assert_eq!(context.access, baseline.access);
+    assert_eq!(context.events, operation_events);
+    assert_eq!(context.actor_message, baseline.actor_message);
+    assert_eq!(context.actor_state, baseline.actor_state);
+    assert_eq!(context.budget.max_steps, Some(100));
+    assert_eq!(context.budget.max_bytes, Some(100));
+    assert_eq!(context.budget.max_items, Some(100));
+    assert_eq!(context.budget.max_messages, Some(100));
+    assert_eq!(context.budget.used_steps, baseline.budget.used_steps + 3);
+    assert_eq!(context.budget.used_bytes, baseline.budget.used_bytes + 4);
+    assert_eq!(context.budget.used_items, baseline.budget.used_items + 5);
+    assert_eq!(
+      context.budget.used_messages,
+      baseline.budget.used_messages + 6,
+    );
+    let transaction = runtime.active_transaction_mut(transaction_id).unwrap();
+    assert_eq!(transaction.staged_puts().count(), 0);
+    assert_eq!(transaction.staged_event_ids(), staged_events);
+
+    runtime
+      .abort_runtime_transaction(&mut context, "context rollback complete")
+      .unwrap();
+    assert_eq!(context.transaction, None);
+    assert_eq!(context.budget.used_steps, baseline.budget.used_steps + 3);
+  }
+
+  #[test]
+  fn transaction_context_identity_includes_task_actor_message_and_state() {
+    fn assert_mismatch(mutate: impl FnOnce(&mut RuntimeContext)) {
+      let mut runtime = MechRuntime::builder().build().unwrap();
+      let mut context = runtime.runtime_context().unwrap();
+      let baseline = context.clone();
+      let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+      mutate(&mut context);
+
+      let error = runtime
+        .run_string_with_context(&mut context, "identity-test := 1")
+        .unwrap_err();
+      assert_eq!(error.kind_name(), "RuntimeTransactionContextMismatch");
+      assert!(runtime.program.root_symbol_value("identity-test").is_err());
+
+      context = baseline;
+      context.transaction = Some(transaction_id);
+      runtime
+        .abort_runtime_transaction(&mut context, "identity mismatch test")
+        .unwrap();
+    }
+
+    assert_mismatch(|context| context.task = Some(TaskId(1)));
+    assert_mismatch(|context| context.actor = Some(ActorId(2)));
+    assert_mismatch(|context| {
+      context.actor_message = Some(MessageRecord::new(
+        MessageId(3),
+        ActorId(2),
+        "identity",
+        Vec::new(),
+      ));
+    });
+    assert_mismatch(|context| context.actor_state = Some(ObjectId(4)));
+  }
+
+  #[test]
+  fn host_callback_cannot_reenter_program_or_transaction_lifecycle() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(500),
+        &BasicSubject::new(&subject),
+        &BasicResource::new("host:demo/reenter"),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let observed_for_host = observed.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new(
+        "demo/reenter",
+        move |_services, _context, _args| {
+          ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+            let target = slot
+              .borrow()
+              .expect("runtime program host target should be active");
+            let runtime = unsafe { &mut *target.runtime };
+            let context = unsafe { &mut *target.context };
+            let errors = [
+              runtime
+                .run_string_with_context(context, "nested-run := 1")
+                .unwrap_err(),
+              runtime.begin_transaction(context).unwrap_err(),
+              runtime.commit_runtime_transaction(context).unwrap_err(),
+              runtime
+                .abort_runtime_transaction(context, "nested abort")
+                .unwrap_err(),
+            ];
+            observed_for_host
+              .lock()
+              .unwrap()
+              .extend(errors.into_iter().map(|error| error.kind_name()));
+          });
+          Err(MechError::new(
+            RuntimeInvalidOperationError {
+              operation: "demo/reenter",
+              reason: "reject outer operation after reentrancy probes".to_string(),
+            },
+            None,
+          ))
+        },
+      ))
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let outer_error = runtime
+      .run_string_with_context(
+        &mut context,
+        "reentrant-result := demo/reenter()",
+      )
+      .unwrap_err();
+
+    assert_eq!(outer_error.kind_name(), "RuntimeInvalidOperation");
+    let observed = observed.lock().unwrap();
+    assert!(!observed.is_empty());
+    assert_eq!(observed.len() % 4, 0);
+    assert!(observed
+      .iter()
+      .all(|kind| kind == "RuntimeProgramOperationReentrant"));
+    assert!(runtime.program.root_symbol_value("reentrant-result").is_err());
+    assert!(runtime.program.root_symbol_value("nested-run").is_err());
+    assert!(runtime.active_transactions.is_empty());
+  }
+
+  #[test]
+  fn completion_event_staging_failure_rolls_back_implicit_program() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(ScriptedEventIdGenerator::new(
+        1,
+        [
+          EventId(100),
+          EventId(101),
+          EventId(102),
+          EventId(102),
+          EventId(103),
+          EventId(104),
+        ],
+      ))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .run_string_with_context(
+        &mut context,
+        "round3-completion-event-failure := 1",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "InvalidRuntimeTransaction");
+    assert!(runtime
+      .program
+      .root_symbol_value("round3-completion-event-failure")
+      .is_err());
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert!(runtime.list_transactions(None).unwrap().is_empty());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::TransactionAborted { .. })
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::ProgramFailed { .. })
+    }));
+    assert!(!events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::ProgramCompleted { .. })
+    }));
+    assert!(!runtime.is_poisoned());
+  }
+
+  #[test]
+  fn incomplete_program_restore_poisons_retained_execution_until_abort() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    runtime.run_string("round3-poison-anchor := 1").unwrap();
+    assert!(runtime.program.interpreter().plan_len() > 0);
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "poison_test",
+      |runtime, _context| {
+        runtime.program.interpreter().plan().0.borrow_mut().clear();
+        Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "poison_test",
+            reason: "deliberate original failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    let error = result.unwrap_err();
+    assert_eq!(error.kind_name(), "RuntimeProgramRollbackFailed");
+    assert!(runtime.is_poisoned());
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+    let poison = match runtime.health() {
+      RuntimeHealth::Healthy => panic!("runtime should be poisoned"),
+      RuntimeHealth::Poisoned(poison) => poison,
+    };
+    assert_eq!(poison.operation, "poison_test");
+    assert!(poison.original_error.contains("deliberate original failure"));
+    assert!(!poison.rollback_failures.is_empty());
+
+    assert_eq!(
+      runtime.run_string("round3-poison-rejected := 1").unwrap_err().kind_name(),
+      "RuntimePoisoned",
+    );
+    let mut fresh_context = runtime.runtime_context().unwrap();
+    assert_eq!(
+      runtime.begin_transaction(&mut fresh_context).unwrap_err().kind_name(),
+      "RuntimePoisoned",
+    );
+    assert_eq!(
+      runtime
+        .commit_runtime_transaction(&mut context)
+        .unwrap_err()
+        .kind_name(),
+      "RuntimePoisoned",
+    );
+    assert!(runtime.list_events(None).is_ok());
+    assert!(runtime.program().root_symbol_value("round3-poison-anchor").is_ok());
+
+    let abort_error = runtime
+      .abort_runtime_transaction(&mut context, "release poisoned owner")
+      .unwrap_err();
+    assert_eq!(abort_error.kind_name(), "RuntimeProgramRollbackFailed");
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(!runtime.active_transactions.contains_key(&transaction_id));
+    assert!(runtime.shutdown().is_ok());
   }
 }

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -490,3 +490,48 @@ impl MechRuntime {
     ))
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn program_transaction_outer_abort_restores_program_baseline() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let root_interpreter_id = runtime.program.interpreter().id;
+    let plan_len_before = runtime.program.interpreter().plan_len();
+
+    runtime
+      .with_atomic_program_operation(
+        &mut context,
+        "program_transaction_test",
+        |runtime, _context| {
+          runtime.program.run_source(&MechSourceCode::String(
+            "round3-owned := 42".to_string(),
+          ))
+        },
+      )
+      .unwrap();
+
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+    assert!(
+      runtime
+        .program
+        .root_symbol_value("round3-owned")
+        .is_ok(),
+    );
+
+    runtime
+      .abort_runtime_transaction(&mut context, "round3 test abort")
+      .unwrap();
+
+    assert_eq!(context.transaction, None);
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(!runtime.active_transactions.contains_key(&transaction_id));
+    assert_eq!(runtime.program.interpreter().id, root_interpreter_id);
+    assert_eq!(runtime.program.interpreter().plan_len(), plan_len_before);
+    assert!(runtime.program.root_symbol_value("round3-owned").is_err());
+  }
+}

--- a/src/runtime/src/runtime/task.rs
+++ b/src/runtime/src/runtime/task.rs
@@ -116,7 +116,7 @@ impl MechRuntime {
 
     if let Some(transaction_id) = context.transaction {
       if let Some(transaction) = self.active_transactions.get(&transaction_id) {
-        if let Some(task) = transaction.get_staged_task(id) {
+        if let Some(task) = transaction.store.get_staged_task(id) {
           return Ok(Some(task));
         }
       }

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -251,6 +251,31 @@ impl MechRuntime {
     reason: String,
     restore_program: bool,
   ) -> MResult<()> {
+    let (transaction_id, rollback_failures) =
+      self.abort_runtime_transaction_cleanup(
+        context,
+        &reason,
+        restore_program,
+      )?;
+
+    if rollback_failures.is_empty() {
+      return Ok(());
+    }
+
+    Err(self.poison_program_operation(
+      "abort_runtime_transaction",
+      Some(transaction_id),
+      reason,
+      rollback_failures,
+    ))
+  }
+
+  pub(super) fn abort_runtime_transaction_cleanup(
+    &mut self,
+    context: &mut RuntimeContext,
+    reason: &str,
+    restore_program: bool,
+  ) -> MResult<(TransactionId, Vec<String>)> {
     self.validate_context_for_runtime(context)?;
 
     let transaction_id = Self::context_transaction_id(context)?;
@@ -280,10 +305,16 @@ impl MechRuntime {
     envelope
       .context_baseline
       .restore_preserving_consumption(context);
+    if let Err(error) = self.validate_context_for_runtime(context) {
+      rollback_failures.push(format!(
+        "context baseline restore invariant failed: {:?}",
+        error,
+      ));
+    }
 
     let transaction = self.active_transactions.remove(&transaction_id);
     if let Some(transaction) = transaction {
-      if let Err(error) = transaction.store.abort(reason.clone()) {
+      if let Err(error) = transaction.store.abort(reason) {
         rollback_failures.push(format!(
           "staged store discard invariant failed: {:?}",
           error,
@@ -304,20 +335,18 @@ impl MechRuntime {
       context,
       RuntimeEventKind::TransactionAborted {
         transaction_id,
-        message: reason.clone(),
+        message: reason.to_string(),
       },
     );
 
-    if !rollback_failures.is_empty() {
-      return Err(self.poison_program_operation(
-        "abort_runtime_transaction",
-        Some(transaction_id),
-        reason,
-        rollback_failures,
+    if let Err(error) = abort_event_result {
+      rollback_failures.push(format!(
+        "transaction abort audit event failed: {:?}",
+        error,
       ));
     }
 
-    abort_event_result.map(|_| ())
+    Ok((transaction_id, rollback_failures))
   }
 
   pub(super) fn active_transaction_mut(

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -260,7 +260,22 @@ impl MechRuntime {
     let owns_program = self.program_transaction_owner == Some(transaction_id);
     let mut rollback_failures = Vec::new();
 
-    let _ = restore_program;
+    if owns_program && restore_program {
+      match &envelope.program {
+        Some(baseline) => {
+          if let Err(error) = self.program.restore(baseline.program.clone()) {
+            rollback_failures.push(format!(
+              "program restore failed: {:?}",
+              error,
+            ));
+          }
+          self.restore_live_state(baseline.live.clone());
+        }
+        None => rollback_failures.push(
+          "program owner transaction has no retained-program baseline".to_string(),
+        ),
+      }
+    }
 
     envelope
       .context_baseline

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -78,6 +78,19 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
   ) -> MResult<TransactionId> {
+    self.ensure_runtime_healthy("begin_transaction")?;
+    self.reject_program_operation_reentrancy("begin_transaction")?;
+    self.begin_runtime_transaction_internal(
+      context,
+      RuntimeExecutionTransactionMode::Explicit,
+    )
+  }
+
+  pub(super) fn begin_runtime_transaction_internal(
+    &mut self,
+    context: &mut RuntimeContext,
+    mode: RuntimeExecutionTransactionMode,
+  ) -> MResult<TransactionId> {
     self.validate_context_for_runtime(context)?;
 
     if context.transaction.is_some() {
@@ -90,8 +103,14 @@ impl MechRuntime {
       ));
     }
 
+    let context_baseline = RuntimeContextCheckpoint::capture(context);
     let id = self.next_transaction_id();
-    let transaction = RuntimeTransaction::new(id, context.subject.clone());
+    let transaction = RuntimeExecutionTransaction::new(
+      RuntimeTransaction::new(id, context.subject.clone()),
+      mode,
+      RuntimeTransactionContextIdentity::capture(context),
+      context_baseline.clone(),
+    );
     self.active_transactions.insert(id, transaction);
     context.transaction = Some(id);
 
@@ -104,7 +123,7 @@ impl MechRuntime {
       Ok(event) => event,
       Err(error) => {
         self.active_transactions.remove(&id);
-        context.transaction = None;
+        context_baseline.restore_preserving_consumption(context);
         return Err(error);
       }
     };
@@ -114,7 +133,7 @@ impl MechRuntime {
       .record_event(started_event)
     {
       self.active_transactions.remove(&id);
-      context.transaction = None;
+      context_baseline.restore_preserving_consumption(context);
       return Err(error);
     }
 
@@ -125,27 +144,34 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
   ) -> MResult<TransactionId> {
+    self.ensure_runtime_healthy("commit_runtime_transaction")?;
+    self.reject_program_operation_reentrancy("commit_runtime_transaction")?;
+    self.commit_runtime_transaction_internal(context)
+  }
+
+  pub(super) fn commit_runtime_transaction_internal(
+    &mut self,
+    context: &mut RuntimeContext,
+  ) -> MResult<TransactionId> {
     self.validate_context_for_runtime(context)?;
 
     let transaction_id = Self::context_transaction_id(context)?;
+    let access = self
+      .active_execution_transaction(transaction_id)?
+      .context_baseline
+      .access_delta(context);
 
     let commit_event = self.make_event(RuntimeEventKind::TransactionCommitted {
       transaction_id,
     });
 
     let commit = {
-      let transaction = self
-        .active_transactions
-        .get_mut(&transaction_id)
-        .ok_or_else(|| {
-          MechError::new(
-            RuntimeTransactionNotFoundError { transaction_id },
-            None,
-          )
-        })?;
+      let transaction = &mut self
+        .active_execution_transaction_mut(transaction_id)?
+        .store;
 
-      transaction.merge_read_set(&context.access.reads)?;
-      transaction.merge_write_set(&context.access.writes)?;
+      transaction.merge_read_set(&access.reads)?;
+      transaction.merge_write_set(&access.writes)?;
 
       let staged_puts: Vec<ObjectRecord> =
         transaction.staged_puts().cloned().collect();
@@ -197,6 +223,9 @@ impl MechRuntime {
 
     self.active_transactions.remove(&transaction_id);
     context.transaction = None;
+    if self.program_transaction_owner == Some(transaction_id) {
+      self.program_transaction_owner = None;
+    }
 
     self.push_persisted_event_to_context(context, commit_event);
 
@@ -208,12 +237,86 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     reason: impl Into<String>,
   ) -> MResult<()> {
+    self.reject_program_operation_reentrancy("abort_runtime_transaction")?;
+    self.abort_runtime_transaction_internal(
+      context,
+      reason.into(),
+      true,
+    )
+  }
+
+  pub(super) fn abort_runtime_transaction_internal(
+    &mut self,
+    context: &mut RuntimeContext,
+    reason: String,
+    restore_program: bool,
+  ) -> MResult<()> {
     self.validate_context_for_runtime(context)?;
 
     let transaction_id = Self::context_transaction_id(context)?;
-    let reason = reason.into();
+    let envelope = self
+      .active_execution_transaction(transaction_id)?
+      .clone();
+    let owns_program = self.program_transaction_owner == Some(transaction_id);
+    let mut rollback_failures = Vec::new();
 
-    let staged_event_ids = self
+    let _ = restore_program;
+
+    envelope
+      .context_baseline
+      .restore_preserving_consumption(context);
+
+    let transaction = self.active_transactions.remove(&transaction_id);
+    if let Some(transaction) = transaction {
+      if let Err(error) = transaction.store.abort(reason.clone()) {
+        rollback_failures.push(format!(
+          "staged store discard invariant failed: {:?}",
+          error,
+        ));
+      }
+    } else {
+      rollback_failures.push(format!(
+        "active execution transaction {} disappeared during abort",
+        transaction_id,
+      ));
+    }
+
+    if owns_program {
+      self.program_transaction_owner = None;
+    }
+
+    let abort_event_result = self.emit_event_immediate_to_context(
+      context,
+      RuntimeEventKind::TransactionAborted {
+        transaction_id,
+        message: reason.clone(),
+      },
+    );
+
+    if !rollback_failures.is_empty() {
+      return Err(self.poison_program_operation(
+        "abort_runtime_transaction",
+        Some(transaction_id),
+        reason,
+        rollback_failures,
+      ));
+    }
+
+    abort_event_result.map(|_| ())
+  }
+
+  pub(super) fn active_transaction_mut(
+    &mut self,
+    transaction_id: TransactionId,
+  ) -> MResult<&mut RuntimeTransaction> {
+    Ok(&mut self.active_execution_transaction_mut(transaction_id)?.store)
+  }
+
+  pub(super) fn active_execution_transaction(
+    &self,
+    transaction_id: TransactionId,
+  ) -> MResult<&RuntimeExecutionTransaction> {
+    self
       .active_transactions
       .get(&transaction_id)
       .ok_or_else(|| {
@@ -221,42 +324,13 @@ impl MechRuntime {
           RuntimeTransactionNotFoundError { transaction_id },
           None,
         )
-      })?
-      .staged_event_ids();
-
-    let transaction = self
-      .active_transactions
-      .remove(&transaction_id)
-      .ok_or_else(|| {
-        MechError::new(
-          RuntimeTransactionNotFoundError { transaction_id },
-          None,
-        )
-      })?;
-
-    let _ = transaction.abort(reason.clone())?;
-
-    context
-      .events
-      .retain(|event| !staged_event_ids.contains(&event.id));
-
-    context.transaction = None;
-
-    self.emit_event_immediate_to_context(
-      context,
-      RuntimeEventKind::TransactionAborted {
-        transaction_id,
-        message: reason,
-      },
-    )?;
-
-    Ok(())
+      })
   }
 
-  pub(super) fn active_transaction_mut(
+  pub(super) fn active_execution_transaction_mut(
     &mut self,
     transaction_id: TransactionId,
-  ) -> MResult<&mut RuntimeTransaction> {
+  ) -> MResult<&mut RuntimeExecutionTransaction> {
     self
       .active_transactions
       .get_mut(&transaction_id)

--- a/src/runtime/src/transaction.rs
+++ b/src/runtime/src/transaction.rs
@@ -1,12 +1,13 @@
 //! Runtime transaction state.
 //!
 //! `TransactionRecord` is the durable store record.
-//! `RuntimeTransaction` is the live transaction used while a task or actor turn
-//! is executing.
+//! `RuntimeTransaction` is the staged-store component used while runtime work
+//! is executing. It stages object, task, actor, message, and event changes.
 //!
-//! The transaction stages object writes until commit. This is the first real
-//! transactional boundary. Later, the same shape can be extended to staged actor,
-//! task, module, message, and capability mutations.
+//! The runtime-private `RuntimeExecutionTransaction` coordinates that store
+//! staging with the context baseline, retained-program checkpoints, live
+//! runtime state, and explicit or implicit transaction mode. Program and live
+//! checkpoints intentionally do not belong to this store-facing type.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -3971,7 +3971,7 @@ fn run_tree_with_context_preflight_failure_emits_failure_and_profile_events() {
   let tree = mech_syntax::parser::parse("+> @env := cli/env\nhome := @env/HOME\n").unwrap();
   let result = runtime.run_tree_with_context(&mut context, &tree);
   assert!(result.is_err());
-  assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. })));
+  assert!(!context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramStarted { .. })));
   assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramFailed { .. })));
   assert!(context.events.iter().any(|event| matches!(event.kind, RuntimeEventKind::ProgramProfiled { .. })));
 }


### PR DESCRIPTION
## Summary

This is the Round 3 stack on `fix/581-program-transactions`. It gives runtime-owned retained program operations an atomic internal boundary across the retained program, live bindings, staged store state, runtime context, and execution events.

## Guarantees

- Runtime-owned retained source operations are internally atomic.
- Explicit transactions hold single-writer program ownership.
- Each operation inside an explicit transaction has a savepoint.
- Outer abort restores the transaction’s original program and live state.
- Store commit failure leaves explicit program changes provisional and abortable.
- Rollback failure poisons the runtime.

## Monotonic state

Rollback does not refund:

- resource budget consumption;
- transaction, event, object, task, actor, or message IDs;
- event sequence numbers;
- elapsed time.

## Current external-effect boundary

This PR restores runtime-host output cells but does not undo arbitrary external host effects, provider writes, or capability-kernel mutations. Those are Round 4.

No provider transaction protocol or host-effect protocol was added.

## Current reactive boundary

Reactive turns and host-input turns do not use whole-program checkpoints. Transactional reactive turns and compact turn deltas are Round 6.

No checkpoint or journal work entered the reactive hot loop.

## Current module boundary

Retained root installation is coordinated, but module resolution, compilation, module-record persistence, dependency invariant reporting, and the full module graph handoff are completed in Round 5.

## Commit stack

- `878e19e96` — `feat(runtime): add execution transaction coordinator`
- `c3c33b81d` — `fix(runtime): restore program state on transaction abort`
- `01d944846` — `fix(runtime): transact retained source execution`
- `c95e16ea6` — `fix(runtime): transact retained root module execution`
- `2b6aed4aa` — `test(runtime): cover program ownership and savepoints`
- `553588adb` — `bench(runtime): measure program transaction overhead`
- `da384fe61` — `fix(runtime): propagate implicit transaction cleanup failures`
- `c789e2c93` — `test(cli): classify macOS serve path regression`

Head: `c789e2c93913f8f301cfa09fe8e1d7023a44f9b2`

## Corrective follow-up

- Implicit operation cleanup errors are no longer discarded.
- Incomplete hidden-transaction cleanup now returns `RuntimeProgramRollbackFailed`.
- The final poison record preserves both the original execution error and every rollback or cleanup failure.
- Added deterministic coverage for staged-store abort failure and missing implicit transaction state.

## Validation

Passing:

- `cargo test -p mech-core --lib`: 135 passed
- `cargo test -p mech-interpreter --lib`: 143 passed
- `cargo test -p mech-program --lib`: 49 passed
- coordinator focus: 15 passed
- both deterministic cleanup-failure tests pass under exact filtering
- `cargo check -p mech-runtime --no-default-features --features base`
- `cargo test -p mech-runtime --test module_smoke`: 232 passed
- benchmark compile, smoke, and full measurement: all 7 scenarios completed
- `git diff --check`

Runtime library result: 356 passed, with only the three known macOS `/var` versus `/private/var` workspace-watch failures:

- `nonrecursive_directory_watch_allows_directory_and_direct_children_only`
- `recursive_directory_watch_still_allows_descendants`
- `target_watch_falls_back_to_existing_parent_when_target_is_deleted`

The serial and normal `cargo test -p mech --lib` runs each produced 289 passes and the same 12 serve-test failures: the proven parent-identical first fixture failure plus 11 poisoned shared-lock follow-ons.

Per the author’s instruction, the corrective follow-up did not run or apply rustfmt. The touched code retains the repository’s existing formatting style; the corrective diff passes `git diff --check`.

## macOS CLI serve-test classification

First failing test: `serve::tests::poll_workspace_once_updates_registry_after_manual_refresh`

Parent:
- SHA: `7a5b0895771de0d5aeda0885ae4c8ae68cb3390b`
- result: fail in 3/3 runs
- expected: `server.workspace_session` is `Some` after loading `main.mec`
- actual: `server.workspace_session` is `None` at `src/serve.rs:2117`

PR:
- SHA: `c789e2c93913f8f301cfa09fe8e1d7023a44f9b2`
- result: fail in 3/3 runs
- expected: `server.workspace_session` is `Some` after loading `main.mec`
- actual: `server.workspace_session` is `None` at `src/serve.rs:2117`

Conclusion: pre-existing fixture failure. A single existing Mech source is classified as a configured served project, which does not create a workspace session. Every run used a canonical `/private/var/folders/.../T/mech-serve-refresh-*` root; the assertion failed before the later `source/main.mec` lookup, and no `/var` versus `/private/var` comparison was reached.

The remaining poisoned-lock failures were follow-on failures from this first test and were not counted independently.

## Benchmark medians

Criterion median point estimates from this run:

| Scenario | Median |
| --- | ---: |
| implicit successful retained operation | 2.172 ms |
| explicit first operation and ownership acquisition | 2.088 ms |
| explicit subsequent savepoint operation | 2.207 ms |
| failed implicit operation with rollback | 4.461 ms |
| failed explicit subsequent operation with rollback | 4.506 ms |
| explicit outer abort after program changes | 0.447 ms |
| implicit transaction store commit | 2.163 ms |

These are visibility measurements, not gates, and do not justify an arena rewrite without representative real Mech workload measurements.

## GitHub Actions

All 8 required jobs passed on run `30185399535` for head `c789e2c93913f8f301cfa09fe8e1d7023a44f9b2`:

- Cargo language tests
- Cargo runtime and host tests
- Dynamic modules
- Project browser
- Project native
- Run-only CLI
- Windows CLI
- cargo