### PR TITLE
Runtime-owned capability transactions and effect audit

### DIFF
--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,12 +1,14 @@
 use criterion::{
   BatchSize, Criterion, criterion_group, criterion_main,
 };
-use mech_core::{MResult, MechSourceCode};
+use mech_core::{MResult, MechSourceCode, Value};
 use mech_runtime::{
-  BasicCapability, CapabilityId, CapabilityRequest, MechRuntime, ObjectId,
-  ObjectRecord, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+  CapabilityRequest, MechRuntime, ObjectId, ObjectRecord,
+  PreparedRuntimeEffect, RuntimeAfterCommitEffect,
   RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
-  RuntimeEffectSource, SequentialIdGenerator,
+  RuntimeEffectSource, RuntimePreparedHostCall, SequentialIdGenerator,
+  StagedClosureHostFunction,
 };
 use std::hint::black_box;
 use std::sync::Arc;
@@ -147,6 +149,50 @@ fn explicit_failure_source() -> MechSourceCode {
       "bench-explicit-error := missing-bench-value + 1".to_string(),
     ),
   ])
+}
+
+fn staged_effect_rollback_fixture(
+  count: usize,
+) -> (ExplicitFixture, MechSourceCode) {
+  let mut runtime = retained_runtime();
+  runtime
+    .grant_capability(Arc::new(BasicCapability::new(
+      CapabilityId(8_000),
+      &BasicSubject::new(runtime.runtime_context().unwrap().subject),
+      &BasicResource::new("host:bench/staged"),
+      [BasicOperation::new("call")],
+    )))
+    .unwrap();
+  runtime
+    .register_mech_host_function(StagedClosureHostFunction::new(
+      "bench/staged",
+      |_services, _context, _arguments| {
+        Ok(RuntimePreparedHostCall {
+          value: Value::Empty,
+          effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+            BenchmarkAfterCommitEffect { sequence: 0 },
+          )),
+        })
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+
+  let mut source = Vec::with_capacity(count.saturating_add(1));
+  for sequence in 0..count {
+    source.push(MechSourceCode::String(format!(
+      "bench-staged-{sequence} := bench/staged()",
+    )));
+  }
+  source.push(MechSourceCode::String(
+    "bench-staged-error := missing-bench-value + 1".to_string(),
+  ));
+
+  (
+    ExplicitFixture { runtime, context },
+    MechSourceCode::Program(source),
+  )
 }
 
 fn program_transaction_benchmarks(c: &mut Criterion) {
@@ -314,11 +360,7 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
     "explicit_effect_savepoint_rollback_with_100_staged",
     |b| {
       b.iter_batched(
-        || {
-          let mut fixture = subsequent_explicit_fixture();
-          stage_after_commit(&mut fixture, 100);
-          (fixture, explicit_failure_source())
-        },
+        || staged_effect_rollback_fixture(100),
         |(mut fixture, source)| {
           let error = fixture
             .runtime

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,15 +1,102 @@
 use criterion::{
   BatchSize, Criterion, criterion_group, criterion_main,
 };
-use mech_core::MechSourceCode;
+use mech_core::{MResult, MechSourceCode};
 use mech_runtime::{
-  MechRuntime, RuntimeContext, SequentialIdGenerator,
+  BasicCapability, CapabilityId, CapabilityRequest, MechRuntime, ObjectId,
+  ObjectRecord, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+  RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
+  RuntimeEffectSource, SequentialIdGenerator,
 };
 use std::hint::black_box;
+use std::sync::Arc;
 
 struct ExplicitFixture {
   runtime: MechRuntime,
   context: RuntimeContext,
+}
+
+#[derive(Debug)]
+struct BenchmarkAfterCommitEffect {
+  sequence: usize,
+}
+
+impl RuntimeAfterCommitEffect for BenchmarkAfterCommitEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "benchmark-after-commit".to_string(),
+      },
+      "deliver",
+    )
+    .with_resource(format!("bench://after-commit/{}", self.sequence))
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+}
+
+#[derive(Debug)]
+struct BenchmarkCompensatableEffect {
+  sequence: usize,
+}
+
+impl RuntimeCompensatableEffect for BenchmarkCompensatableEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "benchmark-compensatable".to_string(),
+      },
+      "apply",
+    )
+    .with_resource(format!("bench://compensatable/{}", self.sequence))
+  }
+
+  fn apply(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+
+  fn compensate(&mut self) -> MResult<()> {
+    black_box(self.sequence);
+    Ok(())
+  }
+}
+
+fn stage_after_commit(
+  fixture: &mut ExplicitFixture,
+  count: usize,
+) {
+  for sequence in 0..count {
+    fixture
+      .runtime
+      .stage_runtime_effect_with_context(
+        &mut fixture.context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          BenchmarkAfterCommitEffect { sequence },
+        )),
+      )
+      .unwrap();
+  }
+}
+
+fn stage_compensatable(
+  fixture: &mut ExplicitFixture,
+  count: usize,
+) {
+  for sequence in 0..count {
+    fixture
+      .runtime
+      .stage_runtime_effect_with_context(
+        &mut fixture.context,
+        PreparedRuntimeEffect::Compensatable(Box::new(
+          BenchmarkCompensatableEffect { sequence },
+        )),
+      )
+      .unwrap();
+  }
 }
 
 fn retained_runtime() -> MechRuntime {
@@ -188,6 +275,165 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
           .unwrap();
         black_box(value);
         black_box((runtime, context))
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  for count in [1, 100] {
+    group.bench_function(
+      format!("stage_{count}_after_commit_effects"),
+      |b| {
+        b.iter_batched(
+          explicit_fixture,
+          |mut fixture| {
+            stage_after_commit(&mut fixture, count);
+            black_box(fixture)
+          },
+          BatchSize::SmallInput,
+        )
+      },
+    );
+
+    group.bench_function(
+      format!("stage_{count}_compensatable_effects"),
+      |b| {
+        b.iter_batched(
+          explicit_fixture,
+          |mut fixture| {
+            stage_compensatable(&mut fixture, count);
+            black_box(fixture)
+          },
+          BatchSize::SmallInput,
+        )
+      },
+    );
+  }
+
+  group.bench_function(
+    "explicit_effect_savepoint_rollback_with_100_staged",
+    |b| {
+      b.iter_batched(
+        || {
+          let mut fixture = subsequent_explicit_fixture();
+          stage_after_commit(&mut fixture, 100);
+          (fixture, explicit_failure_source())
+        },
+        |(mut fixture, source)| {
+          let error = fixture
+            .runtime
+            .run_source_with_context(&mut fixture.context, &source)
+            .unwrap_err();
+          black_box(error);
+          black_box(fixture)
+        },
+        BatchSize::SmallInput,
+      )
+    },
+  );
+
+  group.bench_function("reversible_effect_commit", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_compensatable(&mut fixture, 1);
+        fixture
+      },
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("store_failure_with_compensation", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_compensatable(&mut fixture, 1);
+        fixture
+          .runtime
+          .update_object_with_context(
+            &mut fixture.context,
+            ObjectRecord::text(
+              ObjectId(9_000),
+              "missing",
+              "benchmark",
+            ),
+          )
+          .unwrap();
+        fixture
+      },
+      |mut fixture| {
+        let error = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap_err();
+        black_box(error);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("capability_overlay_lookup", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        let capability = Arc::new(BasicCapability::from_keys(
+          CapabilityId(7_000),
+          "bench-subject",
+          "bench://resource",
+          [":read"],
+        ));
+        fixture
+          .runtime
+          .grant_capability_with_context(
+            &mut fixture.context,
+            capability,
+          )
+          .unwrap();
+        let request = CapabilityRequest::from_keys(
+          "bench-subject",
+          ":read",
+          "bench://resource",
+        );
+        (fixture, request)
+      },
+      |(mut fixture, request)| {
+        let capability = fixture
+          .runtime
+          .check_capability_with_context(
+            &mut fixture.context,
+            &request,
+          )
+          .unwrap();
+        black_box(capability);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("deliver_100_after_commit_effects", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture = explicit_fixture();
+        stage_after_commit(&mut fixture, 100);
+        fixture
+      },
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .commit_runtime_transaction_detailed(&mut fixture.context)
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
       },
       BatchSize::SmallInput,
     )

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -2,11 +2,25 @@ use crate::*;
 
 use mech_core::*;
 use std::sync::Arc;
+use std::any::Any;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 // -----------------------------------------------------------------------------
 // Capability Kernel Trait
 // -----------------------------------------------------------------------------
+
+pub trait CapabilityKernelCheckpoint: std::fmt::Debug + Send {
+  fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+impl<T> CapabilityKernelCheckpoint for T
+where
+  T: std::fmt::Debug + Send + Any,
+{
+  fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    self
+  }
+}
 
 /// Capability authority graph and checking interface.
 ///
@@ -14,6 +28,30 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// audited, cryptographic-token-based, or host-specific authority systems should
 /// implement this trait.
 pub trait CapabilityKernel: std::fmt::Debug + Send {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel does not support transaction checkpoints".to_string(),
+      },
+      None,
+    ))
+  }
+
+  fn restore_checkpoint(
+    &mut self,
+    _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel does not support transaction checkpoint restore"
+          .to_string(),
+      },
+      None,
+    ))
+  }
+
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId>;
 
   /// Administratively remove a grant that has not committed.
@@ -148,6 +186,29 @@ impl BasicCapabilityKernel {
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    Ok(Box::new(self.clone()))
+  }
+
+  fn restore_checkpoint(
+    &mut self,
+    checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    let snapshot = checkpoint
+      .into_any()
+      .downcast::<BasicCapabilityKernel>()
+      .map_err(|_| MechError::new(
+        TransactionStateUnsupportedError {
+          function: "basic capability kernel".to_string(),
+          reason: "checkpoint belongs to a different kernel implementation"
+            .to_string(),
+        },
+        None,
+      ))?;
+    *self = *snapshot;
+    Ok(())
+  }
+
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
     let capability = grant.capability;
     capability.validate()?;
