### PR TITLE
fix(runtime): make module graph execution atomic

### DIFF
--- a/docs/design/runtime-program-transactions.md
+++ b/docs/design/runtime-program-transactions.md
@@ -101,11 +101,14 @@ Transactional `step_with_context` and host-input turns are rejected while a
 transaction is active or owns the program. Nontransactional reactive turns
 retain their existing behavior. Compact reactive-turn deltas belong to Round 6.
 
-Retained root-module installation and execution are coordinated after a root
-module version has been built. Module source resolution, compilation,
-module-record persistence, dependency invariant reporting, and the complete
-module-graph store handoff are not included in the program savepoint. Those
-become atomic in Round 5.
+Retained root-module construction and execution now share the same
+runtime-owned program transaction. The existing recursive dependency builder
+stages module and module-version records in the execution transaction, and the
+program operation savepoint carries a module-journal mark. A pre-store root
+failure therefore restores the prior retained program and exposes no partial
+durable graph. After the durable store commit, graph and program state remain
+committed even if an external transactional participant reports commit
+indeterminacy.
 
 One-shot bytecode execution and isolated dependency-module programs continue
 to use temporary programs and are not retained-operation transactions.

--- a/docs/runtime/atomic-module-graph-transactions.md
+++ b/docs/runtime/atomic-module-graph-transactions.md
@@ -1,0 +1,81 @@
+# Atomic module-graph transactions
+
+Round 5 makes graph-producing runtime APIs atomic without replacing the
+existing recursive `ModuleDependencyGraph` builder. Dependencies are still
+resolved and compiled before their importers, import-edge ordering and
+multiplicity are preserved, and the existing cycle and dependency errors
+remain authoritative.
+
+## Transaction-local publication
+
+Each runtime execution transaction owns a private module journal. The journal
+contains ordered module and module-version puts; it does not contain
+activation changes. Transaction-aware graph construction reads its owning
+journal first and then the committed store. Other transactions and ordinary
+committed-store reads cannot see provisional records.
+
+An operation savepoint records a journal mark alongside the existing staged
+store, effect, capability, context, program, and live-state checkpoints.
+Rolling back an operation truncates the module journal to that mark and
+rebuilds its private indexes. Earlier successful work in an explicit
+transaction therefore remains provisional when a later graph build fails.
+
+At commit, module and module-version records are added to
+`RuntimeStoreCommit`. The in-memory store validates and applies them with the
+other staged categories through one clone, apply, and swap. Equal publication
+is idempotent; a conflicting identity rejects the complete batch.
+
+Module invariants are checked before transactional effects are prepared.
+Owners, dependency versions, and import-edge targets must be visible in the
+same journal or the committed store.
+
+## Retained-root boundary
+
+`resolve_and_run_root_module_with_context` enters
+`with_atomic_program_operation` before resolving or compiling the root.
+Source-resolution events, compiled records, dependency execution, retained
+root installation, live registration, effects, capabilities, and ordinary
+staged store work therefore share one transaction.
+
+A pre-store failure rolls back the graph and retained program together. For an
+implicit operation, the hidden transaction is removed. For an explicit
+transaction, a failed operation restores its savepoint while preserving
+earlier provisional work; a retryable commit failure keeps the complete outer
+transaction available for retry or abort.
+
+Once the durable store commit succeeds, graph and program rollback is no
+longer permitted. A transactional participant commit failure is external
+commit indeterminacy: the graph and retained program stay durable, all
+prepared participants receive the commit decision, and the runtime is
+poisoned. Failure to deliver an after-commit effect also leaves the graph and
+program committed, but follows the existing healthy delivery-failure outcome.
+
+Resolver reads are non-reversible observations. Round 5 stages the records and
+events derived from those reads; it does not claim source snapshot consistency
+or resolution conflict detection.
+
+## Boundaries and exclusions
+
+Standalone `run_module` remains isolated and does not install a retained
+program. It can execute a provisional graph only when called with the owning
+explicit transaction context.
+
+Public `ensure_module` and module activation APIs retain their prior direct
+store behavior and signatures. Activation is not staged and no activation
+compare-and-set protocol is introduced.
+
+Reactive `step_with_context` and host-input turns remain rejected while a
+transaction is active. Compact reactive-turn transaction work remains Round
+6, and no module journal or whole-program checkpoint work enters the reactive
+inner loop.
+
+## Module-version identity
+
+Module-version hashes use the `mech.module.version.full.v2` domain and include
+the owning `ModuleId` before source and build inputs. Equal source text under
+different canonical module identities therefore produces different valid
+version IDs, while equal canonical identity and build inputs reuse one
+version.
+
+Round 5 does not add module history or rewind records, a complete-graph build
+session, activation transactions, or source snapshot transactions.

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -5,6 +5,7 @@ use mech_core::{MResult, MechSourceCode, Value};
 use mech_runtime::{
   BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
   CapabilityRequest, MechRuntime, ObjectId, ObjectRecord,
+  InMemorySourceResolver, ModuleBuildOptions,
   PreparedRuntimeEffect, RuntimeAfterCommitEffect,
   RuntimeCompensatableEffect, RuntimeContext, RuntimeEffectMetadata,
   RuntimeEffectSource, RuntimePreparedHostCall, SequentialIdGenerator,
@@ -112,6 +113,57 @@ fn retained_runtime() -> MechRuntime {
 
 fn explicit_fixture() -> ExplicitFixture {
   let mut runtime = retained_runtime();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+  ExplicitFixture { runtime, context }
+}
+
+fn module_options() -> ModuleBuildOptions<'static> {
+  ModuleBuildOptions::new(
+    "benchmark",
+    "v0.3",
+    "native",
+    &[],
+    &[],
+  )
+}
+
+fn retained_root_fixture() -> MechRuntime {
+  let resolver = InMemorySourceResolver::new()
+    .with_string(
+      "root.mec",
+      "+> ./dep.mec\nanswer := dep/value + 1\nanswer\n",
+    )
+    .with_string(
+      "dep.mec",
+      "value := 41\n<+ value\n",
+    );
+  MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .source_resolver(resolver)
+    .build()
+    .unwrap()
+}
+
+fn retained_root_failure_fixture() -> MechRuntime {
+  let resolver = InMemorySourceResolver::new()
+    .with_string(
+      "root.mec",
+      "+> ./dep.mec\n+> ./missing.mec\nanswer := 1\n",
+    )
+    .with_string(
+      "dep.mec",
+      "value := 41\n<+ value\n",
+    );
+  MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .source_resolver(resolver)
+    .build()
+    .unwrap()
+}
+
+fn explicit_graph_fixture() -> ExplicitFixture {
+  let mut runtime = retained_root_fixture();
   let mut context = runtime.runtime_context().unwrap();
   runtime.begin_transaction(&mut context).unwrap();
   ExplicitFixture { runtime, context }
@@ -480,6 +532,75 @@ fn program_transaction_benchmarks(c: &mut Criterion) {
       BatchSize::SmallInput,
     )
   });
+
+  group.bench_function(
+    "small_retained_root_with_one_dependency_commits",
+    |b| {
+      b.iter_batched(
+        retained_root_fixture,
+        |mut runtime| {
+          let value = runtime
+            .resolve_and_run_root_module(
+              "root.mec",
+              module_options(),
+            )
+            .unwrap();
+          black_box(value);
+          black_box(runtime)
+        },
+        BatchSize::SmallInput,
+      )
+    },
+  );
+
+  group.bench_function(
+    "retained_root_graph_failure_rolls_back",
+    |b| {
+      b.iter_batched(
+        retained_root_failure_fixture,
+        |mut runtime| {
+          let error = runtime
+            .resolve_and_run_root_module(
+              "root.mec",
+              module_options(),
+            )
+            .unwrap_err();
+          black_box(error);
+          black_box(runtime)
+        },
+        BatchSize::SmallInput,
+      )
+    },
+  );
+
+  group.bench_function(
+    "explicit_graph_build_followed_by_abort",
+    |b| {
+      b.iter_batched(
+        explicit_graph_fixture,
+        |mut fixture| {
+          let version = fixture
+            .runtime
+            .build_module_from_request_with_context(
+              &mut fixture.context,
+              "root.mec",
+              module_options(),
+            )
+            .unwrap();
+          fixture
+            .runtime
+            .abort_runtime_transaction(
+              &mut fixture.context,
+              "benchmark graph abort",
+            )
+            .unwrap();
+          black_box(version);
+          black_box(fixture)
+        },
+        BatchSize::SmallInput,
+      )
+    },
+  );
 
   group.finish();
 }

