### PR TITLE
fix(runtime): make host effects transaction-aware

### DIFF
--- a/docs/runtime/transactional-host-functions.md
+++ b/docs/runtime/transactional-host-functions.md
@@ -1,0 +1,81 @@
+# Transactional host functions
+
+Every host function declares how it participates in runtime transactions through
+`HostFunctionTransactionMode`. The default is intentionally conservative:
+unclassified callbacks are `ImmediateOnly`.
+
+## Modes
+
+### `Pure`
+
+Pure functions compute a value and may read immutable process state. They do not
+mutate runtime state or anything outside the runtime.
+
+Use `ClosureHostFunction::new_pure` for closure-backed pure functions. The
+runtime may call a pure function while constructing the native execution plan
+and again while executing it, so the callback must be safe to evaluate more
+than once.
+
+### `RuntimeManaged`
+
+Runtime-managed functions may mutate only through `RuntimeServices` operations
+that already stage their work in the active runtime transaction. They must not
+write files, print output, send network traffic, mutate shared application
+state, or retain a runtime pointer.
+
+This is an unsafe-style contract: the runtime cannot prove that an implementation
+uses only mediated services. During native-plan construction, the runtime runs
+the callback against a private preview savepoint and removes its staged store,
+context, and effect changes afterward. Monotonic IDs and consumed budget are not
+rewound.
+
+Use `ClosureHostFunction::new_runtime_managed` when a closure satisfies this
+contract. The built-in actor state functions use this mode.
+
+### `Staged`
+
+Staged functions return a provisional value and one `PreparedRuntimeEffect`
+through `RuntimePreparedHostCall`. The runtime makes the value available to the
+Mech program immediately and owns the effect lifecycle.
+
+Use `StagedClosureHostFunction::new`. Its callback must only construct the value
+and prepared effect; it must not perform the external mutation itself. Native
+plan construction may invoke the callback to preview the value, but the preview
+effect is discarded. The effect is staged only when the program call executes.
+
+Choose the effect protocol honestly:
+
+- `Transactional` for a real prepare/commit/abort participant.
+- `Compensatable` only when compensation reliably restores the immediately
+  preceding state.
+- `AfterCommit` for stdout, notifications, DOM writes, physical commands, and
+  other irreversible delivery.
+
+The provisional return value must not depend on successful after-commit
+delivery.
+
+### `ImmediateOnly`
+
+`ClosureHostFunction::new` creates an immediate-only callback. It is allowed
+through explicitly nontransactional host calls and ordinary reactive execution.
+The runtime rejects it before invocation whenever a transaction is active,
+including implicit retained-program transactions.
+
+Use this mode for commands whose result cannot be known until an irreversible
+operation has already happened and which cannot implement a real transactional
+preparation protocol.
+
+## Failure behavior
+
+- Operation rollback removes staged host effects created after its savepoint.
+- Outer abort discards all staged host effects.
+- Failed retained execution does not invoke immediate-only callbacks.
+- After-commit delivery failure does not roll back an internally committed
+  transaction and does not poison the runtime.
+- Incomplete effect abort or compensation poisons the runtime.
+- A transactional participant commit failure after the runtime store commits is
+  reported as an indeterminate external commit and poisons the runtime.
+
+Reactive turns remain outside retained-program checkpoints and journals. A
+staged function invoked by an ordinary reactive turn uses the one-effect
+immediate coordinator.

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,12 +1,14 @@
 use criterion::{
   BatchSize, Criterion, criterion_group, criterion_main,
 };
-use mech_core::{MResult, MechSourceCode};
+use mech_core::{MResult, MechSourceCode, Value};
 use mech_runtime::{
-  BasicCapability, CapabilityId, CapabilityRequest, MechRuntime, ObjectId,
-  ObjectRecord, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+  CapabilityRequest, MechRuntime, ObjectId, ObjectRecord,
+  PreparedRuntimeEffect, RuntimeAfterCommitEffect,
   RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
-  RuntimeEffectSource, SequentialIdGenerator,
+  RuntimeEffectSource, RuntimePreparedHostCall, SequentialIdGenerator,
+  StagedClosureHostFunction,
 };
 use std::hint::black_box;
 use std::sync::Arc;
@@ -147,6 +149,50 @@ fn explicit_failure_source() -> MechSourceCode {
       "bench-explicit-error := missing-bench-value + 1".to_string(),
     ),
   ])