@@ -370,6 +431,19 @@ impl SharedCapabilityKernel {
 }
 
 impl CapabilityKernel for SharedCapabilityKernel {
+  fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+    self.inner.lock().unwrap().checkpoint()
+  }
+  fn restore_checkpoint(
+    &mut self,
+    checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+  ) -> MResult<()> {
+    self
+      .inner
+      .lock()
+      .unwrap()
+      .restore_checkpoint(checkpoint)
+  }
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
   fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -38,7 +38,7 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
     ))
   }
 
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -71,6 +71,24 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()>;
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId>;
+
+  fn check_excluding(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    if excluded.is_empty() {
+      return self.check(request);
+    }
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel".to_string(),
+        reason: "kernel cannot exclude transaction-local revocations"
+          .to_string(),
+      },
+      None,
+    ))
+  }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>>;
 
@@ -183,6 +201,74 @@ impl BasicCapabilityKernel {
       !children.is_empty()
     });
   }
+
+  fn check_with_exclusions(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    let Some(ids) = self.by_subject.get(&request.subject) else {
+      return Err(MechError::new(
+        CapabilityDeniedError {
+          subject: request.subject.clone(),
+          operation: request.operation.clone(),
+          resource: request.resource.clone(),
+          reason: "subject has no capabilities".to_string(),
+        },
+        None,
+      ));
+    };
+
+    let ids: Vec<CapabilityId> = ids.iter().copied().collect();
+    let mut last_reason = None;
+
+    for id in ids {
+      if excluded.contains(&id) {
+        last_reason =
+          Some("capability is revoked by the active transaction".to_string());
+        continue;
+      }
+      if self.revoked.contains(&id) {
+        last_reason = Some("capability is revoked".to_string());
+        continue;
+      }
+
+      let Some(capability) = self.capabilities.get(&id) else {
+        continue;
+      };
+
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.successful_uses(id);
+        if actual >= max_uses {
+          last_reason = Some(format!(
+            "use limit exceeded: max {}, actual {}",
+            max_uses, actual,
+          ));
+          continue;
+        }
+      }
+
+      let decision = capability.check(request)?;
+      if !decision.allowed {
+        last_reason = decision.reason;
+        continue;
+      }
+
+      self.increment_uses(id);
+      return Ok(id);
+    }
+
+    Err(MechError::new(
+      CapabilityDeniedError {
+        subject: request.subject.clone(),
+        operation: request.operation.clone(),
+        resource: request.resource.clone(),
+        reason: last_reason
+          .unwrap_or_else(|| "no matching capability".to_string()),
+      },
+      None,
+    ))
+  }
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
@@ -190,7 +276,7 @@ impl CapabilityKernel for BasicCapabilityKernel {
     Ok(Box::new(self.clone()))
   }
 
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -267,65 +353,15 @@ impl CapabilityKernel for BasicCapabilityKernel {
   }
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
-    let Some(ids) = self.by_subject.get(&request.subject) else {
-      return Err(MechError::new(
-        CapabilityDeniedError {
-          subject: request.subject.clone(),
-          operation: request.operation.clone(),
-          resource: request.resource.clone(),
-          reason: "subject has no capabilities".to_string(),
-        },
-        None,
-      ));
-    };
+    self.check_with_exclusions(request, &HashSet::new())
+  }
 
-    let ids: Vec<CapabilityId> = ids.iter().copied().collect();
-    let mut last_reason = None;
-
-    for id in ids {
-      if self.revoked.contains(&id) {
-        last_reason = Some("capability is revoked".to_string());
-        continue;
-      }
-
-      let Some(capability) = self.capabilities.get(&id) else {
-        continue;
-      };
-
-      if let Some(max_uses) = capability.max_uses() {
-        let actual = self.successful_uses(id);
-        if actual >= max_uses {
-          last_reason = Some(format!(
-            "use limit exceeded: max {}, actual {}",
-            max_uses, actual,
-          ));
-          continue;
-        }
-      }
-
-      let decision = capability.check(request)?;
-
-      if !decision.allowed {
-        last_reason = decision.reason;
-        continue;
-      }
-
-      // The generic Capability trait does not expose max_uses, because custom
-      // capabilities can implement their own use accounting inside check().
-      // The default kernel still tracks successful uses for inspection.
-      self.increment_uses(id);
-      return Ok(id);
-    }
-
-    Err(MechError::new(
-      CapabilityDeniedError {
-        subject: request.subject.clone(),
-        operation: request.operation.clone(),
-        resource: request.resource.clone(),
-        reason: last_reason.unwrap_or_else(|| "no matching capability".to_string()),
-      },
-      None,
-    ))
+  fn check_excluding(
+    &mut self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    self.check_with_exclusions(request, excluded)
   }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
@@ -434,7 +470,7 @@ impl CapabilityKernel for SharedCapabilityKernel {
   fn checkpoint(&self) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
     self.inner.lock().unwrap().checkpoint()
   }