--- a/src/runtime/src/id.rs
+++ b/src/runtime/src/id.rs
@@ -361,6 +361,7 @@ pub fn module_id(name: &str) -> ModuleId {
 
 /// Derive a stable ModuleVersionId from all inputs that affect module meaning.
 pub fn module_version_id(
+  module: ModuleId,
   source: &str,
   compiler_version: &str,
   language_edition: &str,
@@ -369,6 +370,7 @@ pub fn module_version_id(
   dependencies: &[ModuleVersionId],
   capability_requirements: &[&str],
 ) -> ModuleVersionId {
+  let module_bytes = module.as_u128().to_le_bytes();
   let mut flags = feature_flags.to_vec();
   flags.sort();
 
@@ -386,8 +388,9 @@ pub fn module_version_id(
     .collect();
 
   ModuleVersionId(blake3_u128(
-    b"mech.module.version.full.v1",
+    b"mech.module.version.full.v2",
     &[
+      &module_bytes,
       compiler_version.as_bytes(),
       language_edition.as_bytes(),
       target.as_bytes(),
@@ -507,21 +510,44 @@ mod tests {
 
   #[test]
   fn module_version_id_is_deterministic() {
-    let a = module_version_id("x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[ModuleVersionId(1)], &["cap1"]);
-    let b = module_version_id("x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[ModuleVersionId(1)], &["cap1"]);
-    let c = module_version_id("x := 2", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[ModuleVersionId(1)], &["cap1"]);
+    let module = module_id("memory://main.mec");
+    let a = module_version_id(module, "x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[ModuleVersionId(1)], &["cap1"]);
+    let b = module_version_id(module, "x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[ModuleVersionId(1)], &["cap1"]);
+    let c = module_version_id(module, "x := 2", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[ModuleVersionId(1)], &["cap1"]);
 
     assert_eq!(a, b);
     assert_ne!(a, c);
   }
 
   #[test]
+  fn module_version_id_includes_module_identity() {
+    let first = module_version_id(module_id("memory://first.mec"), "x := 1", "0.3.5", "2021", "native", &[], &[], &[]);
+    let second = module_version_id(module_id("memory://second.mec"), "x := 1", "0.3.5", "2021", "native", &[], &[], &[]);
+
+    assert_ne!(first, second);
+  }
+
+  #[test]
+  fn module_version_inputs_remain_identity_significant() {
+    let module = module_id("memory://main.mec");
+    let baseline = module_version_id(module, "x := 1", "0.3.5", "2021", "native", &[], &[], &[]);
+    let feature = module_version_id(module, "x := 1", "0.3.5", "2021", "native", &["feature"], &[], &[]);
+    let dependency = module_version_id(module, "x := 1", "0.3.5", "2021", "native", &[], &[ModuleVersionId(1)], &[]);
+    let capability = module_version_id(module, "x := 1", "0.3.5", "2021", "native", &[], &[], &["capability"]);
+
+    assert_ne!(baseline, feature);
+    assert_ne!(baseline, dependency);
+    assert_ne!(baseline, capability);
+  }
+
+  #[test]
   fn dependency_order_is_normalized() {
     let d1 = ModuleVersionId(1);
     let d2 = ModuleVersionId(2);
+    let module = module_id("memory://main.mec");
 
-    let a = module_version_id("x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[d1, d2], &["cap1"]);
-    let b = module_version_id("x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[d2, d1], &["cap1"]);
+    let a = module_version_id(module, "x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[d1, d2], &["cap1"]);
+    let b = module_version_id(module, "x := 1", "0.3.5", "2021", "x86_64-unknown-linux-gnu", &["flag1"], &[d2, d1], &["cap1"]);
 
     assert_eq!(a, b);
   }

--- a/src/runtime/src/module/builder.rs
+++ b/src/runtime/src/module/builder.rs
@@ -94,6 +94,7 @@ impl ModuleBuilder {
     let module_id = module_id(&resolved.canonical_uri);
 
     let module_version = module_version_id(
+      module_id,
       &source_version_input(&resolved),
       &compiler_version,
       &language_edition,
@@ -202,5 +203,49 @@ mod tests {
     .unwrap_err();
 
     assert!(error.kind_as::<NonExecutableModuleSource>().is_some());
+  }
+
+  #[test]
+  fn identical_builds_for_one_uri_reuse_version_identity() {
+    let source = MechSourceCode::String("value := 41".to_string());
+    let first = build(
+      ResolvedSource::new("lib.mec", "memory://lib.mec", source.clone())
+        .with_kind(crate::SourceKind::Mech),
+    )
+    .unwrap();
+    let second = build(
+      ResolvedSource::new("lib.mec", "memory://lib.mec", source)
+        .with_kind(crate::SourceKind::Mech),
+    )
+    .unwrap();
+
+    assert_eq!(first.module_id, second.module_id);
+    assert_eq!(first.module_version, second.module_version);
+  }
+
+  #[test]
+  fn identical_source_at_distinct_uris_has_distinct_version_identity() {
+    let source = MechSourceCode::String("value := 41".to_string());
+    let first = build(
+      ResolvedSource::new(
+        "lib.mec",
+        "memory://first/lib.mec",
+        source.clone(),
+      )
+      .with_kind(crate::SourceKind::Mech),
+    )
+    .unwrap();
+    let second = build(
+      ResolvedSource::new(
+        "lib.mec",
+        "memory://second/lib.mec",
+        source,
+      )
+      .with_kind(crate::SourceKind::Mech),
+    )
+    .unwrap();
+
+    assert_ne!(first.module_id, second.module_id);
+    assert_ne!(first.module_version, second.module_version);
   }
 }

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -350,6 +350,28 @@ impl MechErrorKind for RuntimeModuleImportConflict {
 }
 
 #[derive(Debug, Clone)]
+pub struct RuntimeModuleJournalConflict {
+  pub record_type: &'static str,
+  pub identity: String,
+  pub reason: String,
+}
+
+impl MechErrorKind for RuntimeModuleJournalConflict {
+  fn name(&self) -> &str {
+    "RuntimeModuleJournalConflict"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "{} `{}` conflicts with the transaction module journal: {}",
+      self.record_type,
+      self.identity,
+      self.reason,
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
 pub struct RuntimeModuleImportEdgeInvalid {
   pub module: ModuleVersionId,
   pub reason: String,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3599,7 +3599,9 @@ impl MechRuntime {
       return Ok(());
     }
 
-    let Some(record) = self.store.get_module_version(version)? else {
+    let Some(record) =
+      self.get_module_version_visible(context, version)?
+    else {
       return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
     };
     validate_module_import_edges(&record)?;
@@ -3692,7 +3694,9 @@ impl MechRuntime {
     seen: &mut HashSet<(ModuleVersionId, SourceScope)>,
     module_instances: &mut HashMap<(ModuleVersionId, SourceScope), ModuleInstance>,
   ) -> MResult<PreparedModuleScopeExecution> {
-    let Some(record) = self.store.get_module_version(version)? else {
+    let Some(record) =
+      self.get_module_version_visible(context, version)?
+    else {
       return Err(MechError::new(RuntimeRecordNotFoundError { record_type: "module_version", id: version.to_string() }, None));
     };
     validate_module_import_edges(&record)?;

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -46,6 +46,7 @@ use self::program_transaction::{
   RuntimeExecutionTransaction,
   RuntimeExecutionTransactionMode,
   RuntimeExecutionTransactionState,
+  RuntimeOperationSavepoint,
   RuntimeTransactionContextIdentity,
 };
 use self::capability::{

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -24,6 +24,7 @@ mod execution;
 mod host;
 mod id;
 mod module;
+mod module_transaction;
 mod object;
 mod program_transaction;
 mod schedule;
@@ -51,6 +52,7 @@ use self::capability::{
   RuntimeCapabilityMutation, RuntimeCapabilityOverlay,
 };
 use self::effect::RuntimeEffectJournal;
+use self::module_transaction::RuntimeModuleJournal;
 use crate::{ActiveRuntimeEffectPhase, RuntimeEffectId};
 use crate::runtime::host::*;
 

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -637,30 +637,32 @@ impl MechRuntime {
     request: impl Into<SourceRequest>,
     options: ModuleBuildOptions<'_>,
   ) -> MResult<Value> {
-    let turn_started = Instant::now();
-    self.preflight_atomic_program_operation(
-      context,
-      "resolve_and_run_root_module_with_context",
-    )?;
-
     let request = request.into();
     request.validate()?;
     let root_specifier = request.specifier.clone();
-    let Some(root_version) = self.build_module_from_request_with_context(
-      context,
-      request,
-      options,
-    )? else {
-      return Err(MechError::new(
-        RuntimeRootModuleSourceNotFound { specifier: root_specifier },
-        None,
-      ));
-    };
+    let turn_started = Instant::now();
+    let mut root_version_for_audit = None;
 
     let result = self.with_atomic_program_operation(
       context,
       "resolve_and_run_root_module_with_context",
       |runtime, context| {
+        let Some(root_version) =
+          runtime.build_module_from_request_in_transaction(
+            context,
+            request,
+            options,
+          )?
+        else {
+          return Err(MechError::new(
+            RuntimeRootModuleSourceNotFound {
+              specifier: root_specifier.clone(),
+            },
+            None,
+          ));
+        };
+
+        root_version_for_audit = Some(root_version);
         context.module_version = Some(root_version);
 
         let mut preflight_seen = HashSet::new();
@@ -685,20 +687,22 @@ impl MechRuntime {
     );
 
     if let Err(error) = &result {
-      let _ = self.emit_event_to_context(
-        context,
-        RuntimeEventKind::ModuleExecutionFailed {
-          module_version: root_version,
-          message: format!("{:?}", error),
-        },
-      );
-      let _ = self.emit_event_to_context(
+      let _ = self.emit_event_immediate_to_context(
         context,
         RuntimeEventKind::ProgramFailed {
           task_id: context.task,
           message: format!("{:?}", error),
         },
       );
+      if let Some(root_version) = root_version_for_audit {
+        let _ = self.emit_event_immediate_to_context(
+          context,
+          RuntimeEventKind::ModuleExecutionFailed {
+            module_version: root_version,
+            message: format!("{:?}", error),
+          },
+        );
+      }
     }
     result
   }
@@ -814,7 +818,100 @@ impl MechRuntime {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{InMemorySourceResolver, SourceKind};
+  use crate::capability::{
+    BasicCapability, BasicOperation, BasicResource, BasicSubject,
+  };
+  use crate::{
+    InMemorySourceResolver, PreparedRuntimeEffect,
+    RuntimeAfterCommitEffect, RuntimeEffectMetadata,
+    RuntimeEffectSource, RuntimePreparedHostCall,
+    RuntimeTransactionalEffect, SourceKind, SourceResolver,
+    StagedClosureHostFunction,
+  };
+  use std::sync::Arc;
+  use std::sync::atomic::{AtomicUsize, Ordering};
+
+  #[derive(Debug)]
+  struct CountingSourceResolver {
+    inner: InMemorySourceResolver,
+    calls: Arc<AtomicUsize>,
+  }
+
+  impl SourceResolver for CountingSourceResolver {
+    fn resolve(
+      &self,
+      request: &SourceRequest,
+    ) -> MResult<Option<ResolvedSource>> {
+      self.calls.fetch_add(1, Ordering::SeqCst);
+      self.inner.resolve(request)
+    }
+  }
+
+  #[derive(Debug)]
+  struct CountingAfterCommitEffect {
+    deliveries: Arc<AtomicUsize>,
+    fail: bool,
+  }
+
+  impl RuntimeAfterCommitEffect for CountingAfterCommitEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "round5-after-commit".to_string(),
+        },
+        "deliver",
+      )
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      self.deliveries.fetch_add(1, Ordering::SeqCst);
+      if self.fail {
+        return Err(MechError::new(
+          RuntimeInvalidOperationError {
+            operation: "round5_after_commit",
+            reason: "deliberate delivery failure".to_string(),
+          },
+          None,
+        ));
+      }
+      Ok(())
+    }
+  }
+
+  #[derive(Debug)]
+  struct FailingCommitEffect {
+    aborts: Arc<AtomicUsize>,
+  }
+
+  impl RuntimeTransactionalEffect for FailingCommitEffect {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "round5-failing-commit".to_string(),
+        },
+        "commit",
+      )
+    }
+
+    fn prepare(&mut self) -> MResult<()> {
+      Ok(())
+    }
+
+    fn commit(&mut self) -> MResult<()> {
+      Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "round5_effect_commit",
+          reason: "deliberate post-store failure".to_string(),
+        },
+        None,
+      ))
+    }
+
+    fn abort(&mut self) -> MResult<()> {
+      self.aborts.fetch_add(1, Ordering::SeqCst);
+      Ok(())
+    }
+  }
 
   fn test_module_options() -> ModuleBuildOptions<'static> {
     ModuleBuildOptions::new(
@@ -837,6 +934,22 @@ mod tests {
       MechRuntime::new(RuntimeConfig::default()).unwrap();
     runtime.set_source_resolver(resolver).unwrap();
     runtime
+  }
+
+  fn grant_host_call(
+    runtime: &mut MechRuntime,
+    id: CapabilityId,
+    name: &str,
+  ) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        id,
+        &BasicSubject::new(&subject),
+        &BasicResource::new(format!("host:{name}")),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
   }
 
   #[test]
@@ -1231,5 +1344,523 @@ mod tests {
     runtime
       .abort_runtime_transaction(&mut context_a, "discard A")
       .unwrap();
+  }
+
+  #[test]
+  fn retained_root_graph_begins_inside_hidden_program_transaction() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+
+    runtime
+      .resolve_and_run_root_module(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+
+    let events = runtime.list_events(None).unwrap();
+    let transaction_started = events
+      .iter()
+      .position(|event| matches!(
+        event.kind,
+        RuntimeEventKind::TransactionStarted { .. }
+      ))
+      .unwrap();
+    let source_resolved = events
+      .iter()
+      .position(|event| matches!(
+        event.kind,
+        RuntimeEventKind::SourceResolved { .. }
+      ))
+      .unwrap();
+    let compiled = events
+      .iter()
+      .position(|event| matches!(
+        event.kind,
+        RuntimeEventKind::ModuleCompiled { .. }
+      ))
+      .unwrap();
+
+    assert!(transaction_started < source_resolved);
+    assert!(source_resolved < compiled);
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_some(),
+    );
+    assert!(runtime.root_symbol_value("answer").is_ok());
+    assert!(runtime.active_transactions.is_empty());
+  }
+
+  #[test]
+  fn retained_root_failure_rolls_back_graph_events_and_program() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := missing\nanswer\n",
+    )]);
+    runtime.run_string("baseline := 7").unwrap();
+
+    let error = runtime
+      .resolve_and_run_root_module(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert!(format!("{error:?}").contains("missing"));
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+    assert!(runtime.root_symbol_value("baseline").is_ok());
+    assert!(runtime.root_symbol_value("answer").is_err());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().all(|event| !matches!(
+      event.kind,
+      RuntimeEventKind::SourceResolved { .. }
+        | RuntimeEventKind::ModuleCompiled { .. }
+    )));
+    assert!(events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::ProgramFailed { .. }
+    )));
+    assert!(events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::ModuleExecutionFailed { .. }
+    )));
+    assert!(!runtime.is_poisoned());
+  }
+
+  #[test]
+  fn retained_root_dependency_execution_failure_commits_no_graph() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "root.mec",
+        "+> ./dep.mec\nanswer := dep/value\nanswer\n",
+      ),
+      (
+        "dep.mec",
+        "value := missing\n<+ value\n",
+      ),
+    ]);
+
+    assert!(
+      runtime
+        .resolve_and_run_root_module(
+          "root.mec",
+          test_module_options(),
+        )
+        .is_err(),
+    );
+
+    for uri in ["memory:root.mec", "memory:dep.mec"] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "dependency failure exposed {uri}",
+      );
+    }
+  }
+
+  #[test]
+  fn retained_root_missing_later_dependency_has_no_partial_graph_or_version_audit() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "root.mec",
+        "+> ./first.mec\n+> ./missing.mec\nanswer := 1\n",
+      ),
+      ("first.mec", "value := 1\n<+ value\n"),
+    ]);
+
+    let error = runtime
+      .resolve_and_run_root_module(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert!(
+      error
+        .kind_as::<RuntimeModuleDependencyMissingError>()
+        .is_some(),
+    );
+    for uri in ["memory:root.mec", "memory:first.mec"] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "missing dependency exposed {uri}",
+      );
+    }
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::ProgramFailed { .. }
+    )));
+    assert!(events.iter().all(|event| !matches!(
+      event.kind,
+      RuntimeEventKind::ModuleExecutionFailed { .. }
+    )));
+  }
+
+  #[test]
+  fn failed_root_does_not_deliver_dependency_after_commit_effect() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "root.mec",
+        "+> ./dep.mec\nanswer := missing\nanswer\n",
+      ),
+      (
+        "dep.mec",
+        "value := round5/after_commit()\n<+ value\n",
+      ),
+    ]);
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    let deliveries_for_host = deliveries.clone();
+    runtime
+      .register_mech_host_function(
+        StagedClosureHostFunction::new(
+          "round5/after_commit",
+          move |_services, _context, _args| {
+            Ok(RuntimePreparedHostCall {
+              value: Value::F64(mech_core::Ref::new(1.0)),
+              effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+                CountingAfterCommitEffect {
+                  deliveries: deliveries_for_host.clone(),
+                  fail: false,
+                },
+              )),
+            })
+          },
+        ),
+      )
+      .unwrap();
+    grant_host_call(
+      &mut runtime,
+      CapabilityId(910),
+      "round5/after_commit",
+    );
+
+    assert!(
+      runtime
+        .resolve_and_run_root_module(
+          "root.mec",
+          test_module_options(),
+        )
+        .is_err(),
+    );
+
+    assert_eq!(deliveries.load(Ordering::SeqCst), 0);
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:dep.mec")
+        .unwrap()
+        .is_none(),
+    );
+  }
+
+  #[test]
+  fn explicit_retained_root_is_provisional_and_abort_restores_baseline() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    runtime.run_string("baseline := 7").unwrap();
+    let mut owner = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut owner,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+
+    assert!(runtime.root_symbol_value("answer").is_ok());
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+    runtime
+      .abort_runtime_transaction(
+        &mut owner,
+        "discard provisional retained root",
+      )
+      .unwrap();
+    assert!(runtime.root_symbol_value("baseline").is_ok());
+    assert!(runtime.root_symbol_value("answer").is_err());
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+  }
+
+  #[test]
+  fn retryable_explicit_store_failure_keeps_graph_without_rebuilding() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut inner = InMemorySourceResolver::new();
+    inner
+      .insert_string(
+        "root.mec",
+        "answer := 42\nanswer\n",
+      )
+      .unwrap();
+    let resolver = CountingSourceResolver {
+      inner,
+      calls: calls.clone(),
+    };
+    let mut runtime = RuntimeBuilder::new()
+      .source_resolver(resolver)
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id =
+      runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let calls_after_build = calls.load(Ordering::SeqCst);
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(
+          ObjectId(911),
+          "missing",
+          "provisional update",
+        ),
+      )
+      .unwrap();
+
+    assert!(
+      runtime
+        .commit_runtime_transaction_detailed(&mut context)
+        .is_err(),
+    );
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+    assert!(runtime.root_symbol_value("answer").is_ok());
+    assert_eq!(calls.load(Ordering::SeqCst), calls_after_build);
+
+    runtime
+      .store
+      .put_object(ObjectRecord::text(
+        ObjectId(911),
+        "missing",
+        "baseline",
+      ))
+      .unwrap();
+    runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    assert_eq!(calls.load(Ordering::SeqCst), calls_after_build);
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_some(),
+    );
+    assert!(runtime.root_symbol_value("answer").is_ok());
+  }
+
+  #[test]
+  fn implicit_store_failure_rolls_back_root_and_stays_healthy() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := round5/stage_bad_update()\nanswer\n",
+    )]);
+    runtime.run_string("baseline := 7").unwrap();
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    let deliveries_for_host = deliveries.clone();
+    runtime
+      .register_mech_host_function(
+        StagedClosureHostFunction::new(
+          "round5/stage_bad_update",
+          move |services, context, _args| {
+            services.update_object_with_context(
+              context,
+              ObjectRecord::text(
+                ObjectId(912),
+                "missing",
+                "invalid update",
+              ),
+            )?;
+            Ok(RuntimePreparedHostCall {
+              value: Value::F64(mech_core::Ref::new(42.0)),
+              effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+                CountingAfterCommitEffect {
+                  deliveries: deliveries_for_host.clone(),
+                  fail: false,
+                },
+              )),
+            })
+          },
+        ),
+      )
+      .unwrap();
+    grant_host_call(
+      &mut runtime,
+      CapabilityId(912),
+      "round5/stage_bad_update",
+    );
+
+    assert!(
+      runtime
+        .resolve_and_run_root_module(
+          "root.mec",
+          test_module_options(),
+        )
+        .is_err(),
+    );
+
+    assert!(!runtime.is_poisoned());
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(deliveries.load(Ordering::SeqCst), 0);
+    assert!(runtime.root_symbol_value("baseline").is_ok());
+    assert!(runtime.root_symbol_value("answer").is_err());
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+  }
+
+  #[test]
+  fn post_store_participant_failure_keeps_graph_and_program() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let aborts = Arc::new(AtomicUsize::new(0));
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(
+          FailingCommitEffect {
+            aborts: aborts.clone(),
+          },
+        )),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap_err();
+
+    assert_eq!(
+      error.kind_name(),
+      "RuntimeExternalCommitIndeterminate",
+    );
+    assert!(runtime.is_poisoned());
+    assert_eq!(context.transaction, None);
+    assert_eq!(aborts.load(Ordering::SeqCst), 0);
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_some(),
+    );
+    assert!(runtime.root_symbol_value("answer").is_ok());
+  }
+
+  #[test]
+  fn after_commit_failure_keeps_graph_program_and_runtime_healthy() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          CountingAfterCommitEffect {
+            deliveries: deliveries.clone(),
+            fail: true,
+          },
+        )),
+      )
+      .unwrap();
+
+    let outcome = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    assert_eq!(outcome.delivery_failures.len(), 1);
+    assert_eq!(deliveries.load(Ordering::SeqCst), 1);
+    assert!(!runtime.is_poisoned());
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_some(),
+    );
+    assert!(runtime.root_symbol_value("answer").is_ok());
+  }
+
+  #[test]
+  fn standalone_run_module_does_not_replace_retained_program() {
+    let mut runtime = runtime_with_sources(&[(
+      "isolated.mec",
+      "isolated := 42\nisolated\n",
+    )]);
+    runtime.run_string("retained := 7").unwrap();
+    let version = runtime
+      .resolve_and_store_module_source(
+        "isolated.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+
+    runtime.run_module(version).unwrap();
+
+    assert!(runtime.root_symbol_value("retained").is_ok());
+    assert!(runtime.root_symbol_value("isolated").is_err());
   }
 }

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -822,14 +822,82 @@ mod tests {
     BasicCapability, BasicOperation, BasicResource, BasicSubject,
   };
   use crate::{
+    IdGenerator,
     InMemorySourceResolver, PreparedRuntimeEffect,
+    NodeId,
     RuntimeAfterCommitEffect, RuntimeEffectMetadata,
     RuntimeEffectSource, RuntimePreparedHostCall,
     RuntimeTransactionalEffect, SourceKind, SourceResolver,
     StagedClosureHostFunction,
   };
