### PR TITLE
fix(runtime): complete Round 4 transaction correctness

### DIFF
--- a/docs/runtime/transactional-host-functions.md
+++ b/docs/runtime/transactional-host-functions.md
@@ -41,7 +41,9 @@ Mech program immediately and owns the effect lifecycle.
 Use `StagedClosureHostFunction::new`. Its callback must only construct the value
 and prepared effect; it must not perform the external mutation itself. Native
 plan construction may invoke the callback to preview the value, but the preview
-effect is discarded. The effect is staged only when the program call executes.
+effect is inert and is simply dropped. Preview does not call \`prepare\`,
+\`commit\`, \`abort\`, \`apply\`, \`compensate\`, or \`deliver\`. The effect is
+staged and enters its lifecycle only when the program call executes.
 
 Choose the effect protocol honestly:
 

--- a/src/cli/capabilities.rs
+++ b/src/cli/capabilities.rs
@@ -770,6 +770,6 @@ pub(crate) fn install_file_resolver(
     runtime.set_source_resolver(
         mech_runtime::FileSourceResolver::new(cwd)
             .with_capabilities(access.kernel.clone(), MECH_TOOL_SUBJECT),
-    );
+    )?;
     Ok(())
 }

--- a/src/cli/module_execution.rs
+++ b/src/cli/module_execution.rs
@@ -134,7 +134,7 @@ pub(crate) fn execute_source_module_roots(
     }
 
     let mut runtime = RuntimeBuilder::new().config(config).build()?;
-    runtime.set_source_resolver(resolver);
+    runtime.set_source_resolver(resolver)?;
     for root in canonical_roots {
         runtime.resolve_and_run_root_module(
             SourceRequest::new(root.to_string_lossy().to_string()),

--- a/src/runtime/src/capability/basic.rs
+++ b/src/runtime/src/capability/basic.rs
@@ -205,44 +205,11 @@ impl BasicCapability {
         .iter()
         .any(|prefix| resource.starts_with(prefix))
   }
-}
 
-impl Capability for BasicCapability {
-  fn id(&self) -> CapabilityId {
-    self.id
-  }
-
-  fn subject_key(&self) -> &str {
-    &self.subject
-  }
-
-  fn validate(&self) -> MResult<()> {
-    if self.id.is_zero() {
-      return invalid_capability("id", "must not be zero");
-    }
-
-    if self.subject.trim().is_empty() {
-      return invalid_capability("subject", "must not be empty");
-    }
-
-    if self.resource.trim().is_empty() {
-      return invalid_capability("resource", "must not be empty");
-    }
-
-    if self.operations.is_empty() {
-      return invalid_capability("operations", "must contain at least one operation");
-    }
-
-    for operation in &self.operations {
-      if operation.trim().is_empty() {
-        return invalid_capability("operations", "must not contain empty operation names");
-      }
-    }
-
-    self.constraints.validate()
-  }
-
-  fn check(&self, request: &CapabilityRequest) -> MResult<CapabilityDecision> {
+  fn check_request(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<CapabilityDecision> {
     self.validate()?;
 
     if self.subject != request.subject {
@@ -304,6 +271,53 @@ impl Capability for BasicCapability {
     }
 
     Ok(CapabilityDecision::allow())
+  }
+}
+
+impl Capability for BasicCapability {
+  fn id(&self) -> CapabilityId {
+    self.id
+  }
+
+  fn subject_key(&self) -> &str {
+    &self.subject
+  }
+
+  fn validate(&self) -> MResult<()> {
+    if self.id.is_zero() {
+      return invalid_capability("id", "must not be zero");
+    }
+
+    if self.subject.trim().is_empty() {
+      return invalid_capability("subject", "must not be empty");
+    }
+
+    if self.resource.trim().is_empty() {
+      return invalid_capability("resource", "must not be empty");
+    }
+
+    if self.operations.is_empty() {
+      return invalid_capability("operations", "must contain at least one operation");
+    }
+
+    for operation in &self.operations {
+      if operation.trim().is_empty() {
+        return invalid_capability("operations", "must not contain empty operation names");
+      }
+    }
+
+    self.constraints.validate()
+  }
+
+  fn check(&self, request: &CapabilityRequest) -> MResult<CapabilityDecision> {
+    self.check_request(request)
+  }
+
+  fn preview_check(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<CapabilityDecision> {
+    self.check_request(request)
   }
 
   fn is_revocable(&self) -> bool {

--- a/src/runtime/src/capability/capability.rs
+++ b/src/runtime/src/capability/capability.rs
@@ -27,7 +27,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use mech_core::{MResult, MechError};
+use mech_core::{
+  MResult, MechError, TransactionStateUnsupportedError,
+};
 
 use crate::id::CapabilityId;
 
@@ -222,6 +224,22 @@ pub trait Capability: std::fmt::Debug + Send + Sync {
   fn validate(&self) -> MResult<()>;
 
   fn check(&self, request: &CapabilityRequest) -> MResult<CapabilityDecision>;
+
+  fn preview_check(
+    &self,
+    _request: &CapabilityRequest,
+  ) -> MResult<CapabilityDecision> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability preview".to_string(),
+        reason: format!(
+          "capability {} does not provide a non-consuming preview check",
+          self.id(),
+        ),
+      },
+      None,
+    ))
+  }
 
   fn is_revocable(&self) -> bool {
     true

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -119,6 +119,24 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
     ))
   }
 
+  fn apply_usage_delta(
+    &mut self,
+    _capability: CapabilityId,
+    uses: u64,
+  ) -> MResult<()> {
+    if uses == 0 {
+      return Ok(());
+    }
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel usage commit".to_string(),
+        reason: "kernel does not support transactional capability usage deltas"
+          .to_string(),
+      },
+      None,
+    ))
+  }
+
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>>;
 
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>>;
@@ -471,6 +489,61 @@ impl CapabilityKernel for BasicCapabilityKernel {
     self.preview_check_with_exclusions(request, excluded)
   }
 
+  fn apply_usage_delta(
+    &mut self,
+    capability: CapabilityId,
+    uses: u64,
+  ) -> MResult<()> {
+    if uses == 0 {
+      return Ok(());
+    }
+    let Some(authority) = self.capabilities.get(&capability) else {
+      return Err(MechError::new(
+        CapabilityNotFoundError { capability },
+        None,
+      ));
+    };
+    if self.revoked.contains(&capability) {
+      return Err(MechError::new(
+        CapabilityRevokedError { capability },
+        None,
+      ));
+    }
+    let current = self.successful_uses(capability);
+    let next = current.checked_add(uses).ok_or_else(|| {
+      MechError::new(
+        CapabilityDeniedError {
+          subject: authority.subject_key().to_string(),
+          operation: "commit-usage".to_string(),
+          resource: capability.to_string(),
+          reason: format!(
+            "usage count overflow for capability {}",
+            capability,
+          ),
+        },
+        None,
+      )
+    })?;
+    if let Some(max_uses) = authority.max_uses() {
+      if next > max_uses {
+        return Err(MechError::new(
+          CapabilityDeniedError {
+            subject: authority.subject_key().to_string(),
+            operation: "commit-usage".to_string(),
+            resource: capability.to_string(),
+            reason: format!(
+              "use limit exceeded: max {}, actual {}",
+              max_uses, next,
+            ),
+          },
+          None,
+        ));
+      }
+    }
+    self.uses.insert(capability, next);
+    Ok(())
+  }
+
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
     Ok(self.capabilities.get(&id).cloned())
   }
@@ -594,6 +667,7 @@ impl CapabilityKernel for SharedCapabilityKernel {
   fn check_excluding(&mut self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().check_excluding(request, excluded) }
   fn preview_check(&self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check(request) }
   fn preview_check_excluding(&self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check_excluding(request, excluded) }
+  fn apply_usage_delta(&mut self, capability: CapabilityId, uses: u64) -> MResult<()> { self.inner.lock().unwrap().apply_usage_delta(capability, uses) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>> { self.inner.lock().unwrap().list_for_subject(subject) }
   fn derive_capability(&mut self, derivation: CapabilityDerivation) -> MResult<CapabilityId> { self.inner.lock().unwrap().derive_capability(derivation) }

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -201,6 +201,14 @@ impl BasicCapabilityKernel {
     self.uses.get(&id).copied().unwrap_or(0)
   }
 
+  #[cfg(test)]
+  pub(crate) fn successful_uses_for_test(
+    &self,
+    id: CapabilityId,
+  ) -> u64 {
+    self.successful_uses(id)
+  }
+
   fn increment_uses(&mut self, id: CapabilityId) {
     let value = self.uses.entry(id).or_insert(0);
     *value = value.saturating_add(1);
@@ -642,6 +650,14 @@ impl SharedCapabilityKernel {
 
   pub fn from_kernel(kernel: BasicCapabilityKernel) -> Self {
     Self { inner: Arc::new(Mutex::new(kernel)) }
+  }
+
+  #[cfg(test)]
+  pub(crate) fn successful_uses_for_test(
+    &self,
+    id: CapabilityId,
+  ) -> u64 {
+    self.inner.lock().unwrap().successful_uses_for_test(id)
   }
 
 }

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -72,6 +72,20 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
 
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId>;
 
+  fn preview_check(
+    &self,
+    _request: &CapabilityRequest,
+  ) -> MResult<CapabilityId> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel preview".to_string(),
+        reason: "kernel does not support non-consuming capability preview"
+          .to_string(),
+      },
+      None,
+    ))
+  }
+
   fn check_excluding(
     &mut self,
     request: &CapabilityRequest,
@@ -84,6 +98,21 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
       TransactionStateUnsupportedError {
         function: "capability kernel".to_string(),
         reason: "kernel cannot exclude transaction-local revocations"
+          .to_string(),
+      },
+      None,
+    ))
+  }
+
+  fn preview_check_excluding(
+    &self,
+    _request: &CapabilityRequest,
+    _excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    Err(MechError::new(
+      TransactionStateUnsupportedError {
+        function: "capability kernel preview".to_string(),
+        reason: "kernel does not support non-consuming preview with transaction-local revocations"
           .to_string(),
       },
       None,
@@ -269,6 +298,69 @@ impl BasicCapabilityKernel {
       None,
     ))
   }
+
+  fn preview_check_with_exclusions(
+    &self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    let Some(ids) = self.by_subject.get(&request.subject) else {
+      return Err(MechError::new(
+        CapabilityDeniedError {
+          subject: request.subject.clone(),
+          operation: request.operation.clone(),
+          resource: request.resource.clone(),
+          reason: "subject has no capabilities".to_string(),
+        },
+        None,
+      ));
+    };
+
+    let mut last_reason = None;
+    for id in ids {
+      if excluded.contains(id) {
+        last_reason =
+          Some("capability is revoked by the active transaction".to_string());
+        continue;
+      }
+      if self.revoked.contains(id) {
+        last_reason = Some("capability is revoked".to_string());
+        continue;
+      }
+
+      let Some(capability) = self.capabilities.get(id) else {
+        continue;
+      };
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.successful_uses(*id);
+        if actual >= max_uses {
+          last_reason = Some(format!(
+            "use limit exceeded: max {}, actual {}",
+            max_uses, actual,
+          ));
+          continue;
+        }
+      }
+
+      let decision = capability.preview_check(request)?;
+      if !decision.allowed {
+        last_reason = decision.reason;
+        continue;
+      }
+      return Ok(*id);
+    }
+
+    Err(MechError::new(
+      CapabilityDeniedError {
+        subject: request.subject.clone(),
+        operation: request.operation.clone(),
+        resource: request.resource.clone(),
+        reason: last_reason
+          .unwrap_or_else(|| "no matching capability".to_string()),
+      },
+      None,
+    ))
+  }
 }
 
 impl CapabilityKernel for BasicCapabilityKernel {
@@ -362,6 +454,21 @@ impl CapabilityKernel for BasicCapabilityKernel {
     excluded: &HashSet<CapabilityId>,
   ) -> MResult<CapabilityId> {
     self.check_with_exclusions(request, excluded)
+  }
+
+  fn preview_check(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<CapabilityId> {
+    self.preview_check_with_exclusions(request, &HashSet::new())
+  }
+
+  fn preview_check_excluding(
+    &self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+  ) -> MResult<CapabilityId> {
+    self.preview_check_with_exclusions(request, excluded)
   }
 
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> {
@@ -485,6 +592,8 @@ impl CapabilityKernel for SharedCapabilityKernel {
   fn revoke(&mut self, revocation: CapabilityRevocation) -> MResult<()> { self.inner.lock().unwrap().revoke(revocation) }
   fn check(&mut self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().check(request) }
   fn check_excluding(&mut self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().check_excluding(request, excluded) }
+  fn preview_check(&self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check(request) }
+  fn preview_check_excluding(&self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check_excluding(request, excluded) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>> { self.inner.lock().unwrap().list_for_subject(subject) }
   fn derive_capability(&mut self, derivation: CapabilityDerivation) -> MResult<CapabilityId> { self.inner.lock().unwrap().derive_capability(derivation) }

--- a/src/runtime/src/effect.rs
+++ b/src/runtime/src/effect.rs
@@ -179,6 +179,7 @@ pub enum RuntimeEffectFailurePhase {
   Abort,
   Commit,
   Deliver,
+  Audit,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -205,6 +206,7 @@ pub struct RuntimeEffectFailure {
 pub struct RuntimeCommitOutcome {
   pub transaction_id: TransactionId,
   pub delivery_failures: Vec<RuntimeEffectFailure>,
+  pub audit_failures: Vec<RuntimeEffectFailure>,
 }
 
 #[cfg(test)]

--- a/src/runtime/src/runtime/actor.rs
+++ b/src/runtime/src/runtime/actor.rs
@@ -47,6 +47,7 @@ impl MechRuntime {
   }
 
   pub fn put_actor(&mut self, actor: ActorRecord) -> MResult<ActorId> {
+    self.ensure_runtime_mutation_allowed("put_actor")?;
     let mut context = self.context_for_actor(&actor)?;
     self.put_actor_with_context(&mut context, actor)
   }
@@ -56,6 +57,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     actor: ActorRecord,
   ) -> MResult<ActorId> {
+    self.ensure_runtime_mutation_allowed("put_actor_with_context")?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
@@ -106,6 +108,7 @@ impl MechRuntime {
     state: Option<ObjectId>,
     capabilities: Vec<CapabilityId>,
   ) -> MResult<ActorId> {
+    self.ensure_runtime_mutation_allowed("create_actor")?;
     let id = self.next_actor_id();
 
     let mut actor = ActorRecord::new(id, subject)
@@ -145,6 +148,7 @@ impl MechRuntime {
   }
 
   pub fn update_actor(&mut self, actor: ActorRecord) -> MResult<ActorId> {
+    self.ensure_runtime_mutation_allowed("update_actor")?;
     self.store.update_actor(actor)
   }
 
@@ -153,6 +157,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     actor: ActorRecord,
   ) -> MResult<ActorId> {
+    self.ensure_runtime_mutation_allowed(
+      "update_actor_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     if let Some(transaction_id) = context.transaction {
@@ -174,6 +181,7 @@ impl MechRuntime {
     kind: impl Into<String>,
     payload: Vec<u8>,
   ) -> MResult<MessageId> {
+    self.ensure_runtime_mutation_allowed("send_message")?;
     let Some(actor_record) = self.store.get_actor(actor)? else {
       return Err(MechError::new(
         RuntimeRecordNotFoundError {
@@ -195,6 +203,9 @@ impl MechRuntime {
     kind: impl Into<String>,
     payload: Vec<u8>,
   ) -> MResult<MessageId> {
+    self.ensure_runtime_mutation_allowed(
+      "send_message_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_messages(1)?;
     context.charge_bytes(payload.len() as u64)?;
@@ -302,6 +313,7 @@ impl MechRuntime {
   }
 
   pub fn pop_message(&mut self, actor: ActorId) -> MResult<Option<MessageRecord>> {
+    self.ensure_runtime_mutation_allowed("pop_message")?;
     self.store.pop_message(actor)
   }
 
@@ -310,6 +322,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     actor: ActorId,
   ) -> MResult<Option<MessageRecord>> {
+    self.ensure_runtime_mutation_allowed(
+      "pop_message_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     if let Some(transaction_id) = context.transaction {
@@ -363,6 +378,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     actor_id: ActorId,
   ) -> MResult<Option<ActorTurn>> {
+    self.ensure_runtime_mutation_allowed(
+      "next_actor_turn_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     let Some(actor) = self.get_actor_with_context(context, actor_id)? else {
@@ -387,6 +405,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     turn: &ActorTurn,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("run_actor_turn_envelope")?;
     let turn_started = Instant::now();
     self.validate_context_for_runtime(context)?;
     turn.validate()?;

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -105,6 +105,28 @@ impl RuntimeCapabilityOverlay {
     Ok(None)
   }
 
+  pub(super) fn preview_check(
+    &self,
+    request: &CapabilityRequest,
+  ) -> MResult<Option<CapabilityId>> {
+    for (id, capability) in &self.grants {
+      if capability.subject_key() != request.subject {
+        continue;
+      }
+      if let Some(max_uses) = capability.max_uses() {
+        let actual = self.uses.get(id).copied().unwrap_or(0);
+        if actual >= max_uses {
+          continue;
+        }
+      }
+      let decision = capability.preview_check(request)?;
+      if decision.allowed {
+        return Ok(Some(*id));
+      }
+    }
+    Ok(None)
+  }
+
   pub(super) fn grants(
     &self,
   ) -> impl Iterator<Item = (CapabilityId, Arc<dyn Capability>)> + '_ {
@@ -422,6 +444,32 @@ impl MechRuntime {
         .check_excluding(request, &revocations);
     }
     self.capability_kernel.check(request)
+  }
+
+  pub(super) fn preview_capability_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    request: &CapabilityRequest,
+  ) -> MResult<CapabilityId> {
+    self.validate_context_for_runtime(context)?;
+    context.charge_step()?;
+    if let Some(transaction_id) = context.transaction {
+      let provisional = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .preview_check(request)?;
+      if let Some(capability) = provisional {
+        return Ok(capability);
+      }
+      let revocations = self
+        .active_execution_transaction(transaction_id)?
+        .capabilities
+        .revocation_ids();
+      return self
+        .capability_kernel
+        .preview_check_excluding(request, &revocations);
+    }
+    self.capability_kernel.preview_check(request)
   }
 
   pub fn get_capability(

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -249,6 +249,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     capability: Arc<dyn Capability>,
   ) -> MResult<CapabilityId> {
+    self.ensure_runtime_mutation_allowed(
+      "grant_capability_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     capability.validate()?;
@@ -352,6 +355,7 @@ impl MechRuntime {
   }
 
   pub fn revoke_capability(&mut self, capability: CapabilityId) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("revoke_capability")?;
     let mut context = self.runtime_context()?;
     self.revoke_capability_with_context(&mut context, capability)
   }
@@ -361,6 +365,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     capability: CapabilityId,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "revoke_capability_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
@@ -443,6 +450,7 @@ impl MechRuntime {
     &mut self,
     request: &CapabilityRequest,
   ) -> MResult<CapabilityId> {
+    self.ensure_runtime_mutation_allowed("check_capability")?;
     self.capability_kernel.check(request)
   }
 
@@ -477,6 +485,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     request: &CapabilityRequest,
   ) -> MResult<CapabilityId> {
+    self.ensure_runtime_mutation_allowed(
+      "check_capability_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     if let Some(transaction_id) = context.transaction {

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -459,6 +459,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     request: &CapabilityRequest,
   ) -> MResult<CapabilityId> {
+    self.ensure_runtime_mutation_allowed(
+      "check_capability_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     if let Some(transaction_id) = context.transaction {
@@ -486,7 +489,7 @@ impl MechRuntime {
     request: &CapabilityRequest,
   ) -> MResult<CapabilityId> {
     self.ensure_runtime_mutation_allowed(
-      "check_capability_with_context",
+      "preview_capability_with_context",
     )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -28,6 +28,7 @@ pub(super) enum RuntimeCapabilityMutation {
 pub(super) struct RuntimeCapabilityOverlay {
   operations: Vec<RuntimeCapabilityMutation>,
   grants: HashMap<CapabilityId, Arc<dyn Capability>>,
+  grant_order: Vec<CapabilityId>,
   revocations: HashSet<CapabilityId>,
   uses: HashMap<CapabilityId, u64>,
 }
@@ -85,7 +86,10 @@ impl RuntimeCapabilityOverlay {
     &mut self,
     request: &CapabilityRequest,
   ) -> MResult<Option<CapabilityId>> {
-    for (id, capability) in &self.grants {
+    for id in &self.grant_order {
+      let Some(capability) = self.grants.get(id) else {
+        continue;
+      };
       if capability.subject_key() != request.subject {
         continue;
       }
@@ -109,7 +113,10 @@ impl RuntimeCapabilityOverlay {
     &self,
     request: &CapabilityRequest,
   ) -> MResult<Option<CapabilityId>> {
-    for (id, capability) in &self.grants {
+    for id in &self.grant_order {
+      let Some(capability) = self.grants.get(id) else {
+        continue;
+      };
       if capability.subject_key() != request.subject {
         continue;
       }
@@ -130,10 +137,21 @@ impl RuntimeCapabilityOverlay {
   pub(super) fn grants(
     &self,
   ) -> impl Iterator<Item = (CapabilityId, Arc<dyn Capability>)> + '_ {
-    self
-      .grants
-      .iter()
-      .map(|(id, capability)| (*id, capability.clone()))
+    self.grant_order.iter().filter_map(|id| {
+      self
+        .grants
+        .get(id)
+        .map(|capability| (*id, capability.clone()))
+    })
+  }
+
+  pub(super) fn usage_deltas(
+    &self,
+  ) -> impl Iterator<Item = (CapabilityId, u64)> + '_ {
+    self.grant_order.iter().filter_map(|id| {
+      let uses = self.uses.get(id).copied().unwrap_or(0);
+      (uses != 0).then_some((*id, uses))
+    })
   }
 
   pub(super) fn revocations(
@@ -173,14 +191,22 @@ impl RuntimeCapabilityOverlay {
 
   fn rebuild(&mut self) {
     self.grants.clear();
+    self.grant_order.clear();
     self.revocations.clear();
     for operation in &self.operations {
       match operation {
         RuntimeCapabilityMutation::Grant(capability) => {
+          let id = capability.id();
+          self.revocations.remove(&id);
+          if !self.grants.contains_key(&id) {
+            self.grant_order.push(id);
+          }
           self.grants.insert(capability.id(), capability.clone());
         }
         RuntimeCapabilityMutation::Revoke(capability) => {
-          if self.grants.remove(capability).is_none() {
+          if self.grants.remove(capability).is_some() {
+            self.grant_order.retain(|id| id != capability);
+          } else {
             self.revocations.insert(*capability);
           }
         }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -530,6 +530,7 @@ mod tests {
     BasicCapability, BasicCapabilityKernel, BasicConstraints,
     CapabilityDerivation,
     CapabilityGrant, CapabilityKernel, CapabilityKernelCheckpoint, Subject,
+    SharedCapabilityKernel,
   };
   use crate::id::{
     ActorId, EventId, IdGenerator, MessageId, NodeId, ObjectId, RuntimeId,
@@ -550,6 +551,23 @@ mod tests {
 
   fn request(subject: &str) -> CapabilityRequest {
     CapabilityRequest::from_keys(subject, ":read", "db://users")
+  }
+
+  fn limited_capability(
+    id: CapabilityId,
+    max_uses: u64,
+  ) -> Arc<dyn Capability> {
+    Arc::new(
+      BasicCapability::from_keys(
+        id,
+        "task:1",
+        "db://users",
+        [":read"],
+      )
+      .with_constraints(
+        BasicConstraints::default().with_max_uses(max_uses),
+      ),
+    )
   }
 
   #[derive(Debug)]
@@ -1036,6 +1054,37 @@ mod tests {
   }
 
   #[test]
+  fn provisional_capability_selection_follows_stable_grant_order() {
+    let first = CapabilityId(100);
+    let second = CapabilityId(101);
+    let mut overlay = RuntimeCapabilityOverlay::default();
+    overlay.stage_grant(capability(first, "task:1", true));
+    overlay.stage_grant(capability(second, "task:1", true));
+
+    for _ in 0..32 {
+      assert_eq!(
+        overlay.preview_check(&request("task:1")).unwrap(),
+        Some(first),
+      );
+    }
+    assert_eq!(
+      overlay.check(&request("task:1")).unwrap(),
+      Some(first),
+    );
+    assert_eq!(
+      overlay
+        .grants()
+        .map(|(id, _)| id)
+        .collect::<Vec<_>>(),
+      vec![first, second],
+    );
+    assert_eq!(
+      overlay.usage_deltas().collect::<Vec<_>>(),
+      vec![(first, 1)],
+    );
+  }
+
+  #[test]
   fn provisional_revocation_does_not_leak_to_other_transactions() {
     let mut runtime = MechRuntime::builder()
       .id_generator(SequentialIdGenerator::starting_at(1))
@@ -1140,6 +1189,76 @@ mod tests {
     assert!(runtime.get_capability(id).unwrap().is_some());
     assert!(runtime.capability_kernel().get(id).unwrap().is_some());
     assert_eq!(runtime.check_capability(&request("task:1")).unwrap(), id);
+  }
+
+  #[test]
+  fn provisional_capability_usage_is_committed_to_live_kernel() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        limited_capability(id, 1),
+      )
+      .unwrap();
+    assert_eq!(
+      runtime
+        .check_capability_with_context(&mut context, &request("task:1"))
+        .unwrap(),
+      id,
+    );
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    assert!(runtime.check_capability(&request("task:1")).is_err());
+  }
+
+  #[test]
+  fn store_failure_restores_provisional_usage_delta() {
+    let kernel = SharedCapabilityKernel::new();
+    let observed_kernel = kernel.clone();
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let id = CapabilityId(100);
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        limited_capability(id, 2),
+      )
+      .unwrap();
+    runtime
+      .check_capability_with_context(&mut context, &request("task:1"))
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(ObjectId(500), "note", "missing"),
+      )
+      .unwrap();
+
+    assert!(runtime.commit_runtime_transaction(&mut context).is_err());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(observed_kernel.get(id).unwrap().is_none());
+    assert_eq!(observed_kernel.successful_uses_for_test(id), 0);
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .capabilities
+        .usage_deltas()
+        .collect::<Vec<_>>(),
+      vec![(id, 1)],
+    );
+
+    runtime
+      .abort_runtime_transaction(&mut context, "usage restore cleanup")
+      .unwrap();
   }
 
   #[test]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -803,7 +803,8 @@ impl MechRuntime {
 mod tests {
   use super::*;
   use crate::{
-    BasicCapability, ClosureHostFunction, InMemoryDocsProvider, NodeId,
+    BasicCapability, ClosureHostFunction, InMemoryDocsProvider,
+    InMemorySourceResolver, NodeId, SharedCapabilityKernel,
   };
   use std::collections::HashSet;
   use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1776,10 +1777,13 @@ mod tests {
   }
 
   #[test]
-  fn poisoned_runtime_rejects_owned_mutations_but_allows_abort_cleanup() {
+  fn poisoned_runtime_owned_mutation_is_fail_closed() {
     let callback_calls = Arc::new(AtomicUsize::new(0));
     let observed_calls = callback_calls.clone();
+    let kernel = SharedCapabilityKernel::new();
+    let observed_kernel = kernel.clone();
     let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
       .resource_provider(Box::new(InMemoryDocsProvider::new()))
       .build()
       .unwrap();
@@ -1855,6 +1859,53 @@ mod tests {
         .unwrap_err()
         .kind_name(),
     );
+    let used_steps_before = cleanup_context.budget.used_steps;
+    let capability_uses_before =
+      observed_kernel.successful_uses_for_test(CapabilityId(901));
+    let overlay_uses_before = runtime
+      .active_execution_transaction(cleanup_transaction)
+      .unwrap()
+      .capabilities
+      .usage_deltas()
+      .collect::<Vec<_>>();
+    poison_kinds.push(
+      runtime
+        .check_capability_with_context(
+          &mut cleanup_context,
+          &CapabilityRequest::from_keys(
+            "task:1",
+            ":read",
+            "db://users",
+          ),
+        )
+        .unwrap_err()
+        .kind_name(),
+    );
+    assert_eq!(cleanup_context.budget.used_steps, used_steps_before);
+    assert_eq!(
+      observed_kernel.successful_uses_for_test(CapabilityId(901)),
+      capability_uses_before,
+    );
+    assert_eq!(
+      runtime
+        .active_execution_transaction(cleanup_transaction)
+        .unwrap()
+        .capabilities
+        .usage_deltas()
+        .collect::<Vec<_>>(),
+      overlay_uses_before,
+    );
+    let resolver_before =
+      runtime.source_resolver() as *const dyn SourceResolver;
+    poison_kinds.push(
+      runtime
+        .set_source_resolver(InMemorySourceResolver::new())
+        .unwrap_err()
+        .kind_name(),
+    );
+    let resolver_after =
+      runtime.source_resolver() as *const dyn SourceResolver;
+    assert!(std::ptr::eq(resolver_before, resolver_after));
     poison_kinds.push(
       runtime
         .grant_capability(Arc::new(BasicCapability::from_keys(
@@ -2228,6 +2279,24 @@ mod tests {
     assert_eq!(error.kind_name(), "RuntimeEffectOperationReentrant");
     assert_eq!(context.transaction, None);
     assert!(runtime.active_transactions.is_empty());
+  }
+
+  #[test]
+  fn source_resolver_replacement_is_rejected_while_an_effect_phase_is_active() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let resolver_before =
+      runtime.source_resolver() as *const dyn SourceResolver;
+    runtime.active_effect_phase =
+      Some(ActiveRuntimeEffectPhase::Preparing);
+
+    let error = runtime
+      .set_source_resolver(InMemorySourceResolver::new())
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeEffectOperationReentrant");
+    let resolver_after =
+      runtime.source_resolver() as *const dyn SourceResolver;
+    assert!(std::ptr::eq(resolver_before, resolver_after));
   }
 
   #[test]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -581,8 +581,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     effect: PreparedRuntimeEffect,
   ) -> MResult<RuntimeEffectId> {
-    self.ensure_runtime_healthy("stage_runtime_effect_with_context")?;
-    self.reject_effect_reentrancy("stage_runtime_effect_with_context")?;
+    self.ensure_runtime_mutation_allowed(
+      "stage_runtime_effect_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     let transaction_id = Self::context_transaction_id(context)?;
@@ -660,10 +661,7 @@ impl MechRuntime {
     path: String,
     value: Value,
   ) -> MResult<RuntimeEffectId> {
-    self.ensure_runtime_healthy(
-      "stage_runtime_resource_effect_with_context",
-    )?;
-    self.reject_effect_reentrancy(
+    self.ensure_runtime_mutation_allowed(
       "stage_runtime_resource_effect_with_context",
     )?;
     self.validate_context_for_runtime(context)?;
@@ -745,8 +743,9 @@ impl MechRuntime {
     &mut self,
     mut effect: PreparedRuntimeEffect,
   ) -> MResult<RuntimeEffectId> {
-    self.ensure_runtime_healthy("execute_runtime_effect_immediately")?;
-    self.reject_effect_reentrancy("execute_runtime_effect_immediately")?;
+    self.ensure_runtime_mutation_allowed(
+      "execute_runtime_effect_immediately",
+    )?;
 
     let effect_id = RuntimeEffectId {
       transaction: self.next_transaction_id(),

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -38,10 +38,10 @@ pub(super) struct RuntimeEffectStepFailure {
   pub(super) error: MechError,
 }
 
-pub(super) struct RuntimeEffectCommitFailure {
-  pub(super) step: RuntimeEffectStepFailure,
-  pub(super) participant_outcomes: Vec<String>,
+pub(super) struct RuntimeTransactionalCommitReport {
   pub(super) committed: Vec<RuntimeEffectId>,
+  pub(super) failures: Vec<RuntimeEffectStepFailure>,
+  pub(super) participant_outcomes: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -119,6 +119,24 @@ impl RuntimeEffectJournal {
         Some(entry.id)
       }
     }).collect()
+  }
+
+  pub(super) fn abortable_ids_after(
+    &self,
+    mark: usize,
+  ) -> Vec<RuntimeEffectId> {
+    self.entries
+      .get(mark..)
+      .unwrap_or_default()
+      .iter()
+      .filter_map(|entry| {
+        if matches!(entry.effect, PreparedRuntimeEffect::AfterCommit(_)) {
+          None
+        } else {
+          Some(entry.id)
+        }
+      })
+      .collect()
   }
 
   pub(super) fn validate_active(
@@ -263,12 +281,19 @@ impl RuntimeEffectJournal {
     }
 
     let mut failures = Vec::new();
-    for entry in self.entries[mark..].iter_mut().rev() {
-      if let Err(failure) = abort_effect_entry(entry) {
-        failures.push(failure);
+    let mut tail = self.entries.split_off(mark);
+    let mut failed = Vec::new();
+    while let Some(mut entry) = tail.pop() {
+      match abort_effect_entry(&mut entry) {
+        Ok(()) => {}
+        Err(failure) => {
+          failures.push(failure);
+          failed.push(entry);
+        }
       }
     }
-    self.entries.truncate(mark);
+    failed.reverse();
+    self.entries.extend(failed);
     failures
   }
 
@@ -368,9 +393,10 @@ impl RuntimeEffectJournal {
 
   pub(super) fn commit_transactional(
     &mut self,
-  ) -> Result<Vec<RuntimeEffectId>, RuntimeEffectCommitFailure> {
+  ) -> RuntimeTransactionalCommitReport {
     let mut outcomes = Vec::new();
     let mut committed = Vec::new();
+    let mut failures = Vec::new();
     for entry in &mut self.entries {
       if entry.state != RuntimeEffectState::Prepared {
         continue;
@@ -397,15 +423,15 @@ impl RuntimeEffectJournal {
             entry.id,
             step.failure.message,
           ));
-          return Err(RuntimeEffectCommitFailure {
-            step,
-            participant_outcomes: outcomes,
-            committed,
-          });
+          failures.push(step);
         }
       }
     }
-    Ok(committed)
+    RuntimeTransactionalCommitReport {
+      committed,
+      failures,
+      participant_outcomes: outcomes,
+    }
   }
 
   pub(super) fn deliver_after_commit(
@@ -521,12 +547,17 @@ impl MechRuntime {
   pub(super) fn poison_external_commit_indeterminate(
     &mut self,
     transaction_id: TransactionId,
-    effect_id: RuntimeEffectId,
+    failures: Vec<RuntimeEffectFailure>,
     participant_outcomes: Vec<String>,
   ) -> MechError {
+    let failed_effects = failures
+      .iter()
+      .map(|failure| failure.effect_id.to_string())
+      .collect::<Vec<_>>()
+      .join(", ");
     let original_error = format!(
-      "external effect {} commit failed after runtime store transaction {} committed",
-      effect_id,
+      "external effects [{}] failed to commit after runtime store transaction {} committed",
+      failed_effects,
       transaction_id,
     );
     self.health = RuntimeHealth::Poisoned(RuntimePoisonRecord {
@@ -538,7 +569,7 @@ impl MechRuntime {
     MechError::new(
       RuntimeExternalCommitIndeterminate {
         transaction_id,
-        effect_id,
+        failures,
         participant_outcomes,
       },
       None,
@@ -736,7 +767,11 @@ impl MechRuntime {
         if let Err(error) = commit_result {
           return Err(self.poison_external_commit_indeterminate(
             effect_id.transaction,
-            effect_id,
+            vec![RuntimeEffectFailure {
+              effect_id,
+              phase: RuntimeEffectFailurePhase::Commit,
+              message: format!("{:?}", error),
+            }],
             vec![format!(
               "immediate transactional effect {} commit failed: {:?}",
               effect_id,
@@ -1484,7 +1519,11 @@ mod tests {
       .kind_as::<RuntimeExternalCommitIndeterminate>()
       .unwrap();
     assert_eq!(indeterminate.transaction_id, transaction_id);
-    assert_eq!(indeterminate.effect_id, failing_effect_id);
+    assert_eq!(indeterminate.failures.len(), 1);
+    assert_eq!(
+      indeterminate.failures[0].effect_id,
+      failing_effect_id,
+    );
     assert_eq!(
       *log.lock().unwrap(),
       vec![

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -798,29 +798,6 @@ impl MechRuntime {
     Ok(effect_id)
   }
 
-  pub(super) fn discard_unstaged_runtime_effect(
-    &mut self,
-    mut effect: PreparedRuntimeEffect,
-  ) -> MResult<()> {
-    let result = match &mut effect {
-      PreparedRuntimeEffect::Transactional(effect) => {
-        self.active_effect_phase =
-          Some(ActiveRuntimeEffectPhase::Aborting);
-        let result = effect.abort();
-        self.active_effect_phase = None;
-        result
-      }
-      PreparedRuntimeEffect::Compensatable(effect) => {
-        self.active_effect_phase =
-          Some(ActiveRuntimeEffectPhase::Aborting);
-        let result = effect.abort();
-        self.active_effect_phase = None;
-        result
-      }
-      PreparedRuntimeEffect::AfterCommit(_) => Ok(()),
-    };
-    result
-  }
 }
 
 #[cfg(test)]

--- a/src/runtime/src/runtime/effect.rs
+++ b/src/runtime/src/runtime/effect.rs
@@ -802,7 +802,78 @@ impl MechRuntime {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::{
+    BasicCapability, ClosureHostFunction, InMemoryDocsProvider, NodeId,
+  };
+  use std::collections::HashSet;
+  use std::sync::atomic::{AtomicUsize, Ordering};
   use std::sync::{Arc, Mutex};
+
+  #[derive(Debug)]
+  struct FailingEventIdGenerator {
+    next: u128,
+    event_call: usize,
+    fail_calls: HashSet<usize>,
+  }
+
+  impl FailingEventIdGenerator {
+    fn new(fail_calls: impl IntoIterator<Item = usize>) -> Self {
+      Self {
+        next: 1,
+        event_call: 0,
+        fail_calls: fail_calls.into_iter().collect(),
+      }
+    }
+
+    fn next_id(&mut self) -> u128 {
+      let id = self.next;
+      self.next = self.next.saturating_add(1);
+      id
+    }
+  }
+
+  impl IdGenerator for FailingEventIdGenerator {
+    fn runtime_id(&mut self) -> RuntimeId {
+      RuntimeId(self.next_id())
+    }
+
+    fn object_id(&mut self) -> ObjectId {
+      ObjectId(self.next_id())
+    }
+
+    fn actor_id(&mut self) -> ActorId {
+      ActorId(self.next_id())
+    }
+
+    fn task_id(&mut self) -> TaskId {
+      TaskId(self.next_id())
+    }
+
+    fn capability_id(&mut self) -> CapabilityId {
+      CapabilityId(self.next_id())
+    }
+
+    fn transaction_id(&mut self) -> TransactionId {
+      TransactionId(self.next_id())
+    }
+
+    fn event_id(&mut self) -> EventId {
+      self.event_call = self.event_call.saturating_add(1);
+      if self.fail_calls.contains(&self.event_call) {
+        EventId(0)
+      } else {
+        EventId(1_000 + self.event_call as u128)
+      }
+    }
+
+    fn node_id(&mut self) -> NodeId {
+      NodeId(self.next_id())
+    }
+
+    fn message_id(&mut self) -> MessageId {
+      MessageId(self.next_id())
+    }
+  }
 
   #[derive(Debug, Clone)]
   struct SyntheticEffectError {
@@ -944,6 +1015,32 @@ mod tests {
     fail_deliver: bool,
   }
 
+  #[derive(Debug)]
+  struct FailOnceAbortEffect {
+    attempts: Arc<AtomicUsize>,
+  }
+
+  impl RuntimeTransactionalEffect for FailOnceAbortEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      synthetic_metadata("fail-once-abort")
+    }
+
+    fn prepare(&mut self) -> MResult<()> {
+      Ok(())
+    }
+
+    fn commit(&mut self) -> MResult<()> {
+      Ok(())
+    }
+
+    fn abort(&mut self) -> MResult<()> {
+      if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+        return Err(synthetic_error("deliberate first abort failure"));
+      }
+      Ok(())
+    }
+  }
+
   impl RuntimeAfterCommitEffect for SyntheticAfterCommitEffect {
     fn metadata(&self) -> RuntimeEffectMetadata {
       synthetic_metadata(self.name)
@@ -1072,6 +1169,50 @@ mod tests {
 
     assert_eq!(journal.len(), 2);
     assert_eq!(journal.next_sequence(), 3);
+  }
+
+  #[test]
+  fn failed_savepoint_cleanup_preserves_effect_for_outer_abort_retry() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    let result: MResult<()> = runtime.with_atomic_program_operation(
+      &mut context,
+      "fail_once_effect_cleanup",
+      |runtime, context| {
+        let effect_id = runtime.stage_runtime_effect_with_context(
+          context,
+          PreparedRuntimeEffect::Transactional(Box::new(
+            FailOnceAbortEffect {
+              attempts: attempts.clone(),
+            },
+          )),
+        )?;
+        assert_eq!(effect_id.sequence, 0);
+        Err(synthetic_error("deliberate retained operation failure"))
+      },
+    );
+
+    assert_eq!(
+      result.unwrap_err().kind_name(),
+      "RuntimeProgramRollbackFailed",
+    );
+    assert!(runtime.is_poisoned());
+    let transaction = runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap();
+    assert_eq!(transaction.effects.len(), 1);
+    assert_eq!(transaction.effects.next_sequence(), 1);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+    runtime
+      .abort_runtime_transaction(&mut context, "retry retained effect abort")
+      .unwrap();
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(context.transaction, None);
+    assert!(!runtime.active_transactions.contains_key(&transaction_id));
   }
 
   #[test]
@@ -1529,6 +1670,452 @@ mod tests {
         RuntimeEventKind::ExternalCommitIndeterminate { .. }
       )
     }));
+  }
+
+  #[test]
+  fn every_prepared_participant_receives_commit_and_all_failures_are_reported() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let delivery_log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(transactional(
+          "first",
+          log.clone(),
+        ))),
+      )
+      .unwrap();
+    let mut second = transactional("second", log.clone());
+    second.fail_commit = true;
+    let second_id = runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(second)),
+      )
+      .unwrap();
+    let mut third = transactional("third", log.clone());
+    third.fail_commit = true;
+    let third_id = runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(third)),
+      )
+      .unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(after_commit(
+          "suppressed",
+          delivery_log.clone(),
+        ))),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap_err();
+    let indeterminate = error
+      .kind_as::<RuntimeExternalCommitIndeterminate>()
+      .unwrap();
+
+    assert_eq!(
+      *log.lock().unwrap(),
+      vec![
+        "first:prepare",
+        "second:prepare",
+        "third:prepare",
+        "first:commit",
+        "second:commit",
+        "third:commit",
+      ],
+    );
+    assert_eq!(
+      indeterminate
+        .failures
+        .iter()
+        .map(|failure| failure.effect_id)
+        .collect::<Vec<_>>(),
+      vec![second_id, third_id],
+    );
+    assert!(delivery_log.lock().unwrap().is_empty());
+    let poison = match runtime.health() {
+      RuntimeHealth::Healthy => panic!("runtime should be poisoned"),
+      RuntimeHealth::Poisoned(poison) => poison,
+    };
+    assert!(poison
+      .rollback_failures
+      .iter()
+      .any(|outcome| outcome.contains("second commit failed")));
+    assert!(poison
+      .rollback_failures
+      .iter()
+      .any(|outcome| outcome.contains("third commit failed")));
+    assert_eq!(context.transaction, None);
+    assert!(runtime
+      .get_transaction(transaction_id)
+      .unwrap()
+      .is_some());
+    assert_eq!(
+      runtime
+        .list_events(None)
+        .unwrap()
+        .iter()
+        .filter(|event| {
+          matches!(
+            event.kind,
+            RuntimeEventKind::ExternalCommitIndeterminate { .. }
+          )
+        })
+        .count(),
+      2,
+    );
+  }
+
+  #[test]
+  fn poisoned_runtime_rejects_owned_mutations_but_allows_abort_cleanup() {
+    let callback_calls = Arc::new(AtomicUsize::new(0));
+    let observed_calls = callback_calls.clone();
+    let mut runtime = MechRuntime::builder()
+      .resource_provider(Box::new(InMemoryDocsProvider::new()))
+      .build()
+      .unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::from_keys(
+        CapabilityId(900),
+        &subject,
+        "host:demo/poison-gate",
+        ["call"],
+      )))
+      .unwrap();
+    runtime
+      .grant_capability(Arc::new(BasicCapability::from_keys(
+        CapabilityId(901),
+        "task:1",
+        "db://users",
+        [":read"],
+      )))
+      .unwrap();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new_pure(
+        "demo/poison-gate",
+        move |_services, _context, _args| {
+          observed_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::Empty)
+        },
+      ))
+      .unwrap();
+    let object_id = ObjectId(902);
+    let actor_id = ActorId(903);
+    let task_id = TaskId(904);
+    runtime
+      .put_object(ObjectRecord::text(object_id, "note", "before"))
+      .unwrap();
+    runtime
+      .put_actor(ActorRecord::new(actor_id, "actor:poison"))
+      .unwrap();
+    runtime
+      .put_task(TaskRecord::new(task_id, "task:poison"))
+      .unwrap();
+
+    let mut cleanup_context = runtime.runtime_context().unwrap();
+    let cleanup_transaction = runtime
+      .begin_transaction(&mut cleanup_context)
+      .unwrap();
+    let mut poison_context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut poison_context).unwrap();
+    let mut failing = transactional(
+      "poison-runtime",
+      Arc::new(Mutex::new(Vec::new())),
+    );
+    failing.fail_commit = true;
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut poison_context,
+        PreparedRuntimeEffect::Transactional(Box::new(failing)),
+      )
+      .unwrap();
+    assert_eq!(
+      runtime
+        .commit_runtime_transaction(&mut poison_context)
+        .unwrap_err()
+        .kind_name(),
+      "RuntimeExternalCommitIndeterminate",
+    );
+    assert!(runtime.is_poisoned());
+
+    let mut poison_kinds = Vec::new();
+    poison_kinds.push(
+      runtime
+        .call_host(HostCall::new("demo/poison-gate", Vec::new()))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .grant_capability(Arc::new(BasicCapability::from_keys(
+          CapabilityId(905),
+          "task:1",
+          "db://other",
+          [":read"],
+        )))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .revoke_capability(CapabilityId(901))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .check_capability(&CapabilityRequest::from_keys(
+          "task:1",
+          ":read",
+          "db://users",
+        ))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .write_resource(RuntimeResourceWriteRequest {
+          base_uri: "docs://manual".to_string(),
+          path: "poisoned".to_string(),
+          context_name: "manual".to_string(),
+          operation: RuntimeCapabilityOperation::Write,
+          value: Value::String(mech_core::Ref::new(
+            "must-not-write".to_string(),
+          )),
+          intent: RuntimeResourceWriteIntent::Assign,
+        })
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .update_object(ObjectRecord::text(
+          object_id,
+          "note",
+          "after",
+        ))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .update_actor(ActorRecord::new(actor_id, "actor:changed"))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .update_task(TaskRecord::new(task_id, "task:changed"))
+        .unwrap_err()
+        .kind_name(),
+    );
+    poison_kinds.push(
+      runtime
+        .stage_runtime_effect_with_context(
+          &mut cleanup_context,
+          effect("must-not-stage"),
+        )
+        .unwrap_err()
+        .kind_name(),
+    );
+
+    assert!(poison_kinds
+      .iter()
+      .all(|kind| *kind == "RuntimePoisoned"));
+    assert_eq!(callback_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+      runtime.get_object(object_id).unwrap().unwrap().data,
+      b"before",
+    );
+    assert_eq!(
+      runtime.get_actor(actor_id).unwrap().unwrap().subject,
+      "actor:poison",
+    );
+    assert_eq!(
+      runtime.get_task(task_id).unwrap().unwrap().subject,
+      "task:poison",
+    );
+    assert!(!runtime
+      .capability_kernel()
+      .is_revoked(CapabilityId(901))
+      .unwrap());
+
+    runtime
+      .abort_runtime_transaction(
+        &mut cleanup_context,
+        "poisoned runtime cleanup remains allowed",
+      )
+      .unwrap();
+    assert_eq!(cleanup_context.transaction, None);
+    assert!(!runtime
+      .active_transactions
+      .contains_key(&cleanup_transaction));
+  }
+
+  #[test]
+  fn prepare_failure_audit_failure_is_nonfatal() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder()
+      .id_generator(FailingEventIdGenerator::new([5]))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(transactional(
+          "first",
+          log.clone(),
+        ))),
+      )
+      .unwrap();
+    let mut second = transactional("second", log);
+    second.fail_prepare = true;
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(second)),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "SyntheticEffectError");
+    assert!(error.full_chain_message().contains("second prepare failed"));
+    assert!(!runtime.is_poisoned());
+    assert_eq!(context.transaction, Some(transaction_id));
+    runtime
+      .abort_runtime_transaction(&mut context, "prepare audit cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn compensation_audit_failure_is_nonfatal() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder()
+      .id_generator(FailingEventIdGenerator::new([5]))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Compensatable(Box::new(compensatable(
+          "first",
+          log.clone(),
+        ))),
+      )
+      .unwrap();
+    let mut second = compensatable("second", log);
+    second.fail_apply = true;
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Compensatable(Box::new(second)),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "SyntheticEffectError");
+    assert!(error.full_chain_message().contains("second apply failed"));
+    assert!(!runtime.is_poisoned());
+    assert_eq!(context.transaction, Some(transaction_id));
+    runtime
+      .abort_runtime_transaction(&mut context, "compensation audit cleanup")
+      .unwrap();
+  }
+
+  #[test]
+  fn explicit_abort_audit_failure_does_not_poison() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(FailingEventIdGenerator::new([5]))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(transactional(
+          "abortable",
+          Arc::new(Mutex::new(Vec::new())),
+        ))),
+      )
+      .unwrap();
+
+    runtime
+      .abort_runtime_transaction(&mut context, "audit failure abort")
+      .unwrap();
+
+    assert!(!runtime.is_poisoned());
+    assert_eq!(context.transaction, None);
+  }
+
+  #[test]
+  fn committed_effect_audit_failure_still_delivers_after_commit() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder()
+      .id_generator(FailingEventIdGenerator::new([6]))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(transactional(
+          "transactional",
+          log.clone(),
+        ))),
+      )
+      .unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(after_commit(
+          "after",
+          log.clone(),
+        ))),
+      )
+      .unwrap();
+
+    let outcome = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    assert_eq!(outcome.delivery_failures, Vec::new());
+    assert_eq!(outcome.audit_failures.len(), 1);
+    assert_eq!(
+      outcome.audit_failures[0].phase,
+      RuntimeEffectFailurePhase::Audit,
+    );
+    assert_eq!(
+      *log.lock().unwrap(),
+      vec![
+        "transactional:prepare",
+        "transactional:commit",
+        "after:deliver",
+      ],
+    );
+    assert!(!runtime.is_poisoned());
+    assert_eq!(context.transaction, None);
   }
 
   #[test]

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -7,7 +7,7 @@
 // See /src/core/src/error.rs for the base error types and traits used by these runtime errors.
 
 use super::*;
-use crate::RuntimeEffectId;
+use crate::RuntimeEffectFailure;
 
 #[derive(Debug, Clone)]
 pub struct RuntimeEffectOperationReentrant {
@@ -56,7 +56,7 @@ impl MechErrorKind for RuntimeEffectCleanupFailed {
 #[derive(Debug, Clone)]
 pub struct RuntimeExternalCommitIndeterminate {
   pub transaction_id: TransactionId,
-  pub effect_id: RuntimeEffectId,
+  pub failures: Vec<RuntimeEffectFailure>,
   pub participant_outcomes: Vec<String>,
 }
 
@@ -67,9 +67,9 @@ impl MechErrorKind for RuntimeExternalCommitIndeterminate {
 
   fn message(&self) -> String {
     format!(
-      "runtime store transaction {} committed, but external effect {} has an indeterminate commit outcome: {}",
+      "runtime store transaction {} committed, but {} external participants have indeterminate commit outcomes: {}",
       self.transaction_id,
-      self.effect_id,
+      self.failures.len(),
       self.participant_outcomes.join("; "),
     )
   }

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -80,8 +80,9 @@ impl MechRuntime {
     &mut self,
     function: impl HostFunction + 'static,
   ) -> MResult<()> {
-    self.ensure_runtime_healthy("register_mech_host_function")?;
-    self.reject_effect_reentrancy("register_mech_host_function")?;
+    self.ensure_runtime_mutation_allowed(
+      "register_mech_host_function",
+    )?;
     let name = function.name().to_string();
 
     self
@@ -166,8 +167,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     call: HostCall,
   ) -> MResult<Value> {
-    self.ensure_runtime_healthy("preview_host_call_with_context")?;
-    self.reject_effect_reentrancy("preview_host_call_with_context")?;
+    self.ensure_runtime_mutation_allowed(
+      "preview_host_call_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     call.validate()?;
 
@@ -224,6 +226,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     call: HostCall,
   ) -> MResult<Value> {
+    self.ensure_runtime_mutation_allowed("call_host_with_context")?;
     self.validate_context_for_runtime(context)?;
     call.validate()?;
 

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -521,11 +521,12 @@ mod transaction_tests {
   use std::sync::{Arc, Mutex};
   use std::sync::atomic::{AtomicUsize, Ordering};
   use crate::{
-    BasicCapability, BasicOperation, BasicResource, BasicSubject,
+    BasicCapability, BasicConstraints, BasicOperation, BasicResource,
+    BasicSubject, Capability, CapabilityDecision, CapabilityRequest,
     ClosureHostFunction,
     PreparedRuntimeEffect, RuntimeAfterCommitEffect,
     RuntimeEffectMetadata, RuntimeEffectSource,
-    StagedClosureHostFunction,
+    RuntimeTransactionalEffect, StagedClosureHostFunction,
   };
 
   #[derive(Debug)]
@@ -560,6 +561,120 @@ mod transaction_tests {
         [BasicOperation::new("call")],
       )))
       .unwrap();
+  }
+
+  fn grant_limited_host_call(
+    runtime: &mut MechRuntime,
+    id: CapabilityId,
+    name: &str,
+  ) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(
+        BasicCapability::new(
+          id,
+          &BasicSubject::new(&subject),
+          &BasicResource::new(format!("host:{name}")),
+          [BasicOperation::new("call")],
+        )
+        .with_constraints(
+          BasicConstraints::default().with_max_uses(1),
+        ),
+      ))
+      .unwrap();
+  }
+
+  #[derive(Debug)]
+  struct PreviewUnsupportedCapability {
+    id: CapabilityId,
+    subject: String,
+    resource: String,
+  }
+
+  impl Capability for PreviewUnsupportedCapability {
+    fn id(&self) -> CapabilityId {
+      self.id
+    }
+
+    fn subject_key(&self) -> &str {
+      &self.subject
+    }
+
+    fn validate(&self) -> MResult<()> {
+      Ok(())
+    }
+
+    fn check(
+      &self,
+      request: &CapabilityRequest,
+    ) -> MResult<CapabilityDecision> {
+      Ok(if request.subject == self.subject
+        && request.operation == "call"
+        && request.resource == self.resource
+      {
+        CapabilityDecision::allow()
+      } else {
+        CapabilityDecision::deny("request does not match")
+      })
+    }
+  }
+
+  #[derive(Debug)]
+  struct PreviewLifecycleEffect {
+    log: Arc<Mutex<Vec<String>>>,
+  }
+
+  #[derive(Debug)]
+  struct CountingAfterCommitEffect {
+    deliveries: Arc<AtomicUsize>,
+  }
+
+  impl RuntimeAfterCommitEffect for CountingAfterCommitEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::HostFunction {
+          name: "demo/staged-limited".to_string(),
+        },
+        "deliver",
+      )
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      self.deliveries.fetch_add(1, Ordering::SeqCst);
+      Ok(())
+    }
+  }
+
+  impl RuntimeTransactionalEffect for PreviewLifecycleEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::HostFunction {
+          name: "demo/staged-lifecycle".to_string(),
+        },
+        "preview-lifecycle",
+      )
+    }
+
+    fn prepare(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push("prepare".to_string());
+      Ok(())
+    }
+
+    fn commit(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push("commit".to_string());
+      Ok(())
+    }
+
+    fn abort(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push("abort".to_string());
+      Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "preview_lifecycle_abort",
+          reason: "abort must not run for preview-only effects".to_string(),
+        },
+        None,
+      ))
+    }
   }
 
   #[test]
@@ -685,6 +800,176 @@ mod transaction_tests {
     runtime.commit_runtime_transaction(&mut context).unwrap();
 
     assert_eq!(calls.load(Ordering::SeqCst), 4);
+  }
+
+  #[test]
+  fn pure_host_preview_does_not_consume_single_use_capability() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_limited_host_call(
+      &mut runtime,
+      CapabilityId(710),
+      "demo/pure-limited",
+    );
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new_pure(
+        "demo/pure-limited",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::F64(Ref::new(1.0)))
+        },
+      ))
+      .unwrap();
+
+    runtime
+      .run_string("pure-limited-result := demo/pure-limited()")
+      .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(runtime
+      .call_host(HostCall::new("demo/pure-limited", Vec::new()))
+      .is_err());
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+  }
+
+  #[test]
+  fn runtime_managed_preview_does_not_consume_single_use_capability() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_limited_host_call(
+      &mut runtime,
+      CapabilityId(711),
+      "demo/managed-limited",
+    );
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(
+        ClosureHostFunction::new_runtime_managed(
+          "demo/managed-limited",
+          move |_services, _context, _args| {
+            callback_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Value::F64(Ref::new(1.0)))
+          },
+        ),
+      )
+      .unwrap();
+
+    runtime
+      .run_string("managed-limited-result := demo/managed-limited()")
+      .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(runtime
+      .call_host(HostCall::new("demo/managed-limited", Vec::new()))
+      .is_err());
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+  }
+
+  #[test]
+  fn staged_preview_does_not_consume_single_use_capability() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_limited_host_call(
+      &mut runtime,
+      CapabilityId(712),
+      "demo/staged-limited",
+    );
+    let calls = Arc::new(AtomicUsize::new(0));
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    let delivered = deliveries.clone();
+    runtime
+      .register_mech_host_function(StagedClosureHostFunction::new(
+        "demo/staged-limited",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          let delivered = delivered.clone();
+          Ok(RuntimePreparedHostCall {
+            value: Value::F64(Ref::new(1.0)),
+            effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+              CountingAfterCommitEffect {
+                deliveries: delivered,
+              },
+            )),
+          })
+        },
+      ))
+      .unwrap();
+
+    runtime
+      .run_string("staged-limited-result := demo/staged-limited()")
+      .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(deliveries.load(Ordering::SeqCst), 1);
+    assert!(runtime
+      .call_host(HostCall::new("demo/staged-limited", Vec::new()))
+      .is_err());
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+  }
+
+  #[test]
+  fn custom_capability_without_preview_contract_fails_closed() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(PreviewUnsupportedCapability {
+        id: CapabilityId(713),
+        subject,
+        resource: "host:demo/unsupported-preview".to_string(),
+      }))
+      .unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let callback_calls = calls.clone();
+    runtime
+      .register_mech_host_function(ClosureHostFunction::new_pure(
+        "demo/unsupported-preview",
+        move |_services, _context, _args| {
+          callback_calls.fetch_add(1, Ordering::SeqCst);
+          Ok(Value::Empty)
+        },
+      ))
+      .unwrap();
+
+    let error = runtime
+      .run_string(
+        "unsupported-preview-result := demo/unsupported-preview()",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+  }
+
+  #[test]
+  fn staged_preview_drops_inert_effect_without_lifecycle_calls() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    grant_host_call(&mut runtime, "demo/staged-lifecycle");
+    let lifecycle = Arc::new(Mutex::new(Vec::new()));
+    let effect_log = lifecycle.clone();
+    runtime
+      .register_mech_host_function(StagedClosureHostFunction::new(
+        "demo/staged-lifecycle",
+        move |_services, _context, _args| {
+          Ok(RuntimePreparedHostCall {
+            value: Value::F64(Ref::new(1.0)),
+            effect: PreparedRuntimeEffect::Transactional(Box::new(
+              PreviewLifecycleEffect {
+                log: effect_log.clone(),
+              },
+            )),
+          })
+        },
+      ))
+      .unwrap();
+
+    runtime
+      .run_string(
+        "staged-lifecycle-result := demo/staged-lifecycle()",
+      )
+      .unwrap();
+
+    assert_eq!(
+      lifecycle.lock().unwrap().as_slice(),
+      &["prepare".to_string(), "commit".to_string()],
+    );
   }
 
   #[test]

--- a/src/runtime/src/runtime/host.rs
+++ b/src/runtime/src/runtime/host.rs
@@ -188,7 +188,7 @@ impl MechRuntime {
       .unwrap_or_else(|| {
         default_host_capability_request(context, function.name())
       });
-    self.check_capability_with_context(context, &capability_request)?;
+    self.preview_capability_with_context(context, &capability_request)?;
 
     match function.transaction_mode() {
       HostFunctionTransactionMode::Pure => {
@@ -204,17 +204,7 @@ impl MechRuntime {
       HostFunctionTransactionMode::Staged => {
         let RuntimePreparedHostCall { value, effect } =
           function.stage_call(self, context, call.args)?;
-        if let Err(error) = self.discard_unstaged_runtime_effect(effect) {
-          return Err(self.poison_program_operation(
-            "preview_host_call_with_context",
-            context.transaction,
-            format!(
-              "staged host function `{}` preview cleanup failed",
-              function.name(),
-            ),
-            vec![format!("{:?}", error)],
-          ));
-        }
+        drop(effect);
         Ok(value)
       }
       HostFunctionTransactionMode::ImmediateOnly => {

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -726,6 +726,7 @@ impl MechRuntime {
     module: &str,
     item: &str,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("bind_context_export")?;
     let target = format!("{module}/{item}");
     let base_uri = match self.host_interfaces.resolve_optional(&target)? {
       Some(context) => context.base_uri.clone(),
@@ -743,6 +744,7 @@ impl MechRuntime {
     name: impl Into<String>,
     uri: impl AsRef<str>,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("bind_resource_root")?;
     let name = name.into();
     if !validate_resource_binding_name(&name) {
       return Err(runtime_resource_binding_error(
@@ -856,6 +858,7 @@ impl MechRuntime {
     &mut self,
     spec: RuntimeConfigSpec,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("apply_config_spec")?;
     register_config_spec_resources(&mut self.resources, &spec)?;
     register_config_spec_grants(&mut self.grants, &spec)?;
     Ok(())
@@ -865,6 +868,7 @@ impl MechRuntime {
   where
     G: RuntimeCapabilityGrantInput,
   {
+    self.ensure_runtime_mutation_allowed("grant_capability")?;
     grant.apply(self)
   }
 
@@ -872,6 +876,9 @@ impl MechRuntime {
     &mut self,
     grant: RuntimeCapabilityGrant,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "add_resource_capability_grant",
+    )?;
     self.grants.add_grant(grant)
   }
 
@@ -898,6 +905,9 @@ impl MechRuntime {
     &mut self,
     grant: &RunResourceGrantConfig,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "install_run_resource_grant",
+    )?;
     let context = self.host_interfaces.resolve(&grant.target)?;
     for operation in &grant.operations {
       if !context.operations.iter().any(|allowed| allowed == operation) {
@@ -920,8 +930,9 @@ impl MechRuntime {
     &mut self,
     provider: Box<dyn RuntimeResourceProvider>,
   ) -> MResult<()> {
-    self.ensure_runtime_healthy("register_resource_provider")?;
-    self.reject_effect_reentrancy("register_resource_provider")?;
+    self.ensure_runtime_mutation_allowed(
+      "register_resource_provider",
+    )?;
     self.resources.register_provider(provider)
   }
 
@@ -933,8 +944,7 @@ impl MechRuntime {
     &mut self,
     request: RuntimeResourceWriteRequest,
   ) -> MResult<()> {
-    self.ensure_runtime_healthy("write_resource")?;
-    self.reject_effect_reentrancy("write_resource")?;
+    self.ensure_runtime_mutation_allowed("write_resource")?;
     let effect = self.resources.stage_write(request)?;
     self.execute_runtime_effect_immediately(effect)?;
     Ok(())
@@ -945,8 +955,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     mut request: RuntimeResourceWriteRequest,
   ) -> MResult<RuntimeEffectId> {
-    self.ensure_runtime_healthy("write_resource_with_context")?;
-    self.reject_effect_reentrancy("write_resource_with_context")?;
+    self.ensure_runtime_mutation_allowed(
+      "write_resource_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     if context.transaction.is_some() {
@@ -995,6 +1006,9 @@ impl MechRuntime {
     self.store.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn store_mut(&mut self) -> &mut dyn MechStore {
     self.store.as_mut()
   }
@@ -1003,6 +1017,9 @@ impl MechRuntime {
     self.capability_kernel.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn capability_kernel_mut(&mut self) -> &mut dyn CapabilityKernel {
     self.capability_kernel.as_mut()
   }
@@ -1011,10 +1028,15 @@ impl MechRuntime {
     self.source_resolver.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn source_resolver_mut(&mut self) -> &mut dyn SourceResolver {
     self.source_resolver.as_mut()
   }
 
+  /// Unchecked administrative replacement outside runtime-owned poison
+  /// enforcement.
   pub fn set_source_resolver(&mut self, source_resolver: impl SourceResolver + 'static) {
     self.source_resolver = Box::new(source_resolver);
   }
@@ -1023,6 +1045,9 @@ impl MechRuntime {
     self.host_registry.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn host_registry_mut(&mut self) -> &mut dyn HostRegistry {
     self.host_registry.as_mut()
   }
@@ -1031,6 +1056,9 @@ impl MechRuntime {
     self.host_policy.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn host_policy_mut(&mut self) -> &mut dyn HostCallPolicy {
     self.host_policy.as_mut()
   }
@@ -1039,6 +1067,9 @@ impl MechRuntime {
     self.scheduler.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn scheduler_mut(&mut self) -> &mut dyn Scheduler {
     self.scheduler.as_mut()
   }
@@ -1047,6 +1078,9 @@ impl MechRuntime {
     &self.scheduler_policy
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn scheduler_policy_mut(&mut self) -> &mut SchedulerPolicy {
     &mut self.scheduler_policy
   }
@@ -1055,6 +1089,9 @@ impl MechRuntime {
     self.actor_behavior_driver.as_ref()
   }
 
+  /// Unchecked administrative escape hatch outside runtime-owned poison
+  /// enforcement. Runtime internals must not use it to bypass mutation
+  /// preflight.
   pub fn actor_behavior_driver_mut(&mut self) -> &mut dyn ActorBehaviorDriver {
     self.actor_behavior_driver.as_mut()
   }
@@ -1064,6 +1101,7 @@ impl MechRuntime {
   }
 
   pub fn set_scheduler_policy(&mut self, scheduler_policy: SchedulerPolicy) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("set_scheduler_policy")?;
     scheduler_policy.validate()?;
     self.scheduler_policy = scheduler_policy;
     Ok(())
@@ -1381,7 +1419,7 @@ impl MechRuntime {
       }
     }
 
-    self.append_event(event)?;
+    self.store.append_event(event)?;
 
     Ok(id)
   }
@@ -1398,7 +1436,7 @@ impl MechRuntime {
 
     context.push_event(event.clone());
     self.trim_events_to_retention(&mut context.events);
-    self.append_event(event)?;
+    self.store.append_event(event)?;
 
     Ok(id)
   }

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -1024,7 +1024,7 @@ impl MechRuntime {
     self.capability_kernel.as_mut()
   }
 
-  pub fn source_resolver(&self) -> &dyn SourceResolver {
+  pub fn source_resolver(&self) -> &(dyn SourceResolver + 'static) {
     self.source_resolver.as_ref()
   }
 
@@ -1035,10 +1035,13 @@ impl MechRuntime {
     self.source_resolver.as_mut()
   }
 
-  /// Unchecked administrative replacement outside runtime-owned poison
-  /// enforcement.
-  pub fn set_source_resolver(&mut self, source_resolver: impl SourceResolver + 'static) {
+  pub fn set_source_resolver(
+    &mut self,
+    source_resolver: impl SourceResolver + 'static,
+  ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("set_source_resolver")?;
     self.source_resolver = Box::new(source_resolver);
+    Ok(())
   }
 
   pub fn host_registry(&self) -> &dyn HostRegistry {

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -1407,6 +1407,7 @@ impl MechRuntime {
   ) -> MResult<EventId> {
     self.validate_context_for_runtime(context)?;
 
+    let context_events_before = context.events.clone();
     let event = self.make_event(kind);
     let id = event.id;
 
@@ -1414,12 +1415,18 @@ impl MechRuntime {
     self.trim_events_to_retention(&mut context.events);
     if let Some(transaction_id) = context.transaction {
       if let Some(transaction) = self.active_transactions.get_mut(&transaction_id) {
-        transaction.store.stage_event(event)?;
+        if let Err(error) = transaction.store.stage_event(event) {
+          context.events = context_events_before;
+          return Err(error);
+        }
         return Ok(id);
       }
     }
 
-    self.store.append_event(event)?;
+    if let Err(error) = self.store.append_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
 
     Ok(id)
   }
@@ -1431,12 +1438,16 @@ impl MechRuntime {
   ) -> MResult<EventId> {
     self.validate_context_for_runtime(context)?;
 
+    let context_events_before = context.events.clone();
     let event = self.make_event(kind);
     let id = event.id;
 
     context.push_event(event.clone());
     self.trim_events_to_retention(&mut context.events);
-    self.store.append_event(event)?;
+    if let Err(error) = self.store.append_event(event) {
+      context.events = context_events_before;
+      return Err(error);
+    }
 
     Ok(id)
   }

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -56,6 +56,7 @@ impl MechRuntime {
     name: &str,
     canonical_uri: &str,
   ) -> MResult<ModuleId> {
+    self.ensure_runtime_mutation_allowed("ensure_module")?;
     if let Some(module) = self.store.find_module_by_name(canonical_uri)? {
       return Ok(module.id);
     }
@@ -205,6 +206,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     request: impl Into<SourceRequest>,
   ) -> MResult<Option<ResolvedSource>> {
+    self.ensure_runtime_mutation_allowed(
+      "resolve_source_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
@@ -229,6 +233,7 @@ impl MechRuntime {
     &mut self,
     request: impl Into<SourceRequest>,
   ) -> MResult<Option<ResolvedSource>> {
+    self.ensure_runtime_mutation_allowed("resolve_source_evented")?;
     let mut context = self.runtime_context()?;
     self.resolve_source_with_context(&mut context, request)
   }
@@ -238,6 +243,9 @@ impl MechRuntime {
     resolved: ResolvedSource,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
+    self.ensure_runtime_mutation_allowed(
+      "store_resolved_module_source",
+    )?;
     let mut context = self.runtime_context()?;
 
     self.build_module_from_resolved_source_with_context(
@@ -253,6 +261,9 @@ impl MechRuntime {
     resolved: ResolvedSource,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
+    self.ensure_runtime_mutation_allowed(
+      "build_module_from_resolved_source_with_context",
+    )?;
     let mut dependency_graph = ModuleDependencyGraph::new();
 
     self.build_module_from_resolved_source_with_context_and_graph(
@@ -481,6 +492,9 @@ impl MechRuntime {
     request: impl Into<SourceRequest>,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<Option<ModuleVersionId>> {
+    self.ensure_runtime_mutation_allowed(
+      "resolve_and_store_module_source",
+    )?;
     let mut context = self.runtime_context()?;
 
     self.build_module_from_request_with_context(
@@ -496,6 +510,9 @@ impl MechRuntime {
     request: impl Into<SourceRequest>,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<Option<ModuleVersionId>> {
+    self.ensure_runtime_mutation_allowed(
+      "build_module_from_request_with_context",
+    )?;
     let mut dependency_graph = ModuleDependencyGraph::new();
 
     self.build_module_from_request_with_context_and_graph(
@@ -511,6 +528,9 @@ impl MechRuntime {
     request: impl Into<SourceRequest>,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<Value> {
+    self.ensure_runtime_mutation_allowed(
+      "resolve_and_run_root_module",
+    )?;
     let mut context = self.runtime_context()?;
     self.resolve_and_run_root_module_with_context(&mut context, request, options)
   }
@@ -594,6 +614,7 @@ impl MechRuntime {
     source: &str,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
+    self.ensure_runtime_mutation_allowed("put_source_module")?;
     let mut context = self.runtime_context()?;
 
     self.put_source_module_with_context(
@@ -613,6 +634,9 @@ impl MechRuntime {
     source: &str,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<ModuleVersionId> {
+    self.ensure_runtime_mutation_allowed(
+      "put_source_module_with_context",
+    )?;
     let resolved = ResolvedSource::new(
       name,
       canonical_uri,
@@ -632,6 +656,9 @@ impl MechRuntime {
     module: ModuleId,
     version: ModuleVersionId,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "activate_module_version",
+    )?;
     let mut context = self.runtime_context()?
       .with_module_version(version);
 
@@ -644,6 +671,9 @@ impl MechRuntime {
     module: ModuleId,
     version: ModuleVersionId,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "activate_module_version_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 

--- a/src/runtime/src/runtime/object.rs
+++ b/src/runtime/src/runtime/object.rs
@@ -14,6 +14,7 @@ use super::*;
 impl MechRuntime {
 
   pub fn put_object(&mut self, object: ObjectRecord) -> MResult<ObjectId> {
+    self.ensure_runtime_mutation_allowed("put_object")?;
     let mut context = self.runtime_context()?;
     self.put_object_with_context(&mut context, object)
   }
@@ -23,6 +24,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     object: ObjectRecord,
   ) -> MResult<ObjectId> {
+    self.ensure_runtime_mutation_allowed("put_object_with_context")?;
     self.validate_context_for_runtime(context)?;
     context.charge_bytes(object.data.len() as u64)?;
 
@@ -82,6 +84,7 @@ impl MechRuntime {
   }
 
   pub fn update_object(&mut self, object: ObjectRecord) -> MResult<ObjectId> {
+    self.ensure_runtime_mutation_allowed("update_object")?;
     let mut context = self.runtime_context()?;
     self.update_object_with_context(&mut context, object)
   }
@@ -91,6 +94,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     object: ObjectRecord,
   ) -> MResult<ObjectId> {
+    self.ensure_runtime_mutation_allowed(
+      "update_object_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_bytes(object.data.len() as u64)?;
 

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -313,6 +313,14 @@ impl MechRuntime {
     ))
   }
 
+  pub(super) fn ensure_runtime_mutation_allowed(
+    &self,
+    operation: &'static str,
+  ) -> MResult<()> {
+    self.ensure_runtime_healthy(operation)?;
+    self.reject_effect_reentrancy(operation)
+  }
+
   pub(super) fn reject_transactional_reactive_turn(
     &self,
     context: &RuntimeContext,
@@ -615,9 +623,8 @@ impl MechRuntime {
     context: &RuntimeContext,
     operation: &'static str,
   ) -> MResult<()> {
-    self.ensure_runtime_healthy(operation)?;
+    self.ensure_runtime_mutation_allowed(operation)?;
     self.validate_context_for_runtime(context)?;
-    self.reject_effect_reentrancy(operation)?;
     self.reject_program_operation_reentrancy(operation)?;
 
     if let Some(owner) = self.program_transaction_owner {

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -818,6 +818,8 @@ mod tests {
   use crate::{
     ClosureHostFunction, NodeId, PreparedRuntimeEffect,
     RuntimeAfterCommitEffect, RuntimeEffectMetadata, RuntimeEffectSource,
+    RuntimePreparedHostCall, RuntimeTransactionalEffect,
+    StagedClosureHostFunction,
   };
 
   #[derive(Debug)]
@@ -844,6 +846,76 @@ mod tests {
     PreparedRuntimeEffect::AfterCommit(Box::new(
       SavepointAfterCommitEffect { name },
     ))
+  }
+
+  #[derive(Debug)]
+  struct CommitDecisionEffect {
+    name: &'static str,
+    log: Arc<Mutex<Vec<String>>>,
+    fail_commit: bool,
+  }
+
+  impl RuntimeTransactionalEffect for CommitDecisionEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::HostFunction {
+          name: self.name.to_string(),
+        },
+        "commit-decision",
+      )
+    }
+
+    fn prepare(&mut self) -> MResult<()> {
+      self
+        .log
+        .lock()
+        .unwrap()
+        .push(format!("{}:prepare", self.name));
+      Ok(())
+    }
+
+    fn commit(&mut self) -> MResult<()> {
+      self
+        .log
+        .lock()
+        .unwrap()
+        .push(format!("{}:commit", self.name));
+      if self.fail_commit {
+        return Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "commit_decision_test",
+            reason: format!("{} deliberate commit failure", self.name),
+          },
+          None,
+        ));
+      }
+      Ok(())
+    }
+
+    fn abort(&mut self) -> MResult<()> {
+      self
+        .log
+        .lock()
+        .unwrap()
+        .push(format!("{}:abort", self.name));
+      Ok(())
+    }
+  }
+
+  fn grant_program_host_call(
+    runtime: &mut MechRuntime,
+    id: CapabilityId,
+    name: &str,
+  ) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        id,
+        &BasicSubject::new(&subject),
+        &BasicResource::new(format!("host:{name}")),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
   }
 
   #[derive(Debug)]
@@ -1089,6 +1161,68 @@ mod tests {
         event.kind,
         RuntimeEventKind::TransactionCommitted { .. }
       )
+    }));
+  }
+
+  #[test]
+  fn committed_implicit_participant_failure_never_rolls_back_program() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    for (id, name, fail_commit) in [
+      (CapabilityId(800), "round4/first", false),
+      (CapabilityId(801), "round4/second", true),
+    ] {
+      grant_program_host_call(&mut runtime, id, name);
+      let effect_log = log.clone();
+      runtime
+        .register_mech_host_function(StagedClosureHostFunction::new(
+          name,
+          move |_services, _context, _args| {
+            Ok(RuntimePreparedHostCall {
+              value: Value::F64(mech_core::Ref::new(1.0)),
+              effect: PreparedRuntimeEffect::Transactional(Box::new(
+                CommitDecisionEffect {
+                  name,
+                  log: effect_log.clone(),
+                  fail_commit,
+                },
+              )),
+            })
+          },
+        ))
+        .unwrap();
+    }
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .run_string_with_context(
+        &mut context,
+        "round4-committed-symbol := 41\nfirst-result := round4/first()\nsecond-result := round4/second()",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeExternalCommitIndeterminate");
+    assert_eq!(
+      *log.lock().unwrap(),
+      vec![
+        "round4/first:prepare",
+        "round4/second:prepare",
+        "round4/first:commit",
+        "round4/second:commit",
+      ],
+    );
+    assert!(runtime
+      .program
+      .root_symbol_value("round4-committed-symbol")
+      .is_ok());
+    assert_eq!(context.transaction, None);
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(runtime.active_transactions.is_empty());
+    assert!(runtime.is_poisoned());
+    let transactions = runtime.list_transactions(None).unwrap();
+    assert_eq!(transactions.len(), 1);
+    assert!(!runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::TransactionAborted { .. })
     }));
   }
 

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -387,25 +387,41 @@ impl MechRuntime {
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let effect_rollback = match self.active_transactions.get_mut(&transaction_id) {
       Some(transaction) => {
+        let abortable_ids = transaction
+          .effects
+          .abortable_ids_after(savepoint.effect_mark);
         let effect_failures =
           transaction.effects.rollback_to(savepoint.effect_mark);
         transaction.store = savepoint.store.clone();
         let capability_result = transaction
           .capabilities
           .rollback_to(savepoint.capability_mark);
-        Some((effect_failures, capability_result))
+        Some((effect_failures, capability_result, abortable_ids))
       }
       None => None,
     };
     self.active_effect_phase = None;
     match effect_rollback {
-      Some((effect_failures, capability_result)) => {
+      Some((effect_failures, capability_result, abortable_ids)) => {
+        let failed_effects: HashSet<RuntimeEffectId> = effect_failures
+          .iter()
+          .map(|failure| failure.effect_id)
+          .collect();
         failures.extend(Self::describe_effect_failures(effect_failures));
         if let Err(error) = capability_result {
           failures.push(format!(
             "capability overlay rollback failed: {:?}",
             error,
           ));
+        }
+        for effect_id in abortable_ids {
+          if failed_effects.contains(&effect_id) {
+            continue;
+          }
+          let _ = self.emit_effect_event_outside_transaction(
+            context,
+            RuntimeEventKind::EffectAborted { effect_id },
+          );
         }
       }
       None => failures.push(format!(

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -706,10 +706,22 @@ impl MechRuntime {
     self.active_program_operation = None;
 
     let original_error = match execution_result {
-      Ok(value) if implicit => match self.commit_runtime_transaction_internal(context) {
-        Ok(_) => return Ok(value),
-        Err(error) => error,
-      },
+      Ok(value) if implicit => {
+        match self.commit_runtime_transaction_internal(context) {
+          Ok(super::transaction::RuntimeCommitResolution::Committed(_)) => {
+            return Ok(value);
+          }
+          Ok(
+            super::transaction::RuntimeCommitResolution::CommittedWithError {
+              error,
+              ..
+            },
+          ) => {
+            return Err(error);
+          }
+          Err(error) => error,
+        }
+      }
       Ok(value) => return Ok(value),
       Err(error) => error,
     };

--- a/src/runtime/src/runtime/schedule.rs
+++ b/src/runtime/src/runtime/schedule.rs
@@ -20,6 +20,7 @@ use super::*;
 impl MechRuntime {
 
   pub fn enqueue_work(&mut self, work: ScheduledWork) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("enqueue_work")?;
     let mut context = self.runtime_context()?;
     self.enqueue_work_with_context(&mut context, work)
   }
@@ -29,6 +30,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     work: ScheduledWork,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("enqueue_work_with_context")?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     work.validate()?;
@@ -40,14 +42,17 @@ impl MechRuntime {
   }
 
   pub fn enqueue_task(&mut self, task_id: TaskId) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("enqueue_task")?;
     self.enqueue_work(ScheduledWork::task(task_id))
   }
 
   pub fn enqueue_actor(&mut self, actor_id: ActorId) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("enqueue_actor")?;
     self.enqueue_work(ScheduledWork::actor(actor_id))
   }
 
   pub fn collect_tick(&mut self) -> MResult<SchedulerTick> {
+    self.ensure_runtime_mutation_allowed("collect_tick")?;
     let mut context = self.runtime_context()?;
     self.collect_tick_with_context(&mut context)
   }
@@ -56,6 +61,7 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
   ) -> MResult<SchedulerTick> {
+    self.ensure_runtime_mutation_allowed("collect_tick_with_context")?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
@@ -74,6 +80,9 @@ impl MechRuntime {
     work: ScheduledWork,
     outcome: RuntimeTurnOutcome,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "complete_scheduled_work",
+    )?;
     let mut context = self.runtime_context()?;
     self.complete_scheduled_work_with_context(&mut context, work, outcome)
   }
@@ -84,6 +93,9 @@ impl MechRuntime {
     work: ScheduledWork,
     outcome: RuntimeTurnOutcome,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "complete_scheduled_work_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     work.validate()?;
@@ -99,6 +111,7 @@ impl MechRuntime {
     work: ScheduledWork,
     message: impl Into<String>,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("fail_scheduled_work")?;
     let mut context = self.runtime_context()?;
     self.fail_scheduled_work_with_context(&mut context, work, message)
   }
@@ -109,6 +122,9 @@ impl MechRuntime {
     work: ScheduledWork,
     message: impl Into<String>,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "fail_scheduled_work_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
     work.validate()?;
@@ -123,6 +139,7 @@ impl MechRuntime {
     &mut self,
     work: ScheduledWork,
   ) -> MResult<RuntimeTurnOutcome> {
+    self.ensure_runtime_mutation_allowed("run_scheduled_work")?;
     match work {
       ScheduledWork::Task { task_id } => self.run_scheduled_task(task_id),
       ScheduledWork::Actor { actor_id } => self.run_actor_turn(actor_id),
@@ -133,6 +150,7 @@ impl MechRuntime {
     &mut self,
     task_id: TaskId,
   ) -> MResult<RuntimeTurnOutcome> {
+    self.ensure_runtime_mutation_allowed("run_scheduled_task")?;
     let Some(task) = self.store.get_task(task_id)? else {
       return Err(MechError::new(
         RuntimeRecordNotFoundError {
@@ -198,6 +216,7 @@ impl MechRuntime {
     &mut self,
     actor_id: ActorId,
   ) -> MResult<RuntimeTurnOutcome> {
+    self.ensure_runtime_mutation_allowed("run_actor_turn")?;
     let Some(actor) = self.store.get_actor(actor_id)? else {
       return Err(MechError::new(
         RuntimeRecordNotFoundError {
@@ -284,6 +303,7 @@ impl MechRuntime {
   }
 
   pub fn run_tick(&mut self) -> MResult<Vec<RuntimeTurnOutcome>> {
+    self.ensure_runtime_mutation_allowed("run_tick")?;
     let tick = self.collect_tick()?;
     let mut outcomes = Vec::new();
 

--- a/src/runtime/src/runtime/service.rs
+++ b/src/runtime/src/runtime/service.rs
@@ -7,6 +7,10 @@
 use super::*;
 
 impl RuntimeServices for MechRuntime {
+  // This infallible compatibility allocator is reachable by runtime-managed
+  // code only after the enclosing host/actor operation passes centralized
+  // mutation preflight. Direct administrative use is outside the poison
+  // guarantee, like the raw `*_mut` accessors.
   fn next_object_id(&mut self) -> ObjectId {
     MechRuntime::next_object_id(self)
   }

--- a/src/runtime/src/runtime/task.rs
+++ b/src/runtime/src/runtime/task.rs
@@ -22,6 +22,7 @@ use super::*;
 impl MechRuntime {
 
   pub fn put_task(&mut self, task: TaskRecord) -> MResult<TaskId> {
+    self.ensure_runtime_mutation_allowed("put_task")?;
     let mut context = self.context_for_task(&task)?;
     self.put_task_with_context(&mut context, task)
   }
@@ -31,6 +32,7 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     task: TaskRecord,
   ) -> MResult<TaskId> {
+    self.ensure_runtime_mutation_allowed("put_task_with_context")?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
@@ -80,6 +82,7 @@ impl MechRuntime {
     module_version: Option<ModuleVersionId>,
     capabilities: Vec<CapabilityId>,
   ) -> MResult<TaskId> {
+    self.ensure_runtime_mutation_allowed("start_task")?;
     let id = self.next_task_id();
 
     let mut task = TaskRecord::new(id, subject)
@@ -126,6 +129,7 @@ impl MechRuntime {
   }    
 
   pub fn update_task(&mut self, task: TaskRecord) -> MResult<TaskId> {
+    self.ensure_runtime_mutation_allowed("update_task")?;
     self.store.update_task(task)
   }
 
@@ -134,6 +138,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     task: TaskRecord,
   ) -> MResult<TaskId> {
+    self.ensure_runtime_mutation_allowed(
+      "update_task_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     if let Some(transaction_id) = context.transaction {
@@ -150,6 +157,7 @@ impl MechRuntime {
   }
 
   pub fn complete_task(&mut self, id: TaskId) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("complete_task")?;
     let Some(task) = self.store.get_task(id)? else {
       return Err(MechError::new(
         RuntimeRecordNotFoundError {
@@ -169,6 +177,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     id: TaskId,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed(
+      "complete_task_with_context",
+    )?;
     let Some(mut task) = self.get_task_with_context(context, id)? else {
       return Err(MechError::new(
         RuntimeRecordNotFoundError {
@@ -194,6 +205,7 @@ impl MechRuntime {
   }
 
   pub fn fail_task(&mut self, id: TaskId, reason: impl Into<String>) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("fail_task")?;
     let reason = reason.into();
 
     let Some(task) = self.store.get_task(id)? else {
@@ -216,6 +228,7 @@ impl MechRuntime {
     id: TaskId,
     reason: impl Into<String>,
   ) -> MResult<()> {
+    self.ensure_runtime_mutation_allowed("fail_task_with_context")?;
     let reason = reason.into();
 
     let Some(mut task) = self.get_task_with_context(context, id)? else {

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -22,6 +22,14 @@ use crate::{
   RuntimeEffectFailure, RuntimeEffectFailurePhase,
 };
 
+pub(super) enum RuntimeCommitResolution {
+  Committed(RuntimeCommitOutcome),
+  CommittedWithError {
+    transaction_id: TransactionId,
+    error: MechError,
+  },
+}
+
 impl MechRuntime {
 
   pub fn commit_transaction(
@@ -163,24 +171,29 @@ impl MechRuntime {
     self.ensure_runtime_healthy("commit_runtime_transaction")?;
     self.reject_effect_reentrancy("commit_runtime_transaction")?;
     self.reject_program_operation_reentrancy("commit_runtime_transaction")?;
-    self.commit_runtime_transaction_detailed_internal(context)
+    match self.commit_runtime_transaction_detailed_internal(context)? {
+      RuntimeCommitResolution::Committed(outcome) => Ok(outcome),
+      RuntimeCommitResolution::CommittedWithError {
+        transaction_id,
+        error,
+      } => {
+        let _ = transaction_id;
+        Err(error)
+      }
+    }
   }
 
   pub(super) fn commit_runtime_transaction_internal(
     &mut self,
     context: &mut RuntimeContext,
-  ) -> MResult<TransactionId> {
-    Ok(
-      self
-        .commit_runtime_transaction_detailed_internal(context)?
-        .transaction_id,
-    )
+  ) -> MResult<RuntimeCommitResolution> {
+    self.commit_runtime_transaction_detailed_internal(context)
   }
 
   fn commit_runtime_transaction_detailed_internal(
     &mut self,
     context: &mut RuntimeContext,
-  ) -> MResult<RuntimeCommitOutcome> {
+  ) -> MResult<RuntimeCommitResolution> {
     self.validate_context_for_runtime(context)?;
 
     let transaction_id = Self::context_transaction_id(context)?;
@@ -260,10 +273,10 @@ impl MechRuntime {
         self.program_transaction_owner = None;
       }
       self.push_persisted_event_to_context(context, commit_event);
-      return Ok(RuntimeCommitOutcome {
+      return Ok(RuntimeCommitResolution::Committed(RuntimeCommitOutcome {
         transaction_id: id,
         delivery_failures: Vec::new(),
-      });
+      }));
     }
 
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Preparing);
@@ -512,11 +525,15 @@ impl MechRuntime {
             error,
           ));
         }
-        return Err(self.poison_external_commit_indeterminate(
+        let error = self.poison_external_commit_indeterminate(
           id,
           commit_failure.step.failure.effect_id,
           participant_outcomes,
-        ));
+        );
+        return Ok(RuntimeCommitResolution::CommittedWithError {
+          transaction_id: id,
+          error,
+        });
       }
     };
 
@@ -571,10 +588,10 @@ impl MechRuntime {
       }
     }
 
-    Ok(RuntimeCommitOutcome {
+    Ok(RuntimeCommitResolution::Committed(RuntimeCommitOutcome {
       transaction_id: id,
       delivery_failures,
-    })
+    }))
   }
 
   fn cleanup_before_store_retry(

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -45,6 +45,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     transaction: TransactionRecord,
   ) -> MResult<TransactionId> {
+    self.ensure_runtime_mutation_allowed(
+      "commit_transaction_with_context",
+    )?;
     self.validate_context_for_runtime(context)?;
     context.charge_step()?;
 
@@ -75,6 +78,7 @@ impl MechRuntime {
   }
 
   pub fn append_event(&mut self, event: RuntimeEvent) -> MResult<EventId> {
+    self.ensure_runtime_mutation_allowed("append_event")?;
     self.store.append_event(event)
   }
 
@@ -90,8 +94,7 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
   ) -> MResult<TransactionId> {
-    self.ensure_runtime_healthy("begin_transaction")?;
-    self.reject_effect_reentrancy("begin_transaction")?;
+    self.ensure_runtime_mutation_allowed("begin_transaction")?;
     self.reject_program_operation_reentrancy("begin_transaction")?;
     self.begin_runtime_transaction_internal(
       context,
@@ -104,6 +107,9 @@ impl MechRuntime {
     context: &mut RuntimeContext,
     mode: RuntimeExecutionTransactionMode,
   ) -> MResult<TransactionId> {
+    self.ensure_runtime_mutation_allowed(
+      "begin_runtime_transaction_internal",
+    )?;
     self.validate_context_for_runtime(context)?;
 
     if context.transaction.is_some() {
@@ -168,8 +174,7 @@ impl MechRuntime {
     &mut self,
     context: &mut RuntimeContext,
   ) -> MResult<RuntimeCommitOutcome> {
-    self.ensure_runtime_healthy("commit_runtime_transaction")?;
-    self.reject_effect_reentrancy("commit_runtime_transaction")?;
+    self.ensure_runtime_mutation_allowed("commit_runtime_transaction")?;
     self.reject_program_operation_reentrancy("commit_runtime_transaction")?;
     match self.commit_runtime_transaction_detailed_internal(context)? {
       RuntimeCommitResolution::Committed(outcome) => Ok(outcome),
@@ -657,7 +662,7 @@ impl MechRuntime {
     let id = event.id;
     context.push_event(event.clone());
     self.trim_events_to_retention(&mut context.events);
-    if let Err(error) = self.append_event(event) {
+    if let Err(error) = self.store.append_event(event) {
       context.events = context_events_before;
       return Err(error);
     }

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -276,6 +276,7 @@ impl MechRuntime {
       return Ok(RuntimeCommitResolution::Committed(RuntimeCommitOutcome {
         transaction_id: id,
         delivery_failures: Vec::new(),
+        audit_failures: Vec::new(),
       }));
     }
 
@@ -287,44 +288,29 @@ impl MechRuntime {
       let prepared_ids =
         envelope.effects.prepared_transactional_ids();
       self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
-      let mut cleanup = envelope.effects.abort_prepared_reverse();
+      let cleanup = envelope.effects.abort_prepared_reverse();
       self.active_effect_phase = None;
       let failed_ids: HashSet<RuntimeEffectId> = cleanup
         .iter()
         .map(|failure| failure.effect_id)
         .collect();
-      if let Err(error) = self.stage_effect_lifecycle_event(
+      let _ = self.stage_effect_lifecycle_event(
         &mut envelope,
         context,
         RuntimeEventKind::EffectPreparationFailed {
           effect_id: step.failure.effect_id,
           message: step.failure.message.clone(),
         },
-      ) {
-        cleanup.push(RuntimeEffectFailure {
-          effect_id: step.failure.effect_id,
-          phase: RuntimeEffectFailurePhase::Abort,
-          message: format!(
-            "preparation failure audit event failed: {:?}",
-            error,
-          ),
-        });
-      }
+      );
       for effect_id in prepared_ids {
         if failed_ids.contains(&effect_id) {
           continue;
         }
-        if let Err(error) = self.stage_effect_lifecycle_event(
+        let _ = self.stage_effect_lifecycle_event(
           &mut envelope,
           context,
           RuntimeEventKind::EffectAborted { effect_id },
-        ) {
-          cleanup.push(RuntimeEffectFailure {
-            effect_id,
-            phase: RuntimeEffectFailurePhase::Abort,
-            message: format!("abort audit event failed: {:?}", error),
-          });
-        }
+        );
       }
       envelope.state = RuntimeExecutionTransactionState::Active;
       self.active_transactions.insert(transaction_id, envelope);
@@ -350,7 +336,7 @@ impl MechRuntime {
             envelope.effects.prepared_transactional_ids();
           self.active_effect_phase =
             Some(ActiveRuntimeEffectPhase::Aborting);
-          let mut aborted = envelope.effects.abort_prepared_reverse();
+          let aborted = envelope.effects.abort_prepared_reverse();
           self.active_effect_phase = None;
           let failed_ids: HashSet<RuntimeEffectId> = aborted
             .iter()
@@ -360,22 +346,11 @@ impl MechRuntime {
             if failed_ids.contains(&effect_id) {
               continue;
             }
-            if let Err(audit_error) =
-              self.stage_effect_lifecycle_event(
-                &mut envelope,
-                context,
-                RuntimeEventKind::EffectAborted { effect_id },
-              )
-            {
-              aborted.push(RuntimeEffectFailure {
-                effect_id,
-                phase: RuntimeEffectFailurePhase::Abort,
-                message: format!(
-                  "abort audit event failed: {:?}",
-                  audit_error,
-                ),
-              });
-            }
+            let _ = self.stage_effect_lifecycle_event(
+              &mut envelope,
+              context,
+              RuntimeEventKind::EffectAborted { effect_id },
+            );
           }
           envelope.state = RuntimeExecutionTransactionState::Active;
           self.active_transactions.insert(transaction_id, envelope);
@@ -489,53 +464,8 @@ impl MechRuntime {
     };
 
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Committing);
-    let participant_result = envelope.effects.commit_transactional();
+    let commit_report = envelope.effects.commit_transactional();
     self.active_effect_phase = None;
-    let committed_effects = match participant_result {
-      Ok(committed_effects) => committed_effects,
-      Err(commit_failure) => {
-        context.transaction = None;
-        if self.program_transaction_owner == Some(transaction_id) {
-          self.program_transaction_owner = None;
-        }
-        self.push_persisted_event_to_context(context, commit_event);
-        let mut participant_outcomes =
-          commit_failure.participant_outcomes;
-        for effect_id in commit_failure.committed {
-          if let Err(error) = self.emit_event_to_context(
-            context,
-            RuntimeEventKind::TransactionalEffectCommitted { effect_id },
-          ) {
-            participant_outcomes.push(format!(
-              "transactional effect {} commit audit failed: {:?}",
-              effect_id,
-              error,
-            ));
-          }
-        }
-        if let Err(error) = self.emit_event_to_context(
-          context,
-          RuntimeEventKind::ExternalCommitIndeterminate {
-            transaction_id: id,
-            effect_id: commit_failure.step.failure.effect_id,
-          },
-        ) {
-          participant_outcomes.push(format!(
-            "external commit indeterminate audit failed: {:?}",
-            error,
-          ));
-        }
-        let error = self.poison_external_commit_indeterminate(
-          id,
-          commit_failure.step.failure.effect_id,
-          participant_outcomes,
-        );
-        return Ok(RuntimeCommitResolution::CommittedWithError {
-          transaction_id: id,
-          error,
-        });
-      }
-    };
 
     context.transaction = None;
     if self.program_transaction_owner == Some(transaction_id) {
@@ -543,30 +473,68 @@ impl MechRuntime {
     }
     self.push_persisted_event_to_context(context, commit_event);
 
-    for effect_id in committed_effects {
+    let mut audit_failures = Vec::new();
+    for effect_id in commit_report.committed {
       if let Err(error) = self.emit_event_to_context(
         context,
         RuntimeEventKind::TransactionalEffectCommitted { effect_id },
       ) {
-        return Err(self.poison_effect_cleanup(
-          "commit_runtime_transaction",
-          id,
-          format!(
-            "transactional effect {} committed but its audit event failed",
-            effect_id,
-          ),
-          vec![format!(
-            "transactional effect {} committed but its audit event failed: {:?}",
-            effect_id,
+        audit_failures.push(RuntimeEffectFailure {
+          effect_id,
+          phase: RuntimeEffectFailurePhase::Audit,
+          message: format!(
+            "transactional effect commit audit failed: {:?}",
             error,
-          )],
-        ));
+          ),
+        });
       }
+    }
+
+    if !commit_report.failures.is_empty() {
+      let failures: Vec<RuntimeEffectFailure> = commit_report
+        .failures
+        .into_iter()
+        .map(|step| step.failure)
+        .collect();
+      let mut participant_outcomes = commit_report.participant_outcomes;
+      for failure in &failures {
+        if let Err(error) = self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ExternalCommitIndeterminate {
+            transaction_id: id,
+            effect_id: failure.effect_id,
+          },
+        ) {
+          participant_outcomes.push(format!(
+            "external commit indeterminate audit for effect {} failed: {:?}",
+            failure.effect_id,
+            error,
+          ));
+        }
+      }
+      participant_outcomes.extend(
+        audit_failures.iter().map(|failure| {
+          format!(
+            "effect {} audit failed: {}",
+            failure.effect_id,
+            failure.message,
+          )
+        }),
+      );
+      let error = self.poison_external_commit_indeterminate(
+        id,
+        failures,
+        participant_outcomes,
+      );
+      return Ok(RuntimeCommitResolution::CommittedWithError {
+        transaction_id: id,
+        error,
+      });
     }
 
     let after_commit_ids = envelope.effects.after_commit_ids();
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Delivering);
-    let mut delivery_failures = envelope.effects.deliver_after_commit();
+    let delivery_failures = envelope.effects.deliver_after_commit();
     self.active_effect_phase = None;
     for effect_id in after_commit_ids {
       let kind = match delivery_failures
@@ -580,9 +548,9 @@ impl MechRuntime {
         None => RuntimeEventKind::EffectDelivered { effect_id },
       };
       if let Err(error) = self.emit_event_to_context(context, kind) {
-        delivery_failures.push(RuntimeEffectFailure {
+        audit_failures.push(RuntimeEffectFailure {
           effect_id,
-          phase: RuntimeEffectFailurePhase::Deliver,
+          phase: RuntimeEffectFailurePhase::Audit,
           message: format!("delivery audit event failed: {:?}", error),
         });
       }
@@ -591,6 +559,7 @@ impl MechRuntime {
     Ok(RuntimeCommitResolution::Committed(RuntimeCommitOutcome {
       transaction_id: id,
       delivery_failures,
+      audit_failures,
     }))
   }
 
@@ -621,21 +590,14 @@ impl MechRuntime {
       .iter()
       .map(|failure| failure.effect_id)
       .collect();
-    let mut audit_failures = Vec::new();
     for failure in &compensated {
-      if let Err(error) = self.emit_effect_event_outside_transaction(
+      let _ = self.emit_effect_event_outside_transaction(
         context,
         RuntimeEventKind::EffectCompensationFailed {
           effect_id: failure.effect_id,
           message: failure.message.clone(),
         },
-      ) {
-        audit_failures.push(format!(
-          "effect {} compensation failure audit event failed: {:?}",
-          failure.effect_id,
-          error,
-        ));
-      }
+      );
     }
     let mut failures = Self::describe_effect_failures(compensated);
     if let Some(Err(error)) = capability_restore {
@@ -645,37 +607,24 @@ impl MechRuntime {
       ));
     }
     failures.extend(Self::describe_effect_failures(aborted));
-    failures.extend(audit_failures);
     for effect_id in compensated_ids {
       if failed_compensations.contains(&effect_id) {
         continue;
       }
-      if let Err(error) = self.emit_effect_event_outside_transaction(
+      let _ = self.emit_effect_event_outside_transaction(
         context,
         RuntimeEventKind::EffectCompensated { effect_id },
-      ) {
-        failures.push(format!(
-          "effect {} compensation audit event failed: {:?}",
-          effect_id,
-          error,
-        ));
-      }
+      );
     }
     for effect_id in aborted_ids {
       if failed_aborts.contains(&effect_id) {
         continue;
       }
-      if let Err(error) = self.stage_effect_lifecycle_event(
+      let _ = self.stage_effect_lifecycle_event(
         envelope,
         context,
         RuntimeEventKind::EffectAborted { effect_id },
-      ) {
-        failures.push(format!(
-          "effect {} abort audit event failed: {:?}",
-          effect_id,
-          error,
-        ));
-      }
+      );
     }
     failures
   }
@@ -698,7 +647,7 @@ impl MechRuntime {
     Ok(id)
   }
 
-  fn emit_effect_event_outside_transaction(
+  pub(super) fn emit_effect_event_outside_transaction(
     &mut self,
     context: &mut RuntimeContext,
     kind: RuntimeEventKind,
@@ -909,32 +858,19 @@ impl MechRuntime {
       if failed_effect_aborts.contains(&effect_id) {
         continue;
       }
-      if let Err(error) = self.emit_event_immediate_to_context(
+      let _ = self.emit_event_immediate_to_context(
         context,
         RuntimeEventKind::EffectAborted { effect_id },
-      ) {
-        rollback_failures.push(format!(
-          "effect {} abort audit event failed: {:?}",
-          effect_id,
-          error,
-        ));
-      }
+      );
     }
 
-    let abort_event_result = self.emit_event_immediate_to_context(
+    let _ = self.emit_event_immediate_to_context(
       context,
       RuntimeEventKind::TransactionAborted {
         transaction_id,
         message: reason.to_string(),
       },
     );
-
-    if let Err(error) = abort_event_result {
-      rollback_failures.push(format!(
-        "transaction abort audit event failed: {:?}",
-        error,
-      ));
-    }
 
     Ok((transaction_id, rollback_failures))
   }

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -682,6 +682,11 @@ impl MechRuntime {
         }
       }
     }
+    for (capability, uses) in envelope.capabilities.usage_deltas() {
+      self
+        .capability_kernel
+        .apply_usage_delta(capability, uses)?;
+    }
     Ok(())
   }
 


### PR DESCRIPTION
## Summary

This is the merge-blocking Round 4 correctness pass for #651. It starts at the exact umbrella head `a54e601ec01398b6c20ce4901c8e67fa5e59de71` and stays within the Round 4 runtime/provider boundary.

## Guarantees established

- Post-store participant failures resolve as committed-with-error and cannot enter program, live-state, context, capability, or effect rollback.
- Every prepared transactional participant receives exactly one commit decision after the runtime store commits, even when earlier participants fail.
- External commit indeterminacy retains every participant failure and outcome, suppresses `AfterCommit` delivery, preserves committed state, and poisons the runtime.
- Audit-event failures are reported separately and never alter commit/rollback decisions or poison an otherwise healthy runtime.
- Native host preview authorization is explicitly non-consuming and fails closed for capabilities without a preview contract.
- Preview-only staged effects are inert and are dropped without invoking `prepare`, `commit`, `abort`, or `compensate`.
- Provisional capability uses transfer to the live kernel on commit and are restored by the existing kernel checkpoint if store commit fails.
- Provisional capability selection is deterministic across grant, revoke, and regrant sequences.
- Poisoned runtime-owned mutation is fail-closed before callbacks, budgeting, ID allocation, event creation, provider work, or mutation; explicit abort cleanup and shutdown remain available.
- Failed effect cleanup retains the journal handle for a later outer-abort retry, and effect sequence IDs are not rewound.

## Commits

1. `fec174355` — `fix(runtime): preserve committed implicit transactions`
2. `2e863af1d` — `fix(runtime): complete external participant commit decisions`
3. `665516c5f` — `fix(runtime): make host preview authorization non-consuming`
4. `ce5294739` — `fix(runtime): commit provisional capability usage`
5. `1c22460e3` — `fix(runtime): close poisoned mutation paths`
6. `3393796c8` — `test(runtime): cover round4 commit and capability adversaries`
7. `26a520aeb` — `fix(runtime): close remaining poisoned capability paths`

## Local validation

Focused/adversarial suites:

- runtime effect tests: 22 passed
- runtime capability tests: 19 passed
- runtime host transaction tests: 10 passed
- program transaction coordinator tests: 18 passed
- committed implicit participant failure regression: passed

Required broader validation:

- `mech-runtime --test module_smoke`: 235 passed
- `mech-host-cli`: passed
- `mech-host-console`: 3 passed
- `mech-host-browser`: 40 passed
- `mech-host-scene`: 27 passed
- `mech-host-robot-arm`: passed
- minimal `mech-runtime` (`base`) check: passed
- workspace check: passed (existing warnings only)
- `program_transaction` benchmark compile: passed
- worktree and full-PR diff checks: passed

The full runtime library suite executed 413 tests: 410 passed and the three known macOS workspace-watch tests failed. Each exact failure was reproduced at both parent `a54e601ec01398b6c20ce4901c8e67fa5e59de71` and corrective head `26a520aeb239cf5a275d503356fd7bb89bbbdf13`:

- `nonrecursive_directory_watch_allows_directory_and_direct_children_only`: identical `event_allowed_by_watches` assertion at `watch.rs:783`
- `recursive_directory_watch_still_allows_descendants`: identical `event_allowed_by_watches` assertion at `watch.rs:815`
- `target_watch_falls_back_to_existing_parent_when_target_is_deleted`: identical duplicate `/var/...` plus `/private/var/...` actual path versus single `/var/...` expected path at `watch.rs:465`

These are parent-identical macOS path-alias failures; no transaction, host, capability, effect, or provider failure was classified as pre-existing.

Per project-owner instruction, rustfmt was not run. No repository-wide formatting rewrite was performed.

## Poisoned-runtime boundary follow-up

Commit `26a520aeb239cf5a275d503356fd7bb89bbbdf13` closes the remaining public mutation paths:

- `check_capability_with_context` now rejects poisoned or effect-reentrant calls before context validation, budget charging, transaction lookup, overlay mutation, or live-kernel use accounting.
- `preview_capability_with_context` now identifies itself correctly in poison diagnostics without becoming consuming.
- `set_source_resolver` is a normal fallible runtime mutation, so it rejects poisoned and effect-reentrant replacement while preserving the installed resolver; its two CLI callers now propagate failure.
- The poison-boundary regression proves context capability checks leave budget, live use count, and transaction-local overlay usage unchanged; it also proves explicit abort cleanup remains available.

## Scope boundaries

This PR does not add Round 5 module-graph transactions, Round 6 reactive transactions, history, durable cell IDs, storage-layout changes, or transaction work in the reactive hot loop.

## CI

All eight required GitHub Actions jobs passed at `26a520aeb239cf5a275d503356fd7bb89bbbdf13`:

- Cargo language tests
- Cargo runtime and host tests
- Dynamic modules
- Project browser
- Project native
- Run-only CLI
- Windows CLI
- cargo