+}
+
+fn staged_effect_rollback_fixture(
+  count: usize,
+) -> (ExplicitFixture, MechSourceCode) {
+  let mut runtime = retained_runtime();
+  runtime
+    .grant_capability(Arc::new(BasicCapability::new(
+      CapabilityId(8_000),
+      &BasicSubject::new(runtime.runtime_context().unwrap().subject),
+      &BasicResource::new("host:bench/staged"),
+      [BasicOperation::new("call")],
+    )))
+    .unwrap();
+  runtime
+    .register_mech_host_function(StagedClosureHostFunction::new(
+      "bench/staged",
+      |_services, _context, _arguments| {
+        Ok(RuntimePreparedHostCall {
+          value: Value::Empty,
+          effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+            BenchmarkAfterCommitEffect { sequence: 0 },
+          )),
+        })
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+
+  let mut source = Vec::with_capacity(count.saturating_add(1));
+  for sequence in 0..count {
+    source.push(MechSourceCode::String(format!(
+      "bench-staged-{sequence} := bench/staged()",
+    )));
+  }
+  source.push(MechSourceCode::String(
+    "bench-staged-error := missing-bench-value + 1".to_string(),
+  ));
+
+  (
+    ExplicitFixture { runtime, context },
+    MechSourceCode::Program(source),
+  )
 }
 
 fn program_transaction_benchmarks(c: &mut Criterion) {
@@ -314,11 +360,7 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
     "explicit_effect_savepoint_rollback_with_100_staged",
     |b| {
       b.iter_batched(
-        || {
-          let mut fixture = subsequent_explicit_fixture();
-          stage_after_commit(&mut fixture, 100);
-          (fixture, explicit_failure_source())
-        },
+        || staged_effect_rollback_fixture(100),
         |(mut fixture, source)| {
           let error = fixture
             .runtime

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,15 +1,102 @@
 use criterion::{
   BatchSize, Criterion, criterion_group, criterion_main,
 };
-use mech_core::MechSourceCode;
+use mech_core::{MResult, MechSourceCode};
 use mech_runtime::{
-  MechRuntime, RuntimeContext, SequentialIdGenerator,
+  BasicCapability, CapabilityId, CapabilityRequest, MechRuntime, ObjectId,
+  ObjectRecord, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+  RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
+  RuntimeEffectSource, SequentialIdGenerator,
 };
 use std::hint::black_box;
+use std::sync::Arc;
 
 struct ExplicitFixture {
   runtime: MechRuntime,
   context: RuntimeContext,
+}
+
+#[derive(Debug)]
+struct BenchmarkAfterCommitEffect {
+  sequence: usize,
+}
+
+impl RuntimeAfterCommitEffect for BenchmarkAfterCommitEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "benchmark-after-commit".to_string(),
+      },
+      "deliver",
+    )
+    .with_resource(format!("bench://after-commit/{}", self.sequence))
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+}
+
+#[derive(Debug)]
+struct BenchmarkCompensatableEffect {
+  sequence: usize,
+}
+
+impl RuntimeCompensatableEffect for BenchmarkCompensatableEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "benchmark-compensatable".to_string(),
+      },
+      "apply",
+    )
+    .with_resource(format!("bench://compensatable/{}", self.sequence))
+  }
+
+  fn apply(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+
+  fn compensate(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+}
+
+fn stage_after_commit(
+  fixture: &mut ExplicitFixture,
+  count: usize,
+) {
+  for sequence in 0..count {
+    fixture
+      .runtime
+      .stage_runtime_effect_with_context(
+        &mut fixture.context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          BenchmarkAfterCommitEffect { sequence },
+        )),
+      )
+      .unwrap();
+  }
+}
+
+fn stage_compensatable(
+  fixture: &mut ExplicitFixture,
+  count: usize,
+) {
+  for sequence in 0..count {
+    fixture
+      .runtime
+      .stage_runtime_effect_with_context(
+        &mut fixture.context,
+        PreparedRuntimeEffect::Compensatable(Box::new(
+          BenchmarkCompensatableEffect { sequence },
+        )),
+      )
+      .unwrap();
+  }
 }
 
 fn retained_runtime() -> MechRuntime {
@@ -188,6 +275,165 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
           .unwrap();
         black_box(value);
         black_box((runtime, context))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  for count in [1, 100] {
+    group.bench_function(
+      format!("stage_{count}_after_commit_effects"),
+      |b| {
+        b.iter_batched(
+          explicit_fixture,
+          |mut fixture| {
+            stage_after_commit(&mut fixture, count);
+            black_box(fixture)
+          },
+          BatchSize::SmallInput,
+        )
+      },
+    );
+
+    group.bench_function(
+      format!("stage_{count}_compensatable_effects"),
+      |b| {
+        b.iter_batched(
+          explicit_fixture,
+          |mut fixture| {
+            stage_compensatable(&mut fixture, count);
+            black_box(fixture)
+          },
+          BatchSize::SmallInput,
+        )
+      },
+    );
+  }
+
+  group.bench_function(
+    "explicit_effect_savepoint_rollback_with_100_staged",
+    |b| {
+      b.iter_batched(
+        || {
+          let mut fixture = subsequent_explicit_fixture();
+          stage_after_commit(&mut fixture, 100);
+          (fixture, explicit_failure_source())
+        },
+        |(mut fixture, source)| {
+          let error = fixture
+            .runtime
+            .run_source_with_context(&mut fixture.context, &source)
+            .unwrap_err();
+          black_box(error);
+          black_box(fixture)
+        },
+        BatchSize::SmallInput,
+      )
+    },
+  );
+
+  group.bench_function("reversible_effect_commit", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_compensatable(&mut fixture, 1);
+        fixture
+      },
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("store_failure_with_compensation", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_compensatable(&mut fixture, 1);
+        fixture
+          .runtime
+          .update_object_with_context(
+            &mut fixture.context,
+            ObjectRecord::text(
+              ObjectId(9_000),
+              "missing",
+              "benchmark",
+            ),
+          )
+          .unwrap();
+        fixture
+      },
+      |mut fixture| {
+        let error = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap_err();
+        black_box(error);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("capability_overlay_lookup", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        let capability = Arc::new(BasicCapability::from_keys(
+          CapabilityId(7_000),
+          "bench-subject",
+          "bench://resource",
+          [":read"],
+        ));
+        fixture
+          .runtime
+          .grant_capability_with_context(
+            &mut fixture.context,
+            capability,
+          )
+          .unwrap();
+        let request = CapabilityRequest::from_keys(
+          "bench-subject",
+          ":read",
+          "bench://resource",
+        );
+        (fixture, request)
+      },
+      |(mut fixture, request)| {
+        let capability = fixture
+          .runtime
+          .check_capability_with_context(
+            &mut fixture.context,
+            &request,
+          )
+          .unwrap();
+        black_box(capability);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("deliver_100_after_commit_effects", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_after_commit(&mut fixture, 100);
+        fixture
+      },
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
       },
       BatchSize::SmallInput,
     )

--- a/src/runtime/examples/arbitrary_rust_host_function.rs
+++ b/src/runtime/examples/arbitrary_rust_host_function.rs
@@ -44,7 +44,7 @@ fn main() -> MResult<()> {
 
   println!("runtime: {}", short(runtime.id()));
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/echo",
     |_services, _context, args| {
       let text = host_arg_string("demo/echo", &args, 0)?;
@@ -56,7 +56,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/join",
     |_services, _context, args| {
       let left = host_arg_string("demo/join", &args, 0)?;

--- a/src/runtime/examples/arbitrary_rust_host_functions2.rs
+++ b/src/runtime/examples/arbitrary_rust_host_functions2.rs
@@ -75,7 +75,7 @@ fn main() -> MResult<()> {
 
   println!("runtime: {}", short(runtime.id()));
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/text/shout",
     |_services, _context, args| {
       host_call1("demo/text/shout", &args, |text: String| {
@@ -84,7 +84,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/text/join",
     |_services, _context, args| {
       host_call2("demo/text/join", &args, |left: String, right: String| {
@@ -93,7 +93,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/math/add",
     |_services, _context, args| {
       host_call2("demo/math/add", &args, |left: f64, right: f64| {
@@ -102,7 +102,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/math/affine",
     |_services, _context, args| {
       host_call3(
@@ -115,7 +115,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/bool/not",
     |_services, _context, args| {
       host_call1("demo/bool/not", &args, |value: bool| {
@@ -124,7 +124,7 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/optional/greet",
     |_services, _context, args| {
       let name = host_arg_optional_string(
@@ -138,14 +138,14 @@ fn main() -> MResult<()> {
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/echo",
     |_services, _context, args| {
       Ok(host_arg_cloned("demo/value/echo", &args, 0)?)
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/result/checked-reciprocal",
     |_services, _context, args| {
       host_call_result1(

--- a/src/runtime/examples/host_value_roundtrip.rs
+++ b/src/runtime/examples/host_value_roundtrip.rs
@@ -66,22 +66,18 @@ fn main() -> MResult<()> {
 
   println!("runtime: {}", short(runtime.id()));
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/wrap",
     |_services, _context, args| {
       let input = host_arg_string("demo/value/wrap", &args, 0)?;
 
       let output = format!("rust-wrap({})", input);
 
-      println!("rust demo/value/wrap:");
-      println!("  input:  {:?}", input);
-      println!("  output: {:?}", output);
-
       Ok(value_string(output))
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/append",
     |_services, _context, args| {
       let input = host_arg_string("demo/value/append", &args, 0)?;
@@ -89,22 +85,14 @@ fn main() -> MResult<()> {
 
       let output = format!("{}{}", input, suffix);
 
-      println!("rust demo/value/append:");
-      println!("  input:  {:?}", input);
-      println!("  suffix: {:?}", suffix);
-      println!("  output: {:?}", output);
-
       Ok(value_string(output))
     },
   ))?;
 
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/value/inspect",
     |_services, _context, args| {
       let value = host_arg_cloned("demo/value/inspect", &args, 0)?;
-
-      println!("rust demo/value/inspect:");
-      println!("  value: {}", display_value(&value));
 
       // Return the value unchanged so the Mech program's final result is the
       // value Rust inspected.

--- a/src/runtime/examples/matrix_multiply.rs
+++ b/src/runtime/examples/matrix_multiply.rs
@@ -1,5 +1,5 @@
 use std::fmt::Display;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use mech_core::{MResult, MechMatrix as Matrix, ToMatrix, Value};
 
@@ -60,8 +60,6 @@ fn main() -> MResult<()> {
     .map(|(a, b)| a * b)
     .sum::<f64>();
 
-  let result_store = Arc::new(Mutex::new(None::<f64>));
-
   let mut runtime = RuntimeBuilder::new()
     .capability_kernel(BasicCapabilityKernel::new())
     .build()?;
@@ -74,7 +72,7 @@ fn main() -> MResult<()> {
   {
     let v1 = v1.clone();
 
-    runtime.register_mech_host_function(ClosureHostFunction::new(
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure(
       "demo/matrix/v1",
       move |_services, _context, args| {
         host_call0("demo/matrix/v1", &args, || {
@@ -87,7 +85,7 @@ fn main() -> MResult<()> {
   {
     let v2 = v2.clone();
 
-    runtime.register_mech_host_function(ClosureHostFunction::new(
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure(
       "demo/matrix/v2",
       move |_services, _context, args| {
         host_call0("demo/matrix/v2", &args, || {
@@ -97,46 +95,11 @@ fn main() -> MResult<()> {
     ))?;
   }
 
-  {
-    let result_store = result_store.clone();
-
-    runtime.register_mech_host_function(ClosureHostFunction::new(
-      "demo/matrix/store-result",
-      move |_services, _context, args| {
-        let result = host_arg_matrix_f64(
-          "demo/matrix/store-result",
-          &args,
-          0,
-        )?;
-
-        let shape = result.shape();
-
-        println!("rust received matrix result:");
-        println!("  shape: {:?}", shape);
-        println!("  matrix: {:?}", result);
-
-        let Some(actual) = matrix_scalar_f64(&result) else {
-          panic!(
-            "expected a 1x1 matrix result, got shape {:?}",
-            shape,
-          );
-        };
-
-        println!("  scalar: {}", actual);
-
-        *result_store.lock().unwrap() = Some(actual);
-
-        Ok(Value::MatrixF64(result))
-      },
-    ))?;
-  }
-
   let subject = BasicSubject::new("program:matrix-multiply");
 
   for (id, name) in [
     (1, "demo/matrix/v1"),
     (2, "demo/matrix/v2"),
-    (3, "demo/matrix/store-result"),
   ] {
     runtime.grant_capability(Arc::new(BasicCapability::new(
       CapabilityId(id),
@@ -150,7 +113,7 @@ fn main() -> MResult<()> {
     v1 := demo/matrix/v1()
     v2 := demo/matrix/v2()
     result := v1 ** v2'
-    demo/matrix/store-result(result)
+    result
   "#;
 
   println!();
@@ -169,10 +132,13 @@ fn main() -> MResult<()> {
   println!();
   println!("program result: {:?}", value);
 
-  let stored = result_store
-    .lock()
-    .unwrap()
-    .expect("Rust host did not receive matrix result");
+  let result = host_arg_matrix_f64(
+    "matrix-multiply result",
+    &[value],
+    0,
+  )?;
+  let stored = matrix_scalar_f64(&result)
+    .expect("Mech program did not return a 1x1 matrix");
 
   assert!(
     (stored - expected).abs() < f64::EPSILON,

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -2,11 +2,25 @@ use crate::*;
 
 use mech_core::*;
 use std::sync::Arc;
+use std::any::Any;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 // -----------------------------------------------------------------------------
 // Capability Kernel Trait
 // -----------------------------------------------------------------------------
+
+pub trait CapabilityKernelCheckpoint: std::fmt::Debug + Send {
+  fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+impl<T> CapabilityKernelCheckpoint for T
+where
+  T: std::fmt::Debug + Send + Any,
+{
+  fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    self
+  }
+}
 
 /// Capability authority graph and checking interface.
 ///
@@ -14,6 +28,30 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// audited, cryptographic-token-based, or host-specific authority systems should
 /// implement this trait.
 pub trait CapabilityKernel: std::fmt::Debug + Send {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel does not support transaction checkpoints".to_string(),
+      },
+      None,
+    ))
+  }
+
+  fn restore_checkpoint(
+    &mut self,
+    _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel does not support transaction checkpoint restore"
+          .to_string(),
+      },
+      None,
+    ))
+  }
+
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId>;
 
   /// Administratively remove a grant that has not committed.
@@ -148,6 +186,29 @@ impl BasicCapabilityKernel {
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    Ok(Box::new(self.clone()))
+  }
+
+  fn restore_checkpoint(
+    &mut self,
+    checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    let snapshot = checkpoint
+      .into_any()
+      .downcast::<BasicCapabilityKernel>()
+      .map_err(|_| MechError::new(
+        TransactionStateUnsupportedError {
+          function: "basic capability kernel".to_string(),
+          reason: "checkpoint belongs to a different kernel implementation"
+            .to_string(),
+        },
+        None,
+      ))?;
+    *self = *snapshot;
+    Ok(())
+  }
+
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
     let capability = grant.capability;
     capability.validate()?;
@@ -370,6 +431,19 @@ impl SharedCapabilityKernel {
 }
 
 impl CapabilityKernel for SharedCapabilityKernel {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    self.inner.lock().unwrap().checkpoint()
+  }
+  fn restore_checkpoint(
+    &mut self,
+    checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    self
+      .inner
+      .lock()
+      .unwrap()
+      .restore_checkpoint(checkpoint)
+  }
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
   fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -38,7 +38,7 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
     ))
   }
 
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -71,6 +71,24 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()>;
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId>;
+
+  fn check_excluding(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    if excluded.is_empty() {
+      return self.check(request);
+    }
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel cannot exclude transaction-local revocations"
+          .to_string(),
+      },
+      None,
+    ))
+  }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>>;
 
@@ -183,6 +201,74 @@ impl BasicCapabilityKernel {
       !children.is_empty()
     });
   }
+
+  fn check_with_exclusions(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    let Some(ids) = self.by_subject.get(&request.subject) else {
+      return Err(MechError::new(
+        CapabilityDeniedError {
+          subject: request.subject.clone(),
+          operation: request.operation.clone(),
+          resource: request.resource.clone(),
+          reason: "subject has no capabilities".to_string(),
+        },
+        None,
+      ));
+    };
+
+    let ids: Vec<CapabilityId> = ids.iter().copied().collect();
+    let mut last_reason = None;
+
+    for id in ids {
+      if excluded.contains(&id) {
+        last_reason =
+          Some("capability is revoked by the active transaction".to_string());
+        continue;
+      }
+      if self.revoked.contains(&id) {
+        last_reason = Some("capability is revoked".to_string());
+        continue;
+      }
+
+      let Some(capability) = self.capabilities.get(&id) else {
+        continue;
+      };
+
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.successful_uses(id);
+        if actual >= max_uses {
+          last_reason = Some(format!(
+            "use limit exceeded: max {}, actual {}",
+            max_uses, actual,
+          ));
+          continue;
+        }
+      }
+
+      let decision = capability.check(request)?;
+      if !decision.allowed {
+        last_reason = decision.reason;
+        continue;
+      }
+
+      self.increment_uses(id);
+      return Ok(id);
+    }
+
+    Err(MechError::new(
+      CapabilityDeniedError {
+        subject: request.subject.clone(),
+        operation: request.operation.clone(),
+        resource: request.resource.clone(),
+        reason: last_reason
+          .unwrap_or_else(|| "no matching capability".to_string()),
+      },
+      None,
+    ))
+  }
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
@@ -190,7 +276,7 @@ impl CapabilityKernel for BasicCapabilityKernel {
     Ok(Box::new(self.clone()))
   }
 
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -267,65 +353,15 @@ impl CapabilityKernel for BasicCapabilityKernel {
   }
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
-    let Some(ids) = self.by_subject.get(&request.subject) else {
-      return Err(MechError::new(
-        CapabilityDeniedError {
-          subject: request.subject.clone(),
-          operation: request.operation.clone(),
-          resource: request.resource.clone(),
-          reason: "subject has no capabilities".to_string(),
-        },
-        None,
-      ));
-    };
+    self.check_with_exclusions(request, &HashSet::new())
+  }
 
-    let ids: Vec<CapabilityId> = ids.iter().copied().collect();
-    let mut last_reason = None;
-
-    for id in ids {
-      if self.revoked.contains(&id) {
-        last_reason = Some("capability is revoked".to_string());
-        continue;
-      }
-
-      let Some(capability) = self.capabilities.get(&id) else {
-        continue;
-      };
-
-      if let Some(max_uses) = capability.max_uses() {
-        let actual = self.successful_uses(id);
-        if actual >= max_uses {
-          last_reason = Some(format!(
-            "use limit exceeded: max {}, actual {}",
-            max_uses, actual,
-          ));
-          continue;
-        }
-      }
-
-      let decision = capability.check(request)?;
-
-      if !decision.allowed {
-        last_reason = decision.reason;
-        continue;
-      }
-
-      // The generic Capability trait does not expose max_uses, because custom
-      // capabilities can implement their own use accounting inside check().
-      // The default kernel still tracks successful uses for inspection.
-      self.increment_uses(id);
-      return Ok(id);
-    }
-
-    Err(MechError::new(
-      CapabilityDeniedError {
-        subject: request.subject.clone(),
-        operation: request.operation.clone(),
-        resource: request.resource.clone(),
-        reason: last_reason.unwrap_or_else(|| "no matching capability".to_string()),
-      },
-      None,
-    ))
+  fn check_excluding(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    self.check_with_exclusions(request, excluded)
   }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
@@ -434,7 +470,7 @@ impl CapabilityKernel for SharedCapabilityKernel {
   fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
     self.inner.lock().unwrap().checkpoint()
   }
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -442,12 +478,13 @@ impl CapabilityKernel for SharedCapabilityKernel {
       .inner
       .lock()
       .unwrap()
-      .restore_checkpoint(checkpoint)
+      .restore(checkpoint)
   }
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
   fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().check(request) }
+  fn check_excluding(&mut self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().check_excluding(request, excluded) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>> { self.inner.lock().unwrap().list_for_subject(subject) }
   fn derive_capability(&mut self, derivation: CapabilityDerivation) -> MResult<CapabilityId> { self.inner.lock().unwrap().derive_capability(derivation) }

--- a/src/runtime/src/effect.rs
+++ b/src/runtime/src/effect.rs
@@ -67,6 +67,32 @@ pub struct RuntimeEffectMetadata {
   pub cost: RuntimeEffectCost,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeEffectRecord {
+  pub id: RuntimeEffectId,
+  pub source: RuntimeEffectSource,
+  pub operation: String,
+  pub resource: Option<String>,
+  pub protocol: RuntimeEffectProtocol,
+}
+
+impl RuntimeEffectRecord {
+  pub fn new(
+    id: RuntimeEffectId,
+    metadata: RuntimeEffectMetadata,
+    protocol: RuntimeEffectProtocol,
+  ) -> Self {
+    Self {
+      id,
+      source: metadata.source,
+      operation: metadata.operation,
+      resource: metadata.resource,
+      protocol,
+    }
+  }
+}
+
 impl RuntimeEffectMetadata {
   pub fn new(
     source: RuntimeEffectSource,

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -15,6 +15,9 @@ use crate::id::{
   ActorId, CapabilityId, EventId, ModuleVersionId, ObjectId, RuntimeId, TaskId,
   TransactionId, MessageId
 };
+use crate::effect::{
+  RuntimeEffectId, RuntimeEffectProtocol, RuntimeEffectSource,
+};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -77,6 +80,30 @@ pub enum RuntimeEventKind {
   TransactionCommitted { transaction_id: TransactionId },
   TransactionAborted { transaction_id: TransactionId, message: String },
 
+  EffectStaged {
+    effect_id: RuntimeEffectId,
+    source: RuntimeEffectSource,
+    operation: String,
+    resource: Option<String>,
+    protocol: RuntimeEffectProtocol,
+  },
+  EffectPreparationFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
+  EffectCompensated { effect_id: RuntimeEffectId },
+  EffectAborted { effect_id: RuntimeEffectId },
+  TransactionalEffectCommitted { effect_id: RuntimeEffectId },
+  EffectDelivered { effect_id: RuntimeEffectId },
+  EffectDeliveryFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
+  ExternalCommitIndeterminate {
+    transaction_id: TransactionId,
+    effect_id: RuntimeEffectId,
+  },
+
   SchedulerWorkQueued { work: String },
   SchedulerWorkStarted { work: String },
   SchedulerWorkCompleted { work: String },
@@ -127,6 +154,22 @@ impl RuntimeEventKind {
       RuntimeEventKind::TransactionStarted { .. } => ":transaction/started",
       RuntimeEventKind::TransactionCommitted { .. } => ":transaction/committed",
       RuntimeEventKind::TransactionAborted { .. } => ":transaction/aborted",
+      RuntimeEventKind::EffectStaged { .. } => ":effect/staged",
+      RuntimeEventKind::EffectPreparationFailed { .. } => {
+        ":effect/preparation/failed"
+      }
+      RuntimeEventKind::EffectCompensated { .. } => ":effect/compensated",
+      RuntimeEventKind::EffectAborted { .. } => ":effect/aborted",
+      RuntimeEventKind::TransactionalEffectCommitted { .. } => {
+        ":effect/transactional/committed"
+      }
+      RuntimeEventKind::EffectDelivered { .. } => ":effect/delivered",
+      RuntimeEventKind::EffectDeliveryFailed { .. } => {
+        ":effect/delivery/failed"
+      }
+      RuntimeEventKind::ExternalCommitIndeterminate { .. } => {
+        ":effect/commit/indeterminate"
+      }
       RuntimeEventKind::SchedulerWorkQueued { .. } => ":scheduler/work/queued",
       RuntimeEventKind::SchedulerWorkStarted { .. } => ":scheduler/work/started",
       RuntimeEventKind::SchedulerWorkCompleted { .. } => ":scheduler/work/completed",

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -92,6 +92,10 @@ pub enum RuntimeEventKind {
     message: String,
   },
   EffectCompensated { effect_id: RuntimeEffectId },
+  EffectCompensationFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
   EffectAborted { effect_id: RuntimeEffectId },
   TransactionalEffectCommitted { effect_id: RuntimeEffectId },
   EffectDelivered { effect_id: RuntimeEffectId },
@@ -159,6 +163,9 @@ impl RuntimeEventKind {
         ":effect/preparation/failed"
       }
       RuntimeEventKind::EffectCompensated { .. } => ":effect/compensated",
+      RuntimeEventKind::EffectCompensationFailed { .. } => {
+        ":effect/compensation/failed"
+      }
       RuntimeEventKind::EffectAborted { .. } => ":effect/aborted",
       RuntimeEventKind::TransactionalEffectCommitted { .. } => {
         ":effect/transactional/committed"

--- a/src/runtime/src/host/actor.rs
+++ b/src/runtime/src/host/actor.rs
@@ -32,6 +32,10 @@ impl HostFunction for ActorMessageKindHostFunction {
     "actor/message/kind"
   }
 
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -85,6 +89,10 @@ impl Default for ActorMessagePayloadHostFunction {
 impl HostFunction for ActorMessagePayloadHostFunction {
   fn name(&self) -> &str {
     "actor/message/payload"
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
   }
 
   fn call(
@@ -142,6 +150,10 @@ impl HostFunction for ActorStateIdHostFunction {
     "actor/state/id"
   }
 
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -189,6 +201,10 @@ impl Default for ActorStateGetHostFunction {
 impl HostFunction for ActorStateGetHostFunction {
   fn name(&self) -> &str {
     "actor/state/get"
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
   }
 
   fn call(
@@ -242,6 +258,10 @@ impl Default for ActorStatePutHostFunction {
 impl HostFunction for ActorStatePutHostFunction {
   fn name(&self) -> &str {
     "actor/state/put"
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::RuntimeManaged
   }
 
   fn call(

--- a/src/runtime/src/host/actor.rs
+++ b/src/runtime/src/host/actor.rs
@@ -36,6 +36,15 @@ impl HostFunction for ActorMessageKindHostFunction {
     HostFunctionTransactionMode::RuntimeManaged
   }
 
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -93,6 +102,15 @@ impl HostFunction for ActorMessagePayloadHostFunction {
 
   fn transaction_mode(&self) -> HostFunctionTransactionMode {
     HostFunctionTransactionMode::RuntimeManaged
+  }
+
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
   }
 
   fn call(
@@ -154,6 +172,15 @@ impl HostFunction for ActorStateIdHostFunction {
     HostFunctionTransactionMode::RuntimeManaged
   }
 
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
+  }
+
   fn call(
     &self,
     _services: &mut dyn RuntimeServices,
@@ -205,6 +232,15 @@ impl HostFunction for ActorStateGetHostFunction {
 
   fn transaction_mode(&self) -> HostFunctionTransactionMode {
     HostFunctionTransactionMode::RuntimeManaged
+  }
+
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    self.call(services, context, args)
   }
 
   fn call(
@@ -262,6 +298,25 @@ impl HostFunction for ActorStatePutHostFunction {
 
   fn transaction_mode(&self) -> HostFunctionTransactionMode {
     HostFunctionTransactionMode::RuntimeManaged
+  }
+
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    if context.actor.is_none() {
+      return Err(MechError::new(
+        HostInvalidContextError {
+          function: self.name().to_string(),
+          reason: "no actor is bound to the runtime context".to_string(),
+        },
+        None,
+      ));
+    }
+    host_arg_string(self.name(), &args, 0)?;
+    Ok(Value::String(Ref::new(services.next_object_id().to_string())))
   }
 
   fn call(

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -39,6 +39,14 @@ pub use self::arg::*;
 // Host Function
 // -----------------------------------------------------------------------------
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostFunctionTransactionMode {
+  Pure,
+  RuntimeManaged,
+  Staged,
+  ImmediateOnly,
+}
+
 /// A callable host function.
 ///
 /// This trait is the embedder boundary. Implementations can wrap closures,
@@ -54,6 +62,15 @@ pub trait HostFunction: std::fmt::Debug + Send + Sync {
   /// - `ui.render`
   /// - `net.fetch`
   fn name(&self) -> &str;
+
+  /// Declares how the function participates in runtime transactions.
+  ///
+  /// The conservative default is `ImmediateOnly`: existing host callbacks may
+  /// have arbitrary side effects, so retained execution must not invoke them
+  /// inside an implicit or explicit transaction without an explicit contract.
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::ImmediateOnly
+  }
 
   /// Optional resource key used for capability checks.
   ///
@@ -115,6 +132,7 @@ where
 {
   name: String,
   capability: Option<CapabilityRequest>,
+  transaction_mode: HostFunctionTransactionMode,
   function: F,
 }
 
@@ -126,6 +144,7 @@ where
     f.debug_struct("ClosureHostFunction")
       .field("name", &self.name)
       .field("capability", &self.capability)
+      .field("transaction_mode", &self.transaction_mode)
       .field("function", &"<closure>")
       .finish()
   }
@@ -139,9 +158,44 @@ where
     name: impl Into<String>,
     function: F,
   ) -> Self {
+    Self::with_transaction_mode(
+      name,
+      HostFunctionTransactionMode::ImmediateOnly,
+      function,
+    )
+  }
+
+  pub fn new_pure(
+    name: impl Into<String>,
+    function: F,
+  ) -> Self {
+    Self::with_transaction_mode(
+      name,
+      HostFunctionTransactionMode::Pure,
+      function,
+    )
+  }
+
+  pub fn new_runtime_managed(
+    name: impl Into<String>,
+    function: F,
+  ) -> Self {
+    Self::with_transaction_mode(
+      name,
+      HostFunctionTransactionMode::RuntimeManaged,
+      function,
+    )
+  }
+
+  fn with_transaction_mode(
+    name: impl Into<String>,
+    transaction_mode: HostFunctionTransactionMode,
+    function: F,
+  ) -> Self {
     Self {
       name: name.into(),
       capability: None,
+      transaction_mode,
       function,
     }
   }
@@ -161,6 +215,10 @@ where
 {
   fn name(&self) -> &str {
     &self.name
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    self.transaction_mode
   }
 
   fn required_capability(&self, context: &RuntimeContext) -> Option<CapabilityRequest> {
@@ -631,5 +689,34 @@ mod tests {
       .unwrap();
 
     assert_eq!(result, Value::Empty);
+  }
+
+  #[test]
+  fn closure_constructors_require_explicit_transaction_contracts() {
+    let immediate = ClosureHostFunction::new(
+      "host.immediate",
+      |_services, _ctx, _args| Ok(Value::Empty),
+    );
+    let pure = ClosureHostFunction::new_pure(
+      "host.pure",
+      |_services, _ctx, _args| Ok(Value::Empty),
+    );
+    let runtime_managed = ClosureHostFunction::new_runtime_managed(
+      "host.runtime-managed",
+      |_services, _ctx, _args| Ok(Value::Empty),
+    );
+
+    assert_eq!(
+      immediate.transaction_mode(),
+      HostFunctionTransactionMode::ImmediateOnly,
+    );
+    assert_eq!(
+      pure.transaction_mode(),
+      HostFunctionTransactionMode::Pure,
+    );
+    assert_eq!(
+      runtime_managed.transaction_mode(),
+      HostFunctionTransactionMode::RuntimeManaged,
+    );
   }
 }

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -28,6 +28,7 @@ use crate::capability::{
 use crate::context::RuntimeContext;
 
 use crate::service::RuntimeServices;
+use crate::PreparedRuntimeEffect;
 
 pub mod actor;
 pub mod arg;
@@ -45,6 +46,12 @@ pub enum HostFunctionTransactionMode {
   RuntimeManaged,
   Staged,
   ImmediateOnly,
+}
+
+#[derive(Debug)]
+pub struct RuntimePreparedHostCall {
+  pub value: Value,
+  pub effect: PreparedRuntimeEffect,
 }
 
 /// A callable host function.
@@ -110,13 +117,37 @@ pub trait HostFunction: std::fmt::Debug + Send + Sync {
     args.len() as u64
   }
 
-  /// Invoke the host function.
+  /// Invoke a pure, runtime-managed, or immediate-only host function.
   fn call(
     &self,
-    services: &mut dyn RuntimeServices,
-    context: &mut RuntimeContext,
-    args: Vec<Value>,
-  ) -> MResult<Value>;
+    _services: &mut dyn RuntimeServices,
+    _context: &mut RuntimeContext,
+    _args: Vec<Value>,
+  ) -> MResult<Value> {
+    Err(MechError::new(
+      InvalidHostCallError {
+        function: self.name().to_string(),
+        reason: "host function does not implement immediate invocation".to_string(),
+      },
+      None,
+    ))
+  }
+
+  /// Prepare a staged host call and its provisional program value.
+  fn stage_call(
+    &self,
+    _services: &mut dyn RuntimeServices,
+    _context: &mut RuntimeContext,
+    _args: Vec<Value>,
+  ) -> MResult<RuntimePreparedHostCall> {
+    Err(MechError::new(
+      InvalidHostCallError {
+        function: self.name().to_string(),
+        reason: "host function does not implement staged invocation".to_string(),
+      },
+      None,
+    ))
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -227,6 +258,83 @@ where
   }
 
   fn call(&self, services: &mut dyn RuntimeServices, context: &mut RuntimeContext, args: Vec<Value>) -> MResult<Value> {
+    (self.function)(services, context, args)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Staged Closure Host Function
+// -----------------------------------------------------------------------------
+
+pub struct StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  name: String,
+  capability: Option<CapabilityRequest>,
+  function: F,
+}
+
+impl<F> std::fmt::Debug for StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("StagedClosureHostFunction")
+      .field("name", &self.name)
+      .field("capability", &self.capability)
+      .field("function", &"<staged-closure>")
+      .finish()
+  }
+}
+
+impl<F> StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  pub fn new(
+    name: impl Into<String>,
+    function: F,
+  ) -> Self {
+    Self {
+      name: name.into(),
+      capability: None,
+      function,
+    }
+  }
+
+  pub fn with_capability(
+    mut self,
+    capability: CapabilityRequest,
+  ) -> Self {
+    self.capability = Some(capability);
+    self
+  }
+}
+
+impl<F> HostFunction for StagedClosureHostFunction<F>
+where
+  F: Fn(&mut dyn RuntimeServices, &mut RuntimeContext, Vec<Value>) -> MResult<RuntimePreparedHostCall> + Send + Sync + 'static,
+{
+  fn name(&self) -> &str {
+    &self.name
+  }
+
+  fn transaction_mode(&self) -> HostFunctionTransactionMode {
+    HostFunctionTransactionMode::Staged
+  }
+
+  fn required_capability(&self, context: &RuntimeContext) -> Option<CapabilityRequest> {
+    let _ = context;
+    self.capability.clone()
+  }
+
+  fn stage_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<RuntimePreparedHostCall> {
     (self.function)(services, context, args)
   }
 }

--- a/src/runtime/src/host/mod.rs
+++ b/src/runtime/src/host/mod.rs
@@ -117,6 +117,35 @@ pub trait HostFunction: std::fmt::Debug + Send + Sync {
     args.len() as u64
   }
 
+  /// Produce the provisional value needed while compiling a native call.
+  ///
+  /// Pure functions may reuse their normal callback. Runtime-managed
+  /// functions must override this method without retaining runtime mutation.
+  fn preview_call(
+    &self,
+    services: &mut dyn RuntimeServices,
+    context: &mut RuntimeContext,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    if matches!(
+      self.transaction_mode(),
+      HostFunctionTransactionMode::Pure
+        | HostFunctionTransactionMode::RuntimeManaged
+    ) {
+      return self.call(services, context, args);
+    }
+    Err(MechError::new(
+      InvalidHostCallError {
+        function: self.name().to_string(),
+        reason: format!(
+          "host function transaction mode {:?} requires an explicit non-mutating preview",
+          self.transaction_mode(),
+        ),
+      },
+      None,
+    ))
+  }
+
   /// Invoke a pure, runtime-managed, or immediate-only host function.
   fn call(
     &self,
@@ -664,6 +693,26 @@ impl MechErrorKind for InvalidHostCallError {
 
   fn message(&self) -> String {
     format!("Invalid host call `{}`: {}", self.function, self.reason)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct HostFunctionTransactionUnsupportedError {
+  pub function: String,
+  pub mode: HostFunctionTransactionMode,
+}
+
+impl MechErrorKind for HostFunctionTransactionUnsupportedError {
+  fn name(&self) -> &str {
+    "HostFunctionTransactionUnsupported"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Host function `{}` uses transaction mode {:?} and cannot run inside a runtime transaction",
+      self.function,
+      self.mode,
+    )
   }
 }
 

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -14,7 +14,7 @@
 use super::*;
 use crate::{
   CapabilityAlreadyExistsError, CapabilityNotFoundError,
-  CapabilityNotRevocableError, CapabilityRevokedError,
+  CapabilityNotRevocableError,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -29,6 +29,7 @@ pub(super) struct RuntimeCapabilityOverlay {
   operations: Vec<RuntimeCapabilityMutation>,
   grants: HashMap<CapabilityId, Arc<dyn Capability>>,
   revocations: HashSet<CapabilityId>,
+  uses: HashMap<CapabilityId, u64>,
 }
 
 impl RuntimeCapabilityOverlay {
@@ -80,20 +81,24 @@ impl RuntimeCapabilityOverlay {
     self.grants.get(&capability).cloned()
   }
 
-  pub(super) fn is_revoked(&self, capability: CapabilityId) -> bool {
-    self.revocations.contains(&capability)
-  }
-
   pub(super) fn check(
-    &self,
+    &mut self,
     request: &CapabilityRequest,
   ) -> MResult<Option<CapabilityId>> {
     for (id, capability) in &self.grants {
       if capability.subject_key() != request.subject {
         continue;
       }
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.uses.get(id).copied().unwrap_or(0);
+        if actual >= max_uses {
+          continue;
+        }
+      }
       let decision = capability.check(request)?;
       if decision.allowed {
+        let uses = self.uses.entry(*id).or_insert(0);
+        *uses = uses.saturating_add(1);
         return Ok(Some(*id));
       }
     }
@@ -113,6 +118,10 @@ impl RuntimeCapabilityOverlay {
     &self,
   ) -> impl Iterator<Item = CapabilityId> + '_ {
     self.revocations.iter().copied()
+  }
+
+  pub(super) fn revocation_ids(&self) -> HashSet<CapabilityId> {
+    self.revocations.clone()
   }
 
   pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
@@ -154,6 +163,7 @@ impl RuntimeCapabilityOverlay {
         }
       }
     }
+    self.uses.retain(|id, _| self.grants.contains_key(id));
   }
 }
 
@@ -395,24 +405,20 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     if let Some(transaction_id) = context.transaction {
-      let overlay = &self
-        .active_execution_transaction(transaction_id)?
-        .capabilities;
-      if let Some(capability) = overlay.check(request)? {
+      let provisional = self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .check(request)?;
+      if let Some(capability) = provisional {
         return Ok(capability);
       }
-      let capability = self.capability_kernel.check(request)?;
-      if self
+      let revocations = self
         .active_execution_transaction(transaction_id)?
         .capabilities
-        .is_revoked(capability)
-      {
-        return Err(MechError::new(
-          CapabilityRevokedError { capability },
-          None,
-        ));
-      }
-      return Ok(capability);
+        .revocation_ids();
+      return self
+        .capability_kernel
+        .check_excluding(request, &revocations);
     }
     self.capability_kernel.check(request)
   }
@@ -435,7 +441,8 @@ mod tests {
   use mech_core::{GenericError, MResult, MechError};
 
   use crate::capability::{
-    BasicCapability, BasicCapabilityKernel, CapabilityDerivation,
+    BasicCapability, BasicCapabilityKernel, BasicConstraints,
+    CapabilityDerivation,
     CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
   };
   use crate::id::{
@@ -585,7 +592,7 @@ mod tests {
       self.inner.checkpoint()
     }
 
-    fn restore_checkpoint(
+    fn restore(
       &mut self,
       _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
     ) -> MResult<()> {
@@ -1141,5 +1148,77 @@ mod tests {
     assert!(poison.rollback_failures.iter().any(|failure| {
       failure.contains("deliberate capability checkpoint restore failure")
     }));
+  }
+
+  #[test]
+  fn provisional_capability_enforces_use_limit() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let limited: Arc<dyn Capability> = Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(BasicConstraints {
+        max_uses: Some(1),
+        ..BasicConstraints::default()
+      }),
+    );
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(&mut context, limited)
+      .unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut context, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .is_err());
+  }
+
+  #[test]
+  fn provisional_revocation_does_not_consume_live_use_limit() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut administrative = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let limited: Arc<dyn Capability> = Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(BasicConstraints {
+        max_uses: Some(1),
+        ..BasicConstraints::default()
+      }),
+    );
+    runtime
+      .grant_capability_with_context(&mut administrative, limited)
+      .unwrap();
+
+    let mut owner = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .revoke_capability_with_context(&mut owner, id)
+      .unwrap();
+    assert!(runtime
+      .check_capability_with_context(&mut owner, &request("task:1"))
+      .is_err());
+    runtime
+      .abort_runtime_transaction(&mut owner, "test abort")
+      .unwrap();
+
+    assert_eq!(
+      runtime.check_capability(&request("task:1")).unwrap(),
+      id,
+    );
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -128,7 +128,7 @@ impl RuntimeCapabilityOverlay {
     let mut grants = HashSet::new();
     let mut revocations = HashSet::new();
     let mut mutations = Vec::new();
-    for operation in &self.operations {
+    for operation in self.operations.iter().rev() {
       match operation {
         RuntimeCapabilityMutation::Grant(capability)
           if self.grants.contains_key(&capability.id())
@@ -145,6 +145,7 @@ impl RuntimeCapabilityOverlay {
         _ => {}
       }
     }
+    mutations.reverse();
     mutations
   }
 
@@ -1111,6 +1112,47 @@ mod tests {
 
     assert!(runtime.get_capability(id).unwrap().is_none());
     assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn regrant_after_cancellation_commits_latest_capability() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .revoke_capability_with_context(&mut context, id)
+      .unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        Arc::new(BasicCapability::from_keys(
+          id,
+          "task:1",
+          "db://projects",
+          [":read"],
+        )),
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.check_capability(&request("task:1")).is_err());
+    assert_eq!(
+      runtime
+        .check_capability(&CapabilityRequest::from_keys(
+          "task:1",
+          ":read",
+          "db://projects",
+        ))
+        .unwrap(),
+      id,
+    );
   }
 
   #[test]

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -115,6 +115,30 @@ impl RuntimeCapabilityOverlay {
     self.revocations.iter().copied()
   }
 
+  pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
+    let mut grants = HashSet::new();
+    let mut revocations = HashSet::new();
+    let mut mutations = Vec::new();
+    for operation in &self.operations {
+      match operation {
+        RuntimeCapabilityMutation::Grant(capability)
+          if self.grants.contains_key(&capability.id())
+            && grants.insert(capability.id()) =>
+        {
+          mutations.push(operation.clone());
+        }
+        RuntimeCapabilityMutation::Revoke(capability)
+          if self.revocations.contains(capability)
+            && revocations.insert(*capability) =>
+        {
+          mutations.push(operation.clone());
+        }
+        _ => {}
+      }
+    }
+    mutations
+  }
+
   fn rebuild(&mut self) {
     self.grants.clear();
     self.revocations.clear();
@@ -411,8 +435,8 @@ mod tests {
   use mech_core::{GenericError, MResult, MechError};
 
   use crate::capability::{
-    BasicCapability, BasicCapabilityKernel, CapabilityDerivation, CapabilityGrant,
-    CapabilityKernel, Subject,
+    BasicCapability, BasicCapabilityKernel, CapabilityDerivation,
+    CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
   };
   use crate::id::{
     ActorId, EventId, IdGenerator, MessageId, NodeId, ObjectId, RuntimeId,
@@ -516,6 +540,70 @@ mod tests {
         },
         None,
       ))
+    }
+
+    fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
+      self.inner.revoke(revocation)
+    }
+
+    fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
+      self.inner.check(request)
+    }
+
+    fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
+      self.inner.get(id)
+    }
+
+    fn list_for_subject(
+      &self,
+      subject: &dyn Subject,
+    ) -> MResult<Vec<CapabilityId>> {
+      self.inner.list_for_subject(subject)
+    }
+
+    fn derive_capability(
+      &mut self,
+      derivation: CapabilityDerivation,
+    ) -> MResult<CapabilityId> {
+      self.inner.derive_capability(derivation)
+    }
+
+    fn is_revoked(&self, id: CapabilityId) -> MResult<bool> {
+      self.inner.is_revoked(id)
+    }
+  }
+
+  #[derive(Debug, Default)]
+  struct FailingCheckpointRestoreKernel {
+    inner: BasicCapabilityKernel,
+  }
+
+  impl CapabilityKernel for FailingCheckpointRestoreKernel {
+    fn checkpoint(
+      &self,
+    ) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+      self.inner.checkpoint()
+    }
+
+    fn restore_checkpoint(
+      &mut self,
+      _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+    ) -> MResult<()> {
+      Err(MechError::new(
+        GenericError {
+          msg: "deliberate capability checkpoint restore failure"
+            .to_string(),
+        },
+        None,
+      ))
+    }
+
+    fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
+      self.inner.grant(grant)
+    }
+
+    fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> {
+      self.inner.rollback_grant(capability)
     }
 
     fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
@@ -936,5 +1024,122 @@ mod tests {
     runtime
       .abort_runtime_transaction(&mut context, "test cleanup")
       .unwrap();
+  }
+
+  #[test]
+  fn capability_overlay_commits_kernel_and_store_together() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.get_capability(id).unwrap().is_some());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_some());
+    assert_eq!(runtime.check_capability(&request("task:1")).unwrap(), id);
+  }
+
+  #[test]
+  fn store_commit_failure_restores_capability_kernel_checkpoint() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    assert!(runtime.commit_runtime_transaction(&mut context).is_err());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn provisional_grant_then_revoke_cancels_commit_work() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .revoke_capability_with_context(&mut context, id)
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn capability_checkpoint_restore_failure_poisons_runtime() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .capability_kernel(FailingCheckpointRestoreKernel::default())
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeEffectCleanupFailed");
+    assert!(runtime.is_poisoned());
+    let RuntimeHealth::Poisoned(poison) = &runtime.health else {
+      panic!("runtime must retain capability cleanup failure");
+    };
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("deliberate capability checkpoint restore failure")
+    }));
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -12,6 +12,126 @@
 // Like with actors, there is a _with_context version of each method, allowing for transactional operations and proper event emission within the context of an active transaction.
 
 use super::*;
+use crate::{
+  CapabilityAlreadyExistsError, CapabilityNotFoundError,
+  CapabilityNotRevocableError, CapabilityRevokedError,
+};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Debug)]
+pub(super) enum RuntimeCapabilityMutation {
+  Grant(Arc<dyn Capability>),
+  Revoke(CapabilityId),
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RuntimeCapabilityOverlay {
+  operations: Vec<RuntimeCapabilityMutation>,
+  grants: HashMap<CapabilityId, Arc<dyn Capability>>,
+  revocations: HashSet<CapabilityId>,
+}
+
+impl RuntimeCapabilityOverlay {
+  pub(super) fn mark(&self) -> usize {
+    self.operations.len()
+  }
+
+  pub(super) fn is_empty(&self) -> bool {
+    self.grants.is_empty() && self.revocations.is_empty()
+  }
+
+  pub(super) fn stage_grant(&mut self, capability: Arc<dyn Capability>) {
+    self
+      .operations
+      .push(RuntimeCapabilityMutation::Grant(capability));
+    self.rebuild();
+  }
+
+  pub(super) fn stage_revocation(&mut self, capability: CapabilityId) {
+    self
+      .operations
+      .push(RuntimeCapabilityMutation::Revoke(capability));
+    self.rebuild();
+  }
+
+  pub(super) fn rollback_to(&mut self, mark: usize) -> MResult<()> {
+    if mark > self.operations.len() {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "rollback_capability_overlay",
+          reason: format!(
+            "capability savepoint mark {} exceeds overlay length {}",
+            mark,
+            self.operations.len(),
+          ),
+        },
+        None,
+      ));
+    }
+    self.operations.truncate(mark);
+    self.rebuild();
+    Ok(())
+  }
+
+  pub(super) fn provisional(
+    &self,
+    capability: CapabilityId,
+  ) -> Option<Arc<dyn Capability>> {
+    self.grants.get(&capability).cloned()
+  }
+
+  pub(super) fn is_revoked(&self, capability: CapabilityId) -> bool {
+    self.revocations.contains(&capability)
+  }
+
+  pub(super) fn check(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<Option<CapabilityId>> {
+    for (id, capability) in &self.grants {
+      if capability.subject_key() != request.subject {
+        continue;
+      }
+      let decision = capability.check(request)?;
+      if decision.allowed {
+        return Ok(Some(*id));
+      }
+    }
+    Ok(None)
+  }
+
+  pub(super) fn grants(
+    &self,
+  ) -> impl Iterator<Item = (CapabilityId, Arc<dyn Capability>)> + '_ {
+    self
+      .grants
+      .iter()
+      .map(|(id, capability)| (*id, capability.clone()))
+  }
+
+  pub(super) fn revocations(
+    &self,
+  ) -> impl Iterator<Item = CapabilityId> + '_ {
+    self.revocations.iter().copied()
+  }
+
+  fn rebuild(&mut self) {
+    self.grants.clear();
+    self.revocations.clear();
+    for operation in &self.operations {
+      match operation {
+        RuntimeCapabilityMutation::Grant(capability) => {
+          self.grants.insert(capability.id(), capability.clone());
+        }
+        RuntimeCapabilityMutation::Revoke(capability) => {
+          if self.grants.remove(capability).is_none() {
+            self.revocations.insert(*capability);
+          }
+        }
+      }
+    }
+  }
+}
 
 fn finish_failed_capability_grant(
   capability: CapabilityId,
@@ -51,6 +171,55 @@ impl MechRuntime {
     capability.validate()?;
 
     let id = capability.id();
+
+    if let Some(transaction_id) = context.transaction {
+      if self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .provisional(id)
+        .is_some()
+        || self.capability_kernel.get(id)?.is_some()
+      {
+        return Err(MechError::new(
+          CapabilityAlreadyExistsError { capability: id },
+          None,
+        ));
+      }
+
+      let store_before = self
+        .active_execution_transaction(transaction_id)?
+        .store
+        .clone();
+      let overlay_mark = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .mark();
+      let context_events_before = context.events.clone();
+      let context_capabilities_before = context.capabilities.clone();
+
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_grant(capability);
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::CapabilityGranted {
+          capability_id: id,
+        },
+      ) {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        let rollback_result =
+          transaction.capabilities.rollback_to(overlay_mark);
+        context.events = context_events_before;
+        context.capabilities = context_capabilities_before;
+        rollback_result?;
+        return Err(error);
+      }
+      context.add_capability(id);
+      return Ok(id);
+    }
 
     self.store.grant_capability(id, capability.clone())?;
 
@@ -112,6 +281,64 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
+    if let Some(transaction_id) = context.transaction {
+      let staged = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .provisional(capability);
+      let live = if staged.is_none() {
+        self.capability_kernel.get(capability)?
+      } else {
+        None
+      };
+      let Some(existing) = staged.or(live) else {
+        return Err(MechError::new(
+          CapabilityNotFoundError { capability },
+          None,
+        ));
+      };
+      if !existing.is_revocable() {
+        return Err(MechError::new(
+          CapabilityNotRevocableError { capability },
+          None,
+        ));
+      }
+
+      let store_before = self
+        .active_execution_transaction(transaction_id)?
+        .store
+        .clone();
+      let overlay_mark = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .mark();
+      let context_events_before = context.events.clone();
+      let context_capabilities_before = context.capabilities.clone();
+
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_revocation(capability);
+      context.remove_capability(capability);
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::CapabilityRevoked {
+          capability_id: capability,
+        },
+      ) {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        let rollback_result =
+          transaction.capabilities.rollback_to(overlay_mark);
+        context.events = context_events_before;
+        context.capabilities = context_capabilities_before;
+        rollback_result?;
+        return Err(error);
+      }
+      return Ok(());
+    }
+
     self
       .capability_kernel
       .revoke(CapabilityRevocation::new(capability))?;
@@ -143,6 +370,26 @@ impl MechRuntime {
   ) -> MResult<CapabilityId> {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
+    if let Some(transaction_id) = context.transaction {
+      let overlay = &self
+        .active_execution_transaction(transaction_id)?
+        .capabilities;
+      if let Some(capability) = overlay.check(request)? {
+        return Ok(capability);
+      }
+      let capability = self.capability_kernel.check(request)?;
+      if self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .is_revoked(capability)
+      {
+        return Err(MechError::new(
+          CapabilityRevokedError { capability },
+          None,
+        ));
+      }
+      return Ok(capability);
+    }
     self.capability_kernel.check(request)
   }
 
@@ -570,5 +817,124 @@ mod tests {
         .count(),
       1,
     );
+  }
+
+  #[test]
+  fn provisional_capability_grant_is_visible_only_to_its_transaction() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut owner = runtime.runtime_context().unwrap();
+    let mut observer = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut owner,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut owner, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime
+      .check_capability_with_context(&mut observer, &request("task:1"))
+      .is_err());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+
+    runtime.abort_runtime_transaction(&mut owner, "test abort").unwrap();
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn provisional_revocation_does_not_leak_to_other_transactions() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut administrative = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+
+    let mut owner = runtime.runtime_context().unwrap();
+    let mut observer = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .revoke_capability_with_context(&mut owner, id)
+      .unwrap();
+
+    assert!(runtime
+      .check_capability_with_context(&mut owner, &request("task:1"))
+      .is_err());
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut observer, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(!runtime.capability_kernel().is_revoked(id).unwrap());
+
+    runtime.abort_runtime_transaction(&mut owner, "test abort").unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut owner, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+  }
+
+  #[test]
+  fn failed_retained_operation_truncates_capability_overlay() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let id = CapabilityId(100);
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "test_capability_overlay",
+      |runtime, context| {
+        runtime.grant_capability_with_context(
+          context,
+          capability(id, "task:1", true),
+        )?;
+        Err(MechError::new(
+          GenericError {
+            msg: "deliberate operation failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    assert_eq!(result.unwrap_err().kind_name(), "GenericError");
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .capabilities
+      .is_empty());
+    assert!(runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .is_err());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
   }
 }

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -618,6 +618,30 @@ impl MechRuntime {
     }
     Ok(effect_id)
   }
+
+  pub(super) fn discard_unstaged_runtime_effect(
+    &mut self,
+    mut effect: PreparedRuntimeEffect,
+  ) -> MResult<()> {
+    let result = match &mut effect {
+      PreparedRuntimeEffect::Transactional(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Aborting);
+        let result = effect.abort();
+        self.active_effect_phase = None;
+        result
+      }
+      PreparedRuntimeEffect::Compensatable(effect) => {
+        self.active_effect_phase =
+          Some(ActiveRuntimeEffectPhase::Aborting);
+        let result = effect.abort();
+        self.active_effect_phase = None;
+        result
+      }
+      PreparedRuntimeEffect::AfterCommit(_) => Ok(()),
+    };
+    result
+  }
 }
 
 #[cfg(test)]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::{
   PreparedRuntimeEffect, RuntimeEffectFailure, RuntimeEffectFailurePhase,
-  RuntimeEffectId,
+  RuntimeEffectId, RuntimeEffectRecord,
 };
 #[cfg(test)]
 use crate::{
@@ -41,6 +41,7 @@ pub(super) struct RuntimeEffectStepFailure {
 pub(super) struct RuntimeEffectCommitFailure {
   pub(super) step: RuntimeEffectStepFailure,
   pub(super) participant_outcomes: Vec<String>,
+  pub(super) committed: Vec<RuntimeEffectId>,
 }
 
 #[derive(Debug, Default)]
@@ -60,6 +61,64 @@ impl RuntimeEffectJournal {
 
   pub(super) fn is_empty(&self) -> bool {
     self.entries.is_empty()
+  }
+
+  pub(super) fn records(&self) -> Vec<RuntimeEffectRecord> {
+    self.entries.iter().map(|entry| {
+      RuntimeEffectRecord::new(
+        entry.id,
+        entry.effect.metadata(),
+        entry.effect.protocol(),
+      )
+    }).collect()
+  }
+
+  pub(super) fn prepared_transactional_ids(
+    &self,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if entry.state == RuntimeEffectState::Prepared
+        && matches!(entry.effect, PreparedRuntimeEffect::Transactional(_))
+      {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn applied_compensatable_ids(
+    &self,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if entry.state == RuntimeEffectState::Applied
+        && matches!(entry.effect, PreparedRuntimeEffect::Compensatable(_))
+      {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn after_commit_ids(&self) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn abortable_ids(&self) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+        None
+      } else {
+        Some(entry.id)
+      }
+    }).collect()
   }
 
   pub(super) fn validate_active(
@@ -309,8 +368,9 @@ impl RuntimeEffectJournal {
 
   pub(super) fn commit_transactional(
     &mut self,
-  ) -> Result<Vec<String>, RuntimeEffectCommitFailure> {
+  ) -> Result<Vec<RuntimeEffectId>, RuntimeEffectCommitFailure> {
     let mut outcomes = Vec::new();
+    let mut committed = Vec::new();
     for entry in &mut self.entries {
       if entry.state != RuntimeEffectState::Prepared {
         continue;
@@ -319,10 +379,13 @@ impl RuntimeEffectJournal {
         continue;
       };
       match effect.commit() {
-        Ok(()) => outcomes.push(format!(
-          "transactional effect {} committed",
-          entry.id,
-        )),
+        Ok(()) => {
+          outcomes.push(format!(
+            "transactional effect {} committed",
+            entry.id,
+          ));
+          committed.push(entry.id);
+        }
         Err(error) => {
           let step = effect_step_failure(
             entry.id,
@@ -337,11 +400,12 @@ impl RuntimeEffectJournal {
           return Err(RuntimeEffectCommitFailure {
             step,
             participant_outcomes: outcomes,
+            committed,
           });
         }
       }
     }
-    Ok(outcomes)
+    Ok(committed)
   }
 
   pub(super) fn deliver_after_commit(
@@ -506,15 +570,55 @@ impl MechRuntime {
       ));
     }
     let cost = effect.cost();
+    let metadata = effect.metadata();
+    let protocol = effect.protocol();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;
+    let store_before = self
+      .active_execution_transaction(transaction_id)?
+      .store
+      .clone();
+    let effect_mark = self
+      .active_execution_transaction(transaction_id)?
+      .effects
+      .mark();
+    let context_events_before = context.events.clone();
+    let effect_id = self
+      .active_execution_transaction_mut(transaction_id)?
+      .effects
+      .stage(transaction_id, effect);
 
-    Ok(
-      self
-        .active_execution_transaction_mut(transaction_id)?
-        .effects
-        .stage(transaction_id, effect),
-    )
+    if let Err(error) = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::EffectStaged {
+        effect_id,
+        source: metadata.source,
+        operation: metadata.operation,
+        resource: metadata.resource,
+        protocol,
+      },
+    ) {
+      self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+      let cleanup = {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        transaction.effects.rollback_to(effect_mark)
+      };
+      self.active_effect_phase = None;
+      context.events = context_events_before;
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "stage_runtime_effect_with_context",
+        transaction_id,
+        format!("{:?}", error),
+        Self::describe_effect_failures(cleanup),
+      ));
+    }
+
+    Ok(effect_id)
   }
 
   pub(super) fn stage_runtime_resource_effect_with_context(
@@ -549,21 +653,61 @@ impl MechRuntime {
       ));
     }
     let cost = effect.cost();
+    let metadata = effect.metadata();
+    let protocol = effect.protocol();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;
+    let store_before = self
+      .active_execution_transaction(transaction_id)?
+      .store
+      .clone();
+    let effect_mark = self
+      .active_execution_transaction(transaction_id)?
+      .effects
+      .mark();
+    let context_events_before = context.events.clone();
+    let effect_id = self
+      .active_execution_transaction_mut(transaction_id)?
+      .effects
+      .stage_resource_write(
+        transaction_id,
+        effect,
+        base_uri,
+        path,
+        value,
+      );
 
-    Ok(
-      self
-        .active_execution_transaction_mut(transaction_id)?
-        .effects
-        .stage_resource_write(
-          transaction_id,
-          effect,
-          base_uri,
-          path,
-          value,
-        ),
-    )
+    if let Err(error) = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::EffectStaged {
+        effect_id,
+        source: metadata.source,
+        operation: metadata.operation,
+        resource: metadata.resource,
+        protocol,
+      },
+    ) {
+      self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+      let cleanup = {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        transaction.effects.rollback_to(effect_mark)
+      };
+      self.active_effect_phase = None;
+      context.events = context_events_before;
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "stage_runtime_resource_effect_with_context",
+        transaction_id,
+        format!("{:?}", error),
+        Self::describe_effect_failures(cleanup),
+      ));
+    }
+
+    Ok(effect_id)
   }
 
   pub(super) fn execute_runtime_effect_immediately(
@@ -849,6 +993,28 @@ mod tests {
   }
 
   #[derive(Debug)]
+  struct SensitiveAfterCommit {
+    secret_payload: String,
+  }
+
+  impl RuntimeAfterCommitEffect for SensitiveAfterCommit {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "sensitive-test".to_string(),
+        },
+        "deliver",
+      )
+      .with_resource("test://metadata-only")
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      assert!(!self.secret_payload.is_empty());
+      Ok(())
+    }
+  }
+
+  #[derive(Debug)]
   struct CostedAfterCommit {
     cost: crate::RuntimeEffectCost,
   }
@@ -895,6 +1061,86 @@ mod tests {
 
     assert_eq!(journal.len(), 2);
     assert_eq!(journal.next_sequence(), 3);
+  }
+
+  #[test]
+  fn transaction_history_persists_effect_metadata_without_payload() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let secret = "raw-secret-payload-must-not-be-durable";
+    let effect_id = runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          SensitiveAfterCommit {
+            secret_payload: secret.to_string(),
+          },
+        )),
+      )
+      .unwrap();
+
+    runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    let transaction = runtime
+      .get_transaction(transaction_id)
+      .unwrap()
+      .unwrap();
+    assert_eq!(transaction.effects.len(), 1);
+    assert_eq!(transaction.effects[0].id, effect_id);
+    assert_eq!(
+      transaction.effects[0].protocol,
+      crate::RuntimeEffectProtocol::AfterCommit,
+    );
+    assert_eq!(
+      transaction.effects[0].resource.as_deref(),
+      Some("test://metadata-only"),
+    );
+    assert!(!format!("{:?}", transaction).contains(secret));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectDelivered { effect_id: delivered }
+          if delivered == effect_id
+      )
+    }));
+  }
+
+  #[test]
+  fn savepoint_rollback_discards_effect_and_staging_event() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let result: MResult<RuntimeEffectId> =
+      runtime.with_atomic_program_operation(
+        &mut context,
+        "effect_staging_event_rollback",
+        |runtime, context| {
+          let effect_id = runtime.stage_runtime_effect_with_context(
+            context,
+            effect("rolled-back"),
+          )?;
+          Err(synthetic_error(format!(
+            "deliberate rollback for {}",
+            effect_id,
+          )))
+        },
+      );
+
+    assert_eq!(result.unwrap_err().kind_name(), "SyntheticEffectError");
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .effects
+      .is_empty());
+    assert!(!context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectStaged { .. })
+    }));
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
   }
 
   #[test]
@@ -980,6 +1226,15 @@ mod tests {
       RuntimeExecutionTransactionState::Active,
     );
     assert!(!runtime.is_poisoned());
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectPreparationFailed { .. }
+      )
+    }));
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectAborted { .. })
+    }));
 
     runtime
       .abort_runtime_transaction(&mut context, "prepare test cleanup")