+  use std::collections::VecDeque;
   use std::sync::Arc;
   use std::sync::atomic::{AtomicUsize, Ordering};
+
+  #[derive(Debug)]
+  struct ScriptedEventIdGenerator {
+    next: u128,
+    event_ids: VecDeque<EventId>,
+  }
+
+  impl ScriptedEventIdGenerator {
+    fn new(
+      next: u128,
+      event_ids: impl IntoIterator<Item = EventId>,
+    ) -> Self {
+      Self {
+        next,
+        event_ids: event_ids.into_iter().collect(),
+      }
+    }
+
+    fn next_id(&mut self) -> u128 {
+      let id = self.next;
+      self.next = self.next.saturating_add(1);
+      id
+    }
+  }
+
+  impl IdGenerator for ScriptedEventIdGenerator {
+    fn runtime_id(&mut self) -> RuntimeId {
+      RuntimeId(self.next_id())
+    }
+
+    fn object_id(&mut self) -> ObjectId {
+      ObjectId(self.next_id())
+    }
+
+    fn actor_id(&mut self) -> ActorId {
+      ActorId(self.next_id())
+    }
+
+    fn task_id(&mut self) -> TaskId {
+      TaskId(self.next_id())
+    }
+
+    fn capability_id(&mut self) -> CapabilityId {
+      CapabilityId(self.next_id())
+    }
+
+    fn transaction_id(&mut self) -> TransactionId {
+      TransactionId(self.next_id())
+    }
+
+    fn event_id(&mut self) -> EventId {
+      self
+        .event_ids
+        .pop_front()
+        .unwrap_or_else(|| EventId(self.next_id()))
+    }
+
+    fn node_id(&mut self) -> NodeId {
+      NodeId(self.next_id())
+    }
+
+    fn message_id(&mut self) -> MessageId {
+      MessageId(self.next_id())
+    }
+  }
 
   #[derive(Debug)]
   struct CountingSourceResolver {
@@ -950,6 +1018,29 @@ mod tests {
         [BasicOperation::new("call")],
       )))
       .unwrap();
+  }
+
+  fn staged_test_capability(
+    runtime: &MechRuntime,
+    id: CapabilityId,
+  ) -> (
+    Arc<BasicCapability>,
+    CapabilityRequest,
+  ) {
+    let subject = runtime.runtime_context().unwrap().subject;
+    (
+      Arc::new(BasicCapability::from_keys(
+        id,
+        &subject,
+        "round5://resource",
+        [":read"],
+      )),
+      CapabilityRequest::from_keys(
+        subject,
+        ":read",
+        "round5://resource",
+      ),
+    )
   }
 
   #[test]