-  fn restore_checkpoint(
+  fn restore(
     &mut self,
     checkpoint: Box<dyn CapabilityKernelCheckpoint>,
   ) -> MResult<()> {
@@ -442,12 +478,13 @@ impl CapabilityKernel for SharedCapabilityKernel {
       .inner
       .lock()
       .unwrap()
-      .restore_checkpoint(checkpoint)
+      .restore(checkpoint)
   }
   fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> { self.inner.lock().unwrap().grant(grant) }
   fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> { self.inner.lock().unwrap().rollback_grant(capability) }
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().check(request) }
+  fn check_excluding(&mut self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().check_excluding(request, excluded) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>> { self.inner.lock().unwrap().list_for_subject(subject) }
   fn derive_capability(&mut self, derivation: CapabilityDerivation) -> MResult<CapabilityId> { self.inner.lock().unwrap().derive_capability(derivation) }

--- a/src/runtime/src/effect.rs
+++ b/src/runtime/src/effect.rs
@@ -67,6 +67,32 @@ pub struct RuntimeEffectMetadata {
   pub cost: RuntimeEffectCost,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeEffectRecord {
+  pub id: RuntimeEffectId,
+  pub source: RuntimeEffectSource,
+  pub operation: String,
+  pub resource: Option<String>,
+  pub protocol: RuntimeEffectProtocol,
+}
+
+impl RuntimeEffectRecord {
+  pub fn new(
+    id: RuntimeEffectId,
+    metadata: RuntimeEffectMetadata,
+    protocol: RuntimeEffectProtocol,
+  ) -> Self {
+    Self {
+      id,
+      source: metadata.source,
+      operation: metadata.operation,
+      resource: metadata.resource,
+      protocol,
+    }
+  }
+}
+
 impl RuntimeEffectMetadata {
   pub fn new(
     source: RuntimeEffectSource,

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -15,6 +15,9 @@ use crate::id::{
   ActorId, CapabilityId, EventId, ModuleVersionId, ObjectId, RuntimeId, TaskId,
   TransactionId, MessageId
 };
+use crate::effect::{
+  RuntimeEffectId, RuntimeEffectProtocol, RuntimeEffectSource,
+};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -77,6 +80,30 @@ pub enum RuntimeEventKind {
   TransactionCommitted { transaction_id: TransactionId },
   TransactionAborted { transaction_id: TransactionId, message: String },
 
+  EffectStaged {
+    effect_id: RuntimeEffectId,
+    source: RuntimeEffectSource,
+    operation: String,
+    resource: Option<String>,
+    protocol: RuntimeEffectProtocol,
+  },
+  EffectPreparationFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
+  EffectCompensated { effect_id: RuntimeEffectId },
+  EffectAborted { effect_id: RuntimeEffectId },
+  TransactionalEffectCommitted { effect_id: RuntimeEffectId },
+  EffectDelivered { effect_id: RuntimeEffectId },
+  EffectDeliveryFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
+  ExternalCommitIndeterminate {
+    transaction_id: TransactionId,
+    effect_id: RuntimeEffectId,
+  },
+
   SchedulerWorkQueued { work: String },
   SchedulerWorkStarted { work: String },
   SchedulerWorkCompleted { work: String },
@@ -127,6 +154,22 @@ impl RuntimeEventKind {
       RuntimeEventKind::TransactionStarted { .. } => ":transaction/started",
       RuntimeEventKind::TransactionCommitted { .. } => ":transaction/committed",
       RuntimeEventKind::TransactionAborted { .. } => ":transaction/aborted",
+      RuntimeEventKind::EffectStaged { .. } => ":effect/staged",
+      RuntimeEventKind::EffectPreparationFailed { .. } => {
+        ":effect/preparation/failed"
+      }
+      RuntimeEventKind::EffectCompensated { .. } => ":effect/compensated",
+      RuntimeEventKind::EffectAborted { .. } => ":effect/aborted",
+      RuntimeEventKind::TransactionalEffectCommitted { .. } => {
+        ":effect/transactional/committed"
+      }
+      RuntimeEventKind::EffectDelivered { .. } => ":effect/delivered",
+      RuntimeEventKind::EffectDeliveryFailed { .. } => {
+        ":effect/delivery/failed"
+      }
+      RuntimeEventKind::ExternalCommitIndeterminate { .. } => {
+        ":effect/commit/indeterminate"
+      }
       RuntimeEventKind::SchedulerWorkQueued { .. } => ":scheduler/work/queued",
       RuntimeEventKind::SchedulerWorkStarted { .. } => ":scheduler/work/started",
       RuntimeEventKind::SchedulerWorkCompleted { .. } => ":scheduler/work/completed",

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -92,6 +92,10 @@ pub enum RuntimeEventKind {
     message: String,
   },
   EffectCompensated { effect_id: RuntimeEffectId },
+  EffectCompensationFailed {
+    effect_id: RuntimeEffectId,
+    message: String,
+  },
   EffectAborted { effect_id: RuntimeEffectId },
   TransactionalEffectCommitted { effect_id: RuntimeEffectId },
   EffectDelivered { effect_id: RuntimeEffectId },
@@ -159,6 +163,9 @@ impl RuntimeEventKind {
         ":effect/preparation/failed"
       }
       RuntimeEventKind::EffectCompensated { .. } => ":effect/compensated",
+      RuntimeEventKind::EffectCompensationFailed { .. } => {
+        ":effect/compensation/failed"
+      }
       RuntimeEventKind::EffectAborted { .. } => ":effect/aborted",
       RuntimeEventKind::TransactionalEffectCommitted { .. } => {
         ":effect/transactional/committed"

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -14,7 +14,7 @@
 use super::*;
 use crate::{
   CapabilityAlreadyExistsError, CapabilityNotFoundError,
-  CapabilityNotRevocableError, CapabilityRevokedError,
+  CapabilityNotRevocableError,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -29,6 +29,7 @@ pub(super) struct RuntimeCapabilityOverlay {
   operations: Vec<RuntimeCapabilityMutation>,
   grants: HashMap<CapabilityId, Arc<dyn Capability>>,
   revocations: HashSet<CapabilityId>,
+  uses: HashMap<CapabilityId, u64>,
 }
 
 impl RuntimeCapabilityOverlay {
@@ -80,20 +81,24 @@ impl RuntimeCapabilityOverlay {
     self.grants.get(&capability).cloned()
   }
 
-  pub(super) fn is_revoked(&self, capability: CapabilityId) -> bool {
-    self.revocations.contains(&capability)
-  }
-
   pub(super) fn check(
-    &self,
+    &mut self,
     request: &CapabilityRequest,
   ) -> MResult<Option<CapabilityId>> {
     for (id, capability) in &self.grants {
       if capability.subject_key() != request.subject {
         continue;
       }
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.uses.get(id).copied().unwrap_or(0);
+        if actual >= max_uses {
+          continue;
+        }
+      }
       let decision = capability.check(request)?;
       if decision.allowed {
+        let uses = self.uses.entry(*id).or_insert(0);
+        *uses = uses.saturating_add(1);
         return Ok(Some(*id));
       }
     }
@@ -113,6 +118,10 @@ impl RuntimeCapabilityOverlay {
     &self,
   ) -> impl Iterator<Item = CapabilityId> + '_ {
     self.revocations.iter().copied()
+  }
+
+  pub(super) fn revocation_ids(&self) -> HashSet<CapabilityId> {
+    self.revocations.clone()
   }
 
   pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
@@ -154,6 +163,7 @@ impl RuntimeCapabilityOverlay {
         }
       }
     }
+    self.uses.retain(|id, _| self.grants.contains_key(id));
   }
 }
 
@@ -395,24 +405,20 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     if let Some(transaction_id) = context.transaction {
-      let overlay = &self
-        .active_execution_transaction(transaction_id)?
-        .capabilities;
-      if let Some(capability) = overlay.check(request)? {
+      let provisional = self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .check(request)?;
+      if let Some(capability) = provisional {
         return Ok(capability);
       }
-      let capability = self.capability_kernel.check(request)?;
-      if self
+      let revocations = self
         .active_execution_transaction(transaction_id)?
         .capabilities
-        .is_revoked(capability)
-      {
-        return Err(MechError::new(
-          CapabilityRevokedError { capability },
-          None,
-        ));
-      }
-      return Ok(capability);
+        .revocation_ids();
+      return self
+        .capability_kernel
+        .check_excluding(request, &revocations);
     }
     self.capability_kernel.check(request)
   }
@@ -435,7 +441,8 @@ mod tests {
   use mech_core::{GenericError, MResult, MechError};
 
   use crate::capability::{
-    BasicCapability, BasicCapabilityKernel, CapabilityDerivation,
+    BasicCapability, BasicCapabilityKernel, BasicConstraints,
+    CapabilityDerivation,
     CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
   };
   use crate::id::{
@@ -585,7 +592,7 @@ mod tests {
       self.inner.checkpoint()
     }
 
-    fn restore_checkpoint(
+    fn restore(
       &mut self,
       _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
     ) -> MResult<()> {
@@ -1141,5 +1148,77 @@ mod tests {
     assert!(poison.rollback_failures.iter().any(|failure| {
       failure.contains("deliberate capability checkpoint restore failure")
     }));
+  }
+
+  #[test]
+  fn provisional_capability_enforces_use_limit() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let limited: Arc<dyn Capability> = Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(BasicConstraints {
+        max_uses: Some(1),
+        ..BasicConstraints::default()
+      }),
+    );
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(&mut context, limited)
+      .unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut context, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .is_err());
+  }
+
+  #[test]
+  fn provisional_revocation_does_not_consume_live_use_limit() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut administrative = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let limited: Arc<dyn Capability> = Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(BasicConstraints {
+        max_uses: Some(1),
+        ..BasicConstraints::default()
+      }),
+    );
+    runtime
+      .grant_capability_with_context(&mut administrative, limited)
+      .unwrap();
+
+    let mut owner = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .revoke_capability_with_context(&mut owner, id)
+      .unwrap();
+    assert!(runtime
+      .check_capability_with_context(&mut owner, &request("task:1"))
+      .is_err());
+    runtime
+      .abort_runtime_transaction(&mut owner, "test abort")
+      .unwrap();
+
+    assert_eq!(
+      runtime.check_capability(&request("task:1")).unwrap(),
+      id,
+    );
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -128,7 +128,7 @@ impl RuntimeCapabilityOverlay {
     let mut grants = HashSet::new();
     let mut revocations = HashSet::new();
     let mut mutations = Vec::new();
-    for operation in &self.operations {
+    for operation in self.operations.iter().rev() {
       match operation {
         RuntimeCapabilityMutation::Grant(capability)
           if self.grants.contains_key(&capability.id())
@@ -145,6 +145,7 @@ impl RuntimeCapabilityOverlay {
         _ => {}
       }
     }
+    mutations.reverse();
     mutations
   }
 
@@ -1111,6 +1112,47 @@ mod tests {
 
     assert!(runtime.get_capability(id).unwrap().is_none());
     assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn regrant_after_cancellation_commits_latest_capability() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .revoke_capability_with_context(&mut context, id)
+      .unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        Arc::new(BasicCapability::from_keys(
+          id,
+          "task:1",
+          "db://projects",
+          [":read"],
+        )),
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.check_capability(&request("task:1")).is_err());
+    assert_eq!(
+      runtime
+        .check_capability(&CapabilityRequest::from_keys(
+          "task:1",
+          ":read",
+          "db://projects",
+        ))
+        .unwrap(),
+      id,
+    );
   }
 
   #[test]

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -115,6 +115,30 @@ impl RuntimeCapabilityOverlay {
     self.revocations.iter().copied()
   }
 
+  pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
+    let mut grants = HashSet::new();
+    let mut revocations = HashSet::new();
+    let mut mutations = Vec::new();
+    for operation in &self.operations {
+      match operation {
+        RuntimeCapabilityMutation::Grant(capability)
+          if self.grants.contains_key(&capability.id())
+            && grants.insert(capability.id()) =>
+        {
+          mutations.push(operation.clone());
+        }
+        RuntimeCapabilityMutation::Revoke(capability)
+          if self.revocations.contains(capability)
+            && revocations.insert(*capability) =>
+        {
+          mutations.push(operation.clone());
+        }
+        _ => {}
+      }
+    }
+    mutations
+  }
+
   fn rebuild(&mut self) {
     self.grants.clear();
     self.revocations.clear();
@@ -411,8 +435,8 @@ mod tests {
   use mech_core::{GenericError, MResult, MechError};
 
   use crate::capability::{
-    BasicCapability, BasicCapabilityKernel, CapabilityDerivation, CapabilityGrant,
-    CapabilityKernel, Subject,
+    BasicCapability, BasicCapabilityKernel, CapabilityDerivation,
+    CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
   };
   use crate::id::{
     ActorId, EventId, IdGenerator, MessageId, NodeId, ObjectId, RuntimeId,
@@ -516,6 +540,70 @@ mod tests {
         },
         None,
       ))
+    }
+
+    fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
+      self.inner.revoke(revocation)
+    }
+
+    fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> {
+      self.inner.check(request)
+    }
+
+    fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
+      self.inner.get(id)
+    }
+
+    fn list_for_subject(
+      &self,
+      subject: &dyn Subject,
+    ) -> MResult<Vec<CapabilityId>> {
+      self.inner.list_for_subject(subject)
+    }
+
+    fn derive_capability(
+      &mut self,
+      derivation: CapabilityDerivation,
+    ) -> MResult<CapabilityId> {
+      self.inner.derive_capability(derivation)
+    }
+
+    fn is_revoked(&self, id: CapabilityId) -> MResult<bool> {
+      self.inner.is_revoked(id)
+    }
+  }
+
+  #[derive(Debug, Default)]
+  struct FailingCheckpointRestoreKernel {
+    inner: BasicCapabilityKernel,
+  }
+
+  impl CapabilityKernel for FailingCheckpointRestoreKernel {
+    fn checkpoint(
+      &self,
+    ) -> MResult<Box<dyn CapabilityKernelCheckpoint>> {
+      self.inner.checkpoint()
+    }
+
+    fn restore_checkpoint(
+      &mut self,
+      _checkpoint: Box<dyn CapabilityKernelCheckpoint>,
+    ) -> MResult<()> {
+      Err(MechError::new(
+        GenericError {
+          msg: "deliberate capability checkpoint restore failure"
+            .to_string(),
+        },
+        None,
+      ))
+    }
+
+    fn grant(&mut self, grant: CapabilityGrant) -> MResult<CapabilityId> {
+      self.inner.grant(grant)
+    }
+
+    fn rollback_grant(&mut self, capability: CapabilityId) -> MResult<()> {
+      self.inner.rollback_grant(capability)
     }
 
     fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> {
@@ -936,5 +1024,122 @@ mod tests {
     runtime
       .abort_runtime_transaction(&mut context, "test cleanup")
       .unwrap();
+  }
+
+  #[test]
+  fn capability_overlay_commits_kernel_and_store_together() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.get_capability(id).unwrap().is_some());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_some());
+    assert_eq!(runtime.check_capability(&request("task:1")).unwrap(), id);
+  }
+
+  #[test]
+  fn store_commit_failure_restores_capability_kernel_checkpoint() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    assert!(runtime.commit_runtime_transaction(&mut context).is_err());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn provisional_grant_then_revoke_cancels_commit_work() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .revoke_capability_with_context(&mut context, id)
+      .unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn capability_checkpoint_restore_failure_poisons_runtime() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .capability_kernel(FailingCheckpointRestoreKernel::default())
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeEffectCleanupFailed");
+    assert!(runtime.is_poisoned());
+    let RuntimeHealth::Poisoned(poison) = &runtime.health else {
+      panic!("runtime must retain capability cleanup failure");
+    };
+    assert!(poison.rollback_failures.iter().any(|failure| {
+      failure.contains("deliberate capability checkpoint restore failure")
+    }));
   }
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -12,6 +12,126 @@
 // Like with actors, there is a _with_context version of each method, allowing for transactional operations and proper event emission within the context of an active transaction.
 
 use super::*;
