### PR TITLE
fix(runtime): stage resource provider effects

### DIFF
--- a/docs/runtime/transactional-host-functions.md
+++ b/docs/runtime/transactional-host-functions.md
@@ -1,0 +1,81 @@
+# Transactional host functions
+
+Every host function declares how it participates in runtime transactions through
+`HostFunctionTransactionMode`. The default is intentionally conservative:
+unclassified callbacks are `ImmediateOnly`.
+
+## Modes
+
+### `Pure`
+
+Pure functions compute a value and may read immutable process state. They do not
+mutate runtime state or anything outside the runtime.
+
+Use `ClosureHostFunction::new_pure` for closure-backed pure functions. The
+runtime may call a pure function while constructing the native execution plan
+and again while executing it, so the callback must be safe to evaluate more
+than once.
+
+### `RuntimeManaged`
+
+Runtime-managed functions may mutate only through `RuntimeServices` operations
+that already stage their work in the active runtime transaction. They must not
+write files, print output, send network traffic, mutate shared application
+state, or retain a runtime pointer.
+
+This is an unsafe-style contract: the runtime cannot prove that an implementation
+uses only mediated services. During native-plan construction, the runtime runs
+the callback against a private preview savepoint and removes its staged store,
+context, and effect changes afterward. Monotonic IDs and consumed budget are not
+rewound.
+
+Use `ClosureHostFunction::new_runtime_managed` when a closure satisfies this
+contract. The built-in actor state functions use this mode.
+
+### `Staged`
+
+Staged functions return a provisional value and one `PreparedRuntimeEffect`
+through `RuntimePreparedHostCall`. The runtime makes the value available to the
+Mech program immediately and owns the effect lifecycle.
+
+Use `StagedClosureHostFunction::new`. Its callback must only construct the value
+and prepared effect; it must not perform the external mutation itself. Native
+plan construction may invoke the callback to preview the value, but the preview
+effect is discarded. The effect is staged only when the program call executes.
+
+Choose the effect protocol honestly:
+
+- `Transactional` for a real prepare/commit/abort participant.
+- `Compensatable` only when compensation reliably restores the immediately
+  preceding state.
+- `AfterCommit` for stdout, notifications, DOM writes, physical commands, and
+  other irreversible delivery.
+
+The provisional return value must not depend on successful after-commit
+delivery.
+
+### `ImmediateOnly`
+
+`ClosureHostFunction::new` creates an immediate-only callback. It is allowed
+through explicitly nontransactional host calls and ordinary reactive execution.
+The runtime rejects it before invocation whenever a transaction is active,
+including implicit retained-program transactions.
+
+Use this mode for commands whose result cannot be known until an irreversible
+operation has already happened and which cannot implement a real transactional
+preparation protocol.
+
+## Failure behavior
+
+- Operation rollback removes staged host effects created after its savepoint.
+- Outer abort discards all staged host effects.
+- Failed retained execution does not invoke immediate-only callbacks.
+- After-commit delivery failure does not roll back an internally committed
+  transaction and does not poison the runtime.
+- Incomplete effect abort or compensation poisons the runtime.
+- A transactional participant commit failure after the runtime store commits is
+  reported as an indeterminate external commit and poisons the runtime.
+
+Reactive turns remain outside retained-program checkpoints and journals. A
+staged function invoked by an ordinary reactive turn uses the one-effect
+immediate coordinator.

--- a/hosts/browser/src/config.rs
+++ b/hosts/browser/src/config.rs
@@ -1798,6 +1798,27 @@ config := {
     writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>,
   }
 
+  #[derive(Debug)]
+  struct RecordingBrowserEffect {
+    writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>,
+    path: String,
+    value: String,
+  }
+
+  impl mech_runtime::RuntimeAfterCommitEffect for RecordingBrowserEffect {
+    fn metadata(&self) -> mech_runtime::RuntimeEffectMetadata {
+      mech_runtime::RuntimeEffectMetadata::new(
+        mech_runtime::RuntimeEffectSource::ResourceProvider { scheme: "browser".to_string() },
+        "assign",
+      )
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      self.writes.lock().unwrap().push((self.path.clone(), self.value.clone()));
+      Ok(())
+    }
+  }
+
   impl RuntimeResourceProvider for RecordingBrowserProvider {
     fn scheme(&self) -> &str {
       "browser"
@@ -1818,19 +1839,22 @@ config := {
       Ok(())
     }
 
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<mech_runtime::PreparedRuntimeEffect> {
       self.preflight_write(RuntimeResourceWritePreflightRequest {
-        base_uri: request.base_uri,
+        base_uri: request.base_uri.clone(),
         path: request.path.clone(),
-        context_name: request.context_name,
+        context_name: request.context_name.clone(),
         operation: request.operation.clone(),
         intent: request.intent,
       })?;
       let Value::String(value) = request.value else {
         panic!("configured browser instance test writes a string")
       };
-      self.writes.lock().unwrap().push((request.path, value.borrow().as_str().to_string()));
-      Ok(())
+      Ok(mech_runtime::PreparedRuntimeEffect::AfterCommit(Box::new(RecordingBrowserEffect {
+        writes: self.writes.clone(),
+        path: request.path,
+        value: value.borrow().as_str().to_string(),
+      })))
     }
   }
 

--- a/hosts/browser/src/provider.rs
+++ b/hosts/browser/src/provider.rs
@@ -2,9 +2,15 @@ use mech_core::{
   browser_capability_error, BrowserAuthority, BrowserDomManifestEntry, BrowserDomPath,
   BrowserOperation, BROWSER_DOM_PROVIDER_URI, MResult, MechError, MechErrorKind, Ref, Value,
 };
+use std::sync::{Arc, Mutex, MutexGuard};
 use crate::{BrowserHostConfig, BrowserHostRuntimeConfig};
 
-use mech_runtime::{RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest};
+use mech_runtime::{
+  PreparedRuntimeEffect, RuntimeAfterCommitEffect, RuntimeEffectCost,
+  RuntimeEffectMetadata, RuntimeEffectSource, RuntimeResourceProvider,
+  RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
+  RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
+};
 
 pub trait BrowserDomBackend: std::fmt::Debug {
   fn read_dom_string(
@@ -25,7 +31,7 @@ pub trait BrowserDomBackend: std::fmt::Debug {
 pub struct BrowserResourceProvider<B> {
   instance: String,
   authority: BrowserAuthority,
-  backend: B,
+  backend: Arc<Mutex<B>>,
 }
 
 impl<B> BrowserResourceProvider<B> {
@@ -34,7 +40,11 @@ impl<B> BrowserResourceProvider<B> {
   }
 
   pub fn for_instance(instance: impl Into<String>, authority: BrowserAuthority, backend: B) -> Self {
-    Self { instance: instance.into(), authority, backend }
+    Self {
+      instance: instance.into(),
+      authority,
+      backend: Arc::new(Mutex::new(backend)),
+    }
   }
 
   fn dom_base(&self) -> String {
@@ -54,12 +64,12 @@ impl<B> BrowserResourceProvider<B> {
     &mut self.authority
   }
 
-  pub fn backend(&self) -> &B {
-    &self.backend
+  pub fn backend(&self) -> MutexGuard<'_, B> {
+    self.backend.lock().expect("browser DOM backend lock poisoned")
   }
 
-  pub fn backend_mut(&mut self) -> &mut B {
-    &mut self.backend
+  pub fn backend_mut(&mut self) -> MutexGuard<'_, B> {
+    self.backend.lock().expect("browser DOM backend lock poisoned")
   }
 }
 
@@ -69,7 +79,7 @@ impl<B: BrowserDomBackend> BrowserResourceProvider<B> {
   }
 }
 
-impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B> {
+impl<B: BrowserDomBackend + 'static> RuntimeResourceProvider for BrowserResourceProvider<B> {
   fn scheme(&self) -> &str {
     "browser"
   }
@@ -110,7 +120,16 @@ impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B
       .authority
       .allows_dom(entry.selector.selector.as_str(), BrowserOperation::Read)
       .map_err(browser_capability_error)?;
-    Ok(Value::String(Ref::new(self.backend.read_dom_string(entry, &path)?)))
+    Ok(Value::String(Ref::new(
+      self
+        .backend
+        .lock()
+        .map_err(|_| browser_resource_provider_error(
+          path.as_str(),
+          "browser DOM backend lock poisoned",
+        ))?
+        .read_dom_string(entry, &path)?,
+    )))
   }
 
   fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
@@ -134,7 +153,7 @@ impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B
       .map_err(browser_capability_error)
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
     self.preflight_write(RuntimeResourceWritePreflightRequest {
       base_uri: request.base_uri.clone(),
       path: request.path.clone(),
@@ -157,7 +176,51 @@ impl<B: BrowserDomBackend> RuntimeResourceProvider for BrowserResourceProvider<B
       Value::String(value) => value.borrow().as_str().to_string(),
       value => value.format_value_inline(),
     };
-    self.backend.write_dom_string(&entry, &path, value.as_str())
+    Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
+      BrowserDomWriteEffect {
+        backend: self.backend.clone(),
+        entry,
+        path,
+        value,
+        resource: request.base_uri,
+      },
+    )))
+  }
+}
+
+#[derive(Debug)]
+struct BrowserDomWriteEffect<B: BrowserDomBackend> {
+  backend: Arc<Mutex<B>>,
+  entry: BrowserDomManifestEntry,
+  path: BrowserDomPath,
+  value: String,
+  resource: String,
+}
+
+impl<B: BrowserDomBackend> RuntimeAfterCommitEffect for BrowserDomWriteEffect<B> {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::ResourceProvider {
+        scheme: "browser".to_string(),
+      },
+      "dom-write",
+    )
+    .with_resource(format!("{}/{}", self.resource, self.path.as_str()))
+    .with_cost(RuntimeEffectCost {
+      bytes: u64::try_from(self.value.len()).unwrap_or(u64::MAX),
+      items: 1,
+    })
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    self
+      .backend
+      .lock()
+      .map_err(|_| browser_resource_provider_error(
+        self.path.as_str(),
+        "browser DOM backend lock poisoned",
+      ))?
+      .write_dom_string(&self.entry, &self.path, &self.value)
   }
 }
 

--- a/hosts/browser/tests/provider_compat.rs
+++ b/hosts/browser/tests/provider_compat.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "provider")]
 
-use mech_core::{BrowserAuthority, BrowserCapabilityGrant, BrowserDomManifestEntry, BrowserDomPath, BrowserDomProperty, BrowserDomScope, BrowserOperation, BrowserResource, BROWSER_DOM_PROVIDER_URI, MResult};
+use std::sync::{Arc, Mutex};
+
+use mech_core::{BrowserAuthority, BrowserCapabilityGrant, BrowserDomManifestEntry, BrowserDomPath, BrowserDomProperty, BrowserDomScope, BrowserOperation, BrowserResource, BROWSER_DOM_PROVIDER_URI, MResult, Ref, Value};
 use mech_host_browser::{BrowserDomBackend, BrowserResourceProvider};
-use mech_runtime::{RuntimeCapabilityOperation, RuntimeResourceProvider, RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest};
+use mech_runtime::{PreparedRuntimeEffect, RuntimeCapabilityOperation, RuntimeResourceProvider, RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest};
 
 #[derive(Debug, Clone)]
 struct TestDomBackend;
@@ -13,6 +15,22 @@ impl BrowserDomBackend for TestDomBackend {
   }
 
   fn write_dom_string(&mut self, _entry: &BrowserDomManifestEntry, _requested_path: &BrowserDomPath, _value: &str) -> MResult<()> {
+    Ok(())
+  }
+}
+
+#[derive(Debug, Clone, Default)]
+struct RecordingDomBackend {
+  writes: Arc<Mutex<Vec<String>>>,
+}
+
+impl BrowserDomBackend for RecordingDomBackend {
+  fn read_dom_string(&self, _entry: &BrowserDomManifestEntry, _requested_path: &BrowserDomPath) -> MResult<String> {
+    Ok(String::new())
+  }
+
+  fn write_dom_string(&mut self, _entry: &BrowserDomManifestEntry, _requested_path: &BrowserDomPath, value: &str) -> MResult<()> {
+    self.writes.lock().unwrap().push(value.to_string());
     Ok(())
   }
 }
@@ -58,4 +76,29 @@ fn default_browser_provider_preflights_legacy_dom_base() {
     operation: RuntimeCapabilityOperation::Write,
     intent: RuntimeResourceWriteIntent::Assign,
   }).unwrap();
+}
+
+#[test]
+fn browser_dom_write_is_deferred_until_delivery() {
+  let backend = RecordingDomBackend::default();
+  let observed = backend.clone();
+  let mut provider = BrowserResourceProvider::new(authority(), backend);
+  let effect = provider.stage_write(RuntimeResourceWriteRequest {
+    base_uri: BROWSER_DOM_PROVIDER_URI.to_string(),
+    path: "body/header/title".to_string(),
+    context_name: "ui".to_string(),
+    operation: RuntimeCapabilityOperation::Write,
+    value: Value::String(Ref::new("deferred".to_string())),
+    intent: RuntimeResourceWriteIntent::Assign,
+  }).unwrap();
+
+  assert!(observed.writes.lock().unwrap().is_empty());
+  match effect {
+    PreparedRuntimeEffect::AfterCommit(mut effect) => effect.deliver().unwrap(),
+    effect => panic!("expected browser after-commit effect, got {effect:?}"),
+  }
+  assert_eq!(
+    *observed.writes.lock().unwrap(),
+    vec!["deferred".to_string()],
+  );
 }