@@ -1862,5 +1953,627 @@ mod tests {
 
     assert!(runtime.root_symbol_value("retained").is_ok());
     assert!(runtime.root_symbol_value("isolated").is_err());
+  }
+
+  #[test]
+  fn valid_dependency_then_parse_failure_leaves_no_graph() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "root.mec",
+        "+> ./valid.mec\n+> ./broken.mec\nanswer := 1\n",
+      ),
+      ("valid.mec", "value := 1\n<+ value\n"),
+      ("broken.mec", "value := [1, 2\n"),
+    ]);
+
+    assert!(
+      runtime
+        .resolve_and_store_module_source(
+          "root.mec",
+          test_module_options(),
+        )
+        .is_err(),
+    );
+
+    for uri in [
+      "memory:root.mec",
+      "memory:valid.mec",
+      "memory:broken.mec",
+    ] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "parse failure exposed {uri}",
+      );
+    }
+  }
+
+  #[test]
+  fn source_budget_failure_after_dependency_staging_leaves_no_graph() {
+    let mut config = RuntimeConfig::default();
+    config.limits.max_source_bytes = Some(50);
+    let mut resolver = InMemorySourceResolver::new();
+    resolver
+      .insert_string(
+        "root.mec",
+        "+> ./first.mec\n+> ./large.mec\nx := 1\n",
+      )
+      .unwrap();
+    resolver
+      .insert_string(
+        "first.mec",
+        "x := 1\n<+ x\n",
+      )
+      .unwrap();
+    resolver
+      .insert_string(
+        "large.mec",
+        "this_source_is_deliberately_larger_than_the_configured_fifty_byte_limit := 1\n",
+      )
+      .unwrap();
+    let mut runtime = MechRuntime::new(config).unwrap();
+    runtime.set_source_resolver(resolver).unwrap();
+
+    let error = runtime
+      .resolve_and_store_module_source(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert!(
+      error.kind_as::<ResourceBudgetExceededError>().is_some(),
+    );
+    for uri in [
+      "memory:root.mec",
+      "memory:first.mec",
+      "memory:large.mec",
+    ] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "budget failure exposed {uri}",
+      );
+    }
+  }
+
+  #[test]
+  fn module_event_staging_failure_removes_journal_and_context_suffix() {
+    let mut resolver = InMemorySourceResolver::new();
+    resolver
+      .insert_string(
+        "root.mec",
+        "+> ./dep.mec\nanswer := dep/value\n",
+      )
+      .unwrap();
+    resolver
+      .insert_string("dep.mec", "value := 1\n<+ value\n")
+      .unwrap();
+    let mut runtime = MechRuntime::builder()
+      .id_generator(ScriptedEventIdGenerator::new(
+        1,
+        [
+          EventId(100),
+          EventId(101),
+          EventId(102),
+          EventId(102),
+          EventId(103),
+          EventId(104),
+        ],
+      ))
+      .source_resolver(resolver)
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .build_module_from_request_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "InvalidRuntimeTransaction");
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(context.transaction, None);
+    assert!(context.events.iter().all(|event| !matches!(
+      event.kind,
+      RuntimeEventKind::SourceResolved { .. }
+        | RuntimeEventKind::ModuleCompiled { .. }
+    )));
+    for uri in ["memory:root.mec", "memory:dep.mec"] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+      );
+    }
+  }
+
+  #[test]
+  fn diamond_graph_reuses_one_shared_version() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "root.mec",
+        "+> ./left.mec\n+> ./right.mec\nanswer := 1\n",
+      ),
+      (
+        "left.mec",
+        "+> ./shared.mec\nleft := shared/value\n<+ left\n",
+      ),
+      (
+        "right.mec",
+        "+> ./shared.mec\nright := shared/value\n<+ right\n",
+      ),
+      ("shared.mec", "value := 1\n<+ value\n"),
+    ]);
+
+    let root = runtime
+      .resolve_and_store_module_source(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let root = runtime
+      .store
+      .get_module_version(root)
+      .unwrap()
+      .unwrap();
+    assert_eq!(root.dependencies.len(), 2);
+    let left = runtime
+      .store
+      .get_module_version(root.dependencies[0])
+      .unwrap()
+      .unwrap();
+    let right = runtime
+      .store
+      .get_module_version(root.dependencies[1])
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(left.dependencies.len(), 1);
+    assert_eq!(right.dependencies.len(), 1);
+    assert_eq!(left.dependencies[0], right.dependencies[0]);
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:shared.mec")
+        .unwrap()
+        .is_some(),
+    );
+  }
+
+  #[test]
+  fn equal_publication_from_two_transactions_is_idempotent() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut first = runtime.runtime_context().unwrap();
+    let mut second = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut first).unwrap();
+    runtime.begin_transaction(&mut second).unwrap();
+    let first_version = runtime
+      .build_module_from_request_with_context(
+        &mut first,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let second_version = runtime
+      .build_module_from_request_with_context(
+        &mut second,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    assert_eq!(second_version, first_version);
+
+    runtime
+      .commit_runtime_transaction(&mut first)
+      .unwrap();
+    runtime
+      .commit_runtime_transaction(&mut second)
+      .unwrap();
+
+    assert!(
+      runtime
+        .store
+        .get_module_version(first_version)
+        .unwrap()
+        .is_some(),
+    );
+  }
+
+  #[test]
+  fn deterministic_version_conflict_fails_atomically() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let version = runtime
+      .resolve_and_store_module_source(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let committed = runtime
+      .store
+      .get_module_version(version)
+      .unwrap()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id =
+      runtime.begin_transaction(&mut context).unwrap();
+    let unrelated = ModuleRecord::new(
+      module_id("memory:unrelated.mec"),
+      "memory:unrelated.mec",
+    );
+    runtime
+      .active_execution_transaction_mut(transaction_id)
+      .unwrap()
+      .modules
+      .stage_module(unrelated.clone())
+      .unwrap();
+    runtime
+      .active_execution_transaction_mut(transaction_id)
+      .unwrap()
+      .modules
+      .stage_version(ModuleVersionRecord::new(
+        version,
+        committed.module,
+        committed.version.saturating_add(1),
+      ))
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeModuleJournalConflict");
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(
+      runtime.store.get_module(unrelated.id).unwrap().is_none(),
+    );
+    assert_eq!(
+      runtime.store.get_module_version(version).unwrap(),
+      Some(committed),
+    );
+    runtime
+      .abort_runtime_transaction(&mut context, "discard conflict")
+      .unwrap();
+  }
+
+  #[test]
+  fn graph_object_capability_and_effect_commit_together() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let object =
+      ObjectRecord::text(ObjectId(920), "round5", "committed");
+    runtime
+      .put_object_with_context(&mut context, object.clone())
+      .unwrap();
+    let (capability, request) =
+      staged_test_capability(&runtime, CapabilityId(920));
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability.clone(),
+      )
+      .unwrap();
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          CountingAfterCommitEffect {
+            deliveries: deliveries.clone(),
+            fail: false,
+          },
+        )),
+      )
+      .unwrap();
+
+    runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap();
+
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_some(),
+    );
+    assert_eq!(runtime.get_object(object.id).unwrap(), Some(object));
+    assert_eq!(
+      runtime.check_capability(&request).unwrap(),
+      capability.id(),
+    );
+    assert_eq!(deliveries.load(Ordering::SeqCst), 1);
+    assert!(runtime.root_symbol_value("answer").is_ok());
+  }
+
+  #[test]
+  fn outer_abort_discards_graph_object_capability_effect_and_program() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    runtime.run_string("baseline := 7").unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let object =
+      ObjectRecord::text(ObjectId(921), "round5", "discarded");
+    runtime
+      .put_object_with_context(&mut context, object.clone())
+      .unwrap();
+    let (capability, request) =
+      staged_test_capability(&runtime, CapabilityId(921));
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability,
+      )
+      .unwrap();
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          CountingAfterCommitEffect {
+            deliveries: deliveries.clone(),
+            fail: false,
+          },
+        )),
+      )
+      .unwrap();
+
+    runtime
+      .abort_runtime_transaction(&mut context, "discard all")
+      .unwrap();
+
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+    assert!(runtime.get_object(object.id).unwrap().is_none());
+    assert!(runtime.check_capability(&request).is_err());
+    assert_eq!(deliveries.load(Ordering::SeqCst), 0);
+    assert!(runtime.root_symbol_value("baseline").is_ok());
+    assert!(runtime.root_symbol_value("answer").is_err());
+  }
+
+  #[test]
+  fn store_failure_exposes_none_of_the_staged_categories() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    runtime.run_string("baseline := 7").unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let object =
+      ObjectRecord::text(ObjectId(922), "round5", "provisional");
+    runtime
+      .put_object_with_context(&mut context, object.clone())
+      .unwrap();
+    let (capability, request) =
+      staged_test_capability(&runtime, CapabilityId(922));
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability,
+      )
+      .unwrap();
+    let deliveries = Arc::new(AtomicUsize::new(0));
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::AfterCommit(Box::new(
+          CountingAfterCommitEffect {
+            deliveries: deliveries.clone(),
+            fail: false,
+          },
+        )),
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(
+          ObjectId(9_922),
+          "missing",
+          "invalid update",
+        ),
+      )
+      .unwrap();
+
+    assert!(
+      runtime
+        .commit_runtime_transaction_detailed(&mut context)
+        .is_err(),
+    );
+
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_none(),
+    );
+    assert!(runtime.get_object(object.id).unwrap().is_none());
+    assert!(runtime.check_capability(&request).is_err());
+    assert_eq!(deliveries.load(Ordering::SeqCst), 0);
+    runtime
+      .abort_runtime_transaction(&mut context, "store failure")
+      .unwrap();
+    assert!(runtime.root_symbol_value("baseline").is_ok());
+    assert!(runtime.root_symbol_value("answer").is_err());
+  }
+
+  #[test]
+  fn post_store_failure_preserves_every_durable_category() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .resolve_and_run_root_module_with_context(
+        &mut context,
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap();
+    let object =
+      ObjectRecord::text(ObjectId(923), "round5", "durable");
+    runtime
+      .put_object_with_context(&mut context, object.clone())
+      .unwrap();
+    let (capability, _request) =
+      staged_test_capability(&runtime, CapabilityId(923));
+    runtime
+      .grant_capability_with_context(
+        &mut context,
+        capability.clone(),
+      )
+      .unwrap();
+    let aborts = Arc::new(AtomicUsize::new(0));
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        PreparedRuntimeEffect::Transactional(Box::new(
+          FailingCommitEffect {
+            aborts: aborts.clone(),
+          },
+        )),
+      )
+      .unwrap();
+
+    let error = runtime
+      .commit_runtime_transaction_detailed(&mut context)
+      .unwrap_err();
+
+    assert_eq!(
+      error.kind_name(),
+      "RuntimeExternalCommitIndeterminate",
+    );
+    assert!(
+      runtime
+        .store
+        .find_module_by_name("memory:root.mec")
+        .unwrap()
+        .is_some(),
+    );
+    assert_eq!(runtime.get_object(object.id).unwrap(), Some(object));
+    assert!(
+      runtime.get_capability(capability.id()).unwrap().is_some(),
+    );
+    assert_eq!(aborts.load(Ordering::SeqCst), 0);
+    assert!(runtime.root_symbol_value("answer").is_ok());
+  }
+
+  #[test]
+  fn direct_resolution_ensure_activation_and_reactive_boundaries_are_unchanged() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let events_before = runtime.list_events(None).unwrap();
+    let transactions_before =
+      runtime.list_transactions(None).unwrap().len();
+
+    assert!(
+      runtime.resolve_source("root.mec").unwrap().is_some(),
+    );
+    assert_eq!(runtime.list_events(None).unwrap(), events_before);
+    assert_eq!(
+      runtime.list_transactions(None).unwrap().len(),
+      transactions_before,
+    );
+
+    let direct_module = runtime
+      .ensure_module("direct", "memory:direct.mec")
+      .unwrap();
+    assert!(
+      runtime.store.get_module(direct_module).unwrap().is_some(),
+    );
+    assert_eq!(
+      runtime.list_transactions(None).unwrap().len(),
+      transactions_before,
+    );
+
+    let version = runtime
+      .resolve_and_store_module_source(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let owner = runtime
+      .store
+      .get_module_version(version)
+      .unwrap()
+      .unwrap()
+      .module;
+    let transaction_count =
+      runtime.list_transactions(None).unwrap().len();
+    runtime.activate_module_version(owner, version).unwrap();
+    assert_eq!(
+      runtime.active_module_version(owner).unwrap(),
+      Some(version),
+    );
+    assert_eq!(
+      runtime.list_transactions(None).unwrap().len(),
+      transaction_count,
+    );
+
+    runtime.run_string("reactive-boundary := 1").unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    let error = runtime
+      .step_with_context(&mut context, 1)
+      .unwrap_err();
+    assert_eq!(
+      error.kind_name(),
+      "RuntimeTransactionalReactiveTurnUnsupported",
+    );
+    runtime
+      .abort_runtime_transaction(
+        &mut context,
+        "reactive boundary cleanup",
+      )
+      .unwrap();
   }
 }

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -68,6 +68,44 @@ impl MechRuntime {
     self.store.put_module(module)
   }
 