+use crate::{
+  CapabilityAlreadyExistsError, CapabilityNotFoundError,
+  CapabilityNotRevocableError, CapabilityRevokedError,
+};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Debug)]
+pub(super) enum RuntimeCapabilityMutation {
+  Grant(Arc<dyn Capability>),
+  Revoke(CapabilityId),
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RuntimeCapabilityOverlay {
+  operations: Vec<RuntimeCapabilityMutation>,
+  grants: HashMap<CapabilityId, Arc<dyn Capability>>,
+  revocations: HashSet<CapabilityId>,
+}
+
+impl RuntimeCapabilityOverlay {
+  pub(super) fn mark(&self) -> usize {
+    self.operations.len()
+  }
+
+  pub(super) fn is_empty(&self) -> bool {
+    self.grants.is_empty() && self.revocations.is_empty()
+  }
+
+  pub(super) fn stage_grant(&mut self, capability: Arc<dyn Capability>) {
+    self
+      .operations
+      .push(RuntimeCapabilityMutation::Grant(capability));
+    self.rebuild();
+  }
+
+  pub(super) fn stage_revocation(&mut self, capability: CapabilityId) {
+    self
+      .operations
+      .push(RuntimeCapabilityMutation::Revoke(capability));
+    self.rebuild();
+  }
+
+  pub(super) fn rollback_to(&mut self, mark: usize) -> MResult<()> {
+    if mark > self.operations.len() {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "rollback_capability_overlay",
+          reason: format!(
+            "capability savepoint mark {} exceeds overlay length {}",
+            mark,
+            self.operations.len(),
+          ),
+        },
+        None,
+      ));
+    }
+    self.operations.truncate(mark);
+    self.rebuild();
+    Ok(())
+  }
+
+  pub(super) fn provisional(
+    &self,
+    capability: CapabilityId,
+  ) -> Option<Arc<dyn Capability>> {
+    self.grants.get(&capability).cloned()
+  }
+
+  pub(super) fn is_revoked(&self, capability: CapabilityId) -> bool {
+    self.revocations.contains(&capability)
+  }
+
+  pub(super) fn check(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<Option<CapabilityId>> {
+    for (id, capability) in &self.grants {
+      if capability.subject_key() != request.subject {
+        continue;
+      }
+      let decision = capability.check(request)?;
+      if decision.allowed {
+        return Ok(Some(*id));
+      }
+    }
+    Ok(None)
+  }
+
+  pub(super) fn grants(
+    &self,
+  ) -> impl Iterator<Item = (CapabilityId, Arc<dyn Capability>)> + '_ {
+    self
+      .grants
+      .iter()
+      .map(|(id, capability)| (*id, capability.clone()))
+  }
+
+  pub(super) fn revocations(
+    &self,
+  ) -> impl Iterator<Item = CapabilityId> + '_ {
+    self.revocations.iter().copied()
+  }
+
+  fn rebuild(&mut self) {
+    self.grants.clear();
+    self.revocations.clear();
+    for operation in &self.operations {
+      match operation {
+        RuntimeCapabilityMutation::Grant(capability) => {
+          self.grants.insert(capability.id(), capability.clone());
+        }
+        RuntimeCapabilityMutation::Revoke(capability) => {
+          if self.grants.remove(capability).is_none() {
+            self.revocations.insert(*capability);
+          }
+        }
+      }
+    }
+  }
+}
 
 fn finish_failed_capability_grant(
   capability: CapabilityId,
@@ -51,6 +171,55 @@ impl MechRuntime {
     capability.validate()?;
 
     let id = capability.id();
+
+    if let Some(transaction_id) = context.transaction {
+      if self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .provisional(id)
+        .is_some()
+        || self.capability_kernel.get(id)?.is_some()
+      {
+        return Err(MechError::new(
+          CapabilityAlreadyExistsError { capability: id },
+          None,
+        ));
+      }
+
+      let store_before = self
+        .active_execution_transaction(transaction_id)?
+        .store
+        .clone();
+      let overlay_mark = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .mark();
+      let context_events_before = context.events.clone();
+      let context_capabilities_before = context.capabilities.clone();
+
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_grant(capability);
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::CapabilityGranted {
+          capability_id: id,
+        },
+      ) {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        let rollback_result =
+          transaction.capabilities.rollback_to(overlay_mark);
+        context.events = context_events_before;
+        context.capabilities = context_capabilities_before;
+        rollback_result?;
+        return Err(error);
+      }
+      context.add_capability(id);
+      return Ok(id);
+    }
 
     self.store.grant_capability(id, capability.clone())?;
 
@@ -112,6 +281,64 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
+    if let Some(transaction_id) = context.transaction {
+      let staged = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .provisional(capability);
+      let live = if staged.is_none() {
+        self.capability_kernel.get(capability)?
+      } else {
+        None
+      };
+      let Some(existing) = staged.or(live) else {
+        return Err(MechError::new(
+          CapabilityNotFoundError { capability },
+          None,
+        ));
+      };
+      if !existing.is_revocable() {
+        return Err(MechError::new(
+          CapabilityNotRevocableError { capability },
+          None,
+        ));
+      }
+
+      let store_before = self
+        .active_execution_transaction(transaction_id)?
+        .store
+        .clone();
+      let overlay_mark = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .mark();
+      let context_events_before = context.events.clone();
+      let context_capabilities_before = context.capabilities.clone();
+
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_revocation(capability);
+      context.remove_capability(capability);
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::CapabilityRevoked {
+          capability_id: capability,
+        },
+      ) {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        let rollback_result =
+          transaction.capabilities.rollback_to(overlay_mark);
+        context.events = context_events_before;
+        context.capabilities = context_capabilities_before;
+        rollback_result?;
+        return Err(error);
+      }
+      return Ok(());
+    }
+
     self
       .capability_kernel
       .revoke(CapabilityRevocation::new(capability))?;
@@ -143,6 +370,26 @@ impl MechRuntime {
   ) -> MResult<CapabilityId> {
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
+    if let Some(transaction_id) = context.transaction {
+      let overlay = &self
+        .active_execution_transaction(transaction_id)?
+        .capabilities;
+      if let Some(capability) = overlay.check(request)? {
+        return Ok(capability);
+      }
+      let capability = self.capability_kernel.check(request)?;
+      if self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .is_revoked(capability)
+      {
+        return Err(MechError::new(
+          CapabilityRevokedError { capability },
+          None,
+        ));
+      }
+      return Ok(capability);
+    }
     self.capability_kernel.check(request)
   }
 
@@ -570,5 +817,124 @@ mod tests {
         .count(),
       1,
     );