@@ -1089,6 +1344,12 @@ mod tests {
     );
     assert_eq!(context.transaction, Some(transaction_id));
     assert!(!runtime.is_poisoned());
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectCompensated { .. })
+    }));
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectAborted { .. })
+    }));
 
     runtime
       .abort_runtime_transaction(&mut context, "apply test cleanup")
@@ -1234,6 +1495,19 @@ mod tests {
       .get_transaction(transaction_id)
       .unwrap()
       .is_some());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::TransactionalEffectCommitted { .. }
+      )
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ExternalCommitIndeterminate { .. }
+      )
+    }));
   }
 
   #[test]
@@ -1290,6 +1564,19 @@ mod tests {
       .get_transaction(transaction_id)
       .unwrap()
       .is_some());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectDelivered { .. })
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectDeliveryFailed {
+          effect_id,
+          ..
+        } if effect_id == failing_effect_id
+      )
+    }));
   }
 
   #[test]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -1436,6 +1436,12 @@ mod tests {
       .rollback_failures
       .iter()
       .any(|failure| failure.contains("first compensate failed")));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectCompensationFailed { .. }
+      )
+    }));
 
     assert!(runtime
       .abort_runtime_transaction(&mut context, "poison test cleanup")

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -4541,7 +4541,7 @@ mod tests {
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_for_host = calls.clone();
     runtime
-      .register_mech_host_function(ClosureHostFunction::new(
+      .register_mech_host_function(ClosureHostFunction::new_pure(
         "demo/echo",
         move |_services, context, args| {
           assert_eq!(context.subject, "program:step-host-test");

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -44,7 +44,8 @@ use mech_core::{
   GuardFunctionSafety, Ref, ValueKind,
 };
 use crate::{
-  HostFunctionTransactionMode, RuntimePreparedHostCall,
+  HostFunction, HostFunctionTransactionMode,
+  HostFunctionTransactionUnsupportedError, RuntimePreparedHostCall,
 };
 
 impl MechRuntime {
@@ -103,6 +104,131 @@ impl MechRuntime {
     self.call_host_with_context(&mut context, call)
   }
 
+  fn preview_runtime_managed_host_function(
+    &mut self,
+    context: &mut RuntimeContext,
+    function: &dyn HostFunction,
+    args: Vec<Value>,
+  ) -> MResult<Value> {
+    let transaction_id = Self::context_transaction_id(context)?;
+    let context_checkpoint = RuntimeContextCheckpoint::capture(context);
+    let (store, effect_mark) = {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      (transaction.store.clone(), transaction.effects.mark())
+    };
+
+    let result = function.preview_call(self, context, args);
+    let mut cleanup_failures = Vec::new();
+    self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+    match self.active_transactions.get_mut(&transaction_id) {
+      Some(transaction) => {
+        cleanup_failures.extend(Self::describe_effect_failures(
+          transaction.effects.rollback_to(effect_mark),
+        ));
+        transaction.store = store;
+      }
+      None => cleanup_failures.push(format!(
+        "runtime-managed host preview lost transaction {}",
+        transaction_id,
+      )),
+    }
+    self.active_effect_phase = None;
+    context_checkpoint.restore_preserving_consumption(context);
+    if let Err(error) = self.validate_context_for_runtime(context) {
+      cleanup_failures.push(format!(
+        "runtime-managed host preview context restore failed: {:?}",
+        error,
+      ));
+    }
+
+    if cleanup_failures.is_empty() {
+      return result;
+    }
+
+    let original_error = match result {
+      Ok(_) => format!(
+        "runtime-managed host function `{}` preview cleanup failed",
+        function.name(),
+      ),
+      Err(error) => format!("{:?}", error),
+    };
+    Err(self.poison_program_operation(
+      "preview_runtime_managed_host_function",
+      Some(transaction_id),
+      original_error,
+      cleanup_failures,
+    ))
+  }
+
+  fn preview_host_call_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    call: HostCall,
+  ) -> MResult<Value> {
+    self.ensure_runtime_healthy("preview_host_call_with_context")?;
+    self.reject_effect_reentrancy("preview_host_call_with_context")?;
+    self.validate_context_for_runtime(context)?;
+    call.validate()?;
+
+    let Some(function) = self.host_registry.get_function(&call.name)? else {
+      return Err(MechError::new(
+        HostFunctionNotFoundError {
+          name: call.name,
+        },
+        None,
+      ));
+    };
+
+    self
+      .host_policy
+      .validate_call(context, function.as_ref(), &call.args)?;
+    let capability_request = function
+      .required_capability(context)
+      .unwrap_or_else(|| {
+        default_host_capability_request(context, function.name())
+      });
+    self.check_capability_with_context(context, &capability_request)?;
+
+    match function.transaction_mode() {
+      HostFunctionTransactionMode::Pure => {
+        function.preview_call(self, context, call.args)
+      }
+      HostFunctionTransactionMode::RuntimeManaged => {
+        self.preview_runtime_managed_host_function(
+          context,
+          function.as_ref(),
+          call.args,
+        )
+      }
+      HostFunctionTransactionMode::Staged => {
+        let RuntimePreparedHostCall { value, effect } =
+          function.stage_call(self, context, call.args)?;
+        if let Err(error) = self.discard_unstaged_runtime_effect(effect) {
+          return Err(self.poison_program_operation(
+            "preview_host_call_with_context",
+            context.transaction,
+            format!(
+              "staged host function `{}` preview cleanup failed",
+              function.name(),
+            ),
+            vec![format!("{:?}", error)],
+          ));
+        }
+        Ok(value)
+      }
+      HostFunctionTransactionMode::ImmediateOnly => {
+        Err(MechError::new(
+          HostFunctionTransactionUnsupportedError {
+            function: function.name().to_string(),
+            mode: HostFunctionTransactionMode::ImmediateOnly,
+          },
+          None,
+        ))
+      }
+    }
+  }
+
   pub fn call_host_with_context(
     &mut self,
     context: &mut RuntimeContext,
@@ -138,6 +264,19 @@ impl MechRuntime {
     };
 
     let result = (|| -> MResult<Value> {
+      let transaction_mode = function.transaction_mode();
+      if context.transaction.is_some()
+        && transaction_mode == HostFunctionTransactionMode::ImmediateOnly
+      {
+        return Err(MechError::new(
+          HostFunctionTransactionUnsupportedError {
+            function: function.name().to_string(),
+            mode: transaction_mode,
+          },
+          None,
+        ));
+      }
+
       self
         .host_policy
         .validate_call(context, function.as_ref(), &call.args)?;
@@ -248,7 +387,7 @@ impl NativeFunctionCompiler for RuntimeHostNativeFunctionCompiler {
       // been moved out of `self`, so calling back into the runtime does not
       // alias `self.program`.
       let value = unsafe {
-        (&mut *target.runtime).call_host_with_context(
+        (&mut *target.runtime).preview_host_call_with_context(
           &mut *target.context,
           HostCall::new(&self.host_name, arguments.clone()),
         )
@@ -387,8 +526,10 @@ impl MechFunctionCompiler for RuntimeHostNativeFunction {
 mod transaction_tests {
   use super::*;
   use std::sync::{Arc, Mutex};
+  use std::sync::atomic::{AtomicUsize, Ordering};
   use crate::{
     BasicCapability, BasicOperation, BasicResource, BasicSubject,
+    ClosureHostFunction,
     PreparedRuntimeEffect, RuntimeAfterCommitEffect,
     RuntimeEffectMetadata, RuntimeEffectSource,
     StagedClosureHostFunction,
@@ -471,6 +612,167 @@ mod transaction_tests {
       log.lock().unwrap().as_slice(),
       &["delivered".to_string()],
     );
+  }
+
+  #[test]
+  fn immediate_only_host_is_rejected_before_transactional_callback() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/immediate");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new(
+        "demo/immediate",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::Empty)
+        },
+      ))
+      .unwrap();
+
+    runtime
+      .call_host(HostCall::new("demo/immediate", Vec::new()))
+      .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    let error = runtime
+      .call_host_with_context(
+        &mut context,
+        HostCall::new("demo/immediate", Vec::new()),
+      )
+      .unwrap_err();
+
+    assert_eq!(
+      error.kind_name(),
+      "HostFunctionTransactionUnsupported",
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    runtime
+      .abort_runtime_transaction(&mut context, "discard rejection test")
+      .unwrap();
+
+    let implicit_error = runtime
+      .run_string("result := demo/immediate()")
+      .unwrap_err();
+    assert_eq!(
+      implicit_error.kind_name(),
+      "HostFunctionTransactionUnsupported",
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn pure_host_runs_inside_implicit_and_explicit_transactions() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/pure");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new_pure(
+        "demo/pure",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::F64(Ref::new(42.0)))
+        },
+      ))
+      .unwrap();
+
+    runtime.run_string("implicit := demo/pure()").unwrap();
+
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "explicit := demo/pure()",
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+  }
+
+  #[test]
+  fn failed_later_operation_discards_only_its_staged_host_effect() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/staged");
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let effect_log = log.clone();
+    runtime
+      .register_mech_host_function(StagedClosureHostFunction::new(
+        "demo/staged",
+        move |_services, _context, _args| {
+          Ok(RuntimePreparedHostCall {
+            value: Value::String(Ref::new("provisional".to_string())),
+            effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+              RecordingHostEffect {
+                log: effect_log.clone(),
+                entry: "delivered".to_string(),
+              },
+            )),
+          })
+        },
+      ))
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "first := demo/staged()",
+      )
+      .unwrap();
+    let failed = runtime.run_string_with_context(
+      &mut context,
+      "discarded := demo/staged()\nbroken := missing + 1",
+    );
+
+    assert!(failed.is_err());
+    assert!(runtime.program.root_symbol_value("first").is_ok());
+    assert!(runtime.program.root_symbol_value("discarded").is_err());
+    assert!(log.lock().unwrap().is_empty());
+
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert_eq!(
+      log.lock().unwrap().as_slice(),
+      &["delivered".to_string()],
+    );
+  }
+
+  #[test]
+  fn runtime_managed_preview_does_not_duplicate_staged_mutation() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/runtime-managed");
+    let observed_ids = Arc::new(Mutex::new(Vec::new()));
+    let callback_ids = observed_ids.clone();
+    runtime
+      .register_mech_host_function(
+        ClosureHostFunction::new_runtime_managed(
+          "demo/runtime-managed",
+          move |services, context, _args| {
+            let id = services.next_object_id();
+            callback_ids.lock().unwrap().push(id);
+            services.put_object_with_context(
+              context,
+              ObjectRecord::text(id, "preview-test", "value"),
+            )?;
+            Ok(Value::String(Ref::new(id.to_string())))
+          },
+        ),
+      )
+      .unwrap();
+
+    runtime
+      .run_string("result := demo/runtime-managed()")
+      .unwrap();
+
+    let ids = observed_ids.lock().unwrap().clone();
+    assert_eq!(ids.len(), 2);
+    assert!(runtime.store().get_object(ids[0]).unwrap().is_none());
+    assert!(runtime.store().get_object(ids[1]).unwrap().is_some());
   }
 }
 

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -43,6 +43,9 @@ use super::execution::{
 use mech_core::{
   GuardFunctionSafety, Ref, ValueKind,
 };
+use crate::{
+  HostFunctionTransactionMode, RuntimePreparedHostCall,
+};
 
 impl MechRuntime {
 
@@ -150,7 +153,26 @@ impl MechRuntime {
 
       self.check_capability_with_context(context, &capability_request)?;
 
-      function.call(self, context, call.args)
+      match function.transaction_mode() {
+        HostFunctionTransactionMode::Staged => {
+          let RuntimePreparedHostCall { value, effect } =
+            function.stage_call(self, context, call.args)?;
+          if context.transaction.is_some() {
+            self.stage_runtime_effect_with_context(context, effect)?;
+          } else {
+            let cost = effect.cost();
+            context.charge_bytes(cost.bytes)?;
+            context.charge_items(cost.items)?;
+            self.execute_runtime_effect_immediately(effect)?;
+          }
+          Ok(value)
+        }
+        HostFunctionTransactionMode::Pure
+        | HostFunctionTransactionMode::RuntimeManaged
+        | HostFunctionTransactionMode::ImmediateOnly => {
+          function.call(self, context, call.args)
+        }
+      }
     })();
 
     match &result {
@@ -358,6 +380,97 @@ impl MechFunctionCompiler for RuntimeHostNativeFunction {
       },
       None,
     ))
+  }
+}
+
+#[cfg(test)]
+mod transaction_tests {
+  use super::*;
+  use std::sync::{Arc, Mutex};
+  use crate::{
+    BasicCapability, BasicOperation, BasicResource, BasicSubject,
+    PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+    RuntimeEffectMetadata, RuntimeEffectSource,
+    StagedClosureHostFunction,
+  };
+
+  #[derive(Debug)]
+  struct RecordingHostEffect {
+    log: Arc<Mutex<Vec<String>>>,
+    entry: String,
+  }
+
+  impl RuntimeAfterCommitEffect for RecordingHostEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::HostFunction {
+          name: "demo/staged".to_string(),
+        },
+        "deliver",
+      )
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push(self.entry.clone());
+      Ok(())
+    }
+  }
+
+  fn grant_host_call(runtime: &mut MechRuntime, name: &str) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(700),
+        &BasicSubject::new(&subject),
+        &BasicResource::new(format!("host:{name}")),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
+  }
+
+  #[test]
+  fn staged_host_call_returns_value_before_effect_delivery() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/staged");
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let effect_log = log.clone();
+    runtime
+      .register_mech_host_function(StagedClosureHostFunction::new(
+        "demo/staged",
+        move |_services, _context, _args| {
+          Ok(RuntimePreparedHostCall {
+            value: Value::String(Ref::new("provisional".to_string())),
+            effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+              RecordingHostEffect {
+                log: effect_log.clone(),
+                entry: "delivered".to_string(),
+              },
+            )),
+          })
+        },
+      ))
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    let value = runtime
+      .call_host_with_context(
+        &mut context,
+        HostCall::new("demo/staged", Vec::new()),
+      )
+      .unwrap();
+
+    assert_eq!(
+      value,
+      Value::String(Ref::new("provisional".to_string())),
+    );
+    assert!(log.lock().unwrap().is_empty());
+
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert_eq!(
+      log.lock().unwrap().as_slice(),
+      &["delivered".to_string()],
+    );
   }
 }
 

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -76,6 +76,8 @@ impl MechRuntime {
     &mut self,
     function: impl HostFunction + 'static,
   ) -> MResult<()> {
+    self.ensure_runtime_healthy("register_mech_host_function")?;
+    self.reject_effect_reentrancy("register_mech_host_function")?;
     let name = function.name().to_string();
 
     self

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -14,7 +14,7 @@
 
 // For example, a function to compute an affine transformation could be registered as a host function, and then called from Mech code like this:
 /*
-  runtime.register_mech_host_function(ClosureHostFunction::new(
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure(
     "demo/math/affine",
     |_services, _context, args| {
       host_call3(

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -256,7 +256,7 @@ fn register_sleep_host(
 ) {
   runtime
     .register_mech_host_function(
-      ClosureHostFunction::new(
+      ClosureHostFunction::new_pure(
         name,
         move |_services, _context, args| {
           thread::sleep(
@@ -436,7 +436,7 @@ fn patterned_activation_guard_rejects_runtime_host_before_elaboration() {
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
   runtime
-    .register_mech_host_function(ClosureHostFunction::new(
+    .register_mech_host_function(ClosureHostFunction::new_pure(
       "demo/audit",
       move |_services, _context, _args| {
         host_calls.fetch_add(1, Ordering::SeqCst);
@@ -513,7 +513,7 @@ fn live_input_recomputes_runtime_host_function() {
     .unwrap();
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-plus-one", move |_services, _context, args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/live-plus-one", move |_services, _context, args| {
     host_calls.fetch_add(1, Ordering::SeqCst);
     match &args[0] {
       Value::F64(value) => Ok(Value::F64(Ref::new(*value.borrow() + 1.0))),
@@ -545,7 +545,7 @@ fn runtime_reactive_host_input_executes_only_reachable_branch() {
   grant_host_call(&mut runtime, &subject, 91, "host:demo/left-branch"); grant_host_call(&mut runtime, &subject, 92, "host:demo/right-branch");
   let left_calls = Arc::new(AtomicUsize::new(0)); let right_calls = Arc::new(AtomicUsize::new(0));
   for (name, calls, add) in [("demo/left-branch", left_calls.clone(), 100.0), ("demo/right-branch", right_calls.clone(), 200.0)] {
-    runtime.register_mech_host_function(ClosureHostFunction::new(name, move |_services, _context, args| { calls.fetch_add(1, Ordering::SeqCst); let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + add))) })).unwrap();
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure(name, move |_services, _context, args| { calls.fetch_add(1, Ordering::SeqCst); let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + add))) })).unwrap();
   }
   let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@pulse := test://clock/ticks{:read(left), :read(right)}\nleft-output := demo/left-branch(@pulse/left)\nright-output := demo/right-branch(@pulse/right)").unwrap();
   let left_calls_before = left_calls.load(Ordering::SeqCst);
@@ -569,7 +569,7 @@ fn live_host_string_output_recomputes_without_replacing_reference() {
   grant_read(&mut runtime, "test://clock/ticks", "value");
   let subject = runtime.runtime_context().unwrap().subject;
   grant_host_call(&mut runtime, &subject, 45, "host:demo/live-label");
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-label", |_services, _context, args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/live-label", |_services, _context, args| {
     let value = match &args[0] {
       Value::F64(value) => *value.borrow(),
       Value::MutableReference(value) => match &*value.borrow() {
@@ -611,7 +611,7 @@ fn live_host_output_kind_change_preserves_previous_output() {
   grant_host_call(&mut runtime, &subject, 46, "host:demo/kind-change");
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/kind-change", move |_services, _context, args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/kind-change", move |_services, _context, args| {
     let call = host_calls.fetch_add(1, Ordering::SeqCst);
     if call < 2 {
       let value = match &args[0] {
@@ -658,7 +658,7 @@ fn runtime_reactive_host_input_turn_failure_preserves_admitted_inputs() {
   let (mut runtime, output) = test_runtime_with_output(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0)); grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value"); grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
   let subject = runtime.runtime_context().unwrap().subject; grant_host_call(&mut runtime, &subject, 47, "host:demo/fails-after-first");
   let calls = Arc::new(AtomicUsize::new(0)); let host_calls = calls.clone(); let fail_host = Arc::new(AtomicBool::new(false)); let fail_host_for_call = fail_host.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/fails-after-first", move |_services, _context, args| { host_calls.fetch_add(1, Ordering::SeqCst); if fail_host_for_call.load(Ordering::SeqCst) { return Err(MechError::new(DeliberateHostCallError, None)); } let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + 1.0))) })).unwrap();
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/fails-after-first", move |_services, _context, args| { host_calls.fetch_add(1, Ordering::SeqCst); if fail_host_for_call.load(Ordering::SeqCst) { return Err(MechError::new(DeliberateHostCallError, None)); } let input = host_f64_argument(&args[0]); Ok(Value::F64(Ref::new(input + 1.0))) })).unwrap();
   let mut context = runtime.runtime_context().unwrap(); runtime.run_string_with_context(&mut context, "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\nhost-result := demo/fails-after-first(@pulse/value)\noutput := host-result + 0\n@out/line <- output").unwrap();
   let calls_before = calls.load(Ordering::SeqCst); let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); let host_result_pointer = match &*host_result.borrow() { Value::F64(value) => value.as_ptr(), other => panic!("expected f64 host result, got {other:?}") }; let plan_before = plan_snapshot(&runtime); let lines_before = output.lines();
   assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(output.lines().len(), 1); assert_eq!(runtime.persistent_send_count(), 1);
@@ -673,7 +673,7 @@ fn live_host_empty_output_can_recompute() {
   grant_host_call(&mut runtime, &subject, 48, "host:demo/live-empty");
   let calls = Arc::new(AtomicUsize::new(0));
   let host_calls = calls.clone();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/live-empty", move |_services, _context, _args| {
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/live-empty", move |_services, _context, _args| {
     host_calls.fetch_add(1, Ordering::SeqCst);
     Ok(Value::Empty)
   })).unwrap();
@@ -2022,7 +2022,7 @@ other-value := other-tick + 1.0
   fn failed_patterned_body_does_not_replay_send_on_unrelated_turn() {
     let provider=TestResourceProvider::new().with_value("test://render/timer","tick",Value::F64(Ref::new(0.0))).with_value("test://other/timer","tick",Value::F64(Ref::new(0.0)));let(mut runtime,output)=test_runtime_with_output(provider);grant_read(&mut runtime,"test://render/timer","tick");grant_read(&mut runtime,"test://other/timer","tick");grant_write(&mut runtime,TEST_OUTPUT_BASE_URI,"line");
     let subject=runtime.runtime_context().unwrap().subject;grant_host_call(&mut runtime,&subject,194,"host:demo/patterned-body-fail-second");let calls=Arc::new(AtomicUsize::new(0));let host_calls=calls.clone();
-    runtime.register_mech_host_function(ClosureHostFunction::new("demo/patterned-body-fail-second",move |_services,_context,args|{let call=host_calls.fetch_add(1,Ordering::SeqCst)+1;if call==2{return Err(MechError::new(DeliberateHostCallError,None));}Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))})).unwrap();
+    runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/patterned-body-fail-second",move |_services,_context,args|{let call=host_calls.fetch_add(1,Ordering::SeqCst)+1;if call==2{return Err(MechError::new(DeliberateHostCallError,None));}Ok(Value::F64(Ref::new(host_f64_argument(&args[0]))))})).unwrap();
     runtime.run_string(r#"@tick := test://render/timer{:read(tick)}
 @other := test://other/timer{:read(tick)}
 @out := test://effects/output{:write(line)}
@@ -2139,7 +2139,7 @@ render-tick := @tick/tick
         let calls = Arc::new(AtomicUsize::new(0));
         let host_calls = calls.clone();
         runtime
-            .register_mech_host_function(ClosureHostFunction::new(
+            .register_mech_host_function(ClosureHostFunction::new_pure(
                 "demo/activation-fail-second",
                 move |_services, _context, args| {
                     let call_number = host_calls.fetch_add(1, Ordering::SeqCst) + 1;

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -199,7 +199,7 @@ use crate::event::{
 };
 
 use crate::host::{
-  default_host_capability_request, DefaultHostCallPolicy, HostCall, HostCallPolicy, HostFunction,
+  default_host_capability_request, DefaultHostCallPolicy, HostCall, HostCallPolicy,
   HostFunctionNotFoundError, HostRegistry, InMemoryHostRegistry,
 };
 

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -47,6 +47,7 @@ use self::program_transaction::{
   RuntimeExecutionTransactionState,
   RuntimeTransactionContextIdentity,
 };
+use self::capability::RuntimeCapabilityOverlay;
 use self::effect::RuntimeEffectJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -47,7 +47,9 @@ use self::program_transaction::{
   RuntimeExecutionTransactionState,
   RuntimeTransactionContextIdentity,
 };
-use self::capability::RuntimeCapabilityOverlay;
+use self::capability::{
+  RuntimeCapabilityMutation, RuntimeCapabilityOverlay,
+};
 use self::effect::RuntimeEffectJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -1626,7 +1626,7 @@ mod tests {
     let observed = Arc::new(Mutex::new(Vec::new()));
     let observed_for_host = observed.clone();
     runtime
-      .register_mech_host_function(ClosureHostFunction::new(
+      .register_mech_host_function(ClosureHostFunction::new_runtime_managed(
         "demo/reenter",
         move |_services, _context, _args| {
           ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -180,6 +180,7 @@ pub(super) struct RuntimeExecutionTransaction {
   pub(super) context_baseline: RuntimeContextCheckpoint,
   pub(super) program: Option<RuntimeProgramBaseline>,
   pub(super) effects: RuntimeEffectJournal,
+  pub(super) capabilities: RuntimeCapabilityOverlay,
   pub(super) state: RuntimeExecutionTransactionState,
 }
 
@@ -197,6 +198,7 @@ impl RuntimeExecutionTransaction {
       context_baseline,
       program: None,
       effects: RuntimeEffectJournal::new(),
+      capabilities: RuntimeCapabilityOverlay::default(),
       state: RuntimeExecutionTransactionState::Active,
     }
   }
@@ -208,6 +210,7 @@ pub(super) struct RuntimeProgramOperationSavepoint {
   pub(super) live: RuntimeLiveStateSnapshot,
   pub(super) store: RuntimeTransaction,
   pub(super) effect_mark: usize,
+  pub(super) capability_mark: usize,
   pub(super) context: RuntimeContextCheckpoint,
 }
 
@@ -387,15 +390,24 @@ impl MechRuntime {
         let effect_failures =
           transaction.effects.rollback_to(savepoint.effect_mark);
         transaction.store = savepoint.store.clone();
-        Some(effect_failures)
+        let capability_result = transaction
+          .capabilities
+          .rollback_to(savepoint.capability_mark);
+        Some((effect_failures, capability_result))
       }
       None => None,
     };
     self.active_effect_phase = None;
     match effect_rollback {
-      Some(effect_failures) => failures.extend(
-        Self::describe_effect_failures(effect_failures),
-      ),
+      Some((effect_failures, capability_result)) => {
+        failures.extend(Self::describe_effect_failures(effect_failures));
+        if let Err(error) = capability_result {
+          failures.push(format!(
+            "capability overlay rollback failed: {:?}",
+            error,
+          ));
+        }
+      }
       None => failures.push(format!(
         "active execution transaction {} disappeared before operation rollback",
         transaction_id,
@@ -678,6 +690,10 @@ impl MechRuntime {
       effect_mark: self
         .active_execution_transaction(transaction_id)?
         .effects
+        .mark(),
+      capability_mark: self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
         .mark(),
       context: RuntimeContextCheckpoint::capture(context),
     };

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -17,7 +17,9 @@
 // - `context_transaction_id`: Retrieves the active transaction ID from the context.
 
 use super::*;
-use crate::{AccessSet, RuntimeCommitOutcome};
+use crate::{
+  AccessSet, CapabilityKernelCheckpoint, RuntimeCommitOutcome,
+};
 
 impl MechRuntime {
 
@@ -227,7 +229,7 @@ impl MechRuntime {
         )
       })?;
 
-    if envelope.effects.is_empty() {
+    if envelope.effects.is_empty() && envelope.capabilities.is_empty() {
       let commit_event =
         self.make_event(RuntimeEventKind::TransactionCommitted {
           transaction_id,
@@ -284,13 +286,60 @@ impl MechRuntime {
       ));
     }
 
+    let capability_checkpoint = if envelope.capabilities.is_empty() {
+      None
+    } else {
+      match self.capability_kernel.checkpoint() {
+        Ok(checkpoint) => Some(checkpoint),
+        Err(error) => {
+          let original_error_text = format!("{:?}", error);
+          self.active_effect_phase =
+            Some(ActiveRuntimeEffectPhase::Aborting);
+          let aborted = envelope.effects.abort_prepared_reverse();
+          self.active_effect_phase = None;
+          envelope.state = RuntimeExecutionTransactionState::Active;
+          self.active_transactions.insert(transaction_id, envelope);
+          if aborted.is_empty() {
+            return Err(error);
+          }
+          return Err(self.poison_effect_cleanup(
+            "commit_runtime_transaction",
+            transaction_id,
+            original_error_text,
+            Self::describe_effect_failures(aborted),
+          ));
+        }
+      }
+    };
+
+    if let Err(error) = self.apply_capability_overlay(&envelope) {
+      let original_error_text = format!("{:?}", error);
+      let cleanup = self.cleanup_before_store_retry(
+        &mut envelope,
+        capability_checkpoint,
+      );
+      envelope.state = RuntimeExecutionTransactionState::Active;
+      self.active_transactions.insert(transaction_id, envelope);
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "commit_runtime_transaction",
+        transaction_id,
+        original_error_text,
+        cleanup,
+      ));
+    }
+
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Applying);
     let apply_result = envelope.effects.apply_compensatable();
     self.active_effect_phase = None;
     if let Err(step) = apply_result {
       let original_error_text = format!("{:?}", step.error);
-      let cleanup =
-        self.cleanup_effects_before_store_retry(&mut envelope);
+      let cleanup = self.cleanup_before_store_retry(
+        &mut envelope,
+        capability_checkpoint,
+      );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
       if cleanup.is_empty() {
@@ -315,8 +364,10 @@ impl MechRuntime {
       Ok(commit) => commit,
       Err(error) => {
         let original_error_text = format!("{:?}", error);
-        let cleanup =
-          self.cleanup_effects_before_store_retry(&mut envelope);
+        let cleanup = self.cleanup_before_store_retry(
+          &mut envelope,
+          capability_checkpoint,
+        );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
         if cleanup.is_empty() {
@@ -335,8 +386,10 @@ impl MechRuntime {
       Ok(id) => id,
       Err(error) => {
         let original_error_text = format!("{:?}", error);
-        let cleanup =
-          self.cleanup_effects_before_store_retry(&mut envelope);
+        let cleanup = self.cleanup_before_store_retry(
+          &mut envelope,
+          capability_checkpoint,
+        );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
         if cleanup.is_empty() {
@@ -383,19 +436,51 @@ impl MechRuntime {
     })
   }
 
-  fn cleanup_effects_before_store_retry(
+  fn cleanup_before_store_retry(
     &mut self,
     envelope: &mut RuntimeExecutionTransaction,
+    capability_checkpoint: Option<Box<dyn CapabilityKernelCheckpoint>>,
   ) -> Vec<String> {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Compensating);
     let compensated = envelope.effects.compensate_applied_reverse();
+    let capability_restore = capability_checkpoint
+      .map(|checkpoint| {
+        self.capability_kernel.restore_checkpoint(checkpoint)
+      });
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let aborted = envelope.effects.abort_prepared_reverse();
     self.active_effect_phase = None;
 
     let mut failures = Self::describe_effect_failures(compensated);
+    if let Some(Err(error)) = capability_restore {
+      failures.push(format!(
+        "capability kernel checkpoint restore failed: {:?}",
+        error,
+      ));
+    }
     failures.extend(Self::describe_effect_failures(aborted));
     failures
+  }
+
+  fn apply_capability_overlay(
+    &mut self,
+    envelope: &RuntimeExecutionTransaction,
+  ) -> MResult<()> {
+    for mutation in envelope.capabilities.mutations() {
+      match mutation {
+        RuntimeCapabilityMutation::Grant(capability) => {
+          self
+            .capability_kernel
+            .grant(CapabilityGrant::new(capability))?;
+        }
+        RuntimeCapabilityMutation::Revoke(capability) => {
+          self
+            .capability_kernel
+            .revoke(CapabilityRevocation::new(capability))?;
+        }
+      }
+    }
+    Ok(())
   }
 
   fn build_runtime_store_commit(
@@ -439,6 +524,11 @@ impl MechRuntime {
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
+      capability_grants: envelope.capabilities.grants().collect(),
+      capability_revocations: envelope
+        .capabilities
+        .revocations()
+        .collect(),
       object_puts: staged_puts,
       object_updates: staged_updates,
       task_updates: staged_task_updates,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -19,6 +19,7 @@
 use super::*;
 use crate::{
   AccessSet, CapabilityKernelCheckpoint, RuntimeCommitOutcome,
+  RuntimeEffectFailure, RuntimeEffectFailurePhase,
 };
 
 impl MechRuntime {
@@ -270,9 +271,48 @@ impl MechRuntime {
     self.active_effect_phase = None;
     if let Err(step) = prepare_result {
       let original_error_text = format!("{:?}", step.error);
+      let prepared_ids =
+        envelope.effects.prepared_transactional_ids();
       self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
-      let cleanup = envelope.effects.abort_prepared_reverse();
+      let mut cleanup = envelope.effects.abort_prepared_reverse();
       self.active_effect_phase = None;
+      let failed_ids: HashSet<RuntimeEffectId> = cleanup
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect();
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        &mut envelope,
+        context,
+        RuntimeEventKind::EffectPreparationFailed {
+          effect_id: step.failure.effect_id,
+          message: step.failure.message.clone(),
+        },
+      ) {
+        cleanup.push(RuntimeEffectFailure {
+          effect_id: step.failure.effect_id,
+          phase: RuntimeEffectFailurePhase::Abort,
+          message: format!(
+            "preparation failure audit event failed: {:?}",
+            error,
+          ),
+        });
+      }
+      for effect_id in prepared_ids {
+        if failed_ids.contains(&effect_id) {
+          continue;
+        }
+        if let Err(error) = self.stage_effect_lifecycle_event(
+          &mut envelope,
+          context,
+          RuntimeEventKind::EffectAborted { effect_id },
+        ) {
+          cleanup.push(RuntimeEffectFailure {
+            effect_id,
+            phase: RuntimeEffectFailurePhase::Abort,
+            message: format!("abort audit event failed: {:?}", error),
+          });
+        }
+      }
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
       if cleanup.is_empty() {
@@ -293,10 +333,37 @@ impl MechRuntime {
         Ok(checkpoint) => Some(checkpoint),
         Err(error) => {
           let original_error_text = format!("{:?}", error);
+          let prepared_ids =
+            envelope.effects.prepared_transactional_ids();
           self.active_effect_phase =
             Some(ActiveRuntimeEffectPhase::Aborting);
-          let aborted = envelope.effects.abort_prepared_reverse();
+          let mut aborted = envelope.effects.abort_prepared_reverse();
           self.active_effect_phase = None;
+          let failed_ids: HashSet<RuntimeEffectId> = aborted
+            .iter()
+            .map(|failure| failure.effect_id)
+            .collect();
+          for effect_id in prepared_ids {
+            if failed_ids.contains(&effect_id) {
+              continue;
+            }
+            if let Err(audit_error) =
+              self.stage_effect_lifecycle_event(
+                &mut envelope,
+                context,
+                RuntimeEventKind::EffectAborted { effect_id },
+              )
+            {
+              aborted.push(RuntimeEffectFailure {
+                effect_id,
+                phase: RuntimeEffectFailurePhase::Abort,
+                message: format!(
+                  "abort audit event failed: {:?}",
+                  audit_error,
+                ),
+              });
+            }
+          }
           envelope.state = RuntimeExecutionTransactionState::Active;
           self.active_transactions.insert(transaction_id, envelope);
           if aborted.is_empty() {
@@ -317,6 +384,7 @@ impl MechRuntime {
       let cleanup = self.cleanup_before_store_retry(
         &mut envelope,
         capability_checkpoint,
+        context,
       );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -339,6 +407,7 @@ impl MechRuntime {
       let cleanup = self.cleanup_before_store_retry(
         &mut envelope,
         capability_checkpoint,
+        context,
       );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -367,6 +436,7 @@ impl MechRuntime {
         let cleanup = self.cleanup_before_store_retry(
           &mut envelope,
           capability_checkpoint,
+          context,
         );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
@@ -389,6 +459,7 @@ impl MechRuntime {
         let cleanup = self.cleanup_before_store_retry(
           &mut envelope,
           capability_checkpoint,
+          context,
         );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
@@ -407,18 +478,47 @@ impl MechRuntime {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Committing);
     let participant_result = envelope.effects.commit_transactional();
     self.active_effect_phase = None;
-    if let Err(commit_failure) = participant_result {
-      context.transaction = None;
-      if self.program_transaction_owner == Some(transaction_id) {
-        self.program_transaction_owner = None;
+    let committed_effects = match participant_result {
+      Ok(committed_effects) => committed_effects,
+      Err(commit_failure) => {
+        context.transaction = None;
+        if self.program_transaction_owner == Some(transaction_id) {
+          self.program_transaction_owner = None;
+        }
+        self.push_persisted_event_to_context(context, commit_event);
+        let mut participant_outcomes =
+          commit_failure.participant_outcomes;
+        for effect_id in commit_failure.committed {
+          if let Err(error) = self.emit_event_to_context(
+            context,
+            RuntimeEventKind::TransactionalEffectCommitted { effect_id },
+          ) {
+            participant_outcomes.push(format!(
+              "transactional effect {} commit audit failed: {:?}",
+              effect_id,
+              error,
+            ));
+          }
+        }
+        if let Err(error) = self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ExternalCommitIndeterminate {
+            transaction_id: id,
+            effect_id: commit_failure.step.failure.effect_id,
+          },
+        ) {
+          participant_outcomes.push(format!(
+            "external commit indeterminate audit failed: {:?}",
+            error,
+          ));
+        }
+        return Err(self.poison_external_commit_indeterminate(
+          id,
+          commit_failure.step.failure.effect_id,
+          participant_outcomes,
+        ));
       }
-      self.push_persisted_event_to_context(context, commit_event);
-      return Err(self.poison_external_commit_indeterminate(
-        id,
-        commit_failure.step.failure.effect_id,
-        commit_failure.participant_outcomes,
-      ));
-    }
+    };
 
     context.transaction = None;
     if self.program_transaction_owner == Some(transaction_id) {
@@ -426,9 +526,46 @@ impl MechRuntime {
     }
     self.push_persisted_event_to_context(context, commit_event);
 
+    for effect_id in committed_effects {
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::TransactionalEffectCommitted { effect_id },
+      ) {
+        return Err(self.poison_external_commit_indeterminate(
+          id,
+          effect_id,
+          vec![format!(
+            "transactional effect {} committed but its audit event failed: {:?}",
+            effect_id,
+            error,
+          )],
+        ));
+      }
+    }
+
+    let after_commit_ids = envelope.effects.after_commit_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Delivering);
-    let delivery_failures = envelope.effects.deliver_after_commit();
+    let mut delivery_failures = envelope.effects.deliver_after_commit();
     self.active_effect_phase = None;
+    for effect_id in after_commit_ids {
+      let kind = match delivery_failures
+        .iter()
+        .find(|failure| failure.effect_id == effect_id)
+      {
+        Some(failure) => RuntimeEventKind::EffectDeliveryFailed {
+          effect_id,
+          message: failure.message.clone(),
+        },
+        None => RuntimeEventKind::EffectDelivered { effect_id },
+      };
+      if let Err(error) = self.emit_event_to_context(context, kind) {
+        delivery_failures.push(RuntimeEffectFailure {
+          effect_id,
+          phase: RuntimeEffectFailurePhase::Deliver,
+          message: format!("delivery audit event failed: {:?}", error),
+        });
+      }
+    }
 
     Ok(RuntimeCommitOutcome {
       transaction_id: id,
@@ -440,17 +577,29 @@ impl MechRuntime {
     &mut self,
     envelope: &mut RuntimeExecutionTransaction,
     capability_checkpoint: Option<Box<dyn CapabilityKernelCheckpoint>>,
+    context: &mut RuntimeContext,
   ) -> Vec<String> {
+    let compensated_ids =
+      envelope.effects.applied_compensatable_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Compensating);
     let compensated = envelope.effects.compensate_applied_reverse();
     let capability_restore = capability_checkpoint
       .map(|checkpoint| {
         self.capability_kernel.restore_checkpoint(checkpoint)
       });
+    let aborted_ids = envelope.effects.prepared_transactional_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let aborted = envelope.effects.abort_prepared_reverse();
     self.active_effect_phase = None;
 
+    let failed_compensations: HashSet<RuntimeEffectId> = compensated
+      .iter()
+      .map(|failure| failure.effect_id)
+      .collect();
+    let failed_aborts: HashSet<RuntimeEffectId> = aborted
+      .iter()
+      .map(|failure| failure.effect_id)
+      .collect();
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
       failures.push(format!(
@@ -459,7 +608,57 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
+    for effect_id in compensated_ids {
+      if failed_compensations.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        envelope,
+        context,
+        RuntimeEventKind::EffectCompensated { effect_id },
+      ) {
+        failures.push(format!(
+          "effect {} compensation audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
+    }
+    for effect_id in aborted_ids {
+      if failed_aborts.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        envelope,
+        context,
+        RuntimeEventKind::EffectAborted { effect_id },
+      ) {
+        failures.push(format!(
+          "effect {} abort audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
+    }
     failures
+  }
+
+  fn stage_effect_lifecycle_event(
+    &mut self,
+    envelope: &mut RuntimeExecutionTransaction,
+    context: &mut RuntimeContext,
+    kind: RuntimeEventKind,
+  ) -> MResult<EventId> {
+    let context_events_before = context.events.clone();
+    let event = self.make_event(kind);
+    let id = event.id;
+    context.push_event(event.clone());
+    self.trim_events_to_retention(&mut context.events);
+    if let Err(error) = envelope.store.stage_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
+    Ok(id)
   }
 
   fn apply_capability_overlay(
@@ -520,7 +719,9 @@ impl MechRuntime {
 
     let mut transaction_snapshot = transaction.clone();
     transaction_snapshot.record_event(commit_event.id)?;
-    let transaction_record = transaction_snapshot.into_record()?;
+    let transaction_record = transaction_snapshot
+      .into_record()?
+      .with_effects(envelope.effects.records());
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
@@ -626,9 +827,15 @@ impl MechRuntime {
       ));
     }
 
+    let abortable_effects = envelope.effects.abortable_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let effect_abort_failures = envelope.effects.abort_all();
     self.active_effect_phase = None;
+    let failed_effect_aborts: HashSet<RuntimeEffectId> =
+      effect_abort_failures
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect();
     rollback_failures.extend(
       Self::describe_effect_failures(effect_abort_failures),
     );
@@ -642,6 +849,22 @@ impl MechRuntime {
 
     if owns_program {
       self.program_transaction_owner = None;
+    }
+
+    for effect_id in abortable_effects {
+      if failed_effect_aborts.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.emit_event_immediate_to_context(
+        context,
+        RuntimeEventKind::EffectAborted { effect_id },
+      ) {
+        rollback_failures.push(format!(
+          "effect {} abort audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
     }
 
     let abort_event_result = self.emit_event_immediate_to_context(

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -531,9 +531,13 @@ impl MechRuntime {
         context,
         RuntimeEventKind::TransactionalEffectCommitted { effect_id },
       ) {
-        return Err(self.poison_external_commit_indeterminate(
+        return Err(self.poison_effect_cleanup(
+          "commit_runtime_transaction",
           id,
-          effect_id,
+          format!(
+            "transactional effect {} committed but its audit event failed",
+            effect_id,
+          ),
           vec![format!(
             "transactional effect {} committed but its audit event failed: {:?}",
             effect_id,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -585,7 +585,7 @@ impl MechRuntime {
     let compensated = envelope.effects.compensate_applied_reverse();
     let capability_restore = capability_checkpoint
       .map(|checkpoint| {
-        self.capability_kernel.restore_checkpoint(checkpoint)
+        self.capability_kernel.restore(checkpoint)
       });
     let aborted_ids = envelope.effects.prepared_transactional_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
@@ -600,6 +600,22 @@ impl MechRuntime {
       .iter()
       .map(|failure| failure.effect_id)
       .collect();
+    let mut audit_failures = Vec::new();
+    for failure in &compensated {
+      if let Err(error) = self.emit_effect_event_outside_transaction(
+        context,
+        RuntimeEventKind::EffectCompensationFailed {
+          effect_id: failure.effect_id,
+          message: failure.message.clone(),
+        },
+      ) {
+        audit_failures.push(format!(
+          "effect {} compensation failure audit event failed: {:?}",
+          failure.effect_id,
+          error,
+        ));
+      }
+    }
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
       failures.push(format!(
@@ -608,12 +624,12 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
+    failures.extend(audit_failures);
     for effect_id in compensated_ids {
       if failed_compensations.contains(&effect_id) {
         continue;
       }
-      if let Err(error) = self.stage_effect_lifecycle_event(
-        envelope,
+      if let Err(error) = self.emit_effect_event_outside_transaction(
         context,
         RuntimeEventKind::EffectCompensated { effect_id },
       ) {
@@ -655,6 +671,23 @@ impl MechRuntime {
     context.push_event(event.clone());
     self.trim_events_to_retention(&mut context.events);
     if let Err(error) = envelope.store.stage_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
+    Ok(id)
+  }
+
+  fn emit_effect_event_outside_transaction(
+    &mut self,
+    context: &mut RuntimeContext,
+    kind: RuntimeEventKind,
+  ) -> MResult<EventId> {
+    let context_events_before = context.events.clone();
+    let event = self.make_event(kind);
+    let id = event.id;
+    context.push_event(event.clone());
+    self.trim_events_to_retention(&mut context.events);
+    if let Err(error) = self.append_event(event) {
       context.events = context_events_before;
       return Err(error);
     }

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -25,6 +25,7 @@ use mech_core::{MResult, MechError, MechErrorKind, MechSourceCode};
 use crate::capability::{Capability, CapabilityRequest};
 use crate::context::ResourceBudgetExceededError;
 use crate::event::RuntimeEvent;
+use crate::effect::RuntimeEffectRecord;
 use crate::id::{
   ActorId, CapabilityId, EventId, MessageId, ModuleId, ModuleVersionId,
   ObjectId, TaskId, TransactionId,
@@ -763,6 +764,7 @@ pub struct TransactionRecord {
   pub actor_updates: Vec<ActorId>,
 
   pub events: Vec<EventId>,
+  pub effects: Vec<RuntimeEffectRecord>,
 }
 
 impl TransactionRecord {
@@ -781,6 +783,7 @@ impl TransactionRecord {
       actor_updates: Vec::new(),
 
       events: Vec::new(),
+      effects: Vec::new(),
     }
   }
 
@@ -816,6 +819,11 @@ impl TransactionRecord {
 
   pub fn with_events(mut self, events: Vec<EventId>) -> Self {
     self.events = events;
+    self
+  }
+
+  pub fn with_effects(mut self, effects: Vec<RuntimeEffectRecord>) -> Self {
+    self.effects = effects;
     self
   }
 

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -835,6 +835,8 @@ impl TransactionRecord {
 #[derive(Clone, Debug)]
 pub struct RuntimeStoreCommit {
   pub transaction: TransactionRecord,
+  pub capability_grants: Vec<(CapabilityId, Arc<dyn Capability>)>,
+  pub capability_revocations: Vec<CapabilityId>,
   pub object_puts: Vec<ObjectRecord>,
   pub object_updates: Vec<ObjectRecord>,
   pub task_updates: Vec<TaskRecord>,
@@ -1431,6 +1433,14 @@ impl MechStore for InMemoryStore {
       temporary.enqueue_message(actor, message)?;
     }
 
+    for (capability, grant) in commit.capability_grants {
+      temporary.grant_capability(capability, grant)?;
+    }
+
+    for capability in commit.capability_revocations {
+      temporary.revoke_capability(capability)?;
+    }
+
     for event in commit.events {
       temporary.append_event(event)?;
     }
@@ -1922,6 +1932,8 @@ mod tests {
       transaction: TransactionRecord::new(TransactionId(1), "task:1")
         .with_write_set(vec![ObjectId(1), ObjectId(2)])
         .with_events(vec![EventId(1)]),
+      capability_grants: Vec::new(),
+      capability_revocations: Vec::new(),
       object_puts: vec![ObjectRecord::text(ObjectId(1), "note", "hello")],
       object_updates: vec![ObjectRecord::text(ObjectId(2), "note", "missing")],
       task_updates: Vec::new(),

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -764,6 +764,7 @@ pub struct TransactionRecord {
   pub actor_updates: Vec<ActorId>,
 
   pub events: Vec<EventId>,
+  #[cfg_attr(feature = "serde", serde(default))]
   pub effects: Vec<RuntimeEffectRecord>,
 }
 

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -1883,7 +1883,7 @@ fn module_host_call_works_inside_isolated_execution() {
   std::fs::write(root.join("math.mec"), "tau := demo/value()\n<+ tau\n").unwrap();
   std::fs::write(root.join("main.mec"), "+> ./math.mec\nok := math/tau > 40\n").unwrap();
   let mut runtime = RuntimeBuilder::new().source_resolver(FileSourceResolver::new(&root)).build().unwrap();
-  runtime.register_mech_host_function(ClosureHostFunction::new("demo/value", |_s, _c, _a| Ok(Value::F64(Ref::new(42.0))))).unwrap();
+  runtime.register_mech_host_function(ClosureHostFunction::new_pure("demo/value", |_s, _c, _a| Ok(Value::F64(Ref::new(42.0))))).unwrap();
   runtime.grant_capability(std::sync::Arc::new(BasicCapability::new(
     CapabilityId(1),
     &BasicSubject::new("program:module-host-test"),


### PR DESCRIPTION
## Round 4 stack

This is Round 4C, stacked on #657.

- #656 — prepared effect protocols and the runtime effect journal
- #657 — transactional resource providers
- #658 — transactional host effects
- #659 — capability transactions, durable effect audit, and benchmarks

All four PRs passed their GitHub Actions suites and are ready for review.

## What changed

Every host function now declares one transaction mode:

- `Pure` — no mutation
- `RuntimeManaged` — mutation is already inside runtime-owned staged state
- `Staged` — invocation prepares an effect for the runtime journal
- `ImmediateOnly` — rejected before callback invocation while a transaction is active

The conservative `ClosureHostFunction::new` default remains immediate-only. Explicit pure/runtime-managed constructors and `StagedClosureHostFunction` make stronger contracts deliberate. Built-in actor context/state functions are runtime-managed.

## Native-plan preview safety

The compiler previews native calls while constructing a plan, so preview is separated from actual invocation:

- pure preview may execute directly;
- runtime-managed preview runs behind private store, context, and effect savepoints and is rolled back;
- staged preview effects are explicitly discarded and never enter the active transaction journal;
- immediate-only callbacks are rejected without invocation;
- actual staged effects enter the journal only when the retained program call executes.

This prevents plan construction from duplicating durable state or releasing effects from inactive code paths.

## Commits

- `593fed6f7` — feat(runtime): classify host function transaction behavior
- `a8e5e93e0` — feat(runtime): stage external host function effects
- `ad31ea530` — fix(runtime): reject immediate host effects in transactions
- `422fe2698` — docs(runtime): document transactional host contracts

Head: `422fe2698`

## Validation

Passed on this PR head:

- host transaction regression suite covering all four modes
- module smoke: 235 passed
- generic host: 20 passed
- runtime input: 59 passed
- program coordinator: 17 passed
- actor: 17 passed
- all runtime examples compile; representative examples execute
- minimal `base` feature check

The full runtime suite has only the same three pre-existing macOS `/var` versus `/private/var` workspace-watch failures.

Per maintainer instruction, no `rustfmt` run or broad formatting rewrite was performed.

See #659 for the completed Round 4 capability, audit, benchmark, and cumulative validation layer.