+  fn ensure_module_for_build_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    name: &str,
+    canonical_uri: &str,
+  ) -> MResult<ModuleId> {
+    let transaction_id = Self::context_transaction_id(context)?;
+    if let Some(module) =
+      self.find_module_by_name_visible(context, canonical_uri)?
+    {
+      return Ok(module.id);
+    }
+
+    let id = module_id(canonical_uri);
+    if let Some(module) = self.get_module_visible(context, id)? {
+      if module.name == canonical_uri {
+        return Ok(id);
+      }
+      return Err(MechError::new(
+        RuntimeModuleJournalConflict {
+          record_type: "module",
+          identity: id.to_string(),
+          reason: "visible module ID maps to another canonical URI"
+            .to_string(),
+        },
+        None,
+      ));
+    }
+
+    let module = ModuleRecord::new(id, canonical_uri)
+      .with_description(name.to_string());
+    self
+      .active_execution_transaction_mut(transaction_id)?
+      .modules
+      .stage_module(module)?;
+    Ok(id)
+  }
+
   fn materialize_manifest_context_imports(
     &mut self,
     record: &mut crate::RuntimeModuleRecord,
@@ -264,6 +302,26 @@ impl MechRuntime {
     self.ensure_runtime_mutation_allowed(
       "build_module_from_resolved_source_with_context",
     )?;
+    self.with_atomic_module_operation(
+      context,
+      "build_module_from_resolved_source_with_context",
+      |runtime, context| {
+        runtime.build_module_from_resolved_source_in_transaction(
+          context,
+          resolved,
+          options,
+        )
+      },
+    )
+  }
+
+  fn build_module_from_resolved_source_in_transaction(
+    &mut self,
+    context: &mut RuntimeContext,
+    resolved: ResolvedSource,
+    options: ModuleBuildOptions<'_>,
+  ) -> MResult<ModuleVersionId> {
+    let _ = Self::context_transaction_id(context)?;
     let mut dependency_graph = ModuleDependencyGraph::new();
 
     self.build_module_from_resolved_source_with_context_and_graph(
@@ -282,6 +340,7 @@ impl MechRuntime {
     dependency_graph: &mut ModuleDependencyGraph,
   ) -> MResult<ModuleVersionId> {
     self.validate_context_for_runtime(context)?;
+    let transaction_id = Self::context_transaction_id(context)?;
     context.charge_step()?;
 
     if !resolved.is_executable_mech_source() {
@@ -411,7 +470,8 @@ impl MechRuntime {
       self.materialize_manifest_context_imports(&mut record)?;
       Self::validate_runtime_module_record_address_targets(&record)?;
 
-      let module = self.ensure_module(
+      let module = self.ensure_module_for_build_with_context(
+        context,
         &record.name,
         &record.canonical_uri,
       )?;
@@ -422,17 +482,9 @@ impl MechRuntime {
         "ModuleBuilder and runtime module store derived different ModuleId values",
       );
 
-      if self
-        .store
-        .get_module_version(record.module_version)?
-        .is_some()
-      {
-        dependency_graph.cache_version(&canonical_uri, record.module_version);
-        return Ok(record.module_version);
-      }
-
+      let module_version = record.module_version;
       let version = ModuleVersionRecord::new(
-        record.module_version,
+        module_version,
         module,
         1,
       )
@@ -447,18 +499,41 @@ impl MechRuntime {
       .with_capability_requirements(record.capability_requirements);
       validate_module_import_edges(&version)?;
 
-      self.store.put_module_version(version)?;
+      if let Some(existing) =
+        self.get_module_version_visible(context, module_version)?
+      {
+        if existing != version {
+          return Err(MechError::new(
+            RuntimeModuleJournalConflict {
+              record_type: "module_version",
+              identity: module_version.to_string(),
+              reason: "visible version ID maps to different contents"
+                .to_string(),
+            },
+            None,
+          ));
+        }
+        dependency_graph.cache_version(&canonical_uri, module_version);
+        return Ok(module_version);
+      }
 
-      dependency_graph.cache_version(&canonical_uri, record.module_version);
+      let staged = self
+        .active_execution_transaction_mut(transaction_id)?
+        .modules
+        .stage_version(version)?;
 
-      self.emit_event_to_context(
-        context,
-        RuntimeEventKind::ModuleCompiled {
-          module_version: record.module_version,
-        },
-      )?;
+      dependency_graph.cache_version(&canonical_uri, module_version);
 
-      Ok(record.module_version)
+      if staged {
+        self.emit_event_to_context(
+          context,
+          RuntimeEventKind::ModuleCompiled {
+            module_version,
+          },
+        )?;
+      }
+
+      Ok(module_version)
     })();
 
     dependency_graph.leave(&canonical_uri);
@@ -513,6 +588,27 @@ impl MechRuntime {
     self.ensure_runtime_mutation_allowed(
       "build_module_from_request_with_context",
     )?;
+    let request = request.into();
+    self.with_atomic_module_operation(
+      context,
+      "build_module_from_request_with_context",
+      |runtime, context| {
+        runtime.build_module_from_request_in_transaction(
+          context,
+          request,
+          options,
+        )
+      },
+    )
+  }
+
+  pub(super) fn build_module_from_request_in_transaction(
+    &mut self,
+    context: &mut RuntimeContext,
+    request: impl Into<SourceRequest>,
+    options: ModuleBuildOptions<'_>,
+  ) -> MResult<Option<ModuleVersionId>> {
+    let _ = Self::context_transaction_id(context)?;
     let mut dependency_graph = ModuleDependencyGraph::new();
 
     self.build_module_from_request_with_context_and_graph(
@@ -644,10 +740,16 @@ impl MechRuntime {
     )
     .with_kind(crate::SourceKind::Mech);
 
-    self.build_module_from_resolved_source_with_context(
+    self.with_atomic_module_operation(
       context,
-      resolved,
-      options,
+      "put_source_module_with_context",
+      |runtime, context| {
+        runtime.build_module_from_resolved_source_in_transaction(
+          context,
+          resolved,
+          options,
+        )
+      },
     )
   }
 
@@ -712,7 +814,30 @@ impl MechRuntime {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::SourceKind;
+  use crate::{InMemorySourceResolver, SourceKind};
+
+  fn test_module_options() -> ModuleBuildOptions<'static> {
+    ModuleBuildOptions::new(
+      "test",
+      "v0.3",
+      "native",
+      &[],
+      &[],
+    )
+  }
+
+  fn runtime_with_sources(
+    sources: &[(&str, &str)],
+  ) -> MechRuntime {
+    let mut resolver = InMemorySourceResolver::new();
+    for (specifier, source) in sources {
+      resolver.insert_string(*specifier, *source).unwrap();
+    }
+    let mut runtime =
+      MechRuntime::new(RuntimeConfig::default()).unwrap();
+    runtime.set_source_resolver(resolver).unwrap();
+    runtime
+  }
 
   #[test]
   fn max_source_bytes_rejects_module_source() {
@@ -771,5 +896,340 @@ mod tests {
       .unwrap_err();
 
     assert!(error.kind_as::<NonExecutableModuleSource>().is_some());
+  }
+
+  #[test]
+  fn missing_later_dependency_commits_no_graph() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "main.mec",
+        "+> ./first.mec\n+> ./missing.mec\nanswer := 1\n",
+      ),
+      ("first.mec", "value := 1\n<+ value\n"),
+    ]);
+
+    let error = runtime
+      .resolve_and_store_module_source(
+        "main.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert!(
+      error
+        .kind_as::<RuntimeModuleDependencyMissingError>()
+        .is_some(),
+      "expected missing dependency, got {error:?}",
+    );
+    for uri in ["memory:main.mec", "memory:first.mec"] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "failed graph exposed {uri}",
+      );
+    }
+    assert!(
+      runtime
+        .list_events(None)
+        .unwrap()
+        .iter()
+        .all(|event| !matches!(
+          event.kind,
+          RuntimeEventKind::ModuleCompiled { .. }
+        )),
+    );
+  }
+
+  #[test]
+  fn deep_parse_failure_commits_no_graph() {
+    let mut runtime = runtime_with_sources(&[
+      ("main.mec", "+> ./middle.mec\nanswer := 1\n"),
+      ("middle.mec", "+> ./leaf.mec\nvalue := 1\n"),
+      ("leaf.mec", "value := [1, 2\n"),
+    ]);
+
+    assert!(
+      runtime
+        .resolve_and_store_module_source(
+          "main.mec",
+          test_module_options(),
+        )
+        .is_err(),
+    );
+
+    for uri in [
+      "memory:main.mec",
+      "memory:middle.mec",
+      "memory:leaf.mec",
+    ] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "failed graph exposed {uri}",
+      );
+    }
+  }
+
+  #[test]
+  fn cycle_error_retains_deterministic_path() {
+    let mut runtime = runtime_with_sources(&[
+      ("main.mec", "+> ./middle.mec\nanswer := 1\n"),
+      ("middle.mec", "+> ./leaf.mec\nvalue := 1\n"),
+      ("leaf.mec", "+> ./main.mec\nvalue := 2\n"),
+    ]);
+
+    let error = runtime
+      .resolve_and_store_module_source(
+        "main.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+    let cycle = error
+      .kind_as::<RuntimeModuleDependencyCycleError>()
+      .expect("existing cycle error type");
+
+    assert_eq!(
+      cycle.cycle,
+      vec![
+        "memory:main.mec".to_string(),
+        "memory:middle.mec".to_string(),
+        "memory:leaf.mec".to_string(),
+        "memory:main.mec".to_string(),
+      ],
+    );
+  }
+
+  #[test]
+  fn explicit_transaction_owns_provisional_graph_visibility() {
+    let mut runtime = runtime_with_sources(&[(
+      "main.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut owner = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut owner).unwrap();
+
+    let version = runtime
+      .build_module_from_request_with_context(
+        &mut owner,
+        "main.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let module = module_id("memory:main.mec");
+    let observer = runtime.runtime_context().unwrap();
+
+    assert!(
+      runtime
+        .get_module_visible(&owner, module)
+        .unwrap()
+        .is_some(),
+    );
+    assert!(
+      runtime
+        .get_module_version_visible(&owner, version)
+        .unwrap()
+        .is_some(),
+    );
+    assert!(
+      runtime
+        .get_module_visible(&observer, module)
+        .unwrap()
+        .is_none(),
+    );
+    assert!(
+      runtime
+        .get_module_version_visible(&observer, version)
+        .unwrap()
+        .is_none(),
+    );
+    assert!(runtime.store.get_module(module).unwrap().is_none());
+    assert!(
+      runtime.store.get_module_version(version).unwrap().is_none(),
+    );
+    assert!(
+      runtime
+        .run_module_with_context(&mut owner, version)
+        .is_ok(),
+    );
+    assert!(runtime.run_module(version).is_err());
+
+    runtime
+      .commit_runtime_transaction(&mut owner)
+      .unwrap();
+    assert!(runtime.store.get_module(module).unwrap().is_some());
+    assert!(
+      runtime.store.get_module_version(version).unwrap().is_some(),
+    );
+  }
+
+  #[test]
+  fn explicit_abort_discards_provisional_graph() {
+    let mut runtime = runtime_with_sources(&[(
+      "main.mec",
+      "answer := 42\nanswer\n",
+    )]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    let version = runtime
+      .build_module_from_request_with_context(
+        &mut context,
+        "main.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+
+    runtime
+      .abort_runtime_transaction(&mut context, "discard graph")
+      .unwrap();
+
+    assert!(
+      runtime
+        .store
+        .get_module(module_id("memory:main.mec"))
+        .unwrap()
+        .is_none(),
+    );
+    assert!(
+      runtime.store.get_module_version(version).unwrap().is_none(),
+    );
+  }
+
+  #[test]
+  fn failed_later_build_preserves_earlier_provisional_graph() {
+    let mut runtime = runtime_with_sources(&[
+      ("earlier.mec", "value := 1\nvalue\n"),
+      (
+        "later.mec",
+        "+> ./later-dependency.mec\n+> ./missing.mec\nvalue := 2\n",
+      ),
+      ("later-dependency.mec", "value := 3\n<+ value\n"),
+    ]);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+    let earlier = runtime
+      .build_module_from_request_with_context(
+        &mut context,
+        "earlier.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+
+    assert!(
+      runtime
+        .build_module_from_request_with_context(
+          &mut context,
+          "later.mec",
+          test_module_options(),
+        )
+        .is_err(),
+    );
+
+    assert!(
+      runtime
+        .get_module_version_visible(&context, earlier)
+        .unwrap()
+        .is_some(),
+    );
+    for uri in ["memory:later.mec", "memory:later-dependency.mec"] {
+      assert!(
+        runtime
+          .find_module_by_name_visible(&context, uri)
+          .unwrap()
+          .is_none(),
+        "failed operation retained {uri}",
+      );
+    }
+
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+    assert!(
+      runtime.store.get_module_version(earlier).unwrap().is_some(),
+    );
+  }
+
+  #[test]
+  fn committed_equal_version_emits_no_second_compile_event() {
+    let mut runtime = runtime_with_sources(&[(
+      "main.mec",
+      "value := 1\nvalue\n",
+    )]);
+    let first = runtime
+      .resolve_and_store_module_source(
+        "main.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let compiled_before = runtime
+      .list_events(None)
+      .unwrap()
+      .iter()
+      .filter(|event| matches!(
+        event.kind,
+        RuntimeEventKind::ModuleCompiled { .. }
+      ))
+      .count();
+
+    let second = runtime
+      .resolve_and_store_module_source(
+        "main.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+    let compiled_after = runtime
+      .list_events(None)
+      .unwrap()
+      .iter()
+      .filter(|event| matches!(
+        event.kind,
+        RuntimeEventKind::ModuleCompiled { .. }
+      ))
+      .count();
+
+    assert_eq!(second, first);
+    assert_eq!(compiled_after, compiled_before);
+  }
+
+  #[test]
+  fn module_only_work_is_allowed_while_another_transaction_owns_program() {
+    let mut runtime = runtime_with_sources(&[(
+      "module-b.mec",
+      "value := 2\nvalue\n",
+    )]);
+    let mut context_a = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context_a).unwrap();
+    runtime
+      .run_string_with_context(
+        &mut context_a,
+        "transaction-a-owner := 1",
+      )
+      .unwrap();
+
+    let mut context_b = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context_b).unwrap();
+    let version = runtime
+      .build_module_from_request_with_context(
+        &mut context_b,
+        "module-b.mec",
+        test_module_options(),
+      )
+      .unwrap()
+      .unwrap();
+
+    assert!(
+      runtime
+        .get_module_version_visible(&context_b, version)
+        .unwrap()
+        .is_some(),
+    );
+    runtime
+      .abort_runtime_transaction(&mut context_b, "discard B")
+      .unwrap();
+    runtime
+      .abort_runtime_transaction(&mut context_a, "discard A")
+      .unwrap();
   }
 }

--- a/src/runtime/src/runtime/module_transaction.rs
+++ b/src/runtime/src/runtime/module_transaction.rs
@@ -1,0 +1,394 @@
+//! Transaction-local staging for module and module-version records.
+
+use super::*;
+
+#[derive(Debug)]
+pub(super) enum RuntimeModuleMutation {
+  PutModule(ModuleRecord),
+  PutVersion(ModuleVersionRecord),
+}
+
+#[derive(Debug, Default)]
+pub(super) struct RuntimeModuleJournal {
+  operations: Vec<RuntimeModuleMutation>,
+  module_index: HashMap<ModuleId, usize>,
+  module_name_index: HashMap<String, ModuleId>,
+  version_index: HashMap<ModuleVersionId, usize>,
+}
+
+impl RuntimeModuleJournal {
+  pub(super) fn new() -> Self {
+    Self::default()
+  }
+
+  pub(super) fn is_empty(&self) -> bool {
+    self.operations.is_empty()
+  }
+
+  pub(super) fn mark(&self) -> usize {
+    self.operations.len()
+  }
+
+  pub(super) fn rollback_to(&mut self, mark: usize) -> MResult<()> {
+    if mark > self.operations.len() {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "rollback_module_journal",
+          reason: format!(
+            "module journal mark {} exceeds operation length {}",
+            mark,
+            self.operations.len(),
+          ),
+        },
+        None,
+      ));
+    }
+
+    self.operations.truncate(mark);
+    self.rebuild_indexes()
+  }
+
+  pub(super) fn get_module(
+    &self,
+    id: ModuleId,
+  ) -> Option<&ModuleRecord> {
+    let index = *self.module_index.get(&id)?;
+    match self.operations.get(index)? {
+      RuntimeModuleMutation::PutModule(module) => Some(module),
+      RuntimeModuleMutation::PutVersion(_) => None,
+    }
+  }
+
+  pub(super) fn find_module_by_name(
+    &self,
+    canonical_uri: &str,
+  ) -> Option<&ModuleRecord> {
+    let id = *self.module_name_index.get(canonical_uri)?;
+    self.get_module(id)
+  }
+
+  pub(super) fn get_version(
+    &self,
+    id: ModuleVersionId,
+  ) -> Option<&ModuleVersionRecord> {
+    let index = *self.version_index.get(&id)?;
+    match self.operations.get(index)? {
+      RuntimeModuleMutation::PutVersion(version) => Some(version),
+      RuntimeModuleMutation::PutModule(_) => None,
+    }
+  }
+
+  pub(super) fn stage_module(
+    &mut self,
+    module: ModuleRecord,
+  ) -> MResult<bool> {
+    module.validate()?;
+    if module.id != module_id(&module.name) {
+      return module_journal_conflict(
+        "module",
+        module.id.to_string(),
+        "module ID does not match its canonical URI",
+      );
+    }
+
+    if let Some(existing) = self.get_module(module.id) {
+      if existing.name == module.name {
+        return Ok(false);
+      }
+      return module_journal_conflict(
+        "module",
+        module.id.to_string(),
+        "module ID is already staged for another canonical URI",
+      );
+    }
+
+    if let Some(existing_id) =
+      self.module_name_index.get(&module.name)
+    {
+      return module_journal_conflict(
+        "module.name",
+        module.name.clone(),
+        format!(
+          "canonical URI is already staged for module {}",
+          existing_id,
+        ),
+      );
+    }
+
+    let index = self.operations.len();
+    self.module_index.insert(module.id, index);
+    self
+      .module_name_index
+      .insert(module.name.clone(), module.id);
+    self
+      .operations
+      .push(RuntimeModuleMutation::PutModule(module));
+    Ok(true)
+  }
+
+  pub(super) fn stage_version(
+    &mut self,
+    version: ModuleVersionRecord,
+  ) -> MResult<bool> {
+    version.validate()?;
+    version.validate_import_edges()?;
+
+    if let Some(existing) = self.get_version(version.id) {
+      if existing == &version {
+        return Ok(false);
+      }
+      return module_journal_conflict(
+        "module_version",
+        version.id.to_string(),
+        "version ID is already staged with different contents",
+      );
+    }
+
+    let index = self.operations.len();
+    self.version_index.insert(version.id, index);
+    self
+      .operations
+      .push(RuntimeModuleMutation::PutVersion(version));
+    Ok(true)
+  }
+
+  pub(super) fn module_puts(
+    &self,
+  ) -> impl Iterator<Item = &ModuleRecord> {
+    self.operations.iter().filter_map(|operation| match operation {
+      RuntimeModuleMutation::PutModule(module) => Some(module),
+      RuntimeModuleMutation::PutVersion(_) => None,
+    })
+  }
+
+  pub(super) fn version_puts(
+    &self,
+  ) -> impl Iterator<Item = &ModuleVersionRecord> {
+    self.operations.iter().filter_map(|operation| match operation {
+      RuntimeModuleMutation::PutVersion(version) => Some(version),
+      RuntimeModuleMutation::PutModule(_) => None,
+    })
+  }
+
+  fn rebuild_indexes(&mut self) -> MResult<()> {
+    self.module_index.clear();
+    self.module_name_index.clear();
+    self.version_index.clear();
+
+    for (index, operation) in self.operations.iter().enumerate() {
+      match operation {
+        RuntimeModuleMutation::PutModule(module) => {
+          module.validate()?;
+          if module.id != module_id(&module.name) {
+            return module_journal_conflict(
+              "module",
+              module.id.to_string(),
+              "rollback retained a module whose ID does not match its canonical URI",
+            );
+          }
+          if let Some(existing_index) =
+            self.module_index.get(&module.id)
+          {
+            let RuntimeModuleMutation::PutModule(existing) =
+              &self.operations[*existing_index]
+            else {
+              unreachable!();
+            };
+            if existing.name != module.name {
+              return module_journal_conflict(
+                "module",
+                module.id.to_string(),
+                "rollback retained conflicting canonical URIs",
+              );
+            }
+            continue;
+          }
+          if let Some(existing_id) =
+            self.module_name_index.get(&module.name)
+          {
+            if existing_id != &module.id {
+              return module_journal_conflict(
+                "module.name",
+                module.name.clone(),
+                "rollback retained conflicting module IDs",
+              );
+            }
+            continue;
+          }
+          self.module_index.insert(module.id, index);
+          self
+            .module_name_index
+            .insert(module.name.clone(), module.id);
+        }
+        RuntimeModuleMutation::PutVersion(version) => {
+          version.validate()?;
+          version.validate_import_edges()?;
+          if let Some(existing_index) =
+            self.version_index.get(&version.id)
+          {
+            let RuntimeModuleMutation::PutVersion(existing) =
+              &self.operations[*existing_index]
+            else {
+              unreachable!();
+            };
+            if existing != version {
+              return module_journal_conflict(
+                "module_version",
+                version.id.to_string(),
+                "rollback retained conflicting version records",
+              );
+            }
+            continue;
+          }
+          self.version_index.insert(version.id, index);
+        }
+      }
+    }
+    Ok(())
+  }
+}
+
+fn module_journal_conflict<T>(
+  record_type: &'static str,
+  identity: impl Into<String>,
+  reason: impl Into<String>,
+) -> MResult<T> {
+  Err(MechError::new(
+    RuntimeModuleJournalConflict {
+      record_type,
+      identity: identity.into(),
+      reason: reason.into(),
+    },
+    None,
+  ))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn module(uri: &str, description: &str) -> ModuleRecord {
+    ModuleRecord::new(module_id(uri), uri)
+      .with_description(description)
+  }
+
+  #[test]
+  fn module_staging_ignores_description_differences() {
+    let mut journal = RuntimeModuleJournal::new();
+    let first = module("memory://module.mec", "first");
+    let second = module("memory://module.mec", "second");
+
+    assert!(journal.stage_module(first.clone()).unwrap());
+    assert!(!journal.stage_module(second).unwrap());
+    assert_eq!(
+      journal.get_module(first.id).unwrap().description.as_deref(),
+      Some("first"),
+    );
+    assert_eq!(journal.mark(), 1);
+  }
+
+  #[test]
+  fn conflicting_module_identity_fails_without_mutation() {
+    let mut journal = RuntimeModuleJournal::new();
+    let first = module("memory://module.mec", "first");
+    journal.stage_module(first.clone()).unwrap();
+    let mark = journal.mark();
+    let conflict = ModuleRecord::new(
+      first.id,
+      "memory://other.mec",
+    );
+
+    let error = journal.stage_module(conflict).unwrap_err();
+
+    assert!(
+      error.kind_as::<RuntimeModuleJournalConflict>().is_some(),
+    );
+    assert_eq!(journal.mark(), mark);
+    assert_eq!(journal.get_module(first.id), Some(&first));
+  }
+
+  #[test]
+  fn conflicting_version_identity_fails_without_mutation() {
+    let mut journal = RuntimeModuleJournal::new();
+    let owner = module_id("memory://module.mec");
+    let first =
+      ModuleVersionRecord::new(ModuleVersionId(10), owner, 1);
+    journal.stage_version(first.clone()).unwrap();
+    let mark = journal.mark();
+    let conflict =
+      ModuleVersionRecord::new(ModuleVersionId(10), owner, 2);
+
+    let error = journal.stage_version(conflict).unwrap_err();
+
+    assert!(
+      error.kind_as::<RuntimeModuleJournalConflict>().is_some(),
+    );
+    assert_eq!(journal.mark(), mark);
+    assert_eq!(journal.get_version(first.id), Some(&first));
+  }
+
+  #[test]
+  fn rollback_retains_prefix_and_removes_suffix() {
+    let mut journal = RuntimeModuleJournal::new();
+    let first = module("memory://first.mec", "first");
+    let second = module("memory://second.mec", "second");
+    journal.stage_module(first.clone()).unwrap();
+    let mark = journal.mark();
+    journal.stage_module(second.clone()).unwrap();
+
+    journal.rollback_to(mark).unwrap();
+
+    assert_eq!(journal.get_module(first.id), Some(&first));
+    assert!(journal.get_module(second.id).is_none());
+    assert!(
+      journal
+        .find_module_by_name("memory://second.mec")
+        .is_none(),
+    );
+  }
+
+  #[test]
+  fn program_operation_rollback_removes_later_module_work() {
+    let mut runtime =
+      MechRuntime::new(RuntimeConfig::default()).unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id =
+      runtime.begin_transaction(&mut context).unwrap();
+    let earlier = module("memory://earlier.mec", "earlier");
+    let later = module("memory://later.mec", "later");
+    runtime
+      .active_execution_transaction_mut(transaction_id)
+      .unwrap()
+      .modules
+      .stage_module(earlier.clone())
+      .unwrap();
+
+    let error = runtime
+      .with_atomic_program_operation(
+        &mut context,
+        "module_journal_savepoint_test",
+        |runtime, _| {
+          runtime
+            .active_execution_transaction_mut(transaction_id)?
+            .modules
+            .stage_module(later.clone())?;
+          Err::<(), _>(MechError::new(
+            RuntimeInvalidOperationError {
+              operation: "module_journal_savepoint_test",
+              reason: "deliberate failure".to_string(),
+            },
+            None,
+          ))
+        },
+      )
+      .unwrap_err();
+
+    assert!(error.kind_as::<RuntimeInvalidOperationError>().is_some());
+    let journal = &runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .modules;
+    assert_eq!(journal.get_module(earlier.id), Some(&earlier));
+    assert!(journal.get_module(later.id).is_none());
+  }
+}

--- a/src/runtime/src/runtime/module_transaction.rs
+++ b/src/runtime/src/runtime/module_transaction.rs
@@ -263,6 +263,171 @@ fn module_journal_conflict<T>(
   ))
 }
 
+impl MechRuntime {
+  pub(super) fn get_module_visible(
+    &self,
+    context: &RuntimeContext,
+    id: ModuleId,
+  ) -> MResult<Option<ModuleRecord>> {
+    if let Some(transaction_id) = context.transaction {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      if let Some(module) = transaction.modules.get_module(id) {
+        return Ok(Some(module.clone()));
+      }
+    }
+    self.store.get_module(id)
+  }
+
+  pub(super) fn find_module_by_name_visible(
+    &self,
+    context: &RuntimeContext,
+    canonical_uri: &str,
+  ) -> MResult<Option<ModuleRecord>> {
+    if let Some(transaction_id) = context.transaction {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      if let Some(module) = transaction
+        .modules
+        .find_module_by_name(canonical_uri)
+      {
+        return Ok(Some(module.clone()));
+      }
+    }
+    self.store.find_module_by_name(canonical_uri)
+  }
+
+  pub(super) fn get_module_version_visible(
+    &self,
+    context: &RuntimeContext,
+    id: ModuleVersionId,
+  ) -> MResult<Option<ModuleVersionRecord>> {
+    if let Some(transaction_id) = context.transaction {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      if let Some(version) = transaction.modules.get_version(id) {
+        return Ok(Some(version.clone()));
+      }
+    }
+    self.store.get_module_version(id)
+  }
+
+  pub(super) fn with_atomic_module_operation<T>(
+    &mut self,
+    context: &mut RuntimeContext,
+    operation: &'static str,
+    execute: impl FnOnce(
+      &mut MechRuntime,
+      &mut RuntimeContext,
+    ) -> MResult<T>,
+  ) -> MResult<T> {
+    self.ensure_runtime_mutation_allowed(operation)?;
+    self.validate_context_for_runtime(context)?;
+    self.reject_program_operation_reentrancy(operation)?;
+
+    let implicit = context.transaction.is_none();
+    if implicit {
+      self.begin_runtime_transaction_internal(
+        context,
+        RuntimeExecutionTransactionMode::ImplicitModuleOperation,
+      )?;
+    }
+
+    let transaction_id = Self::context_transaction_id(context)?;
+    if self.active_execution_transaction(transaction_id)?.mode
+      != if implicit {
+        RuntimeExecutionTransactionMode::ImplicitModuleOperation
+      } else {
+        RuntimeExecutionTransactionMode::Explicit
+      }
+    {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation,
+          reason: format!(
+            "transaction {} has an incompatible execution mode",
+            transaction_id,
+          ),
+        },
+        None,
+      ));
+    }
+
+    let savepoint =
+      self.capture_runtime_operation_savepoint(context, transaction_id)?;
+    match execute(self, context) {
+      Ok(value) if !implicit => Ok(value),
+      Ok(value) => match self
+        .commit_runtime_transaction_internal(context)
+      {
+        Ok(super::transaction::RuntimeCommitResolution::Committed(_)) => {
+          Ok(value)
+        }
+        Ok(
+          super::transaction::RuntimeCommitResolution::CommittedWithError {
+            error,
+            ..
+          },
+        ) => Err(error),
+        Err(error) => self.finish_failed_module_operation(
+          context,
+          operation,
+          transaction_id,
+          &savepoint,
+          error,
+          true,
+        ),
+      },
+      Err(error) => self.finish_failed_module_operation(
+        context,
+        operation,
+        transaction_id,
+        &savepoint,
+        error,
+        implicit,
+      ),
+    }
+  }
+
+  fn finish_failed_module_operation<T>(
+    &mut self,
+    context: &mut RuntimeContext,
+    operation: &'static str,
+    transaction_id: TransactionId,
+    savepoint: &RuntimeOperationSavepoint,
+    original_error: MechError,
+    implicit: bool,
+  ) -> MResult<T> {
+    let original_error_text = format!("{:?}", original_error);
+    let mut rollback_failures = self.rollback_runtime_operation(
+      context,
+      transaction_id,
+      savepoint,
+    );
+
+    if implicit {
+      rollback_failures.extend(
+        self.cleanup_failed_implicit_operation(
+          context,
+          operation,
+          transaction_id,
+          &format!("module operation `{}` failed", operation),
+        ),
+      );
+    }
+
+    if rollback_failures.is_empty() {
+      return Err(original_error);
+    }
+    Err(self.poison_program_operation(
+      operation,
+      Some(transaction_id),
+      original_error_text,
+      rollback_failures,
+    ))
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -175,6 +175,7 @@ pub(super) struct RuntimeProgramBaseline {
 
 pub(super) struct RuntimeExecutionTransaction {
   pub(super) store: RuntimeTransaction,
+  pub(super) modules: RuntimeModuleJournal,
   pub(super) mode: RuntimeExecutionTransactionMode,
   pub(super) context_identity: RuntimeTransactionContextIdentity,
   pub(super) context_baseline: RuntimeContextCheckpoint,
@@ -193,6 +194,7 @@ impl RuntimeExecutionTransaction {
   ) -> Self {
     Self {
       store,
+      modules: RuntimeModuleJournal::new(),
       mode,
       context_identity,
       context_baseline,
@@ -205,13 +207,19 @@ impl RuntimeExecutionTransaction {
 }
 
 #[derive(Clone)]
-pub(super) struct RuntimeProgramOperationSavepoint {
-  pub(super) program: MechProgramCheckpoint,
-  pub(super) live: RuntimeLiveStateSnapshot,
+pub(super) struct RuntimeOperationSavepoint {
   pub(super) store: RuntimeTransaction,
+  pub(super) module_mark: usize,
   pub(super) effect_mark: usize,
   pub(super) capability_mark: usize,
   pub(super) context: RuntimeContextCheckpoint,
+}
+
+#[derive(Clone)]
+pub(super) struct RuntimeProgramOperationSavepoint {
+  pub(super) program: MechProgramCheckpoint,
+  pub(super) live: RuntimeLiveStateSnapshot,
+  pub(super) runtime: RuntimeOperationSavepoint,
 }
 
 #[derive(Clone, Debug)]
@@ -378,19 +386,29 @@ impl MechRuntime {
     ))
   }
 
-  fn rollback_program_operation(
+  pub(super) fn capture_runtime_operation_savepoint(
+    &self,
+    context: &RuntimeContext,
+    transaction_id: TransactionId,
+  ) -> MResult<RuntimeOperationSavepoint> {
+    let transaction =
+      self.active_execution_transaction(transaction_id)?;
+    Ok(RuntimeOperationSavepoint {
+      store: transaction.store.clone(),
+      module_mark: transaction.modules.mark(),
+      effect_mark: transaction.effects.mark(),
+      capability_mark: transaction.capabilities.mark(),
+      context: RuntimeContextCheckpoint::capture(context),
+    })
+  }
+
+  pub(super) fn rollback_runtime_operation(
     &mut self,
     context: &mut RuntimeContext,
     transaction_id: TransactionId,
-    savepoint: &RuntimeProgramOperationSavepoint,
+    savepoint: &RuntimeOperationSavepoint,
   ) -> Vec<String> {
     let mut failures = Vec::new();
-
-    if let Err(error) = self.program.restore(savepoint.program.clone()) {
-      failures.push(format!("program restore failed: {:?}", error));
-    }
-
-    self.restore_live_state(savepoint.live.clone());
 
     self.active_effect_phase = Some(ActiveRuntimeEffectPhase::Aborting);
     let effect_rollback = match self.active_transactions.get_mut(&transaction_id) {
@@ -400,17 +418,29 @@ impl MechRuntime {
           .abortable_ids_after(savepoint.effect_mark);
         let effect_failures =
           transaction.effects.rollback_to(savepoint.effect_mark);
-        transaction.store = savepoint.store.clone();
         let capability_result = transaction
           .capabilities
           .rollback_to(savepoint.capability_mark);
-        Some((effect_failures, capability_result, abortable_ids))
+        let module_result =
+          transaction.modules.rollback_to(savepoint.module_mark);
+        transaction.store = savepoint.store.clone();
+        Some((
+          effect_failures,
+          capability_result,
+          module_result,
+          abortable_ids,
+        ))
       }
       None => None,
     };
     self.active_effect_phase = None;
     match effect_rollback {
-      Some((effect_failures, capability_result, abortable_ids)) => {
+      Some((
+        effect_failures,
+        capability_result,
+        module_result,
+        abortable_ids,
+      )) => {
         let failed_effects: HashSet<RuntimeEffectId> = effect_failures
           .iter()
           .map(|failure| failure.effect_id)
@@ -419,6 +449,12 @@ impl MechRuntime {
         if let Err(error) = capability_result {
           failures.push(format!(
             "capability overlay rollback failed: {:?}",
+            error,
+          ));
+        }
+        if let Err(error) = module_result {
+          failures.push(format!(
+            "module journal rollback failed: {:?}",
             error,
           ));
         }
@@ -446,6 +482,27 @@ impl MechRuntime {
       failures.push(format!("context restore invariant failed: {:?}", error));
     }
 
+    failures
+  }
+
+  fn rollback_program_operation(
+    &mut self,
+    context: &mut RuntimeContext,
+    transaction_id: TransactionId,
+    savepoint: &RuntimeProgramOperationSavepoint,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    if let Err(error) = self.program.restore(savepoint.program.clone()) {
+      failures.push(format!("program restore failed: {:?}", error));
+    }
+
+    self.restore_live_state(savepoint.live.clone());
+    failures.extend(self.rollback_runtime_operation(
+      context,
+      transaction_id,
+      &savepoint.runtime,
+    ));
     failures
   }
 
@@ -706,19 +763,10 @@ impl MechRuntime {
     let savepoint = RuntimeProgramOperationSavepoint {
       program: program_checkpoint,
       live: live_checkpoint,
-      store: self
-        .active_execution_transaction(transaction_id)?
-        .store
-        .clone(),
-      effect_mark: self
-        .active_execution_transaction(transaction_id)?
-        .effects
-        .mark(),
-      capability_mark: self
-        .active_execution_transaction(transaction_id)?
-        .capabilities
-        .mark(),
-      context: RuntimeContextCheckpoint::capture(context),
+      runtime: self.capture_runtime_operation_savepoint(
+        context,
+        transaction_id,
+      )?,
     };
 
     self.active_program_operation = Some(ActiveRuntimeProgramOperation {

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -10,6 +10,7 @@ use crate::AccessSet;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum RuntimeExecutionTransactionMode {
   Explicit,
+  ImplicitModuleOperation,
   ImplicitProgramOperation,
 }
 
@@ -613,7 +614,7 @@ impl MechRuntime {
     failures
   }
 
-  fn cleanup_failed_implicit_operation(
+  pub(super) fn cleanup_failed_implicit_operation(
     &mut self,
     context: &mut RuntimeContext,
     operation: &'static str,

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -30,7 +30,122 @@ pub(super) enum RuntimeCommitResolution {
   },
 }
 
+fn module_journal_validation_error(
+  record_type: &'static str,
+  identity: impl Into<String>,
+  reason: impl Into<String>,
+) -> MechError {
+  MechError::new(
+    RuntimeModuleJournalConflict {
+      record_type,
+      identity: identity.into(),
+      reason: reason.into(),
+    },
+    None,
+  )
+}
+
 impl MechRuntime {
+
+  fn validate_runtime_module_journal(
+    &self,
+    transaction_id: TransactionId,
+  ) -> MResult<()> {
+    let journal =
+      &self.active_execution_transaction(transaction_id)?.modules;
+
+    for module in journal.module_puts() {
+      module.validate()?;
+      if module.id != module_id(&module.name) {
+        return Err(module_journal_validation_error(
+          "module",
+          module.id.to_string(),
+          "module ID does not match its canonical URI",
+        ));
+      }
+      if let Some(existing) = self.store.get_module(module.id)? {
+        if existing.name != module.name {
+          return Err(module_journal_validation_error(
+            "module",
+            module.id.to_string(),
+            "committed module ID maps to another canonical URI",
+          ));
+        }
+      }
+      if let Some(existing) =
+        self.store.find_module_by_name(&module.name)?
+      {
+        if existing.id != module.id {
+          return Err(module_journal_validation_error(
+            "module.name",
+            module.name.clone(),
+            "committed canonical URI maps to another module ID",
+          ));
+        }
+      }
+    }
+
+    for version in journal.version_puts() {
+      version.validate()?;
+      version.validate_import_edges()?;
+      if let Some(existing) =
+        self.store.get_module_version(version.id)?
+      {
+        if existing != *version {
+          return Err(module_journal_validation_error(
+            "module_version",
+            version.id.to_string(),
+            "committed version ID maps to different contents",
+          ));
+        }
+      }
+      if journal.get_module(version.module).is_none()
+        && self.store.get_module(version.module)?.is_none()
+      {
+        return Err(module_journal_validation_error(
+          "module_version.owner",
+          version.module.to_string(),
+          format!(
+            "owner of version {} is not visible",
+            version.id,
+          ),
+        ));
+      }
+      for dependency in &version.dependencies {
+        if journal.get_version(*dependency).is_none()
+          && self.store.get_module_version(*dependency)?.is_none()
+        {
+          return Err(module_journal_validation_error(
+            "module_version.dependency",
+            dependency.to_string(),
+            format!(
+              "dependency of version {} is not visible",
+              version.id,
+            ),
+          ));
+        }
+      }
+      for edge in &version.import_edges {
+        if journal.get_version(edge.dependency).is_none()
+          && self
+            .store
+            .get_module_version(edge.dependency)?
+            .is_none()
+        {
+          return Err(module_journal_validation_error(
+            "module_version.import_edge",
+            edge.dependency.to_string(),
+            format!(
+              "import-edge target of version {} is not visible",
+              version.id,
+            ),
+          ));
+        }
+      }
+    }
+
+    Ok(())
+  }
 
   pub fn commit_transaction(
     &mut self,
@@ -219,6 +334,8 @@ impl MechRuntime {
         journal_failures,
       ));
     }
+
+    self.validate_runtime_module_journal(transaction_id)?;
 
     {
       let transaction =
@@ -738,6 +855,12 @@ impl MechRuntime {
 
     Ok(RuntimeStoreCommit {
       transaction: transaction_record,
+      module_puts: envelope.modules.module_puts().cloned().collect(),
+      module_version_puts: envelope
+        .modules
+        .version_puts()
+        .cloned()
+        .collect(),
       capability_grants: envelope.capabilities.grants().collect(),
       capability_revocations: envelope
         .capabilities
@@ -938,6 +1061,43 @@ impl MechRuntime {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::{
+    PreparedRuntimeEffect, RuntimeEffectMetadata,
+    RuntimeEffectSource, RuntimeTransactionalEffect,
+  };
+  use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+  };
+
+  #[derive(Debug)]
+  struct PrepareProbe {
+    prepared: Arc<AtomicBool>,
+  }
+
+  impl RuntimeTransactionalEffect for PrepareProbe {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "module-validation-probe".to_string(),
+        },
+        "prepare",
+      )
+    }
+
+    fn prepare(&mut self) -> MResult<()> {
+      self.prepared.store(true, Ordering::SeqCst);
+      Ok(())
+    }
+
+    fn commit(&mut self) -> MResult<()> {
+      Ok(())
+    }
+
+    fn abort(&mut self) -> MResult<()> {
+      Ok(())
+    }
+  }
 
   fn event_count(
     events: &[RuntimeEvent],
@@ -994,6 +1154,48 @@ mod tests {
       ),
       0,
     );
+  }
+
+  #[test]
+  fn module_journal_validation_precedes_effect_preparation() {
+    let mut runtime = new_runtime();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id =
+      runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .active_execution_transaction_mut(transaction_id)
+      .unwrap()
+      .modules
+      .stage_version(ModuleVersionRecord::new(
+        ModuleVersionId(10),
+        module_id("memory://missing.mec"),
+        1,
+      ))
+      .unwrap();
+    let prepared = Arc::new(AtomicBool::new(false));
+    runtime
+      .active_execution_transaction_mut(transaction_id)
+      .unwrap()
+      .effects
+      .stage(
+        transaction_id,
+        PreparedRuntimeEffect::Transactional(Box::new(
+          PrepareProbe {
+            prepared: prepared.clone(),
+          },
+        )),
+      );
+
+    let error =
+      runtime.commit_runtime_transaction(&mut context).unwrap_err();
+
+    assert!(
+      error.kind_as::<RuntimeModuleJournalConflict>().is_some(),
+    );
+    assert!(!prepared.load(Ordering::SeqCst));
+    assert!(runtime.active_transactions.contains_key(&transaction_id));
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert!(matches!(runtime.health(), RuntimeHealth::Healthy));
   }
 
   #[test]

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -53,6 +53,9 @@ impl MechRuntime {
   ) -> MResult<()> {
     let journal =
       &self.active_execution_transaction(transaction_id)?.modules;
+    if journal.is_empty() {
+      return Ok(());
+    }
 
     for module in journal.module_puts() {
       module.validate()?;

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -30,6 +30,7 @@ use crate::id::{
   ActorId, CapabilityId, EventId, MessageId, ModuleId, ModuleVersionId,
   ObjectId, TaskId, TransactionId,
 };
+use crate::module_id;
 use crate::resolver::{
   import_requires_source_dependency, ModuleScopeMetadata, SourceAddressReference,
   SourceContextDeclaration, SourceExportDeclaration, SourceImportAlias, SourceImportDeclaration,
@@ -844,6 +845,8 @@ impl TransactionRecord {
 #[derive(Clone, Debug)]
 pub struct RuntimeStoreCommit {
   pub transaction: TransactionRecord,
+  pub module_puts: Vec<ModuleRecord>,
+  pub module_version_puts: Vec<ModuleVersionRecord>,
   pub capability_grants: Vec<(CapabilityId, Arc<dyn Capability>)>,
   pub capability_revocations: Vec<CapabilityId>,
   pub object_puts: Vec<ObjectRecord>,
@@ -940,6 +943,86 @@ impl InMemoryStore {
       ));
     }
 
+    Ok(())
+  }
+
+  fn commit_module_put(
+    &mut self,
+    module: ModuleRecord,
+  ) -> MResult<()> {
+    module.validate()?;
+    if module.id != module_id(&module.name) {
+      return Err(MechError::new(
+        InvalidStoreRecordError {
+          field: "module.id",
+          reason: "module ID does not match its canonical URI",
+        },
+        None,
+      ));
+    }
+
+    if let Some(existing) = self.modules.get(&module.id) {
+      if existing.name == module.name {
+        return Ok(());
+      }
+      return Err(MechError::new(
+        InvalidStoreRecordError {
+          field: "module.id",
+          reason: "module ID maps to another canonical URI",
+        },
+        None,
+      ));
+    }
+
+    if let Some(existing_id) =
+      self.modules_by_name.get(&module.name)
+    {
+      return Err(MechError::new(
+        InvalidStoreRecordError {
+          field: "module.name",
+          reason: if existing_id == &module.id {
+            "module name index is missing its primary record"
+          } else {
+            "canonical URI maps to another module ID"
+          },
+        },
+        None,
+      ));
+    }
+
+    self.modules_by_name.insert(module.name.clone(), module.id);
+    self.modules.insert(module.id, module);
+    Ok(())
+  }
+
+  fn commit_module_version_put(
+    &mut self,
+    version: ModuleVersionRecord,
+  ) -> MResult<()> {
+    version.validate()?;
+    version.validate_import_edges()?;
+    self.ensure_module_exists(version.module)?;
+    for dependency in &version.dependencies {
+      self.ensure_module_version_exists(*dependency)?;
+    }
+    for edge in &version.import_edges {
+      self.ensure_module_version_exists(edge.dependency)?;
+    }
+
+    if let Some(existing) = self.module_versions.get(&version.id) {
+      if existing == &version {
+        return Ok(());
+      }
+      return Err(MechError::new(
+        InvalidStoreRecordError {
+          field: "module_version.id",
+          reason: "version ID maps to different contents",
+        },
+        None,
+      ));
+    }
+
+    self.module_versions.insert(version.id, version);
     Ok(())
   }
 }
@@ -1418,6 +1501,14 @@ impl MechStore for InMemoryStore {
     let id = commit.transaction.id;
     let mut temporary = self.clone();
 
+    for module in commit.module_puts {
+      temporary.commit_module_put(module)?;
+    }
+
+    for version in commit.module_version_puts {
+      temporary.commit_module_version_put(version)?;
+    }
+
     for object in commit.object_puts {
       temporary.put_object(object)?;
     }
@@ -1599,6 +1690,30 @@ mod tests {
   use crate::event::{
     RuntimeEvent, RuntimeEventKind,
   };
+
+  fn runtime_commit(
+    id: u128,
+    module_puts: Vec<ModuleRecord>,
+    module_version_puts: Vec<ModuleVersionRecord>,
+  ) -> RuntimeStoreCommit {
+    RuntimeStoreCommit {
+      transaction: TransactionRecord::new(
+        TransactionId(id),
+        "test",
+      ),
+      module_puts,
+      module_version_puts,
+      capability_grants: Vec::new(),
+      capability_revocations: Vec::new(),
+      object_puts: Vec::new(),
+      object_updates: Vec::new(),
+      task_updates: Vec::new(),
+      actor_updates: Vec::new(),
+      message_acks: Vec::new(),
+      message_enqueues: Vec::new(),
+      events: Vec::new(),
+    }
+  }
 
   #[test]
   fn module_round_trip() {
@@ -1941,6 +2056,8 @@ mod tests {
       transaction: TransactionRecord::new(TransactionId(1), "task:1")
         .with_write_set(vec![ObjectId(1), ObjectId(2)])
         .with_events(vec![EventId(1)]),
+      module_puts: Vec::new(),
+      module_version_puts: Vec::new(),
       capability_grants: Vec::new(),
       capability_revocations: Vec::new(),
       object_puts: vec![ObjectRecord::text(ObjectId(1), "note", "hello")],
@@ -1959,6 +2076,154 @@ mod tests {
     assert!(store.get_transaction(TransactionId(1)).unwrap().is_none());
     assert!(store.list_events(None).unwrap().is_empty());
     assert!(store.list_transactions(None).unwrap().is_empty());
+  }
+
+  #[test]
+  fn runtime_commit_publishes_module_and_version_together() {
+    let mut store = InMemoryStore::new();
+    let module =
+      ModuleRecord::new(module_id("memory://main.mec"), "memory://main.mec");
+    let version =
+      ModuleVersionRecord::new(ModuleVersionId(10), module.id, 1);
+
+    store
+      .commit_runtime(runtime_commit(
+        1,
+        vec![module.clone()],
+        vec![version.clone()],
+      ))
+      .unwrap();
+
+    assert_eq!(store.get_module(module.id).unwrap(), Some(module));
+    assert_eq!(
+      store.get_module_version(version.id).unwrap(),
+      Some(version),
+    );
+  }
+
+  #[test]
+  fn runtime_commit_missing_module_owner_is_atomic() {
+    let mut store = InMemoryStore::new();
+    let version = ModuleVersionRecord::new(
+      ModuleVersionId(10),
+      module_id("memory://missing.mec"),
+      1,
+    );
+
+    assert!(
+      store
+        .commit_runtime(runtime_commit(1, Vec::new(), vec![version]))
+        .is_err(),
+    );
+    assert!(store.list_transactions(None).unwrap().is_empty());
+    assert!(
+      store
+        .get_module_version(ModuleVersionId(10))
+        .unwrap()
+        .is_none(),
+    );
+  }
+
+  #[test]
+  fn runtime_commit_missing_dependency_is_atomic() {
+    let mut store = InMemoryStore::new();
+    let module =
+      ModuleRecord::new(module_id("memory://main.mec"), "memory://main.mec");
+    let version = ModuleVersionRecord::new(
+      ModuleVersionId(10),
+      module.id,
+      1,
+    )
+    .with_dependencies(vec![ModuleVersionId(99)]);
+
+    assert!(
+      store
+        .commit_runtime(runtime_commit(
+          1,
+          vec![module.clone()],
+          vec![version],
+        ))
+        .is_err(),
+    );
+    assert!(store.get_module(module.id).unwrap().is_none());
+    assert!(store.list_transactions(None).unwrap().is_empty());
+  }
+
+  #[test]
+  fn identical_runtime_module_publication_is_idempotent() {
+    let mut store = InMemoryStore::new();
+    let module =
+      ModuleRecord::new(module_id("memory://main.mec"), "memory://main.mec")
+        .with_description("first");
+    let version =
+      ModuleVersionRecord::new(ModuleVersionId(10), module.id, 1);
+    store
+      .commit_runtime(runtime_commit(
+        1,
+        vec![module.clone()],
+        vec![version.clone()],
+      ))
+      .unwrap();
+
+    store
+      .commit_runtime(runtime_commit(
+        2,
+        vec![
+          ModuleRecord::new(module.id, module.name.clone())
+            .with_description("second"),
+        ],
+        vec![version],
+      ))
+      .unwrap();
+
+    assert_eq!(
+      store
+        .get_module(module.id)
+        .unwrap()
+        .unwrap()
+        .description
+        .as_deref(),
+      Some("first"),
+    );
+  }
+
+  #[test]
+  fn runtime_module_conflict_leaves_other_categories_unchanged() {
+    let mut store = InMemoryStore::new();
+    let module =
+      ModuleRecord::new(module_id("memory://main.mec"), "memory://main.mec");
+    let version =
+      ModuleVersionRecord::new(ModuleVersionId(10), module.id, 1);
+    store
+      .commit_runtime(runtime_commit(
+        1,
+        vec![module.clone()],
+        vec![version],
+      ))
+      .unwrap();
+    let mut conflict = runtime_commit(
+      2,
+      vec![module],
+      vec![ModuleVersionRecord::new(
+        ModuleVersionId(10),
+        module_id("memory://other.mec"),
+        1,
+      )],
+    );
+    conflict.object_puts.push(ObjectRecord::text(
+      ObjectId(20),
+      "note",
+      "must not commit",
+    ));
+
+    assert!(store.commit_runtime(conflict).is_err());
+    assert!(store.get_object(ObjectId(20)).unwrap().is_none());
+    assert!(
+      store
+        .get_transaction(TransactionId(2))
+        .unwrap()
+        .is_none(),
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

This is one PR with four implementation commits, 5A through 5D.
The labels describe commit layers, not separate pull requests.

Round 5 makes graph-producing module APIs atomic and places retained-root
module construction inside the existing runtime-owned program transaction.
It preserves the existing recursive `ModuleDependencyGraph` builder and the
completed Round 4 effect, capability, commit, and poison semantics.

Base: `ab5123749cb9355f72a419b89064cd8e5a12391d`

Final head: `b0972b80a5d691a9d4f3f60a159819ea7f43e522`

## Round 5 boundary

`resolve_and_run_root_module_with_context` now begins
`with_atomic_program_operation` before source resolution and compilation. One
boundary therefore contains source resolution, dependency-first compilation,
module and version staging, invariant validation, isolated dependency
execution, retained-root installation, live registration, effects,
capabilities, ordinary staged store work, and commit.

The existing recursive builder, import ordering, duplicate-import behavior,
cycle paths, and error types remain in use. There is no replacement graph
builder or complete-graph build-session subsystem.

## Atomicity guarantee

For a retained root operation:

```text
module graph durable
  ⇔ runtime transaction durable
  ⇔ retained root program durable
```

A normal pre-store failure leaves no newly committed module or module-version
record, retained-program mutation, live-registration mutation, committed
module success event, delivered external effect, or durable transaction
record.

After `store.commit_runtime` succeeds, graph and retained program rollback is
forbidden. A transactional participant commit failure preserves durable graph,
program, object, and capability state and poisons the runtime with the existing
external-commit-indeterminate error. After-commit delivery failure also keeps
the graph and program committed while retaining the existing healthy outcome.

## Implementation

- Added a private ordered `RuntimeModuleJournal` to
  `RuntimeExecutionTransaction` for module and module-version puts only.
- Added a module-journal mark to the shared runtime operation savepoint.
- Added owner-only transaction-visible module reads; observers fall back to the
  committed store and never search another transaction.
- Changed the existing recursive graph builder to stage records and reuse equal
  visible versions without another `ModuleCompiled` event.
- Added module and module-version fields to `RuntimeStoreCommit`; the in-memory
  store validates and publishes them with the existing atomic clone/apply/swap.
- Runs module invariant validation before effect preparation.
- Extended the existing `program_transaction` benchmark with exactly three
  representative graph cases.
- Added `docs/runtime/atomic-module-graph-transactions.md` and updated the
  retained-program transaction design guarantee.

The module-version hash domain is now
`mech.module.version.full.v2`, with `ModuleId` included before source and build
inputs. Equal source under different canonical module identities therefore has
different valid version IDs.

## Four commits

1. `3c0e4dc64a003913c7d9a31aaba6cabf60fc14d9`
   `feat(runtime): stage module records in runtime transactions`
2. `f72d0bc0a21c620467e7d53e224ba5ef6f84af6a`
   `refactor(runtime): make module graph builds transaction-aware`
3. `337b2fe017fc2093d4c6f346c57b205f5f0c29ac`
   `fix(runtime): transact retained root module construction`
4. `b0972b80a5d691a9d4f3f60a159819ea7f43e522`
   `test(runtime): harden atomic module graph rollback`

## Failure semantics

- Failed implicit graph operations restore their operation savepoint and remove
  the hidden module transaction.
- Failed explicit graph operations restore only their operation suffix and
  preserve earlier provisional transaction work.
- Retryable explicit pre-store commit failure preserves the graph and retained
  program for retry or abort without resolving or compiling again.
- Ordinary failures return the original error when rollback succeeds.
- Incomplete rollback retains the original error and cleanup failures and uses
  the existing poisoned-runtime behavior.
- Failure audits run best-effort outside the rolled-back transaction and do not
  replace the original error.

## Transaction visibility

The owning explicit context can build and execute its provisional graph.
Other contexts, standalone `run_module`, and committed-store reads cannot see
those records. Explicit commit publishes the complete graph; explicit abort
removes it and restores the outer program baseline.

Module-only work in transaction B remains allowed while transaction A owns the
retained program.

## Excluded scope

- No `module_build.rs`, `RuntimeModuleBuildSession`, graph snapshot, or
  replacement builder.
- No activation staging, activation compare-and-set, or activation API change.
- No module fields in `TransactionRecord` and no module history/rewind.
- No source snapshot consistency transaction or resolution-conflict protocol.
- No new event kind or failure classifier.
- No module journal or whole-program checkpoint work in the reactive inner
  loop; transactional reactive turns remain Round 6.
- No arena rewrite, allocator dependency, or durable cell-history work.
- Standalone `run_module` remains isolated.

Per project direction, rustfmt was not run and no formatting-only changes are
included.

## Validation

Focused:

- 5A: module-version identity 5/5; module journal 5/5; store 36/36;
  runtime transaction 12/12; module builder 4/4; compile check passed.
- 5B: module/journal 15/15; module journal 5/5; program transaction
  18/18; module smoke 235/235; compile check passed.
- 5C: module/journal 26/26; program transaction 18/18; effects 22/22;
  module smoke 235/235; generic host 20/20; compile check passed.
- 5D module/journal hardening: 37/37.

Full local matrix:

- `cargo test -p mech-runtime --lib`: 455 passed, 3 known macOS
  workspace-watch failures classified below.
- `cargo test -p mech-runtime --test module_smoke`: 235 passed.
- `cargo test -p mech-runtime --test generic_host`: 20 passed.
- browser-project WASM: 26 passed.
- CLI host integration: 37 passed.
- requested CLI, console, browser, scene, and robot-arm host crates: passed.
- minimal-feature runtime check: passed.
- workspace check: passed.
- `program_transaction` benchmark `--no-run`: passed.
- `program_transaction` benchmark `-- --test`: all 19 cases passed, including
  the three new graph cases.
- `git diff --check`: clean.
- GitHub Actions: all eight required jobs passed on the rewritten head:
  Cargo language tests, Cargo runtime and host tests, Dynamic modules, Project
  browser, Project native, Run-only CLI, Windows CLI, and cargo.

No module, store, transaction, resolver, retained-program, capability, effect,
or host failure was classified as pre-existing.

## Known pre-existing failures

The following exact macOS workspace-watch tests fail identically at both the
required base `ab5123749cb9355f72a419b89064cd8e5a12391d` and rewritten head
`b0972b80a5d691a9d4f3f60a159819ea7f43e522`:

- `workspace::watch::tests::nonrecursive_directory_watch_allows_directory_and_direct_children_only`
  - `event_allowed_by_watches(... docs.join("main.mec"))` is false.
- `workspace::watch::tests::recursive_directory_watch_still_allows_descendants`
  - `event_allowed_by_watches(... nested_file)` is false.
- `workspace::watch::tests::target_watch_falls_back_to_existing_parent_when_target_is_deleted`
  - actual contains both `/var/.../main.mec` and
    `/private/var/.../main.mec`; expected contains only `/var/.../main.mec`.

The assertions and path behavior were reproduced individually with `--exact
--nocapture` on both SHAs.