+  }
+
+  #[test]
+  fn provisional_capability_grant_is_visible_only_to_its_transaction() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut owner = runtime.runtime_context().unwrap();
+    let mut observer = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut owner,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut owner, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(runtime
+      .check_capability_with_context(&mut observer, &request("task:1"))
+      .is_err());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+
+    runtime.abort_runtime_transaction(&mut owner, "test abort").unwrap();
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    assert!(runtime.capability_kernel().get(id).unwrap().is_none());
+  }
+
+  #[test]
+  fn provisional_revocation_does_not_leak_to_other_transactions() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut administrative = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        capability(id, "task:1", true),
+      )
+      .unwrap();
+
+    let mut owner = runtime.runtime_context().unwrap();
+    let mut observer = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+    runtime
+      .revoke_capability_with_context(&mut owner, id)
+      .unwrap();
+
+    assert!(runtime
+      .check_capability_with_context(&mut owner, &request("task:1"))
+      .is_err());
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut observer, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    assert!(!runtime.capability_kernel().is_revoked(id).unwrap());
+
+    runtime.abort_runtime_transaction(&mut owner, "test abort").unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut owner, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+  }
+
+  #[test]
+  fn failed_retained_operation_truncates_capability_overlay() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(SequentialIdGenerator::starting_at(1))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let id = CapabilityId(100);
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "test_capability_overlay",
+      |runtime, context| {
+        runtime.grant_capability_with_context(
+          context,
+          capability(id, "task:1", true),
+        )?;
+        Err(MechError::new(
+          GenericError {
+            msg: "deliberate operation failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    assert_eq!(result.unwrap_err().kind_name(), "GenericError");
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .capabilities
+      .is_empty());
+    assert!(runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .is_err());
+    assert!(runtime.get_capability(id).unwrap().is_none());
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
   }
 }

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::{
   PreparedRuntimeEffect, RuntimeEffectFailure, RuntimeEffectFailurePhase,
-  RuntimeEffectId,
+  RuntimeEffectId, RuntimeEffectRecord,
 };
 #[cfg(test)]
 use crate::{
@@ -41,6 +41,7 @@ pub(super) struct RuntimeEffectStepFailure {
 pub(super) struct RuntimeEffectCommitFailure {
   pub(super) step: RuntimeEffectStepFailure,
   pub(super) participant_outcomes: Vec<String>,
+  pub(super) committed: Vec<RuntimeEffectId>,
 }
 
 #[derive(Debug, Default)]
@@ -60,6 +61,64 @@ impl RuntimeEffectJournal {
 
   pub(super) fn is_empty(&self) -> bool {
     self.entries.is_empty()
+  }
+
+  pub(super) fn records(&self) -> Vec<RuntimeEffectRecord> {
+    self.entries.iter().map(|entry| {
+      RuntimeEffectRecord::new(
+        entry.id,
+        entry.effect.metadata(),
+        entry.effect.protocol(),
+      )
+    }).collect()
+  }
+
+  pub(super) fn prepared_transactional_ids(
+    &self,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if entry.state == RuntimeEffectState::Prepared
+        && matches!(entry.effect, PreparedRuntimeEffect::Transactional(_))
+      {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn applied_compensatable_ids(
+    &self,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if entry.state == RuntimeEffectState::Applied
+        && matches!(entry.effect, PreparedRuntimeEffect::Compensatable(_))
+      {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn after_commit_ids(&self) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+        Some(entry.id)
+      } else {
+        None
+      }
+    }).collect()
+  }
+
+  pub(super) fn abortable_ids(&self) -> Vec<RuntimeEffectId> {
+    self.entries.iter().filter_map(|entry| {
+      if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+        None
+      } else {
+        Some(entry.id)
+      }
+    }).collect()
   }
 
   pub(super) fn validate_active(
@@ -309,8 +368,9 @@ impl RuntimeEffectJournal {
 
   pub(super) fn commit_transactional(
     &mut self,
-  ) -> Result<Vec<String>, RuntimeEffectCommitFailure> {
+  ) -> Result<Vec<RuntimeEffectId>, RuntimeEffectCommitFailure> {
     let mut outcomes = Vec::new();
+    let mut committed = Vec::new();
     for entry in &mut self.entries {
       if entry.state != RuntimeEffectState::Prepared {
         continue;
@@ -319,10 +379,13 @@ impl RuntimeEffectJournal {
         continue;
       };
       match effect.commit() {
-        Ok(()) => outcomes.push(format!(
-          "transactional effect {} committed",
-          entry.id,
-        )),
+        Ok(()) => {
+          outcomes.push(format!(
+            "transactional effect {} committed",
+            entry.id,
+          ));
+          committed.push(entry.id);
+        }
         Err(error) => {
           let step = effect_step_failure(
             entry.id,
@@ -337,11 +400,12 @@ impl RuntimeEffectJournal {
           return Err(RuntimeEffectCommitFailure {
             step,
             participant_outcomes: outcomes,
+            committed,
           });
         }
       }
     }
-    Ok(outcomes)
+    Ok(committed)
   }
 
   pub(super) fn deliver_after_commit(
@@ -506,15 +570,55 @@ impl MechRuntime {
       ));
     }
     let cost = effect.cost();
+    let metadata = effect.metadata();
+    let protocol = effect.protocol();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;
+    let store_before = self
+      .active_execution_transaction(transaction_id)?
+      .store
+      .clone();
+    let effect_mark = self
+      .active_execution_transaction(transaction_id)?
+      .effects
+      .mark();
+    let context_events_before = context.events.clone();
+    let effect_id = self
+      .active_execution_transaction_mut(transaction_id)?
+      .effects
+      .stage(transaction_id, effect);
 
-    Ok(
-      self
-        .active_execution_transaction_mut(transaction_id)?
-        .effects
-        .stage(transaction_id, effect),
-    )
+    if let Err(error) = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::EffectStaged {
+        effect_id,
+        source: metadata.source,
+        operation: metadata.operation,
+        resource: metadata.resource,
+        protocol,
+      },
+    ) {
+      self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+      let cleanup = {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        transaction.effects.rollback_to(effect_mark)
+      };
+      self.active_effect_phase = None;
+      context.events = context_events_before;
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "stage_runtime_effect_with_context",
+        transaction_id,
+        format!("{:?}", error),
+        Self::describe_effect_failures(cleanup),
+      ));
+    }
+
+    Ok(effect_id)
   }
 
   pub(super) fn stage_runtime_resource_effect_with_context(
@@ -549,21 +653,61 @@ impl MechRuntime {
       ));
     }
     let cost = effect.cost();
+    let metadata = effect.metadata();
+    let protocol = effect.protocol();
     context.charge_bytes(cost.bytes)?;
     context.charge_items(cost.items)?;
+    let store_before = self
+      .active_execution_transaction(transaction_id)?
+      .store
+      .clone();
+    let effect_mark = self
+      .active_execution_transaction(transaction_id)?
+      .effects
+      .mark();
+    let context_events_before = context.events.clone();
+    let effect_id = self
+      .active_execution_transaction_mut(transaction_id)?
+      .effects
+      .stage_resource_write(
+        transaction_id,
+        effect,
+        base_uri,
+        path,
+        value,
+      );
 
-    Ok(
-      self
-        .active_execution_transaction_mut(transaction_id)?
-        .effects
-        .stage_resource_write(
-          transaction_id,
-          effect,
-          base_uri,
-          path,
-          value,
-        ),
-    )
+    if let Err(error) = self.emit_event_to_context(
+      context,
+      RuntimeEventKind::EffectStaged {
+        effect_id,
+        source: metadata.source,
+        operation: metadata.operation,
+        resource: metadata.resource,
+        protocol,
+      },
+    ) {
+      self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
+      let cleanup = {
+        let transaction =
+          self.active_execution_transaction_mut(transaction_id)?;
+        transaction.store = store_before;
+        transaction.effects.rollback_to(effect_mark)
+      };
+      self.active_effect_phase = None;
+      context.events = context_events_before;
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "stage_runtime_resource_effect_with_context",
+        transaction_id,
+        format!("{:?}", error),
+        Self::describe_effect_failures(cleanup),
+      ));
+    }
+
+    Ok(effect_id)
   }
 
   pub(super) fn execute_runtime_effect_immediately(
@@ -849,6 +993,28 @@ mod tests {
   }
 
   #[derive(Debug)]
+  struct SensitiveAfterCommit {
+    secret_payload: String,
+  }
+
+  impl RuntimeAfterCommitEffect for SensitiveAfterCommit {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "sensitive-test".to_string(),
+        },
+        "deliver",
+      )
+      .with_resource("test://metadata-only")
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      assert!(!self.secret_payload.is_empty());
+      Ok(())
+    }
+  }
+
+  #[derive(Debug)]
   struct CostedAfterCommit {
     cost: crate::RuntimeEffectCost,
   }
@@ -895,6 +1061,86 @@ mod tests {
 
     assert_eq!(journal.len(), 2);
     assert_eq!(journal.next_sequence(), 3);
+  }
+
+  #[test]
+  fn transaction_history_persists_effect_metadata_without_payload() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let secret = "raw-secret-payload-must-not-be-durable";
+    let effect_id = runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          SensitiveAfterCommit {
+            secret_payload: secret.to_string(),
+          },
+        )),
+      )
+      .unwrap();
+
+    runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    let transaction = runtime
+      .get_transaction(transaction_id)
+      .unwrap()
+      .unwrap();
+    assert_eq!(transaction.effects.len(), 1);
+    assert_eq!(transaction.effects[0].id, effect_id);
+    assert_eq!(
+      transaction.effects[0].protocol,
+      crate::RuntimeEffectProtocol::AfterCommit,
+    );
+    assert_eq!(
+      transaction.effects[0].resource.as_deref(),
+      Some("test://metadata-only"),
+    );
+    assert!(!format!("{:?}", transaction).contains(secret));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectDelivered { effect_id: delivered }
+          if delivered == effect_id
+      )
+    }));
+  }
+
+  #[test]
+  fn savepoint_rollback_discards_effect_and_staging_event() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    let result: MResult<RuntimeEffectId> =
+      runtime.with_atomic_program_operation(
+        &mut context,
+        "effect_staging_event_rollback",
+        |runtime, context| {
+          let effect_id = runtime.stage_runtime_effect_with_context(
+            context,
+            effect("rolled-back"),
+          )?;
+          Err(synthetic_error(format!(
+            "deliberate rollback for {}",
+            effect_id,
+          )))
+        },
+      );
+
+    assert_eq!(result.unwrap_err().kind_name(), "SyntheticEffectError");
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .effects
+      .is_empty());
+    assert!(!context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectStaged { .. })
+    }));
+    runtime
+      .abort_runtime_transaction(&mut context, "test cleanup")
+      .unwrap();
   }
 
   #[test]
@@ -980,6 +1226,15 @@ mod tests {
       RuntimeExecutionTransactionState::Active,
     );
     assert!(!runtime.is_poisoned());
+    assert!(context.events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectPreparationFailed { .. }
+      )
+    }));
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectAborted { .. })
+    }));
 
     runtime
       .abort_runtime_transaction(&mut context, "prepare test cleanup")
@@ -1089,6 +1344,12 @@ mod tests {
     );
     assert_eq!(context.transaction, Some(transaction_id));
     assert!(!runtime.is_poisoned());
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectCompensated { .. })
+    }));
+    assert!(context.events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectAborted { .. })
+    }));
 
     runtime
       .abort_runtime_transaction(&mut context, "apply test cleanup")
@@ -1234,6 +1495,19 @@ mod tests {
       .get_transaction(transaction_id)
       .unwrap()
       .is_some());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::TransactionalEffectCommitted { .. }
+      )
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::ExternalCommitIndeterminate { .. }
+      )
+    }));
   }
 
   #[test]
@@ -1290,6 +1564,19 @@ mod tests {
       .get_transaction(transaction_id)
       .unwrap()
       .is_some());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::EffectDelivered { .. })
