### PR TITLE
fix(runtime): transact reactive and host-input turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "ignore",
  "mech-core",
  "mech-host-cli",
+ "mech-interpreter",
  "mech-program",
  "mech-syntax",
  "notify",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -156,6 +156,7 @@ host_delegation_signing = ["host_delegation", "dep:ed25519-dalek", "dep:rand_cor
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 mech-host-cli = { path = "../../hosts/cli", features = ["provider"] }
+mech-interpreter = { path = "../interpreter", default-features = false }
 serde_json = "1.0.150"
 
 [dependencies]
@@ -278,5 +279,10 @@ required-features = ["program"]
 
 [[bench]]
 name = "program_transaction"
+harness = false
+required-features = ["baselib"]
+
+[[bench]]
+name = "reactive_transaction"
 harness = false
 required-features = ["baselib"]

--- a/src/runtime/benches/reactive_transaction.rs
+++ b/src/runtime/benches/reactive_transaction.rs
@@ -1,0 +1,716 @@
+use criterion::{
+  BatchSize, Criterion, criterion_group, criterion_main,
+};
+use mech_core::{
+  CompileCtx, GenericError, MResult, MechError, MechFunctionCompiler,
+  MechFunctionImpl, ReactiveSolveStatus, Ref, Register, Value, hash_str,
+};
+use mech_interpreter::Interpreter;
+use mech_program::{
+  MechProgram, MechProgramConfig, ProgramInputId, ProgramInputUpdate,
+  ProgramReactiveTurnJournal,
+};
+use mech_runtime::{
+  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+  ClosureHostFunction, MechRuntime, ObjectRecord,
+  PreparedRuntimeEffect,
+  RuntimeAfterCommitEffect, RuntimeCapabilityGrant,
+  RuntimeCapabilityOperation, RuntimeContext, RuntimeEffectMetadata,
+  RuntimeEffectSource, RuntimeHostInput, RuntimeHostInputSource,
+  RuntimeHostInputValue, RuntimePreparedHostCall,
+  RuntimeResourceProvider, RuntimeResourceReadRequest,
+  SequentialIdGenerator, StagedClosureHostFunction,
+};
+use std::hint::black_box;
+use std::sync::{
+  Arc,
+  atomic::{AtomicBool, Ordering},
+};
+
+const INPUT_BASE_URI: &str = "bench://clock/ticks";
+const INPUT_PATH: &str = "value";
+
+struct StepFixture {
+  runtime: MechRuntime,
+  context: RuntimeContext,
+}
+
+struct HostInputFixture {
+  runtime: MechRuntime,
+  context: RuntimeContext,
+  source: RuntimeHostInputSource,
+}
+
+struct TwoInterpreterFixture {
+  program: MechProgram,
+  updates: Vec<ProgramInputUpdate>,
+}
+
+struct BenchStepFunction {
+  output: Ref<usize>,
+  fail: bool,
+}
+
+impl MechFunctionImpl for BenchStepFunction {
+  fn solve(&self) {}
+
+  fn solve_result(&self) -> MResult<()> {
+    self.solve_reactive().map(|_| ())
+  }
+
+  fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+    *self.output.borrow_mut() += 1;
+    if self.fail {
+      return Err(MechError::new(
+        GenericError {
+          msg: "benchmark tail failure".to_string(),
+        },
+        None,
+      ));
+    }
+    Ok(ReactiveSolveStatus::Changed)
+  }
+
+  fn out(&self) -> Value {
+    Value::Index(self.output.clone())
+  }
+
+  fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+    Ok(vec![Value::Index(self.output.clone())])
+  }
+
+  fn to_string(&self) -> String {
+    "ReactiveTransactionBenchmarkStep".to_string()
+  }
+}
+
+impl MechFunctionCompiler for BenchStepFunction {
+  fn compile(&self, _context: &mut CompileCtx) -> MResult<Register> {
+    Ok(0)
+  }
+}
+
+#[derive(Debug)]
+struct BenchInputProvider;
+
+impl RuntimeResourceProvider for BenchInputProvider {
+  fn scheme(&self) -> &str {
+    "bench"
+  }
+
+  fn base_uris(&self) -> Vec<String> {
+    vec![INPUT_BASE_URI.to_string()]
+  }
+
+  fn read(
+    &self,
+    request: RuntimeResourceReadRequest,
+  ) -> MResult<Value> {
+    if request.base_uri == INPUT_BASE_URI
+      && request.path == INPUT_PATH
+    {
+      return Ok(Value::F64(Ref::new(1.0)));
+    }
+    Err(MechError::new(
+      GenericError {
+        msg: format!(
+          "missing benchmark input {} / {}",
+          request.base_uri,
+          request.path,
+        ),
+      },
+      None,
+    ))
+  }
+}
+
+#[derive(Debug)]
+struct BenchAfterCommitEffect;
+
+impl RuntimeAfterCommitEffect for BenchAfterCommitEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::Custom {
+        name: "reactive-transaction-benchmark".to_string(),
+      },
+      "deliver",
+    )
+  }
+
+  fn deliver(&mut self) -> MResult<()> {
+    black_box(());
+    Ok(())
+  }
+}
+
+fn add_step_functions(
+  runtime: &mut MechRuntime,
+  count: usize,
+  fail_tail: bool,
+) {
+  for index in 0..count {
+    runtime
+      .program_mut()
+      .interpreter()
+      .plan()
+      .add_function(Box::new(BenchStepFunction {
+        output: Ref::new(index),
+        fail: fail_tail && index + 1 == count,
+      }));
+  }
+}
+
+fn step_fixture(count: usize, fail_tail: bool) -> StepFixture {
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .build()
+    .unwrap();
+  add_step_functions(&mut runtime, count, fail_tail);
+  let context = runtime.runtime_context().unwrap();
+  StepFixture { runtime, context }
+}
+
+fn grant_input_read(runtime: &mut MechRuntime) {
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime
+    .grant_capability(RuntimeCapabilityGrant {
+      subject,
+      resource: INPUT_BASE_URI.to_string(),
+      operations: vec![RuntimeCapabilityOperation::Read],
+      paths: vec![INPUT_PATH.to_string()],
+    })
+    .unwrap();
+}
+
+fn grant_host_call(
+  runtime: &mut MechRuntime,
+  capability: u64,
+  name: &str,
+) {
+  let subject = runtime.runtime_context().unwrap().subject;
+  runtime
+    .grant_capability(Arc::new(BasicCapability::new(
+      CapabilityId(capability.into()),
+      &BasicSubject::new(subject),
+      &BasicResource::new(format!("host:{name}")),
+      [BasicOperation::new("call")],
+    )))
+    .unwrap();
+}
+
+fn host_input_fixture(source_tail: &str) -> HostInputFixture {
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .resource_provider(Box::new(BenchInputProvider))
+    .build()
+    .unwrap();
+  grant_input_read(&mut runtime);
+  let mut context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      &format!(
+        "@pulse := {INPUT_BASE_URI}{{:read({INPUT_PATH})}}\n{source_tail}",
+      ),
+    )
+    .unwrap();
+  HostInputFixture {
+    runtime,
+    context,
+    source: RuntimeHostInputSource::new(
+      INPUT_BASE_URI,
+      INPUT_PATH,
+    )
+    .unwrap(),
+  }
+}
+
+fn apply_host_input(
+  fixture: &mut HostInputFixture,
+) -> MResult<mech_runtime::RuntimeHostInputOutcome> {
+  fixture.runtime.apply_host_input_with_context(
+    &mut fixture.context,
+    RuntimeHostInput::single(
+      fixture.source.clone(),
+      RuntimeHostInputValue::F64(2.0),
+    ),
+  )
+}
+
+fn chain_source(length: usize) -> String {
+  let mut source = String::new();
+  let mut previous = format!("@pulse/{INPUT_PATH}");
+  for index in 0..length {
+    let name = format!("chain-{index}");
+    source.push_str(&format!("{name} := {previous} + 1.0\n"));
+    previous = name;
+  }
+  source
+}
+
+fn sparse_source(length: usize) -> String {
+  let mut source = String::new();
+  for index in 0..length {
+    source.push_str(&format!(
+      "sparse-{index} := @pulse/{INPUT_PATH} + {index}.0\n",
+    ));
+  }
+  source
+}
+
+fn register_source(count: usize) -> String {
+  let mut source = String::new();
+  for index in 0..count {
+    source.push_str(&format!("~register-{index} := 0.0\n"));
+  }
+  for index in 0..count {
+    source.push_str(&format!(
+      "register-{index} = @pulse/{INPUT_PATH} + {index}.0\n",
+    ));
+  }
+  source
+}
+
+fn copied_host_f64(arguments: &[Value]) -> Value {
+  let value = match arguments.first() {
+    Some(Value::F64(value)) => *value.borrow(),
+    Some(Value::MutableReference(value)) => {
+      match &*value.borrow() {
+        Value::F64(value) => *value.borrow(),
+        other => panic!(
+          "expected f64 benchmark host input, got {other:?}",
+        ),
+      }
+    }
+    other => panic!(
+      "expected f64 benchmark host argument, got {other:?}",
+    ),
+  };
+  Value::F64(Ref::new(value))
+}
+
+fn failing_host_input_fixture() -> HostInputFixture {
+  let fail = Arc::new(AtomicBool::new(false));
+  let fail_for_host = fail.clone();
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .resource_provider(Box::new(BenchInputProvider))
+    .build()
+    .unwrap();
+  grant_input_read(&mut runtime);
+  grant_host_call(&mut runtime, 9_001, "bench/fail-tail");
+  runtime
+    .register_mech_host_function(ClosureHostFunction::new_pure(
+      "bench/fail-tail",
+      move |_services, _context, arguments| {
+        if fail_for_host.load(Ordering::SeqCst) {
+          return Err(MechError::new(
+            GenericError {
+              msg: "benchmark reactive tail failure".to_string(),
+            },
+            None,
+          ));
+        }
+        Ok(copied_host_f64(&arguments))
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      &format!(
+        "@pulse := {INPUT_BASE_URI}{{:read({INPUT_PATH})}}\n\
+         tail := bench/fail-tail(@pulse/{INPUT_PATH})",
+      ),
+    )
+    .unwrap();
+  fail.store(true, Ordering::SeqCst);
+  HostInputFixture {
+    runtime,
+    context,
+    source: RuntimeHostInputSource::new(
+      INPUT_BASE_URI,
+      INPUT_PATH,
+    )
+    .unwrap(),
+  }
+}
+
+fn capability_host_input_fixture() -> HostInputFixture {
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .resource_provider(Box::new(BenchInputProvider))
+    .build()
+    .unwrap();
+  grant_input_read(&mut runtime);
+  grant_host_call(&mut runtime, 9_002, "bench/capability");
+  runtime
+    .register_mech_host_function(ClosureHostFunction::new_pure(
+      "bench/capability",
+      |_services, _context, arguments| {
+        Ok(copied_host_f64(&arguments))
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      &format!(
+        "@pulse := {INPUT_BASE_URI}{{:read({INPUT_PATH})}}\n\
+         checked := bench/capability(@pulse/{INPUT_PATH})",
+      ),
+    )
+    .unwrap();
+  HostInputFixture {
+    runtime,
+    context,
+    source: RuntimeHostInputSource::new(
+      INPUT_BASE_URI,
+      INPUT_PATH,
+    )
+    .unwrap(),
+  }
+}
+
+fn effect_host_input_fixture() -> HostInputFixture {
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .resource_provider(Box::new(BenchInputProvider))
+    .build()
+    .unwrap();
+  grant_input_read(&mut runtime);
+  grant_host_call(&mut runtime, 9_003, "bench/after-commit");
+  runtime
+    .register_mech_host_function(StagedClosureHostFunction::new(
+      "bench/after-commit",
+      |_services, _context, arguments| {
+        Ok(RuntimePreparedHostCall {
+          value: copied_host_f64(&arguments),
+          effect: PreparedRuntimeEffect::AfterCommit(Box::new(
+            BenchAfterCommitEffect,
+          )),
+        })
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      &format!(
+        "@pulse := {INPUT_BASE_URI}{{:read({INPUT_PATH})}}\n\
+         delivered := bench/after-commit(@pulse/{INPUT_PATH})",
+      ),
+    )
+    .unwrap();
+  HostInputFixture {
+    runtime,
+    context,
+    source: RuntimeHostInputSource::new(
+      INPUT_BASE_URI,
+      INPUT_PATH,
+    )
+    .unwrap(),
+  }
+}
+
+fn object_host_input_fixture() -> HostInputFixture {
+  let mut runtime = MechRuntime::builder()
+    .id_generator(SequentialIdGenerator::starting_at(1))
+    .resource_provider(Box::new(BenchInputProvider))
+    .build()
+    .unwrap();
+  grant_input_read(&mut runtime);
+  grant_host_call(&mut runtime, 9_004, "bench/object");
+  runtime
+    .register_mech_host_function(ClosureHostFunction::new_pure(
+      "bench/object",
+      |services, context, arguments| {
+        let id = services.next_object_id();
+        services.put_object_with_context(
+          context,
+          ObjectRecord::text(id, "benchmark", "reactive turn"),
+        )?;
+        Ok(copied_host_f64(&arguments))
+      },
+    ))
+    .unwrap();
+  let mut context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      &format!(
+        "@pulse := {INPUT_BASE_URI}{{:read({INPUT_PATH})}}\n\
+         stored := bench/object(@pulse/{INPUT_PATH})",
+      ),
+    )
+    .unwrap();
+  HostInputFixture {
+    runtime,
+    context,
+    source: RuntimeHostInputSource::new(
+      INPUT_BASE_URI,
+      INPUT_PATH,
+    )
+    .unwrap(),
+  }
+}
+
+fn two_interpreter_fixture() -> TwoInterpreterFixture {
+  let mut program = MechProgram::new(MechProgramConfig::default());
+  let mut updates = Vec::new();
+  for interpreter_id in [101, 202] {
+    let mut interpreter =
+      Interpreter::new_with_full_stdlib(interpreter_id);
+    interpreter
+      .interpret(
+        &mech_syntax::parser::parse(
+          "input := 1.0\noutput := input + 1.0",
+        )
+        .unwrap(),
+      )
+      .unwrap();
+    program
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(
+        interpreter_id,
+        Ref::new(Box::new(interpreter)),
+      );
+    updates.push(ProgramInputUpdate {
+      input: ProgramInputId {
+        interpreter_id,
+        symbol_id: hash_str("input"),
+      },
+      value: Value::F64(Ref::new(2.0)),
+    });
+  }
+  TwoInterpreterFixture { program, updates }
+}
+
+fn reactive_transaction_benchmarks(c: &mut Criterion) {
+  let mut group = c.benchmark_group("runtime_reactive_transaction");
+  group.sample_size(10);
+
+  group.bench_function("implicit_selected_step", |b| {
+    b.iter_batched(
+      || step_fixture(1, false),
+      |mut fixture| {
+        fixture
+          .runtime
+          .step_with_context(&mut fixture.context, 1)
+          .unwrap();
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("implicit_whole_plan_step", |b| {
+    b.iter_batched(
+      || step_fixture(10, false),
+      |mut fixture| {
+        fixture
+          .runtime
+          .step_with_context(&mut fixture.context, 0)
+          .unwrap();
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  for (name, setup) in [
+    (
+      "one_scalar_host_input_turn",
+      host_input_fixture as fn(&str) -> HostInputFixture,
+    ),
+  ] {
+    group.bench_function(name, |b| {
+      b.iter_batched(
+        || setup("output := @pulse/value + 1.0"),
+        |mut fixture| {
+          black_box(apply_host_input(&mut fixture).unwrap());
+          black_box(fixture)
+        },
+        BatchSize::SmallInput,
+      )
+    });
+  }
+
+  group.bench_function("100_node_reactive_chain", |b| {
+    b.iter_batched(
+      || host_input_fixture(&chain_source(100)),
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("1000_node_sparse_graph", |b| {
+    b.iter_batched(
+      || host_input_fixture(&sparse_source(1_000)),
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("one_register_turn", |b| {
+    b.iter_batched(
+      || host_input_fixture(&register_source(1)),
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("100_register_turn", |b| {
+    b.iter_batched(
+      || host_input_fixture(&register_source(100)),
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("two_affected_interpreters", |b| {
+    b.iter_batched(
+      two_interpreter_fixture,
+      |mut fixture| {
+        let mut journal = ProgramReactiveTurnJournal::new();
+        let outcome = fixture
+          .program
+          .update_inputs_and_advance_turn_with_journal(
+            &fixture.updates,
+            &mut journal,
+          )
+          .unwrap();
+        assert!(
+          outcome.interpreter_turns.len() == 2,
+          "benchmark fixture must affect exactly two interpreters",
+        );
+        black_box(outcome);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("failed_tail_with_complete_rollback", |b| {
+    b.iter_batched(
+      failing_host_input_fixture,
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap_err());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("explicit_first_turn_with_outer_checkpoint", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture =
+          host_input_fixture("output := @pulse/value + 1.0");
+        fixture
+          .runtime
+          .begin_transaction(&mut fixture.context)
+          .unwrap();
+        fixture
+      },
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.bench_function("explicit_later_turn_without_outer_checkpoint", |b| {
+    b.iter_batched(
+      || {
+        let mut fixture =
+          host_input_fixture("output := @pulse/value + 1.0");
+        fixture
+          .runtime
+          .begin_transaction(&mut fixture.context)
+          .unwrap();
+        apply_host_input(&mut fixture).unwrap();
+        fixture
+      },
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  for (name, setup) in [
+    (
+      "turn_using_one_live_capability",
+      capability_host_input_fixture as fn() -> HostInputFixture,
+    ),
+    (
+      "turn_with_one_after_commit_effect",
+      effect_host_input_fixture as fn() -> HostInputFixture,
+    ),
+    (
+      "turn_with_one_runtime_managed_object_update",
+      object_host_input_fixture as fn() -> HostInputFixture,
+    ),
+  ] {
+    group.bench_function(name, |b| {
+      b.iter_batched(
+        setup,
+        |mut fixture| {
+          black_box(apply_host_input(&mut fixture).unwrap());
+          black_box(fixture)
+        },
+        BatchSize::SmallInput,
+      )
+    });
+  }
+
+  group.bench_function("unbound_host_input_packet", |b| {
+    b.iter_batched(
+      || host_input_fixture("output := @pulse/value + 1.0"),
+      |mut fixture| {
+        let outcome = fixture
+          .runtime
+          .apply_host_input_with_context(
+            &mut fixture.context,
+            RuntimeHostInput::single(
+              RuntimeHostInputSource::new(
+                INPUT_BASE_URI,
+                "unbound",
+              )
+              .unwrap(),
+              RuntimeHostInputValue::F64(2.0),
+            ),
+          )
+          .unwrap();
+        black_box(outcome);
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
+  group.finish();
+}
+
+criterion_group!(benches, reactive_transaction_benchmarks);
+criterion_main!(benches);

--- a/src/runtime/src/capability/kernel.rs
+++ b/src/runtime/src/capability/kernel.rs
@@ -119,6 +119,28 @@ pub trait CapabilityKernel: std::fmt::Debug + Send {
     ))
   }
 
+  fn preview_check_excluding_with_pending_uses(
+    &self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+    pending_uses: &HashMap<CapabilityId, u64>,
+  ) -> MResult<CapabilityId> {
+    if pending_uses.values().any(|uses| *uses != 0) {
+      return Err(MechError::new(
+        TransactionStateUnsupportedError {
+          function:
+            "capability kernel transactional preview".to_string(),
+          reason:
+            "kernel does not support preview with transaction-local use reservations"
+              .to_string(),
+        },
+        None,
+      ));
+    }
+
+    self.preview_check_excluding(request, excluded)
+  }
+
   fn apply_usage_delta(
     &mut self,
     _capability: CapabilityId,
@@ -325,10 +347,11 @@ impl BasicCapabilityKernel {
     ))
   }
 
-  fn preview_check_with_exclusions(
+  fn preview_check_with_exclusions_and_pending_uses(
     &self,
     request: &CapabilityRequest,
     excluded: &HashSet<CapabilityId>,
+    pending_uses: &HashMap<CapabilityId, u64>,
   ) -> MResult<CapabilityId> {
     let Some(ids) = self.by_subject.get(&request.subject) else {
       return Err(MechError::new(
@@ -358,7 +381,22 @@ impl BasicCapabilityKernel {
         continue;
       };
       if let Some(max_uses) = capability.max_uses() {
-        let actual = self.successful_uses(*id);
+        let committed = self.successful_uses(*id);
+        let pending = pending_uses.get(id).copied().unwrap_or(0);
+        let actual = committed.checked_add(pending).ok_or_else(|| {
+          MechError::new(
+            CapabilityDeniedError {
+              subject: request.subject.clone(),
+              operation: request.operation.clone(),
+              resource: request.resource.clone(),
+              reason: format!(
+                "usage count overflow for capability {}",
+                id,
+              ),
+            },
+            None,
+          )
+        })?;
         if actual >= max_uses {
           last_reason = Some(format!(
             "use limit exceeded: max {}, actual {}",
@@ -486,7 +524,11 @@ impl CapabilityKernel for BasicCapabilityKernel {
     &self,
     request: &CapabilityRequest,
   ) -> MResult<CapabilityId> {
-    self.preview_check_with_exclusions(request, &HashSet::new())
+    self.preview_check_with_exclusions_and_pending_uses(
+      request,
+      &HashSet::new(),
+      &HashMap::new(),
+    )
   }
 
   fn preview_check_excluding(
@@ -494,7 +536,24 @@ impl CapabilityKernel for BasicCapabilityKernel {
     request: &CapabilityRequest,
     excluded: &HashSet<CapabilityId>,
   ) -> MResult<CapabilityId> {
-    self.preview_check_with_exclusions(request, excluded)
+    self.preview_check_with_exclusions_and_pending_uses(
+      request,
+      excluded,
+      &HashMap::new(),
+    )
+  }
+
+  fn preview_check_excluding_with_pending_uses(
+    &self,
+    request: &CapabilityRequest,
+    excluded: &HashSet<CapabilityId>,
+    pending_uses: &HashMap<CapabilityId, u64>,
+  ) -> MResult<CapabilityId> {
+    self.preview_check_with_exclusions_and_pending_uses(
+      request,
+      excluded,
+      pending_uses,
+    )
   }
 
   fn apply_usage_delta(
@@ -683,6 +742,7 @@ impl CapabilityKernel for SharedCapabilityKernel {
   fn check_excluding(&mut self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().check_excluding(request, excluded) }
   fn preview_check(&self, request: &CapabilityRequest) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check(request) }
   fn preview_check_excluding(&self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check_excluding(request, excluded) }
+  fn preview_check_excluding_with_pending_uses(&self, request: &CapabilityRequest, excluded: &HashSet<CapabilityId>, pending_uses: &HashMap<CapabilityId, u64>) -> MResult<CapabilityId> { self.inner.lock().unwrap().preview_check_excluding_with_pending_uses(request, excluded, pending_uses) }
   fn apply_usage_delta(&mut self, capability: CapabilityId, uses: u64) -> MResult<()> { self.inner.lock().unwrap().apply_usage_delta(capability, uses) }
   fn get(&self, id: CapabilityId) -> MResult<Option<Arc<dyn Capability>>> { self.inner.lock().unwrap().get(id) }
   fn list_for_subject(&self, subject: &dyn Subject) -> MResult<Vec<CapabilityId>> { self.inner.lock().unwrap().list_for_subject(subject) }

--- a/src/runtime/src/capability/mod.rs
+++ b/src/runtime/src/capability/mod.rs
@@ -22,6 +22,8 @@ pub use grant::*;
 #[cfg(test)]
 mod tests {
   use crate::*;
+  use mech_core::MResult;
+  use std::collections::{HashMap, HashSet};
   use std::sync::Arc;
 
   #[test]
@@ -555,6 +557,197 @@ mod tests {
 
     assert!(kernel.is_revoked(CapabilityId(1)).unwrap());
     assert!(kernel.is_revoked(CapabilityId(2)).unwrap());
+  }
+
+  fn pending_use_fixture(
+    max_uses: u64,
+  ) -> (
+    BasicCapabilityKernel,
+    CapabilityRequest,
+    CapabilityId,
+  ) {
+    let subject = BasicSubject::new("task://pending");
+    let resource = BasicResource::new("db://users");
+    let id = CapabilityId(900);
+    let capability = BasicCapability::new(
+      id,
+      &subject,
+      &resource,
+      [BasicOperation::read()],
+    )
+    .with_constraints(
+      BasicConstraints::default().with_max_uses(max_uses),
+    );
+    let mut kernel = BasicCapabilityKernel::new();
+    kernel
+      .grant(CapabilityGrant::new(Arc::new(capability)))
+      .unwrap();
+    (
+      kernel,
+      CapabilityRequest::new(
+        &subject,
+        &BasicOperation::read(),
+        &resource,
+      ),
+      id,
+    )
+  }
+
+  #[test]
+  fn pending_transactional_uses_enforce_live_capability_limit() {
+    let (kernel, request, id) = pending_use_fixture(1);
+    assert_eq!(
+      kernel
+        .preview_check_excluding_with_pending_uses(
+          &request,
+          &HashSet::new(),
+          &HashMap::new(),
+        )
+        .unwrap(),
+      id,
+    );
+    assert!(kernel
+      .preview_check_excluding_with_pending_uses(
+        &request,
+        &HashSet::new(),
+        &HashMap::from([(id, 1)]),
+      )
+      .is_err());
+    assert_eq!(kernel.successful_uses_for_test(id), 0);
+  }
+
+  #[test]
+  fn committed_and_pending_capability_uses_are_combined() {
+    let (mut kernel, request, id) = pending_use_fixture(2);
+    kernel.apply_usage_delta(id, 1).unwrap();
+
+    assert_eq!(
+      kernel
+        .preview_check_excluding_with_pending_uses(
+          &request,
+          &HashSet::new(),
+          &HashMap::new(),
+        )
+        .unwrap(),
+      id,
+    );
+    assert!(kernel
+      .preview_check_excluding_with_pending_uses(
+        &request,
+        &HashSet::new(),
+        &HashMap::from([(id, 1)]),
+      )
+      .is_err());
+    assert_eq!(kernel.successful_uses_for_test(id), 1);
+  }
+
+  #[test]
+  fn pending_use_preview_keeps_exclusions_and_shared_forwarding() {
+    let (kernel, request, id) = pending_use_fixture(2);
+    assert!(kernel
+      .preview_check_excluding_with_pending_uses(
+        &request,
+        &HashSet::from([id]),
+        &HashMap::new(),
+      )
+      .is_err());
+
+    let shared = SharedCapabilityKernel::from_kernel(kernel);
+    assert_eq!(
+      shared
+        .preview_check_excluding_with_pending_uses(
+          &request,
+          &HashSet::new(),
+          &HashMap::from([(id, 1)]),
+        )
+        .unwrap(),
+      id,
+    );
+    assert_eq!(shared.successful_uses_for_test(id), 0);
+  }
+
+  #[derive(Debug)]
+  struct LegacyPreviewKernel {
+    selected: CapabilityId,
+  }
+
+  impl CapabilityKernel for LegacyPreviewKernel {
+    fn grant(&mut self, _grant: CapabilityGrant) -> MResult<CapabilityId> {
+      unimplemented!()
+    }
+
+    fn rollback_grant(&mut self, _capability: CapabilityId) -> MResult<()> {
+      unimplemented!()
+    }
+
+    fn revoke(&mut self, _revocation: CapabilityRevocation) -> MResult<()> {
+      unimplemented!()
+    }
+
+    fn check(
+      &mut self,
+      _request: &CapabilityRequest,
+    ) -> MResult<CapabilityId> {
+      unimplemented!()
+    }
+
+    fn preview_check_excluding(
+      &self,
+      _request: &CapabilityRequest,
+      _excluded: &HashSet<CapabilityId>,
+    ) -> MResult<CapabilityId> {
+      Ok(self.selected)
+    }
+
+    fn get(
+      &self,
+      _id: CapabilityId,
+    ) -> MResult<Option<Arc<dyn Capability>>> {
+      unimplemented!()
+    }
+
+    fn list_for_subject(
+      &self,
+      _subject: &dyn Subject,
+    ) -> MResult<Vec<CapabilityId>> {
+      unimplemented!()
+    }
+
+    fn derive_capability(
+      &mut self,
+      _derivation: CapabilityDerivation,
+    ) -> MResult<CapabilityId> {
+      unimplemented!()
+    }
+
+    fn is_revoked(&self, _id: CapabilityId) -> MResult<bool> {
+      unimplemented!()
+    }
+  }
+
+  #[test]
+  fn unsupported_kernel_fails_closed_for_pending_uses() {
+    let (_, request, id) = pending_use_fixture(1);
+    let kernel = LegacyPreviewKernel { selected: id };
+
+    assert_eq!(
+      kernel
+        .preview_check_excluding_with_pending_uses(
+          &request,
+          &HashSet::new(),
+          &HashMap::new(),
+        )
+        .unwrap(),
+      id,
+    );
+    let error = kernel
+      .preview_check_excluding_with_pending_uses(
+        &request,
+        &HashSet::new(),
+        &HashMap::from([(id, 1)]),
+      )
+      .unwrap_err();
+    assert_eq!(error.kind_name(), "TransactionStateUnsupported");
   }
 
 }

--- a/src/runtime/src/runtime/capability.rs
+++ b/src/runtime/src/runtime/capability.rs
@@ -22,6 +22,7 @@ use std::collections::{HashMap, HashSet};
 pub(super) enum RuntimeCapabilityMutation {
   Grant(Arc<dyn Capability>),
   Revoke(CapabilityId),
+  Use(CapabilityId),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -31,6 +32,7 @@ pub(super) struct RuntimeCapabilityOverlay {
   grant_order: Vec<CapabilityId>,
   revocations: HashSet<CapabilityId>,
   uses: HashMap<CapabilityId, u64>,
+  usage_order: Vec<CapabilityId>,
 }
 
 impl RuntimeCapabilityOverlay {
@@ -39,21 +41,30 @@ impl RuntimeCapabilityOverlay {
   }
 
   pub(super) fn is_empty(&self) -> bool {
-    self.grants.is_empty() && self.revocations.is_empty()
+    self.grants.is_empty()
+      && self.revocations.is_empty()
+      && self.uses.is_empty()
   }
 
-  pub(super) fn stage_grant(&mut self, capability: Arc<dyn Capability>) {
-    self
-      .operations
-      .push(RuntimeCapabilityMutation::Grant(capability));
-    self.rebuild();
+  pub(super) fn stage_grant(
+    &mut self,
+    capability: Arc<dyn Capability>,
+  ) -> MResult<()> {
+    self.stage_operation(RuntimeCapabilityMutation::Grant(capability))
   }
 
-  pub(super) fn stage_revocation(&mut self, capability: CapabilityId) {
-    self
-      .operations
-      .push(RuntimeCapabilityMutation::Revoke(capability));
-    self.rebuild();
+  pub(super) fn stage_revocation(
+    &mut self,
+    capability: CapabilityId,
+  ) -> MResult<()> {
+    self.stage_operation(RuntimeCapabilityMutation::Revoke(capability))
+  }
+
+  pub(super) fn stage_use(
+    &mut self,
+    capability: CapabilityId,
+  ) -> MResult<()> {
+    self.stage_operation(RuntimeCapabilityMutation::Use(capability))
   }
 
   pub(super) fn rollback_to(&mut self, mark: usize) -> MResult<()> {
@@ -71,8 +82,7 @@ impl RuntimeCapabilityOverlay {
       ));
     }
     self.operations.truncate(mark);
-    self.rebuild();
-    Ok(())
+    self.rebuild()
   }
 
   pub(super) fn provisional(
@@ -86,27 +96,11 @@ impl RuntimeCapabilityOverlay {
     &mut self,
     request: &CapabilityRequest,
   ) -> MResult<Option<CapabilityId>> {
-    for id in &self.grant_order {
-      let Some(capability) = self.grants.get(id) else {
-        continue;
-      };
-      if capability.subject_key() != request.subject {
-        continue;
-      }
-      if let Some(max_uses) = capability.max_uses() {
-        let actual = self.uses.get(id).copied().unwrap_or(0);
-        if actual >= max_uses {
-          continue;
-        }
-      }
-      let decision = capability.check(request)?;
-      if decision.allowed {
-        let uses = self.uses.entry(*id).or_insert(0);
-        *uses = uses.saturating_add(1);
-        return Ok(Some(*id));
-      }
+    let selected = self.preview_check(request)?;
+    if let Some(capability) = selected {
+      self.stage_use(capability)?;
     }
-    Ok(None)
+    Ok(selected)
   }
 
   pub(super) fn preview_check(
@@ -148,10 +142,16 @@ impl RuntimeCapabilityOverlay {
   pub(super) fn usage_deltas(
     &self,
   ) -> impl Iterator<Item = (CapabilityId, u64)> + '_ {
-    self.grant_order.iter().filter_map(|id| {
+    self.usage_order.iter().filter_map(|id| {
       let uses = self.uses.get(id).copied().unwrap_or(0);
       (uses != 0).then_some((*id, uses))
     })
+  }
+
+  pub(super) fn pending_uses(
+    &self,
+  ) -> &HashMap<CapabilityId, u64> {
+    &self.uses
   }
 
   pub(super) fn revocations(
@@ -164,35 +164,27 @@ impl RuntimeCapabilityOverlay {
     self.revocations.clone()
   }
 
-  pub(super) fn mutations(&self) -> Vec<RuntimeCapabilityMutation> {
-    let mut grants = HashSet::new();
-    let mut revocations = HashSet::new();
-    let mut mutations = Vec::new();
-    for operation in self.operations.iter().rev() {
-      match operation {
-        RuntimeCapabilityMutation::Grant(capability)
-          if self.grants.contains_key(&capability.id())
-            && grants.insert(capability.id()) =>
-        {
-          mutations.push(operation.clone());
-        }
-        RuntimeCapabilityMutation::Revoke(capability)
-          if self.revocations.contains(capability)
-            && revocations.insert(*capability) =>
-        {
-          mutations.push(operation.clone());
-        }
-        _ => {}
-      }
+  fn stage_operation(
+    &mut self,
+    operation: RuntimeCapabilityMutation,
+  ) -> MResult<()> {
+    self.operations.push(operation);
+    if let Err(error) = self.rebuild() {
+      self.operations.pop();
+      self.rebuild().expect(
+        "previous capability overlay state must remain valid",
+      );
+      return Err(error);
     }
-    mutations.reverse();
-    mutations
+    Ok(())
   }
 
-  fn rebuild(&mut self) {
+  fn rebuild(&mut self) -> MResult<()> {
     self.grants.clear();
     self.grant_order.clear();
     self.revocations.clear();
+    self.uses.clear();
+    self.usage_order.clear();
     for operation in &self.operations {
       match operation {
         RuntimeCapabilityMutation::Grant(capability) => {
@@ -206,13 +198,54 @@ impl RuntimeCapabilityOverlay {
         RuntimeCapabilityMutation::Revoke(capability) => {
           if self.grants.remove(capability).is_some() {
             self.grant_order.retain(|id| id != capability);
+            self.uses.remove(capability);
+            self.usage_order.retain(|id| id != capability);
           } else {
             self.revocations.insert(*capability);
           }
         }
+        RuntimeCapabilityMutation::Use(capability) => {
+          if self.revocations.contains(capability) {
+            return Err(MechError::new(
+              RuntimeInvalidOperationError {
+                operation: "rebuild_capability_overlay",
+                reason: format!(
+                  "capability {} was used after transaction-local revocation",
+                  capability,
+                ),
+              },
+              None,
+            ));
+          }
+          if !self.uses.contains_key(capability) {
+            self.usage_order.push(*capability);
+          }
+          let current = self.uses.get(capability).copied().unwrap_or(0);
+          let next =
+            Self::incremented_usage(*capability, current)?;
+          self.uses.insert(*capability, next);
+        }
       }
     }
-    self.uses.retain(|id, _| self.grants.contains_key(id));
+    Ok(())
+  }
+
+  fn incremented_usage(
+    capability: CapabilityId,
+    current: u64,
+  ) -> MResult<u64> {
+    current.checked_add(1).ok_or_else(|| {
+      MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "rebuild_capability_overlay",
+          reason: format!(
+            "capability {} transaction-local usage count overflowed",
+            capability,
+          ),
+        },
+        None,
+      )
+    })
   }
 }
 
@@ -286,7 +319,7 @@ impl MechRuntime {
       self
         .active_execution_transaction_mut(transaction_id)?
         .capabilities
-        .stage_grant(capability);
+        .stage_grant(capability)?;
       if let Err(error) = self.emit_event_to_context(
         context,
         RuntimeEventKind::CapabilityGranted {
@@ -408,7 +441,7 @@ impl MechRuntime {
       self
         .active_execution_transaction_mut(transaction_id)?
         .capabilities
-        .stage_revocation(capability);
+        .stage_revocation(capability)?;
       context.remove_capability(capability);
       if let Err(error) = self.emit_event_to_context(
         context,
@@ -472,13 +505,22 @@ impl MechRuntime {
       if let Some(capability) = provisional {
         return Ok(capability);
       }
-      let revocations = self
-        .active_execution_transaction(transaction_id)?
-        .capabilities
-        .revocation_ids();
-      return self
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      let revocations = transaction.capabilities.revocation_ids();
+      let pending_uses = transaction.capabilities.pending_uses().clone();
+      let capability = self
         .capability_kernel
-        .check_excluding(request, &revocations);
+        .preview_check_excluding_with_pending_uses(
+          request,
+          &revocations,
+          &pending_uses,
+        )?;
+      self
+        .active_execution_transaction_mut(transaction_id)?
+        .capabilities
+        .stage_use(capability)?;
+      return Ok(capability);
     }
     self.capability_kernel.check(request)
   }
@@ -501,13 +543,17 @@ impl MechRuntime {
       if let Some(capability) = provisional {
         return Ok(capability);
       }
-      let revocations = self
-        .active_execution_transaction(transaction_id)?
-        .capabilities
-        .revocation_ids();
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      let revocations = transaction.capabilities.revocation_ids();
+      let pending_uses = transaction.capabilities.pending_uses().clone();
       return self
         .capability_kernel
-        .preview_check_excluding(request, &revocations);
+        .preview_check_excluding_with_pending_uses(
+          request,
+          &revocations,
+          &pending_uses,
+        );
     }
     self.capability_kernel.preview_check(request)
   }
@@ -1061,8 +1107,12 @@ mod tests {
     let first = CapabilityId(100);
     let second = CapabilityId(101);
     let mut overlay = RuntimeCapabilityOverlay::default();
-    overlay.stage_grant(capability(first, "task:1", true));
-    overlay.stage_grant(capability(second, "task:1", true));
+    overlay
+      .stage_grant(capability(first, "task:1", true))
+      .unwrap();
+    overlay
+      .stage_grant(capability(second, "task:1", true))
+      .unwrap();
 
     for _ in 0..32 {
       assert_eq!(
@@ -1085,6 +1135,120 @@ mod tests {
       overlay.usage_deltas().collect::<Vec<_>>(),
       vec![(first, 1)],
     );
+  }
+
+  #[test]
+  fn capability_use_journal_savepoints_restore_only_later_uses() {
+    let id = CapabilityId(100);
+    let mut overlay = RuntimeCapabilityOverlay::default();
+    let empty_mark = overlay.mark();
+
+    overlay.stage_use(id).unwrap();
+    assert!(!overlay.is_empty());
+    assert_eq!(overlay.usage_deltas().collect::<Vec<_>>(), vec![(id, 1)]);
+
+    let later_mark = overlay.mark();
+    overlay.stage_use(id).unwrap();
+    assert_eq!(overlay.usage_deltas().collect::<Vec<_>>(), vec![(id, 2)]);
+
+    overlay.rollback_to(later_mark).unwrap();
+    assert_eq!(overlay.usage_deltas().collect::<Vec<_>>(), vec![(id, 1)]);
+
+    overlay.rollback_to(empty_mark).unwrap();
+    assert!(overlay.is_empty());
+    assert!(overlay.usage_deltas().next().is_none());
+  }
+
+  #[test]
+  fn capability_use_journal_preserves_live_usage_order() {
+    let first = CapabilityId(100);
+    let second = CapabilityId(101);
+    let mut overlay = RuntimeCapabilityOverlay::default();
+
+    overlay.stage_use(second).unwrap();
+    overlay.stage_use(first).unwrap();
+    overlay.stage_use(second).unwrap();
+
+    assert_eq!(
+      overlay.usage_deltas().collect::<Vec<_>>(),
+      vec![(second, 2), (first, 1)],
+    );
+    assert_eq!(
+      overlay.pending_uses(),
+      &HashMap::from([(first, 1), (second, 2)]),
+    );
+  }
+
+  #[test]
+  fn provisional_grant_use_revoke_cancels_all_authority_work() {
+    let id = CapabilityId(100);
+    let mut overlay = RuntimeCapabilityOverlay::default();
+
+    overlay
+      .stage_grant(limited_capability(id, 2))
+      .unwrap();
+    overlay.stage_use(id).unwrap();
+    overlay.stage_revocation(id).unwrap();
+
+    assert!(overlay.is_empty());
+    assert!(overlay.grants().next().is_none());
+    assert!(overlay.revocations().next().is_none());
+    assert!(overlay.usage_deltas().next().is_none());
+  }
+
+  #[test]
+  fn live_use_revoke_and_later_provisional_regrant_are_ordered() {
+    let id = CapabilityId(100);
+    let mut live_overlay = RuntimeCapabilityOverlay::default();
+    live_overlay.stage_use(id).unwrap();
+    live_overlay.stage_revocation(id).unwrap();
+    assert_eq!(
+      live_overlay.usage_deltas().collect::<Vec<_>>(),
+      vec![(id, 1)],
+    );
+    assert_eq!(
+      live_overlay.revocations().collect::<Vec<_>>(),
+      vec![id],
+    );
+
+    let mut provisional_overlay = RuntimeCapabilityOverlay::default();
+    provisional_overlay
+      .stage_grant(limited_capability(id, 2))
+      .unwrap();
+    provisional_overlay.stage_use(id).unwrap();
+    provisional_overlay.stage_revocation(id).unwrap();
+    provisional_overlay
+      .stage_grant(limited_capability(id, 2))
+      .unwrap();
+    provisional_overlay.stage_use(id).unwrap();
+    assert_eq!(
+      provisional_overlay.usage_deltas().collect::<Vec<_>>(),
+      vec![(id, 1)],
+    );
+  }
+
+  #[test]
+  fn failed_capability_rebuild_restores_previous_valid_overlay() {
+    let id = CapabilityId(100);
+    let mut overlay = RuntimeCapabilityOverlay::default();
+    overlay.stage_use(id).unwrap();
+    overlay.stage_revocation(id).unwrap();
+    let mark = overlay.mark();
+
+    let error = overlay.stage_use(id).unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeInvalidOperation");
+    assert_eq!(overlay.mark(), mark);
+    assert_eq!(
+      overlay.usage_deltas().collect::<Vec<_>>(),
+      vec![(id, 1)],
+    );
+    assert_eq!(overlay.revocations().collect::<Vec<_>>(), vec![id]);
+
+    let overflow =
+      RuntimeCapabilityOverlay::incremented_usage(id, u64::MAX)
+        .unwrap_err();
+    assert_eq!(overflow.kind_name(), "RuntimeInvalidOperation");
   }
 
   #[test]

--- a/src/runtime/src/runtime/errors.rs
+++ b/src/runtime/src/runtime/errors.rs
@@ -140,28 +140,6 @@ impl MechErrorKind for RuntimeProgramOperationReentrant {
 }
 
 #[derive(Debug, Clone)]
-pub struct RuntimeTransactionalReactiveTurnUnsupported {
-  pub operation: &'static str,
-  pub transaction_id: Option<TransactionId>,
-  pub owner: Option<TransactionId>,
-}
-
-impl MechErrorKind for RuntimeTransactionalReactiveTurnUnsupported {
-  fn name(&self) -> &str {
-    "RuntimeTransactionalReactiveTurnUnsupported"
-  }
-
-  fn message(&self) -> String {
-    format!(
-      "reactive operation `{}` cannot run transactionally yet (transaction {:?}, program owner {:?})",
-      self.operation,
-      self.transaction_id,
-      self.owner,
-    )
-  }
-}
-
-#[derive(Debug, Clone)]
 pub struct RuntimeTransactionalLiveRegistrationUnsupported {
   pub transaction_id: TransactionId,
   pub owner: Option<TransactionId>,

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -12,6 +12,7 @@
 // Both methods have corresponding _with_context versions that accept a mutable reference to a RuntimeContext, allowing for execution within the context of an active transaction. This ensures that any changes made during execution are properly staged within the transaction that if an error occurs, the transaction can be rolled back to maintain consistency.
 
 use super::*;
+use super::reactive_transaction::PreparedRuntimeHostInput;
 use crate::{SourceDeclaration, SourceImportDeclaration, SourceIndex};
 use crate::RuntimeResourceWritePreflightRequest;
 
@@ -4697,8 +4698,25 @@ impl MechRuntime {
   }
 
   pub fn apply_host_input(&mut self, input: crate::RuntimeHostInput) -> MResult<crate::RuntimeHostInputOutcome> {
+    self.ensure_runtime_mutation_allowed("apply_host_input")?;
+    self.reject_program_operation_reentrancy("apply_host_input")?;
+    let prepared = self.prepare_runtime_host_input(&input)?;
+    if prepared.binding_count == 0 {
+      return Ok(crate::RuntimeHostInputOutcome {
+        update_count: prepared.update_count,
+        ignored_update_count: prepared.ignored_update_count,
+        binding_count: 0,
+        turn: None,
+      });
+    }
+
     let mut context = self.live_turn_context()?;
-    self.apply_host_input_with_context(&mut context, input)
+    self.validate_context_for_runtime(&context)?;
+    self.validate_live_turn_context(&context)?;
+    self.apply_prepared_host_input_with_context(
+      &mut context,
+      prepared,
+    )
   }
 
   pub fn apply_host_input_with_context(
@@ -4725,6 +4743,14 @@ impl MechRuntime {
       });
     }
 
+    self.apply_prepared_host_input_with_context(context, prepared)
+  }
+
+  fn apply_prepared_host_input_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    prepared: PreparedRuntimeHostInput,
+  ) -> MResult<crate::RuntimeHostInputOutcome> {
     self.with_atomic_reactive_turn(
       context,
       "apply_host_input_with_context",

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3502,37 +3502,48 @@ impl MechRuntime {
   }
 
   #[cfg(feature = "functions")]
-  pub fn step(&mut self, count: u64) -> MResult<()> {
+  pub fn step(&mut self, step_id: u64) -> MResult<()> {
     let mut context = self.runtime_context()?;
-    self.step_with_context(&mut context, count)
+    self.step_with_context(&mut context, step_id)
   }
 
   #[cfg(feature = "functions")]
   pub fn step_with_context(
     &mut self,
     context: &mut RuntimeContext,
-    count: u64,
+    step_id: u64,
   ) -> MResult<()> {
-    let turn_started = Instant::now();
-    self.validate_context_for_runtime(context)?;
-    self.reject_transactional_reactive_turn(context, "step_with_context")?;
-    context.charge_step()?;
+    self.with_atomic_reactive_turn(
+      context,
+      "step_with_context",
+      |runtime, context, program_journal| {
+        context.charge_step()?;
+        let turn_started = Instant::now();
+        let program_config = runtime.program.config.clone();
+        let mut program = std::mem::replace(
+          &mut runtime.program,
+          MechProgram::new(program_config),
+        );
 
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
+        let result = {
+          let runtime_ptr: *mut MechRuntime = runtime;
+          let context_ptr: *mut RuntimeContext = context;
+          let _host_guard =
+            ActiveRuntimeProgramHostGuard::install(
+              runtime_ptr,
+              context_ptr,
+            );
+          program.step_with_reactive_turn_journal(
+            step_id,
+            program_journal,
+          )
+        };
 
-    let runtime_ptr: *mut MechRuntime = self;
-    let context_ptr: *mut RuntimeContext = context;
-    let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-    let result = program.step(count);
-
-    self.program = program;
-    result?;
-    self.enforce_turn_duration(turn_started)
+        runtime.program = program;
+        result?;
+        runtime.enforce_turn_duration(turn_started)
+      },
+    )
   }
 
   pub fn run_module(&mut self, version: ModuleVersionId) -> MResult<Value> {
@@ -4686,87 +4697,73 @@ impl MechRuntime {
   }
 
   pub fn apply_host_input(&mut self, input: crate::RuntimeHostInput) -> MResult<crate::RuntimeHostInputOutcome> {
-    input.validate()?;
-    if self.program_transaction_owner.is_some() {
-      return Err(MechError::new(
-        RuntimeTransactionalReactiveTurnUnsupported {
-          operation: "apply_host_input",
-          transaction_id: None,
-          owner: self.program_transaction_owner,
-        },
-        None,
-      ));
-    }
-    let mut target_updates = Vec::new();
-    let mut seen_targets = std::collections::HashSet::new();
-    let mut ignored_update_count = 0;
+    let mut context = self.live_turn_context()?;
+    self.apply_host_input_with_context(&mut context, input)
+  }
 
-    for update in &input.updates {
-      let Some(bindings) = self.live_input_bindings.get(&update.source).cloned() else {
-        ignored_update_count += 1;
-        continue;
-      };
-      if bindings.is_empty() {
-        ignored_update_count += 1;
-        continue;
-      }
-      let value = update.value.clone().into_mech_value()?;
-      for program_input in bindings {
-        if !seen_targets.insert(program_input) {
-          return Err(MechError::new(mech_program::ProgramInputDuplicateTarget { input: program_input }, None));
-        }
-        target_updates.push(mech_program::ProgramInputUpdate { input: program_input, value: value.clone() });
-      }
-    }
+  pub fn apply_host_input_with_context(
+    &mut self,
+    context: &mut RuntimeContext,
+    input: crate::RuntimeHostInput,
+  ) -> MResult<crate::RuntimeHostInputOutcome> {
+    self.ensure_runtime_mutation_allowed(
+      "apply_host_input_with_context",
+    )?;
+    self.validate_context_for_runtime(context)?;
+    self.reject_program_operation_reentrancy(
+      "apply_host_input_with_context",
+    )?;
+    self.validate_live_turn_context(context)?;
+    let prepared = self.prepare_runtime_host_input(&input)?;
 
-    if target_updates.is_empty() {
+    if prepared.binding_count == 0 {
       return Ok(crate::RuntimeHostInputOutcome {
-        update_count: input.updates.len(),
-        ignored_update_count,
+        update_count: prepared.update_count,
+        ignored_update_count: prepared.ignored_update_count,
         binding_count: 0,
         turn: None,
       });
     }
 
-    let mut context = self.live_turn_context()?;
-    self.validate_context_for_runtime(&context)?;
-    context.charge_step()?;
+    self.with_atomic_reactive_turn(
+      context,
+      "apply_host_input_with_context",
+      move |runtime, context, program_journal| {
+        context.charge_step()?;
+        let turn_started = Instant::now();
+        let program_config = runtime.program.config.clone();
+        let mut program = std::mem::replace(
+          &mut runtime.program,
+          MechProgram::new(program_config),
+        );
 
-    let turn_started = Instant::now();
+        let result = {
+          let runtime_ptr: *mut MechRuntime = runtime;
+          let context_ptr: *mut RuntimeContext = context;
+          let _host_guard =
+            ActiveRuntimeProgramHostGuard::install(
+              runtime_ptr,
+              context_ptr,
+            );
+          program.update_inputs_and_advance_turn_with_journal(
+            &prepared.updates,
+            program_journal,
+          )
+        };
 
-    let program_config = self.program.config.clone();
-    let mut program = std::mem::replace(
-      &mut self.program,
-      MechProgram::new(program_config),
-    );
+        runtime.program = program;
+        let turn = result?;
+        runtime.enforce_turn_duration(turn_started)?;
+        runtime.execute_persistent_sends(context, &turn)?;
 
-    let result = (|| -> MResult<crate::RuntimeHostInputOutcome> {
-      let runtime_ptr: *mut MechRuntime = self;
-      let context_ptr: *mut RuntimeContext = &mut context;
-      let _host_guard = ActiveRuntimeProgramHostGuard::install(runtime_ptr, context_ptr);
-
-      // The program API performs complete input preflight, commits the
-      // accepted input batch, and advances one persistent reactive turn
-      // per affected interpreter. Errors after input admission preserve
-      // accepted writes and completed register commits.
-      let turn =
-        program.update_inputs_and_advance_turn(
-          &target_updates,
-        )?;
-      self.enforce_turn_duration(turn_started)?;
-      self.execute_persistent_sends(&mut context, &turn)?;
-
-      Ok(crate::RuntimeHostInputOutcome {
-        update_count: input.updates.len(),
-        ignored_update_count,
-        binding_count: turn.updated_count,
-        turn: Some(turn),
-      })
-    })();
-
-    self.program = program;
-
-    result
+        Ok(crate::RuntimeHostInputOutcome {
+          update_count: prepared.update_count,
+          ignored_update_count: prepared.ignored_update_count,
+          binding_count: prepared.binding_count,
+          turn: Some(turn),
+        })
+      },
+    )
   }
 
   fn execute_persistent_sends(&mut self, context: &mut RuntimeContext, turn: &mech_program::ProgramInputTurnOutcome) -> MResult<()> {

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -910,6 +910,26 @@ fn host_input_preparation_opens_no_transaction_or_budget_charge() {
 }
 
 #[test]
+fn unbound_host_input_without_a_live_program_is_a_noop() {
+  let mut runtime = MechRuntime::builder().build().unwrap();
+  let event_sequence = runtime.event_sequence;
+  let input = RuntimeHostInput::single(
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing").unwrap(),
+    RuntimeHostInputValue::F64(4.0),
+  );
+
+  let outcome = runtime.apply_host_input(input).unwrap();
+
+  assert_eq!(outcome.update_count, 1);
+  assert_eq!(outcome.ignored_update_count, 1);
+  assert_eq!(outcome.binding_count, 0);
+  assert!(outcome.turn.is_none());
+  assert_eq!(runtime.event_sequence, event_sequence);
+  assert!(runtime.active_transactions.is_empty());
+  assert_eq!(runtime.program_transaction_owner, None);
+}
+
+#[test]
 fn explicit_host_input_is_provisional_until_outer_decision() {
   let mut runtime =
     test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -845,6 +845,282 @@ fn live_context_capability_order_does_not_cause_mismatch() {
   runtime.run_string_with_context(&mut context_b, "@pulse := test://clock/ticks{:read(value)}\nother := @pulse/value").unwrap();
 }
 
+#[test]
+fn host_input_preparation_opens_no_transaction_or_budget_charge() {
+  let mut runtime =
+    test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let mut load_context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut load_context,
+      "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+    )
+    .unwrap();
+  let source =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  let mut context = runtime.live_turn_context().unwrap();
+  let used_steps = context.budget.used_steps;
+  let event_sequence = runtime.event_sequence;
+
+  let empty = RuntimeHostInput { updates: Vec::new() };
+  assert!(runtime
+    .apply_host_input_with_context(&mut context, empty)
+    .is_err());
+  assert_eq!(context.budget.used_steps, used_steps);
+  assert_eq!(runtime.event_sequence, event_sequence);
+  assert!(runtime.active_transactions.is_empty());
+
+  let target = runtime.live_input_bindings[&source][0];
+  let alias =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "alias").unwrap();
+  runtime
+    .live_input_bindings
+    .insert(alias.clone(), vec![target]);
+  let duplicate = RuntimeHostInput::new(vec![
+    RuntimeHostInputUpdate {
+      source: source.clone(),
+      value: RuntimeHostInputValue::F64(2.0),
+    },
+    RuntimeHostInputUpdate {
+      source: alias,
+      value: RuntimeHostInputValue::F64(3.0),
+    },
+  ])
+  .unwrap();
+  let error = runtime
+    .apply_host_input_with_context(&mut context, duplicate)
+    .unwrap_err();
+  assert_eq!(error.kind_name(), "ProgramInputDuplicateTarget");
+  assert_eq!(context.budget.used_steps, used_steps);
+  assert_eq!(runtime.event_sequence, event_sequence);
+  assert!(runtime.active_transactions.is_empty());
+
+  let unbound = RuntimeHostInput::single(
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "missing").unwrap(),
+    RuntimeHostInputValue::F64(4.0),
+  );
+  let outcome = runtime
+    .apply_host_input_with_context(&mut context, unbound)
+    .unwrap();
+  assert!(outcome.turn.is_none());
+  assert_eq!(context.budget.used_steps, used_steps);
+  assert_eq!(runtime.event_sequence, event_sequence);
+  assert!(runtime.active_transactions.is_empty());
+}
+
+#[test]
+fn explicit_host_input_is_provisional_until_outer_decision() {
+  let mut runtime =
+    test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let mut load_context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut load_context,
+      "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
+    )
+    .unwrap();
+  let source =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  let mut context = runtime.live_turn_context().unwrap();
+  let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+  let outcome = runtime
+    .apply_host_input_with_context(
+      &mut context,
+      RuntimeHostInput::single(
+        source.clone(),
+        RuntimeHostInputValue::F64(5.0),
+      ),
+    )
+    .unwrap();
+  assert!(outcome.turn.is_some());
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 10.0);
+  assert_eq!(
+    runtime.program_transaction_owner,
+    Some(transaction_id),
+  );
+  assert!(runtime.active_transactions.contains_key(&transaction_id));
+
+  runtime
+    .abort_runtime_transaction(&mut context, "discard host input")
+    .unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0);
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 1.0);
+
+  let mut commit_context = runtime.live_turn_context().unwrap();
+  runtime.begin_transaction(&mut commit_context).unwrap();
+  runtime
+    .apply_host_input_with_context(
+      &mut commit_context,
+      RuntimeHostInput::single(
+        source,
+        RuntimeHostInputValue::F64(7.0),
+      ),
+    )
+    .unwrap();
+  runtime
+    .commit_runtime_transaction(&mut commit_context)
+    .unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 14.0);
+}
+
+#[test]
+fn implicit_host_input_cannot_drive_an_explicit_program_owner() {
+  let mut runtime =
+    test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let mut load_context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut load_context,
+      "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value * 2",
+    )
+    .unwrap();
+  let source =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  let mut owner_context = runtime.live_turn_context().unwrap();
+  let owner = runtime.begin_transaction(&mut owner_context).unwrap();
+  runtime
+    .step_with_context(&mut owner_context, 0)
+    .unwrap();
+
+  let error = runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::F64(5.0),
+    ))
+    .unwrap_err();
+  assert_eq!(error.kind_name(), "RuntimeProgramBusy");
+  assert_eq!(runtime.program_transaction_owner, Some(owner));
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 1.0);
+
+  runtime
+    .abort_runtime_transaction(&mut owner_context, "release input owner")
+    .unwrap();
+}
+
+#[test]
+fn host_input_context_accepts_transaction_capabilities_but_rejects_drift() {
+  let mut runtime =
+    test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let mut load_context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut load_context,
+      "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+    )
+    .unwrap();
+  let source =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+
+  let mut context = runtime.live_turn_context().unwrap();
+  runtime.begin_transaction(&mut context).unwrap();
+  let capability_id = CapabilityId(910);
+  let subject = context.subject.clone();
+  runtime
+    .grant_capability_with_context(
+      &mut context,
+      Arc::new(BasicCapability::new(
+        capability_id,
+        &BasicSubject::new(&subject),
+        &BasicResource::new("db://host-input"),
+        [BasicOperation::read()],
+      )),
+    )
+    .unwrap();
+  runtime
+    .apply_host_input_with_context(
+      &mut context,
+      RuntimeHostInput::single(
+        source.clone(),
+        RuntimeHostInputValue::F64(2.0),
+      ),
+    )
+    .unwrap();
+  runtime
+    .revoke_capability_with_context(&mut context, capability_id)
+    .unwrap();
+  runtime
+    .apply_host_input_with_context(
+      &mut context,
+      RuntimeHostInput::single(
+        source.clone(),
+        RuntimeHostInputValue::F64(3.0),
+      ),
+    )
+    .unwrap();
+  runtime
+    .abort_runtime_transaction(&mut context, "capability context test")
+    .unwrap();
+
+  let mut drift = runtime.live_turn_context().unwrap();
+  drift.add_capability(CapabilityId(999));
+  let error = runtime
+    .apply_host_input_with_context(
+      &mut drift,
+      RuntimeHostInput::single(
+        source.clone(),
+        RuntimeHostInputValue::F64(4.0),
+      ),
+    )
+    .unwrap_err();
+  assert!(format!("{error:?}").contains("RuntimeLiveContextMismatch"));
+
+  let mut maxima = runtime.live_turn_context().unwrap();
+  maxima.budget.max_steps = Some(1);
+  let error = runtime
+    .apply_host_input_with_context(
+      &mut maxima,
+      RuntimeHostInput::single(
+        source,
+        RuntimeHostInputValue::F64(5.0),
+      ),
+    )
+    .unwrap_err();
+  assert!(format!("{error:?}").contains("RuntimeLiveContextMismatch"));
+}
+
+#[test]
+fn failed_dequeued_host_input_is_consumed_and_later_packet_remains() {
+  let mut runtime =
+    test_runtime(test_provider_with(TEST_CLOCK_BASE_URI, "value", 1.0));
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let mut context = runtime.runtime_context().unwrap();
+  runtime
+    .run_string_with_context(
+      &mut context,
+      "@pulse := test://clock/ticks{:read(value)}\noutput := @pulse/value",
+    )
+    .unwrap();
+  let source =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  let ingress = runtime.ingress();
+  ingress
+    .submit(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::String("wrong kind".to_string()),
+    ))
+    .unwrap();
+  ingress
+    .submit(RuntimeHostInput::single(
+      source,
+      RuntimeHostInputValue::F64(9.0),
+    ))
+    .unwrap();
+
+  assert!(runtime.drain_host_inputs(2).is_err());
+  assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 1.0);
+
+  let outcomes = runtime.drain_host_inputs(1).unwrap();
+  assert_eq!(outcomes.len(), 1);
+  assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "output")), 9.0);
+}
+
 #[derive(Debug, Clone)]
 struct MockDriver {
   name: String,
@@ -1521,13 +1797,22 @@ output := hour + 1
   }
 
   #[test]
-  fn persistent_send_provider_failure_returns_from_drain() {
+  fn persistent_send_delivery_failure_keeps_committed_drain_healthy() {
     let (mut runtime, driver, console) = runtime_with_console(snapshot(1.0, 2.0, 3.0, 4.0), false);
     load(&mut runtime, "scalar-output");
     console.fail_next("expected drain failure");
     driver.publish(snapshot(5.0, 6.0, 7.0, 8.0)).unwrap();
-    let err = runtime.drain_host_inputs(1).unwrap_err();
-    assert!(format!("{err:?}").contains("expected drain failure"));
+    let outcomes = runtime.drain_host_inputs(1).unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert!(outcomes[0].turn.is_some());
+    assert!(!runtime.is_poisoned());
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        &event.kind,
+        RuntimeEventKind::EffectDeliveryFailed { message, .. }
+          if message.contains("expected drain failure")
+      )
+    }));
   }
 
   #[test]
@@ -2196,7 +2481,7 @@ render-tick := @tick/tick
     }
 
     #[test]
-    fn activation_send_provider_failure_is_fail_fast_and_registration_is_retained() {
+    fn activation_send_delivery_failure_continues_and_registration_is_retained() {
         let provider = TestResourceProvider::new().with_value(
             "test://render/timer",
             "tick",
@@ -2233,21 +2518,32 @@ latest := render-tick + 1.0
         assert_eq!(activation_send_count(&runtime), 3);
         let plan_before = activation_plan_snapshot(&runtime);
         output.fail_once_at(2);
-        let error = runtime
+        let outcome = runtime
             .apply_host_input(RuntimeHostInput::single(
                 RuntimeHostInputSource::new("test://render/timer", "tick").unwrap(),
                 RuntimeHostInputValue::F64(1.0),
             ))
-            .unwrap_err();
-        assert!(
-            error.kind_as::<PersistentSendTestError>().is_some(),
-            "unexpected error: {error:?}"
-        );
+            .unwrap();
+        assert!(outcome.turn.is_some());
+        assert!(!runtime.is_poisoned());
+        assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+          matches!(
+            event.kind,
+            RuntimeEventKind::EffectDeliveryFailed { .. }
+          )
+        }));
         assert_eq!(
             output.attempts(),
-            vec!["\"first\"".to_string(), "\"second\"".to_string()]
+            vec![
+                "\"first\"".to_string(),
+                "\"second\"".to_string(),
+                "\"third\"".to_string()
+            ]
         );
-        assert_eq!(output.successes(), vec!["\"first\"".to_string()]);
+        assert_eq!(
+            output.successes(),
+            vec!["\"first\"".to_string(), "\"third\"".to_string()]
+        );
         assert_eq!(
             f64_value(&symbol_value(&runtime, "latest")),
             2.0,
@@ -2262,6 +2558,7 @@ latest := render-tick + 1.0
             vec![
                 "\"first\"".to_string(),
                 "\"second\"".to_string(),
+                "\"third\"".to_string(),
                 "\"first\"".to_string(),
                 "\"second\"".to_string(),
                 "\"third\"".to_string()
@@ -2271,6 +2568,7 @@ latest := render-tick + 1.0
             output.successes(),
             vec![
                 "\"first\"".to_string(),
+                "\"third\"".to_string(),
                 "\"first\"".to_string(),
                 "\"second\"".to_string(),
                 "\"third\"".to_string()

--- a/src/runtime/src/runtime/mod.rs
+++ b/src/runtime/src/runtime/mod.rs
@@ -27,6 +27,7 @@ mod module;
 mod module_transaction;
 mod object;
 mod program_transaction;
+mod reactive_transaction;
 mod schedule;
 mod service;
 mod task;
@@ -47,10 +48,11 @@ use self::program_transaction::{
   RuntimeExecutionTransactionMode,
   RuntimeExecutionTransactionState,
   RuntimeOperationSavepoint,
+  RuntimeProgramOwnershipAcquisition,
   RuntimeTransactionContextIdentity,
 };
 use self::capability::{
-  RuntimeCapabilityMutation, RuntimeCapabilityOverlay,
+  RuntimeCapabilityOverlay,
 };
 use self::effect::RuntimeEffectJournal;
 use self::module_transaction::RuntimeModuleJournal;

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -2561,13 +2561,14 @@ mod tests {
 
     runtime.run_string("reactive-boundary := 1").unwrap();
     let mut context = runtime.runtime_context().unwrap();
-    runtime.begin_transaction(&mut context).unwrap();
-    let error = runtime
+    let transaction_id =
+      runtime.begin_transaction(&mut context).unwrap();
+    runtime
       .step_with_context(&mut context, 1)
-      .unwrap_err();
+      .unwrap();
     assert_eq!(
-      error.kind_name(),
-      "RuntimeTransactionalReactiveTurnUnsupported",
+      runtime.program_transaction_owner,
+      Some(transaction_id),
     );
     runtime
       .abort_runtime_transaction(

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -12,6 +12,7 @@ pub(super) enum RuntimeExecutionTransactionMode {
   Explicit,
   ImplicitModuleOperation,
   ImplicitProgramOperation,
+  ImplicitReactiveTurn,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -174,6 +175,14 @@ pub(super) struct RuntimeProgramBaseline {
   pub(super) live: RuntimeLiveStateSnapshot,
 }
 
+pub(super) enum RuntimeProgramOwnershipAcquisition {
+  Existing,
+  NewlyAcquired {
+    program: MechProgramCheckpoint,
+    live: RuntimeLiveStateSnapshot,
+  },
+}
+
 pub(super) struct RuntimeExecutionTransaction {
   pub(super) store: RuntimeTransaction,
   pub(super) modules: RuntimeModuleJournal,
@@ -241,6 +250,8 @@ thread_local! {
   static PROGRAM_TRANSACTION_TEST_FAULT:
     std::cell::RefCell<Option<ProgramTransactionTestFault>> =
       const { std::cell::RefCell::new(None) };
+  static RUNTIME_PROGRAM_CHECKPOINT_COUNT:
+    std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -258,6 +269,16 @@ fn take_program_transaction_test_fault() -> Option<ProgramTransactionTestFault> 
   PROGRAM_TRANSACTION_TEST_FAULT.with(|slot| slot.replace(None))
 }
 
+#[cfg(test)]
+pub(super) fn reset_runtime_program_checkpoint_count() {
+  RUNTIME_PROGRAM_CHECKPOINT_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(super) fn runtime_program_checkpoint_count() -> usize {
+  RUNTIME_PROGRAM_CHECKPOINT_COUNT.with(std::cell::Cell::get)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimeHealth {
   Healthy,
@@ -273,6 +294,121 @@ pub struct RuntimePoisonRecord {
 }
 
 impl MechRuntime {
+  fn capture_runtime_program_checkpoint(
+    &self,
+  ) -> MResult<MechProgramCheckpoint> {
+    #[cfg(test)]
+    RUNTIME_PROGRAM_CHECKPOINT_COUNT.with(|count| {
+      count.set(count.get().saturating_add(1));
+    });
+    self.program.checkpoint()
+  }
+
+  pub(super) fn acquire_program_transaction_ownership(
+    &mut self,
+    transaction_id: TransactionId,
+    operation: &'static str,
+  ) -> MResult<RuntimeProgramOwnershipAcquisition> {
+    if let Some(owner) = self.program_transaction_owner {
+      if owner != transaction_id {
+        return Err(MechError::new(
+          RuntimeProgramBusy {
+            operation,
+            owner,
+            requester: Some(transaction_id),
+          },
+          None,
+        ));
+      }
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      if transaction.mode != RuntimeExecutionTransactionMode::Explicit {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "program owner transaction is not explicit",
+        );
+      }
+      if transaction.program.is_none() {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "program ownership exists without a transaction program baseline",
+        );
+      }
+      return Ok(RuntimeProgramOwnershipAcquisition::Existing);
+    }
+
+    {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      if transaction.mode != RuntimeExecutionTransactionMode::Explicit {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "program ownership can only be acquired by an explicit transaction",
+        );
+      }
+      if transaction.program.is_some() {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "transaction has a program baseline without program ownership",
+        );
+      }
+    }
+
+    let program = self.capture_runtime_program_checkpoint()?;
+    let live = self.live_state_snapshot();
+    self.active_execution_transaction_mut(transaction_id)?.program =
+      Some(RuntimeProgramBaseline {
+        program: program.clone(),
+        live: live.clone(),
+      });
+    self.program_transaction_owner = Some(transaction_id);
+    Ok(RuntimeProgramOwnershipAcquisition::NewlyAcquired {
+      program,
+      live,
+    })
+  }
+
+  pub(super) fn release_new_program_transaction_ownership(
+    &mut self,
+    transaction_id: TransactionId,
+  ) -> MResult<()> {
+    if self.program_transaction_owner != Some(transaction_id) {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "release_new_program_transaction_ownership",
+          reason: format!(
+            "transaction {} does not own the retained program",
+            transaction_id,
+          ),
+        },
+        None,
+      ));
+    }
+    if self
+      .active_execution_transaction(transaction_id)?
+      .program
+      .is_none()
+    {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "release_new_program_transaction_ownership",
+          reason: format!(
+            "transaction {} has no retained program baseline",
+            transaction_id,
+          ),
+        },
+        None,
+      ));
+    }
+    self.active_execution_transaction_mut(transaction_id)?.program = None;
+    self.program_transaction_owner = None;
+    Ok(())
+  }
+
   pub(super) fn ensure_runtime_healthy(
     &self,
     operation: &'static str,
@@ -330,24 +466,6 @@ impl MechRuntime {
     self.reject_effect_reentrancy(operation)
   }
 
-  pub(super) fn reject_transactional_reactive_turn(
-    &self,
-    context: &RuntimeContext,
-    operation: &'static str,
-  ) -> MResult<()> {
-    if context.transaction.is_none() && self.program_transaction_owner.is_none() {
-      return Ok(());
-    }
-    Err(MechError::new(
-      RuntimeTransactionalReactiveTurnUnsupported {
-        operation,
-        transaction_id: context.transaction,
-        owner: self.program_transaction_owner,
-      },
-      None,
-    ))
-  }
-
   pub(super) fn poison_program_operation(
     &mut self,
     operation: &'static str,
@@ -372,7 +490,7 @@ impl MechRuntime {
     )
   }
 
-  fn coordinator_invariant_failure<T>(
+  pub(super) fn coordinator_invariant_failure<T>(
     &mut self,
     operation: &'static str,
     transaction_id: Option<TransactionId>,
@@ -717,7 +835,8 @@ impl MechRuntime {
     let mut first_explicit_operation = false;
 
     let (transaction_id, program_checkpoint, live_checkpoint) = if implicit {
-      let program_checkpoint = self.program.checkpoint()?;
+      let program_checkpoint =
+        self.capture_runtime_program_checkpoint()?;
       let live_checkpoint = self.live_state_snapshot();
       let transaction_id = self.begin_runtime_transaction_internal(
         context,
@@ -732,33 +851,23 @@ impl MechRuntime {
       (transaction_id, program_checkpoint, live_checkpoint)
     } else {
       let transaction_id = requested_transaction.unwrap();
-      let mode = self.active_execution_transaction(transaction_id)?.mode;
-      if mode != RuntimeExecutionTransactionMode::Explicit {
-        return self.coordinator_invariant_failure(
-          operation,
-          Some(transaction_id),
-          "a public retained operation entered an implicit execution transaction without reentrancy detection",
-        );
+      match self.acquire_program_transaction_ownership(
+        transaction_id,
+        operation,
+      )? {
+        RuntimeProgramOwnershipAcquisition::NewlyAcquired {
+          program,
+          live,
+        } => {
+          first_explicit_operation = true;
+          (transaction_id, program, live)
+        }
+        RuntimeProgramOwnershipAcquisition::Existing => (
+          transaction_id,
+          self.capture_runtime_program_checkpoint()?,
+          self.live_state_snapshot(),
+        ),
       }
-
-      let program_checkpoint = self.program.checkpoint()?;
-      let live_checkpoint = self.live_state_snapshot();
-      if self.program_transaction_owner.is_none() {
-        self.active_execution_transaction_mut(transaction_id)?.program =
-          Some(RuntimeProgramBaseline {
-            program: program_checkpoint.clone(),
-            live: live_checkpoint.clone(),
-          });
-        self.program_transaction_owner = Some(transaction_id);
-        first_explicit_operation = true;
-      } else if self.active_execution_transaction(transaction_id)?.program.is_none() {
-        return self.coordinator_invariant_failure(
-          operation,
-          Some(transaction_id),
-          "program ownership exists without a transaction program baseline",
-        );
-      }
-      (transaction_id, program_checkpoint, live_checkpoint)
     };
 
     let savepoint = RuntimeProgramOperationSavepoint {
@@ -823,11 +932,18 @@ impl MechRuntime {
           cleanup_failures,
         ));
       } else if first_explicit_operation {
-        self.program_transaction_owner = None;
-        if let Ok(transaction) =
-          self.active_execution_transaction_mut(transaction_id)
+        if let Err(error) =
+          self.release_new_program_transaction_ownership(transaction_id)
         {
-          transaction.program = None;
+          return Err(self.poison_program_operation(
+            operation,
+            Some(transaction_id),
+            original_error_text,
+            vec![format!(
+              "program ownership release failed: {:?}",
+              error,
+            )],
+          ));
         }
       }
       return Err(original_error);

--- a/src/runtime/src/runtime/reactive_transaction.rs
+++ b/src/runtime/src/runtime/reactive_transaction.rs
@@ -1,0 +1,1464 @@
+//! Runtime coordination for compact reactive program turns.
+
+use super::*;
+use mech_program::{
+  ProgramInputUpdate, ProgramReactiveTurnJournal,
+};
+
+pub(super) struct PreparedRuntimeHostInput {
+  pub(super) update_count: usize,
+  pub(super) ignored_update_count: usize,
+  pub(super) binding_count: usize,
+  pub(super) updates: Vec<ProgramInputUpdate>,
+}
+
+impl MechRuntime {
+  pub(super) fn prepare_runtime_host_input(
+    &self,
+    input: &crate::RuntimeHostInput,
+  ) -> MResult<PreparedRuntimeHostInput> {
+    input.validate()?;
+    let mut updates = Vec::new();
+    let mut seen_targets = HashSet::new();
+    let mut ignored_update_count = 0;
+
+    for update in &input.updates {
+      let Some(bindings) =
+        self.live_input_bindings.get(&update.source)
+      else {
+        ignored_update_count += 1;
+        continue;
+      };
+      if bindings.is_empty() {
+        ignored_update_count += 1;
+        continue;
+      }
+      let value = update.value.clone().into_mech_value()?;
+      for program_input in bindings {
+        if !seen_targets.insert(*program_input) {
+          return Err(MechError::new(
+            mech_program::ProgramInputDuplicateTarget {
+              input: *program_input,
+            },
+            None,
+          ));
+        }
+        updates.push(ProgramInputUpdate {
+          input: *program_input,
+          value: value.clone(),
+        });
+      }
+    }
+
+    Ok(PreparedRuntimeHostInput {
+      update_count: input.updates.len(),
+      ignored_update_count,
+      binding_count: updates.len(),
+      updates,
+    })
+  }
+
+  pub(super) fn validate_live_turn_context(
+    &self,
+    context: &RuntimeContext,
+  ) -> MResult<()> {
+    let template = self.live_context_template.as_ref().ok_or_else(|| {
+      MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "RuntimeLiveContextMissing",
+          reason:
+            "host input turn requires a stored live program context"
+              .to_string(),
+        },
+        None,
+      )
+    })?;
+
+    let identity_matches =
+      template.runtime == context.runtime
+        && template.subject == context.subject
+        && template.task == context.task
+        && template.actor == context.actor
+        && template.module_version == context.module_version
+        && template.actor_message == context.actor_message
+        && template.actor_state == context.actor_state
+        && template.budget_limits.max_steps
+          == context.budget.max_steps
+        && template.budget_limits.max_bytes
+          == context.budget.max_bytes
+        && template.budget_limits.max_items
+          == context.budget.max_items
+        && template.budget_limits.max_messages
+          == context.budget.max_messages;
+    if !identity_matches {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "RuntimeLiveContextMismatch",
+          reason:
+            "host input attempted to change the live program execution identity or budget maxima"
+              .to_string(),
+        },
+        None,
+      ));
+    }
+
+    let mut expected_capabilities = template.capabilities.clone();
+    if let Some(transaction_id) = context.transaction {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      expected_capabilities.extend(
+        transaction
+          .capabilities
+          .grants()
+          .map(|(capability, _)| capability),
+      );
+      let revocations = transaction.capabilities.revocation_ids();
+      expected_capabilities
+        .retain(|capability| !revocations.contains(capability));
+    }
+    expected_capabilities.sort_unstable();
+    expected_capabilities.dedup();
+
+    let mut supplied_capabilities = context.capabilities.clone();
+    supplied_capabilities.sort_unstable();
+    supplied_capabilities.dedup();
+    if supplied_capabilities != expected_capabilities {
+      return Err(MechError::new(
+        RuntimeInvalidOperationError {
+          operation: "RuntimeLiveContextMismatch",
+          reason:
+            "host input context capabilities do not match the live program and active transaction"
+              .to_string(),
+        },
+        None,
+      ));
+    }
+
+    Ok(())
+  }
+
+  pub(super) fn with_atomic_reactive_turn<T>(
+    &mut self,
+    context: &mut RuntimeContext,
+    operation: &'static str,
+    execute: impl FnOnce(
+      &mut MechRuntime,
+      &mut RuntimeContext,
+      &mut ProgramReactiveTurnJournal,
+    ) -> MResult<T>,
+  ) -> MResult<T> {
+    self.preflight_atomic_program_operation(context, operation)?;
+
+    let implicit = context.transaction.is_none();
+    let (transaction_id, newly_acquired_ownership) = if implicit {
+      let transaction_id = self.begin_runtime_transaction_internal(
+        context,
+        RuntimeExecutionTransactionMode::ImplicitReactiveTurn,
+      )?;
+      if self
+        .active_execution_transaction(transaction_id)?
+        .program
+        .is_some()
+      {
+        return self.coordinator_invariant_failure(
+          operation,
+          Some(transaction_id),
+          "implicit reactive turn unexpectedly retained a full program baseline",
+        );
+      }
+      self.program_transaction_owner = Some(transaction_id);
+      (transaction_id, false)
+    } else {
+      let transaction_id = context.transaction.unwrap();
+      let newly_acquired = matches!(
+        self.acquire_program_transaction_ownership(
+          transaction_id,
+          operation,
+        )?,
+        RuntimeProgramOwnershipAcquisition::NewlyAcquired { .. },
+      );
+      (transaction_id, newly_acquired)
+    };
+
+    let runtime_savepoint =
+      match self.capture_runtime_operation_savepoint(
+        context,
+        transaction_id,
+      ) {
+        Ok(savepoint) => savepoint,
+        Err(error) => {
+          let original_error = format!("{:?}", error);
+          let mut failures = if implicit {
+            self.cleanup_failed_implicit_operation(
+              context,
+              operation,
+              transaction_id,
+              "reactive turn savepoint capture failed",
+            )
+          } else {
+            Vec::new()
+          };
+          if newly_acquired_ownership {
+            if let Err(release_error) =
+              self.release_new_program_transaction_ownership(transaction_id)
+            {
+              failures.push(format!(
+                "program ownership release failed: {:?}",
+                release_error,
+              ));
+            }
+          }
+          if failures.is_empty() {
+            return Err(error);
+          }
+          return Err(self.poison_program_operation(
+            operation,
+            Some(transaction_id),
+            original_error,
+            failures,
+          ));
+        }
+      };
+
+    let mut program_journal = ProgramReactiveTurnJournal::new();
+    self.active_program_operation = Some(ActiveRuntimeProgramOperation {
+      transaction_id,
+      operation,
+    });
+    let execution_result =
+      execute(self, context, &mut program_journal);
+    self.active_program_operation = None;
+
+    match execution_result {
+      Ok(value) if implicit => {
+        match self.commit_runtime_transaction_internal(context) {
+          Ok(super::transaction::RuntimeCommitResolution::Committed(_)) => {
+            Ok(value)
+          }
+          Ok(
+            super::transaction::RuntimeCommitResolution::CommittedWithError {
+              error,
+              ..
+            },
+          ) => Err(error),
+          Err(error) => self.finish_failed_reactive_turn(
+            context,
+            operation,
+            transaction_id,
+            program_journal,
+            &runtime_savepoint,
+            error,
+            true,
+            false,
+          ),
+        }
+      }
+      Ok(value) => Ok(value),
+      Err(error) => self.finish_failed_reactive_turn(
+        context,
+        operation,
+        transaction_id,
+        program_journal,
+        &runtime_savepoint,
+        error,
+        implicit,
+        newly_acquired_ownership,
+      ),
+    }
+  }
+
+  fn rollback_reactive_turn_operation(
+    &mut self,
+    context: &mut RuntimeContext,
+    transaction_id: TransactionId,
+    program_journal: ProgramReactiveTurnJournal,
+    runtime_savepoint: &RuntimeOperationSavepoint,
+  ) -> Vec<String> {
+    let mut failures = Vec::new();
+    if let Err(error) =
+      self.program.rollback_reactive_turn(program_journal)
+    {
+      failures.push(format!(
+        "compact program reactive-turn rollback failed: {:?}",
+        error,
+      ));
+    }
+    failures.extend(self.rollback_runtime_operation(
+      context,
+      transaction_id,
+      runtime_savepoint,
+    ));
+    failures
+  }
+
+  fn finish_failed_reactive_turn<T>(
+    &mut self,
+    context: &mut RuntimeContext,
+    operation: &'static str,
+    transaction_id: TransactionId,
+    program_journal: ProgramReactiveTurnJournal,
+    runtime_savepoint: &RuntimeOperationSavepoint,
+    original_error: MechError,
+    implicit: bool,
+    newly_acquired_ownership: bool,
+  ) -> MResult<T> {
+    let original_error_text = format!("{:?}", original_error);
+    let mut rollback_failures = self.rollback_reactive_turn_operation(
+      context,
+      transaction_id,
+      program_journal,
+      runtime_savepoint,
+    );
+
+    if implicit {
+      rollback_failures.extend(self.cleanup_failed_implicit_operation(
+        context,
+        operation,
+        transaction_id,
+        &format!("reactive operation `{}` failed", operation),
+      ));
+    } else if newly_acquired_ownership
+      && rollback_failures.is_empty()
+    {
+      if let Err(error) =
+        self.release_new_program_transaction_ownership(transaction_id)
+      {
+        rollback_failures.push(format!(
+          "program ownership release failed: {:?}",
+          error,
+        ));
+      }
+    }
+
+    if rollback_failures.is_empty() {
+      return Err(original_error);
+    }
+
+    Err(self.poison_program_operation(
+      operation,
+      Some(transaction_id),
+      original_error_text,
+      rollback_failures,
+    ))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::cell::RefCell;
+  use std::rc::Rc;
+  use std::sync::{Arc, Mutex};
+
+  use crate::capability::{
+    BasicCapability, BasicConstraints, BasicOperation, BasicResource,
+    BasicSubject, SharedCapabilityKernel,
+  };
+  use crate::ClosureHostFunction;
+  use crate::{
+    PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+    RuntimeEffectMetadata, RuntimeEffectSource,
+    RuntimeTransactionalEffect,
+  };
+  use super::super::program_transaction::{
+    reset_runtime_program_checkpoint_count,
+    runtime_program_checkpoint_count,
+  };
+  use mech_core::{
+    GenericError, ReactiveSolveStatus, Ref,
+  };
+
+  struct ReactiveTransactionTestFunction {
+    output: Ref<usize>,
+    calls: Rc<RefCell<usize>>,
+    fail_on_call: Option<usize>,
+  }
+
+  #[derive(Debug)]
+  struct ReactiveTransactionalProbe {
+    log: Arc<Mutex<Vec<&'static str>>>,
+    fail_prepare: bool,
+    fail_commit: bool,
+    fail_abort: bool,
+  }
+
+  impl RuntimeTransactionalEffect for ReactiveTransactionalProbe {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "reactive-transaction-probe".to_string(),
+        },
+        "reactive-transaction-probe",
+      )
+    }
+
+    fn prepare(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push("prepare");
+      if self.fail_prepare {
+        return Err(MechError::new(
+          GenericError {
+            msg: "deliberate reactive prepare failure".to_string(),
+          },
+          None,
+        ));
+      }
+      Ok(())
+    }
+
+    fn commit(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push("commit");
+      if self.fail_commit {
+        return Err(MechError::new(
+          GenericError {
+            msg: "deliberate reactive commit failure".to_string(),
+          },
+          None,
+        ));
+      }
+      Ok(())
+    }
+
+    fn abort(&mut self) -> MResult<()> {
+      self.log.lock().unwrap().push("abort");
+      if self.fail_abort {
+        return Err(MechError::new(
+          GenericError {
+            msg: "deliberate reactive abort failure".to_string(),
+          },
+          None,
+        ));
+      }
+      Ok(())
+    }
+  }
+
+  #[derive(Debug)]
+  struct ReactiveAfterCommitFailure;
+
+  impl RuntimeAfterCommitEffect for ReactiveAfterCommitFailure {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+      RuntimeEffectMetadata::new(
+        RuntimeEffectSource::Custom {
+          name: "reactive-after-commit-failure".to_string(),
+        },
+        "reactive-after-commit-failure",
+      )
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+      Err(MechError::new(
+        GenericError {
+          msg: "deliberate reactive delivery failure".to_string(),
+        },
+        None,
+      ))
+    }
+  }
+
+  impl MechFunctionImpl for ReactiveTransactionTestFunction {
+    fn solve(&self) {}
+
+    fn solve_result(&self) -> MResult<()> {
+      self.solve_reactive().map(|_| ())
+    }
+
+    fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+      let call = {
+        let mut calls = self.calls.borrow_mut();
+        *calls += 1;
+        *calls
+      };
+      *self.output.borrow_mut() += 1;
+      if self.fail_on_call == Some(call) {
+        return Err(MechError::new(
+          GenericError {
+            msg: "deliberate reactive transaction failure".to_string(),
+          },
+          None,
+        ));
+      }
+      Ok(ReactiveSolveStatus::Changed)
+    }
+
+    fn out(&self) -> Value {
+      Value::Index(self.output.clone())
+    }
+
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+      Ok(vec![Value::Index(self.output.clone())])
+    }
+
+    fn to_string(&self) -> String {
+      "ReactiveTransactionTestFunction".to_string()
+    }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for ReactiveTransactionTestFunction {
+    fn compile(&self, _context: &mut CompileCtx) -> MResult<Register> {
+      Ok(0)
+    }
+  }
+
+  fn add_test_function(
+    runtime: &mut MechRuntime,
+    fail_on_call: Option<usize>,
+  ) -> (Ref<usize>, Rc<RefCell<usize>>) {
+    let output = Ref::new(0usize);
+    let calls = Rc::new(RefCell::new(0usize));
+    runtime
+      .program
+      .interpreter()
+      .plan()
+      .add_function(Box::new(ReactiveTransactionTestFunction {
+        output: output.clone(),
+        calls: calls.clone(),
+        fail_on_call,
+      }));
+    (output, calls)
+  }
+
+  fn initialize_program_journal(
+    runtime: &mut MechRuntime,
+    journal: &mut ProgramReactiveTurnJournal,
+  ) -> MResult<()> {
+    runtime
+      .program
+      .step_with_reactive_turn_journal(0, journal)
+  }
+
+  #[test]
+  fn implicit_reactive_turns_use_no_full_program_checkpoints() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    add_test_function(&mut runtime, None);
+    reset_runtime_program_checkpoint_count();
+
+    for _ in 0..100 {
+      runtime.step(0).unwrap();
+    }
+
+    assert_eq!(runtime_program_checkpoint_count(), 0);
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+  }
+
+  #[test]
+  fn reactive_step_budget_failure_cleans_up_without_poisoning() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, calls) = add_test_function(&mut runtime, None);
+    let mut context = runtime
+      .runtime_context()
+      .unwrap()
+      .with_budget(ResourceBudget::default().with_max_steps(0));
+    reset_runtime_program_checkpoint_count();
+
+    let error = runtime
+      .step_with_context(&mut context, 0)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "ResourceBudgetExceeded");
+    assert_eq!(*output.borrow(), 0);
+    assert_eq!(*calls.borrow(), 0);
+    assert!(!runtime.is_poisoned());
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert_eq!(runtime_program_checkpoint_count(), 0);
+  }
+
+  #[test]
+  fn explicit_reactive_turns_reuse_one_outer_program_checkpoint() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    reset_runtime_program_checkpoint_count();
+
+    runtime.step_with_context(&mut context, 0).unwrap();
+    assert_eq!(runtime_program_checkpoint_count(), 1);
+    for _ in 0..99 {
+      runtime.step_with_context(&mut context, 0).unwrap();
+    }
+
+    assert_eq!(runtime_program_checkpoint_count(), 1);
+    assert_eq!(
+      runtime.program_transaction_owner,
+      Some(transaction_id),
+    );
+    runtime
+      .abort_runtime_transaction(&mut context, "checkpoint test")
+      .unwrap();
+  }
+
+  #[test]
+  fn failed_implicit_turn_restores_program_and_removes_envelope() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, calls) = add_test_function(&mut runtime, Some(1));
+    reset_runtime_program_checkpoint_count();
+
+    let error = runtime.step(1).unwrap_err();
+
+    assert_eq!(error.kind_name(), "GenericError");
+    assert_eq!(*output.borrow(), 0);
+    assert_eq!(*calls.borrow(), 1);
+    assert_eq!(runtime_program_checkpoint_count(), 0);
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(matches!(runtime.health, RuntimeHealth::Healthy));
+  }
+
+  #[test]
+  fn failed_explicit_turn_releases_or_preserves_ownership_by_position() {
+    let mut first_runtime = MechRuntime::builder().build().unwrap();
+    let (first_output, _) =
+      add_test_function(&mut first_runtime, Some(1));
+    let mut first_context = first_runtime.runtime_context().unwrap();
+    let first_transaction =
+      first_runtime.begin_transaction(&mut first_context).unwrap();
+
+    assert!(first_runtime
+      .step_with_context(&mut first_context, 1)
+      .is_err());
+    assert_eq!(*first_output.borrow(), 0);
+    assert_eq!(first_runtime.program_transaction_owner, None);
+    assert!(first_runtime
+      .active_execution_transaction(first_transaction)
+      .unwrap()
+      .program
+      .is_none());
+    first_runtime
+      .abort_runtime_transaction(&mut first_context, "first failure")
+      .unwrap();
+
+    let mut later_runtime = MechRuntime::builder().build().unwrap();
+    let (later_output, _) =
+      add_test_function(&mut later_runtime, Some(2));
+    let mut later_context = later_runtime.runtime_context().unwrap();
+    let later_transaction =
+      later_runtime.begin_transaction(&mut later_context).unwrap();
+    later_runtime
+      .step_with_context(&mut later_context, 1)
+      .unwrap();
+
+    assert!(later_runtime
+      .step_with_context(&mut later_context, 1)
+      .is_err());
+    assert_eq!(*later_output.borrow(), 1);
+    assert_eq!(
+      later_runtime.program_transaction_owner,
+      Some(later_transaction),
+    );
+    assert!(later_runtime
+      .active_execution_transaction(later_transaction)
+      .unwrap()
+      .program
+      .is_some());
+    later_runtime
+      .abort_runtime_transaction(&mut later_context, "later failure")
+      .unwrap();
+    assert_eq!(*later_output.borrow(), 0);
+  }
+
+  #[test]
+  fn explicit_program_owner_excludes_other_reactive_transactions() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, _) = add_test_function(&mut runtime, None);
+    let mut context_a = runtime.runtime_context().unwrap();
+    let transaction_a = runtime.begin_transaction(&mut context_a).unwrap();
+    runtime.step_with_context(&mut context_a, 0).unwrap();
+
+    let mut context_b = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context_b).unwrap();
+    let error = runtime
+      .step_with_context(&mut context_b, 0)
+      .unwrap_err();
+    assert_eq!(error.kind_name(), "RuntimeProgramBusy");
+    assert_eq!(*output.borrow(), 1);
+
+    runtime
+      .put_object_with_context(
+        &mut context_b,
+        ObjectRecord::text(
+          ObjectId(699),
+          "note",
+          "independent store work",
+        ),
+      )
+      .unwrap();
+    runtime
+      .run_string_with_context(
+        &mut context_a,
+        "reactive-owner-source := 1",
+      )
+      .unwrap();
+    runtime.step_with_context(&mut context_a, 0).unwrap();
+    assert_eq!(*output.borrow(), 2);
+    assert_eq!(
+      runtime.program_transaction_owner,
+      Some(transaction_a),
+    );
+
+    runtime
+      .abort_runtime_transaction(&mut context_a, "restore owner A")
+      .unwrap();
+    assert_eq!(*output.borrow(), 0);
+    assert!(runtime
+      .program
+      .root_symbol_value("reactive-owner-source")
+      .is_err());
+    assert!(runtime.get_object(ObjectId(699)).unwrap().is_none());
+    runtime
+      .abort_runtime_transaction(&mut context_b, "discard B store work")
+      .unwrap();
+  }
+
+  #[test]
+  fn failed_first_explicit_turn_retains_owner_when_rollback_is_incomplete() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, _) = add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    let error: MechError = runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "incomplete_first_explicit_turn_rollback",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.stage_runtime_effect_with_context(
+            context,
+            PreparedRuntimeEffect::Transactional(Box::new(
+              ReactiveTransactionalProbe {
+                log: log.clone(),
+                fail_prepare: false,
+                fail_commit: false,
+                fail_abort: true,
+              },
+            )),
+          )?;
+          Err::<(), _>(MechError::new(
+            GenericError {
+              msg: "deliberate first explicit turn failure".to_string(),
+            },
+            None,
+          ))
+        },
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeProgramRollbackFailed");
+    assert!(format!("{error:?}")
+      .contains("deliberate first explicit turn failure"));
+    assert!(format!("{error:?}")
+      .contains("deliberate reactive abort failure"));
+    assert_eq!(*output.borrow(), 0);
+    assert_eq!(
+      runtime.program_transaction_owner,
+      Some(transaction_id),
+    );
+    assert!(runtime
+      .active_execution_transaction(transaction_id)
+      .unwrap()
+      .program
+      .is_some());
+    assert!(runtime.is_poisoned());
+    assert_eq!(*log.lock().unwrap(), vec!["abort"]);
+  }
+
+  fn limited_live_capability(
+    id: CapabilityId,
+    subject: &str,
+    max_uses: u64,
+  ) -> Arc<dyn Capability> {
+    Arc::new(
+      BasicCapability::new(
+        id,
+        &BasicSubject::new(subject),
+        &BasicResource::new("db://reactive"),
+        [BasicOperation::read()],
+      )
+      .with_constraints(
+        BasicConstraints::default().with_max_uses(max_uses),
+      ),
+    )
+  }
+
+  fn reactive_capability_request(subject: &str) -> CapabilityRequest {
+    CapabilityRequest::new(
+      &BasicSubject::new(subject),
+      &BasicOperation::read(),
+      &BasicResource::new("db://reactive"),
+    )
+  }
+
+  #[test]
+  fn implicit_reactive_capability_use_commits_or_rolls_back_once() {
+    let kernel = SharedCapabilityKernel::new();
+    let observed = kernel.clone();
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    add_test_function(&mut runtime, None);
+    let mut administrative = runtime.runtime_context().unwrap();
+    let subject = administrative.subject.clone();
+    let id = CapabilityId(700);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        limited_live_capability(id, &subject, 2),
+      )
+      .unwrap();
+    let request = reactive_capability_request(&subject);
+
+    let mut failed_context = runtime.runtime_context().unwrap();
+    let failed: MResult<()> = runtime.with_atomic_reactive_turn(
+      &mut failed_context,
+      "failed_capability_turn",
+      |runtime, context, journal| {
+        initialize_program_journal(runtime, journal)?;
+        runtime.check_capability_with_context(context, &request)?;
+        Err(MechError::new(
+          GenericError {
+            msg: "deliberate failed capability turn".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+    assert_eq!(failed.unwrap_err().kind_name(), "GenericError");
+    assert_eq!(observed.successful_uses_for_test(id), 0);
+
+    let mut successful_context = runtime.runtime_context().unwrap();
+    runtime
+      .with_atomic_reactive_turn(
+        &mut successful_context,
+        "successful_capability_turn",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.check_capability_with_context(context, &request)?;
+          Ok(())
+        },
+      )
+      .unwrap();
+    assert_eq!(observed.successful_uses_for_test(id), 1);
+  }
+
+  #[test]
+  fn explicit_reactive_capability_reservations_commit_or_abort() {
+    let kernel = SharedCapabilityKernel::new();
+    let observed = kernel.clone();
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    add_test_function(&mut runtime, None);
+    let mut administrative = runtime.runtime_context().unwrap();
+    let subject = administrative.subject.clone();
+    let id = CapabilityId(701);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        limited_live_capability(id, &subject, 3),
+      )
+      .unwrap();
+    let request = reactive_capability_request(&subject);
+
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "explicit_capability_turn",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.check_capability_with_context(context, &request)?;
+          Ok(())
+        },
+      )
+      .unwrap();
+    assert_eq!(observed.successful_uses_for_test(id), 0);
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .capabilities
+        .usage_deltas()
+        .collect::<Vec<_>>(),
+      vec![(id, 1)],
+    );
+
+    let failed: MResult<()> = runtime.with_atomic_reactive_turn(
+      &mut context,
+      "failed_later_capability_turn",
+      |runtime, context, journal| {
+        initialize_program_journal(runtime, journal)?;
+        runtime.check_capability_with_context(context, &request)?;
+        Err(MechError::new(
+          GenericError {
+            msg: "deliberate later capability failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+    assert_eq!(failed.unwrap_err().kind_name(), "GenericError");
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .capabilities
+        .usage_deltas()
+        .collect::<Vec<_>>(),
+      vec![(id, 1)],
+    );
+    assert_eq!(observed.successful_uses_for_test(id), 0);
+
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert_eq!(observed.successful_uses_for_test(id), 1);
+
+    let mut abort_context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut abort_context).unwrap();
+    runtime
+      .with_atomic_reactive_turn(
+        &mut abort_context,
+        "aborted_capability_turn",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.check_capability_with_context(context, &request)?;
+          Ok(())
+        },
+      )
+      .unwrap();
+    runtime
+      .abort_runtime_transaction(&mut abort_context, "discard reservation")
+      .unwrap();
+    assert_eq!(observed.successful_uses_for_test(id), 1);
+  }
+
+  #[test]
+  fn retryable_store_failure_commits_reserved_use_without_rerun() {
+    let kernel = SharedCapabilityKernel::new();
+    let observed = kernel.clone();
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    let (_, calls) = add_test_function(&mut runtime, None);
+    let mut administrative = runtime.runtime_context().unwrap();
+    let subject = administrative.subject.clone();
+    let capability_id = CapabilityId(702);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        limited_live_capability(
+          capability_id,
+          &subject,
+          1,
+        ),
+      )
+      .unwrap();
+    let request = reactive_capability_request(&subject);
+    let missing_object = ObjectId(703);
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "retryable_capability_turn",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.check_capability_with_context(context, &request)?;
+          Ok(())
+        },
+      )
+      .unwrap();
+    runtime
+      .update_object_with_context(
+        &mut context,
+        ObjectRecord::text(
+          missing_object,
+          "note",
+          "staged update",
+        ),
+      )
+      .unwrap();
+
+    assert!(runtime
+      .commit_runtime_transaction(&mut context)
+      .is_err());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(*calls.borrow(), 1);
+    assert_eq!(observed.successful_uses_for_test(capability_id), 0);
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .capabilities
+        .usage_deltas()
+        .collect::<Vec<_>>(),
+      vec![(capability_id, 1)],
+    );
+
+    runtime
+      .put_object(ObjectRecord::text(
+        missing_object,
+        "note",
+        "durable baseline",
+      ))
+      .unwrap();
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert_eq!(observed.successful_uses_for_test(capability_id), 1);
+    assert_eq!(
+      runtime
+        .get_object(missing_object)
+        .unwrap()
+        .unwrap()
+        .data,
+      b"staged update".to_vec(),
+    );
+  }
+
+  #[test]
+  fn provisional_capability_grant_and_use_commit_together() {
+    let kernel = SharedCapabilityKernel::new();
+    let observed = kernel.clone();
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+    let subject = context.subject.clone();
+    let capability_id = CapabilityId(704);
+    let request = reactive_capability_request(&subject);
+    runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "provisional_grant_and_use",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.grant_capability_with_context(
+            context,
+            limited_live_capability(
+              capability_id,
+              &subject,
+              1,
+            ),
+          )?;
+          runtime.check_capability_with_context(context, &request)?;
+          Ok(())
+        },
+      )
+      .unwrap();
+
+    assert_eq!(observed.successful_uses_for_test(capability_id), 0);
+    assert!(observed.get(capability_id).unwrap().is_none());
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert!(observed.get(capability_id).unwrap().is_some());
+    assert_eq!(observed.successful_uses_for_test(capability_id), 1);
+  }
+
+  #[test]
+  fn live_capability_use_commits_before_transactional_revocation() {
+    let kernel = SharedCapabilityKernel::new();
+    let observed = kernel.clone();
+    let mut runtime = MechRuntime::builder()
+      .capability_kernel(kernel)
+      .build()
+      .unwrap();
+    add_test_function(&mut runtime, None);
+    let mut administrative = runtime.runtime_context().unwrap();
+    let subject = administrative.subject.clone();
+    let capability_id = CapabilityId(705);
+    runtime
+      .grant_capability_with_context(
+        &mut administrative,
+        limited_live_capability(
+          capability_id,
+          &subject,
+          1,
+        ),
+      )
+      .unwrap();
+    let request = reactive_capability_request(&subject);
+    let mut context = runtime.runtime_context().unwrap();
+    runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "live_use_then_revoke",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.check_capability_with_context(context, &request)?;
+          runtime.revoke_capability_with_context(
+            context,
+            capability_id,
+          )?;
+          Ok(())
+        },
+      )
+      .unwrap();
+
+    assert_eq!(observed.successful_uses_for_test(capability_id), 0);
+    assert!(!observed.is_revoked(capability_id).unwrap());
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+    assert_eq!(observed.successful_uses_for_test(capability_id), 1);
+    assert!(observed.is_revoked(capability_id).unwrap());
+  }
+
+  #[test]
+  fn failed_reactive_turn_rolls_back_staged_object_and_program_state() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, _) = add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+    let object_id = ObjectId(800);
+
+    let result: MResult<()> = runtime.with_atomic_reactive_turn(
+      &mut context,
+      "failed_object_turn",
+      |runtime, context, journal| {
+        initialize_program_journal(runtime, journal)?;
+        runtime.put_object_with_context(
+          context,
+          ObjectRecord::text(object_id, "note", "provisional"),
+        )?;
+        Err(MechError::new(
+          GenericError {
+            msg: "deliberate object turn failure".to_string(),
+          },
+          None,
+        ))
+      },
+    );
+
+    assert_eq!(result.unwrap_err().kind_name(), "GenericError");
+    assert_eq!(*output.borrow(), 0);
+    assert!(runtime.get_object(object_id).unwrap().is_none());
+    assert!(runtime.active_transactions.is_empty());
+  }
+
+  #[test]
+  fn reactive_host_callback_rejects_nested_lifecycle_but_allows_staging() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let subject = runtime.runtime_context().unwrap().subject;
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(920),
+        &BasicSubject::new(&subject),
+        &BasicResource::new("host:demo/reactive-reenter"),
+        [BasicOperation::new("call")],
+      )))
+      .unwrap();
+    runtime
+      .grant_capability(Arc::new(BasicCapability::new(
+        CapabilityId(921),
+        &BasicSubject::new(&subject),
+        &BasicResource::new("db://reactive-staging"),
+        [BasicOperation::read()],
+      )))
+      .unwrap();
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let observed_for_host = observed.clone();
+    runtime
+      .register_mech_host_function(
+        ClosureHostFunction::new_runtime_managed(
+          "demo/reactive-reenter",
+          move |_services, _context, _args| {
+            ACTIVE_RUNTIME_PROGRAM_HOST.with(|slot| {
+              let target = slot
+                .borrow()
+                .expect("runtime program host target should be active");
+              let runtime = unsafe { &mut *target.runtime };
+              let context = unsafe { &mut *target.context };
+              if runtime
+                .active_program_operation
+                .as_ref()
+                .is_some_and(|active| {
+                  active.operation == "step_with_context"
+                })
+              {
+                let tree =
+                  mech_syntax::parser::parse("nested-tree := 1")
+                    .unwrap();
+                let source = MechSourceCode::String(
+                  "nested-source := 1".to_string(),
+                );
+                let interpreter_id = runtime.program.interpreter().id;
+                let probes = vec![
+                  (
+                    "step",
+                    runtime.step_with_context(context, 0).unwrap_err(),
+                  ),
+                  (
+                    "host_input",
+                    runtime
+                      .apply_host_input_with_context(
+                        context,
+                        crate::RuntimeHostInput::single(
+                          crate::RuntimeHostInputSource::new(
+                            "test://reentrant/input",
+                            "value",
+                          )
+                          .unwrap(),
+                          crate::RuntimeHostInputValue::F64(1.0),
+                        ),
+                      )
+                      .unwrap_err(),
+                  ),
+                  (
+                    "run_string",
+                    runtime
+                      .run_string_with_context(
+                        context,
+                        "nested-string := 1",
+                      )
+                      .unwrap_err(),
+                  ),
+                  (
+                    "run_tree",
+                    runtime
+                      .run_tree_with_context(context, &tree)
+                      .unwrap_err(),
+                  ),
+                  (
+                    "run_source",
+                    runtime
+                      .run_source_with_context(context, &source)
+                      .unwrap_err(),
+                  ),
+                  (
+                    "begin",
+                    runtime.begin_transaction(context).unwrap_err(),
+                  ),
+                  (
+                    "commit",
+                    runtime
+                      .commit_runtime_transaction(context)
+                      .unwrap_err(),
+                  ),
+                  (
+                    "abort",
+                    runtime
+                      .abort_runtime_transaction(
+                        context,
+                        "nested abort",
+                      )
+                      .unwrap_err(),
+                  ),
+                  (
+                    "bind_ans",
+                    runtime
+                      .bind_ans_for_interpreter(
+                        interpreter_id,
+                        &Value::Empty,
+                      )
+                      .unwrap_err(),
+                  ),
+                ];
+                observed_for_host.lock().unwrap().extend(
+                  probes.into_iter().map(|(name, error)| {
+                    (name, error.kind_name())
+                  }),
+                );
+
+                runtime
+                  .put_object_with_context(
+                    context,
+                    ObjectRecord::text(
+                      ObjectId(922),
+                      "note",
+                      "reactive staging",
+                    ),
+                  )
+                  .unwrap();
+                runtime
+                  .check_capability_with_context(
+                    context,
+                    &CapabilityRequest::new(
+                      &BasicSubject::new(&context.subject),
+                      &BasicOperation::read(),
+                      &BasicResource::new(
+                        "db://reactive-staging",
+                      ),
+                    ),
+                  )
+                  .unwrap();
+                runtime
+                  .emit_event_to_context(
+                    context,
+                    RuntimeEventKind::RuntimeTickStarted,
+                  )
+                  .unwrap();
+              }
+            });
+            Ok(Value::F64(Ref::new(1.0)))
+          },
+        ),
+      )
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "reactive-result := demo/reactive-reenter()",
+      )
+      .unwrap();
+    observed.lock().unwrap().clear();
+
+    runtime.step_with_context(&mut context, 0).unwrap();
+
+    let observed = observed.lock().unwrap();
+    assert_eq!(observed.len(), 9);
+    for (name, kind) in observed.iter() {
+      if *name == "bind_ans" {
+        assert_eq!(*kind, "RuntimeProgramBusy");
+      } else {
+        assert_eq!(*kind, "RuntimeProgramOperationReentrant");
+      }
+    }
+    assert!(runtime.get_object(ObjectId(922)).unwrap().is_some());
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::RuntimeTickStarted)
+    }));
+  }
+
+  #[test]
+  fn pre_store_effect_failure_rolls_back_reactive_and_runtime_state() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, _) = add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+    let object_id = ObjectId(930);
+
+    let error = runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "reactive_prepare_failure",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.put_object_with_context(
+            context,
+            ObjectRecord::text(
+              object_id,
+              "note",
+              "must roll back",
+            ),
+          )?;
+          runtime.stage_runtime_effect_with_context(
+            context,
+            PreparedRuntimeEffect::Transactional(Box::new(
+              ReactiveTransactionalProbe {
+                log: log.clone(),
+                fail_prepare: true,
+                fail_commit: false,
+                fail_abort: false,
+              },
+            )),
+          )?;
+          Ok(())
+        },
+      )
+      .unwrap_err();
+
+    assert!(format!("{error:?}")
+      .contains("deliberate reactive prepare failure"));
+    assert_eq!(*output.borrow(), 0);
+    assert!(runtime.get_object(object_id).unwrap().is_none());
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(matches!(runtime.health, RuntimeHealth::Healthy));
+    assert_eq!(*log.lock().unwrap(), vec!["prepare", "abort"]);
+  }
+
+  #[test]
+  fn post_store_participant_failure_never_rolls_back_reactive_state() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, _) = add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+    let object_id = ObjectId(931);
+
+    let error = runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "reactive_commit_failure",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.put_object_with_context(
+            context,
+            ObjectRecord::text(
+              object_id,
+              "note",
+              "must remain committed",
+            ),
+          )?;
+          runtime.stage_runtime_effect_with_context(
+            context,
+            PreparedRuntimeEffect::Transactional(Box::new(
+              ReactiveTransactionalProbe {
+                log: log.clone(),
+                fail_prepare: false,
+                fail_commit: true,
+                fail_abort: false,
+              },
+            )),
+          )?;
+          Ok(())
+        },
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "RuntimeExternalCommitIndeterminate");
+    assert_eq!(*output.borrow(), 1);
+    assert!(runtime.get_object(object_id).unwrap().is_some());
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert!(runtime.is_poisoned());
+    assert_eq!(*log.lock().unwrap(), vec!["prepare", "commit"]);
+  }
+
+  #[test]
+  fn after_commit_delivery_failure_keeps_reactive_state_and_health() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let (output, _) = add_test_function(&mut runtime, None);
+    let mut context = runtime.runtime_context().unwrap();
+
+    runtime
+      .with_atomic_reactive_turn(
+        &mut context,
+        "reactive_delivery_failure",
+        |runtime, context, journal| {
+          initialize_program_journal(runtime, journal)?;
+          runtime.stage_runtime_effect_with_context(
+            context,
+            PreparedRuntimeEffect::AfterCommit(Box::new(
+              ReactiveAfterCommitFailure,
+            )),
+          )?;
+          Ok(())
+        },
+      )
+      .unwrap();
+
+    assert_eq!(*output.borrow(), 1);
+    assert!(!runtime.is_poisoned());
+    assert!(runtime.active_transactions.is_empty());
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        &event.kind,
+        RuntimeEventKind::EffectDeliveryFailed { message, .. }
+          if message.contains("deliberate reactive delivery failure")
+      )
+    }));
+  }
+}

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -793,24 +793,20 @@ impl MechRuntime {
     &mut self,
     envelope: &RuntimeExecutionTransaction,
   ) -> MResult<()> {
-    for mutation in envelope.capabilities.mutations() {
-      match mutation {
-        RuntimeCapabilityMutation::Grant(capability) => {
-          self
-            .capability_kernel
-            .grant(CapabilityGrant::new(capability))?;
-        }
-        RuntimeCapabilityMutation::Revoke(capability) => {
-          self
-            .capability_kernel
-            .revoke(CapabilityRevocation::new(capability))?;
-        }
-      }
+    for (_, capability) in envelope.capabilities.grants() {
+      self
+        .capability_kernel
+        .grant(CapabilityGrant::new(capability))?;
     }
     for (capability, uses) in envelope.capabilities.usage_deltas() {
       self
         .capability_kernel
         .apply_usage_delta(capability, uses)?;
+    }
+    for capability in envelope.capabilities.revocations() {
+      self
+        .capability_kernel
+        .revoke(CapabilityRevocation::new(capability))?;
     }
     Ok(())
   }


### PR DESCRIPTION
## Summary

PR7 joins PR6's compact `ProgramReactiveTurnJournal` to the runtime transaction envelope for runtime stepping and host-input turns.

- Runtime-owned reactive turns now commit or roll back program values, scheduler state, store staging, capabilities, modules, effects, events, and context as one decision.
- Implicit turns use a compact reactive journal and no full program checkpoint.
- Explicit transactions capture one outer program checkpoint and retain successful turns until outer commit or abort.
- Capability grants, revocations, and uses now share one ordered, savepoint-aware journal.
- Live capability uses are previewed and reserved transaction-locally, then applied exactly once at commit.
- Host-input preparation happens before transaction creation; bound inputs and persistent sends execute inside the reactive transaction.
- Pre-store failures restore reactive and runtime state. Post-store participant failures remain committed and poison. After-commit delivery failures remain committed and healthy.

No documentation, rewind, replay, durable reactive history, stable historical cell IDs, value arena, provider protocol, or storage-layout changes are included.

## Commits

### 7A — `6dd06f85b38f9e5584fea15b5d63811613b2f0fd`

`fix(runtime): transact reactive and host-input turns`

- `src/runtime/src/capability/kernel.rs`
- `src/runtime/src/capability/mod.rs`
- `src/runtime/src/runtime/capability.rs`
- `src/runtime/src/runtime/errors.rs`
- `src/runtime/src/runtime/execution.rs`
- `src/runtime/src/runtime/input_tests.rs`
- `src/runtime/src/runtime/mod.rs`
- `src/runtime/src/runtime/module.rs`
- `src/runtime/src/runtime/program_transaction.rs`
- `src/runtime/src/runtime/reactive_transaction.rs`
- `src/runtime/src/runtime/transaction.rs`

### 7B — `f34efc0315b9b017b7e506f32be48afb39279bd7`

`test(runtime): harden transactional reactive turns`

- `Cargo.lock`
- `src/runtime/Cargo.toml`
- `src/runtime/benches/reactive_transaction.rs`

### CI follow-up — `727637162d2b7cfbe0b3d08eb386c7d0079ae466`

`fix(runtime): preserve unbound host-input draining`

- `src/runtime/src/runtime/execution.rs`
- `src/runtime/src/runtime/input_tests.rs`

The context-free host-input API now validates and classifies an unbound packet
before requiring a live-program context. This preserves the existing ingress
queue recovery contract without opening a transaction or weakening bound-input
context validation. The exact native timer recovery regression and a direct
runtime no-live-program regression test both pass.

## Transaction and ownership coverage

- Capability journal: all 10 ordered-use/savepoint/cancellation/overflow cases pass.
- Pending-use kernel: all 7 limit, exclusion, non-consuming preview, fail-closed, and shared-forwarding cases pass.
- Reactive capability integration covers rollback, commit-once, explicit reservation, abort, later-turn savepoints, retryable store failure, provisional grant/use, use/revoke order, and callback non-rerun.
- Reactive coordinator: 17 passed.
- Program transaction coordinator: 18 passed.
- Host input and persistent sends: 65 passed.
- Effect boundary tests: 22 passed.
- Runtime host transaction tests: 11 passed.
- Reentrancy rejects all nested lifecycle/program operations while allowing runtime-managed staging.
- 100 implicit turns capture 0 full program checkpoints.
- The first explicit turn captures 1 outer checkpoint; 99 later turns remain at 1.
- Failed first explicit turns release ownership after complete rollback and retain ownership/baseline after incomplete rollback.
- Transaction B cannot drive transaction A's program; B's store-only work remains allowed.
- Implicit host input cannot drive an explicitly owned program.
- Owner A can run retained structural work between reactive turns, and outer abort restores the pre-turn program.

## Validation

- `mech-core --lib`: 147 passed.
- `mech-interpreter --lib`: 161 passed.
- `mech-program --lib`: 76 passed.
- `mech-program --test program`: 5 passed.
- `mech-runtime --lib`: 487 passed; 3 parent-identical macOS path failures described below.
- `module_smoke`: 235 passed.
- `generic_host`: 20 passed.
- Host crates: browser 40, console 3, scene 27, time 14, timer default 36 and native 46; CLI and robot-arm have no tests. All passed.
- `mech-wasm` `browser_project`: 26 passed.
- Minimal runtime `base` feature check: passed.
- Workspace check: passed.
- Program reactive rollback benchmark: compiles.
- Runtime program-transaction benchmark: compiles.
- Runtime reactive-transaction benchmark: compiles; all 15 test-mode cases pass.
- `git diff --check`: passed.
- No rustfmt run and no formatting-only changes.

## macOS `/var` versus `/private/var` comparison

Base: `20ecd06faf4ff5c308b3ad0e040ae71764967e6b`  
Head: `727637162d2b7cfbe0b3d08eb386c7d0079ae466`

Each exact assertion reproduces at both SHAs:

- `workspace::watch::tests::recursive_directory_watch_still_allows_descendants`
  - `src/runtime/src/workspace/watch.rs:815`
  - `assertion failed: event_allowed_by_watches(&watches, &nested_file)`
- `workspace::watch::tests::nonrecursive_directory_watch_allows_directory_and_direct_children_only`
  - `src/runtime/src/workspace/watch.rs:783`
  - `assertion failed: event_allowed_by_watches(&watches, &docs.join("main.mec"))`
- `workspace::watch::tests::target_watch_falls_back_to_existing_parent_when_target_is_deleted`
  - `src/runtime/src/workspace/watch.rs:465`
  - actual contains both `/var/.../main.mec` and `/private/var/.../main.mec`; expected contains only `/var/.../main.mec`

These are unchanged filesystem-path identity failures from the exact parent. No transaction code or path comparison was weakened to hide them.

## Commit-boundary guarantees

- Failed turns do not consume live capability uses.
- Pending live capability uses transfer exactly once at commit.
- Retryable store failures retain reservations without rerunning reactive callbacks.
- No successful compact journal is persisted.
- No successful pre-store cleanup leaves partial reactive/runtime state.
- No post-store failure invokes compact or runtime rollback.
- Persistent sends remain staged until the existing transaction reaches after-commit delivery.

## CI

All eight required jobs pass on `727637162d2b7cfbe0b3d08eb386c7d0079ae466`:

- `cargo`: passed (6m15s)
- `Cargo language tests`: passed (6m03s)
- `Cargo runtime and host tests`: passed (8m19s)
- `Dynamic modules`: passed (2m52s)
- `Project native`: passed (5m12s)
- `Project browser`: passed (7m49s)
- `Run-only CLI`: passed (2m50s)
- `Windows CLI`: passed (6m42s)