--- a/hosts/cli/src/provider.rs
+++ b/hosts/cli/src/provider.rs
@@ -1,10 +1,16 @@
-use std::{env::VarError, io::Write};
+use std::{
+    env::VarError,
+    io::Write,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 use mech_core::{MResult, MechError, MechErrorKind, Ref, Value};
 use mech_runtime::{
     materialize_host_manifest, ConfigValue, HostManifestConfig, RuntimeHostFactory,
     RuntimeHostInstallation, RuntimeResourceProvider, RuntimeResourceReadRequest,
     RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
+    PreparedRuntimeEffect, RuntimeAfterCommitEffect, RuntimeEffectCost,
+    RuntimeEffectMetadata, RuntimeEffectSource,
 };
 
 pub trait CliBackend: std::fmt::Debug {
@@ -48,7 +54,7 @@ impl CliBackend for StdCliBackend {
 #[derive(Debug)]
 pub struct CliResourceProvider<B: CliBackend> {
     instance: String,
-    backend: B,
+    backend: Arc<Mutex<B>>,
 }
 
 impl<B: CliBackend> CliResourceProvider<B> {
@@ -56,7 +62,10 @@ impl<B: CliBackend> CliResourceProvider<B> {
         Self::for_instance("cli", backend)
     }
     pub fn for_instance(instance: impl Into<String>, backend: B) -> Self {
-        Self { instance: instance.into(), backend }
+        Self {
+            instance: instance.into(),
+            backend: Arc::new(Mutex::new(backend)),
+        }
     }
     fn base(&self, context: &str) -> String {
         format!("cli://{}/{}", self.instance, context)
@@ -64,15 +73,15 @@ impl<B: CliBackend> CliResourceProvider<B> {
     fn matches_base(&self, base_uri: &str, context: &str) -> bool {
         base_uri == self.base(context) || (self.instance == "cli" && base_uri == format!("cli://{}", context))
     }
-    pub fn backend(&self) -> &B {
-        &self.backend
+    pub fn backend(&self) -> MutexGuard<'_, B> {
+        self.backend.lock().expect("CLI backend lock poisoned")
     }
-    pub fn backend_mut(&mut self) -> &mut B {
-        &mut self.backend
+    pub fn backend_mut(&mut self) -> MutexGuard<'_, B> {
+        self.backend.lock().expect("CLI backend lock poisoned")
     }
 }
 
-impl<B: CliBackend> RuntimeResourceProvider for CliResourceProvider<B> {
+impl<B: CliBackend + 'static> RuntimeResourceProvider for CliResourceProvider<B> {
     fn scheme(&self) -> &str {
         "cli"
     }
@@ -99,7 +108,12 @@ impl<B: CliBackend> RuntimeResourceProvider for CliResourceProvider<B> {
     fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
         if self.matches_base(&request.base_uri, "env") {
                 validate_env_key(&request.path)?;
-                let value = self.backend.env_var(&request.path)?.ok_or_else(|| {
+                let value = self
+                    .backend
+                    .lock()
+                    .map_err(|_| cli_error(request.base_uri.clone(), "CLI backend lock poisoned"))?
+                    .env_var(&request.path)?
+                    .ok_or_else(|| {
                     MechError::new(
                         CliResourceProviderError {
                             resource: request.base_uri.clone(),
@@ -141,7 +155,7 @@ impl<B: CliBackend> RuntimeResourceProvider for CliResourceProvider<B> {
         }
     }
 
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
         self.preflight_write(RuntimeResourceWritePreflightRequest {
             base_uri: request.base_uri.clone(),
             path: request.path.clone(),
@@ -156,10 +170,62 @@ impl<B: CliBackend> RuntimeResourceProvider for CliResourceProvider<B> {
             _ => unreachable!("cli stdout/stderr path validated by preflight_write"),
         };
         let text = value_to_text(&request.value) + suffix;
-        if self.matches_base(&request.base_uri, "stdout") {
-            self.backend.write_stdout(&text)
+        let stream = if self.matches_base(&request.base_uri, "stdout") {
+            CliOutputStream::Stdout
         } else {
-            self.backend.write_stderr(&text)
+            CliOutputStream::Stderr
+        };
+        Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
+            CliOutputEffect {
+                backend: self.backend.clone(),
+                stream,
+                text,
+                resource: request.base_uri,
+            },
+        )))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CliOutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug)]
+struct CliOutputEffect<B: CliBackend> {
+    backend: Arc<Mutex<B>>,
+    stream: CliOutputStream,
+    text: String,
+    resource: String,
+}
+
+impl<B: CliBackend> RuntimeAfterCommitEffect for CliOutputEffect<B> {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+        RuntimeEffectMetadata::new(
+            RuntimeEffectSource::ResourceProvider {
+                scheme: "cli".to_string(),
+            },
+            match self.stream {
+                CliOutputStream::Stdout => "stdout",
+                CliOutputStream::Stderr => "stderr",
+            },
+        )
+        .with_resource(self.resource.clone())
+        .with_cost(RuntimeEffectCost {
+            bytes: u64::try_from(self.text.len()).unwrap_or(u64::MAX),
+            items: 1,
+        })
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+        let mut backend = self
+            .backend
+            .lock()
+            .map_err(|_| cli_error(self.resource.clone(), "CLI backend lock poisoned"))?;
+        match self.stream {
+            CliOutputStream::Stdout => backend.write_stdout(&self.text),
+            CliOutputStream::Stderr => backend.write_stderr(&self.text),
         }
     }
 }

--- a/hosts/cli/tests/provider.rs
+++ b/hosts/cli/tests/provider.rs
@@ -4,7 +4,7 @@ use mech_core::{MResult, MechError, MechErrorKind, Ref, Value};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::{
     RuntimeCapabilityOperation, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
-    RuntimeResourceWriteRequest,
+    RuntimeResourceWriteRequest, PreparedRuntimeEffect,
 };
 
 #[derive(Debug, Default)]
@@ -54,6 +54,16 @@ impl MechErrorKind for FakeCliBackendError {
 
 fn str_value(text: &str) -> Value {
     Value::String(Ref::new(text.to_string()))
+}
+
+fn execute_write(
+    provider: &mut CliResourceProvider<FakeCliBackend>,
+    request: RuntimeResourceWriteRequest,
+) -> MResult<()> {
+    match provider.stage_write(request)? {
+        PreparedRuntimeEffect::AfterCommit(mut effect) => effect.deliver(),
+        effect => panic!("expected CLI after-commit effect, got {effect:?}"),
+    }
 }
 
 #[test]
@@ -124,7 +134,7 @@ fn env_write_and_send_error() {
     ] {
         assert!(
             provider
-                .write(RuntimeResourceWriteRequest {
+                .stage_write(RuntimeResourceWriteRequest {
                     base_uri: "cli://env".to_string(),
                     path: "HOME".to_string(),
                     context_name: "env".to_string(),
@@ -140,8 +150,7 @@ fn env_write_and_send_error() {
 #[test]
 fn stdout_and_stderr_send_text_and_line() {
     let mut provider = CliResourceProvider::new(FakeCliBackend::default());
-    provider
-        .write(RuntimeResourceWriteRequest {
+    execute_write(&mut provider, RuntimeResourceWriteRequest {
             base_uri: "cli://stdout".to_string(),
             path: "text".to_string(),
             context_name: "out".to_string(),
@@ -150,8 +159,7 @@ fn stdout_and_stderr_send_text_and_line() {
             intent: RuntimeResourceWriteIntent::Send,
         })
         .unwrap();
-    provider
-        .write(RuntimeResourceWriteRequest {
+    execute_write(&mut provider, RuntimeResourceWriteRequest {
             base_uri: "cli://stdout".to_string(),
             path: "line".to_string(),
             context_name: "out".to_string(),
@@ -160,8 +168,7 @@ fn stdout_and_stderr_send_text_and_line() {
             intent: RuntimeResourceWriteIntent::Send,
         })
         .unwrap();
-    provider
-        .write(RuntimeResourceWriteRequest {
+    execute_write(&mut provider, RuntimeResourceWriteRequest {
             base_uri: "cli://stderr".to_string(),
             path: "text".to_string(),
             context_name: "err".to_string(),
@@ -170,8 +177,7 @@ fn stdout_and_stderr_send_text_and_line() {
             intent: RuntimeResourceWriteIntent::Send,
         })
         .unwrap();
-    provider
-        .write(RuntimeResourceWriteRequest {
+    execute_write(&mut provider, RuntimeResourceWriteRequest {
             base_uri: "cli://stderr".to_string(),
             path: "line".to_string(),
             context_name: "err".to_string(),
@@ -185,11 +191,35 @@ fn stdout_and_stderr_send_text_and_line() {
 }
 
 #[test]
+fn stdout_stage_write_buffers_until_delivery() {
+    let mut provider = CliResourceProvider::new(FakeCliBackend::default());
+    let effect = provider
+        .stage_write(RuntimeResourceWriteRequest {
+            base_uri: "cli://stdout".to_string(),
+            path: "line".to_string(),
+            context_name: "out".to_string(),
+            operation: RuntimeCapabilityOperation::Write,
+            value: str_value("buffered"),
+            intent: RuntimeResourceWriteIntent::Send,
+        })
+        .unwrap();
+
+    assert!(provider.backend().stdout.is_empty());
+    match effect {
+        PreparedRuntimeEffect::AfterCommit(mut effect) => {
+            effect.deliver().unwrap();
+        }
+        effect => panic!("expected CLI after-commit effect, got {effect:?}"),
+    }
+    assert_eq!(provider.backend().stdout, vec!["buffered\n"]);
+}
+
+#[test]
 fn stdout_and_stderr_reject_assign_read_and_unknown_path() {
     let mut provider = CliResourceProvider::new(FakeCliBackend::default());
     assert!(
         provider
-            .write(RuntimeResourceWriteRequest {
+            .stage_write(RuntimeResourceWriteRequest {
                 base_uri: "cli://stdout".to_string(),
                 path: "line".to_string(),
                 context_name: "out".to_string(),
@@ -210,7 +240,7 @@ fn stdout_and_stderr_reject_assign_read_and_unknown_path() {
     );
     assert!(
         provider
-            .write(RuntimeResourceWriteRequest {
+            .stage_write(RuntimeResourceWriteRequest {
                 base_uri: "cli://stderr".to_string(),
                 path: "foo".to_string(),
                 context_name: "err".to_string(),

--- a/hosts/console/src/provider.rs
+++ b/hosts/console/src/provider.rs
@@ -5,6 +5,8 @@ use mech_runtime::{
   materialize_host_manifest, ConfigValue, HostManifestConfig, RuntimeHostFactory,
   RuntimeHostInstallation, RuntimeResourceProvider, RuntimeResourceReadRequest,
   RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
+  PreparedRuntimeEffect, RuntimeAfterCommitEffect, RuntimeEffectCost,
+  RuntimeEffectMetadata, RuntimeEffectSource,
 };
 
 use crate::{console_error, console_host_manifest};
@@ -38,16 +40,23 @@ impl ConsoleBackend for RecordingConsoleBackend {
 #[derive(Debug)]
 pub struct ConsoleResourceProvider<B: ConsoleBackend> {
   instance: String,
-  backend: B,
+  backend: Arc<Mutex<B>>,
 }
 
 impl<B: ConsoleBackend> ConsoleResourceProvider<B> {
   pub fn new(instance: impl Into<String>, backend: B) -> Self {
-    Self { instance: instance.into(), backend }
+    Self {
+      instance: instance.into(),
+      backend: Arc::new(Mutex::new(backend)),
+    }
   }
 
-  pub fn backend(&self) -> &B { &self.backend }
-  pub fn backend_mut(&mut self) -> &mut B { &mut self.backend }
+  pub fn backend(&self) -> std::sync::MutexGuard<'_, B> {
+    self.backend.lock().expect("console backend lock poisoned")
+  }
+  pub fn backend_mut(&mut self) -> std::sync::MutexGuard<'_, B> {
+    self.backend.lock().expect("console backend lock poisoned")
+  }
 
   fn base(&self) -> String { format!("console://{}/output", self.instance) }
 
@@ -56,7 +65,7 @@ impl<B: ConsoleBackend> ConsoleResourceProvider<B> {
   }
 }
 
-impl<B: ConsoleBackend> RuntimeResourceProvider for ConsoleResourceProvider<B> {
+impl<B: ConsoleBackend + 'static> RuntimeResourceProvider for ConsoleResourceProvider<B> {
   fn scheme(&self) -> &str { "console" }
 
   fn base_uris(&self) -> Vec<String> {
@@ -90,7 +99,7 @@ impl<B: ConsoleBackend> RuntimeResourceProvider for ConsoleResourceProvider<B> {
     Ok(())
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
     self.preflight_write(RuntimeResourceWritePreflightRequest {
       base_uri: request.base_uri.clone(),
       path: request.path.clone(),
@@ -98,7 +107,45 @@ impl<B: ConsoleBackend> RuntimeResourceProvider for ConsoleResourceProvider<B> {
       operation: request.operation.clone(),
       intent: request.intent,
     })?;
-    self.backend.write_line(&value_to_text(&request.value))
+    let text = value_to_text(&request.value);
+    Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
+      ConsoleOutputEffect {
+        backend: self.backend.clone(),
+        text,
+        resource: request.base_uri,
+      },
+    )))
+  }
+}
+
+#[derive(Debug)]
+struct ConsoleOutputEffect<B: ConsoleBackend> {
+  backend: Arc<Mutex<B>>,
+  text: String,
+  resource: String,
+}
+
+impl<B: ConsoleBackend> RuntimeAfterCommitEffect for ConsoleOutputEffect<B> {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::ResourceProvider {
+        scheme: "console".to_string(),
+      },
+      "write-line",
+    )
+    .with_resource(self.resource.clone())
+    .with_cost(RuntimeEffectCost {
+      bytes: u64::try_from(self.text.len()).unwrap_or(u64::MAX),
+      items: 1,
+    })
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    self
+      .backend
+      .lock()
+      .map_err(|_| console_error(&self.resource, "console backend lock poisoned"))?
+      .write_line(&self.text)
   }
 }
 

--- a/hosts/console/tests/provider.rs
+++ b/hosts/console/tests/provider.rs
@@ -1,20 +1,30 @@
 use mech_core::Value;
 use mech_host_console::{ConsoleHostFactory, ConsoleResourceProvider, RecordingConsoleBackend};
-use mech_runtime::{RuntimeHostFactory, RuntimeResourceProvider, RuntimeResourceWriteIntent, RuntimeResourceWriteRequest, RuntimeCapabilityOperation};
+use mech_runtime::{PreparedRuntimeEffect, RuntimeHostFactory, RuntimeResourceProvider, RuntimeResourceWriteIntent, RuntimeResourceWriteRequest, RuntimeCapabilityOperation};
+
+fn deliver(
+  provider: &mut ConsoleResourceProvider<RecordingConsoleBackend>,
+  request: RuntimeResourceWriteRequest,
+) {
+  match provider.stage_write(request).unwrap() {
+    PreparedRuntimeEffect::AfterCommit(mut effect) => effect.deliver().unwrap(),
+    effect => panic!("expected console after-commit effect, got {effect:?}"),
+  }
+}
 
 #[test]
 fn provider_writes_line_to_backend() {
   let backend = RecordingConsoleBackend::new();
   let observed = backend.clone();
   let mut provider = ConsoleResourceProvider::new("console", backend);
-  provider.write(RuntimeResourceWriteRequest {
+  deliver(&mut provider, RuntimeResourceWriteRequest {
     base_uri: "console://console/output".to_string(),
     path: "line".to_string(),
     context_name: "out".to_string(),
     operation: RuntimeCapabilityOperation::Write,
     value: Value::from("hello".to_string()),
     intent: RuntimeResourceWriteIntent::Send,
-  }).unwrap();
+  });
   assert_eq!(observed.lines(), vec!["hello".to_string()]);
 }
 
@@ -22,7 +32,7 @@ fn provider_writes_line_to_backend() {
 fn provider_rejects_unknown_path() {
   let backend = RecordingConsoleBackend::new();
   let mut provider = ConsoleResourceProvider::new("console", backend);
-  let err = provider.write(RuntimeResourceWriteRequest {
+  let err = provider.stage_write(RuntimeResourceWriteRequest {
     base_uri: "console://console/output".to_string(),
     path: "text".to_string(),
     context_name: "out".to_string(),

--- a/hosts/robot-arm/src/provider.rs
+++ b/hosts/robot-arm/src/provider.rs
@@ -5,9 +5,11 @@ use mech_runtime::{
     ConfigValue, HostManifestConfig, RuntimeHostFactory, RuntimeHostInstallation,
     RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
     RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, materialize_host_manifest,
+    PreparedRuntimeEffect, RuntimeCompensatableEffect, RuntimeEffectCost,
+    RuntimeEffectMetadata, RuntimeEffectSource,
 };
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RobotArmState {
     pub position: Option<Value>,
     pub gripper: Option<Value>,
@@ -89,7 +91,7 @@ impl RuntimeResourceProvider for RobotArmResourceProvider {
         )
     }
 
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
         self.preflight_write(RuntimeResourceWritePreflightRequest {
             base_uri: request.base_uri.clone(),
             path: request.path.clone(),
@@ -97,31 +99,88 @@ impl RuntimeResourceProvider for RobotArmResourceProvider {
             operation: request.operation.clone(),
             intent: request.intent,
         })?;
+        Ok(PreparedRuntimeEffect::Compensatable(Box::new(
+            RobotCommandEffect {
+                state: self.state.clone(),
+                base_uri: request.base_uri,
+                operation: request.operation.name().to_string(),
+                path: request.path,
+                value: request.value,
+                previous: None,
+                applied: false,
+            },
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct RobotCommandEffect {
+    state: Arc<Mutex<RobotArmState>>,
+    base_uri: String,
+    operation: String,
+    path: String,
+    value: Value,
+    previous: Option<RobotArmState>,
+    applied: bool,
+}
+
+impl RuntimeCompensatableEffect for RobotCommandEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+        RuntimeEffectMetadata::new(
+            RuntimeEffectSource::ResourceProvider {
+                scheme: "robot".to_string(),
+            },
+            self.operation.clone(),
+        )
+        .with_resource(format!("{}/{}", self.base_uri, self.path))
+        .with_cost(RuntimeEffectCost {
+            bytes: 0,
+            items: 1,
+        })
+    }
+
+    fn apply(&mut self) -> MResult<()> {
         let mut state = self
             .state
             .lock()
-            .map_err(|_| robot_error(request.base_uri.clone(), "robot state lock poisoned"))?;
-        match (request.operation.name(), request.path.as_str()) {
+            .map_err(|_| robot_error(self.base_uri.clone(), "robot state lock poisoned"))?;
+        let previous = state.clone();
+        match (self.operation.as_str(), self.path.as_str()) {
             ("move", "move") => {
-                state.position = Some(request.value);
+                state.position = Some(self.value.clone());
                 state.last_command = Some("move".to_string());
-                Ok(())
             }
             ("grip", "grip") => {
-                state.gripper = Some(request.value);
+                state.gripper = Some(self.value.clone());
                 state.last_command = Some("grip".to_string());
-                Ok(())
             }
             ("home", "home") => {
                 state.position = Some(Value::Empty);
                 state.last_command = Some("home".to_string());
-                Ok(())
             }
             (operation, path) => Err(robot_error(
-                request.base_uri,
+                self.base_uri.clone(),
                 format!("unsupported robot command `{operation}` at path `{path}`"),
-            )),
+            ))?,
         }
+        self.previous = Some(previous);
+        self.applied = true;
+        Ok(())
+    }
+
+    fn compensate(&mut self) -> MResult<()> {
+        if !self.applied {
+            return Ok(());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| robot_error(self.base_uri.clone(), "robot state lock poisoned"))?;
+        if let Some(previous) = self.previous.take() {
+            *state = previous;
+        }
+        self.applied = false;
+        Ok(())
     }
 }
 
@@ -225,29 +284,45 @@ mod tests {
         Value::Bool(Ref::new(value))
     }
 
+    fn apply_write(
+        provider: &mut RobotArmResourceProvider,
+        request: RuntimeResourceWriteRequest,
+    ) -> MResult<PreparedRuntimeEffect> {
+        let mut effect = provider.stage_write(request)?;
+        match &mut effect {
+            PreparedRuntimeEffect::Compensatable(effect) => effect.apply()?,
+            effect => panic!("expected robot compensatable effect, got {effect:?}"),
+        }
+        Ok(effect)
+    }
+
     #[test]
     fn robot_provider_receives_move_and_grip_operations() {
         let mut provider = RobotArmResourceProvider::new("arm");
-        provider
-            .write(RuntimeResourceWriteRequest {
+        apply_write(
+            &mut provider,
+            RuntimeResourceWriteRequest {
                 base_uri: "robot://arm/commands".to_string(),
                 path: "move".to_string(),
                 context_name: "commands".to_string(),
                 operation: RuntimeCapabilityOperation::Custom("move".to_string()),
                 value: bool_value(true),
                 intent: RuntimeResourceWriteIntent::Send,
-            })
-            .unwrap();
-        provider
-            .write(RuntimeResourceWriteRequest {
+            },
+        )
+        .unwrap();
+        apply_write(
+            &mut provider,
+            RuntimeResourceWriteRequest {
                 base_uri: "robot://arm/commands".to_string(),
                 path: "grip".to_string(),
                 context_name: "commands".to_string(),
                 operation: RuntimeCapabilityOperation::Custom("grip".to_string()),
                 value: bool_value(false),
                 intent: RuntimeResourceWriteIntent::Send,
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         let state = provider.state.lock().unwrap();
         assert_eq!(state.last_command.as_deref(), Some("grip"));
         assert!(state.position.is_some());
@@ -269,7 +344,7 @@ mod tests {
     fn robot_provider_accepts_exact_command_paths() {
         let mut provider = RobotArmResourceProvider::new("arm");
         for (operation, path) in [("move", "move"), ("grip", "grip"), ("home", "home")] {
-            provider.write(send_request(operation, path)).unwrap();
+            apply_write(&mut provider, send_request(operation, path)).unwrap();
         }
     }
 
@@ -277,7 +352,7 @@ mod tests {
     fn robot_provider_rejects_command_subpaths() {
         let mut provider = RobotArmResourceProvider::new("arm");
         for (operation, path) in [("move", "move/typo"), ("grip", "grip/closed"), ("home", "home/reset")] {
-            let error = provider.write(send_request(operation, path)).expect_err("subpath should be rejected");
+            let error = provider.stage_write(send_request(operation, path)).expect_err("subpath should be rejected");
             let message = error.display_message();
             assert!(message.contains(operation), "got {message}");
             assert!(message.contains(path), "got {message}");
@@ -288,7 +363,7 @@ mod tests {
     fn robot_provider_rejects_mismatched_operation_and_path() {
         let mut provider = RobotArmResourceProvider::new("arm");
         for (operation, path) in [("move", "grip"), ("grip", "move")] {
-            let error = provider.write(send_request(operation, path)).expect_err("mismatch should be rejected");
+            let error = provider.stage_write(send_request(operation, path)).expect_err("mismatch should be rejected");
             let message = error.display_message();
             assert!(message.contains(operation), "got {message}");
             assert!(message.contains(path), "got {message}");
@@ -300,7 +375,7 @@ mod tests {
         let mut provider = RobotArmResourceProvider::new("arm");
         assert!(
             provider
-                .write(RuntimeResourceWriteRequest {
+                .stage_write(RuntimeResourceWriteRequest {
                     base_uri: "robot://arm/commands".to_string(),
                     path: "move".to_string(),
                     context_name: "commands".to_string(),
@@ -312,7 +387,7 @@ mod tests {
         );
         assert!(
             provider
-                .write(RuntimeResourceWriteRequest {
+                .stage_write(RuntimeResourceWriteRequest {
                     base_uri: "robot://arm/commands".to_string(),
                     path: "dance".to_string(),
                     context_name: "commands".to_string(),
@@ -322,5 +397,27 @@ mod tests {
                 })
                 .is_err()
         );
+    }
+
+    #[test]
+    fn robot_effect_compensation_restores_mock_state() {
+        let mut provider = RobotArmResourceProvider::new("arm");
+        let mut effect =
+            apply_write(&mut provider, send_request("move", "move")).unwrap();
+        assert_eq!(
+            provider.state.lock().unwrap().last_command.as_deref(),
+            Some("move"),
+        );
+
+        match &mut effect {
+            PreparedRuntimeEffect::Compensatable(effect) => {
+                effect.compensate().unwrap();
+            }
+            effect => panic!("expected robot compensatable effect, got {effect:?}"),
+        }
+
+        let state = provider.state.lock().unwrap();
+        assert!(state.position.is_none());
+        assert!(state.last_command.is_none());
     }
 }

--- a/hosts/scene/src/provider.rs
+++ b/hosts/scene/src/provider.rs
@@ -5,6 +5,8 @@ use mech_runtime::{
     ConfigValue, HostManifestConfig, RuntimeHostFactory, RuntimeHostInstallation,
     RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent,
     RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, materialize_host_manifest,
+    PreparedRuntimeEffect, RuntimeAfterCommitEffect, RuntimeEffectCost,
+    RuntimeEffectMetadata, RuntimeEffectSource,
 };
 
 use crate::{
@@ -49,15 +51,15 @@ impl SceneBackend for RecordingSceneBackend {
 #[derive(Debug)]
 pub struct SceneResourceProvider<B: SceneBackend> {
     instance: String,
-    backend: B,
-    last_accepted: Option<SceneSnapshot>,
+    backend: Arc<Mutex<B>>,
+    last_accepted: Arc<Mutex<Option<SceneSnapshot>>>,
 }
 impl<B: SceneBackend> SceneResourceProvider<B> {
     pub fn new(instance: impl Into<String>, backend: B) -> Self {
         Self {
             instance: instance.into(),
-            backend,
-            last_accepted: None,
+            backend: Arc::new(Mutex::new(backend)),
+            last_accepted: Arc::new(Mutex::new(None)),
         }
     }
     fn base(&self) -> String {
@@ -98,7 +100,7 @@ impl<B: SceneBackend> RuntimeResourceProvider for SceneResourceProvider<B> {
         }
         Ok(())
     }
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
         self.preflight_write(RuntimeResourceWritePreflightRequest {
             base_uri: request.base_uri.clone(),
             path: request.path.clone(),
@@ -107,11 +109,60 @@ impl<B: SceneBackend> RuntimeResourceProvider for SceneResourceProvider<B> {
             intent: request.intent,
         })?;
         let scene = SceneSnapshot::from_value(&request.value)?;
-        if self.last_accepted.as_ref() == Some(&scene) {
+        Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
+            SceneReplaceEffect {
+                backend: self.backend.clone(),
+                last_accepted: self.last_accepted.clone(),
+                scene,
+                resource: request.base_uri,
+            },
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct SceneReplaceEffect<B: SceneBackend> {
+    backend: Arc<Mutex<B>>,
+    last_accepted: Arc<Mutex<Option<SceneSnapshot>>>,
+    scene: SceneSnapshot,
+    resource: String,
+}
+
+impl<B: SceneBackend> RuntimeAfterCommitEffect for SceneReplaceEffect<B> {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+        RuntimeEffectMetadata::new(
+            RuntimeEffectSource::ResourceProvider {
+                scheme: "scene".to_string(),
+            },
+            "replace",
+        )
+        .with_resource(self.resource.clone())
+        .with_cost(RuntimeEffectCost {
+            bytes: 0,
+            items: 1,
+        })
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+        let mut last_accepted = self
+            .last_accepted
+            .lock()
+            .map_err(|_| scene_error(
+                "SceneResourceProvider",
+                "scene acceptance lock is poisoned",
+            ))?;
+        if last_accepted.as_ref() == Some(&self.scene) {
             return Ok(());
         }
-        self.backend.replace_scene(scene.clone())?;
-        self.last_accepted = Some(scene);
+        self
+            .backend
+            .lock()
+            .map_err(|_| scene_error(
+                "SceneResourceProvider",
+                "scene backend lock is poisoned",
+            ))?
+            .replace_scene(self.scene.clone())?;
+        *last_accepted = Some(self.scene.clone());
         Ok(())
     }
 }

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -3,9 +3,21 @@ use std::collections::BTreeMap;
 use mech_core::{MechError, MechErrorKind, MechRecord, MechTable, MechTuple, Ref, Value};
 use mech_host_scene::*;
 use mech_runtime::{
-    ConfigValue, RuntimeCapabilityOperation, RuntimeHostFactory, RuntimeResourceProvider,
+    ConfigValue, PreparedRuntimeEffect, RuntimeCapabilityOperation, RuntimeResourceProvider,
     RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
 };
+#[cfg(feature = "native")]
+use mech_runtime::RuntimeHostFactory;
+
+fn deliver_write(
+    provider: &mut dyn RuntimeResourceProvider,
+    request: RuntimeResourceWriteRequest,
+) -> mech_core::MResult<()> {
+    match provider.stage_write(request)? {
+        PreparedRuntimeEffect::AfterCommit(mut effect) => effect.deliver(),
+        effect => panic!("expected scene after-commit effect, got {effect:?}"),
+    }
+}
 
 fn f(value: f64) -> Value {
     Value::F64(Ref::new(value))
@@ -421,8 +433,46 @@ fn unknown_send_path_rejected() {
 fn latest_scene_replaces_older_scene() {
     let backend = RecordingSceneBackend::new();
     let mut provider = SceneResourceProvider::new("view", backend.clone());
-    provider
-        .write(RuntimeResourceWriteRequest {
+    deliver_write(
+        &mut provider,
+        RuntimeResourceWriteRequest {
+            base_uri: "scene://view/frame".to_string(),
+            path: "replace".to_string(),
+            context_name: "view".to_string(),
+            operation: RuntimeCapabilityOperation::Write,
+            intent: RuntimeResourceWriteIntent::Send,
+            value: empty_scene(),
+        },
+    )
+    .unwrap();
+    let newer = record(vec![
+        ("width", f(200.0)),
+        ("height", f(50.0)),
+        ("background", s("#000")),
+        ("circles", tuple(vec![])),
+        ("lines", tuple(vec![])),
+    ]);
+    deliver_write(
+        &mut provider,
+        RuntimeResourceWriteRequest {
+            base_uri: "scene://view/frame".to_string(),
+            path: "replace".to_string(),
+            context_name: "view".to_string(),
+            operation: RuntimeCapabilityOperation::Write,
+            intent: RuntimeResourceWriteIntent::Send,
+            value: newer,
+        },
+    )
+    .unwrap();
+    assert_eq!(backend.latest().unwrap().width, 200.0);
+}
+
+#[test]
+fn scene_stage_write_does_not_render_before_delivery() {
+    let backend = RecordingSceneBackend::new();
+    let mut provider = SceneResourceProvider::new("view", backend.clone());
+    let effect = provider
+        .stage_write(RuntimeResourceWriteRequest {
             base_uri: "scene://view/frame".to_string(),
             path: "replace".to_string(),
             context_name: "view".to_string(),
@@ -431,24 +481,15 @@ fn latest_scene_replaces_older_scene() {
             value: empty_scene(),
         })
         .unwrap();
-    let newer = record(vec![
-        ("width", f(200.0)),
-        ("height", f(50.0)),
-        ("background", s("#000")),
-        ("circles", tuple(vec![])),
-        ("lines", tuple(vec![])),
-    ]);
-    provider
-        .write(RuntimeResourceWriteRequest {
-            base_uri: "scene://view/frame".to_string(),
-            path: "replace".to_string(),
-            context_name: "view".to_string(),
-            operation: RuntimeCapabilityOperation::Write,
-            intent: RuntimeResourceWriteIntent::Send,
-            value: newer,
-        })
-        .unwrap();
-    assert_eq!(backend.latest().unwrap().width, 200.0);
+
+    assert_eq!(backend.generation(), 0);
+    match effect {
+        PreparedRuntimeEffect::AfterCommit(mut effect) => {
+            effect.deliver().unwrap();
+        }
+        effect => panic!("expected scene after-commit effect, got {effect:?}"),
+    }
+    assert_eq!(backend.generation(), 1);
 }
 
 #[cfg(feature = "native")]
@@ -474,7 +515,7 @@ fn native_scene_instances_are_isolated() {
         .unwrap()
         .resource_providers
         .remove(0);
-    main.write(RuntimeResourceWriteRequest {
+    deliver_write(main.as_mut(), RuntimeResourceWriteRequest {
         base_uri: "scene://main/frame".to_string(),
         path: "replace".to_string(),
         context_name: "view".to_string(),
@@ -489,7 +530,7 @@ fn native_scene_instances_are_isolated() {
         ]),
     })
     .unwrap();
-    hud.write(RuntimeResourceWriteRequest {
+    deliver_write(hud.as_mut(), RuntimeResourceWriteRequest {
         base_uri: "scene://hud/frame".to_string(),
         path: "replace".to_string(),
         context_name: "view".to_string(),
@@ -521,9 +562,9 @@ fn scene_provider_deduplicates_identical_replacements() {
         value,
     };
 
-    provider.write(write(empty_scene())).unwrap();
+    deliver_write(&mut provider, write(empty_scene())).unwrap();
     assert_eq!(backend.generation(), 1);
-    provider.write(write(empty_scene())).unwrap();
+    deliver_write(&mut provider, write(empty_scene())).unwrap();
     assert_eq!(backend.generation(), 1);
 
     let changed = record(vec![
@@ -533,12 +574,12 @@ fn scene_provider_deduplicates_identical_replacements() {
         ("circles", tuple(vec![])),
         ("lines", tuple(vec![])),
     ]);
-    provider.write(write(changed)).unwrap();
+    deliver_write(&mut provider, write(changed)).unwrap();
     assert_eq!(backend.generation(), 2);
 
     let other_backend = RecordingSceneBackend::new();
     let mut other_provider = SceneResourceProvider::new("other", other_backend.clone());
-    other_provider.write(RuntimeResourceWriteRequest {
+    deliver_write(&mut other_provider, RuntimeResourceWriteRequest {
         base_uri: "scene://other/frame".to_string(),
         path: "replace".to_string(),
         context_name: "main".to_string(),
@@ -589,10 +630,10 @@ fn scene_provider_failed_replace_does_not_advance_dedup_state() {
         value,
     };
     backend.fail_next();
-    assert!(provider.write(write(empty_scene())).is_err());
+    assert!(deliver_write(&mut provider, write(empty_scene())).is_err());
     assert_eq!(backend.generation(), 0);
-    provider.write(write(empty_scene())).unwrap();
+    deliver_write(&mut provider, write(empty_scene())).unwrap();
     assert_eq!(backend.generation(), 1);
-    provider.write(write(empty_scene())).unwrap();
+    deliver_write(&mut provider, write(empty_scene())).unwrap();
     assert_eq!(backend.generation(), 1);
 }

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,12 +1,14 @@
 use criterion::{
   BatchSize, Criterion, criterion_group, criterion_main,
 };
-use mech_core::{MResult, MechSourceCode};
+use mech_core::{MResult, MechSourceCode, Value};
 use mech_runtime::{
-  BasicCapability, CapabilityId, CapabilityRequest, MechRuntime, ObjectId,
-  ObjectRecord, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+  CapabilityRequest, MechRuntime, ObjectId, ObjectRecord,
+  PreparedRuntimeEffect, RuntimeAfterCommitEffect,
   RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
-  RuntimeEffectSource, SequentialIdGenerator,
+  RuntimeEffectSource, RuntimePreparedHostCall, SequentialIdGenerator,
+  StagedClosureHostFunction,
 };
 use std::hint::black_box;
 use std::sync::Arc;
@@ -147,6 +149,50 @@ fn explicit_failure_source() -> MechSourceCode {
       "bench-explicit-error := missing-bench-value + 1".to_string(),
     ),
   ])
+}
+
+fn staged_effect_rollback_fixture(
+  count: usize,
+) -> (ExplicitFixture, MechSourceCode) {
+  let mut runtime = retained_runtime();
+  runtime
+    .grant_capability(Arc::new(BasicCapability::new(
+      CapabilityId(8_000),
+      &BasicSubject::new(runtime.runtime_context().unwrap().subject),
+      &BasicResource::new("host:bench/staged"),
+      [BasicOperation::new("call")],
+    )))
+    .unwrap();
+  runtime
+    .register_mech_host_function(StagedClosureHostFunction::new(
+      "bench/staged",
+      |_services, _context, _arguments| {
+        Ok(RuntimePreparedHostCall {
+          value: Value::Empty,
+          effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+            BenchmarkAfterCommitEffect { sequence: 0 },
+          )),
+        })
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+
+  let mut source = Vec::with_capacity(count.saturating_add(1));
+  for sequence in 0..count {
+    source.push(MechSourceCode::String(format!(
+      "bench-staged-{sequence} := bench/staged()",
+    )));
+  }
+  source.push(MechSourceCode::String(
+    "bench-staged-error := missing-bench-value + 1".to_string(),
+  ));
+
+  (
+    ExplicitFixture { runtime, context },
+    MechSourceCode::Program(source),
+  )
 }
 
 fn program_transaction_benchmarks(c: &mut Criterion) {
@@ -314,11 +360,7 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
     "explicit_effect_savepoint_rollback_with_100_staged",
     |b| {
       b.iter_batched(
-        || {
-          let mut fixture = subsequent_explicit_fixture();
-          stage_after_commit(&mut fixture, 100);
-          (fixture, explicit_failure_source())
-        },
+        || staged_effect_rollback_fixture(100),
         |(mut fixture, source)| {
           let error = fixture
             .runtime

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,15 +1,102 @@
 use criterion::{
   BatchSize, Criterion, criterion_group, criterion_main,
 };
-use mech_core::MechSourceCode;
+use mech_core::{MResult, MechSourceCode};
 use mech_runtime::{
-  MechRuntime, RuntimeContext, SequentialIdGenerator,
+  BasicCapability, CapabilityId, CapabilityRequest, MechRuntime, ObjectId,
+  ObjectRecord, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+  RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
+  RuntimeEffectSource, SequentialIdGenerator,
 };
 use std::hint::black_box;
+use std::sync::Arc;
 
 struct ExplicitFixture {
   runtime: MechRuntime,
   context: RuntimeContext,
+}
+
+#[derive(Debug)]
+struct BenchmarkAfterCommitEffect {
+  sequence: usize,
+}
+
+impl RuntimeAfterCommitEffect for BenchmarkAfterCommitEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "benchmark-after-commit".to_string(),
+      },
+      "deliver",
+    )
+    .with_resource(format!("bench://after-commit/{}", self.sequence))
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+}
+
+#[derive(Debug)]
+struct BenchmarkCompensatableEffect {
+  sequence: usize,
+}
+
+impl RuntimeCompensatableEffect for BenchmarkCompensatableEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "benchmark-compensatable".to_string(),
+      },
+      "apply",
+    )
+    .with_resource(format!("bench://compensatable/{}", self.sequence))
+  }
+
+  fn apply(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+
+  fn compensate(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+}
+
+fn stage_after_commit(
+  fixture: &mut ExplicitFixture,
+  count: usize,
+) {
+  for sequence in 0..count {
+    fixture
+      .runtime
+      .stage_runtime_effect_with_context(
+        &mut fixture.context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          BenchmarkAfterCommitEffect { sequence },
+        )),
+      )
+      .unwrap();
+  }
+}
+
+fn stage_compensatable(
+  fixture: &mut ExplicitFixture,
+  count: usize,
+) {
+  for sequence in 0..count {
+    fixture
+      .runtime
+      .stage_runtime_effect_with_context(
+        &mut fixture.context,
+        PreparedRuntimeEffect::Compensatable(Box::new(
+          BenchmarkCompensatableEffect { sequence },
+        )),
+      )
+      .unwrap();
+  }
 }
 
 fn retained_runtime() -> MechRuntime {
@@ -188,6 +275,165 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
           .unwrap();
         black_box(value);
         black_box((runtime, context))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  for count in [1, 100] {
+    group.bench_function(
+      format!("stage_{count}_after_commit_effects"),
+      |b| {
+        b.iter_batched(
+          explicit_fixture,
+          |mut fixture| {
+            stage_after_commit(&mut fixture, count);
+            black_box(fixture)
+          },
+          BatchSize::SmallInput,
+        )
+      },
+    );
+
+    group.bench_function(
+      format!("stage_{count}_compensatable_effects"),
+      |b| {
+        b.iter_batched(
+          explicit_fixture,
+          |mut fixture| {
+            stage_compensatable(&mut fixture, count);
+            black_box(fixture)
+          },
+          BatchSize::SmallInput,
+        )
+      },
+    );
+  }
+
+  group.bench_function(
+    "explicit_effect_savepoint_rollback_with_100_staged",
+    |b| {
+      b.iter_batched(
+        || {
+          let mut fixture = subsequent_explicit_fixture();
+          stage_after_commit(&mut fixture, 100);
+          (fixture, explicit_failure_source())
+        },
+        |(mut fixture, source)| {
+          let error = fixture
+            .runtime
+            .run_source_with_context(&mut fixture.context, &source)
+            .unwrap_err();
+          black_box(error);
+          black_box(fixture)
+        },
+        BatchSize::SmallInput,
+      )
+    },
+  );
+
+  group.bench_function("reversible_effect_commit", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_compensatable(&mut fixture, 1);
+        fixture
+      },
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("store_failure_with_compensation", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_compensatable(&mut fixture, 1);
+        fixture
+          .runtime
+          .update_object_with_context(
+            &mut fixture.context,
+            ObjectRecord::text(
+              ObjectId(9_000),
+              "missing",
+              "benchmark",
+            ),
+          )
+          .unwrap();
+        fixture
+      },
+      |mut fixture| {
+        let error = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap_err();
+        black_box(error);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("capability_overlay_lookup", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        let capability = Arc::new(BasicCapability::from_keys(
+          CapabilityId(7_000),
+          "bench-subject",
+          "bench://resource",
+          [":read"],
+        ));
+        fixture
+          .runtime
+          .grant_capability_with_context(
+            &mut fixture.context,
+            capability,
+          )
+          .unwrap();
+        let request = CapabilityRequest::from_keys(
+          "bench-subject",
+          ":read",
+          "bench://resource",
+        );
+        (fixture, request)
+      },
+      |(mut fixture, request)| {
+        let capability = fixture
+          .runtime
+          .check_capability_with_context(
+            &mut fixture.context,
+            &request,
+          )
+          .unwrap();
+        black_box(capability);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("deliver_100_after_commit_effects", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_after_commit(&mut fixture, 100);
+        fixture
+      },
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
       },
       BatchSize::SmallInput,
     )

--- a/src/runtime/examples/arbitrary_rust_host_function.rs
+++ b/src/runtime/examples/arbitrary_rust_host_function.rs
@@ -44,7 +44,7 @@ fn main() -> MResult<()> {
 
   println!("runtime: {}", short(runtime.id()));
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/echo",
     |_services, _context, args| {
       let text = host_arg_string("demo/echo", &args, 0)?;
@@ -56,7 +56,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/join",
     |_services, _context, args| {
       let left = host_arg_string("demo/join", &args, 0)?;

--- a/src/runtime/examples/arbitrary_rust_host_functions2.rs
+++ b/src/runtime/examples/arbitrary_rust_host_functions2.rs
@@ -75,7 +75,7 @@ fn main() -> MResult<()> {
 
   println!("runtime: {}", short(runtime.id()));
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/text/shout",
     |_services, _context, args| {
       host_call1("demo/text/shout", &args, |text: String| {
@@ -84,7 +84,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/text/join",
     |_services, _context, args| {
       host_call2("demo/text/join", &args, |left: String, right: String| {
@@ -93,7 +93,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/math/add",
     |_services, _context, args| {
       host_call2("demo/math/add", &args, |left: f64, right: f64| {
@@ -102,7 +102,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/math/affine",
     |_services, _context, args| {
       host_call3(
@@ -115,7 +115,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/bool/not",
     |_services, _context, args| {
       host_call1("demo/bool/not", &args, |value: bool| {
@@ -124,7 +124,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/optional/greet",
     |_services, _context, args| {
       let name = host_arg_optional_string(
@@ -138,14 +138,14 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/echo",
     |_services, _context, args| {
       Ok(host_arg_cloned("demo/value/echo", &args, 0)?)
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/result/checked-reciprocal",
     |_services, _context, args| {
       host_call_result1(

--- a/src/runtime/examples/host_value_roundtrip.rs
+++ b/src/runtime/examples/host_value_roundtrip.rs
@@ -66,22 +66,18 @@ fn main() -> MResult<()> {
 
   println!("runtime: {}", short(runtime.id()));
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/wrap",
     |_services, _context, args| {
       let input = host_arg_string("demo/value/wrap", &args, 0)?;
 
       let output = format!("rust-wrap({})", input);
 
-      println!("rust demo/value/wrap:");
-      println!("  input:  {:?}", input);
-      println!("  output: {:?}", output);
-
       Ok(value_string(output))
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/append",
     |_services, _context, args| {
       let input = host_arg_string("demo/value/append", &args, 0)?;
@@ -89,22 +85,14 @@ fn main() -> MResult<()> {
 
       let output = format!("{}{}", input, suffix);
 
-      println!("rust demo/value/append:");
-      println!("  input:  {:?}", input);
-      println!("  suffix: {:?}", suffix);
-      println!("  output: {:?}", output);
-
       Ok(value_string(output))
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/inspect",
     |_services, _context, args| {
       let value = host_arg_cloned("demo/value/inspect", &args, 0)?;
-
-      println!("rust demo/value/inspect:");
-      println!("  value: {}", display_value(&value));
 
       // Return the value unchanged so the Mech program's final result is the
       // value Rust inspected.

--- a/src/runtime/examples/matrix_multiply.rs
+++ b/src/runtime/examples/matrix_multiply.rs
@@ -1,5 +1,5 @@
 use std::fmt::Display;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use mech_core::{MResult, MechMatrix as Matrix, ToMatrix, Value};
 
@@ -60,8 +60,6 @@ fn main() -> MResult<()> {
     .map(|(a, b)| a * b)
     .sum::<f64>();
 
-  let result_store = Arc::new(Mutex::new(None::<f64>));
-
   let mut runtime = RuntimeBuilder::new()
     .capability_kernel(BasicCapabilityKernel::new())
     .build()?;
@@ -74,7 +72,7 @@ fn main() -> MResult<()> {
   {
     let v1 = v1.clone();
 
-    runtime.register_mech_host_function(ClosureHostFunction::new(
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure(
       "demo/matrix/v1",
       move |_services, _context, args| {
         host_call0("demo/matrix/v1", &args, || {
@@ -87,7 +85,7 @@ fn main() -> MResult<()> {
   {
     let v2 = v2.clone();
 
-    runtime.register_mech_host_function(ClosureHostFunction::new(
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure(
       "demo/matrix/v2",
       move |_services, _context, args| {
         host_call0("demo/matrix/v2", &args, || {
@@ -97,46 +95,11 @@ fn main() -> MResult<()> {
     ))?;
   }
 
-  {
-    let result_store = result_store.clone();
-
-    runtime.register_mech_host_function(ClosureHostFunction::new(
-      "demo/matrix/store-result",
-      move |_services, _context, args| {
-        let result = host_arg_matrix_f64(
-          "demo/matrix/store-result",
-          &args,
-          0,
-        )?;
-
-        let shape = result.shape();
-
-        println!("rust received matrix result:");
-        println!("  shape: {:?}", shape);
-        println!("  matrix: {:?}", result);
-
-        let Some(actual) = matrix_scalar_f64(&result) else {
-          panic!(
-            "expected a 1x1 matrix result, got shape {:?}",
-            shape,
-          );
-        };
-
-        println!("  scalar: {}", actual);
-
-        *result_store.lock().unwrap() = Some(actual);
-
-        Ok(Value::MatrixF64(result))
-      },
-    ))?;
-  }
-
   let subject = BasicSubject::new("program:matrix-multiply");
 
   for (id, name) in [
     (1, "demo/matrix/v1"),
     (2, "demo/matrix/v2"),
-    (3, "demo/matrix/store-result"),
   ] {
     runtime.grant_capability(Arc::new(BasicCapability::new(
       CapabilityId(id),
@@ -150,7 +113,7 @@ fn main() -> MResult<()> {
     v1 := demo/matrix/v1()
     v2 := demo/matrix/v2()
     result := v1 ** v2'
-    demo/matrix/store-result(result)
+    result
   "#;
 
   println!();
@@ -169,10 +132,13 @@ fn main() -> MResult<()> {
   println!();
   println!("program result: {:?}", value);
 
-  let stored = result_store
-    .lock()
-    .unwrap()
-    .expect("Rust host did not receive matrix result");
+  let result = host_arg_matrix_f64(
+    "matrix-multiply result",
+    &[value],
+    0,
+  )?;
+  let stored = matrix_scalar_f64(&result)
+    .expect("Mech program did not return a 1x1 matrix");
 
   assert!(
     (stored - expected).abs() < f64::EPSILON,

--- a/src/runtime/src/bin/address_target_diagnostics.rs
+++ b/src/runtime/src/bin/address_target_diagnostics.rs
@@ -1,5 +1,5 @@
 use mech_core::{Ref, Value};
-use mech_runtime::{FileSourceResolver, InMemoryDocsProvider, ModuleBuildOptions, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeInMemoryDocsResourceSpec, RuntimeResourceConfigSpec, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent, RuntimeResourceWriteRequest, SourceScope};
+use mech_runtime::{FileSourceResolver, InMemoryDocsProvider, ModuleBuildOptions, PreparedRuntimeEffect, RuntimeBuilder, RuntimeCapabilityGrant, RuntimeCapabilityOperation, RuntimeConfigSpec, RuntimeInMemoryDocsResourceSpec, RuntimeResourceConfigSpec, RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWriteIntent, RuntimeResourceWriteRequest, SourceScope};
 
 fn write_case(root: &std::path::Path, name: &str, source: &str) -> std::path::PathBuf {
   let case_root = root.join(name);
@@ -76,7 +76,11 @@ fn main() {
   let mut provider = InMemoryDocsProvider::new();
   println!("provider write/read:");
   println!("  write docs://manual intro/title = true");
-  provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: Value::Bool(Ref::new(true)), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  let effect = provider.stage_write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: Value::Bool(Ref::new(true)), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  match effect {
+    PreparedRuntimeEffect::Compensatable(mut effect) => effect.apply().unwrap(),
+    other => panic!("in-memory docs returned unexpected effect protocol: {:?}", other.protocol()),
+  }
   let value = provider.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
   match value {
     Value::Bool(value) => println!("  read result: Bool({})", value.borrow()),

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -2,11 +2,25 @@ use crate::*;
 
 use mech_core::*;
 use std::sync::Arc;
+use std::any::Any;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 // -----------------------------------------------------------------------------
 // Capability Kernel Trait
 // -----------------------------------------------------------------------------
+
+pub trait CapabilityKernelCheckpoint: std::fmt::Debug + Send {
+  fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+impl<T> CapabilityKernelCheckpoint for T
+where
+  T: std::fmt::Debug + Send + Any,
+{
+  fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    self
+  }
+}
 
 /// Capability authority graph and checking interface.
 ///
@@ -14,6 +28,30 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// audited, cryptographic-token-based, or host-specific authority systems should
 /// implement this trait.
 pub trait CapabilityKernel: std::fmt::Debug + Send {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel does not support transaction checkpoints".to_string(),
+      },
+      None,
+    ))
+  }
+
+  fn restore_checkpoint(
+    &mut self,
+    _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel does not support transaction checkpoint restore"
+          .to_string(),
+      },
+      None,
+    ))
+  }
+
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId>;
 
   /// Administratively remove a grant that has not committed.
@@ -148,6 +186,29 @@ impl BasicCapabilityKernel {
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    Ok(Box::new(self.clone()))
+  }
+
+  fn restore_checkpoint(
+    &mut self,
+    checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    let snapshot = checkpoint
+      .into_any()
+      .downcast::<BasicCapabilityKernel>()
+      .map_err(|_| MechError::new(
+        TransactionStateUnsupportedError {
+          function: "basic capability kernel".to_string(),
+          reason: "checkpoint belongs to a different kernel implementation"
+            .to_string(),
+        },
+        None,
+      ))?;
+    *self = *snapshot;
+    Ok(())
+  }
+
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
     let capability = grant.capability;
     capability.validate()?;
@@ -370,6 +431,19 @@ impl SharedCapabilityKernel {
 }
 
 impl CapabilityKernel for SharedCapabilityKernel {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    self.inner.lock().unwrap().checkpoint()
+  }
+  fn restore_checkpoint(
+    &mut self,
+    checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    self
+      .inner
+      .lock()
+      .unwrap()
+      .restore_checkpoint(checkpoint)
+  }
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
   fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -38,7 +38,7 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
     ))
   }
 
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -71,6 +71,24 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()>;
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId>;
+
+  fn check_excluding(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    if excluded.is_empty() {
+      return self.check(request);
+    }
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel cannot exclude transaction-local revocations"
+          .to_string(),
+      },
+      None,
+    ))
+  }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>>;
 
@@ -183,6 +201,74 @@ impl BasicCapabilityKernel {
       !children.is_empty()
     });
   }
+
+  fn check_with_exclusions(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    let Some(ids) = self.by_subject.get(&request.subject) else {
+      return Err(MechError::new(
+        CapabilityDeniedError {
+          subject: request.subject.clone(),
+          operation: request.operation.clone(),
+          resource: request.resource.clone(),
+          reason: "subject has no capabilities".to_string(),
+        },
+        None,
+      ));
+    };
+
+    let ids: Vec<CapabilityId> = ids.iter().copied().collect();
+    let mut last_reason = None;
+
+    for id in ids {
+      if excluded.contains(&id) {
+        last_reason =
+          Some("capability is revoked by the active transaction".to_string());
+        continue;
+      }
+      if self.revoked.contains(&id) {
+        last_reason = Some("capability is revoked".to_string());
+        continue;
+      }
+
+      let Some(capability) = self.capabilities.get(&id) else {
+        continue;
+      };
+
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.successful_uses(id);
+        if actual >= max_uses {
+          last_reason = Some(format!(
+            "use limit exceeded: max {}, actual {}",
+            max_uses, actual,
+          ));
+          continue;
+        }
+      }
+
+      let decision = capability.check(request)?;
+      if !decision.allowed {
+        last_reason = decision.reason;
+        continue;
+      }
+
+      self.increment_uses(id);
+      return Ok(id);
+    }
+
+    Err(MechError::new(
+      CapabilityDeniedError {
+        subject: request.subject.clone(),
+        operation: request.operation.clone(),
+        resource: request.resource.clone(),
+        reason: last_reason
+          .unwrap_or_else(|| "no matching capability".to_string()),
+      },
+      None,
+    ))
+  }
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
@@ -190,7 +276,7 @@ impl CapabilityKernel for BasicCapabilityKernel {
     Ok(Box::new(self.clone()))
   }
 
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -267,65 +353,15 @@ impl CapabilityKernel for BasicCapabilityKernel {
   }
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
-    let Some(ids) = self.by_subject.get(&request.subject) else {
-      return Err(MechError::new(
-        CapabilityDeniedError {
-          subject: request.subject.clone(),
-          operation: request.operation.clone(),
-          resource: request.resource.clone(),
-          reason: "subject has no capabilities".to_string(),
-        },
-        None,
-      ));
-    };
+    self.check_with_exclusions(request, &HashSet::new())
+  }
 
-    let ids: Vec<CapabilityId> = ids.iter().copied().collect();
-    let mut last_reason = None;
-
-    for id in ids {
-      if self.revoked.contains(&id) {
-        last_reason = Some("capability is revoked".to_string());
-        continue;
-      }
-
-      let Some(capability) = self.capabilities.get(&id) else {
-        continue;
-      };
-
-      if let Some(max_uses) = capability.max_uses() {
-        let actual = self.successful_uses(id);
-        if actual >= max_uses {
-          last_reason = Some(format!(
-            "use limit exceeded: max {}, actual {}",
-            max_uses, actual,
-          ));
-          continue;
-        }
-      }
-
-      let decision = capability.check(request)?;
-
-      if !decision.allowed {
-        last_reason = decision.reason;
-        continue;
-      }
-
-      // The generic Capability trait does not expose max_uses, because custom
-      // capabilities can implement their own use accounting inside check().
-      // The default kernel still tracks successful uses for inspection.
-      self.increment_uses(id);
-      return Ok(id);
-    }
-
-    Err(MechError::new(
-      CapabilityDeniedError {
-        subject: request.subject.clone(),
-        operation: request.operation.clone(),
-        resource: request.resource.clone(),
-        reason: last_reason.unwrap_or_else(|| "no matching capability".to_string()),
-      },
-      None,
-    ))
+  fn check_excluding(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    self.check_with_exclusions(request, excluded)
   }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
@@ -434,7 +470,7 @@ impl CapabilityKernel for SharedCapabilityKernel {
   fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
     self.inner.lock().unwrap().checkpoint()
   }
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -442,12 +478,13 @@ impl CapabilityKernel for SharedCapabilityKernel {
       .inner
       .lock()
       .unwrap()
-      .restore_checkpoint(checkpoint)
+      .restore(checkpoint)
   }
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
   fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().check(request) }
+  fn check_excluding(&mut self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().check_excluding(request, excluded) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>> { self.inner.lock().unwrap().list_for_subject(subject) }
   fn derive_capability(&mut self, derivation: CapabilityDerivation) -> MResult<CapabilityId> { self.inner.lock().unwrap().derive_capability(derivation) }

--- a/src/runtime/src/effect.rs
+++ b/src/runtime/src/effect.rs
@@ -67,6 +67,32 @@ pub struct RuntimeEffectMetadata {
   pub cost: RuntimeEffectCost,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeEffectRecord {
+  pub id: RuntimeEffectId,
+  pub source: RuntimeEffectSource,
+  pub operation: String,
+  pub resource: Option<String>,
+  pub protocol: RuntimeEffectProtocol,
+}
+
+impl RuntimeEffectRecord {
+  pub fn new(
+    id: RuntimeEffectId,
+    metadata: RuntimeEffectMetadata,
+    protocol: RuntimeEffectProtocol,
+  ) -> Self {
+    Self {
+      id,
+      source: metadata.source,
+      operation: metadata.operation,
+      resource: metadata.resource,
+      protocol,
+    }
+  }
+}
+
 impl RuntimeEffectMetadata {
   pub fn new(
     source: RuntimeEffectSource,

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -15,6 +15,9 @@ use crate::id::{
   ActorId, CapabilityId, EventId, ModuleVersionId, ObjectId, RuntimeId, TaskId,
   TransactionId, MessageId
 };
+use crate::effect::{
+  RuntimeEffectId, RuntimeEffectProtocol, RuntimeEffectSource,
+};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -77,6 +80,30 @@ pub enum RuntimeEventKind {
   TransactionCommitted { transaction_id: TransactionId },
   TransactionAborted { transaction_id: TransactionId, message: String },
 
+  EffectStaged {
+    effect_id: RuntimeEffectId,
+    source: RuntimeEffectSource,
+    operation: String,
+    resource: Option<String>,
+    protocol: RuntimeEffectProtocol,
+  },
+  EffectPreparationFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
+  EffectCompensated { effect_id: RuntimeEffectId },
+  EffectAborted { effect_id: RuntimeEffectId },
+  TransactionalEffectCommitted { effect_id: RuntimeEffectId },
+  EffectDelivered { effect_id: RuntimeEffectId },
+  EffectDeliveryFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
+  ExternalCommitIndeterminate {
+    transaction_id: TransactionId,
+    effect_id: RuntimeEffectId,
+  },
+
   SchedulerWorkQueued { work: String },
   SchedulerWorkStarted { work: String },
   SchedulerWorkCompleted { work: String },
@@ -127,6 +154,22 @@ impl RuntimeEventKind {
       RuntimeEventKind::TransactionStarted { .. } => ":transaction/started",
       RuntimeEventKind::TransactionCommitted { .. } => ":transaction/committed",
       RuntimeEventKind::TransactionAborted { .. } => ":transaction/aborted",
+      RuntimeEventKind::EffectStaged { .. } => ":effect/staged",
+      RuntimeEventKind::EffectPreparationFailed { .. } => {
+        ":effect/preparation/failed"
+      }
+      RuntimeEventKind::EffectCompensated { .. } => ":effect/compensated",
+      RuntimeEventKind::EffectAborted { .. } => ":effect/aborted",
+      RuntimeEventKind::TransactionalEffectCommitted { .. } => {
+        ":effect/transactional/committed"
+      }
+      RuntimeEventKind::EffectDelivered { .. } => ":effect/delivered",
+      RuntimeEventKind::EffectDeliveryFailed { .. } => {
+        ":effect/delivery/failed"
+      }
+      RuntimeEventKind::ExternalCommitIndeterminate { .. } => {
+        ":effect/commit/indeterminate"
+      }
       RuntimeEventKind::SchedulerWorkQueued { .. } => ":scheduler/work/queued",
       RuntimeEventKind::SchedulerWorkStarted { .. } => ":scheduler/work/started",
       RuntimeEventKind::SchedulerWorkCompleted { .. } => ":scheduler/work/completed",

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -92,6 +92,10 @@ pub enum RuntimeEventKind {
     message: String,
   },
   EffectCompensated { effect_id: RuntimeEffectId },
+  EffectCompensationFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
   EffectAborted { effect_id: RuntimeEffectId },
   TransactionalEffectCommitted { effect_id: RuntimeEffectId },
   EffectDelivered { effect_id: RuntimeEffectId },
@@ -159,6 +163,9 @@ impl RuntimeEventKind {
         ":effect/preparation/failed"
       }
       RuntimeEventKind::EffectCompensated { .. } => ":effect/compensated",
+      RuntimeEventKind::EffectCompensationFailed { .. } => {
+        ":effect/compensation/failed"
+      }
       RuntimeEventKind::EffectAborted { .. } => ":effect/aborted",
       RuntimeEventKind::TransactionalEffectCommitted { .. } => {
         ":effect/transactional/committed"

--- a/src/runtime/src/host/actor.rs
+++ b/src/runtime/src/host/actor.rs
@@ -32,6 +32,10 @@ impl HostFunction for ActorMessageKindHostFunction {
     "actor/message/kind"
   }
 
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -85,6 +89,10 @@ impl Default for ActorMessagePayloadHostFunction {
 impl HostFunction for ActorMessagePayloadHostFunction {
   fn name(&self) -> &str {
     "actor/message/payload"
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
   }
 
   fn call(
@@ -142,6 +150,10 @@ impl HostFunction for ActorStateIdHostFunction {
     "actor/state/id"
   }
 
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -189,6 +201,10 @@ impl Default for ActorStateGetHostFunction {
 impl HostFunction for ActorStateGetHostFunction {
   fn name(&self) -> &str {
     "actor/state/get"
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
   }
 
   fn call(
@@ -242,6 +258,10 @@ impl Default for ActorStatePutHostFunction {
 impl HostFunction for ActorStatePutHostFunction {
   fn name(&self) -> &str {
     "actor/state/put"
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
   }
 
   fn call(

--- a/src/runtime/src/host/actor.rs
+++ b/src/runtime/src/host/actor.rs
@@ -36,6 +36,15 @@ impl HostFunction for ActorMessageKindHostFunction {
     HostFunctionTransactionMode::RuntimeManaged
   }
 
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -93,6 +102,15 @@ impl HostFunction for ActorMessagePayloadHostFunction {
 
   fn transaction_mode(&self) -> HostFunctionTransactionMode {
     HostFunctionTransactionMode::RuntimeManaged
+  }
+
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
   }
 
   fn call(
@@ -154,6 +172,15 @@ impl HostFunction for ActorStateIdHostFunction {
     HostFunctionTransactionMode::RuntimeManaged
   }
 
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -205,6 +232,15 @@ impl HostFunction for ActorStateGetHostFunction {
 
   fn transaction_mode(&self) -> HostFunctionTransactionMode {
     HostFunctionTransactionMode::RuntimeManaged
+  }
+
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
   }
 
   fn call(
@@ -262,6 +298,25 @@ impl HostFunction for ActorStatePutHostFunction {
 
   fn transaction_mode(&self) -> HostFunctionTransactionMode {
     HostFunctionTransactionMode::RuntimeManaged
+  }
+
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    if context.actor.is_none() {
+      return Err(MechError::new(
+        HostInvalidContextError {
+          function: self.name().to_string(),
+          reason: "no actor is bound to the runtime context".to_string(),
+        },
+        None,
+      ));
+    }
+    host_arg_string(self.name(), &args, 0)?;
+    Ok(Value::String(Ref::new(services.next_object_id().to_string())))
   }
 
   fn call(

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -39,6 +39,14 @@ pub use self::arg::*;
 // Host Function
 // -----------------------------------------------------------------------------
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostFunctionTransactionMode {
+  Pure,
+  RuntimeManaged,
+  Staged,
+  ImmediateOnly,
+}
+
 /// A callable host function.
 ///
 /// This trait is the embedder boundary. Implementations can wrap closures,
@@ -54,6 +62,15 @@ pub trait HostFunction: std::fmt::Debug + Send + Sync {
   /// - `ui.render`
   /// - `net.fetch`
   fn name(&self) -> &str;
+
+  /// Declares how the function participates in runtime transactions.
+  ///
+  /// The conservative default is `ImmediateOnly`: existing host callbacks may
+  /// have arbitrary side effects, so retained execution must not invoke them
+  /// inside an implicit or explicit transaction without an explicit contract.
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::ImmediateOnly
+  }
 
   /// Optional resource key used for capability checks.
   ///
@@ -115,6 +132,7 @@ where
 {
   name: String,
   capability: Option<CapabilityRequest>,
+  transaction_mode: HostFunctionTransactionMode,
   function: F,
 }
 
@@ -126,6 +144,7 @@ where
     f.debug_struct("ClosureHostFunction")
       .field("name", &self.name)
       .field("capability", &self.capability)
+      .field("transaction_mode", &self.transaction_mode)
       .field("function", &"<closure>")
       .finish()
   }
@@ -139,9 +158,44 @@ where
     name: impl Into<String>,
     function: F,
   ) -> Self {
+    Self::with_transaction_mode(
+      name,
+      HostFunctionTransactionMode::ImmediateOnly,
+      function,
+    )
+  }
+
+  pub fn new_pure(
+    name: impl Into<String>,
+    function: F,
+  ) -> Self {
+    Self::with_transaction_mode(
+      name,
+      HostFunctionTransactionMode::Pure,
+      function,
+    )
+  }
+
+  pub fn new_runtime_managed(
+    name: impl Into<String>,
+    function: F,
+  ) -> Self {
+    Self::with_transaction_mode(
+      name,
+      HostFunctionTransactionMode::RuntimeManaged,
+      function,
+    )
+  }
+
+  fn with_transaction_mode(
+    name: impl Into<String>,
+    transaction_mode: HostFunctionTransactionMode,
+    function: F,
+  ) -> Self {
     Self {
       name: name.into(),
       capability: None,
+      transaction_mode,
       function,
     }
   }
@@ -161,6 +215,10 @@ where
 {
   fn name(&self) -> &str {
     &self.name
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    self.transaction_mode
   }
 
   fn required_capability(&self, context: &RuntimeContext) -> Option<CapabilityRequest> {
@@ -631,5 +689,34 @@ mod tests {
       .unwrap();
 
     assert_eq!(result, Value::Empty);
+  }
+
+  #[test]
+  fn closure_constructors_require_explicit_transaction_contracts() {
+    let immediate = ClosureHostFunction::new(
+      "host.immediate",
+      |_services, _ctx, _args| Ok(Value::Empty),
+    );
+    let pure = ClosureHostFunction::new_pure(
+      "host.pure",
+      |_services, _ctx, _args| Ok(Value::Empty),
+    );
+    let runtime_managed = ClosureHostFunction::new_runtime_managed(
+      "host.runtime-managed",
+      |_services, _ctx, _args| Ok(Value::Empty),
+    );
+
+    assert_eq!(
+      immediate.transaction_mode(),
+      HostFunctionTransactionMode::ImmediateOnly,
+    );
+    assert_eq!(
+      pure.transaction_mode(),
+      HostFunctionTransactionMode::Pure,
+    );
+    assert_eq!(
+      runtime_managed.transaction_mode(),
+      HostFunctionTransactionMode::RuntimeManaged,
+    );
   }
 }

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -28,6 +28,7 @@ use crate::capability::{
 use crate::context::RuntimeContext;
 
 use crate::service::RuntimeServices;
+use crate::PreparedRuntimeEffect;
 
 pub mod actor;
 pub mod arg;
@@ -45,6 +46,12 @@ pub enum HostFunctionTransactionMode {
   RuntimeManaged,
   Staged,
   ImmediateOnly,
+}
+
+#[derive(Debug)]
+pub struct RuntimePreparedHostCall {
+  pub value: Value,
+  pub effect: PreparedRuntimeEffect,
 }
 
 /// A callable host function.
@@ -110,13 +117,37 @@ pub trait HostFunction: std::fmt::Debug + Send + Sync {
     args.len() as u64
   }
 
-  /// Invoke the host function.
+  /// Invoke a pure, runtime-managed, or immediate-only host function.
   fn call(
     &self,
-    services: &mut dyn RuntimeServices,
-    context: &mut RuntimeContext,
-    args: Vec<Value>,
-  ) -> MResult<Value>;
+    _services: &mut dyn RuntimeServices,
+    _context: &mut RuntimeContext,
+    _args: Vec<Value>,
+  ) -> MResult<Value> {
+    Err(MechError::new(
+      InvalidHostCallError {
+        function: self.name().to_string(),
+        reason: "host function does not implement immediate invocation".to_string(),
+      },
+      None,
+    ))
+  }
+
+  /// Prepare a staged host call and its provisional program value.
+  fn stage_call(
+    &self,
+    _services: &mut dyn RuntimeServices,
+    _context: &mut RuntimeContext,
+    _args: Vec<Value>,
+  ) -> MResult<RuntimePreparedHostCall> {
+    Err(MechError::new(
+      InvalidHostCallError {
+        function: self.name().to_string(),
+        reason: "host function does not implement staged invocation".to_string(),
+      },
+      None,
+    ))
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -227,6 +258,83 @@ where
   }
 
   fn call(&self, services: &mut dyn RuntimeServices, context: &mut RuntimeContext, args: Vec<Value>) -> MResult<Value> {
+    (self.function)(services, context, args)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Staged Closure Host Function
+// -----------------------------------------------------------------------------
+
+pub struct StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  name: String,
+  capability: Option<CapabilityRequest>,
+  function: F,
+}
+
+impl<F> std::fmt::Debug for StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("StagedClosureHostFunction")
+      .field("name", &self.name)
+      .field("capability", &self.capability)
+      .field("function", &"<staged-closure>")
+      .finish()
+  }
+}
+
+impl<F> StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  pub fn new(
+    name: impl Into<String>,
+    function: F,
+  ) -> Self {
+    Self {
+      name: name.into(),
+      capability: None,
+      function,
+    }
+  }
+
+  pub fn with_capability(
+    mut self,
+    capability: CapabilityRequest,
+  ) -> Self {
+    self.capability = Some(capability);
+    self
+  }
+}
+
+impl<F> HostFunction for StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  fn name(&self) -> &str {
+    &self.name
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::Staged
+  }
+
+  fn required_capability(&self, context: &RuntimeContext) -> Option<CapabilityRequest> {
+    let _ = context;
+    self.capability.clone()
+  }
+
+  fn stage_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<RuntimePreparedHostCall> {
     (self.function)(services, context, args)
   }
 }

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -117,6 +117,35 @@ pub trait HostFunction: std::fmt::Debug + Send + Sync {
     args.len() as u64
   }
 
+  /// Produce the provisional value needed while compiling a native call.
+  ///
+  /// Pure functions may reuse their normal callback. Runtime-managed
+  /// functions must override this method without retaining runtime mutation.
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    if matches!(
+      self.transaction_mode(),
+      HostFunctionTransactionMode::Pure
+        | HostFunctionTransactionMode::RuntimeManaged
+    ) {
+      return self.call(services, context, args);
+    }
+    Err(MechError::new(
+      InvalidHostCallError {
+        function: self.name().to_string(),
+        reason: format!(
+          "host function transaction mode {:?} requires an explicit non-mutating preview",
+          self.transaction_mode(),
+        ),
+      },
+      None,
+    ))
+  }
+
   /// Invoke a pure, runtime-managed, or immediate-only host function.
   fn call(
     &self,
@@ -664,6 +693,26 @@ impl MechErrorKind for InvalidHostCallError {
 
   fn message(&self) -> String {
     format!("Invalid host call `{}`: {}", self.function, self.reason)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct HostFunctionTransactionUnsupportedError {
+  pub function: String,
+  pub mode: HostFunctionTransactionMode,
+}
+
+impl MechErrorKind for HostFunctionTransactionUnsupportedError {
+  fn name(&self) -> &str {
+    "HostFunctionTransactionUnsupported"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Host function `{}` uses transaction mode {:?} and cannot run inside a runtime transaction",
+      self.function,
+      self.mode,
+    )
   }
 }
 

--- a/src/runtime/src/resource.rs
+++ b/src/runtime/src/resource.rs
@@ -1,8 +1,13 @@
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use mech_core::{MResult, MechError, MechErrorKind, Value};
 
-use crate::RuntimeCapabilityOperation;
+use crate::{
+  PreparedRuntimeEffect, RuntimeCapabilityOperation,
+  RuntimeCompensatableEffect, RuntimeEffectCost, RuntimeEffectMetadata,
+  RuntimeEffectSource,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeResourceReadRequest {
@@ -56,7 +61,10 @@ pub trait RuntimeResourceProvider: std::fmt::Debug {
     ))
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(
+    &mut self,
+    request: RuntimeResourceWriteRequest,
+  ) -> MResult<PreparedRuntimeEffect> {
     Err(MechError::new(
       RuntimeResourceWriteUnsupported {
         scheme: self.scheme().to_string(),
@@ -205,7 +213,10 @@ impl RuntimeResourceRegistry {
     entry.provider.preflight_write(request)
   }
 
-  pub fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  pub fn stage_write(
+    &mut self,
+    request: RuntimeResourceWriteRequest,
+  ) -> MResult<PreparedRuntimeEffect> {
     let scheme = resource_uri_scheme(&request.base_uri)?.to_string();
     let Some(entry) = self.provider_entry_for_mut(&scheme, &request.base_uri) else {
       return Err(MechError::new(
@@ -213,13 +224,13 @@ impl RuntimeResourceRegistry {
         None,
       ));
     };
-    entry.provider.write(request)
+    entry.provider.stage_write(request)
   }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryDocsProvider {
-  documents: HashMap<String, HashMap<String, Value>>,
+  documents: Arc<Mutex<HashMap<String, HashMap<String, Value>>>>,
 }
 
 impl InMemoryDocsProvider {
@@ -254,7 +265,13 @@ impl InMemoryDocsProvider {
         None,
       ));
     }
-    self.documents.entry(base_uri).or_default().insert(path, value);
+    self
+      .documents
+      .lock()
+      .map_err(|_| in_memory_docs_lock_error(&base_uri))?
+      .entry(base_uri)
+      .or_default()
+      .insert(path, value);
     Ok(())
   }
 
@@ -275,11 +292,19 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
   }
 
   fn base_uris(&self) -> Vec<String> {
-    self.documents.keys().cloned().collect()
+    self
+      .documents
+      .lock()
+      .map(|documents| documents.keys().cloned().collect())
+      .unwrap_or_default()
   }
 
   fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
-    let Some(document) = self.documents.get(&request.base_uri) else {
+    let documents = self
+      .documents
+      .lock()
+      .map_err(|_| in_memory_docs_lock_error(&request.base_uri))?;
+    let Some(document) = documents.get(&request.base_uri) else {
       return Err(MechError::new(
         RuntimeResourcePathNotFound {
           base_uri: request.base_uri,
@@ -336,7 +361,10 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
     Ok(())
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(
+    &mut self,
+    request: RuntimeResourceWriteRequest,
+  ) -> MResult<PreparedRuntimeEffect> {
     self.preflight_write(RuntimeResourceWritePreflightRequest {
       base_uri: request.base_uri.clone(),
       path: request.path.clone(),
@@ -345,13 +373,102 @@ impl RuntimeResourceProvider for InMemoryDocsProvider {
       intent: request.intent,
     })?;
 
-    self.documents
-      .entry(request.base_uri)
-      .or_default()
-      .insert(request.path, request.value);
+    Ok(PreparedRuntimeEffect::Compensatable(Box::new(
+      InMemoryDocsWriteEffect {
+        documents: self.documents.clone(),
+        base_uri: request.base_uri,
+        path: request.path,
+        value: request.value,
+        previous: None,
+        base_existed: false,
+        applied: false,
+      },
+    )))
+  }
+}
 
+#[derive(Debug)]
+struct InMemoryDocsWriteEffect {
+  documents: Arc<Mutex<HashMap<String, HashMap<String, Value>>>>,
+  base_uri: String,
+  path: String,
+  value: Value,
+  previous: Option<Value>,
+  base_existed: bool,
+  applied: bool,
+}
+
+impl RuntimeCompensatableEffect for InMemoryDocsWriteEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::ResourceProvider {
+        scheme: "docs".to_string(),
+      },
+      "write",
+    )
+    .with_resource(format!("{}/{}", self.base_uri, self.path))
+    .with_cost(RuntimeEffectCost {
+      bytes: 0,
+      items: 1,
+    })
+  }
+
+  fn apply(&mut self) -> MResult<()> {
+    let mut documents = self
+      .documents
+      .lock()
+      .map_err(|_| in_memory_docs_lock_error(&self.base_uri))?;
+    self.base_existed = documents.contains_key(&self.base_uri);
+    self.previous = documents
+      .entry(self.base_uri.clone())
+      .or_default()
+      .insert(self.path.clone(), self.value.clone());
+    self.applied = true;
     Ok(())
   }
+
+  fn compensate(&mut self) -> MResult<()> {
+    if !self.applied {
+      return Ok(());
+    }
+    let mut documents = self
+      .documents
+      .lock()
+      .map_err(|_| in_memory_docs_lock_error(&self.base_uri))?;
+    match self.previous.take() {
+      Some(previous) => {
+        documents
+          .entry(self.base_uri.clone())
+          .or_default()
+          .insert(self.path.clone(), previous);
+      }
+      None => {
+        let remove_base = if let Some(document) =
+          documents.get_mut(&self.base_uri)
+        {
+          document.remove(&self.path);
+          !self.base_existed && document.is_empty()
+        } else {
+          false
+        };
+        if remove_base {
+          documents.remove(&self.base_uri);
+        }
+      }
+    }
+    self.applied = false;
+    Ok(())
+  }
+}
+
+fn in_memory_docs_lock_error(base_uri: &str) -> MechError {
+  MechError::new(
+    RuntimeResourceInvalidUri {
+      uri: base_uri.to_string(),
+      reason: "in-memory docs resource lock is poisoned".to_string(),
+    },
+    None,
+  )
 }
 
 pub fn resource_base_matches(base: &str, candidate: &str) -> bool {
@@ -510,5 +627,164 @@ impl MechErrorKind for RuntimeResourceCapabilityDenied {
       self.operation,
       self.path,
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use mech_core::Ref;
+
+  fn bool_value(value: bool) -> Value {
+    Value::Bool(Ref::new(value))
+  }
+
+  fn write_request(path: &str, value: bool) -> RuntimeResourceWriteRequest {
+    RuntimeResourceWriteRequest {
+      base_uri: "docs://manual".to_string(),
+      path: path.to_string(),
+      context_name: "manual".to_string(),
+      operation: RuntimeCapabilityOperation::Write,
+      value: bool_value(value),
+      intent: RuntimeResourceWriteIntent::Assign,
+    }
+  }
+
+  fn read_request(path: &str) -> RuntimeResourceReadRequest {
+    RuntimeResourceReadRequest {
+      base_uri: "docs://manual".to_string(),
+      path: path.to_string(),
+      context_name: "manual".to_string(),
+    }
+  }
+
+  #[test]
+  fn docs_write_is_invisible_until_explicit_commit() {
+    let provider = InMemoryDocsProvider::new();
+    let observed = provider.clone();
+    let mut runtime = crate::MechRuntime::builder()
+      .resource_provider(Box::new(provider))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    let effect_id = runtime
+      .write_resource_with_context(
+        &mut context,
+        write_request("intro/enabled", true),
+      )
+      .unwrap();
+
+    assert_eq!(effect_id.sequence, 0);
+    assert!(observed.read(read_request("intro/enabled")).is_err());
+
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+    assert_eq!(
+      observed.read(read_request("intro/enabled")).unwrap(),
+      bool_value(true),
+    );
+  }
+
+  #[test]
+  fn docs_write_is_discarded_by_explicit_abort() {
+    let mut provider = InMemoryDocsProvider::new();
+    provider
+      .insert("docs://manual", "intro/enabled", bool_value(false))
+      .unwrap();
+    let observed = provider.clone();
+    let mut runtime = crate::MechRuntime::builder()
+      .resource_provider(Box::new(provider))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .write_resource_with_context(
+        &mut context,
+        write_request("intro/enabled", true),
+      )
+      .unwrap();
+
+    runtime
+      .abort_runtime_transaction(&mut context, "discard docs write")
+      .unwrap();
+
+    assert_eq!(
+      observed.read(read_request("intro/enabled")).unwrap(),
+      bool_value(false),
+    );
+  }
+
+  #[test]
+  fn store_failure_compensates_docs_overwrite_and_creation() {
+    let mut provider = InMemoryDocsProvider::new();
+    provider
+      .insert("docs://manual", "intro/enabled", bool_value(false))
+      .unwrap();
+    let observed = provider.clone();
+    let mut runtime = crate::MechRuntime::builder()
+      .resource_provider(Box::new(provider))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .write_resource_with_context(
+        &mut context,
+        write_request("intro/enabled", true),
+      )
+      .unwrap();
+    runtime
+      .write_resource_with_context(
+        &mut context,
+        write_request("intro/created", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        crate::ObjectRecord::text(
+          crate::ObjectId(990),
+          "missing",
+          "update",
+        ),
+      )
+      .unwrap();
+
+    assert!(runtime
+      .commit_runtime_transaction(&mut context)
+      .is_err());
+
+    assert_eq!(
+      observed.read(read_request("intro/enabled")).unwrap(),
+      bool_value(false),
+    );
+    assert!(observed.read(read_request("intro/created")).is_err());
+
+    runtime
+      .abort_runtime_transaction(&mut context, "store failure cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn administrative_docs_write_executes_immediately() {
+    let provider = InMemoryDocsProvider::new();
+    let observed = provider.clone();
+    let mut runtime = crate::MechRuntime::builder()
+      .resource_provider(Box::new(provider))
+      .build()
+      .unwrap();
+
+    runtime
+      .write_resource(write_request("intro/enabled", true))
+      .unwrap();
+
+    assert_eq!(
+      observed.read(read_request("intro/enabled")).unwrap(),
+      bool_value(true),
+    );
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -14,7 +14,7 @@
 use super::*;
 use crate::{
   CapabilityAlreadyExistsError, CapabilityNotFoundError,
-  CapabilityNotRevocableError, CapabilityRevokedError,
+  CapabilityNotRevocableError,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -29,6 +29,7 @@ pub(super) struct RuntimeCapabilityOverlay {
   operations: Vec<RuntimeCapabilityMutation>,
   grants: HashMap<CapabilityId, Arc<dyn Capability>>,
   revocations: HashSet<CapabilityId>,
+  uses: HashMap<CapabilityId, u64>,
 }
 
 impl RuntimeCapabilityOverlay {
@@ -80,20 +81,24 @@ impl RuntimeCapabilityOverlay {
     self.grants.get(&capability).cloned()
   }
 
-  pub(super) fn is_revoked(&self, capability: CapabilityId) -> bool {
-    self.revocations.contains(&capability)
-  }
-
   pub(super) fn check(
-    &self,
+    &mut self,
     request: &CapabilityRequest,
   ) -> MResult<Option<CapabilityId>> {
     for (id, capability) in &self.grants {
       if capability.subject_key() != request.subject {
         continue;
       }
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.uses.get(id).copied().unwrap_or(0);
+        if actual >= max_uses {
+          continue;
+        }
+      }
       let decision = capability.check(request)?;
       if decision.allowed {
+        let uses = self.uses.entry(*id).or_insert(0);
+        *uses = uses.saturating_add(1);
         return Ok(Some(*id));
       }
     }
@@ -113,6 +118,10 @@ impl RuntimeCapabilityOverlay {
     &self,
   ) -> impl Iterator<Item = CapabilityId> + '_ {
     self.revocations.iter().copied()
+  }
+
+  pub(super) fn revocation_ids(&self) -> HashSet<CapabilityId> {
+    self.revocations.clone()
   }
 
   pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
@@ -154,6 +163,7 @@ impl RuntimeCapabilityOverlay {
         }
       }
     }
+    self.uses.retain(|id, _| self.grants.contains_key(id));
   }
 }
 
@@ -395,24 +405,20 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     if let Some(transaction_id) = context.transaction {
-      let overlay = &self
-        .active_execution_transaction(transaction_id)?
-        .capabilities;
-      if let Some(capability) = overlay.check(request)? {
+      let provisional = self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .check(request)?;
+      if let Some(capability) = provisional {
         return Ok(capability);
       }
-      let capability = self.capability_kernel.check(request)?;
-      if self
+      let revocations = self
         .active_execution_transaction(transaction_id)?
         .capabilities
-        .is_revoked(capability)
-      {
-        return Err(MechError::new(
-          CapabilityRevokedError { capability },
-          None,
-        ));
-      }
-      return Ok(capability);
+        .revocation_ids();
+      return self
+        .capability_kernel
+        .check_excluding(request, &revocations);
     }
     self.capability_kernel.check(request)
   }
@@ -435,7 +441,8 @@ mod tests {
   use mech_core::{GenericError, MResult, MechError};
 
   use crate::capability::{
-    BasicCapability, BasicCapabilityKernel, CapabilityDerivation,
+    BasicCapability, BasicCapabilityKernel, BasicConstraints,
+    CapabilityDerivation,
     CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
   };
   use crate::id::{
@@ -585,7 +592,7 @@ mod tests {
       self.inner.checkpoint()
     }
 
-    fn restore_checkpoint(
+    fn restore(
       &mut self,
       _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
     ) -> MResult<()> {
@@ -1141,5 +1148,77 @@ mod tests {
     assert!(poison.rollback_failures.iter().any(|failure| {
       failure.contains("deliberate capability checkpoint restore failure")
     }));
+  }
+
+  #[test]
+  fn provisional_capability_enforces_use_limit() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let limited: Arc<dyn Capability> = Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(BasicConstraints {
+        max_uses: Some(1),
+        ..BasicConstraints::default()
+      }),
+    );
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(&mut context, limited)
+      .unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut context, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .is_err());
+  }
+
+  #[test]
+  fn provisional_revocation_does_not_consume_live_use_limit() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut administrative = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let limited: Arc<dyn Capability> = Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(BasicConstraints {
+        max_uses: Some(1),
+        ..BasicConstraints::default()
+      }),
+    );
+    runtime
+      .grant_capability_with_context(&mut administrative, limited)
+      .unwrap();
+
+    let mut owner = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .revoke_capability_with_context(&mut owner, id)
+      .unwrap();
+    assert!(runtime
+      .check_capability_with_context(&mut owner, &request("task:1"))
+      .is_err());
+    runtime
+      .abort_runtime_transaction(&mut owner, "test abort")
+      .unwrap();
+
+    assert_eq!(
+      runtime.check_capability(&request("task:1")).unwrap(),
+      id,
+    );
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -128,7 +128,7 @@ impl RuntimeCapabilityOverlay {
     let mut grants = HashSet::new();
     let mut revocations = HashSet::new();
     let mut mutations = Vec::new();
-    for operation in &self.operations {
+    for operation in self.operations.iter().rev() {
       match operation {
         RuntimeCapabilityMutation::Grant(capability)
           if self.grants.contains_key(&capability.id())
@@ -145,6 +145,7 @@ impl RuntimeCapabilityOverlay {
         _ => {}
       }
     }
+    mutations.reverse();
     mutations
   }
 
@@ -1111,6 +1112,47 @@ mod tests {
 
     assert!(runtime.get_capability(id).unwrap().is_none());
     assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn regrant_after_cancellation_commits_latest_capability() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .revoke_capability_with_context(&mut context, id)
+      .unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        Arc::new(BasicCapability::from_keys(
+          id,
+          "task:1",
+          "db://projects",
+          [":read"],
+        )),
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.check_capability(&request("task:1")).is_err());
+    assert_eq!(
+      runtime
+        .check_capability(&CapabilityRequest::from_keys(
+          "task:1",
+          ":read",
+          "db://projects",
+        ))
+        .unwrap(),
+      id,
+    );
   }
 
   #[test]

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -115,6 +115,30 @@ impl RuntimeCapabilityOverlay {
     self.revocations.iter().copied()
   }
 
+  pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
+    let mut grants = HashSet::new();
+    let mut revocations = HashSet::new();
+    let mut mutations = Vec::new();
+    for operation in &self.operations {
+      match operation {
+        RuntimeCapabilityMutation::Grant(capability)
+          if self.grants.contains_key(&capability.id())
+            && grants.insert(capability.id()) =>
+        {
+          mutations.push(operation.clone());
+        }
+        RuntimeCapabilityMutation::Revoke(capability)
+          if self.revocations.contains(capability)
+            && revocations.insert(*capability) =>
+        {
+          mutations.push(operation.clone());
+        }
+        _ => {}
+      }
+    }
+    mutations
+  }
+
   fn rebuild(&mut self) {
     self.grants.clear();
     self.revocations.clear();
@@ -411,8 +435,8 @@ mod tests {
   use mech_core::{GenericError, MResult, MechError};
 
   use crate::capability::{
-    BasicCapability, BasicCapabilityKernel, CapabilityDerivation, CapabilityGrant,
-    CapabilityKernel, Subject,
+    BasicCapability, BasicCapabilityKernel, CapabilityDerivation,
+    CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
   };
   use crate::id::{
     ActorId, EventId, IdGenerator, MessageId, NodeId, ObjectId, RuntimeId,
@@ -516,6 +540,70 @@ mod tests {
         },
         None,
       ))
+    }
+
+    fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
+      self.inner.revoke(revocation)
+    }
+
+    fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
+      self.inner.check(request)
+    }
+
+    fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
+      self.inner.get(id)
+    }
+
+    fn list_for_subject(
+      &self,
+      subject: &dyn Subject,
+    ) -> MResult<Vec<CapabilityId>> {
+      self.inner.list_for_subject(subject)
+    }
+
+    fn derive_capability(
+      &mut self,
+      derivation: CapabilityDerivation,
+    ) -> MResult<CapabilityId> {
+      self.inner.derive_capability(derivation)
+    }
+
+    fn is_revoked(&self, id: CapabilityId) -> MResult<bool> {
+      self.inner.is_revoked(id)
+    }
+  }
+
+  #[derive(Debug, Default)]
+  struct FailingCheckpointRestoreKernel {
+    inner: BasicCapabilityKernel,
+  }
+
+  impl CapabilityKernel for FailingCheckpointRestoreKernel {
+    fn checkpoint(
+      &self,
+    ) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+      self.inner.checkpoint()
+    }
+
+    fn restore_checkpoint(
+      &mut self,
+      _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+    ) -> MResult<()> {
+      Err(MechError::new(
+        GenericError {
+          msg: "deliberate capability checkpoint restore failure"
+            .to_string(),
+        },
+        None,
+      ))
+    }
+
+    fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
+      self.inner.grant(grant)
+    }
+
+    fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> {
+      self.inner.rollback_grant(capability)
     }
 
     fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
@@ -936,5 +1024,122 @@ mod tests {
     runtime
       .abort_runtime_transaction(&mut context, "test cleanup")
       .unwrap();
+  }
+
+  #[test]
+  fn capability_overlay_commits_kernel_and_store_together() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.get_capability(id).unwrap().is_some());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_some());
+    assert_eq!(runtime.check_capability(&request("task:1")).unwrap(), id);
+  }
+
+  #[test]
+  fn store_commit_failure_restores_capability_kernel_checkpoint() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    assert!(runtime.commit_runtime_transaction(&mut context).is_err());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn provisional_grant_then_revoke_cancels_commit_work() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .revoke_capability_with_context(&mut context, id)
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn capability_checkpoint_restore_failure_poisons_runtime() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .capability_kernel(FailingCheckpointRestoreKernel::default())
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeEffectCleanupFailed");
+    assert!(runtime.is_poisoned());
+    let RuntimeHealth::Poisoned(poison) = &runtime.health else {
+      panic!("runtime must retain capability cleanup failure");
+    };
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("deliberate capability checkpoint restore failure")
+    }));
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -12,6 +12,126 @@
 // Like with actors, there is a _with_context version of each method, allowing for transactional operations and proper event emission within the context of an active transaction.
 
 use super::*;
+use crate::{
+  CapabilityAlreadyExistsError, CapabilityNotFoundError,
+  CapabilityNotRevocableError, CapabilityRevokedError,
+};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Debug)]
+pub(super) enum RuntimeCapabilityMutation {
+  Grant(Arc<dyn Capability>),
+  Revoke(CapabilityId),
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RuntimeCapabilityOverlay {
+  operations: Vec<RuntimeCapabilityMutation>,
+  grants: HashMap<CapabilityId, Arc<dyn Capability>>,
+  revocations: HashSet<CapabilityId>,
+}
+
+impl RuntimeCapabilityOverlay {
+  pub(super) fn mark(&self) -> usize {
+    self.operations.len()
+  }
+
+  pub(super) fn is_empty(&self) -> bool {
+    self.grants.is_empty() && self.revocations.is_empty()
+  }
+
+  pub(super) fn stage_grant(&mut self, capability: Arc<dyn Capability>) {
+    self
+      .operations
+      .push(RuntimeCapabilityMutation::Grant(capability));
+    self.rebuild();
+  }
+
+  pub(super) fn stage_revocation(&mut self, capability: CapabilityId) {
+    self
+      .operations
+      .push(RuntimeCapabilityMutation::Revoke(capability));
+    self.rebuild();
+  }
+
+  pub(super) fn rollback_to(&mut self, mark: usize) -> MResult<()> {
+    if mark > self.operations.len() {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "rollback_capability_overlay",
+          reason: format!(
+            "capability savepoint mark {} exceeds overlay length {}",
+            mark,
+            self.operations.len(),
+          ),
+        },
+        None,
+      ));
+    }
+    self.operations.truncate(mark);
+    self.rebuild();
+    Ok(())
+  }
+
+  pub(super) fn provisional(
+    &self,
+    capability: CapabilityId,
+  ) -> Option<Arc<dyn Capability>> {
+    self.grants.get(&capability).cloned()
+  }
+
+  pub(super) fn is_revoked(&self, capability: CapabilityId) -> bool {
+    self.revocations.contains(&capability)
+  }
+
+  pub(super) fn check(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<Option<CapabilityId>> {
+    for (id, capability) in &self.grants {
+      if capability.subject_key() != request.subject {
+        continue;
+      }
+      let decision = capability.check(request)?;
+      if decision.allowed {
+        return Ok(Some(*id));
+      }
+    }
+    Ok(None)
+  }
+
+  pub(super) fn grants(
+    &self,
+  ) -> impl Iterator<Item = (CapabilityId, Arc<dyn Capability>)> + '_ {
+    self
+      .grants
+      .iter()
+      .map(|(id, capability)| (*id, capability.clone()))
+  }
+
+  pub(super) fn revocations(
+    &self,
+  ) -> impl Iterator<Item = CapabilityId> + '_ {
+    self.revocations.iter().copied()
+  }
+
+  fn rebuild(&mut self) {
+    self.grants.clear();
+    self.revocations.clear();
+    for operation in &self.operations {
+      match operation {
+        RuntimeCapabilityMutation::Grant(capability) => {
+          self.grants.insert(capability.id(), capability.clone());
+        }
+        RuntimeCapabilityMutation::Revoke(capability) => {
+          if self.grants.remove(capability).is_none() {
+            self.revocations.insert(*capability);
+          }
+        }
+      }
+    }
+  }
+}
 
 fn finish_failed_capability_grant(
   capability: CapabilityId,
@@ -51,6 +171,55 @@ impl MechRuntime {
     capability.validate()?;
 
     let id = capability.id();
+
+    if let Some(transaction_id) = context.transaction {
+      if self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .provisional(id)
+        .is_some()
+        || self.capability_kernel.get(id)?.is_some()
+      {
+        return Err(MechError::new(
+          CapabilityAlreadyExistsError { capability: id },
+          None,
+        ));
+      }
+
+      let store_before = self
+        .active_execution_transaction(transaction_id)?
+        .store
+        .clone();
+      let overlay_mark = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .mark();
+      let context_events_before = context.events.clone();
+      let context_capabilities_before = context.capabilities.clone();
+
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_grant(capability);
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::CapabilityGranted {
+          capability_id: id,
+        },
+      ) {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        let rollback_result =
+          transaction.capabilities.rollback_to(overlay_mark);
+        context.events = context_events_before;
+        context.capabilities = context_capabilities_before;
+        rollback_result?;
+        return Err(error);
+      }
+      context.add_capability(id);
+      return Ok(id);
+    }
 
     self.store.grant_capability(id, capability.clone())?;
 
@@ -112,6 +281,64 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
+    if let Some(transaction_id) = context.transaction {
+      let staged = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .provisional(capability);
+      let live = if staged.is_none() {
+        self.capability_kernel.get(capability)?
+      } else {
+        None
+      };
+      let Some(existing) = staged.or(live) else {
+        return Err(MechError::new(
+          CapabilityNotFoundError { capability },
+          None,
+        ));
+      };
+      if !existing.is_revocable() {
+        return Err(MechError::new(
+          CapabilityNotRevocableError { capability },
+          None,
+        ));
+      }
+
+      let store_before = self
+        .active_execution_transaction(transaction_id)?
+        .store
+        .clone();
+      let overlay_mark = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .mark();
+      let context_events_before = context.events.clone();
+      let context_capabilities_before = context.capabilities.clone();
+
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_revocation(capability);
+      context.remove_capability(capability);
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::CapabilityRevoked {
+          capability_id: capability,
+        },
+      ) {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        let rollback_result =
+          transaction.capabilities.rollback_to(overlay_mark);
+        context.events = context_events_before;
+        context.capabilities = context_capabilities_before;
+        rollback_result?;
+        return Err(error);
+      }
+      return Ok(());
+    }
+
     self
       .capability_kernel
       .revoke(CapabilityRevocation::new(capability))?;
@@ -143,6 +370,26 @@ impl MechRuntime {
   ) -> MResult<CapabilityId> {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
+    if let Some(transaction_id) = context.transaction {
+      let overlay = &self
+        .active_execution_transaction(transaction_id)?
+        .capabilities;
+      if let Some(capability) = overlay.check(request)? {
+        return Ok(capability);
+      }
+      let capability = self.capability_kernel.check(request)?;
+      if self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .is_revoked(capability)
+      {
+        return Err(MechError::new(
+          CapabilityRevokedError { capability },
+          None,
+        ));
+      }
+      return Ok(capability);
+    }
     self.capability_kernel.check(request)
   }
 
@@ -570,5 +817,124 @@ mod tests {
         .count(),
       1,
     );
+  }
+
+  #[test]
+  fn provisional_capability_grant_is_visible_only_to_its_transaction() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut owner = runtime.runtime_context().unwrap();
+    let mut observer = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut owner,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut owner, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime
+      .check_capability_with_context(&mut observer, &request("task:1"))
+      .is_err());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+
+    runtime.abort_runtime_transaction(&mut owner, "test abort").unwrap();
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn provisional_revocation_does_not_leak_to_other_transactions() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut administrative = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+
+    let mut owner = runtime.runtime_context().unwrap();
+    let mut observer = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .revoke_capability_with_context(&mut owner, id)
+      .unwrap();
+
+    assert!(runtime
+      .check_capability_with_context(&mut owner, &request("task:1"))
+      .is_err());
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut observer, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(!runtime.capability_kernel().is_revoked(id).unwrap());
+
+    runtime.abort_runtime_transaction(&mut owner, "test abort").unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut owner, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+  }
+
+  #[test]
+  fn failed_retained_operation_truncates_capability_overlay() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let id = CapabilityId(100);
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "test_capability_overlay",
+      |runtime, context| {
+        runtime.grant_capability_with_context(
+          context,
+          capability(id, "task:1", true),
+        )?;
+        Err(MechError::new(
+          GenericError {
+            msg: "deliberate operation failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    assert_eq!(result.unwrap_err().kind_name(), "GenericError");
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .capabilities
+      .is_empty());
+    assert!(runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .is_err());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
   }
 }

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -464,6 +464,59 @@ impl MechRuntime {
         .stage(transaction_id, effect),
     )
   }
+
+  pub(super) fn execute_runtime_effect_immediately(
+    &mut self,
+    mut effect: PreparedRuntimeEffect,
+  ) -> MResult<RuntimeEffectId> {
+    self.ensure_runtime_healthy("execute_runtime_effect_immediately")?;
+    self.reject_effect_reentrancy("execute_runtime_effect_immediately")?;
+
+    let effect_id = RuntimeEffectId {
+      transaction: self.next_transaction_id(),
+      sequence: 0,
+    };
+    match &mut effect {
+      PreparedRuntimeEffect::Transactional(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Preparing);
+        let prepare_result = effect.prepare();
+        self.active_effect_phase = None;
+        prepare_result?;
+
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Committing);
+        let commit_result = effect.commit();
+        self.active_effect_phase = None;
+        if let Err(error) = commit_result {
+          return Err(self.poison_external_commit_indeterminate(
+            effect_id.transaction,
+            effect_id,
+            vec![format!(
+              "immediate transactional effect {} commit failed: {:?}",
+              effect_id,
+              error,
+            )],
+          ));
+        }
+      }
+      PreparedRuntimeEffect::Compensatable(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Applying);
+        let result = effect.apply();
+        self.active_effect_phase = None;
+        result?;
+      }
+      PreparedRuntimeEffect::AfterCommit(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Delivering);
+        let result = effect.deliver();
+        self.active_effect_phase = None;
+        result?;
+      }
+    }
+    Ok(effect_id)
+  }
 }
 
 #[cfg(test)]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -618,6 +618,30 @@ impl MechRuntime {
     }
     Ok(effect_id)
   }
+
+  pub(super) fn discard_unstaged_runtime_effect(
+    &mut self,
+    mut effect: PreparedRuntimeEffect,
+  ) -> MResult<()> {
+    let result = match &mut effect {
+      PreparedRuntimeEffect::Transactional(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Aborting);
+        let result = effect.abort();
+        self.active_effect_phase = None;
+        result
+      }
+      PreparedRuntimeEffect::Compensatable(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Aborting);
+        let result = effect.abort();
+        self.active_effect_phase = None;
+        result
+      }
+      PreparedRuntimeEffect::AfterCommit(_) => Ok(()),
+    };
+    result
+  }
 }
 
 #[cfg(test)]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::{
   PreparedRuntimeEffect, RuntimeEffectFailure, RuntimeEffectFailurePhase,
-  RuntimeEffectId,
+  RuntimeEffectId, RuntimeEffectRecord,
 };
 #[cfg(test)]
 use crate::{
@@ -41,6 +41,7 @@ pub(super) struct RuntimeEffectStepFailure {
 pub(super) struct RuntimeEffectCommitFailure {
   pub(super) step: RuntimeEffectStepFailure,
   pub(super) participant_outcomes: Vec<String>,
+  pub(super) committed: Vec<RuntimeEffectId>,
 }
 
 #[derive(Debug, Default)]
@@ -60,6 +61,64 @@ impl RuntimeEffectJournal {
 
   pub(super) fn is_empty(&self) -> bool {
     self.entries.is_empty()
+  }
+
+  pub(super) fn records(&self) -> Vec<RuntimeEffectRecord> {
+    self.entries.iter().map(|entry| {
+      RuntimeEffectRecord::new(
+        entry.id,
+        entry.effect.metadata(),
+        entry.effect.protocol(),
+      )
+    }).collect()
+  }
+
+  pub(super) fn prepared_transactional_ids(
+    &self,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if entry.state == RuntimeEffectState::Prepared
+        && matches!(entry.effect, PreparedRuntimeEffect::Transactional(_))
+      {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn applied_compensatable_ids(
+    &self,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if entry.state == RuntimeEffectState::Applied
+        && matches!(entry.effect, PreparedRuntimeEffect::Compensatable(_))
+      {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn after_commit_ids(&self) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn abortable_ids(&self) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+        None
+      } else {
+        Some(entry.id)
+      }
+    }).collect()
   }
 
   pub(super) fn validate_active(
@@ -309,8 +368,9 @@ impl RuntimeEffectJournal {
 
   pub(super) fn commit_transactional(
     &mut self,
-  ) -> Result<Vec<String>, RuntimeEffectCommitFailure> {
+  ) -> Result<Vec<RuntimeEffectId>, RuntimeEffectCommitFailure> {
     let mut outcomes = Vec::new();
+    let mut committed = Vec::new();
     for entry in &mut self.entries {
       if entry.state != RuntimeEffectState::Prepared {
         continue;
@@ -319,10 +379,13 @@ impl RuntimeEffectJournal {
         continue;
       };
       match effect.commit() {
-        Ok(()) => outcomes.push(format!(
-          "transactional effect {} committed",
-          entry.id,
-        )),
+        Ok(()) => {
+          outcomes.push(format!(
+            "transactional effect {} committed",
+            entry.id,
+          ));
+          committed.push(entry.id);
+        }
         Err(error) => {
           let step = effect_step_failure(
             entry.id,
@@ -337,11 +400,12 @@ impl RuntimeEffectJournal {
           return Err(RuntimeEffectCommitFailure {
             step,
             participant_outcomes: outcomes,
+            committed,
           });
         }
       }
     }
-    Ok(outcomes)
+    Ok(committed)
   }
 
   pub(super) fn deliver_after_commit(
@@ -506,15 +570,55 @@ impl MechRuntime {
       ));
     }
     let cost = effect.cost();
+    let metadata = effect.metadata();
+    let protocol = effect.protocol();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;
+    let store_before = self
+      .active_execution_transaction(transaction_id)?
+      .store
+      .clone();
+    let effect_mark = self
+      .active_execution_transaction(transaction_id)?
+      .effects
+      .mark();
+    let context_events_before = context.events.clone();
+    let effect_id = self
+      .active_execution_transaction_mut(transaction_id)?
+      .effects
+      .stage(transaction_id, effect);
 
-    Ok(
-      self
-        .active_execution_transaction_mut(transaction_id)?
-        .effects
-        .stage(transaction_id, effect),
-    )
+    if let Err(error) = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::EffectStaged {
+        effect_id,
+        source: metadata.source,
+        operation: metadata.operation,
+        resource: metadata.resource,
+        protocol,
+      },
+    ) {
+      self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+      let cleanup = {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        transaction.effects.rollback_to(effect_mark)
+      };
+      self.active_effect_phase = None;
+      context.events = context_events_before;
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "stage_runtime_effect_with_context",
+        transaction_id,
+        format!("{:?}", error),
+        Self::describe_effect_failures(cleanup),
+      ));
+    }
+
+    Ok(effect_id)
   }
 
   pub(super) fn stage_runtime_resource_effect_with_context(
@@ -549,21 +653,61 @@ impl MechRuntime {
       ));
     }
     let cost = effect.cost();
+    let metadata = effect.metadata();
+    let protocol = effect.protocol();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;
+    let store_before = self
+      .active_execution_transaction(transaction_id)?
+      .store
+      .clone();
+    let effect_mark = self
+      .active_execution_transaction(transaction_id)?
+      .effects
+      .mark();
+    let context_events_before = context.events.clone();
+    let effect_id = self
+      .active_execution_transaction_mut(transaction_id)?
+      .effects
+      .stage_resource_write(
+        transaction_id,
+        effect,
+        base_uri,
+        path,
+        value,
+      );
 
-    Ok(
-      self
-        .active_execution_transaction_mut(transaction_id)?
-        .effects
-        .stage_resource_write(
-          transaction_id,
-          effect,
-          base_uri,
-          path,
-          value,
-        ),
-    )
+    if let Err(error) = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::EffectStaged {
+        effect_id,
+        source: metadata.source,
+        operation: metadata.operation,
+        resource: metadata.resource,
+        protocol,
+      },
+    ) {
+      self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+      let cleanup = {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        transaction.effects.rollback_to(effect_mark)
+      };
+      self.active_effect_phase = None;
+      context.events = context_events_before;
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "stage_runtime_resource_effect_with_context",
+        transaction_id,
+        format!("{:?}", error),
+        Self::describe_effect_failures(cleanup),
+      ));
+    }
+
+    Ok(effect_id)
   }
 
   pub(super) fn execute_runtime_effect_immediately(
@@ -849,6 +993,28 @@ mod tests {
   }
 
   #[derive(Debug)]
+  struct SensitiveAfterCommit {
+    secret_payload: String,
+  }
+
+  impl RuntimeAfterCommitEffect for SensitiveAfterCommit {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "sensitive-test".to_string(),
+        },
+        "deliver",
+      )
+      .with_resource("test://metadata-only")
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      assert!(!self.secret_payload.is_empty());
+      Ok(())
+    }
+  }
+
+  #[derive(Debug)]
   struct CostedAfterCommit {
     cost: crate::RuntimeEffectCost,
   }
@@ -895,6 +1061,86 @@ mod tests {
 
     assert_eq!(journal.len(), 2);
     assert_eq!(journal.next_sequence(), 3);
+  }
+
+  #[test]
+  fn transaction_history_persists_effect_metadata_without_payload() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let secret = "raw-secret-payload-must-not-be-durable";
+    let effect_id = runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          SensitiveAfterCommit {
+            secret_payload: secret.to_string(),
+          },
+        )),
+      )
+      .unwrap();
+
+    runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    let transaction = runtime
+      .get_transaction(transaction_id)
+      .unwrap()
+      .unwrap();
+    assert_eq!(transaction.effects.len(), 1);
+    assert_eq!(transaction.effects[0].id, effect_id);
+    assert_eq!(
+      transaction.effects[0].protocol,
+      crate::RuntimeEffectProtocol::AfterCommit,
+    );
+    assert_eq!(
+      transaction.effects[0].resource.as_deref(),
+      Some("test://metadata-only"),
+    );
+    assert!(!format!("{:?}", transaction).contains(secret));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectDelivered { effect_id: delivered }
+          if delivered == effect_id
+      )
+    }));
+  }
+
+  #[test]
+  fn savepoint_rollback_discards_effect_and_staging_event() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let result: MResult<RuntimeEffectId> =
+      runtime.with_atomic_program_operation(
+        &mut context,
+        "effect_staging_event_rollback",
+        |runtime, context| {
+          let effect_id = runtime.stage_runtime_effect_with_context(
+            context,
+            effect("rolled-back"),
+          )?;
+          Err(synthetic_error(format!(
+            "deliberate rollback for {}",
+            effect_id,
+          )))
+        },
+      );
+
+    assert_eq!(result.unwrap_err().kind_name(), "SyntheticEffectError");
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .effects
+      .is_empty());
+    assert!(!context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectStaged { .. })
+    }));
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
   }
 
   #[test]
@@ -980,6 +1226,15 @@ mod tests {
       RuntimeExecutionTransactionState::Active,
     );
     assert!(!runtime.is_poisoned());
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectPreparationFailed { .. }
+      )
+    }));
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectAborted { .. })
+    }));
 
     runtime
       .abort_runtime_transaction(&mut context, "prepare test cleanup")
@@ -1089,6 +1344,12 @@ mod tests {
     );
     assert_eq!(context.transaction, Some(transaction_id));
     assert!(!runtime.is_poisoned());
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectCompensated { .. })
+    }));
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectAborted { .. })
+    }));
 
     runtime
       .abort_runtime_transaction(&mut context, "apply test cleanup")
@@ -1234,6 +1495,19 @@ mod tests {
       .get_transaction(transaction_id)
       .unwrap()
       .is_some());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::TransactionalEffectCommitted { .. }
+      )
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ExternalCommitIndeterminate { .. }
+      )
+    }));
   }
 
   #[test]
@@ -1290,6 +1564,19 @@ mod tests {
       .get_transaction(transaction_id)
       .unwrap()
       .is_some());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectDelivered { .. })
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectDeliveryFailed {
+          effect_id,
+          ..
+        } if effect_id == failing_effect_id
+      )
+    }));
   }
 
   #[test]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -23,6 +23,14 @@ pub(super) struct RuntimeEffectEntry {
   pub(super) id: RuntimeEffectId,
   pub(super) state: RuntimeEffectState,
   pub(super) effect: PreparedRuntimeEffect,
+  resource_write: Option<RuntimeStagedResourceWrite>,
+}
+
+#[derive(Debug)]
+struct RuntimeStagedResourceWrite {
+  base_uri: String,
+  path: String,
+  value: Value,
 }
 
 pub(super) struct RuntimeEffectStepFailure {
@@ -115,6 +123,34 @@ impl RuntimeEffectJournal {
     transaction: TransactionId,
     effect: PreparedRuntimeEffect,
   ) -> RuntimeEffectId {
+    self.stage_entry(transaction, effect, None)
+  }
+
+  pub(super) fn stage_resource_write(
+    &mut self,
+    transaction: TransactionId,
+    effect: PreparedRuntimeEffect,
+    base_uri: String,
+    path: String,
+    value: Value,
+  ) -> RuntimeEffectId {
+    self.stage_entry(
+      transaction,
+      effect,
+      Some(RuntimeStagedResourceWrite {
+        base_uri,
+        path,
+        value,
+      }),
+    )
+  }
+
+  fn stage_entry(
+    &mut self,
+    transaction: TransactionId,
+    effect: PreparedRuntimeEffect,
+    resource_write: Option<RuntimeStagedResourceWrite>,
+  ) -> RuntimeEffectId {
     let id = RuntimeEffectId {
       transaction,
       sequence: self.next_sequence,
@@ -124,8 +160,24 @@ impl RuntimeEffectJournal {
       id,
       state: RuntimeEffectState::Staged,
       effect,
+      resource_write,
     });
     id
+  }
+
+  pub(super) fn staged_resource_value(
+    &self,
+    base_uri: &str,
+    path: &str,
+  ) -> Option<Value> {
+    self.entries.iter().rev().find_map(|entry| {
+      let write = entry.resource_write.as_ref()?;
+      if write.base_uri == base_uri && write.path == path {
+        Some(write.value.clone())
+      } else {
+        None
+      }
+    })
   }
 
   pub(super) fn rollback_to(
@@ -462,6 +514,55 @@ impl MechRuntime {
         .active_execution_transaction_mut(transaction_id)?
         .effects
         .stage(transaction_id, effect),
+    )
+  }
+
+  pub(super) fn stage_runtime_resource_effect_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    effect: PreparedRuntimeEffect,
+    base_uri: String,
+    path: String,
+    value: Value,
+  ) -> MResult<RuntimeEffectId> {
+    self.ensure_runtime_healthy(
+      "stage_runtime_resource_effect_with_context",
+    )?;
+    self.reject_effect_reentrancy(
+      "stage_runtime_resource_effect_with_context",
+    )?;
+    self.validate_context_for_runtime(context)?;
+
+    let transaction_id = Self::context_transaction_id(context)?;
+    if self.active_execution_transaction(transaction_id)?.state
+      != RuntimeExecutionTransactionState::Active
+    {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "stage_runtime_resource_effect_with_context",
+          reason: format!(
+            "transaction {} is not accepting new effects",
+            transaction_id,
+          ),
+        },
+        None,
+      ));
+    }
+    let cost = effect.cost();
+    context.charge_bytes(cost.bytes)?;
+    context.charge_items(cost.items)?;
+
+    Ok(
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .effects
+        .stage_resource_write(
+          transaction_id,
+          effect,
+          base_uri,
+          path,
+          value,
+        ),
     )
   }
 

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -1436,6 +1436,12 @@ mod tests {
       .rollback_failures
       .iter()
       .any(|failure| failure.contains("first compensate failed")));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectCompensationFailed { .. }
+      )
+    }));
 
     assert!(runtime
       .abort_runtime_transaction(&mut context, "poison test cleanup")

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -706,7 +706,7 @@ impl MechRuntime {
 
   fn write_context_resource(
     &mut self,
-    context: &RuntimeContext,
+    context: &mut RuntimeContext,
     binding: &RuntimeContextBinding,
     path: &str,
     value: Value,
@@ -734,14 +734,14 @@ impl MechRuntime {
         path: resolved.provider_path,
       }, None));
     }
-    self.resources.write(RuntimeResourceWriteRequest {
+    self.write_resource_with_context(context, RuntimeResourceWriteRequest {
       base_uri: resolved.provider_base_uri,
       path: resolved.provider_path,
       context_name: binding.name.clone(),
       operation: operation.clone(),
       value,
       intent,
-    })
+    }).map(|_| ())
   }
 
   fn bind_context_read_temp(
@@ -1464,7 +1464,7 @@ impl MechRuntime {
 
   fn push_direct_code(
     &mut self,
-    context: &RuntimeContext,
+    context: &mut RuntimeContext,
     program: &mut MechProgram,
     registry: &RuntimeContextRegistry,
     pending: &mut Vec<mech_core::SectionElement>,
@@ -4713,7 +4713,7 @@ impl MechRuntime {
           &target_updates,
         )?;
       self.enforce_turn_duration(turn_started)?;
-      self.execute_persistent_sends(&context, &turn)?;
+      self.execute_persistent_sends(&mut context, &turn)?;
 
       Ok(crate::RuntimeHostInputOutcome {
         update_count: input.updates.len(),
@@ -4728,7 +4728,7 @@ impl MechRuntime {
     result
   }
 
-  fn execute_persistent_sends(&mut self, context: &RuntimeContext, turn: &mech_program::ProgramInputTurnOutcome) -> MResult<()> {
+  fn execute_persistent_sends(&mut self, context: &mut RuntimeContext, turn: &mech_program::ProgramInputTurnOutcome) -> MResult<()> {
     for send in self.persistent_sends.clone() {
       let should_send = match send.schedule {
         RuntimePersistentSendSchedule::EveryAcceptedTurn => true,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -4541,7 +4541,7 @@ mod tests {
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_for_host = calls.clone();
     runtime
-      .register_mech_host_function(ClosureHostFunction::new(
+      .register_mech_host_function(ClosureHostFunction::new_pure(
         "demo/echo",
         move |_services, context, args| {
           assert_eq!(context.subject, "program:step-host-test");

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -697,6 +697,18 @@ impl MechRuntime {
         path: resolved.provider_path,
       }, None));
     }
+    if let Some(transaction_id) = context.transaction {
+      if let Some(value) = self
+        .active_execution_transaction(transaction_id)?
+        .effects
+        .staged_resource_value(
+          &resolved.provider_base_uri,
+          &resolved.provider_path,
+        )
+      {
+        return Ok(value);
+      }
+    }
     self.resources.read(RuntimeResourceReadRequest {
       base_uri: resolved.provider_base_uri,
       path: resolved.provider_path,

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -44,7 +44,8 @@ use mech_core::{
   GuardFunctionSafety, Ref, ValueKind,
 };
 use crate::{
-  HostFunctionTransactionMode, RuntimePreparedHostCall,
+  HostFunction, HostFunctionTransactionMode,
+  HostFunctionTransactionUnsupportedError, RuntimePreparedHostCall,
 };
 
 impl MechRuntime {
@@ -103,6 +104,131 @@ impl MechRuntime {
     self.call_host_with_context(&mut context, call)
   }
 
+  fn preview_runtime_managed_host_function(
+    &mut self,
+    context: &mut RuntimeContext,
+    function: &dyn HostFunction,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    let transaction_id = Self::context_transaction_id(context)?;
+    let context_checkpoint = RuntimeContextCheckpoint::capture(context);
+    let (store, effect_mark) = {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      (transaction.store.clone(), transaction.effects.mark())
+    };
+
+    let result = function.preview_call(self, context, args);
+    let mut cleanup_failures = Vec::new();
+    self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+    match self.active_transactions.get_mut(&transaction_id) {
+      Some(transaction) => {
+        cleanup_failures.extend(Self::describe_effect_failures(
+          transaction.effects.rollback_to(effect_mark),
+        ));
+        transaction.store = store;
+      }
+      None => cleanup_failures.push(format!(
+        "runtime-managed host preview lost transaction {}",
+        transaction_id,
+      )),
+    }
+    self.active_effect_phase = None;
+    context_checkpoint.restore_preserving_consumption(context);
+    if let Err(error) = self.validate_context_for_runtime(context) {
+      cleanup_failures.push(format!(
+        "runtime-managed host preview context restore failed: {:?}",
+        error,
+      ));
+    }
+
+    if cleanup_failures.is_empty() {
+      return result;
+    }
+
+    let original_error = match result {
+      Ok(_) => format!(
+        "runtime-managed host function `{}` preview cleanup failed",
+        function.name(),
+      ),
+      Err(error) => format!("{:?}", error),
+    };
+    Err(self.poison_program_operation(
+      "preview_runtime_managed_host_function",
+      Some(transaction_id),
+      original_error,
+      cleanup_failures,
+    ))
+  }
+
+  fn preview_host_call_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    call: HostCall,
+  ) -> MResult<Value> {
+    self.ensure_runtime_healthy("preview_host_call_with_context")?;
+    self.reject_effect_reentrancy("preview_host_call_with_context")?;
+    self.validate_context_for_runtime(context)?;
+    call.validate()?;
+
+    let Some(function) = self.host_registry.get_function(&call.name)? else {
+      return Err(MechError::new(
+        HostFunctionNotFoundError {
+          name: call.name,
+        },
+        None,
+      ));
+    };
+
+    self
+      .host_policy
+      .validate_call(context, function.as_ref(), &call.args)?;
+    let capability_request = function
+      .required_capability(context)
+      .unwrap_or_else(|| {
+        default_host_capability_request(context, function.name())
+      });
+    self.check_capability_with_context(context, &capability_request)?;
+
+    match function.transaction_mode() {
+      HostFunctionTransactionMode::Pure => {
+        function.preview_call(self, context, call.args)
+      }
+      HostFunctionTransactionMode::RuntimeManaged => {
+        self.preview_runtime_managed_host_function(
+          context,
+          function.as_ref(),
+          call.args,
+        )
+      }
+      HostFunctionTransactionMode::Staged => {
+        let RuntimePreparedHostCall { value, effect } =
+          function.stage_call(self, context, call.args)?;
+        if let Err(error) = self.discard_unstaged_runtime_effect(effect) {
+          return Err(self.poison_program_operation(
+            "preview_host_call_with_context",
+            context.transaction,
+            format!(
+              "staged host function `{}` preview cleanup failed",
+              function.name(),
+            ),
+            vec![format!("{:?}", error)],
+          ));
+        }
+        Ok(value)
+      }
+      HostFunctionTransactionMode::ImmediateOnly => {
+        Err(MechError::new(
+          HostFunctionTransactionUnsupportedError {
+            function: function.name().to_string(),
+            mode: HostFunctionTransactionMode::ImmediateOnly,
+          },
+          None,
+        ))
+      }
+    }
+  }
+
   pub fn call_host_with_context(
     &mut self,
     context: &mut RuntimeContext,
@@ -138,6 +264,19 @@ impl MechRuntime {
     };
 
     let result = (|| -> MResult<Value> {
+      let transaction_mode = function.transaction_mode();
+      if context.transaction.is_some()
+        && transaction_mode == HostFunctionTransactionMode::ImmediateOnly
+      {
+        return Err(MechError::new(
+          HostFunctionTransactionUnsupportedError {
+            function: function.name().to_string(),
+            mode: transaction_mode,
+          },
+          None,
+        ));
+      }
+
       self
         .host_policy
         .validate_call(context, function.as_ref(), &call.args)?;
@@ -248,7 +387,7 @@ impl NativeFunctionCompiler for RuntimeHostNativeFunctionCompiler {
       // been moved out of `self`, so calling back into the runtime does not
       // alias `self.program`.
       let value = unsafe {
-        (&mut *target.runtime).call_host_with_context(
+        (&mut *target.runtime).preview_host_call_with_context(
           &mut *target.context,
           HostCall::new(&self.host_name, arguments.clone()),
         )
@@ -387,8 +526,10 @@ impl MechFunctionCompiler for RuntimeHostNativeFunction {
 mod transaction_tests {
   use super::*;
   use std::sync::{Arc, Mutex};
+  use std::sync::atomic::{AtomicUsize, Ordering};
   use crate::{
     BasicCapability, BasicOperation, BasicResource, BasicSubject,
+    ClosureHostFunction,
     PreparedRuntimeEffect, RuntimeAfterCommitEffect,
     RuntimeEffectMetadata, RuntimeEffectSource,
     StagedClosureHostFunction,
@@ -471,6 +612,167 @@ mod transaction_tests {
       log.lock().unwrap().as_slice(),
       &["delivered".to_string()],
     );
+  }
+
+  #[test]
+  fn immediate_only_host_is_rejected_before_transactional_callback() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/immediate");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new(
+        "demo/immediate",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::Empty)
+        },
+      ))
+      .unwrap();
+
+    runtime
+      .call_host(HostCall::new("demo/immediate", Vec::new()))
+      .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    let error = runtime
+      .call_host_with_context(
+        &mut context,
+        HostCall::new("demo/immediate", Vec::new()),
+      )
+      .unwrap_err();
+
+    assert_eq!(
+      error.kind_name(),
+      "HostFunctionTransactionUnsupported",
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    runtime
+      .abort_runtime_transaction(&mut context, "discard rejection test")
+      .unwrap();
+
+    let implicit_error = runtime
+      .run_string("result := demo/immediate()")
+      .unwrap_err();
+    assert_eq!(
+      implicit_error.kind_name(),
+      "HostFunctionTransactionUnsupported",
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn pure_host_runs_inside_implicit_and_explicit_transactions() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/pure");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new_pure(
+        "demo/pure",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::F64(Ref::new(42.0)))
+        },
+      ))
+      .unwrap();
+
+    runtime.run_string("implicit := demo/pure()").unwrap();
+
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "explicit := demo/pure()",
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+  }
+
+  #[test]
+  fn failed_later_operation_discards_only_its_staged_host_effect() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/staged");
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let effect_log = log.clone();
+    runtime
+      .register_mech_host_function(StagedClosureHostFunction::new(
+        "demo/staged",
+        move |_services, _context, _args| {
+          Ok(RuntimePreparedHostCall {
+            value: Value::String(Ref::new("provisional".to_string())),
+            effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+              RecordingHostEffect {
+                log: effect_log.clone(),
+                entry: "delivered".to_string(),
+              },
+            )),
+          })
+        },
+      ))
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "first := demo/staged()",
+      )
+      .unwrap();
+    let failed = runtime.run_string_with_context(
+      &mut context,
+      "discarded := demo/staged()\nbroken := missing + 1",
+    );
+
+    assert!(failed.is_err());
+    assert!(runtime.program.root_symbol_value("first").is_ok());
+    assert!(runtime.program.root_symbol_value("discarded").is_err());
+    assert!(log.lock().unwrap().is_empty());
+
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert_eq!(
+      log.lock().unwrap().as_slice(),
+      &["delivered".to_string()],
+    );
+  }
+
+  #[test]
+  fn runtime_managed_preview_does_not_duplicate_staged_mutation() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/runtime-managed");
+    let observed_ids = Arc::new(Mutex::new(Vec::new()));
+    let callback_ids = observed_ids.clone();
+    runtime
+      .register_mech_host_function(
+        ClosureHostFunction::new_runtime_managed(
+          "demo/runtime-managed",
+          move |services, context, _args| {
+            let id = services.next_object_id();
+            callback_ids.lock().unwrap().push(id);
+            services.put_object_with_context(
+              context,
+              ObjectRecord::text(id, "preview-test", "value"),
+            )?;
+            Ok(Value::String(Ref::new(id.to_string())))
+          },
+        ),
+      )
+      .unwrap();
+
+    runtime
+      .run_string("result := demo/runtime-managed()")
+      .unwrap();
+
+    let ids = observed_ids.lock().unwrap().clone();
+    assert_eq!(ids.len(), 2);
+    assert!(runtime.store().get_object(ids[0]).unwrap().is_none());
+    assert!(runtime.store().get_object(ids[1]).unwrap().is_some());
   }
 }
 

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -43,6 +43,9 @@ use super::execution::{
 use mech_core::{
   GuardFunctionSafety, Ref, ValueKind,
 };
+use crate::{
+  HostFunctionTransactionMode, RuntimePreparedHostCall,
+};
 
 impl MechRuntime {
 
@@ -150,7 +153,26 @@ impl MechRuntime {
 
       self.check_capability_with_context(context, &capability_request)?;
 
-      function.call(self, context, call.args)
+      match function.transaction_mode() {
+        HostFunctionTransactionMode::Staged => {
+          let RuntimePreparedHostCall { value, effect } =
+            function.stage_call(self, context, call.args)?;
+          if context.transaction.is_some() {
+            self.stage_runtime_effect_with_context(context, effect)?;
+          } else {
+            let cost = effect.cost();
+            context.charge_bytes(cost.bytes)?;
+            context.charge_items(cost.items)?;
+            self.execute_runtime_effect_immediately(effect)?;
+          }
+          Ok(value)
+        }
+        HostFunctionTransactionMode::Pure
+        | HostFunctionTransactionMode::RuntimeManaged
+        | HostFunctionTransactionMode::ImmediateOnly => {
+          function.call(self, context, call.args)
+        }
+      }
     })();
 
     match &result {
@@ -358,6 +380,97 @@ impl MechFunctionCompiler for RuntimeHostNativeFunction {
       },
       None,
     ))
+  }
+}
+
+#[cfg(test)]
+mod transaction_tests {
+  use super::*;
+  use std::sync::{Arc, Mutex};
+  use crate::{
+    BasicCapability, BasicOperation, BasicResource, BasicSubject,
+    PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+    RuntimeEffectMetadata, RuntimeEffectSource,
+    StagedClosureHostFunction,
+  };
+
+  #[derive(Debug)]
+  struct RecordingHostEffect {
+    log: Arc<Mutex<Vec<String>>>,
+    entry: String,
+  }
+
+  impl RuntimeAfterCommitEffect for RecordingHostEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::HostFunction {
+          name: "demo/staged".to_string(),
+        },
+        "deliver",
+      )
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push(self.entry.clone());
+      Ok(())
+    }
+  }
+
+  fn grant_host_call(runtime: &mut MechRuntime, name: &str) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(700),
+        &BasicSubject::new(&subject),
+        &BasicResource::new(format!("host:{name}")),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
+  }
+
+  #[test]
+  fn staged_host_call_returns_value_before_effect_delivery() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/staged");
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let effect_log = log.clone();
+    runtime
+      .register_mech_host_function(StagedClosureHostFunction::new(
+        "demo/staged",
+        move |_services, _context, _args| {
+          Ok(RuntimePreparedHostCall {
+            value: Value::String(Ref::new("provisional".to_string())),
+            effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+              RecordingHostEffect {
+                log: effect_log.clone(),
+                entry: "delivered".to_string(),
+              },
+            )),
+          })
+        },
+      ))
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    let value = runtime
+      .call_host_with_context(
+        &mut context,
+        HostCall::new("demo/staged", Vec::new()),
+      )
+      .unwrap();
+
+    assert_eq!(
+      value,
+      Value::String(Ref::new("provisional".to_string())),
+    );
+    assert!(log.lock().unwrap().is_empty());
+
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert_eq!(
+      log.lock().unwrap().as_slice(),
+      &["delivered".to_string()],
+    );
   }
 }
 

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -76,6 +76,8 @@ impl MechRuntime {
     &mut self,
     function: impl HostFunction + 'static,
   ) -> MResult<()> {
+    self.ensure_runtime_healthy("register_mech_host_function")?;
+    self.reject_effect_reentrancy("register_mech_host_function")?;
     let name = function.name().to_string();
 
     self

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -14,7 +14,7 @@
 
 // For example, a function to compute an affine transformation could be registered as a host function, and then called from Mech code like this:
 /*
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/math/affine",
     |_services, _context, args| {
       host_call3(

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -256,7 +256,7 @@ fn register_sleep_host(
 ) {
   runtime
     .register_mech_host_function(
-      ClosureHostFunction::new(
+      ClosureHostFunction::new_pure(
         name,
         move |_services, _context, args| {
           thread::sleep(
@@ -436,7 +436,7 @@ fn patterned_activation_guard_rejects_runtime_host_before_elaboration() {
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
   runtime
-    .register_mech_host_function(ClosureHostFunction::new(
+    .register_mech_host_function(ClosureHostFunction::new_pure(
       "demo/audit",
       move |_services, _context, _args| {
         host_calls.fetch_add(1, Ordering::SeqCst);
@@ -513,7 +513,7 @@ fn live_input_recomputes_runtime_host_function() {
     .unwrap();
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-plus-one", move |_services, _context, args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/live-plus-one", move |_services, _context, args| {
     host_calls.fetch_add(1, Ordering::SeqCst);
     match &args[0] {
       Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
@@ -545,7 +545,7 @@ fn runtime_reactive_host_input_executes_only_reachable_branch() {
   grant_host_call(&mut runtime, &subject, 91, "host:demo/left-branch"); grant_host_call(&mut runtime, &subject, 92, "host:demo/right-branch");
   let left_calls = Arc::new(AtomicUsize::new(0)); let right_calls = Arc::new(AtomicUsize::new(0));
   for (name, calls, add) in [("demo/left-branch", left_calls.clone(), 100.0), ("demo/right-branch", right_calls.clone(), 200.0)] {
-    runtime.register_mech_host_function(ClosureHostFunction::new(name, move |_services, _context, args| { calls.fetch_add(1, Ordering::SeqCst); let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + add))) })).unwrap();
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure(name, move |_services, _context, args| { calls.fetch_add(1, Ordering::SeqCst); let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + add))) })).unwrap();
   }
   let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(left), :read(right)}\nleft-output := demo/left-branch(@pulse/left)\nright-output := demo/right-branch(@pulse/right)").unwrap();
   let left_calls_before = left_calls.load(Ordering::SeqCst);
@@ -569,7 +569,7 @@ fn live_host_string_output_recomputes_without_replacing_reference() {
   grant_read(&mut runtime, "test://clock/ticks", "value");
   let subject = runtime.runtime_context().unwrap().subject;
   grant_host_call(&mut runtime, &subject, 45, "host:demo/live-label");
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-label", |_services, _context, args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/live-label", |_services, _context, args| {
     let value = match &args[0] {
       Value::F64(value) => *value.borrow(),
       Value::MutableReference(value) => match &*value.borrow() {
@@ -611,7 +611,7 @@ fn live_host_output_kind_change_preserves_previous_output() {
   grant_host_call(&mut runtime, &subject, 46, "host:demo/kind-change");
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/kind-change", move |_services, _context, args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/kind-change", move |_services, _context, args| {
     let call = host_calls.fetch_add(1, Ordering::SeqCst);
     if call < 2 {
       let value = match &args[0] {
@@ -658,7 +658,7 @@ fn runtime_reactive_host_input_turn_failure_preserves_admitted_inputs() {
   let (mut runtime, output) = test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0)); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
   let subject = runtime.runtime_context().unwrap().subject; grant_host_call(&mut runtime, &subject, 47, "host:demo/fails-after-first");
   let calls = Arc::new(AtomicUsize::new(0)); let host_calls = calls.clone(); let fail_host = Arc::new(AtomicBool::new(false)); let fail_host_for_call = fail_host.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/fails-after-first", move |_services, _context, args| { host_calls.fetch_add(1, Ordering::SeqCst); if fail_host_for_call.load(Ordering::SeqCst) { return Err(MechError::new(DeliberateHostCallError, None)); } let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + 1.0))) })).unwrap();
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/fails-after-first", move |_services, _context, args| { host_calls.fetch_add(1, Ordering::SeqCst); if fail_host_for_call.load(Ordering::SeqCst) { return Err(MechError::new(DeliberateHostCallError, None)); } let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + 1.0))) })).unwrap();
   let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/fails-after-first(@pulse/value)\noutput := host-result + 0\n@out/line <- output").unwrap();
   let calls_before = calls.load(Ordering::SeqCst); let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); let host_result_pointer = match &*host_result.borrow() { Value::F64(value) => value.as_ptr(), other => panic!("expected f64 host result, got {other:?}") }; let plan_before = plan_snapshot(&runtime); let lines_before = output.lines();
   assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(output.lines().len(), 1); assert_eq!(runtime.persistent_send_count(), 1);
@@ -673,7 +673,7 @@ fn live_host_empty_output_can_recompute() {
   grant_host_call(&mut runtime, &subject, 48, "host:demo/live-empty");
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-empty", move |_services, _context, _args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/live-empty", move |_services, _context, _args| {
     host_calls.fetch_add(1, Ordering::SeqCst);
     Ok(Value::Empty)
   })).unwrap();
@@ -2022,7 +2022,7 @@ other-value := other-tick + 1.0
   fn failed_patterned_body_does_not_replay_send_on_unrelated_turn() {
     let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_read(&mut runtime,"test://other/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
     let subject=runtime.runtime_context().unwrap().subject;grant_host_call(&mut runtime,&subject,194,"host:demo/patterned-body-fail-second");let calls=Arc::new(AtomicUsize::new(0));let host_calls=calls.clone();
-    runtime.register_mech_host_function(ClosureHostFunction::new("demo/patterned-body-fail-second",move |_services,_context,args|{let call=host_calls.fetch_add(1,Ordering::SeqCst)+1;if call==2{return Err(MechError::new(DeliberateHostCallError,None));}Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))})).unwrap();
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/patterned-body-fail-second",move |_services,_context,args|{let call=host_calls.fetch_add(1,Ordering::SeqCst)+1;if call==2{return Err(MechError::new(DeliberateHostCallError,None));}Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))})).unwrap();
     runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
 @other := test://other/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
@@ -2139,7 +2139,7 @@ render-tick := @tick/tick
         let calls = Arc::new(AtomicUsize::new(0));
         let host_calls = calls.clone();
         runtime
-            .register_mech_host_function(ClosureHostFunction::new(
+            .register_mech_host_function(ClosureHostFunction::new_pure(
                 "demo/activation-fail-second",
                 move |_services, _context, args| {
                     let call_number = host_calls.fetch_add(1, Ordering::SeqCst) + 1;

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -14,6 +14,7 @@ use crate::{
   RuntimeCapabilityGrant, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
   RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInputOutcome, RuntimeIngress,
   RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, RuntimeResourceWriteIntent, ClosureHostFunction, materialize_host_manifest,
+  PreparedRuntimeEffect, RuntimeAfterCommitEffect, RuntimeEffectMetadata, RuntimeEffectSource,
 };
 
 const TEST_CLOCK_BASE_URI: &str =
@@ -30,6 +31,22 @@ struct TestFixtureError(String);
 impl MechErrorKind for TestFixtureError {
   fn name(&self) -> &str { "TestFixtureError" }
   fn message(&self) -> String { self.0.clone() }
+}
+
+struct TestAfterCommitEffect {
+  metadata: RuntimeEffectMetadata,
+  delivery: Box<dyn FnMut() -> MResult<()>>,
+}
+
+impl std::fmt::Debug for TestAfterCommitEffect {
+  fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    formatter.debug_struct("TestAfterCommitEffect").field("metadata", &self.metadata).finish_non_exhaustive()
+  }
+}
+
+impl RuntimeAfterCommitEffect for TestAfterCommitEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata { self.metadata.clone() }
+  fn deliver(&mut self) -> MResult<()> { (self.delivery)() }
 }
 
 #[derive(Debug, Default)]
@@ -63,9 +80,14 @@ impl RuntimeResourceProvider for TestOutputProvider {
   fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
     if request.base_uri == TEST_OUTPUT_BASE_URI && request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send { Ok(()) } else { Err(MechError::new(TestFixtureError(format!("invalid test output write: {} / {}", request.base_uri, request.path)), None)) }
   }
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
     self.preflight_write(RuntimeResourceWritePreflightRequest { base_uri: request.base_uri.clone(), path: request.path.clone(), context_name: request.context_name.clone(), operation: request.operation.clone(), intent: request.intent })?;
-    self.backend.lines.borrow_mut().push(format!("{}", request.value)); Ok(())
+    let lines = self.backend.lines.clone();
+    let rendered = format!("{}", request.value);
+    Ok(PreparedRuntimeEffect::AfterCommit(Box::new(TestAfterCommitEffect {
+      metadata: RuntimeEffectMetadata::new(RuntimeEffectSource::ResourceProvider { scheme: "test".to_string() }, "send").with_resource(format!("{}/{}", request.base_uri, request.path)),
+      delivery: Box::new(move || { lines.borrow_mut().push(rendered.clone()); Ok(()) }),
+    })))
   }
 }
 
@@ -724,7 +746,7 @@ fn failed_source_does_not_leave_live_state_armed() {
     "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value\n@out/line <- output\nmissing := missing-live-value + 1",
   );
   assert!(error.is_err());
-  assert!(!output.lines().is_empty());
+  assert!(output.lines().is_empty());
   assert!(runtime.live_context_template.is_none());
   assert!(runtime.live_input_bindings.is_empty());
   assert!(runtime.persistent_sends.is_empty());
@@ -1184,19 +1206,26 @@ mod persistent_send_tests {
     fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
       if request.path == "line" && request.intent == RuntimeResourceWriteIntent::Send { Ok(()) } else { Err(MechError::new(PersistentSendTestError("bad console write".to_string()), None)) }
     }
-    fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+    fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
       self.preflight_write(RuntimeResourceWritePreflightRequest {
-        base_uri: request.base_uri,
-        path: request.path,
-        context_name: request.context_name,
-        operation: request.operation,
+        base_uri: request.base_uri.clone(),
+        path: request.path.clone(),
+        context_name: request.context_name.clone(),
+        operation: request.operation.clone(),
         intent: request.intent,
       })?;
-      if let Some(reason) = self.backend.fail_next.borrow_mut().take() {
-        return Err(MechError::new(PersistentSendTestError(reason), None));
-      }
-      self.backend.lines.borrow_mut().push(format!("{}", request.value));
-      Ok(())
+      let backend = self.backend.clone();
+      let rendered = format!("{}", request.value);
+      Ok(PreparedRuntimeEffect::AfterCommit(Box::new(TestAfterCommitEffect {
+        metadata: RuntimeEffectMetadata::new(RuntimeEffectSource::ResourceProvider { scheme: "console".to_string() }, "send").with_resource(format!("{}/{}", request.base_uri, request.path)),
+        delivery: Box::new(move || {
+          if let Some(reason) = backend.fail_next.borrow_mut().take() {
+            return Err(MechError::new(PersistentSendTestError(reason), None));
+          }
+          backend.lines.borrow_mut().push(rendered.clone());
+          Ok(())
+        }),
+      })))
     }
   }
 
@@ -1278,7 +1307,7 @@ mod persistent_send_tests {
                 ))
             }
         }
-        fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
             self.preflight_write(RuntimeResourceWritePreflightRequest {
                 base_uri: request.base_uri.clone(),
                 path: request.path.clone(),
@@ -1287,30 +1316,39 @@ mod persistent_send_tests {
                 intent: request.intent,
             })?;
             let rendered = format!("{}", request.value);
-            let attempt_number = {
-                let mut attempts = self.backend.attempts.borrow_mut();
-                attempts.push(rendered.clone());
-                attempts.len()
-            };
-            let should_fail = {
-                let mut fail_once_at = self.backend.fail_once_at.borrow_mut();
-                if *fail_once_at == Some(attempt_number) {
-                    *fail_once_at = None;
-                    true
-                } else {
-                    false
-                }
-            };
-            if should_fail {
-                return Err(MechError::new(
-                    PersistentSendTestError(format!(
-                        "intentional output failure on attempt {attempt_number}"
-                    )),
-                    None,
-                ));
-            }
-            self.backend.successes.borrow_mut().push(rendered);
-            Ok(())
+            let backend = self.backend.clone();
+            Ok(PreparedRuntimeEffect::AfterCommit(Box::new(TestAfterCommitEffect {
+                metadata: RuntimeEffectMetadata::new(
+                    RuntimeEffectSource::ResourceProvider { scheme: "test".to_string() },
+                    "send",
+                ).with_resource(format!("{}/{}", request.base_uri, request.path)),
+                delivery: Box::new(move || {
+                    let attempt_number = {
+                        let mut attempts = backend.attempts.borrow_mut();
+                        attempts.push(rendered.clone());
+                        attempts.len()
+                    };
+                    let should_fail = {
+                        let mut fail_once_at = backend.fail_once_at.borrow_mut();
+                        if *fail_once_at == Some(attempt_number) {
+                            *fail_once_at = None;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if should_fail {
+                        return Err(MechError::new(
+                            PersistentSendTestError(format!(
+                                "intentional output failure on attempt {attempt_number}"
+                            )),
+                            None,
+                        ));
+                    }
+                    backend.successes.borrow_mut().push(rendered.clone());
+                    Ok(())
+                }),
+            })))
         }
     }
 

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -199,7 +199,7 @@ use crate::event::{
 };
 
 use crate::host::{
-  default_host_capability_request, DefaultHostCallPolicy, HostCall, HostCallPolicy, HostFunction,
+  default_host_capability_request, DefaultHostCallPolicy, HostCall, HostCallPolicy,
   HostFunctionNotFoundError, HostRegistry, InMemoryHostRegistry,
 };
 

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -940,17 +940,41 @@ impl MechRuntime {
   pub fn write_resource_with_context(
     &mut self,
     context: &mut RuntimeContext,
-    request: RuntimeResourceWriteRequest,
+    mut request: RuntimeResourceWriteRequest,
   ) -> MResult<RuntimeEffectId> {
     self.ensure_runtime_healthy("write_resource_with_context")?;
     self.reject_effect_reentrancy("write_resource_with_context")?;
     self.validate_context_for_runtime(context)?;
 
-    let effect = self.resources.stage_write(request)?;
     if context.transaction.is_some() {
-      return self.stage_runtime_effect_with_context(context, effect);
+      request.value = request.value.deep_snapshot();
+      let staged_resource = if request.intent
+        == RuntimeResourceWriteIntent::Assign
+      {
+        Some((
+          request.base_uri.clone(),
+          request.path.clone(),
+          request.value.clone(),
+        ))
+      } else {
+        None
+      };
+      let effect = self.resources.stage_write(request)?;
+      return match staged_resource {
+        Some((base_uri, path, value)) => {
+          self.stage_runtime_resource_effect_with_context(
+            context,
+            effect,
+            base_uri,
+            path,
+            value,
+          )
+        }
+        None => self.stage_runtime_effect_with_context(context, effect),
+      };
     }
 
+    let effect = self.resources.stage_write(request)?;
     let cost = effect.cost();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -48,7 +48,7 @@ use self::program_transaction::{
   RuntimeTransactionContextIdentity,
 };
 use self::effect::RuntimeEffectJournal;
-use crate::ActiveRuntimeEffectPhase;
+use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;
 
 use std::sync::Arc;
@@ -917,6 +917,8 @@ impl MechRuntime {
     &mut self,
     provider: Box<dyn RuntimeResourceProvider>,
   ) -> MResult<()> {
+    self.ensure_runtime_healthy("register_resource_provider")?;
+    self.reject_effect_reentrancy("register_resource_provider")?;
     self.resources.register_provider(provider)
   }
 
@@ -928,7 +930,31 @@ impl MechRuntime {
     &mut self,
     request: RuntimeResourceWriteRequest,
   ) -> MResult<()> {
-    self.resources.write(request)
+    self.ensure_runtime_healthy("write_resource")?;
+    self.reject_effect_reentrancy("write_resource")?;
+    let effect = self.resources.stage_write(request)?;
+    self.execute_runtime_effect_immediately(effect)?;
+    Ok(())
+  }
+
+  pub fn write_resource_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    request: RuntimeResourceWriteRequest,
+  ) -> MResult<RuntimeEffectId> {
+    self.ensure_runtime_healthy("write_resource_with_context")?;
+    self.reject_effect_reentrancy("write_resource_with_context")?;
+    self.validate_context_for_runtime(context)?;
+
+    let effect = self.resources.stage_write(request)?;
+    if context.transaction.is_some() {
+      return self.stage_runtime_effect_with_context(context, effect);
+    }
+
+    let cost = effect.cost();
+    context.charge_bytes(cost.bytes)?;
+    context.charge_items(cost.items)?;
+    self.execute_runtime_effect_immediately(effect)
   }
 
   pub fn read_resource(

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -47,6 +47,7 @@ use self::program_transaction::{
   RuntimeExecutionTransactionState,
   RuntimeTransactionContextIdentity,
 };
+use self::capability::RuntimeCapabilityOverlay;
 use self::effect::RuntimeEffectJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -47,7 +47,9 @@ use self::program_transaction::{
   RuntimeExecutionTransactionState,
   RuntimeTransactionContextIdentity,
 };
-use self::capability::RuntimeCapabilityOverlay;
+use self::capability::{
+  RuntimeCapabilityMutation, RuntimeCapabilityOverlay,
+};
 use self::effect::RuntimeEffectJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -1626,7 +1626,7 @@ mod tests {
     let observed = Arc::new(Mutex::new(Vec::new()));
     let observed_for_host = observed.clone();
     runtime
-      .register_mech_host_function(ClosureHostFunction::new(
+      .register_mech_host_function(ClosureHostFunction::new_runtime_managed(
         "demo/reenter",
         move |_services, _context, _args| {
           ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -180,6 +180,7 @@ pub(super) struct RuntimeExecutionTransaction {
   pub(super) context_baseline: RuntimeContextCheckpoint,
   pub(super) program: Option<RuntimeProgramBaseline>,
   pub(super) effects: RuntimeEffectJournal,
+  pub(super) capabilities: RuntimeCapabilityOverlay,
   pub(super) state: RuntimeExecutionTransactionState,
 }
 
@@ -197,6 +198,7 @@ impl RuntimeExecutionTransaction {
       context_baseline,
       program: None,
       effects: RuntimeEffectJournal::new(),
+      capabilities: RuntimeCapabilityOverlay::default(),
       state: RuntimeExecutionTransactionState::Active,
     }
   }
@@ -208,6 +210,7 @@ pub(super) struct RuntimeProgramOperationSavepoint {
   pub(super) live: RuntimeLiveStateSnapshot,
   pub(super) store: RuntimeTransaction,
   pub(super) effect_mark: usize,
+  pub(super) capability_mark: usize,
   pub(super) context: RuntimeContextCheckpoint,
 }
 
@@ -387,15 +390,24 @@ impl MechRuntime {
         let effect_failures =
           transaction.effects.rollback_to(savepoint.effect_mark);
         transaction.store = savepoint.store.clone();
-        Some(effect_failures)
+        let capability_result = transaction
+          .capabilities
+          .rollback_to(savepoint.capability_mark);
+        Some((effect_failures, capability_result))
       }
       None => None,
     };
     self.active_effect_phase = None;
     match effect_rollback {
-      Some(effect_failures) => failures.extend(
-        Self::describe_effect_failures(effect_failures),
-      ),
+      Some((effect_failures, capability_result)) => {
+        failures.extend(Self::describe_effect_failures(effect_failures));
+        if let Err(error) = capability_result {
+          failures.push(format!(
+            "capability overlay rollback failed: {:?}",
+            error,
+          ));
+        }
+      }
       None => failures.push(format!(
         "active execution transaction {} disappeared before operation rollback",
         transaction_id,
@@ -678,6 +690,10 @@ impl MechRuntime {
       effect_mark: self
         .active_execution_transaction(transaction_id)?
         .effects
+        .mark(),
+      capability_mark: self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
         .mark(),
       context: RuntimeContextCheckpoint::capture(context),
     };

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -969,6 +969,42 @@ mod tests {
   }
 
   #[test]
+  fn resource_provider_staging_failure_leaves_effect_journal_unchanged() {
+    let mut runtime = MechRuntime::builder()
+      .resource_provider(Box::new(InMemoryDocsProvider::new()))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    let result = runtime.write_resource_with_context(
+      &mut context,
+      RuntimeResourceWriteRequest {
+        base_uri: "docs://manual".to_string(),
+        path: String::new(),
+        context_name: "manual".to_string(),
+        operation: RuntimeCapabilityOperation::Write,
+        value: Value::Bool(mech_core::Ref::new(true)),
+        intent: RuntimeResourceWriteIntent::Assign,
+      },
+    );
+
+    assert!(result.is_err());
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .effects
+        .len(),
+      0,
+    );
+
+    runtime
+      .abort_runtime_transaction(&mut context, "discard failed staging")
+      .unwrap();
+  }
+
+  #[test]
   fn program_transaction_implicit_success_commits_program_store_and_events() {
     let mut runtime = MechRuntime::builder().build().unwrap();
     let mut context = runtime.runtime_context().unwrap();

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -17,7 +17,9 @@
 // - `context_transaction_id`: Retrieves the active transaction ID from the context.
 
 use super::*;
-use crate::{AccessSet, RuntimeCommitOutcome};
+use crate::{
+  AccessSet, CapabilityKernelCheckpoint, RuntimeCommitOutcome,
+};
 
 impl MechRuntime {
 
@@ -227,7 +229,7 @@ impl MechRuntime {
         )
       })?;
 
-    if envelope.effects.is_empty() {
+    if envelope.effects.is_empty() && envelope.capabilities.is_empty() {
       let commit_event =
         self.make_event(RuntimeEventKind::TransactionCommitted {
           transaction_id,
@@ -284,13 +286,60 @@ impl MechRuntime {
       ));
     }
 
+    let capability_checkpoint = if envelope.capabilities.is_empty() {
+      None
+    } else {
+      match self.capability_kernel.checkpoint() {
+        Ok(checkpoint) => Some(checkpoint),
+        Err(error) => {
+          let original_error_text = format!("{:?}", error);
+          self.active_effect_phase =
+            Some(ActiveRuntimeEffectPhase::Aborting);
+          let aborted = envelope.effects.abort_prepared_reverse();
+          self.active_effect_phase = None;
+          envelope.state = RuntimeExecutionTransactionState::Active;
+          self.active_transactions.insert(transaction_id, envelope);
+          if aborted.is_empty() {
+            return Err(error);
+          }
+          return Err(self.poison_effect_cleanup(
+            "commit_runtime_transaction",
+            transaction_id,
+            original_error_text,
+            Self::describe_effect_failures(aborted),
+          ));
+        }
+      }
+    };
+
+    if let Err(error) = self.apply_capability_overlay(&envelope) {
+      let original_error_text = format!("{:?}", error);
+      let cleanup = self.cleanup_before_store_retry(
+        &mut envelope,
+        capability_checkpoint,
+      );
+      envelope.state = RuntimeExecutionTransactionState::Active;
+      self.active_transactions.insert(transaction_id, envelope);
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "commit_runtime_transaction",
+        transaction_id,
+        original_error_text,
+        cleanup,
+      ));
+    }
+
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Applying);
     let apply_result = envelope.effects.apply_compensatable();
     self.active_effect_phase = None;
     if let Err(step) = apply_result {
       let original_error_text = format!("{:?}", step.error);
-      let cleanup =
-        self.cleanup_effects_before_store_retry(&mut envelope);
+      let cleanup = self.cleanup_before_store_retry(
+        &mut envelope,
+        capability_checkpoint,
+      );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
       if cleanup.is_empty() {
@@ -315,8 +364,10 @@ impl MechRuntime {
       Ok(commit) => commit,
       Err(error) => {
         let original_error_text = format!("{:?}", error);
-        let cleanup =
-          self.cleanup_effects_before_store_retry(&mut envelope);
+        let cleanup = self.cleanup_before_store_retry(
+          &mut envelope,
+          capability_checkpoint,
+        );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
         if cleanup.is_empty() {
@@ -335,8 +386,10 @@ impl MechRuntime {
       Ok(id) => id,
       Err(error) => {
         let original_error_text = format!("{:?}", error);
-        let cleanup =
-          self.cleanup_effects_before_store_retry(&mut envelope);
+        let cleanup = self.cleanup_before_store_retry(
+          &mut envelope,
+          capability_checkpoint,
+        );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
         if cleanup.is_empty() {
@@ -383,19 +436,51 @@ impl MechRuntime {
     })
   }
 
-  fn cleanup_effects_before_store_retry(
+  fn cleanup_before_store_retry(
     &mut self,
     envelope: &mut RuntimeExecutionTransaction,
+    capability_checkpoint: Option<Box<dyn CapabilityKernelCheckpoint>>,
   ) -> Vec<String> {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Compensating);
     let compensated = envelope.effects.compensate_applied_reverse();
+    let capability_restore = capability_checkpoint
+      .map(|checkpoint| {
+        self.capability_kernel.restore_checkpoint(checkpoint)
+      });
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let aborted = envelope.effects.abort_prepared_reverse();
     self.active_effect_phase = None;
 
     let mut failures = Self::describe_effect_failures(compensated);
+    if let Some(Err(error)) = capability_restore {
+      failures.push(format!(
+        "capability kernel checkpoint restore failed: {:?}",
+        error,
+      ));
+    }
     failures.extend(Self::describe_effect_failures(aborted));
     failures
+  }
+
+  fn apply_capability_overlay(
+    &mut self,
+    envelope: &RuntimeExecutionTransaction,
+  ) -> MResult<()> {
+    for mutation in envelope.capabilities.mutations() {
+      match mutation {
+        RuntimeCapabilityMutation::Grant(capability) => {
+          self
+            .capability_kernel
+            .grant(CapabilityGrant::new(capability))?;
+        }
+        RuntimeCapabilityMutation::Revoke(capability) => {
+          self
+            .capability_kernel
+            .revoke(CapabilityRevocation::new(capability))?;
+        }
+      }
+    }
+    Ok(())
   }
 
   fn build_runtime_store_commit(
@@ -439,6 +524,11 @@ impl MechRuntime {
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
+      capability_grants: envelope.capabilities.grants().collect(),
+      capability_revocations: envelope
+        .capabilities
+        .revocations()
+        .collect(),
       object_puts: staged_puts,
       object_updates: staged_updates,
       task_updates: staged_task_updates,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -19,6 +19,7 @@
 use super::*;
 use crate::{
   AccessSet, CapabilityKernelCheckpoint, RuntimeCommitOutcome,
+  RuntimeEffectFailure, RuntimeEffectFailurePhase,
 };
 
 impl MechRuntime {
@@ -270,9 +271,48 @@ impl MechRuntime {
     self.active_effect_phase = None;
     if let Err(step) = prepare_result {
       let original_error_text = format!("{:?}", step.error);
+      let prepared_ids =
+        envelope.effects.prepared_transactional_ids();
       self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
-      let cleanup = envelope.effects.abort_prepared_reverse();
+      let mut cleanup = envelope.effects.abort_prepared_reverse();
       self.active_effect_phase = None;
+      let failed_ids: HashSet<RuntimeEffectId> = cleanup
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect();
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        &mut envelope,
+        context,
+        RuntimeEventKind::EffectPreparationFailed {
+          effect_id: step.failure.effect_id,
+          message: step.failure.message.clone(),
+        },
+      ) {
+        cleanup.push(RuntimeEffectFailure {
+          effect_id: step.failure.effect_id,
+          phase: RuntimeEffectFailurePhase::Abort,
+          message: format!(
+            "preparation failure audit event failed: {:?}",
+            error,
+          ),
+        });
+      }
+      for effect_id in prepared_ids {
+        if failed_ids.contains(&effect_id) {
+          continue;
+        }
+        if let Err(error) = self.stage_effect_lifecycle_event(
+          &mut envelope,
+          context,
+          RuntimeEventKind::EffectAborted { effect_id },
+        ) {
+          cleanup.push(RuntimeEffectFailure {
+            effect_id,
+            phase: RuntimeEffectFailurePhase::Abort,
+            message: format!("abort audit event failed: {:?}", error),
+          });
+        }
+      }
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
       if cleanup.is_empty() {
@@ -293,10 +333,37 @@ impl MechRuntime {
         Ok(checkpoint) => Some(checkpoint),
         Err(error) => {
           let original_error_text = format!("{:?}", error);
+          let prepared_ids =
+            envelope.effects.prepared_transactional_ids();
           self.active_effect_phase =
             Some(ActiveRuntimeEffectPhase::Aborting);
-          let aborted = envelope.effects.abort_prepared_reverse();
+          let mut aborted = envelope.effects.abort_prepared_reverse();
           self.active_effect_phase = None;
+          let failed_ids: HashSet<RuntimeEffectId> = aborted
+            .iter()
+            .map(|failure| failure.effect_id)
+            .collect();
+          for effect_id in prepared_ids {
+            if failed_ids.contains(&effect_id) {
+              continue;
+            }
+            if let Err(audit_error) =
+              self.stage_effect_lifecycle_event(
+                &mut envelope,
+                context,
+                RuntimeEventKind::EffectAborted { effect_id },
+              )
+            {
+              aborted.push(RuntimeEffectFailure {
+                effect_id,
+                phase: RuntimeEffectFailurePhase::Abort,
+                message: format!(
+                  "abort audit event failed: {:?}",
+                  audit_error,
+                ),
+              });
+            }
+          }
           envelope.state = RuntimeExecutionTransactionState::Active;
           self.active_transactions.insert(transaction_id, envelope);
           if aborted.is_empty() {
@@ -317,6 +384,7 @@ impl MechRuntime {
       let cleanup = self.cleanup_before_store_retry(
         &mut envelope,
         capability_checkpoint,
+        context,
       );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -339,6 +407,7 @@ impl MechRuntime {
       let cleanup = self.cleanup_before_store_retry(
         &mut envelope,
         capability_checkpoint,
+        context,
       );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -367,6 +436,7 @@ impl MechRuntime {
         let cleanup = self.cleanup_before_store_retry(
           &mut envelope,
           capability_checkpoint,
+          context,
         );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
@@ -389,6 +459,7 @@ impl MechRuntime {
         let cleanup = self.cleanup_before_store_retry(
           &mut envelope,
           capability_checkpoint,
+          context,
         );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
@@ -407,18 +478,47 @@ impl MechRuntime {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Committing);
     let participant_result = envelope.effects.commit_transactional();
     self.active_effect_phase = None;
-    if let Err(commit_failure) = participant_result {
-      context.transaction = None;
-      if self.program_transaction_owner == Some(transaction_id) {
-        self.program_transaction_owner = None;
+    let committed_effects = match participant_result {
+      Ok(committed_effects) => committed_effects,
+      Err(commit_failure) => {
+        context.transaction = None;
+        if self.program_transaction_owner == Some(transaction_id) {
+          self.program_transaction_owner = None;
+        }
+        self.push_persisted_event_to_context(context, commit_event);
+        let mut participant_outcomes =
+          commit_failure.participant_outcomes;
+        for effect_id in commit_failure.committed {
+          if let Err(error) = self.emit_event_to_context(
+            context,
+            RuntimeEventKind::TransactionalEffectCommitted { effect_id },
+          ) {
+            participant_outcomes.push(format!(
+              "transactional effect {} commit audit failed: {:?}",
+              effect_id,
+              error,
+            ));
+          }
+        }
+        if let Err(error) = self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ExternalCommitIndeterminate {
+            transaction_id: id,
+            effect_id: commit_failure.step.failure.effect_id,
+          },
+        ) {
+          participant_outcomes.push(format!(
+            "external commit indeterminate audit failed: {:?}",
+            error,
+          ));
+        }
+        return Err(self.poison_external_commit_indeterminate(
+          id,
+          commit_failure.step.failure.effect_id,
+          participant_outcomes,
+        ));
       }
-      self.push_persisted_event_to_context(context, commit_event);
-      return Err(self.poison_external_commit_indeterminate(
-        id,
-        commit_failure.step.failure.effect_id,
-        commit_failure.participant_outcomes,
-      ));
-    }
+    };
 
     context.transaction = None;
     if self.program_transaction_owner == Some(transaction_id) {
@@ -426,9 +526,46 @@ impl MechRuntime {
     }
     self.push_persisted_event_to_context(context, commit_event);
 
+    for effect_id in committed_effects {
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::TransactionalEffectCommitted { effect_id },
+      ) {
+        return Err(self.poison_external_commit_indeterminate(
+          id,
+          effect_id,
+          vec![format!(
+            "transactional effect {} committed but its audit event failed: {:?}",
+            effect_id,
+            error,
+          )],
+        ));
+      }
+    }
+
+    let after_commit_ids = envelope.effects.after_commit_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Delivering);
-    let delivery_failures = envelope.effects.deliver_after_commit();
+    let mut delivery_failures = envelope.effects.deliver_after_commit();
     self.active_effect_phase = None;
+    for effect_id in after_commit_ids {
+      let kind = match delivery_failures
+        .iter()
+        .find(|failure| failure.effect_id == effect_id)
+      {
+        Some(failure) => RuntimeEventKind::EffectDeliveryFailed {
+          effect_id,
+          message: failure.message.clone(),
+        },
+        None => RuntimeEventKind::EffectDelivered { effect_id },
+      };
+      if let Err(error) = self.emit_event_to_context(context, kind) {
+        delivery_failures.push(RuntimeEffectFailure {
+          effect_id,
+          phase: RuntimeEffectFailurePhase::Deliver,
+          message: format!("delivery audit event failed: {:?}", error),
+        });
+      }
+    }
 
     Ok(RuntimeCommitOutcome {
       transaction_id: id,
@@ -440,17 +577,29 @@ impl MechRuntime {
     &mut self,
     envelope: &mut RuntimeExecutionTransaction,
     capability_checkpoint: Option<Box<dyn CapabilityKernelCheckpoint>>,
+    context: &mut RuntimeContext,
   ) -> Vec<String> {
+    let compensated_ids =
+      envelope.effects.applied_compensatable_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Compensating);
     let compensated = envelope.effects.compensate_applied_reverse();
     let capability_restore = capability_checkpoint
       .map(|checkpoint| {
         self.capability_kernel.restore_checkpoint(checkpoint)
       });
+    let aborted_ids = envelope.effects.prepared_transactional_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let aborted = envelope.effects.abort_prepared_reverse();
     self.active_effect_phase = None;
 
+    let failed_compensations: HashSet<RuntimeEffectId> = compensated
+      .iter()
+      .map(|failure| failure.effect_id)
+      .collect();
+    let failed_aborts: HashSet<RuntimeEffectId> = aborted
+      .iter()
+      .map(|failure| failure.effect_id)
+      .collect();
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
       failures.push(format!(
@@ -459,7 +608,57 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
+    for effect_id in compensated_ids {
+      if failed_compensations.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        envelope,
+        context,
+        RuntimeEventKind::EffectCompensated { effect_id },
+      ) {
+        failures.push(format!(
+          "effect {} compensation audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
+    }
+    for effect_id in aborted_ids {
+      if failed_aborts.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        envelope,
+        context,
+        RuntimeEventKind::EffectAborted { effect_id },
+      ) {
+        failures.push(format!(
+          "effect {} abort audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
+    }
     failures
+  }
+
+  fn stage_effect_lifecycle_event(
+    &mut self,
+    envelope: &mut RuntimeExecutionTransaction,
+    context: &mut RuntimeContext,
+    kind: RuntimeEventKind,
+  ) -> MResult<EventId> {
+    let context_events_before = context.events.clone();
+    let event = self.make_event(kind);
+    let id = event.id;
+    context.push_event(event.clone());
+    self.trim_events_to_retention(&mut context.events);
+    if let Err(error) = envelope.store.stage_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
+    Ok(id)
   }
 
   fn apply_capability_overlay(
@@ -520,7 +719,9 @@ impl MechRuntime {
 
     let mut transaction_snapshot = transaction.clone();
     transaction_snapshot.record_event(commit_event.id)?;
-    let transaction_record = transaction_snapshot.into_record()?;
+    let transaction_record = transaction_snapshot
+      .into_record()?
+      .with_effects(envelope.effects.records());
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
@@ -626,9 +827,15 @@ impl MechRuntime {
       ));
     }
 
+    let abortable_effects = envelope.effects.abortable_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let effect_abort_failures = envelope.effects.abort_all();
     self.active_effect_phase = None;
+    let failed_effect_aborts: HashSet<RuntimeEffectId> =
+      effect_abort_failures
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect();
     rollback_failures.extend(
       Self::describe_effect_failures(effect_abort_failures),
     );
@@ -642,6 +849,22 @@ impl MechRuntime {
 
     if owns_program {
       self.program_transaction_owner = None;
+    }
+
+    for effect_id in abortable_effects {
+      if failed_effect_aborts.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.emit_event_immediate_to_context(
+        context,
+        RuntimeEventKind::EffectAborted { effect_id },
+      ) {
+        rollback_failures.push(format!(
+          "effect {} abort audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
     }
 
     let abort_event_result = self.emit_event_immediate_to_context(

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -531,9 +531,13 @@ impl MechRuntime {
         context,
         RuntimeEventKind::TransactionalEffectCommitted { effect_id },
       ) {
-        return Err(self.poison_external_commit_indeterminate(
+        return Err(self.poison_effect_cleanup(
+          "commit_runtime_transaction",
           id,
-          effect_id,
+          format!(
+            "transactional effect {} committed but its audit event failed",
+            effect_id,
+          ),
           vec![format!(
             "transactional effect {} committed but its audit event failed: {:?}",
             effect_id,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -585,7 +585,7 @@ impl MechRuntime {
     let compensated = envelope.effects.compensate_applied_reverse();
     let capability_restore = capability_checkpoint
       .map(|checkpoint| {
-        self.capability_kernel.restore_checkpoint(checkpoint)
+        self.capability_kernel.restore(checkpoint)
       });
     let aborted_ids = envelope.effects.prepared_transactional_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
@@ -600,6 +600,22 @@ impl MechRuntime {
       .iter()
       .map(|failure| failure.effect_id)
       .collect();
+    let mut audit_failures = Vec::new();
+    for failure in &compensated {
+      if let Err(error) = self.emit_effect_event_outside_transaction(
+        context,
+        RuntimeEventKind::EffectCompensationFailed {
+          effect_id: failure.effect_id,
+          message: failure.message.clone(),
+        },
+      ) {
+        audit_failures.push(format!(
+          "effect {} compensation failure audit event failed: {:?}",
+          failure.effect_id,
+          error,
+        ));
+      }
+    }
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
       failures.push(format!(
@@ -608,12 +624,12 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
+    failures.extend(audit_failures);
     for effect_id in compensated_ids {
       if failed_compensations.contains(&effect_id) {
         continue;
       }
-      if let Err(error) = self.stage_effect_lifecycle_event(
-        envelope,
+      if let Err(error) = self.emit_effect_event_outside_transaction(
         context,
         RuntimeEventKind::EffectCompensated { effect_id },
       ) {
@@ -655,6 +671,23 @@ impl MechRuntime {
     context.push_event(event.clone());
     self.trim_events_to_retention(&mut context.events);
     if let Err(error) = envelope.store.stage_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
+    Ok(id)
+  }
+
+  fn emit_effect_event_outside_transaction(
+    &mut self,
+    context: &mut RuntimeContext,
+    kind: RuntimeEventKind,
+  ) -> MResult<EventId> {
+    let context_events_before = context.events.clone();
+    let event = self.make_event(kind);
+    let id = event.id;
+    context.push_event(event.clone());
+    self.trim_events_to_retention(&mut context.events);
+    if let Err(error) = self.append_event(event) {
       context.events = context_events_before;
       return Err(error);
     }

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -25,6 +25,7 @@ use mech_core::{MResult, MechError, MechErrorKind, MechSourceCode};
 use crate::capability::{Capability, CapabilityRequest};
 use crate::context::ResourceBudgetExceededError;
 use crate::event::RuntimeEvent;
+use crate::effect::RuntimeEffectRecord;
 use crate::id::{
   ActorId, CapabilityId, EventId, MessageId, ModuleId, ModuleVersionId,
   ObjectId, TaskId, TransactionId,
@@ -763,6 +764,7 @@ pub struct TransactionRecord {
   pub actor_updates: Vec<ActorId>,
 
   pub events: Vec<EventId>,
+  pub effects: Vec<RuntimeEffectRecord>,
 }
 
 impl TransactionRecord {
@@ -781,6 +783,7 @@ impl TransactionRecord {
       actor_updates: Vec::new(),
 
       events: Vec::new(),
+      effects: Vec::new(),
     }
   }
 
@@ -816,6 +819,11 @@ impl TransactionRecord {
 
   pub fn with_events(mut self, events: Vec<EventId>) -> Self {
     self.events = events;
+    self
+  }
+
+  pub fn with_effects(mut self, effects: Vec<RuntimeEffectRecord>) -> Self {
+    self.effects = effects;
     self
   }
 

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -835,6 +835,8 @@ impl TransactionRecord {
 #[derive(Clone, Debug)]
 pub struct RuntimeStoreCommit {
   pub transaction: TransactionRecord,
+  pub capability_grants: Vec<(CapabilityId, Arc<dyn Capability>)>,
+  pub capability_revocations: Vec<CapabilityId>,
   pub object_puts: Vec<ObjectRecord>,
   pub object_updates: Vec<ObjectRecord>,
   pub task_updates: Vec<TaskRecord>,
@@ -1431,6 +1433,14 @@ impl MechStore for InMemoryStore {
       temporary.enqueue_message(actor, message)?;
     }
 
+    for (capability, grant) in commit.capability_grants {
+      temporary.grant_capability(capability, grant)?;
+    }
+
+    for capability in commit.capability_revocations {
+      temporary.revoke_capability(capability)?;
+    }
+
     for event in commit.events {
       temporary.append_event(event)?;
     }
@@ -1922,6 +1932,8 @@ mod tests {
       transaction: TransactionRecord::new(TransactionId(1), "task:1")
         .with_write_set(vec![ObjectId(1), ObjectId(2)])
         .with_events(vec![EventId(1)]),
+      capability_grants: Vec::new(),
+      capability_revocations: Vec::new(),
       object_puts: vec![ObjectRecord::text(ObjectId(1), "note", "hello")],
       object_updates: vec![ObjectRecord::text(ObjectId(2), "note", "missing")],
       task_updates: Vec::new(),

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -764,6 +764,7 @@ pub struct TransactionRecord {
   pub actor_updates: Vec<ActorId>,
 
   pub events: Vec<EventId>,
+  #[cfg_attr(feature = "serde", serde(default))]
   pub effects: Vec<RuntimeEffectRecord>,
 }
 

--- a/src/runtime/tests/generic_host.rs
+++ b/src/runtime/tests/generic_host.rs
@@ -4,6 +4,29 @@ use mech_core::{MResult, MechError, MechErrorKind, Ref, Value};
 use mech_runtime::*;
 
 #[derive(Debug)]
+struct RecordingAfterCommitEffect {
+  scheme: String,
+  operation: String,
+  resource: String,
+  log: Arc<Mutex<Vec<String>>>,
+  entry: String,
+}
+
+impl RuntimeAfterCommitEffect for RecordingAfterCommitEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::ResourceProvider { scheme: self.scheme.clone() },
+      self.operation.clone(),
+    ).with_resource(self.resource.clone())
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    self.log.lock().unwrap().push(self.entry.clone());
+    Ok(())
+  }
+}
+
+#[derive(Debug)]
 struct FakeRobotFactory {
   manifest: HostManifestConfig,
   log: Arc<Mutex<Vec<String>>>,
@@ -62,10 +85,15 @@ impl RuntimeResourceProvider for FakeRobotProvider {
       _ => Err(fake_error(format!("unsupported fake robot command path `{}`", request.path))),
     }
   }
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
     self.preflight_write(RuntimeResourceWritePreflightRequest { base_uri: request.base_uri.clone(), path: request.path.clone(), context_name: request.context_name.clone(), operation: request.operation.clone(), intent: request.intent })?;
-    self.log.lock().unwrap().push(request.path);
-    Ok(())
+    Ok(PreparedRuntimeEffect::AfterCommit(Box::new(RecordingAfterCommitEffect {
+      scheme: "fake-robot".to_string(),
+      operation: request.operation.name().to_string(),
+      resource: format!("{}/{}", request.base_uri, request.path),
+      log: self.log.clone(),
+      entry: request.path,
+    })))
   }
 }
 
@@ -426,10 +454,15 @@ impl RuntimeResourceProvider for PlotterProvider {
       _ => Err(fake_error(format!("unsupported plotter command path `{}`", request.path))),
     }
   }
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+  fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> MResult<PreparedRuntimeEffect> {
     self.preflight_write(RuntimeResourceWritePreflightRequest { base_uri: request.base_uri.clone(), path: request.path.clone(), context_name: request.context_name.clone(), operation: request.operation.clone(), intent: request.intent })?;
-    self.log.lock().unwrap().push(request.operation.name().to_string());
-    Ok(())
+    Ok(PreparedRuntimeEffect::AfterCommit(Box::new(RecordingAfterCommitEffect {
+      scheme: "plotter".to_string(),
+      operation: request.operation.name().to_string(),
+      resource: format!("{}/{}", request.base_uri, request.path),
+      log: self.log.clone(),
+      entry: request.operation.name().to_string(),
+    })))
   }
 }
 

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -6,6 +6,17 @@ use mech_program::{MechProgram, MechProgramConfig};
 use mech_host_cli::{CliBackend, CliResourceProvider};
 use mech_runtime::*;
 
+fn apply_prepared_effect(effect: PreparedRuntimeEffect) -> mech_core::MResult<()> {
+  match effect {
+    PreparedRuntimeEffect::Transactional(mut effect) => {
+      effect.prepare()?;
+      effect.commit()
+    }
+    PreparedRuntimeEffect::Compensatable(mut effect) => effect.apply(),
+    PreparedRuntimeEffect::AfterCommit(mut effect) => effect.deliver(),
+  }
+}
+
 fn temp_root(name: &str) -> std::path::PathBuf {
   let root = std::env::temp_dir().join(format!("mech-runtime-module-smoke-{name}-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()));
   std::fs::create_dir_all(&root).unwrap();
@@ -371,7 +382,8 @@ fn failed_retained_root_restores_live_state_and_imported_environment() {
 #[test]
 fn in_memory_docs_provider_write_then_read_returns_value() {
   let mut provider = InMemoryDocsProvider::new();
-  provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  let effect = provider.stage_write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  apply_prepared_effect(effect).unwrap();
   let value = provider.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
   assert_bool_true(value, "provider write then read");
 }
@@ -380,7 +392,8 @@ fn in_memory_docs_provider_write_then_read_returns_value() {
 fn resource_registry_write_then_read_returns_value() {
   let mut registry = RuntimeResourceRegistry::new();
   registry.register_provider(Box::new(InMemoryDocsProvider::new())).unwrap();
-  registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  let effect = registry.stage_write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign }).unwrap();
+  apply_prepared_effect(effect).unwrap();
   let value = registry.read(RuntimeResourceReadRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string() }).unwrap();
   assert_bool_true(value, "registry write then read");
 }
@@ -388,7 +401,7 @@ fn resource_registry_write_then_read_returns_value() {
 #[test]
 fn resource_registry_write_missing_provider_fails() {
   let mut registry = RuntimeResourceRegistry::new();
-  let result = registry.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  let result = registry.stage_write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("RuntimeResourceProviderNotFound"), "expected missing provider error, got {error}");
@@ -399,7 +412,7 @@ fn resource_registry_write_missing_provider_fails() {
 #[test]
 fn in_memory_docs_write_invalid_scheme_fails() {
   let mut provider = InMemoryDocsProvider::new();
-  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "db://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  let result = provider.stage_write(RuntimeResourceWriteRequest { base_uri: "db://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
@@ -409,7 +422,7 @@ fn in_memory_docs_write_invalid_scheme_fails() {
 #[test]
 fn in_memory_docs_write_empty_path_fails() {
   let mut provider = InMemoryDocsProvider::new();
-  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: String::new(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  let result = provider.stage_write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: String::new(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("RuntimeResourceInvalidUri"), "expected invalid URI error, got {error}");
@@ -427,7 +440,7 @@ impl RuntimeResourceProvider for ReadOnlyDocsProvider {
 #[test]
 fn provider_default_write_is_unsupported() {
   let mut provider = ReadOnlyDocsProvider;
-  let result = provider.write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
+  let result = provider.stage_write(RuntimeResourceWriteRequest { base_uri: "docs://manual".to_string(), path: "intro/title".to_string(), context_name: "manual".to_string(), operation: RuntimeCapabilityOperation::Write, value: bool_value(true), intent: RuntimeResourceWriteIntent::Assign });
   assert!(result.is_err());
   let error = format!("{:?}", result.err().unwrap());
   assert!(error.contains("RuntimeResourceWriteUnsupported"), "expected unsupported write error, got {error}");
@@ -4107,6 +4120,51 @@ struct RecordingResourceProvider {
   writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
 }
 
+#[derive(Debug)]
+struct RecordingResourceWriteEffect {
+  scheme: String,
+  base_uri: String,
+  path: String,
+  value: Value,
+  values: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Value>>>,
+  writes: std::sync::Arc<std::sync::Mutex<Vec<(String, String, Value)>>>,
+  previous: Option<Option<Value>>,
+  previous_writes_len: Option<usize>,
+}
+
+impl RuntimeCompensatableEffect for RecordingResourceWriteEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::ResourceProvider { scheme: self.scheme.clone() },
+      "write",
+    ).with_resource(format!("{}/{}", self.base_uri, self.path))
+  }
+
+  fn apply(&mut self) -> mech_core::MResult<()> {
+    let key = format!("{}|{}", self.base_uri, self.path);
+    self.previous = Some(self.values.lock().unwrap().insert(key, self.value.clone()));
+    let mut writes = self.writes.lock().unwrap();
+    self.previous_writes_len = Some(writes.len());
+    writes.push((self.base_uri.clone(), self.path.clone(), self.value.clone()));
+    Ok(())
+  }
+
+  fn compensate(&mut self) -> mech_core::MResult<()> {
+    if let Some(previous_writes_len) = self.previous_writes_len.take() {
+      self.writes.lock().unwrap().truncate(previous_writes_len);
+    }
+    if let Some(previous) = self.previous.take() {
+      let key = format!("{}|{}", self.base_uri, self.path);
+      let mut values = self.values.lock().unwrap();
+      match previous {
+        Some(value) => { values.insert(key, value); }
+        None => { values.remove(&key); }
+      }
+    }
+    Ok(())
+  }
+}
+
 impl RecordingResourceProvider {
   fn new(scheme: &'static str, bases: &[&str]) -> Self {
     Self {
@@ -4141,10 +4199,17 @@ impl RuntimeResourceProvider for RecordingResourceProvider {
       .ok_or_else(|| mech_core::MechError::new(RuntimeResourcePathNotFound { base_uri: request.base_uri, path: request.path }, None))
   }
 
-  fn write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<()> {
-    self.writes.lock().unwrap().push((request.base_uri.clone(), request.path.clone(), request.value.clone()));
-    self.values.lock().unwrap().insert(format!("{}|{}", request.base_uri, request.path), request.value);
-    Ok(())
+  fn stage_write(&mut self, request: RuntimeResourceWriteRequest) -> mech_core::MResult<PreparedRuntimeEffect> {
+    Ok(PreparedRuntimeEffect::Compensatable(Box::new(RecordingResourceWriteEffect {
+      scheme: self.scheme.to_string(),
+      base_uri: request.base_uri,
+      path: request.path,
+      value: request.value,
+      values: self.values.clone(),
+      writes: self.writes.clone(),
+      previous: None,
+      previous_writes_len: None,
+    })))
   }
 }
 
@@ -4555,6 +4620,69 @@ fn top_level_context_send_writes_stdout() {
   let stdout = state.lock().unwrap().stdout.clone();
   assert_eq!(stdout, vec!["top-level-send-ok\n".to_string()]);
 }
+
+#[test]
+fn explicit_transaction_buffers_stdout_until_commit() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "@out := cli://stdout{:write(line)}\n@out/line <- \"commit-once\"\n",
+  ).unwrap();
+
+  assert!(state.lock().unwrap().stdout.is_empty());
+  runtime.commit_runtime_transaction(&mut context).unwrap();
+  assert_eq!(
+    state.lock().unwrap().stdout,
+    vec!["commit-once\n".to_string()],
+  );
+}
+
+#[test]
+fn explicit_transaction_abort_discards_buffered_stdout() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "@out := cli://stdout{:write(line)}\n@out/line <- \"discard-me\"\n",
+  ).unwrap();
+
+  assert!(state.lock().unwrap().stdout.is_empty());
+  runtime.abort_runtime_transaction(&mut context, "discard output").unwrap();
+  assert!(state.lock().unwrap().stdout.is_empty());
+}
+
+#[test]
+fn failed_explicit_operation_discards_only_its_buffered_stdout() {
+  let (mut runtime, state) = runtime_with_recording_cli();
+  grant_runtime_stdout_line(&mut runtime);
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+
+  runtime.run_string_with_context(
+    &mut context,
+    "@out := cli://stdout{:write(line)}\n@out/line <- \"keep-me\"\n",
+  ).unwrap();
+  let failed = runtime.run_string_with_context(
+    &mut context,
+    "@out := cli://stdout{:write(line)}\n@out/line <- \"discard-me\"\nmissing := unavailable + 1\n",
+  );
+
+  assert!(failed.is_err());
+  assert!(state.lock().unwrap().stdout.is_empty());
+  runtime.commit_runtime_transaction(&mut context).unwrap();
+  assert_eq!(
+    state.lock().unwrap().stdout,
+    vec!["keep-me\n".to_string()],
+  );
+}
+
 #[test]
 fn unknown_context_send_target_fails_preflight_before_writes() {
   let (mut runtime, state) = runtime_with_recording_cli();

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1883,7 +1883,7 @@ fn module_host_call_works_inside_isolated_execution() {
   std::fs::write(root.join("math.mec"), "tau := demo/value()\n<+ tau\n").unwrap();
   std::fs::write(root.join("main.mec"), "+> ./math.mec\nok := math/tau > 40\n").unwrap();
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/value", |_s, _c, _a| Ok(Value::F64(Ref::new(42.0))))).unwrap();
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/value", |_s, _c, _a| Ok(Value::F64(Ref::new(42.0))))).unwrap();
   runtime.grant_capability(std::sync::Arc::new(BasicCapability::new(
     CapabilityId(1),
     &BasicSubject::new("program:module-host-test"),


### PR DESCRIPTION
## Round 4 stack

This is Round 4B, stacked on #656.

- #656 — prepared effect protocols and the runtime effect journal
- #657 — transactional resource providers
- #658 — transactional host effects
- #659 — capability transactions, durable effect audit, and benchmarks

All four PRs passed their GitHub Actions suites and are ready for review.

## What changed

- Replaces immediate provider `write` with prepared `stage_write`.
- Routes retained context assignments and sends through the runtime effect journal.
- Provides transaction-local read-your-writes without mutating provider state early.
- Uses compensatable effects for in-memory docs and the robot-arm mock.
- Buffers CLI/console output, browser DOM writes, and scene delivery until commit.
- Leaves ordinary reactive sends on the immediate coordinator path, outside the retained journal.

## Guarantees

- Parsing or retained execution failure emits no provider effect.
- Explicit abort discards staged provider work.
- Successful commit delivers after-commit effects once, in source order.
- A failed later explicit operation removes only effects after its savepoint.
- Provider staging failure leaves no effect-journal entry.
- Docs overwrite/create mutations are compensated on store failure.
- The robot-arm implementation is explicitly a reversible mock; no claim is made that physical robot commands can use that protocol.

## Commits

- `d67ba30c3` — feat(runtime): stage resource provider writes
- `a7c2306b1` — fix(host-cli): buffer output until transaction commit
- `48896c0b8` — fix(host-browser): defer DOM writes until commit
- `4f948d28e` — fix(host-robot-arm): compensate mock command effects

Head: `4f948d28e`

## Validation

Passed on this PR head:

- `cargo check --workspace`
- minimal `base` feature check
- module smoke: 235 passed
- generic host: 20 passed
- provider integration and coordinator suites
- CLI provider: 7 passed
- console provider: 3 passed
- browser: 44 passed
- scene provider: 27 passed
- robot-arm: 6 passed

The full runtime suite has only the same three pre-existing macOS `/var` versus `/private/var` workspace-watch failures. The all-target check reaches unrelated pre-existing syntax benchmark import failures; normal workspace checking passes.

Per maintainer instruction, no `rustfmt` run or broad formatting rewrite was performed.