+    }));
+    assert!(events.iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectDeliveryFailed {
+          effect_id,
+          ..
+        } if effect_id == failing_effect_id
+      )
+    }));
   }
 
   #[test]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -1436,6 +1436,12 @@ mod tests {
       .rollback_failures
       .iter()
       .any(|failure| failure.contains("first compensate failed")));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::EffectCompensationFailed { .. }
+      )
+    }));
 
     assert!(runtime
       .abort_runtime_transaction(&mut context, "poison test cleanup")

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -47,6 +47,7 @@ use self::program_transaction::{
   RuntimeExecutionTransactionState,
   RuntimeTransactionContextIdentity,
 };
+use self::capability::RuntimeCapabilityOverlay;
 use self::effect::RuntimeEffectJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -47,7 +47,9 @@ use self::program_transaction::{
   RuntimeExecutionTransactionState,
   RuntimeTransactionContextIdentity,
 };
-use self::capability::RuntimeCapabilityOverlay;
+use self::capability::{
+  RuntimeCapabilityMutation, RuntimeCapabilityOverlay,
+};
 use self::effect::RuntimeEffectJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -180,6 +180,7 @@ pub(super) struct RuntimeExecutionTransaction {
   pub(super) context_baseline: RuntimeContextCheckpoint,
   pub(super) program: Option<RuntimeProgramBaseline>,
   pub(super) effects: RuntimeEffectJournal,
+  pub(super) capabilities: RuntimeCapabilityOverlay,
   pub(super) state: RuntimeExecutionTransactionState,
 }
 
@@ -197,6 +198,7 @@ impl RuntimeExecutionTransaction {
       context_baseline,
       program: None,
       effects: RuntimeEffectJournal::new(),
+      capabilities: RuntimeCapabilityOverlay::default(),
       state: RuntimeExecutionTransactionState::Active,
     }
   }
@@ -208,6 +210,7 @@ pub(super) struct RuntimeProgramOperationSavepoint {
   pub(super) live: RuntimeLiveStateSnapshot,
   pub(super) store: RuntimeTransaction,
   pub(super) effect_mark: usize,
+  pub(super) capability_mark: usize,
   pub(super) context: RuntimeContextCheckpoint,
 }
 
@@ -387,15 +390,24 @@ impl MechRuntime {
         let effect_failures =
           transaction.effects.rollback_to(savepoint.effect_mark);
         transaction.store = savepoint.store.clone();
-        Some(effect_failures)
+        let capability_result = transaction
+          .capabilities
+          .rollback_to(savepoint.capability_mark);
+        Some((effect_failures, capability_result))
       }
       None => None,
     };
     self.active_effect_phase = None;
     match effect_rollback {
-      Some(effect_failures) => failures.extend(
-        Self::describe_effect_failures(effect_failures),
-      ),
+      Some((effect_failures, capability_result)) => {
+        failures.extend(Self::describe_effect_failures(effect_failures));
+        if let Err(error) = capability_result {
+          failures.push(format!(
+            "capability overlay rollback failed: {:?}",
+            error,
+          ));
+        }
+      }
       None => failures.push(format!(
         "active execution transaction {} disappeared before operation rollback",
         transaction_id,
@@ -678,6 +690,10 @@ impl MechRuntime {
       effect_mark: self
         .active_execution_transaction(transaction_id)?
         .effects
+        .mark(),
+      capability_mark: self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
         .mark(),
       context: RuntimeContextCheckpoint::capture(context),
     };

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -17,7 +17,9 @@
 // - `context_transaction_id`: Retrieves the active transaction ID from the context.
 
 use super::*;
-use crate::{AccessSet, RuntimeCommitOutcome};
+use crate::{
+  AccessSet, CapabilityKernelCheckpoint, RuntimeCommitOutcome,
+};
 
 impl MechRuntime {
 
@@ -227,7 +229,7 @@ impl MechRuntime {
         )
       })?;
 
-    if envelope.effects.is_empty() {
+    if envelope.effects.is_empty() && envelope.capabilities.is_empty() {
       let commit_event =
         self.make_event(RuntimeEventKind::TransactionCommitted {
           transaction_id,
@@ -284,13 +286,60 @@ impl MechRuntime {
       ));
     }
 
+    let capability_checkpoint = if envelope.capabilities.is_empty() {
+      None
+    } else {
+      match self.capability_kernel.checkpoint() {
+        Ok(checkpoint) => Some(checkpoint),
+        Err(error) => {
+          let original_error_text = format!("{:?}", error);
+          self.active_effect_phase =
+            Some(ActiveRuntimeEffectPhase::Aborting);
+          let aborted = envelope.effects.abort_prepared_reverse();
+          self.active_effect_phase = None;
+          envelope.state = RuntimeExecutionTransactionState::Active;
+          self.active_transactions.insert(transaction_id, envelope);
+          if aborted.is_empty() {
+            return Err(error);
+          }
+          return Err(self.poison_effect_cleanup(
+            "commit_runtime_transaction",
+            transaction_id,
+            original_error_text,
+            Self::describe_effect_failures(aborted),
+          ));
+        }
+      }
+    };
+
+    if let Err(error) = self.apply_capability_overlay(&envelope) {
+      let original_error_text = format!("{:?}", error);
+      let cleanup = self.cleanup_before_store_retry(
+        &mut envelope,
+        capability_checkpoint,
+      );
+      envelope.state = RuntimeExecutionTransactionState::Active;
+      self.active_transactions.insert(transaction_id, envelope);
+      if cleanup.is_empty() {
+        return Err(error);
+      }
+      return Err(self.poison_effect_cleanup(
+        "commit_runtime_transaction",
+        transaction_id,
+        original_error_text,
+        cleanup,
+      ));
+    }
+
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Applying);
     let apply_result = envelope.effects.apply_compensatable();
     self.active_effect_phase = None;
     if let Err(step) = apply_result {
       let original_error_text = format!("{:?}", step.error);
-      let cleanup =
-        self.cleanup_effects_before_store_retry(&mut envelope);
+      let cleanup = self.cleanup_before_store_retry(
+        &mut envelope,
+        capability_checkpoint,
+      );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
       if cleanup.is_empty() {
@@ -315,8 +364,10 @@ impl MechRuntime {
       Ok(commit) => commit,
       Err(error) => {
         let original_error_text = format!("{:?}", error);
-        let cleanup =
-          self.cleanup_effects_before_store_retry(&mut envelope);
+        let cleanup = self.cleanup_before_store_retry(
+          &mut envelope,
+          capability_checkpoint,
+        );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
         if cleanup.is_empty() {
@@ -335,8 +386,10 @@ impl MechRuntime {
       Ok(id) => id,
       Err(error) => {
         let original_error_text = format!("{:?}", error);
-        let cleanup =
-          self.cleanup_effects_before_store_retry(&mut envelope);
+        let cleanup = self.cleanup_before_store_retry(
+          &mut envelope,
+          capability_checkpoint,
+        );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
         if cleanup.is_empty() {
@@ -383,19 +436,51 @@ impl MechRuntime {
     })
   }
 
-  fn cleanup_effects_before_store_retry(
+  fn cleanup_before_store_retry(
     &mut self,
     envelope: &mut RuntimeExecutionTransaction,
+    capability_checkpoint: Option<Box<dyn CapabilityKernelCheckpoint>>,
   ) -> Vec<String> {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Compensating);
     let compensated = envelope.effects.compensate_applied_reverse();
+    let capability_restore = capability_checkpoint
+      .map(|checkpoint| {
+        self.capability_kernel.restore_checkpoint(checkpoint)
+      });
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let aborted = envelope.effects.abort_prepared_reverse();
     self.active_effect_phase = None;
 
     let mut failures = Self::describe_effect_failures(compensated);
+    if let Some(Err(error)) = capability_restore {
+      failures.push(format!(
+        "capability kernel checkpoint restore failed: {:?}",
+        error,
+      ));
+    }
     failures.extend(Self::describe_effect_failures(aborted));
     failures
+  }
+
+  fn apply_capability_overlay(
+    &mut self,
+    envelope: &RuntimeExecutionTransaction,
+  ) -> MResult<()> {
+    for mutation in envelope.capabilities.mutations() {
+      match mutation {
+        RuntimeCapabilityMutation::Grant(capability) => {
+          self
+            .capability_kernel
+            .grant(CapabilityGrant::new(capability))?;
+        }
+        RuntimeCapabilityMutation::Revoke(capability) => {
+          self
+            .capability_kernel
+            .revoke(CapabilityRevocation::new(capability))?;
+        }
+      }
+    }
+    Ok(())
   }
 
   fn build_runtime_store_commit(
@@ -439,6 +524,11 @@ impl MechRuntime {
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
+      capability_grants: envelope.capabilities.grants().collect(),
+      capability_revocations: envelope
+        .capabilities
+        .revocations()
+        .collect(),
       object_puts: staged_puts,
       object_updates: staged_updates,
       task_updates: staged_task_updates,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -19,6 +19,7 @@
 use super::*;
 use crate::{
   AccessSet, CapabilityKernelCheckpoint, RuntimeCommitOutcome,
+  RuntimeEffectFailure, RuntimeEffectFailurePhase,
 };
 
 impl MechRuntime {
@@ -270,9 +271,48 @@ impl MechRuntime {
     self.active_effect_phase = None;
     if let Err(step) = prepare_result {
       let original_error_text = format!("{:?}", step.error);
+      let prepared_ids =
+        envelope.effects.prepared_transactional_ids();
       self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
-      let cleanup = envelope.effects.abort_prepared_reverse();
+      let mut cleanup = envelope.effects.abort_prepared_reverse();
       self.active_effect_phase = None;
+      let failed_ids: HashSet<RuntimeEffectId> = cleanup
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect();
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        &mut envelope,
+        context,
+        RuntimeEventKind::EffectPreparationFailed {
+          effect_id: step.failure.effect_id,
+          message: step.failure.message.clone(),
+        },
+      ) {
+        cleanup.push(RuntimeEffectFailure {
+          effect_id: step.failure.effect_id,
+          phase: RuntimeEffectFailurePhase::Abort,
+          message: format!(
+            "preparation failure audit event failed: {:?}",
+            error,
+          ),
+        });
+      }
+      for effect_id in prepared_ids {
+        if failed_ids.contains(&effect_id) {
+          continue;
+        }
+        if let Err(error) = self.stage_effect_lifecycle_event(
+          &mut envelope,
+          context,
+          RuntimeEventKind::EffectAborted { effect_id },
+        ) {
+          cleanup.push(RuntimeEffectFailure {
+            effect_id,
+            phase: RuntimeEffectFailurePhase::Abort,
+            message: format!("abort audit event failed: {:?}", error),
+          });
+        }
+      }
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
       if cleanup.is_empty() {
@@ -293,10 +333,37 @@ impl MechRuntime {
         Ok(checkpoint) => Some(checkpoint),
         Err(error) => {
           let original_error_text = format!("{:?}", error);
+          let prepared_ids =
+            envelope.effects.prepared_transactional_ids();
           self.active_effect_phase =
             Some(ActiveRuntimeEffectPhase::Aborting);
-          let aborted = envelope.effects.abort_prepared_reverse();
+          let mut aborted = envelope.effects.abort_prepared_reverse();
           self.active_effect_phase = None;
+          let failed_ids: HashSet<RuntimeEffectId> = aborted
+            .iter()
+            .map(|failure| failure.effect_id)
+            .collect();
+          for effect_id in prepared_ids {
+            if failed_ids.contains(&effect_id) {
+              continue;
+            }
+            if let Err(audit_error) =
+              self.stage_effect_lifecycle_event(
+                &mut envelope,
+                context,
+                RuntimeEventKind::EffectAborted { effect_id },
+              )
+            {
+              aborted.push(RuntimeEffectFailure {
+                effect_id,
+                phase: RuntimeEffectFailurePhase::Abort,
+                message: format!(
+                  "abort audit event failed: {:?}",
+                  audit_error,
+                ),
+              });
+            }
+          }
           envelope.state = RuntimeExecutionTransactionState::Active;
           self.active_transactions.insert(transaction_id, envelope);
           if aborted.is_empty() {
@@ -317,6 +384,7 @@ impl MechRuntime {
       let cleanup = self.cleanup_before_store_retry(
         &mut envelope,
         capability_checkpoint,
+        context,
       );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -339,6 +407,7 @@ impl MechRuntime {
       let cleanup = self.cleanup_before_store_retry(
         &mut envelope,
         capability_checkpoint,
+        context,
       );
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -367,6 +436,7 @@ impl MechRuntime {
         let cleanup = self.cleanup_before_store_retry(
           &mut envelope,
           capability_checkpoint,
+          context,
         );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
@@ -389,6 +459,7 @@ impl MechRuntime {
         let cleanup = self.cleanup_before_store_retry(
           &mut envelope,
           capability_checkpoint,
+          context,
         );
         envelope.state = RuntimeExecutionTransactionState::Active;
         self.active_transactions.insert(transaction_id, envelope);
@@ -407,18 +478,47 @@ impl MechRuntime {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Committing);
     let participant_result = envelope.effects.commit_transactional();
     self.active_effect_phase = None;
-    if let Err(commit_failure) = participant_result {
-      context.transaction = None;
-      if self.program_transaction_owner == Some(transaction_id) {
-        self.program_transaction_owner = None;
+    let committed_effects = match participant_result {
+      Ok(committed_effects) => committed_effects,
+      Err(commit_failure) => {
+        context.transaction = None;
+        if self.program_transaction_owner == Some(transaction_id) {
+          self.program_transaction_owner = None;
+        }
+        self.push_persisted_event_to_context(context, commit_event);
+        let mut participant_outcomes =
+          commit_failure.participant_outcomes;
+        for effect_id in commit_failure.committed {
+          if let Err(error) = self.emit_event_to_context(
+            context,
+            RuntimeEventKind::TransactionalEffectCommitted { effect_id },
+          ) {
+            participant_outcomes.push(format!(
+              "transactional effect {} commit audit failed: {:?}",
+              effect_id,
+              error,
+            ));
+          }
+        }
+        if let Err(error) = self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ExternalCommitIndeterminate {
+            transaction_id: id,
+            effect_id: commit_failure.step.failure.effect_id,
+          },
+        ) {
+          participant_outcomes.push(format!(
+            "external commit indeterminate audit failed: {:?}",
+            error,
+          ));
+        }
+        return Err(self.poison_external_commit_indeterminate(
+          id,
+          commit_failure.step.failure.effect_id,
+          participant_outcomes,
+        ));
       }
-      self.push_persisted_event_to_context(context, commit_event);
-      return Err(self.poison_external_commit_indeterminate(
-        id,
-        commit_failure.step.failure.effect_id,
-        commit_failure.participant_outcomes,
-      ));
-    }
+    };
 
     context.transaction = None;
     if self.program_transaction_owner == Some(transaction_id) {
@@ -426,9 +526,46 @@ impl MechRuntime {
     }
     self.push_persisted_event_to_context(context, commit_event);
 
+    for effect_id in committed_effects {
+      if let Err(error) = self.emit_event_to_context(
+        context,
+        RuntimeEventKind::TransactionalEffectCommitted { effect_id },
+      ) {
+        return Err(self.poison_external_commit_indeterminate(
+          id,
+          effect_id,
+          vec![format!(
+            "transactional effect {} committed but its audit event failed: {:?}",
+            effect_id,
+            error,
+          )],
+        ));
+      }
+    }
+
+    let after_commit_ids = envelope.effects.after_commit_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Delivering);
-    let delivery_failures = envelope.effects.deliver_after_commit();
+    let mut delivery_failures = envelope.effects.deliver_after_commit();
     self.active_effect_phase = None;
+    for effect_id in after_commit_ids {
+      let kind = match delivery_failures
+        .iter()
+        .find(|failure| failure.effect_id == effect_id)
+      {
+        Some(failure) => RuntimeEventKind::EffectDeliveryFailed {
+          effect_id,
+          message: failure.message.clone(),
+        },
+        None => RuntimeEventKind::EffectDelivered { effect_id },
+      };
+      if let Err(error) = self.emit_event_to_context(context, kind) {
+        delivery_failures.push(RuntimeEffectFailure {
+          effect_id,
+          phase: RuntimeEffectFailurePhase::Deliver,
+          message: format!("delivery audit event failed: {:?}", error),
+        });
+      }
+    }
 
     Ok(RuntimeCommitOutcome {
       transaction_id: id,
@@ -440,17 +577,29 @@ impl MechRuntime {
     &mut self,
     envelope: &mut RuntimeExecutionTransaction,
     capability_checkpoint: Option<Box<dyn CapabilityKernelCheckpoint>>,
+    context: &mut RuntimeContext,
   ) -> Vec<String> {
+    let compensated_ids =
+      envelope.effects.applied_compensatable_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Compensating);
     let compensated = envelope.effects.compensate_applied_reverse();
     let capability_restore = capability_checkpoint
       .map(|checkpoint| {
         self.capability_kernel.restore_checkpoint(checkpoint)
       });
+    let aborted_ids = envelope.effects.prepared_transactional_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let aborted = envelope.effects.abort_prepared_reverse();
     self.active_effect_phase = None;
 
+    let failed_compensations: HashSet<RuntimeEffectId> = compensated
+      .iter()
+      .map(|failure| failure.effect_id)
+      .collect();
+    let failed_aborts: HashSet<RuntimeEffectId> = aborted
+      .iter()
+      .map(|failure| failure.effect_id)
+      .collect();
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
       failures.push(format!(
@@ -459,7 +608,57 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
+    for effect_id in compensated_ids {
+      if failed_compensations.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        envelope,
+        context,
+        RuntimeEventKind::EffectCompensated { effect_id },
+      ) {
+        failures.push(format!(
+          "effect {} compensation audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
+    }
+    for effect_id in aborted_ids {
+      if failed_aborts.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.stage_effect_lifecycle_event(
+        envelope,
+        context,
+        RuntimeEventKind::EffectAborted { effect_id },
+      ) {
+        failures.push(format!(
+          "effect {} abort audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
+    }
     failures
+  }
+
+  fn stage_effect_lifecycle_event(
+    &mut self,
+    envelope: &mut RuntimeExecutionTransaction,
+    context: &mut RuntimeContext,
+    kind: RuntimeEventKind,
+  ) -> MResult<EventId> {
+    let context_events_before = context.events.clone();
+    let event = self.make_event(kind);
+    let id = event.id;
+    context.push_event(event.clone());
+    self.trim_events_to_retention(&mut context.events);
+    if let Err(error) = envelope.store.stage_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
+    Ok(id)
   }
 
   fn apply_capability_overlay(
@@ -520,7 +719,9 @@ impl MechRuntime {
 
     let mut transaction_snapshot = transaction.clone();
     transaction_snapshot.record_event(commit_event.id)?;
-    let transaction_record = transaction_snapshot.into_record()?;
+    let transaction_record = transaction_snapshot
+      .into_record()?
+      .with_effects(envelope.effects.records());
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
@@ -626,9 +827,15 @@ impl MechRuntime {
       ));
     }
 
+    let abortable_effects = envelope.effects.abortable_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let effect_abort_failures = envelope.effects.abort_all();
     self.active_effect_phase = None;
+    let failed_effect_aborts: HashSet<RuntimeEffectId> =
+      effect_abort_failures
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect();
     rollback_failures.extend(
       Self::describe_effect_failures(effect_abort_failures),
     );
@@ -642,6 +849,22 @@ impl MechRuntime {
 
     if owns_program {
       self.program_transaction_owner = None;
+    }
+
+    for effect_id in abortable_effects {
+      if failed_effect_aborts.contains(&effect_id) {
+        continue;
+      }
+      if let Err(error) = self.emit_event_immediate_to_context(
+        context,
+        RuntimeEventKind::EffectAborted { effect_id },
+      ) {
+        rollback_failures.push(format!(
+          "effect {} abort audit event failed: {:?}",
+          effect_id,
+          error,
+        ));
+      }
     }
 
     let abort_event_result = self.emit_event_immediate_to_context(

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -531,9 +531,13 @@ impl MechRuntime {
         context,
         RuntimeEventKind::TransactionalEffectCommitted { effect_id },
       ) {
-        return Err(self.poison_external_commit_indeterminate(
+        return Err(self.poison_effect_cleanup(
+          "commit_runtime_transaction",
           id,
-          effect_id,
+          format!(
+            "transactional effect {} committed but its audit event failed",
+            effect_id,
+          ),
           vec![format!(
             "transactional effect {} committed but its audit event failed: {:?}",
             effect_id,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -585,7 +585,7 @@ impl MechRuntime {
     let compensated = envelope.effects.compensate_applied_reverse();
     let capability_restore = capability_checkpoint
       .map(|checkpoint| {
-        self.capability_kernel.restore_checkpoint(checkpoint)
+        self.capability_kernel.restore(checkpoint)
       });
     let aborted_ids = envelope.effects.prepared_transactional_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
@@ -600,6 +600,22 @@ impl MechRuntime {
       .iter()
       .map(|failure| failure.effect_id)
       .collect();
+    let mut audit_failures = Vec::new();
+    for failure in &compensated {
+      if let Err(error) = self.emit_effect_event_outside_transaction(
+        context,
+        RuntimeEventKind::EffectCompensationFailed {
+          effect_id: failure.effect_id,
+          message: failure.message.clone(),
+        },
+      ) {
+        audit_failures.push(format!(
+          "effect {} compensation failure audit event failed: {:?}",
+          failure.effect_id,
+          error,
+        ));
+      }
+    }
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
       failures.push(format!(
@@ -608,12 +624,12 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
+    failures.extend(audit_failures);
     for effect_id in compensated_ids {
       if failed_compensations.contains(&effect_id) {
         continue;
       }
-      if let Err(error) = self.stage_effect_lifecycle_event(
-        envelope,
+      if let Err(error) = self.emit_effect_event_outside_transaction(
         context,
         RuntimeEventKind::EffectCompensated { effect_id },
       ) {
@@ -655,6 +671,23 @@ impl MechRuntime {
     context.push_event(event.clone());
     self.trim_events_to_retention(&mut context.events);
     if let Err(error) = envelope.store.stage_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
+    Ok(id)
+  }
+
+  fn emit_effect_event_outside_transaction(
+    &mut self,
+    context: &mut RuntimeContext,
+    kind: RuntimeEventKind,
+  ) -> MResult<EventId> {
+    let context_events_before = context.events.clone();
+    let event = self.make_event(kind);
+    let id = event.id;
+    context.push_event(event.clone());
+    self.trim_events_to_retention(&mut context.events);
+    if let Err(error) = self.append_event(event) {
       context.events = context_events_before;
       return Err(error);
     }

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -25,6 +25,7 @@ use mech_core::{MResult, MechError, MechErrorKind, MechSourceCode};
 use crate::capability::{Capability, CapabilityRequest};
 use crate::context::ResourceBudgetExceededError;
 use crate::event::RuntimeEvent;
+use crate::effect::RuntimeEffectRecord;
 use crate::id::{
   ActorId, CapabilityId, EventId, MessageId, ModuleId, ModuleVersionId,
   ObjectId, TaskId, TransactionId,
@@ -763,6 +764,7 @@ pub struct TransactionRecord {
   pub actor_updates: Vec<ActorId>,
 
   pub events: Vec<EventId>,
+  pub effects: Vec<RuntimeEffectRecord>,
 }
 
 impl TransactionRecord {
@@ -781,6 +783,7 @@ impl TransactionRecord {
       actor_updates: Vec::new(),
 
       events: Vec::new(),
+      effects: Vec::new(),
     }
   }
 
@@ -816,6 +819,11 @@ impl TransactionRecord {
 
   pub fn with_events(mut self, events: Vec<EventId>) -> Self {
     self.events = events;
+    self
+  }
+
+  pub fn with_effects(mut self, effects: Vec<RuntimeEffectRecord>) -> Self {
+    self.effects = effects;
     self
   }
 

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -835,6 +835,8 @@ impl TransactionRecord {
 #[derive(Clone, Debug)]
 pub struct RuntimeStoreCommit {
   pub transaction: TransactionRecord,
+  pub capability_grants: Vec<(CapabilityId, Arc<dyn Capability>)>,
+  pub capability_revocations: Vec<CapabilityId>,
   pub object_puts: Vec<ObjectRecord>,
   pub object_updates: Vec<ObjectRecord>,
   pub task_updates: Vec<TaskRecord>,
@@ -1431,6 +1433,14 @@ impl MechStore for InMemoryStore {
       temporary.enqueue_message(actor, message)?;
     }
 
+    for (capability, grant) in commit.capability_grants {
+      temporary.grant_capability(capability, grant)?;
+    }
+
+    for capability in commit.capability_revocations {
+      temporary.revoke_capability(capability)?;
+    }
+
     for event in commit.events {
       temporary.append_event(event)?;
     }
@@ -1922,6 +1932,8 @@ mod tests {
       transaction: TransactionRecord::new(TransactionId(1), "task:1")
         .with_write_set(vec![ObjectId(1), ObjectId(2)])
         .with_events(vec![EventId(1)]),
+      capability_grants: Vec::new(),
+      capability_revocations: Vec::new(),
       object_puts: vec![ObjectRecord::text(ObjectId(1), "note", "hello")],
       object_updates: vec![ObjectRecord::text(ObjectId(2), "note", "missing")],
       task_updates: Vec::new(),

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -764,6 +764,7 @@ pub struct TransactionRecord {
   pub actor_updates: Vec<ActorId>,
 
   pub events: Vec<EventId>,
+  #[cfg_attr(feature = "serde", serde(default))]
   pub effects: Vec<RuntimeEffectRecord>,
 }
 


### PR DESCRIPTION
## Stack

Round 4D, stacked on #658. This is the final Round 4 PR.

- #656 prepared effect protocols and the runtime effect journal
- #657 transactional resource providers
- #658 transactional host effects
- this PR adds capability transactions, effect audit history, and performance coverage

## What changed

- Stages capability grants and revocations in a transaction-local overlay with O(1) savepoint marks.
- Makes provisional authority visible only to the owning transaction, including local use-limit accounting.
- Adds opaque capability-kernel checkpoints; unsupported kernels reject transactional mutation before live state changes.
- Coordinates kernel apply/restore with effect preparation, compensation, runtime-store commit, and participant commit.
- Persists metadata-only `RuntimeEffectRecord` entries in `TransactionRecord`; raw payloads are never retained.
- Emits typed staged, prepare-failed, compensated, compensation-failed, aborted, committed, delivered, delivery-failed, and indeterminate lifecycle events.
- Keeps compensation failures and post-commit outcomes in immediate durable audit history.
- Adds the requested Criterion matrix for journal, capability-overlay, compensation, and delivery overhead.

## Correctness invariants

- Live store and capability-kernel state are unchanged until commit.
- A store/apply failure restores the capability checkpoint and keeps successful cleanup retryable.
- Kernel restoration or effect cleanup failure poisons the runtime with the complete diagnostic.
- Transaction-local revocation cannot consume a live capability use count.
- Grant followed by revoke cancels live/store commit work; a later regrant commits the latest capability definition.
- Failed retained operations truncate capability mutations and effect staging events to their savepoint.
- Transactional participant commit and audit failures are distinguished from external-commit indeterminacy.
- The ordinary reactive inner loop remains outside program checkpoints and the effect journal.

## Commits

- `4e8b988e4` feat(runtime): stage capability grants and revocations
- `25a51a8f9` fix(runtime): restore capability kernel on commit failure
- `3a2a9ec8f` feat(runtime): persist transaction effect summaries
- `b20f1ee69` bench(runtime): measure transactional effect overhead
- `3293dbbc3` fix(runtime): isolate revoked authority and compensation audit
- `792b97d9e` fix(runtime): close capability and audit edge cases
- `002055bfc` bench(runtime): exercise staged savepoint rollback

Head: `002055bfc`

## Validation

Passed locally:

- `cargo check --workspace`
- `cargo check -p mech-runtime --no-default-features --features base`
- `cargo test -p mech-core --lib` — 135 passed
- `cargo test -p mech-interpreter --lib` — 143 passed
- `cargo test -p mech-program --lib` — 49 passed
- runtime capability coordinator tests — 16 passed
- runtime effect coordinator tests — 14 passed
- host CLI, console, browser, scene, and robot-arm library suites
- `cargo bench -p mech-runtime --bench program_transaction --no-run`
- `cargo bench -p mech-runtime --bench program_transaction -- --test`
- full Criterion run, plus the corrected staged-effect rollback case
- `git diff --check`

Known parent-identical macOS failures:

- runtime: 393 passed, 3 known workspace-watch failures involving `/var` and `/private/var` identity
- CLI serial: 289 passed; first failure is `serve::tests::poll_workspace_once_updates_registry_after_manual_refresh`, followed by 11 poisoned-lock failures

The CLI failure was compared repeatedly against the parent during #654 and is unchanged by this stack.

Per project direction, no `rustfmt` run or broad formatting rewrite was performed.

## Benchmark medians

- effect-free implicit retained operation: 2.1377 ms
- stage 1 after-commit effect: 644.48 ns
- stage 100 after-commit effects: 719.61 µs
- stage 1 compensatable effect: 761.82 ns
- stage 100 compensatable effects: 692.42 µs
- explicit savepoint rollback that stages and removes 100 effects: 178.74 ms
- reversible effect commit: 2.1417 µs
- store failure plus compensation: 2.7909 µs
- capability overlay lookup: 309.67 ns
- deliver 100 after-commit effects: 33.273 µs

No timing assertions were added.

## CI

All eight GitHub Actions jobs passed for head `002055bfc`. The complete four-PR stack passed 32 of 32 jobs.