### PR TITLE
feat(runtime): enforce integrity constraints transactionally

### DIFF
--- a/docs/runtime/integrity-constraints.md
+++ b/docs/runtime/integrity-constraints.md
@@ -1,0 +1,59 @@
+# Transactional integrity constraints
+
+Mech’s named constraint syntax (`name! := expression`) defines a live
+integrity constraint. Constraints inspect the settled candidate state after
+reactive propagation and register writes, but before that state is published.
+
+Only scalar Boolean `true` passes. Boolean `false`, non-Boolean results, and
+an unreadable settled result reject the operation. The program evaluates every
+retained constraint and reports all failures in deterministic interpreter and
+constraint order.
+
+An invalid operation is restored through the same compact program journal and
+runtime transaction savepoint used for other execution failures. External
+effects are still provisional at validation time, so controller commands,
+console or browser output, provider writes, and after-commit delivery cannot
+observe invalid state.
+
+Explicit transactions retain earlier valid provisional operations when a
+later operation violates a constraint. The invalid suffix is removed, the
+transaction remains open, and the caller may repair the candidate or abort.
+The runtime revalidates the retained program immediately before a final
+explicit commit; a failed final check leaves the transaction active and does
+not claim that rollback occurred.
+
+After a successful operation rollback, the runtime emits
+`:program/integrity-constraint/violated` through the immediate audit path.
+Its payload is detached: it contains stable names, expressions, kinds, and
+attempted values, never live cells or addresses. General `ProgramFailed` and
+module-failure events remain available as well.
+
+Integrity enforcement has no warning mode, ignore flag, or debug bypass.
+Bytecode constraint metadata is deliberately unsupported in this change, so
+`mech test` requires source input for named constraints.
+
+## Minimal source example
+
+See [`examples/transactional-integrity`](../../examples/transactional-integrity/)
+for a declaration-only program with an initial target of 90, a maximum of 120,
+and one named integrity constraint. Running the source evaluates that valid
+initial candidate once. It does not inject host inputs or deliver receiver
+commands.
+
+## Automated end-to-end transaction proof
+
+The runtime acceptance test exercises the complete `100 → 150 → 110` flow:
+
+- `100` stages, prepares, commits, and delivers a receiver effect;
+- `150` reaches receiver staging, then fails the Mech integrity constraint and
+  is aborted before effect preparation, durable store commit, delivery, or
+  committed capability accounting;
+- `110` commits and delivers afterward, proving the runtime remains healthy.
+
+Run the focused proof with:
+
+```sh
+cargo test -p mech-runtime \
+  integrity_invalid_host_input_aborts_staged_receiver_before_commit \
+  -- --nocapture
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ Read about progress on our [blog](https://mech-lang.org/blog/), follow us on Twi
 
 - analog-clock - A maintained native/browser project using time, console, and scene hosts.
 - browser-dom-demo - A static browser bundle demonstrating browser DOM grants.
+- transactional-integrity - An integrity-constraint declaration example.
 - aspirational - These programs don't yet work, but they will eventually once missing features are implemented.
 - working - These programs are functional and demonstrate features that are implemented so far.
 

--- a/examples/README.mec
+++ b/examples/README.mec
@@ -25,6 +25,12 @@ examples/analog-clock/
 examples/browser-dom-demo/
 ```
 
+Integrity-constraint declaration examples include:
+
+```text
+examples/transactional-integrity/
+```
+
 Robot arm examples live with the host crate:
 
 ```text

--- a/examples/transactional-integrity/README.md
+++ b/examples/transactional-integrity/README.md
@@ -1,0 +1,18 @@
+# Integrity-constraint declaration example
+
+This source is a minimal declaration example. Running it evaluates one valid
+initial candidate with a controller target of `90`, a maximum target of `120`,
+and a named integrity constraint.
+
+Run it with:
+
+```sh
+mech run examples/transactional-integrity/main.mec
+```
+
+The command evaluates the declaration once. It does not inject host inputs or
+deliver a receiver command.
+
+The complete host-input, staged-receiver, rollback, and recovery path is
+covered by the runtime acceptance test
+`integrity_invalid_host_input_aborts_staged_receiver_before_commit`.

--- a/examples/transactional-integrity/main.mec
+++ b/examples/transactional-integrity/main.mec
@@ -1,0 +1,5 @@
+target := 90.0
+maximum-target := 120.0
+
+candidate-controller-command := target
+safe-target! := candidate-controller-command <= maximum-target

--- a/src/cli/diagnostics.rs
+++ b/src/cli/diagnostics.rs
@@ -1,6 +1,10 @@
 use ariadne::{Color, Label, Report, ReportKind, sources};
 use mech_core::*;
 use mech_syntax::ParserErrorReport;
+#[cfg(feature = "invariant_define")]
+use mech_program::{
+    IntegrityConstraintFailureReason, IntegrityConstraintViolationSet,
+};
 
 use crate::WatchPathFailed;
 
@@ -37,6 +41,10 @@ fn source_range_to_offset_range(file_content: &str, range: &SourceRange) -> (usi
 }
 
 pub(crate) fn print_mech_error(err: &MechError) {
+    if let Some(rendered) = format_integrity_constraint_error(err) {
+        println!("{rendered}");
+        return;
+    }
     if let Some(watch_error) = err.kind_as::<WatchPathFailed>() {
         let src_file_path = watch_error.file_path.to_string();
         match &err.source {
@@ -105,5 +113,90 @@ pub(crate) fn print_mech_error(err: &MechError) {
     } else {
         println!("Error:");
         println!("{:#?}", err);
+    }
+}
+
+#[cfg(feature = "invariant_define")]
+pub(crate) fn format_integrity_constraint_error(
+    error: &MechError,
+) -> Option<String> {
+    let failures = error.kind_as::<IntegrityConstraintViolationSet>()?;
+    let mut rendered = failures
+        .violations
+        .iter()
+        .map(|violation| {
+            let reason = match violation.reason {
+                IntegrityConstraintFailureReason::EvaluatedFalse => "evaluated to false",
+                IntegrityConstraintFailureReason::ExpectedBool => "expected a scalar bool",
+                IntegrityConstraintFailureReason::BorrowConflict => {
+                    "could not read the settled constraint result"
+                }
+            };
+            let mut lines = vec![
+                format!("Integrity constraint `{}` failed", violation.name),
+                format!("  {}", violation.expression),
+                format!("  reason: {reason}"),
+            ];
+            if let Some(actual) = &violation.actual {
+                lines.push(format!("  actual: {actual}"));
+            }
+            if let Some(expected) = &violation.expected {
+                lines.push(format!("  expected: {expected}"));
+            }
+            lines.join("\n")
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    rendered.push_str(
+        "\n\nReactive turn rolled back.\nNo external effects were committed.",
+    );
+    Some(rendered)
+}
+
+#[cfg(not(feature = "invariant_define"))]
+pub(crate) fn format_integrity_constraint_error(
+    _error: &MechError,
+) -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "invariant_define")]
+    use mech_program::IntegrityConstraintViolation;
+
+    #[cfg(feature = "invariant_define")]
+    #[test]
+    fn integrity_constraint_formatter_is_structured_and_address_free() {
+        let error = MechError::new(
+            IntegrityConstraintViolationSet {
+                checked: 1,
+                violations: vec![IntegrityConstraintViolation {
+                    interpreter_id: 7,
+                    constraint_id: 11,
+                    name: "safe-target!".to_string(),
+                    expression: "target<=maximum-target".to_string(),
+                    reason: IntegrityConstraintFailureReason::EvaluatedFalse,
+                    evaluated_kind: Some(ValueKind::Bool),
+                    actual: Some("150".to_string()),
+                    operator: None,
+                    expected: Some("120".to_string()),
+                    tokens: Vec::new(),
+                }],
+            },
+            None,
+        );
+
+        let rendered = format_integrity_constraint_error(&error).unwrap();
+
+        assert!(rendered.contains("Integrity constraint `safe-target!` failed"));
+        assert!(rendered.contains("reason: evaluated to false"));
+        assert!(rendered.contains("actual: 150"));
+        assert!(rendered.contains("expected: 120"));
+        assert!(rendered.contains("Reactive turn rolled back."));
+        assert!(rendered.contains("No external effects were committed."));
+        assert!(!rendered.contains("@0x"));
+        assert!(!rendered.contains("RefCell"));
     }
 }

--- a/src/core/src/error.rs
+++ b/src/core/src/error.rs
@@ -377,30 +377,6 @@ impl MechErrorKind for IoErrorWrapper {
   }
 }
 
-#[derive(Clone, Debug)]
-pub struct InvariantViolationError {
-  pub invariant_name: String,
-  pub expression: String,
-  pub lhs_addr: Option<u64>,
-  pub lhs_value: Option<String>,
-  pub operator: Option<FormulaOperator>,
-  pub rhs_addr: Option<u64>,
-  pub rhs_value: Option<String>,
-  pub reason: String,
-  pub evaluated_kind: String,
-}
-impl MechErrorKind for InvariantViolationError {
-  fn name(&self) -> &str { "InvariantViolationError" }
-  fn message(&self) -> String {
-    let details = match (&self.lhs_addr, &self.lhs_value, &self.operator, &self.rhs_addr, &self.rhs_value) {
-      (Some(la), Some(lv), Some(op), Some(ra), Some(rv)) =>
-        format!(" | expr: {} | lhs(@{:x})={} op={:?} rhs(@{:x})={}", self.expression, la, lv, op, ra, rv),
-      _ => format!(" | expr: {}", self.expression),
-    };
-    format!("Invariant `{}` violation: {} | evaluated kind: {}{}", self.invariant_name, self.reason, self.evaluated_kind, details)
-  }
-}
-
 #[derive(Debug, Clone)]
 pub struct HttpTextDecodeFailed {
   pub url: String,

--- a/src/core/src/program/mod.rs
+++ b/src/core/src/program/mod.rs
@@ -1,9 +1,11 @@
 use crate::*;
 use std::io::Cursor;
 #[cfg(not(feature = "no_std"))]
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 #[cfg(feature = "no_std")]
 use hashbrown::HashSet;
+#[cfg(feature = "no_std")]
+use alloc::collections::BTreeMap;
 
 #[cfg(any(feature = "compiler", feature = "program"))]
 pub mod compiler;
@@ -26,26 +28,20 @@ pub type Dictionary = HashMap<u64,String>;
 pub type KindTable = HashMap<u64, ValueKind>;
 #[cfg(feature = "enum")]
 pub type EnumTable = HashMap<u64, MechEnum>;
-#[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-pub type InvariantTable = HashMap<u64, (String, ValRef)>;
-#[cfg(feature = "invariant_define")]
-pub type InvariantExpressionTable = HashMap<u64, String>;
 #[cfg(feature = "invariant_define")]
 #[derive(Clone, Debug)]
-pub struct InvariantEvaluation {
-  pub reason: String,
-  pub evaluated_kind: String,
-  pub actual: String,
-  pub expected: String,
-}
-#[cfg(feature = "invariant_define")]
-pub type InvariantEvaluationTable = HashMap<u64, InvariantEvaluation>;
-#[cfg(feature = "invariant_define")]
-#[derive(Clone, Debug)]
-pub struct InvariantViolation {
+pub struct IntegrityConstraint {
   pub id: u64,
-  pub error: MechError,
+  pub name: String,
+  pub expression: String,
+  pub result: ValRef,
+  pub lhs: Option<ValRef>,
+  pub operator: Option<FormulaOperator>,
+  pub rhs: Option<ValRef>,
+  pub tokens: Vec<Token>,
 }
+#[cfg(feature = "invariant_define")]
+pub type IntegrityConstraintTable = BTreeMap<u64, IntegrityConstraint>;
 
 pub struct ProgramState {
   #[cfg(feature = "symbol_table")]
@@ -59,14 +55,8 @@ pub struct ProgramState {
   pub kinds: KindTable,
   #[cfg(feature = "enum")]
   pub enums: EnumTable,
-  #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-  pub invariants: InvariantTable,
   #[cfg(feature = "invariant_define")]
-  pub invariant_violations: Vec<InvariantViolation>,
-  #[cfg(feature = "invariant_define")]
-  pub invariant_expressions: InvariantExpressionTable,
-  #[cfg(feature = "invariant_define")]
-  pub invariant_evaluations: InvariantEvaluationTable,
+  pub integrity_constraints: IntegrityConstraintTable,
   pub dictionary: Ref<Dictionary>,
 }
 
@@ -84,14 +74,8 @@ impl Clone for ProgramState {
       kinds: self.kinds.clone(),
       #[cfg(feature = "enum")]
       enums: self.enums.clone(),
-      #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-      invariants: self.invariants.clone(),
       #[cfg(feature = "invariant_define")]
-      invariant_violations: self.invariant_violations.clone(),
-      #[cfg(feature = "invariant_define")]
-      invariant_expressions: self.invariant_expressions.clone(),
-      #[cfg(feature = "invariant_define")]
-      invariant_evaluations: self.invariant_evaluations.clone(),
+      integrity_constraints: self.integrity_constraints.clone(),
       dictionary: self.dictionary.clone(),
     }
   }
@@ -111,14 +95,8 @@ impl ProgramState {
       kinds: KindTable::new(),
       #[cfg(feature = "enum")]
       enums: EnumTable::new(),
-      #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-      invariants: InvariantTable::new(),
       #[cfg(feature = "invariant_define")]
-      invariant_violations: vec![],
-      #[cfg(feature = "invariant_define")]
-      invariant_expressions: InvariantExpressionTable::new(),
-      #[cfg(feature = "invariant_define")]
-      invariant_evaluations: InvariantEvaluationTable::new(),
+      integrity_constraints: IntegrityConstraintTable::new(),
       dictionary: Ref::new(Dictionary::new()),
     }
   }

--- a/src/interpreter/src/interpreter.rs
+++ b/src/interpreter/src/interpreter.rs
@@ -368,14 +368,8 @@ struct ProgramStateCheckpoint {
   enums: EnumTable,
   #[cfg(feature = "enum")]
   enum_dictionaries: Vec<RefPayloadCheckpoint<Dictionary>>,
-  #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-  invariants: InvariantTable,
   #[cfg(feature = "invariant_define")]
-  invariant_violations: Vec<InvariantViolation>,
-  #[cfg(feature = "invariant_define")]
-  invariant_expressions: InvariantExpressionTable,
-  #[cfg(feature = "invariant_define")]
-  invariant_evaluations: InvariantEvaluationTable,
+  integrity_constraints: IntegrityConstraintTable,
   dictionary: RefPayloadCheckpoint<Dictionary>,
 }
 
@@ -442,9 +436,15 @@ impl ProgramStateCheckpoint {
       }
     }
 
-    #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-    for (_, value) in state.invariants.values() {
-      journal.capture_val_ref(value)?;
+    #[cfg(feature = "invariant_define")]
+    for constraint in state.integrity_constraints.values() {
+      journal.capture_val_ref(&constraint.result)?;
+      if let Some(lhs) = &constraint.lhs {
+        journal.capture_val_ref(lhs)?;
+      }
+      if let Some(rhs) = &constraint.rhs {
+        journal.capture_val_ref(rhs)?;
+      }
     }
 
     Ok(Self {
@@ -466,14 +466,8 @@ impl ProgramStateCheckpoint {
       enums,
       #[cfg(feature = "enum")]
       enum_dictionaries,
-      #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-      invariants: state.invariants.clone(),
       #[cfg(feature = "invariant_define")]
-      invariant_violations: state.invariant_violations.clone(),
-      #[cfg(feature = "invariant_define")]
-      invariant_expressions: state.invariant_expressions.clone(),
-      #[cfg(feature = "invariant_define")]
-      invariant_evaluations: state.invariant_evaluations.clone(),
+      integrity_constraints: state.integrity_constraints.clone(),
       dictionary: RefPayloadCheckpoint::capture(&state.dictionary, interpreter_id)?,
     })
   }
@@ -518,15 +512,9 @@ impl ProgramStateCheckpoint {
       {
         state.enums = self.enums.clone();
       }
-      #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-      {
-        state.invariants = self.invariants.clone();
-      }
       #[cfg(feature = "invariant_define")]
       {
-        state.invariant_violations = self.invariant_violations.clone();
-        state.invariant_expressions = self.invariant_expressions.clone();
-        state.invariant_evaluations = self.invariant_evaluations.clone();
+        state.integrity_constraints = self.integrity_constraints.clone();
       }
       state.dictionary = self.dictionary.target.clone();
     }
@@ -2145,34 +2133,28 @@ mod checkpoint_tests {
       );
     }
     #[cfg(feature = "invariant_define")]
+    let invariant_result = Ref::new(Value::Bool(Ref::new(true)));
+    #[cfg(feature = "invariant_define")]
+    let invariant_rhs = Ref::new(Value::F64(Ref::new(2.0)));
+    #[cfg(feature = "invariant_define")]
     {
       let invariant_id = hash_str("checkpoint-invariant");
-      let invariant_value = Ref::new(Value::Bool(Ref::new(true)));
       let mut state = root.state.borrow_mut();
-      state
-        .invariants
-        .insert(invariant_id, ("checkpoint invariant".to_string(), invariant_value));
-      state
-        .invariant_expressions
-        .insert(invariant_id, "value == true".to_string());
-      state.invariant_evaluations.insert(
+      state.integrity_constraints.insert(
         invariant_id,
-        InvariantEvaluation {
-          reason: "checkpoint reason".to_string(),
-          evaluated_kind: "bool".to_string(),
-          actual: "true".to_string(),
-          expected: "true".to_string(),
+        IntegrityConstraint {
+          id: invariant_id,
+          name: "checkpoint invariant".to_string(),
+          expression: "kept <= 2.0".to_string(),
+          result: invariant_result.clone(),
+          lhs: Some(symbol_cell.clone()),
+          operator: Some(FormulaOperator::Comparison(
+            ComparisonOp::LessThanEqual,
+          )),
+          rhs: Some(invariant_rhs.clone()),
+          tokens: Vec::new(),
         },
       );
-      state.invariant_violations.push(InvariantViolation {
-        id: invariant_id,
-        error: MechError::new(
-          GenericError {
-            msg: "checkpoint violation".to_string(),
-          },
-          None,
-        ),
-      });
     }
 
     let state_address = root.state.addr();
@@ -2243,6 +2225,15 @@ mod checkpoint_tests {
     *symbol_backing.borrow_mut() = 11.0;
     *child_backing.borrow_mut() = 21.0;
     *grandchild_backing.borrow_mut() = 31.0;
+    #[cfg(feature = "invariant_define")]
+    {
+      if let Value::Bool(value) = &*invariant_result.borrow() {
+        *value.borrow_mut() = false;
+      }
+      if let Value::F64(value) = &*invariant_rhs.borrow() {
+        *value.borrow_mut() = 99.0;
+      }
+    }
 
     let removed_child = root
       .sub_interpreters
@@ -2331,21 +2322,28 @@ mod checkpoint_tests {
     {
       let state = root.state.borrow();
       let invariant_id = hash_str("checkpoint-invariant");
-      assert!(state.invariants.contains_key(&invariant_id));
+      let constraint = state.integrity_constraints.get(&invariant_id).unwrap();
+      assert_eq!(constraint.id, invariant_id);
+      assert_eq!(constraint.name, "checkpoint invariant");
+      assert_eq!(constraint.expression, "kept <= 2.0");
       assert_eq!(
-        state.invariant_expressions.get(&invariant_id).unwrap(),
-        "value == true",
+        constraint.operator,
+        Some(FormulaOperator::Comparison(
+          ComparisonOp::LessThanEqual,
+        )),
       );
-      assert_eq!(
-        state
-          .invariant_evaluations
-          .get(&invariant_id)
-          .unwrap()
-          .reason,
-        "checkpoint reason",
-      );
-      assert_eq!(state.invariant_violations.len(), 1);
-      assert_eq!(state.invariant_violations[0].id, invariant_id);
+      assert_eq!(constraint.result.addr(), invariant_result.addr());
+      assert_eq!(constraint.rhs.as_ref().unwrap().addr(), invariant_rhs.addr());
+      if let Value::Bool(value) = &*constraint.result.borrow() {
+        assert!(*value.borrow());
+      } else {
+        panic!("restored constraint result must remain bool");
+      }
+      if let Value::F64(value) = &*constraint.rhs.as_ref().unwrap().borrow() {
+        assert_eq!(*value.borrow(), 2.0);
+      } else {
+        panic!("restored constraint rhs must remain f64");
+      }
     }
     assert_eq!(root.sub_interpreters.addr(), sub_interpreters_address);
     assert_eq!(root.registers.len(), 1);

--- a/src/interpreter/src/statements.rs
+++ b/src/interpreter/src/statements.rs
@@ -671,69 +671,39 @@ pub fn invariant_define(inv_def: &InvariantDefine, p: &InterpreterExecution<'_>)
   }
   let plan = p.plan();
   let result = expression(&inv_def.expression, None, p)?;
-  let rhs_ref = value_to_ref(result.clone());
   let detached_result = detach_variable_value(&result);
-  {
-    let mut state_brrw = p.state.borrow_mut();
-    state_brrw.save_symbol(invariant_id, invariant_name.clone(), detached_result.clone(), false);
-    let var_define_arguments = vec![detached_result.clone(), Value::String(Ref::new(invariant_name.clone())), Value::Bool(Ref::new(false))];
-    let var_def_fxn = VarDefine{}.compile(&var_define_arguments)?;
-    plan.register_function(var_def_fxn, &[])?;
-  }
-  p.state.borrow_mut().invariant_expressions.insert(invariant_id, invariant_expression.clone());
-  #[cfg(all(feature = "invariant_define", feature = "symbol_table"))]
-  {
-    let invariant_value = {
-      let state_brrw = p.state.borrow();
-      state_brrw.get_symbol(invariant_id)
-    };
-    if let Some(invariant_value) = invariant_value {
-      p.state.borrow_mut().invariants.insert(invariant_id, (invariant_name.clone(), invariant_value));
-    }
-  }
-  let violation_error = match &result {
-    Value::Bool(b) => if *b.borrow() { None } else { Some("evaluated to false".to_string()) },
-    other => Some(format!("must evaluate to bool, got {}", other.kind())),
+  let result_ref = {
+    let state = p.state.borrow();
+    state.save_symbol(
+      invariant_id,
+      invariant_name.clone(),
+      detached_result.clone(),
+      false,
+    )
   };
-  let operand_detail = invariant_operand_refs(inv_def, p);
-  let (lhs_addr, lhs_value, operator, rhs_addr, rhs_value) = match operand_detail {
-    Some((lhs, op, rhs)) => {
-      let lhs_addr = lhs.as_ref().map(|v| v.addr() as u64);
-      let lhs_value = lhs.as_ref().map(|v| format!("{:?}", v.borrow()));
-      let rhs_addr = rhs.as_ref().map(|v| v.addr() as u64);
-      let rhs_value = rhs.as_ref().map(|v| format!("{:?}", v.borrow()));
-      (lhs_addr, lhs_value, op, rhs_addr, rhs_value)
-    }
-    None => (None, None, None, Some(rhs_ref.addr() as u64), Some(format!("{:?}", rhs_ref.borrow()))),
-  };
-  {
-    let reason = violation_error.clone().unwrap_or_else(|| "evaluated to true".to_string());
-    let actual = lhs_value.clone().unwrap_or_else(|| format!("{:?}", rhs_ref.borrow()));
-    let expected = rhs_value.clone().unwrap_or_else(|| format!("{:?}", rhs_ref.borrow()));
-    p.state.borrow_mut().invariant_evaluations.insert(invariant_id, InvariantEvaluation {
-      reason,
-      evaluated_kind: result.kind().to_string(),
-      actual,
-      expected,
-    });
-  }
-  if let Some(error) = violation_error {
-    let err = MechError::new(
-      InvariantViolationError{
-        invariant_name: invariant_name.clone(),
-        expression: invariant_expression,
-        lhs_addr,
-        lhs_value,
-        operator,
-        rhs_addr,
-        rhs_value,
-        reason: error,
-        evaluated_kind: result.kind().to_string(),
-      },
-      None
-    ).with_compiler_loc().with_tokens(inv_def.expression.tokens());
-    p.state.borrow_mut().invariant_violations.push(InvariantViolation { id: invariant_id, error: err });
-  }
+
+  let var_define_arguments = vec![
+    detached_result,
+    Value::String(Ref::new(invariant_name.clone())),
+    Value::Bool(Ref::new(false)),
+  ];
+  let var_def_fxn = VarDefine{}.compile(&var_define_arguments)?;
+  plan.register_function(var_def_fxn, &[])?;
+
+  let (lhs, operator, rhs) = integrity_constraint_operands(inv_def, p);
+  p.state.borrow_mut().integrity_constraints.insert(
+    invariant_id,
+    IntegrityConstraint {
+      id: invariant_id,
+      name: invariant_name,
+      expression: invariant_expression,
+      result: result_ref,
+      lhs,
+      operator,
+      rhs,
+      tokens: inv_def.expression.tokens(),
+    },
+  );
   Ok(result)
 }
 
@@ -751,19 +721,74 @@ fn value_to_ref(value: Value) -> ValRef {
 }
 
 #[cfg(feature = "invariant_define")]
-fn invariant_operand_refs(inv_def: &InvariantDefine, p: &InterpreterExecution<'_>) -> Option<(Option<ValRef>, Option<FormulaOperator>, Option<ValRef>)> {
+fn integrity_constraint_operands(
+  inv_def: &InvariantDefine,
+  p: &InterpreterExecution<'_>,
+) -> (Option<ValRef>, Option<FormulaOperator>, Option<ValRef>) {
   let factor = match &inv_def.expression {
-    Expression::Formula(f) => f,
+    Expression::Formula(factor) => factor,
+    _ => return (None, None, None),
+  };
+  let term = match transparent_factor(factor) {
+    Factor::Term(term) => term,
+    _ => return (None, None, None),
+  };
+  if term.rhs.len() != 1 {
+    return (None, None, None);
+  }
+  let (operator, rhs_factor) = &term.rhs[0];
+  if !matches!(
+    operator,
+    FormulaOperator::Comparison(
+      ComparisonOp::Equal
+        | ComparisonOp::NotEqual
+        | ComparisonOp::LessThan
+        | ComparisonOp::LessThanEqual
+        | ComparisonOp::GreaterThan
+        | ComparisonOp::GreaterThanEqual
+    )
+  ) {
+    return (None, None, None);
+  }
+  (
+    integrity_constraint_operand(&term.lhs, p),
+    Some(operator.clone()),
+    integrity_constraint_operand(rhs_factor, p),
+  )
+}
+
+#[cfg(feature = "invariant_define")]
+fn transparent_factor(factor: &Factor) -> &Factor {
+  match factor {
+    Factor::Parenthetical(inner) => transparent_factor(inner),
+    Factor::Term(term) if term.rhs.is_empty() => transparent_factor(&term.lhs),
+    other => other,
+  }
+}
+
+#[cfg(feature = "invariant_define")]
+fn integrity_constraint_operand(
+  factor: &Factor,
+  p: &InterpreterExecution<'_>,
+) -> Option<ValRef> {
+  let expression = match transparent_factor(factor) {
+    Factor::Expression(expression) => expression.as_ref(),
     _ => return None,
   };
-  let term = match factor {
-    Factor::Term(t) => t,
-    _ => return None,
-  };
-  let (op, rhs_factor) = term.rhs.first()?;
-  let lhs_value = expression(&Expression::Formula(term.lhs.clone()), None, p).ok().map(value_to_ref);
-  let rhs_value = expression(&Expression::Formula(rhs_factor.clone()), None, p).ok().map(value_to_ref);
-  Some((lhs_value, Some(op.clone()), rhs_value))
+  match expression {
+    Expression::Var(var) if var.context.is_none() && var.kind.is_none() => {
+      p.state.borrow().get_symbol(var.name.hash())
+    }
+    Expression::Literal(
+      literal_node @ (
+        Literal::Atom(_)
+        | Literal::Boolean(_)
+        | Literal::Number(_)
+        | Literal::String(_)
+      ),
+    ) => literal(literal_node, p).ok().map(value_to_ref),
+    _ => None,
+  }
 }
 
 #[cfg(all(feature = "enum", feature = "atom"))]

--- a/src/program/Cargo.toml
+++ b/src/program/Cargo.toml
@@ -202,3 +202,8 @@ required-features = ["baselib", "program", "compiler"]
 name = "reactive_turn_rollback"
 harness = false
 required-features = ["baselib", "program", "compiler"]
+
+[[bench]]
+name = "integrity_constraints"
+harness = false
+required-features = ["baselib", "program", "compiler", "invariant_define"]

--- a/src/program/benches/integrity_constraints.rs
+++ b/src/program/benches/integrity_constraints.rs
@@ -1,0 +1,77 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use mech_program::{MechProgram, MechProgramConfig};
+use std::hint::black_box;
+
+fn program(source: &str) -> MechProgram {
+  let mut program = MechProgram::new(MechProgramConfig::default());
+  if !source.is_empty() {
+    program.run_string(source).unwrap();
+  }
+  program
+}
+
+fn passing_constraints(count: usize) -> String {
+  (0..count)
+    .map(|index| {
+      format!("integrity-{index}! := {index}.0 <= {index}.0")
+    })
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn failing_constraints(count: usize) -> String {
+  (0..count)
+    .map(|index| {
+      format!("integrity-{index}! := {}.0 < {index}.0", index + 1)
+    })
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn integrity_constraint_benchmarks(c: &mut Criterion) {
+  let zero = program("");
+  c.bench_function("integrity_constraints/zero", |b| {
+    b.iter(|| {
+      black_box(zero.integrity_constraint_report().unwrap())
+    })
+  });
+
+  let one = program(&passing_constraints(1));
+  c.bench_function("integrity_constraints/one_passing", |b| {
+    b.iter(|| {
+      black_box(one.validate_integrity_constraints().unwrap())
+    })
+  });
+
+  let hundred = program(&passing_constraints(100));
+  c.bench_function("integrity_constraints/one_hundred_passing", |b| {
+    b.iter(|| {
+      black_box(hundred.validate_integrity_constraints().unwrap())
+    })
+  });
+
+  let one_failed = program(&failing_constraints(1));
+  c.bench_function("integrity_constraints/one_failed", |b| {
+    b.iter(|| {
+      black_box(
+        one_failed
+          .validate_integrity_constraints()
+          .unwrap_err(),
+      )
+    })
+  });
+
+  let ten_failed = program(&failing_constraints(10));
+  c.bench_function("integrity_constraints/ten_failed_aggregated", |b| {
+    b.iter(|| {
+      black_box(
+        ten_failed
+          .validate_integrity_constraints()
+          .unwrap_err(),
+      )
+    })
+  });
+}
+
+criterion_group!(benches, integrity_constraint_benchmarks);
+criterion_main!(benches);

--- a/src/program/src/integrity.rs
+++ b/src/program/src/integrity.rs
@@ -1,0 +1,1103 @@
+use crate::MechProgram;
+use mech_core::*;
+use mech_interpreter::{Interpreter, InterpreterRef};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IntegrityConstraintFailureReason {
+  EvaluatedFalse,
+  ExpectedBool,
+  BorrowConflict,
+}
+
+#[derive(Clone, Debug)]
+pub struct IntegrityConstraintEvaluation {
+  pub interpreter_id: u64,
+  pub constraint_id: u64,
+  pub name: String,
+  pub expression: String,
+  pub passed: bool,
+  pub reason: Option<IntegrityConstraintFailureReason>,
+  pub evaluated_kind: Option<ValueKind>,
+  pub actual: Option<String>,
+  pub operator: Option<FormulaOperator>,
+  pub expected: Option<String>,
+  pub tokens: Vec<Token>,
+}
+
+#[derive(Clone, Debug)]
+pub struct IntegrityConstraintViolation {
+  pub interpreter_id: u64,
+  pub constraint_id: u64,
+  pub name: String,
+  pub expression: String,
+  pub reason: IntegrityConstraintFailureReason,
+  pub evaluated_kind: Option<ValueKind>,
+  pub actual: Option<String>,
+  pub operator: Option<FormulaOperator>,
+  pub expected: Option<String>,
+  pub tokens: Vec<Token>,
+}
+
+#[derive(Clone, Debug)]
+pub struct IntegrityConstraintReport {
+  pub checked: usize,
+  pub evaluations: Vec<IntegrityConstraintEvaluation>,
+  pub violations: Vec<IntegrityConstraintViolation>,
+}
+
+#[derive(Clone, Debug)]
+pub struct IntegrityConstraintViolationSet {
+  pub checked: usize,
+  pub violations: Vec<IntegrityConstraintViolation>,
+}
+
+impl MechErrorKind for IntegrityConstraintViolationSet {
+  fn name(&self) -> &str {
+    "IntegrityConstraintViolationSet"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "{} integrity constraint{} failed out of {} checked.",
+      self.violations.len(),
+      if self.violations.len() == 1 { "" } else { "s" },
+      self.checked,
+    )
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntegrityConstraintHierarchyConflict {
+  pub interpreter_id: u64,
+}
+
+impl MechErrorKind for IntegrityConstraintHierarchyConflict {
+  fn name(&self) -> &str {
+    "IntegrityConstraintHierarchyConflict"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Interpreter {} appears more than once in the integrity-constraint hierarchy.",
+      self.interpreter_id,
+    )
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntegrityConstraintRegistryBorrowConflict {
+  pub interpreter_id: u64,
+  pub registry: &'static str,
+}
+
+impl MechErrorKind for IntegrityConstraintRegistryBorrowConflict {
+  fn name(&self) -> &str {
+    "IntegrityConstraintRegistryBorrowConflict"
+  }
+
+  fn message(&self) -> String {
+    format!(
+      "Cannot read the {} registry for interpreter {} while validating integrity constraints.",
+      self.registry,
+      self.interpreter_id,
+    )
+  }
+}
+
+struct ResolvedIntegrityValue {
+  kind: ValueKind,
+  scalar_bool: Option<bool>,
+  formatted: String,
+}
+
+impl MechProgram {
+  pub fn integrity_constraint_report(
+    &self,
+  ) -> MResult<IntegrityConstraintReport> {
+    let mut evaluations = Vec::new();
+    let mut visited = Vec::new();
+    collect_interpreter_constraints(
+      self.interpreter(),
+      None,
+      &mut visited,
+      &mut evaluations,
+    )?;
+    evaluations.sort_by_key(|evaluation| {
+      (evaluation.interpreter_id, evaluation.constraint_id)
+    });
+    let violations = evaluations
+      .iter()
+      .filter_map(|evaluation| {
+        let reason = evaluation.reason.clone()?;
+        Some(IntegrityConstraintViolation {
+          interpreter_id: evaluation.interpreter_id,
+          constraint_id: evaluation.constraint_id,
+          name: evaluation.name.clone(),
+          expression: evaluation.expression.clone(),
+          reason,
+          evaluated_kind: evaluation.evaluated_kind.clone(),
+          actual: evaluation.actual.clone(),
+          operator: evaluation.operator.clone(),
+          expected: evaluation.expected.clone(),
+          tokens: evaluation.tokens.clone(),
+        })
+      })
+      .collect::<Vec<_>>();
+    Ok(IntegrityConstraintReport {
+      checked: evaluations.len(),
+      evaluations,
+      violations,
+    })
+  }
+
+  pub fn validate_integrity_constraints(&self) -> MResult<()> {
+    let report = self.integrity_constraint_report()?;
+    if report.violations.is_empty() {
+      return Ok(());
+    }
+    let tokens = report
+      .violations
+      .iter()
+      .flat_map(|violation| violation.tokens.clone())
+      .collect::<Vec<_>>();
+    Err(MechError::new(
+      IntegrityConstraintViolationSet {
+        checked: report.checked,
+        violations: report.violations,
+      },
+      None,
+    ).with_compiler_loc().with_tokens(tokens))
+  }
+}
+
+fn collect_interpreter_constraints(
+  interpreter: &Interpreter,
+  handle: Option<&InterpreterRef>,
+  visited: &mut Vec<InterpreterRef>,
+  evaluations: &mut Vec<IntegrityConstraintEvaluation>,
+) -> MResult<()> {
+  if let Some(handle) = handle {
+    if visited.iter().any(|seen| seen.same_handle(handle)) {
+      return Err(MechError::new(
+        IntegrityConstraintHierarchyConflict {
+          interpreter_id: interpreter.id,
+        },
+        None,
+      ).with_compiler_loc());
+    }
+    visited.push(handle.clone());
+  }
+
+  let constraints = interpreter
+    .state
+    .try_borrow()
+    .map_err(|_| {
+      MechError::new(
+        IntegrityConstraintRegistryBorrowConflict {
+          interpreter_id: interpreter.id,
+          registry: "program-state",
+        },
+        None,
+      ).with_compiler_loc()
+    })?
+    .integrity_constraints
+    .values()
+    .cloned()
+    .collect::<Vec<_>>();
+  for constraint in constraints {
+    evaluations.push(evaluate_constraint(interpreter.id, &constraint));
+  }
+
+  let child_handles = interpreter
+    .sub_interpreters
+    .try_borrow()
+    .map_err(|_| {
+      MechError::new(
+        IntegrityConstraintRegistryBorrowConflict {
+          interpreter_id: interpreter.id,
+          registry: "child-interpreter",
+        },
+        None,
+      ).with_compiler_loc()
+    })?
+    .values()
+    .cloned()
+    .collect::<Vec<_>>();
+  let mut children = Vec::with_capacity(child_handles.len());
+  for child in child_handles {
+    let child_id = child
+      .try_borrow()
+      .map_err(|_| {
+        MechError::new(
+          IntegrityConstraintRegistryBorrowConflict {
+            interpreter_id: interpreter.id,
+            registry: "child-interpreter",
+          },
+          None,
+        ).with_compiler_loc()
+      })?
+      .id;
+    children.push((child_id, child));
+  }
+  children.sort_by_key(|(child_id, _)| *child_id);
+  for (_, child) in children {
+    let child_borrow = child
+      .try_borrow()
+      .map_err(|_| {
+        MechError::new(
+          IntegrityConstraintRegistryBorrowConflict {
+            interpreter_id: interpreter.id,
+            registry: "child-interpreter",
+          },
+          None,
+        ).with_compiler_loc()
+      })?;
+    collect_interpreter_constraints(
+      &child_borrow,
+      Some(&child),
+      visited,
+      evaluations,
+    )?;
+  }
+  Ok(())
+}
+
+fn evaluate_constraint(
+  interpreter_id: u64,
+  constraint: &IntegrityConstraint,
+) -> IntegrityConstraintEvaluation {
+  let resolved = constraint
+    .result
+    .try_borrow()
+    .map_err(|_| ())
+    .and_then(|value| resolve_value(&value));
+  match resolved {
+    Err(()) => constraint_evaluation(
+      interpreter_id,
+      constraint,
+      false,
+      Some(IntegrityConstraintFailureReason::BorrowConflict),
+      None,
+      None,
+      None,
+    ),
+    Ok(resolved) if resolved.scalar_bool == Some(true) => {
+      constraint_evaluation(
+        interpreter_id,
+        constraint,
+        true,
+        None,
+        Some(resolved.kind),
+        Some("true".to_string()),
+        Some("true".to_string()),
+      )
+    }
+    Ok(resolved) if resolved.scalar_bool == Some(false) => {
+      let lhs = format_operand(constraint.lhs.as_ref());
+      let rhs = format_operand(constraint.rhs.as_ref());
+      let (actual, expected) = if constraint.lhs.is_some()
+        || constraint.rhs.is_some()
+      {
+        (lhs, rhs)
+      } else {
+        (Some("false".to_string()), Some("true".to_string()))
+      };
+      constraint_evaluation(
+        interpreter_id,
+        constraint,
+        false,
+        Some(IntegrityConstraintFailureReason::EvaluatedFalse),
+        Some(resolved.kind),
+        actual,
+        expected,
+      )
+    }
+    Ok(resolved) => constraint_evaluation(
+      interpreter_id,
+      constraint,
+      false,
+      Some(IntegrityConstraintFailureReason::ExpectedBool),
+      Some(resolved.kind),
+      Some(resolved.formatted),
+      Some("scalar bool true".to_string()),
+    ),
+  }
+}
+
+fn constraint_evaluation(
+  interpreter_id: u64,
+  constraint: &IntegrityConstraint,
+  passed: bool,
+  reason: Option<IntegrityConstraintFailureReason>,
+  evaluated_kind: Option<ValueKind>,
+  actual: Option<String>,
+  expected: Option<String>,
+) -> IntegrityConstraintEvaluation {
+  IntegrityConstraintEvaluation {
+    interpreter_id,
+    constraint_id: constraint.id,
+    name: constraint.name.clone(),
+    expression: constraint.expression.clone(),
+    passed,
+    reason,
+    evaluated_kind,
+    actual,
+    operator: constraint.operator.clone(),
+    expected,
+    tokens: constraint.tokens.clone(),
+  }
+}
+
+fn format_operand(operand: Option<&ValRef>) -> Option<String> {
+  let operand = operand?;
+  let value = operand.try_borrow().ok()?;
+  resolve_value(&value).ok().map(|resolved| resolved.formatted)
+}
+
+fn resolve_value(value: &Value) -> Result<ResolvedIntegrityValue, ()> {
+  match value {
+    Value::MutableReference(reference) => {
+      let value = reference.try_borrow().map_err(|_| ())?;
+      resolve_value(&value)
+    }
+    Value::Typed(value, _) => resolve_value(value),
+    #[cfg(any(feature = "bool", feature = "variable_define"))]
+    Value::Bool(value) => {
+      let value = *value.try_borrow().map_err(|_| ())?;
+      Ok(ResolvedIntegrityValue {
+        kind: ValueKind::Bool,
+        scalar_bool: Some(value),
+        formatted: value.to_string(),
+      })
+    }
+    _ => Ok(ResolvedIntegrityValue {
+      kind: stable_value_kind(value)?,
+      scalar_bool: None,
+      formatted: stable_value_string(value)?,
+    }),
+  }
+}
+
+fn stable_value_string(value: &Value) -> Result<String, ()> {
+  match value {
+    #[cfg(feature = "u8")]
+    Value::U8(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "u16")]
+    Value::U16(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "u32")]
+    Value::U32(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "u64")]
+    Value::U64(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "u128")]
+    Value::U128(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "i8")]
+    Value::I8(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "i16")]
+    Value::I16(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "i32")]
+    Value::I32(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "i64")]
+    Value::I64(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "i128")]
+    Value::I128(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "f32")]
+    Value::F32(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "f64")]
+    Value::F64(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(any(feature = "string", feature = "variable_define"))]
+    Value::String(value) => {
+      Ok(format!("\"{}\"", value.try_borrow().map_err(|_| ())?))
+    }
+    #[cfg(feature = "complex")]
+    Value::C64(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "rational")]
+    Value::R64(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    #[cfg(feature = "atom")]
+    Value::Atom(value) => {
+      let atom = value.try_borrow().map_err(|_| ())?;
+      let dictionary = atom.0.1.try_borrow().map_err(|_| ())?;
+      let name = dictionary
+        .get(&atom.0.0)
+        .cloned()
+        .unwrap_or_else(|| atom.0.0.to_string());
+      Ok(format!(":{name}"))
+    }
+    Value::Id(value) => Ok(value.to_string()),
+    Value::Index(value) => Ok(value.try_borrow().map_err(|_| ())?.to_string()),
+    Value::Empty => Ok("_".to_string()),
+    Value::EmptyKind(kind) => Ok(format!("<{}>", kind)),
+    Value::Kind(kind) => Ok(format!("<{}>", kind)),
+    Value::IndexAll => Ok(":".to_string()),
+    _ => Ok(format!("<{}>", stable_value_kind(value)?)),
+  }
+}
+
+fn stable_value_kind(value: &Value) -> Result<ValueKind, ()> {
+  match value {
+    #[cfg(feature = "complex")]
+    Value::C64(_) => Ok(ValueKind::C64),
+    #[cfg(feature = "rational")]
+    Value::R64(_) => Ok(ValueKind::R64),
+    #[cfg(feature = "u8")]
+    Value::U8(_) => Ok(ValueKind::U8),
+    #[cfg(feature = "u16")]
+    Value::U16(_) => Ok(ValueKind::U16),
+    #[cfg(feature = "u32")]
+    Value::U32(_) => Ok(ValueKind::U32),
+    #[cfg(feature = "u64")]
+    Value::U64(_) => Ok(ValueKind::U64),
+    #[cfg(feature = "u128")]
+    Value::U128(_) => Ok(ValueKind::U128),
+    #[cfg(feature = "i8")]
+    Value::I8(_) => Ok(ValueKind::I8),
+    #[cfg(feature = "i16")]
+    Value::I16(_) => Ok(ValueKind::I16),
+    #[cfg(feature = "i32")]
+    Value::I32(_) => Ok(ValueKind::I32),
+    #[cfg(feature = "i64")]
+    Value::I64(_) => Ok(ValueKind::I64),
+    #[cfg(feature = "i128")]
+    Value::I128(_) => Ok(ValueKind::I128),
+    #[cfg(feature = "f32")]
+    Value::F32(_) => Ok(ValueKind::F32),
+    #[cfg(feature = "f64")]
+    Value::F64(_) => Ok(ValueKind::F64),
+    #[cfg(any(feature = "string", feature = "variable_define"))]
+    Value::String(_) => Ok(ValueKind::String),
+    #[cfg(any(feature = "bool", feature = "variable_define"))]
+    Value::Bool(_) => Ok(ValueKind::Bool),
+    #[cfg(feature = "atom")]
+    Value::Atom(value) => {
+      let atom = value.try_borrow().map_err(|_| ())?;
+      let dictionary = atom.0.1.try_borrow().map_err(|_| ())?;
+      let name = dictionary
+        .get(&atom.0.0)
+        .cloned()
+        .unwrap_or_else(|| atom.0.0.to_string());
+      Ok(ValueKind::Atom(atom.0.0, name))
+    }
+    #[cfg(feature = "matrix")]
+    Value::MatrixIndex(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::Index), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "bool"))]
+    Value::MatrixBool(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::Bool), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "u8"))]
+    Value::MatrixU8(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::U8), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "u16"))]
+    Value::MatrixU16(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::U16), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "u32"))]
+    Value::MatrixU32(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::U32), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "u64"))]
+    Value::MatrixU64(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::U64), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "u128"))]
+    Value::MatrixU128(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::U128), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "i8"))]
+    Value::MatrixI8(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::I8), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "i16"))]
+    Value::MatrixI16(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::I16), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "i32"))]
+    Value::MatrixI32(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::I32), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "i64"))]
+    Value::MatrixI64(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::I64), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "i128"))]
+    Value::MatrixI128(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::I128), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "f32"))]
+    Value::MatrixF32(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::F32), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "f64"))]
+    Value::MatrixF64(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::F64), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "string"))]
+    Value::MatrixString(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::String), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "rational"))]
+    Value::MatrixR64(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::R64), Vec::new()))
+    }
+    #[cfg(all(feature = "matrix", feature = "complex"))]
+    Value::MatrixC64(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::C64), Vec::new()))
+    }
+    #[cfg(feature = "matrix")]
+    Value::MatrixValue(_) => {
+      Ok(ValueKind::Matrix(Box::new(ValueKind::Any), Vec::new()))
+    }
+    #[cfg(feature = "set")]
+    Value::Set(_) => Ok(ValueKind::Set(Box::new(ValueKind::Any), None)),
+    #[cfg(feature = "map")]
+    Value::Map(_) => Ok(ValueKind::Map(
+      Box::new(ValueKind::Any),
+      Box::new(ValueKind::Any),
+    )),
+    #[cfg(feature = "record")]
+    Value::Record(_) => Ok(ValueKind::Record(Vec::new())),
+    #[cfg(feature = "table")]
+    Value::Table(_) => Ok(ValueKind::Table(Vec::new(), 0)),
+    #[cfg(feature = "tuple")]
+    Value::Tuple(_) => Ok(ValueKind::Tuple(Vec::new())),
+    #[cfg(feature = "enum")]
+    Value::Enum(value) => {
+      let enum_value = value.try_borrow().map_err(|_| ())?;
+      let dictionary = enum_value.names.try_borrow().map_err(|_| ())?;
+      let name = dictionary
+        .get(&enum_value.id)
+        .cloned()
+        .unwrap_or_else(|| enum_value.id.to_string());
+      Ok(ValueKind::Enum(enum_value.id, name))
+    }
+    Value::Id(_) => Ok(ValueKind::Id),
+    Value::Index(_) => Ok(ValueKind::Index),
+    Value::Empty => Ok(ValueKind::Empty),
+    Value::EmptyKind(kind) | Value::Kind(kind) => Ok(kind.clone()),
+    Value::IndexAll => Ok(ValueKind::Empty),
+    Value::Typed(_, kind) => Ok(kind.clone()),
+    Value::MutableReference(reference) => {
+      let value = reference.try_borrow().map_err(|_| ())?;
+      stable_value_kind(&value)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{MechProgramConfig, ProgramInputUpdate};
+  use mech_syntax::parser;
+  use std::{cell::Cell, rc::Rc};
+
+  fn program_with_constraint(source: &str) -> MechProgram {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program.run_string(source).unwrap();
+    program
+  }
+
+  fn set_constraint_result(
+    program: &MechProgram,
+    name: &str,
+    result: Value,
+  ) {
+    program
+      .interpreter()
+      .state
+      .borrow_mut()
+      .integrity_constraints
+      .get_mut(&hash_str(name))
+      .unwrap()
+      .result = Ref::new(result);
+  }
+
+  fn install_constraint_result(
+    program: &MechProgram,
+    name: &str,
+    result: Ref<bool>,
+  ) {
+    let id = hash_str(name);
+    program
+      .interpreter()
+      .state
+      .borrow_mut()
+      .integrity_constraints
+      .insert(
+        id,
+        IntegrityConstraint {
+          id,
+          name: name.to_string(),
+          expression: name.to_string(),
+          result: Ref::new(Value::Bool(result)),
+          lhs: None,
+          operator: None,
+          rhs: None,
+          tokens: Vec::new(),
+        },
+      );
+  }
+
+  #[test]
+  fn scalar_constraint_results_are_classified_without_mutation() {
+    let passing = program_with_constraint("safe! := true");
+    let report = passing.integrity_constraint_report().unwrap();
+    assert_eq!(report.checked, 1);
+    assert!(report.violations.is_empty());
+    assert!(report.evaluations[0].passed);
+
+    let false_result = program_with_constraint("safe! := false");
+    let error = false_result.validate_integrity_constraints().unwrap_err();
+    let failures = error
+      .kind_as::<IntegrityConstraintViolationSet>()
+      .unwrap();
+    assert_eq!(failures.checked, 1);
+    assert_eq!(
+      failures.violations[0].reason,
+      IntegrityConstraintFailureReason::EvaluatedFalse,
+    );
+
+    let non_bool = program_with_constraint("safe! := 42.0");
+    let failure = non_bool
+      .integrity_constraint_report()
+      .unwrap()
+      .violations
+      .remove(0);
+    assert_eq!(
+      failure.reason,
+      IntegrityConstraintFailureReason::ExpectedBool,
+    );
+    assert_eq!(failure.evaluated_kind, Some(ValueKind::F64));
+    assert_eq!(failure.actual.as_deref(), Some("42"));
+  }
+
+  #[test]
+  fn typed_and_mutable_reference_results_are_resolved() {
+    for (wrapped, passes) in [
+      (
+        Value::Typed(
+          Box::new(Value::Bool(Ref::new(true))),
+          ValueKind::Bool,
+        ),
+        true,
+      ),
+      (
+        Value::Typed(
+          Box::new(Value::Bool(Ref::new(false))),
+          ValueKind::Bool,
+        ),
+        false,
+      ),
+      (
+        Value::MutableReference(Ref::new(Value::Bool(Ref::new(true)))),
+        true,
+      ),
+      (
+        Value::MutableReference(Ref::new(Value::Bool(Ref::new(false)))),
+        false,
+      ),
+    ] {
+      let program = program_with_constraint("wrapped! := true");
+      set_constraint_result(&program, "wrapped!", wrapped);
+      let report = program.integrity_constraint_report().unwrap();
+      assert_eq!(report.checked, 1);
+      assert_eq!(report.evaluations[0].passed, passes);
+      assert_eq!(report.violations.is_empty(), passes);
+    }
+  }
+
+  #[test]
+  fn violations_are_aggregated_in_stable_constraint_order() {
+    let program = program_with_constraint(
+      "later! := false\nearlier! := 7.0\npassing! := true",
+    );
+    let report = program.integrity_constraint_report().unwrap();
+    assert_eq!(report.checked, 3);
+    assert_eq!(report.violations.len(), 2);
+    assert!(report
+      .evaluations
+      .windows(2)
+      .all(|pair| pair[0].constraint_id < pair[1].constraint_id));
+    assert!(report
+      .violations
+      .windows(2)
+      .all(|pair| pair[0].constraint_id < pair[1].constraint_id));
+  }
+
+  #[test]
+  fn hierarchy_validation_is_complete_and_keyed_by_interpreter() {
+    let mut program = program_with_constraint("shared! := false");
+    let root_id = program.interpreter().id;
+    let child_id = root_id.wrapping_add(101);
+    let grandchild_id = root_id.wrapping_add(202);
+    let mut child = Interpreter::new_with_full_stdlib(child_id);
+    child
+      .interpret(&parser::parse("shared! := false").unwrap())
+      .unwrap();
+    let mut grandchild = Interpreter::new_with_full_stdlib(grandchild_id);
+    grandchild
+      .interpret(&parser::parse("nested! := false").unwrap())
+      .unwrap();
+    child
+      .sub_interpreters
+      .borrow_mut()
+      .insert(grandchild_id, Ref::new(Box::new(grandchild)));
+    program
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(child_id, Ref::new(Box::new(child)));
+
+    let report = program.integrity_constraint_report().unwrap();
+
+    assert_eq!(report.checked, 3);
+    assert_eq!(report.violations.len(), 3);
+    assert_eq!(
+      report
+        .violations
+        .iter()
+        .map(|failure| failure.interpreter_id)
+        .collect::<Vec<_>>(),
+      vec![root_id, child_id, grandchild_id],
+    );
+    let shared_id = hash_str("shared!");
+    assert_eq!(
+      report
+        .violations
+        .iter()
+        .filter(|failure| failure.constraint_id == shared_id)
+        .count(),
+      2,
+    );
+  }
+
+  #[test]
+  fn repeated_interpreter_handle_is_an_infrastructure_error() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let child_id = program.interpreter().id.wrapping_add(1);
+    let child = Ref::new(Box::new(Interpreter::new_with_full_stdlib(
+      child_id,
+    )));
+    program
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(1, child.clone());
+    program
+      .interpreter_mut()
+      .sub_interpreters
+      .borrow_mut()
+      .insert(2, child);
+
+    let error = program.integrity_constraint_report().unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintHierarchyConflict");
+    assert!(!error.kind_message().contains("0x"));
+  }
+
+  #[test]
+  fn result_borrow_conflict_is_an_aggregated_constraint_failure() {
+    let program = program_with_constraint("safe! := true");
+    let result = program
+      .interpreter()
+      .state
+      .borrow()
+      .integrity_constraints
+      .values()
+      .next()
+      .unwrap()
+      .result
+      .clone();
+    let _borrow = result.borrow_mut();
+
+    let report = program.integrity_constraint_report().unwrap();
+
+    assert_eq!(report.violations.len(), 1);
+    assert_eq!(
+      report.violations[0].reason,
+      IntegrityConstraintFailureReason::BorrowConflict,
+    );
+    assert_eq!(report.violations[0].evaluated_kind, None);
+  }
+
+  #[test]
+  fn operand_borrow_conflict_preserves_evaluated_false_reason() {
+    let program = program_with_constraint(
+      "target := 2.0\nmaximum := 1.0\nsafe! := target <= maximum",
+    );
+    let lhs = program
+      .interpreter()
+      .state
+      .borrow()
+      .integrity_constraints
+      .get(&hash_str("safe!"))
+      .unwrap()
+      .lhs
+      .clone()
+      .unwrap();
+    let _borrow = lhs.borrow_mut();
+
+    let report = program.integrity_constraint_report().unwrap();
+
+    assert_eq!(
+      report.violations[0].reason,
+      IntegrityConstraintFailureReason::EvaluatedFalse,
+    );
+    assert_eq!(report.violations[0].actual, None);
+    assert_eq!(
+      report.violations[0].expected.as_deref(),
+      Some("1"),
+    );
+  }
+
+  #[test]
+  fn reporting_is_repeatable_and_does_not_change_program_state() {
+    let program = program_with_constraint(
+      "target := 1.0\nmaximum := 2.0\nsafe! := target <= maximum",
+    );
+    let plan_handle = program.interpreter().plan().0.id();
+    let pending_before =
+      program.interpreter().has_pending_reactive_registers();
+    let state_len = program
+      .interpreter()
+      .state
+      .borrow()
+      .integrity_constraints
+      .len();
+
+    let first = program.integrity_constraint_report().unwrap();
+    let second = program.integrity_constraint_report().unwrap();
+
+    let summary = |report: &IntegrityConstraintReport| {
+      report
+        .evaluations
+        .iter()
+        .map(|evaluation| {
+          (
+            evaluation.interpreter_id,
+            evaluation.constraint_id,
+            evaluation.passed,
+            evaluation.reason.clone(),
+            evaluation.actual.clone(),
+            evaluation.expected.clone(),
+          )
+        })
+        .collect::<Vec<_>>()
+    };
+    assert_eq!(summary(&first), summary(&second));
+    assert_eq!(program.interpreter().plan().0.id(), plan_handle);
+    assert_eq!(
+      program.interpreter().has_pending_reactive_registers(),
+      pending_before,
+    );
+    assert_eq!(
+      program
+        .interpreter()
+        .state
+        .borrow()
+        .integrity_constraints
+        .len(),
+      state_len,
+    );
+  }
+
+  struct IntegrityOperationFunction {
+    next_result: Rc<Cell<bool>>,
+    result: Ref<bool>,
+    output: Ref<usize>,
+    hidden: Ref<usize>,
+  }
+
+  impl MechFunctionImpl for IntegrityOperationFunction {
+    fn solve(&self) {
+      *self.result.borrow_mut() = self.next_result.get();
+      *self.output.borrow_mut() += 1;
+      *self.hidden.borrow_mut() += 1;
+    }
+
+    fn out(&self) -> Value {
+      Value::Bool(self.result.clone())
+    }
+
+    fn transaction_state_values(&self) -> MResult<Vec<Value>> {
+      Ok(vec![
+        Value::Bool(self.result.clone()),
+        Value::Index(self.output.clone()),
+        Value::Index(self.hidden.clone()),
+      ])
+    }
+
+    fn to_string(&self) -> String {
+      "integrity-operation".to_string()
+    }
+  }
+
+  #[cfg(feature = "compiler")]
+  impl MechFunctionCompiler for IntegrityOperationFunction {
+    fn compile(&self, _ctx: &mut CompileCtx) -> MResult<Register> {
+      Ok(0)
+    }
+  }
+
+  fn integrity_operation_function(
+    next_result: Rc<Cell<bool>>,
+    result: Ref<bool>,
+    output: Ref<usize>,
+    hidden: Ref<usize>,
+  ) -> IntegrityOperationFunction {
+    IntegrityOperationFunction {
+      next_result,
+      result,
+      output,
+      hidden,
+    }
+  }
+
+  fn assert_step_integrity_rollback(step_id: u64) {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let next_result = Rc::new(Cell::new(false));
+    let result = Ref::new(true);
+    let output = Ref::new(10usize);
+    let hidden = Ref::new(20usize);
+    program.interpreter().plan().add_function(Box::new(
+      integrity_operation_function(
+        next_result.clone(),
+        result.clone(),
+        output.clone(),
+        hidden.clone(),
+      ),
+    ));
+    install_constraint_result(&program, "step-safe!", result.clone());
+
+    let error = program.step(step_id).unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert_eq!(
+      (*result.borrow(), *output.borrow(), *hidden.borrow()),
+      (true, 10, 20),
+    );
+    next_result.set(true);
+    program.step(step_id).unwrap();
+    assert_eq!(
+      (*result.borrow(), *output.borrow(), *hidden.borrow()),
+      (true, 11, 21),
+    );
+  }
+
+  #[test]
+  fn whole_plan_step_rolls_back_an_invalid_candidate() {
+    assert_step_integrity_rollback(0);
+  }
+
+  #[test]
+  fn selected_step_rolls_back_an_invalid_candidate() {
+    assert_step_integrity_rollback(1);
+  }
+
+  #[test]
+  fn advance_reactive_turn_rolls_back_an_invalid_candidate() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let interpreter_id = program.interpreter().id;
+    let trigger = Ref::new(0usize);
+    let next_result = Rc::new(Cell::new(false));
+    let result = Ref::new(true);
+    let output = Ref::new(10usize);
+    let hidden = Ref::new(20usize);
+    program
+      .interpreter()
+      .plan()
+      .0
+      .borrow_mut()
+      .register(
+        Box::new(integrity_operation_function(
+          next_result.clone(),
+          result.clone(),
+          output.clone(),
+          hidden.clone(),
+        )),
+        &[Value::Index(trigger.clone())],
+      )
+      .unwrap();
+    install_constraint_result(&program, "advance-safe!", result.clone());
+    let dirty_cells = Value::Index(trigger).reactive_root_cell_ids();
+
+    let error = program
+      .advance_reactive_turn(interpreter_id, &dirty_cells)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert_eq!(
+      (*result.borrow(), *output.borrow(), *hidden.borrow()),
+      (true, 10, 20),
+    );
+    assert!(!program.interpreter().has_pending_reactive_registers());
+    next_result.set(true);
+    program
+      .advance_reactive_turn(interpreter_id, &dirty_cells)
+      .unwrap();
+    assert_eq!(
+      (*result.borrow(), *output.borrow(), *hidden.borrow()),
+      (true, 11, 21),
+    );
+  }
+
+  #[test]
+  fn invalid_reactive_candidate_rolls_back_and_later_valid_turn_succeeds() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    let interpreter_id = program.interpreter().id;
+    let input = program
+      .ensure_input(
+        interpreter_id,
+        hash_str("input"),
+        "input",
+        Value::F64(Ref::new(1.0)),
+      )
+      .unwrap();
+    program
+      .run_string("output := input * 2.0\nsafe! := output <= 10.0")
+      .unwrap();
+
+    let error = program
+      .update_inputs_and_advance_turn(&[ProgramInputUpdate {
+        input,
+        value: Value::F64(Ref::new(6.0)),
+      }])
+      .unwrap_err();
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert_eq!(
+      *program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("input"))
+        .unwrap()
+        .borrow()
+        .as_f64()
+        .unwrap()
+        .borrow(),
+      1.0,
+    );
+    assert_eq!(
+      *program
+        .interpreter()
+        .symbols()
+        .borrow()
+        .get(hash_str("output"))
+        .unwrap()
+        .borrow()
+        .as_f64()
+        .unwrap()
+        .borrow(),
+      2.0,
+    );
+    program.validate_integrity_constraints().unwrap();
+
+    program
+      .update_inputs_and_advance_turn(&[ProgramInputUpdate {
+        input,
+        value: Value::F64(Ref::new(4.0)),
+      }])
+      .unwrap();
+    program.validate_integrity_constraints().unwrap();
+  }
+}

--- a/src/program/src/lib.rs
+++ b/src/program/src/lib.rs
@@ -13,6 +13,8 @@ pub use mech_interpreter::ExecutionServicesBorrowConflict;
 
 #[cfg(feature = "program")]
 pub mod program;
+#[cfg(feature = "invariant_define")]
+pub mod integrity;
 #[cfg(feature = "native")]
 pub mod native;
 //#[cfg(feature = "runloop")]
@@ -22,6 +24,8 @@ pub mod native;
 
 #[cfg(feature = "program")]
 pub use crate::program::*;
+#[cfg(feature = "invariant_define")]
+pub use crate::integrity::*;
 #[cfg(feature = "native")]
 pub use crate::native::*;
 //#[cfg(feature = "runloop")]

--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -1479,6 +1479,102 @@ mod tests {
   use super::*;
   use mech_core::Ref;
 
+  #[cfg(feature = "invariant_define")]
+  fn constraint<'a>(
+    program: &'a MechProgram,
+    name: &str,
+  ) -> mech_core::IntegrityConstraint {
+    program
+      .interpreter()
+      .state
+      .borrow()
+      .integrity_constraints
+      .get(&hash_str(name))
+      .unwrap()
+      .clone()
+  }
+
+  #[cfg(feature = "invariant_define")]
+  #[test]
+  fn integrity_constraint_declarations_create_live_descriptors_without_enforcement() {
+    for (name, expression) in [
+      ("true!", "1.0 <= 2.0"),
+      ("false!", "2.0 <= 1.0"),
+      ("number!", "42.0"),
+    ] {
+      let mut program = MechProgram::new(MechProgramConfig::default());
+      program
+        .run_string(&format!("{name} := {expression}"))
+        .unwrap();
+      let descriptor = constraint(&program, name);
+      assert_eq!(descriptor.id, hash_str(name));
+      assert_eq!(descriptor.name, name);
+      assert!(!descriptor.expression.is_empty());
+      assert!(!descriptor.tokens.is_empty());
+      assert_eq!(
+        program
+          .interpreter()
+          .state
+          .borrow()
+          .integrity_constraints
+          .len(),
+        1,
+      );
+    }
+  }
+
+  #[cfg(feature = "invariant_define")]
+  #[test]
+  fn integrity_constraint_direct_operands_remain_live() {
+    let mut program = MechProgram::new(MechProgramConfig::default());
+    program
+      .run_string("target := 1.0\nmaximum := 2.0\nsafe! := target <= maximum")
+      .unwrap();
+
+    let descriptor = constraint(&program, "safe!");
+    let target = program
+      .interpreter()
+      .symbols()
+      .borrow()
+      .get(hash_str("target"))
+      .unwrap();
+    assert_eq!(descriptor.lhs.as_ref().unwrap().addr(), target.addr());
+    assert!(descriptor.rhs.is_some());
+    if let Value::F64(value) = &*target.borrow() {
+      *value.borrow_mut() = 3.0;
+    } else {
+      panic!("target must be f64");
+    }
+    if let Value::F64(value) = &*descriptor.lhs.unwrap().borrow() {
+      assert_eq!(*value.borrow(), 3.0);
+    } else {
+      panic!("captured lhs must remain the target cell");
+    }
+  }
+
+  #[cfg(feature = "invariant_define")]
+  #[test]
+  fn integrity_constraint_diagnostics_do_not_recompile_complex_operands() {
+    let source = "target := 1.0\nmaximum := 3.0";
+    let expression = "target + 1.0 <= maximum";
+    let mut ordinary = MechProgram::new(MechProgramConfig::default());
+    ordinary
+      .run_string(&format!("{source}\ncandidate := {expression}"))
+      .unwrap();
+    let ordinary_plan_len = ordinary.interpreter().plan_len();
+
+    let mut constrained = MechProgram::new(MechProgramConfig::default());
+    constrained
+      .run_string(&format!("{source}\nsafe! := {expression}"))
+      .unwrap();
+    let descriptor = constraint(&constrained, "safe!");
+
+    assert_eq!(constrained.interpreter().plan_len(), ordinary_plan_len);
+    assert!(descriptor.lhs.is_none());
+    assert!(descriptor.operator.is_some());
+    assert!(descriptor.rhs.is_some());
+  }
+
   fn program_with_nested_interpreter(nested_id: u64, child_id: u64) -> MechProgram {
     let mut program = MechProgram::new(MechProgramConfig::default());
     let mut child = program.interpreter().clone();

--- a/src/program/src/program.rs
+++ b/src/program/src/program.rs
@@ -841,23 +841,33 @@ impl MechProgram {
         services,
       );
       match execution {
-        Ok(()) => match finalize() {
-          ProgramTurnFinalization::Commit => {
-            journal.commit();
-            Ok(())
-          }
-          ProgramTurnFinalization::Rollback(error) => {
-            self.finish_failed_reactive_operation(
+        Ok(()) => {
+          #[cfg(feature = "invariant_define")]
+          if let Err(error) = self.validate_integrity_constraints() {
+            return self.finish_failed_reactive_operation(
               "step",
               journal,
               error,
-            )
+            );
           }
-          ProgramTurnFinalization::CommitWithError(error) => {
-            journal.commit();
-            Err(error)
+          match finalize() {
+            ProgramTurnFinalization::Commit => {
+              journal.commit();
+              Ok(())
+            }
+            ProgramTurnFinalization::Rollback(error) => {
+              self.finish_failed_reactive_operation(
+                "step",
+                journal,
+                error,
+              )
+            }
+            ProgramTurnFinalization::CommitWithError(error) => {
+              journal.commit();
+              Err(error)
+            }
           }
-        },
+        }
         Err(error) => self.finish_failed_reactive_operation(
           "step",
           journal,
@@ -1014,6 +1024,22 @@ impl MechProgram {
     dirty_cells: &[ReactiveCellId],
     services: &mut dyn MechExecutionServices,
   ) -> MResult<ReactiveTurnOutcome> {
+    self.advance_reactive_turn_coordinated(
+      interpreter_id,
+      dirty_cells,
+      services,
+      |_| ProgramTurnFinalization::Commit,
+    )
+  }
+
+  #[cfg(feature = "functions")]
+  pub fn advance_reactive_turn_coordinated(
+    &mut self,
+    interpreter_id: u64,
+    dirty_cells: &[ReactiveCellId],
+    services: &mut dyn MechExecutionServices,
+    finalize: impl FnOnce(&ReactiveTurnOutcome) -> ProgramTurnFinalization,
+  ) -> MResult<ReactiveTurnOutcome> {
     with_reactive_journal_participant(|participant| {
       let mut journal = ProgramReactiveTurnJournal::new(participant);
       let execution = self.advance_reactive_turn_with_journal(
@@ -1024,8 +1050,31 @@ impl MechProgram {
       );
       match execution {
         Ok(outcome) => {
-          journal.commit();
-          Ok(outcome)
+          #[cfg(feature = "invariant_define")]
+          if let Err(error) = self.validate_integrity_constraints() {
+            return self.finish_failed_reactive_operation(
+              "advance_reactive_turn",
+              journal,
+              error,
+            );
+          }
+          match finalize(&outcome) {
+            ProgramTurnFinalization::Commit => {
+              journal.commit();
+              Ok(outcome)
+            }
+            ProgramTurnFinalization::Rollback(error) => {
+              self.finish_failed_reactive_operation(
+                "advance_reactive_turn",
+                journal,
+                error,
+              )
+            }
+            ProgramTurnFinalization::CommitWithError(error) => {
+              journal.commit();
+              Err(error)
+            }
+          }
         }
         Err(error) => self.finish_failed_reactive_operation(
           "advance_reactive_turn",
@@ -1105,23 +1154,33 @@ impl MechProgram {
         services,
       );
       match execution {
-        Ok(outcome) => match finalize(&outcome) {
-          ProgramTurnFinalization::Commit => {
-            journal.commit();
-            Ok(outcome)
-          }
-          ProgramTurnFinalization::Rollback(error) => {
-            self.finish_failed_reactive_operation(
+        Ok(outcome) => {
+          #[cfg(feature = "invariant_define")]
+          if let Err(error) = self.validate_integrity_constraints() {
+            return self.finish_failed_reactive_operation(
               "update_inputs_and_advance_turn",
               journal,
               error,
-            )
+            );
           }
-          ProgramTurnFinalization::CommitWithError(error) => {
-            journal.commit();
-            Err(error)
+          match finalize(&outcome) {
+            ProgramTurnFinalization::Commit => {
+              journal.commit();
+              Ok(outcome)
+            }
+            ProgramTurnFinalization::Rollback(error) => {
+              self.finish_failed_reactive_operation(
+                "update_inputs_and_advance_turn",
+                journal,
+                error,
+              )
+            }
+            ProgramTurnFinalization::CommitWithError(error) => {
+              journal.commit();
+              Err(error)
+            }
           }
-        },
+        }
         Err(error) => self.finish_failed_reactive_operation(
           "update_inputs_and_advance_turn",
           journal,

--- a/src/runtime/benches/reactive_transaction.rs
+++ b/src/runtime/benches/reactive_transaction.rs
@@ -664,6 +664,21 @@ fn reactive_transaction_benchmarks(c: &mut Criterion) {
     )
   });
 
+  group.bench_function("valid_turn_with_one_integrity_constraint", |b| {
+    b.iter_batched(
+      || {
+        host_input_fixture(
+          "output := @pulse/value + 1.0\noutput-safe! := output <= 100.0",
+        )
+      },
+      |mut fixture| {
+        black_box(apply_host_input(&mut fixture).unwrap());
+        black_box(fixture)
+      },
+      BatchSize::SmallInput,
+    )
+  });
+
   group.finish();
 }
 

--- a/src/runtime/src/event.rs
+++ b/src/runtime/src/event.rs
@@ -21,6 +21,28 @@ use crate::effect::{
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeIntegrityConstraintFailureReason {
+  EvaluatedFalse,
+  ExpectedBool,
+  BorrowConflict,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeIntegrityConstraintViolation {
+  pub interpreter_id: u64,
+  pub constraint_id: u64,
+  pub name: String,
+  pub expression: String,
+  pub reason: RuntimeIntegrityConstraintFailureReason,
+  pub evaluated_kind: Option<String>,
+  pub actual: Option<String>,
+  pub operator: Option<String>,
+  pub expected: Option<String>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimeEventKind {
   RuntimeCreated { runtime_id: RuntimeId },
   RuntimeShutdown { runtime_id: RuntimeId },
@@ -57,6 +79,11 @@ pub enum RuntimeEventKind {
   ProgramStarted { task_id: Option<TaskId> },
   ProgramCompleted { task_id: Option<TaskId> },
   ProgramFailed { task_id: Option<TaskId>, message: String },
+  IntegrityConstraintViolated {
+    transaction_id: TransactionId,
+    task_id: Option<TaskId>,
+    violations: Vec<RuntimeIntegrityConstraintViolation>,
+  },
   ProgramProfiled {
     task_id: Option<TaskId>,
     duration_ns: u128,
@@ -143,6 +170,9 @@ impl RuntimeEventKind {
       RuntimeEventKind::ProgramStarted { .. } => ":program/started",
       RuntimeEventKind::ProgramCompleted { .. } => ":program/completed",
       RuntimeEventKind::ProgramFailed { .. } => ":program/failed",
+      RuntimeEventKind::IntegrityConstraintViolated { .. } => {
+        ":program/integrity-constraint/violated"
+      }
       RuntimeEventKind::ProgramProfiled { .. } => ":program/profiled",
       RuntimeEventKind::TaskCreated { .. } => ":task/created",
       RuntimeEventKind::TaskStarted { .. } => ":task/started",

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3600,65 +3600,11 @@ impl MechRuntime {
     self.program.compile_bytecode()
   }
 
-  #[cfg(all(feature = "invariant_define", feature = "bool"))]
-  pub fn invariant_snapshots(
+  #[cfg(feature = "invariant_define")]
+  pub fn integrity_constraint_report(
     &self,
-  ) -> Vec<crate::RuntimeInvariantSnapshot> {
-    let state = self.program.interpreter().state.borrow();
-    state
-      .integrity_constraints
-      .values()
-      .map(|constraint| {
-        let borrowed = constraint.result.try_borrow();
-        let (passed, reason, evaluated_kind, actual) = match borrowed.as_deref() {
-          Ok(Value::Bool(value)) => match value.try_borrow() {
-            Ok(value) if *value => (
-              true,
-              "evaluated to true".to_string(),
-              "bool".to_string(),
-              "true".to_string(),
-            ),
-            Ok(_) => (
-              false,
-              "evaluated to false".to_string(),
-              "bool".to_string(),
-              "false".to_string(),
-            ),
-            Err(_) => (
-              false,
-              "could not read settled result".to_string(),
-              "unknown".to_string(),
-              "<unavailable>".to_string(),
-            ),
-          },
-          Ok(value) => {
-            let kind = value.kind().to_string();
-            (
-              false,
-              "expected a scalar bool".to_string(),
-              kind.clone(),
-              format!("<{}>", kind),
-            )
-          }
-          Err(_) => (
-            false,
-            "could not read settled result".to_string(),
-            "unknown".to_string(),
-            "<unavailable>".to_string(),
-          ),
-        };
-        crate::RuntimeInvariantSnapshot {
-          id: constraint.id,
-          name: constraint.name.clone(),
-          passed,
-          expression: constraint.expression.clone(),
-          reason,
-          evaluated_kind,
-          actual,
-          expected: "true".to_string(),
-        }
-      })
-      .collect()
+  ) -> MResult<mech_program::IntegrityConstraintReport> {
+    self.program.integrity_constraint_report()
   }
 
   pub fn out_string(&self) -> String {

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -3605,61 +3605,58 @@ impl MechRuntime {
     &self,
   ) -> Vec<crate::RuntimeInvariantSnapshot> {
     let state = self.program.interpreter().state.borrow();
-    let violations = state
-      .invariant_violations
-      .iter()
-      .filter_map(|violation| {
-        violation
-          .error
-          .kind_as::<mech_core::InvariantViolationError>()
-          .map(|error| (violation.id, error))
-      })
-      .collect::<HashMap<_, _>>();
-    let mut ids = state.invariants.keys().copied().collect::<Vec<_>>();
-    ids.sort_unstable();
-    ids
-      .into_iter()
-      .filter_map(|id| {
-        let (name, value) = state.invariants.get(&id)?;
-        let passed = matches!(
-          &*value.borrow(),
-          Value::Bool(value) if *value.borrow()
-        );
-        let evaluation = state.invariant_evaluations.get(&id);
-        let violation = violations.get(&id);
-        Some(crate::RuntimeInvariantSnapshot {
-          id,
-          name: name.clone(),
+    state
+      .integrity_constraints
+      .values()
+      .map(|constraint| {
+        let borrowed = constraint.result.try_borrow();
+        let (passed, reason, evaluated_kind, actual) = match borrowed.as_deref() {
+          Ok(Value::Bool(value)) => match value.try_borrow() {
+            Ok(value) if *value => (
+              true,
+              "evaluated to true".to_string(),
+              "bool".to_string(),
+              "true".to_string(),
+            ),
+            Ok(_) => (
+              false,
+              "evaluated to false".to_string(),
+              "bool".to_string(),
+              "false".to_string(),
+            ),
+            Err(_) => (
+              false,
+              "could not read settled result".to_string(),
+              "unknown".to_string(),
+              "<unavailable>".to_string(),
+            ),
+          },
+          Ok(value) => {
+            let kind = value.kind().to_string();
+            (
+              false,
+              "expected a scalar bool".to_string(),
+              kind.clone(),
+              format!("<{}>", kind),
+            )
+          }
+          Err(_) => (
+            false,
+            "could not read settled result".to_string(),
+            "unknown".to_string(),
+            "<unavailable>".to_string(),
+          ),
+        };
+        crate::RuntimeInvariantSnapshot {
+          id: constraint.id,
+          name: constraint.name.clone(),
           passed,
-          expression: violation
-            .map(|error| error.expression.clone())
-            .or_else(|| state.invariant_expressions.get(&id).cloned())
-            .unwrap_or_else(|| name.clone()),
-          reason: violation
-            .map(|error| error.reason.clone())
-            .or_else(|| evaluation.map(|value| value.reason.clone()))
-            .unwrap_or_else(|| {
-              if passed {
-                "evaluated to true".to_string()
-              } else {
-                "Invariant evaluated to false or non-bool value".to_string()
-              }
-            }),
-          evaluated_kind: violation
-            .map(|error| error.evaluated_kind.clone())
-            .or_else(|| evaluation.map(|value| value.evaluated_kind.clone()))
-            .unwrap_or_else(|| "bool".to_string()),
-          actual: violation
-            .and_then(|error| error.lhs_value.clone())
-            .or_else(|| evaluation.map(|value| value.actual.clone()))
-            .unwrap_or_else(|| {
-              if passed { "true" } else { "?" }.to_string()
-            }),
-          expected: violation
-            .and_then(|error| error.rhs_value.clone())
-            .or_else(|| evaluation.map(|value| value.expected.clone()))
-            .unwrap_or_else(|| "true".to_string()),
-        })
+          expression: constraint.expression.clone(),
+          reason,
+          evaluated_kind,
+          actual,
+          expected: "true".to_string(),
+        }
       })
       .collect()
   }

--- a/src/runtime/src/runtime/execution.rs
+++ b/src/runtime/src/runtime/execution.rs
@@ -4121,6 +4121,17 @@ impl MechRuntime {
         return Err(error);
       }
     };
+    #[cfg(feature = "invariant_define")]
+    if let Err(error) = module_program.validate_integrity_constraints() {
+      self.emit_event_to_context(
+        context,
+        RuntimeEventKind::ModuleExecutionFailed {
+          module_version: version,
+          message: format!("{:?}", error),
+        },
+      )?;
+      return Err(error);
+    }
     let mut exports = HashMap::new();
     {
       let symbols = module_program.interpreter_mut().symbols();

--- a/src/runtime/src/runtime/input_tests.rs
+++ b/src/runtime/src/runtime/input_tests.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
-use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
+use std::sync::{Arc, Mutex, atomic::{AtomicBool, AtomicUsize, Ordering}};
 use std::thread;
 use std::time::Duration;
 
@@ -9,13 +9,14 @@ use mech_core::{hash_str, MResult, MechError, MechErrorKind, ReactiveCellId, Rea
 
 use super::*;
 use crate::{
-  BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
+  BasicCapability, BasicConstraints, BasicOperation, BasicResource, BasicSubject, CapabilityId,
   ConfigValue, HostContextManifest, HostInstanceConfig, HostManifestConfig,
-  ResourcePathCapability, ResourcePathScope, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
+  PlannedStagedHostFunction, ResourcePathCapability, ResourcePathScope, RuntimeHostFactory, RuntimeHostInstallation, RuntimeHostInput,
   RuntimeHostInputSource, RuntimeHostInputUpdate, RuntimeHostInputValue, RuntimeHostInputOutcome, RuntimeIngress,
   RuntimeAuthorityScope,
   RuntimeResourceProvider, RuntimeResourceReadRequest, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest, RuntimeResourceWriteIntent, DeterministicHostFunction, HostArgumentValue, PlannedPureHostFunction, RegisteredHostFunction, RuntimeCallContext, RuntimeValueSnapshot, materialize_host_manifest,
   PreparedRuntimeEffect, RuntimeAfterCommitEffect, RuntimeEffectMetadata, RuntimeEffectSource,
+  RuntimePreparedHostCall, RuntimeTransactionalEffect, SharedCapabilityKernel,
 };
 
 const TEST_CLOCK_BASE_URI: &str =
@@ -48,6 +49,89 @@ impl std::fmt::Debug for TestAfterCommitEffect {
 impl RuntimeAfterCommitEffect for TestAfterCommitEffect {
   fn metadata(&self) -> RuntimeEffectMetadata { self.metadata.clone() }
   fn deliver(&mut self) -> MResult<()> { (self.delivery)() }
+}
+
+#[derive(Debug, Default)]
+struct ReceiverCounters {
+  stage_count: AtomicUsize,
+  prepare_count: AtomicUsize,
+  commit_count: AtomicUsize,
+  abort_count: AtomicUsize,
+  delivery_count: AtomicUsize,
+  staged_payloads: Mutex<Vec<f64>>,
+  prepared_payloads: Mutex<Vec<f64>>,
+  committed_payloads: Mutex<Vec<f64>>,
+  aborted_payloads: Mutex<Vec<f64>>,
+  delivered_payloads: Mutex<Vec<f64>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ReceiverSnapshot {
+  stage_count: usize,
+  prepare_count: usize,
+  commit_count: usize,
+  abort_count: usize,
+  delivery_count: usize,
+  staged_payloads: Vec<f64>,
+  prepared_payloads: Vec<f64>,
+  committed_payloads: Vec<f64>,
+  aborted_payloads: Vec<f64>,
+  delivered_payloads: Vec<f64>,
+}
+
+fn receiver_snapshot(
+  counters: &ReceiverCounters,
+) -> ReceiverSnapshot {
+  ReceiverSnapshot {
+    stage_count: counters.stage_count.load(Ordering::SeqCst),
+    prepare_count: counters.prepare_count.load(Ordering::SeqCst),
+    commit_count: counters.commit_count.load(Ordering::SeqCst),
+    abort_count: counters.abort_count.load(Ordering::SeqCst),
+    delivery_count: counters.delivery_count.load(Ordering::SeqCst),
+    staged_payloads: counters.staged_payloads.lock().unwrap().clone(),
+    prepared_payloads: counters.prepared_payloads.lock().unwrap().clone(),
+    committed_payloads: counters.committed_payloads.lock().unwrap().clone(),
+    aborted_payloads: counters.aborted_payloads.lock().unwrap().clone(),
+    delivered_payloads: counters.delivered_payloads.lock().unwrap().clone(),
+  }
+}
+
+#[derive(Debug)]
+struct ReceiverTransactionalEffect {
+  payload: f64,
+  counters: Arc<ReceiverCounters>,
+}
+
+impl RuntimeTransactionalEffect for ReceiverTransactionalEffect {
+  fn metadata(&self) -> RuntimeEffectMetadata {
+    RuntimeEffectMetadata::new(
+      RuntimeEffectSource::HostFunction {
+        name: "test/receiver-send".to_string(),
+      },
+      "receiver-send",
+    )
+    .with_resource("test://receiver/delivery")
+  }
+
+  fn prepare(&mut self) -> MResult<()> {
+    self.counters.prepare_count.fetch_add(1, Ordering::SeqCst);
+    self.counters.prepared_payloads.lock().unwrap().push(self.payload);
+    Ok(())
+  }
+
+  fn commit(&mut self) -> MResult<()> {
+    self.counters.commit_count.fetch_add(1, Ordering::SeqCst);
+    self.counters.committed_payloads.lock().unwrap().push(self.payload);
+    self.counters.delivery_count.fetch_add(1, Ordering::SeqCst);
+    self.counters.delivered_payloads.lock().unwrap().push(self.payload);
+    Ok(())
+  }
+
+  fn abort(&mut self) -> MResult<()> {
+    self.counters.abort_count.fetch_add(1, Ordering::SeqCst);
+    self.counters.aborted_payloads.lock().unwrap().push(self.payload);
+    Ok(())
+  }
 }
 
 #[derive(Debug, Default)]
@@ -739,6 +823,477 @@ fn runtime_reactive_host_input_turn_failure_restores_admitted_inputs() {
   let calls_before = calls.load(Ordering::SeqCst); let input_source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap(); let input_identity = source_cell(&runtime, &input_source); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); let host_result_pointer = match &*host_result.borrow() { Value::F64(value) => value.as_ptr(), other => panic!("expected f64 host result, got {other:?}") }; let plan_before = plan_snapshot(&runtime); let lines_before = output.lines();
   assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0); assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(output.lines().len(), 1); assert_eq!(runtime.persistent_send_count(), 1);
   fail_host.store(true, Ordering::SeqCst); let error = runtime.apply_host_input(RuntimeHostInput::single(input_source.clone(), RuntimeHostInputValue::F64(9.0))).unwrap_err(); assert!(format!("{error:?}").contains("DeliberateHostCallError")); assert!(calls.load(Ordering::SeqCst) > calls_before); assert_eq!(f64_value(&source_value(&runtime, &input_source)), 1.0); assert_eq!(source_cell(&runtime, &input_source), input_identity); let host_result = runtime.program.interpreter().symbols().borrow().get(hash_str("host-result")).unwrap(); match &*host_result.borrow() { Value::F64(value) => assert_eq!(value.as_ptr(), host_result_pointer), other => panic!("expected f64 host result, got {other:?}") }; assert_eq!(f64_value(&symbol_value(&runtime, "host-result")), 2.0); assert_eq!(f64_value(&symbol_value(&runtime, "output")), 2.0); assert_eq!(plan_snapshot(&runtime), plan_before); assert_eq!(output.lines(), lines_before); assert_eq!(runtime.persistent_send_count(), 1); runtime.run_string("recovery := 1").unwrap(); assert_eq!(f64_value(&symbol_value(&runtime, "recovery")), 1.0);
+}
+
+#[test]
+fn integrity_invalid_host_input_is_restored_before_output_audit_and_recovery() {
+  let provider = test_provider_with(TEST_CLOCK_BASE_URI, "value", 90.0);
+  let (mut runtime, output) = test_runtime_with_output(provider);
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  grant_write(&mut runtime, TEST_OUTPUT_BASE_URI, "line");
+  runtime
+    .run_string(
+      "@out := test://effects/output{:write(line)}\n@pulse := test://clock/ticks{:read(value)}\ntarget := @pulse/value\nmaximum-target := 120.0\ncontroller-command := target\nsafe-target! := target <= maximum-target\n@out/line <- controller-command",
+    )
+    .unwrap();
+  let source =
+    RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  let initial_deliveries = output.lines().len();
+
+  runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::F64(100.0),
+    ))
+    .unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 100.0);
+  assert_eq!(output.lines().len(), initial_deliveries + 1);
+  let deliveries_before_invalid = output.lines().len();
+  let events_before_invalid = runtime.list_events(None).unwrap().len();
+
+  let error = runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::F64(150.0),
+    ))
+    .unwrap_err();
+
+  assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+  let failures = error
+    .kind_as::<mech_program::IntegrityConstraintViolationSet>()
+    .unwrap();
+  assert_eq!(failures.violations.len(), 1);
+  assert_eq!(failures.violations[0].actual.as_deref(), Some("150"));
+  assert_eq!(failures.violations[0].expected.as_deref(), Some("120"));
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 100.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 100.0);
+  assert_eq!(
+    f64_value(&symbol_value(&runtime, "controller-command")),
+    100.0,
+  );
+  match symbol_value(&runtime, "safe-target!") {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected scalar constraint result, got {other:?}"),
+  }
+  assert_eq!(output.lines().len(), deliveries_before_invalid);
+  assert!(runtime.active_transactions.is_empty());
+  assert!(!runtime.is_poisoned());
+  let events = runtime.list_events(None).unwrap();
+  let audit = events[events_before_invalid..]
+    .iter()
+    .find_map(|event| match &event.kind {
+      RuntimeEventKind::IntegrityConstraintViolated {
+        violations,
+        ..
+      } => violations.first(),
+      _ => None,
+    })
+    .expect("invalid candidate emits a detached integrity audit");
+  assert_eq!(audit.actual.as_deref(), Some("150"));
+  assert_eq!(audit.expected.as_deref(), Some("120"));
+
+  runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source,
+      RuntimeHostInputValue::F64(110.0),
+    ))
+    .unwrap();
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 110.0);
+  assert_eq!(output.lines().len(), deliveries_before_invalid + 1);
+  assert!(!runtime.is_poisoned());
+}
+
+#[test]
+fn integrity_invalid_host_input_aborts_staged_receiver_before_commit() {
+  let receiver = Arc::new(ReceiverCounters::default());
+  let receiver_for_stage = receiver.clone();
+  let receiver_host = PlannedStagedHostFunction::new(
+    "test/receiver-send",
+    |_context: &RuntimeCallContext, arguments: &[RuntimeValueSnapshot]| {
+      let payload = host_f64_argument(&arguments[0]);
+      Ok(Value::F64(Ref::new(payload)).into())
+    },
+    move |_context: &RuntimeCallContext, arguments: Vec<RuntimeValueSnapshot>| {
+      let payload = host_f64_argument(&arguments[0]);
+      receiver_for_stage.stage_count.fetch_add(1, Ordering::SeqCst);
+      receiver_for_stage.staged_payloads.lock().unwrap().push(payload);
+      Ok(RuntimePreparedHostCall {
+        value: Value::F64(Ref::new(payload)).into(),
+        effect: PreparedRuntimeEffect::Transactional(Box::new(
+          ReceiverTransactionalEffect {
+            payload,
+            counters: receiver_for_stage.clone(),
+          },
+        )),
+      })
+    },
+  );
+  let store_commit_calls = Arc::new(AtomicUsize::new(0));
+  let store = InMemoryStore::new()
+    .with_commit_runtime_counter_for_test(store_commit_calls.clone());
+  let kernel = SharedCapabilityKernel::new();
+  let observed_kernel = kernel.clone();
+  let provider = TestResourceProvider::new().with_value(
+    TEST_CLOCK_BASE_URI,
+    "value",
+    Value::F64(Ref::new(90.0)),
+  );
+  let mut runtime = RuntimeBuilder::new()
+    .store(store)
+    .capability_kernel(kernel)
+    .resource_provider(Box::new(provider))
+    .host_function(receiver_host)
+    .unwrap()
+    .build()
+    .unwrap();
+  grant_read(&mut runtime, TEST_CLOCK_BASE_URI, "value");
+  let subject = runtime.runtime_context().unwrap().subject;
+  let receiver_capability_id = CapabilityId(970);
+  let capability = BasicCapability::new(
+    receiver_capability_id,
+    &BasicSubject::new(&subject),
+    &BasicResource::new("host:test/receiver-send"),
+    [BasicOperation::new("call")],
+  )
+  .with_constraints(
+    BasicConstraints::default().with_max_uses(8),
+  );
+  runtime.grant_capability(Arc::new(capability)).unwrap();
+  runtime
+    .run_string(
+      r#"@pulse := test://clock/ticks{:read(value)}
+
+target := @pulse/value
+maximum-target := 120.0
+
+receiver-result := test/receiver-send(target)
+
+safe-target! := receiver-result <= maximum-target
+"#,
+    )
+    .unwrap();
+  let source = RuntimeHostInputSource::new(TEST_CLOCK_BASE_URI, "value").unwrap();
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 90.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 90.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "receiver-result")), 90.0);
+  match symbol_value(&runtime, "safe-target!") {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected scalar constraint result, got {other:?}"),
+  }
+  assert_eq!(runtime.runtime_health(), RuntimeHealth::Healthy);
+  assert!(runtime.active_transactions.is_empty());
+  assert_eq!(runtime.program_transaction_owner, None);
+
+  let installed_receiver = receiver_snapshot(&receiver);
+  let installed_store_commits = store_commit_calls.load(Ordering::SeqCst);
+  let installed_capability_uses =
+    observed_kernel.successful_uses_for_test(receiver_capability_id);
+  let installed_events = runtime.list_events(None).unwrap().len();
+
+  let before_100 = receiver_snapshot(&receiver);
+  let store_before_100 = store_commit_calls.load(Ordering::SeqCst);
+  let capability_before_100 =
+    observed_kernel.successful_uses_for_test(receiver_capability_id);
+  let events_before_100 = runtime.list_events(None).unwrap().len();
+  runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::F64(100.0),
+    ))
+    .unwrap();
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 100.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 100.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "receiver-result")), 100.0);
+  match symbol_value(&runtime, "safe-target!") {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected scalar constraint result, got {other:?}"),
+  }
+  let after_100 = receiver_snapshot(&receiver);
+  assert_eq!(after_100.stage_count, before_100.stage_count + 1);
+  assert_eq!(after_100.prepare_count, before_100.prepare_count + 1);
+  assert_eq!(after_100.commit_count, before_100.commit_count + 1);
+  assert_eq!(after_100.delivery_count, before_100.delivery_count + 1);
+  assert_eq!(after_100.abort_count, before_100.abort_count);
+  assert_eq!(
+    &after_100.staged_payloads[before_100.staged_payloads.len()..],
+    &[100.0],
+  );
+  assert_eq!(
+    &after_100.prepared_payloads[before_100.prepared_payloads.len()..],
+    &[100.0],
+  );
+  assert_eq!(
+    &after_100.committed_payloads[before_100.committed_payloads.len()..],
+    &[100.0],
+  );
+  assert_eq!(
+    &after_100.delivered_payloads[before_100.delivered_payloads.len()..],
+    &[100.0],
+  );
+  assert_eq!(
+    &after_100.aborted_payloads[before_100.aborted_payloads.len()..],
+    &[] as &[f64],
+  );
+  assert_eq!(
+    store_commit_calls.load(Ordering::SeqCst),
+    store_before_100 + 1,
+  );
+  assert_eq!(
+    observed_kernel.successful_uses_for_test(receiver_capability_id),
+    capability_before_100 + 1,
+  );
+  let events = runtime.list_events(None).unwrap();
+  let operation_events = &events[events_before_100..];
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionStarted { .. }
+    )).count(),
+    1,
+  );
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionCommitted { .. }
+    )).count(),
+    1,
+  );
+  assert!(!operation_events.iter().any(|event| matches!(
+    event.kind,
+    RuntimeEventKind::TransactionAborted { .. }
+  )));
+  assert!(!operation_events.iter().any(|event| matches!(
+    event.kind,
+    RuntimeEventKind::IntegrityConstraintViolated { .. }
+  )));
+  assert_eq!(runtime.runtime_health(), RuntimeHealth::Healthy);
+  assert!(runtime.active_transactions.is_empty());
+  assert_eq!(runtime.program_transaction_owner, None);
+
+  let before_150 = receiver_snapshot(&receiver);
+  let store_before_150 = store_commit_calls.load(Ordering::SeqCst);
+  let capability_before_150 =
+    observed_kernel.successful_uses_for_test(receiver_capability_id);
+  let events_before_150 = runtime.list_events(None).unwrap().len();
+  let error = runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::F64(150.0),
+    ))
+    .unwrap_err();
+  let failures = error
+    .kind_as::<mech_program::IntegrityConstraintViolationSet>()
+    .expect("invalid candidate returns integrity violations");
+  assert_eq!(failures.violations.len(), 1);
+  let violation = &failures.violations[0];
+  assert_eq!(violation.name, "safe-target!");
+  assert_eq!(
+    violation.reason,
+    mech_program::IntegrityConstraintFailureReason::EvaluatedFalse,
+  );
+  assert_eq!(violation.actual.as_deref(), Some("150"));
+  assert_eq!(violation.expected.as_deref(), Some("120"));
+  let after_150 = receiver_snapshot(&receiver);
+  assert_eq!(after_150.stage_count, before_150.stage_count + 1);
+  assert_eq!(after_150.abort_count, before_150.abort_count + 1);
+  assert_eq!(after_150.prepare_count, before_150.prepare_count);
+  assert_eq!(after_150.commit_count, before_150.commit_count);
+  assert_eq!(after_150.delivery_count, before_150.delivery_count);
+  assert_eq!(
+    &after_150.staged_payloads[before_150.staged_payloads.len()..],
+    &[150.0],
+  );
+  assert_eq!(
+    &after_150.aborted_payloads[before_150.aborted_payloads.len()..],
+    &[150.0],
+  );
+  assert_eq!(
+    &after_150.prepared_payloads[before_150.prepared_payloads.len()..],
+    &[] as &[f64],
+  );
+  assert_eq!(
+    &after_150.committed_payloads[before_150.committed_payloads.len()..],
+    &[] as &[f64],
+  );
+  assert_eq!(
+    &after_150.delivered_payloads[before_150.delivered_payloads.len()..],
+    &[] as &[f64],
+  );
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 100.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 100.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "receiver-result")), 100.0);
+  match symbol_value(&runtime, "safe-target!") {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected scalar constraint result, got {other:?}"),
+  }
+  assert_eq!(
+    store_commit_calls.load(Ordering::SeqCst),
+    store_before_150,
+  );
+  assert_eq!(
+    observed_kernel.successful_uses_for_test(receiver_capability_id),
+    capability_before_150,
+  );
+  assert!(runtime.active_transactions.is_empty());
+  assert_eq!(runtime.program_transaction_owner, None);
+  let events = runtime.list_events(None).unwrap();
+  let operation_events = &events[events_before_150..];
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionStarted { .. }
+    )).count(),
+    1,
+  );
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionAborted { .. }
+    )).count(),
+    1,
+  );
+  assert!(!operation_events.iter().any(|event| matches!(
+    event.kind,
+    RuntimeEventKind::TransactionCommitted { .. }
+  )));
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::IntegrityConstraintViolated { .. }
+    )).count(),
+    1,
+  );
+  let abort_index = operation_events.iter().position(|event| matches!(
+    event.kind,
+    RuntimeEventKind::TransactionAborted { .. }
+  )).unwrap();
+  let audit_index = operation_events.iter().position(|event| matches!(
+    event.kind,
+    RuntimeEventKind::IntegrityConstraintViolated { .. }
+  )).unwrap();
+  assert!(abort_index < audit_index);
+  let audit = operation_events.iter().find_map(|event| match &event.kind {
+    RuntimeEventKind::IntegrityConstraintViolated {
+      violations,
+      ..
+    } => violations.first(),
+    _ => None,
+  }).unwrap();
+  assert_eq!(audit.actual.as_deref(), Some("150"));
+  assert_eq!(audit.expected.as_deref(), Some("120"));
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 100.0);
+  assert_eq!(runtime.runtime_health(), RuntimeHealth::Healthy);
+  assert!(!runtime.is_poisoned());
+
+  let before_110 = receiver_snapshot(&receiver);
+  let store_before_110 = store_commit_calls.load(Ordering::SeqCst);
+  let capability_before_110 =
+    observed_kernel.successful_uses_for_test(receiver_capability_id);
+  let events_before_110 = runtime.list_events(None).unwrap().len();
+  runtime
+    .apply_host_input(RuntimeHostInput::single(
+      source.clone(),
+      RuntimeHostInputValue::F64(110.0),
+    ))
+    .unwrap();
+  assert_eq!(f64_value(&source_value(&runtime, &source)), 110.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "target")), 110.0);
+  assert_eq!(f64_value(&symbol_value(&runtime, "receiver-result")), 110.0);
+  match symbol_value(&runtime, "safe-target!") {
+    Value::Bool(value) => assert!(*value.borrow()),
+    other => panic!("expected scalar constraint result, got {other:?}"),
+  }
+  let after_110 = receiver_snapshot(&receiver);
+  assert_eq!(after_110.stage_count, before_110.stage_count + 1);
+  assert_eq!(after_110.prepare_count, before_110.prepare_count + 1);
+  assert_eq!(after_110.commit_count, before_110.commit_count + 1);
+  assert_eq!(after_110.delivery_count, before_110.delivery_count + 1);
+  assert_eq!(after_110.abort_count, before_110.abort_count);
+  assert_eq!(
+    &after_110.staged_payloads[before_110.staged_payloads.len()..],
+    &[110.0],
+  );
+  assert_eq!(
+    &after_110.prepared_payloads[before_110.prepared_payloads.len()..],
+    &[110.0],
+  );
+  assert_eq!(
+    &after_110.committed_payloads[before_110.committed_payloads.len()..],
+    &[110.0],
+  );
+  assert_eq!(
+    &after_110.delivered_payloads[before_110.delivered_payloads.len()..],
+    &[110.0],
+  );
+  assert_eq!(
+    &after_110.aborted_payloads[before_110.aborted_payloads.len()..],
+    &[] as &[f64],
+  );
+  assert_eq!(
+    store_commit_calls.load(Ordering::SeqCst),
+    store_before_110 + 1,
+  );
+  assert_eq!(
+    observed_kernel.successful_uses_for_test(receiver_capability_id),
+    capability_before_110 + 1,
+  );
+  let events = runtime.list_events(None).unwrap();
+  let operation_events = &events[events_before_110..];
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionStarted { .. }
+    )).count(),
+    1,
+  );
+  assert_eq!(
+    operation_events.iter().filter(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionCommitted { .. }
+    )).count(),
+    1,
+  );
+  assert!(!operation_events.iter().any(|event| matches!(
+    event.kind,
+    RuntimeEventKind::TransactionAborted { .. }
+  )));
+  assert!(!operation_events.iter().any(|event| matches!(
+    event.kind,
+    RuntimeEventKind::IntegrityConstraintViolated { .. }
+  )));
+  assert_eq!(runtime.runtime_health(), RuntimeHealth::Healthy);
+  assert!(runtime.active_transactions.is_empty());
+  assert_eq!(runtime.program_transaction_owner, None);
+
+  assert_eq!(
+    &after_110.committed_payloads[installed_receiver.committed_payloads.len()..],
+    &[100.0, 110.0],
+  );
+  assert_eq!(
+    &after_110.delivered_payloads[installed_receiver.delivered_payloads.len()..],
+    &[100.0, 110.0],
+  );
+  assert_eq!(
+    &after_110.staged_payloads[installed_receiver.staged_payloads.len()..],
+    &[100.0, 150.0, 110.0],
+  );
+  assert_eq!(
+    &after_110.aborted_payloads[installed_receiver.aborted_payloads.len()..],
+    &[150.0],
+  );
+  assert_eq!(
+    &after_110.prepared_payloads[installed_receiver.prepared_payloads.len()..],
+    &[100.0, 110.0],
+  );
+  assert_eq!(
+    store_commit_calls.load(Ordering::SeqCst),
+    installed_store_commits + 2,
+  );
+  assert_eq!(
+    observed_kernel.successful_uses_for_test(receiver_capability_id),
+    installed_capability_uses + 2,
+  );
+  assert!(runtime.list_events(None).unwrap().len() > installed_events);
 }
 
 #[test]

--- a/src/runtime/src/runtime/module.rs
+++ b/src/runtime/src/runtime/module.rs
@@ -1601,6 +1601,101 @@ mod tests {
   }
 
   #[test]
+  fn retained_root_integrity_failure_exposes_no_graph_or_completion() {
+    let mut runtime = runtime_with_sources(&[(
+      "root.mec",
+      "integrity-root-value := 2.0\nintegrity-root-limit := 1.0\nintegrity-root-safe! := integrity-root-value <= integrity-root-limit\nintegrity-root-value\n",
+    )]);
+    runtime.run_string("integrity-baseline := 7").unwrap();
+    let events_before = runtime.list_events(None).unwrap().len();
+
+    let error = runtime
+      .resolve_and_run_root_module(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert!(runtime.program.root_symbol_value("integrity-baseline").is_ok());
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-root-value")
+      .is_err());
+    assert!(runtime
+      .store
+      .find_module_by_name("memory:root.mec")
+      .unwrap()
+      .is_none());
+    let events = runtime.list_events(None).unwrap();
+    let operation_events = &events[events_before..];
+    assert!(operation_events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::ProgramFailed { .. }
+    )));
+    assert!(operation_events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::IntegrityConstraintViolated { .. }
+    )));
+    assert!(operation_events.iter().all(|event| !matches!(
+      event.kind,
+      RuntimeEventKind::ProgramCompleted { .. }
+        | RuntimeEventKind::ModuleExecutionCompleted { .. }
+    )));
+    assert!(!runtime.is_poisoned());
+  }
+
+  #[test]
+  fn isolated_dependency_integrity_failure_prevents_root_materialization() {
+    let mut runtime = runtime_with_sources(&[
+      (
+        "root.mec",
+        "+> ./dep.mec\nintegrity-root-ran := dep/value\nintegrity-root-ran\n",
+      ),
+      (
+        "dep.mec",
+        "value := 2.0\nlimit := 1.0\ndep-safe! := value <= limit\n<+ value\n",
+      ),
+    ]);
+    let events_before = runtime.list_events(None).unwrap().len();
+
+    let error = runtime
+      .resolve_and_run_root_module(
+        "root.mec",
+        test_module_options(),
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-root-ran")
+      .is_err());
+    for uri in ["memory:root.mec", "memory:dep.mec"] {
+      assert!(
+        runtime.store.find_module_by_name(uri).unwrap().is_none(),
+        "invalid dependency exposed {uri}",
+      );
+    }
+    let events = runtime.list_events(None).unwrap();
+    let operation_events = &events[events_before..];
+    assert!(operation_events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::ProgramFailed { .. }
+    )));
+    assert!(operation_events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::IntegrityConstraintViolated { .. }
+    )));
+    assert!(operation_events.iter().all(|event| !matches!(
+      event.kind,
+      RuntimeEventKind::ProgramCompleted { .. }
+        | RuntimeEventKind::ModuleExecutionCompleted { .. }
+    )));
+    assert!(!runtime.is_poisoned());
+  }
+
+  #[test]
   fn retained_root_missing_later_dependency_has_no_partial_graph_or_version_audit() {
     let mut runtime = runtime_with_sources(&[
       (

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -6,6 +6,67 @@
 
 use super::*;
 use crate::{AccessSet, RuntimeAuthorityScope};
+#[cfg(feature = "invariant_define")]
+use mech_program::{
+  IntegrityConstraintFailureReason, IntegrityConstraintViolationSet,
+};
+#[cfg(feature = "invariant_define")]
+use crate::{
+  RuntimeIntegrityConstraintFailureReason,
+  RuntimeIntegrityConstraintViolation,
+};
+
+#[cfg(feature = "invariant_define")]
+pub(super) struct IntegrityFailureAudit {
+  transaction_id: TransactionId,
+  task_id: Option<TaskId>,
+  violations: Vec<RuntimeIntegrityConstraintViolation>,
+}
+
+#[cfg(feature = "invariant_define")]
+pub(super) fn integrity_failure_audit(
+  error: &MechError,
+  transaction_id: TransactionId,
+  task_id: Option<TaskId>,
+) -> Option<IntegrityFailureAudit> {
+  let failures =
+    error.kind_as::<IntegrityConstraintViolationSet>()?;
+  let violations = failures
+    .violations
+    .iter()
+    .map(|violation| RuntimeIntegrityConstraintViolation {
+      interpreter_id: violation.interpreter_id,
+      constraint_id: violation.constraint_id,
+      name: violation.name.clone(),
+      expression: violation.expression.clone(),
+      reason: match violation.reason {
+        IntegrityConstraintFailureReason::EvaluatedFalse => {
+          RuntimeIntegrityConstraintFailureReason::EvaluatedFalse
+        }
+        IntegrityConstraintFailureReason::ExpectedBool => {
+          RuntimeIntegrityConstraintFailureReason::ExpectedBool
+        }
+        IntegrityConstraintFailureReason::BorrowConflict => {
+          RuntimeIntegrityConstraintFailureReason::BorrowConflict
+        }
+      },
+      evaluated_kind: violation
+        .evaluated_kind
+        .as_ref()
+        .map(ToString::to_string),
+      actual: violation.actual.clone(),
+      operator: violation.operator.as_ref().map(|operator| {
+        format!("{:?}", operator)
+      }),
+      expected: violation.expected.clone(),
+    })
+    .collect();
+  Some(IntegrityFailureAudit {
+    transaction_id,
+    task_id,
+    violations,
+  })
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum RuntimeExecutionTransactionMode {
@@ -306,6 +367,25 @@ pub struct RuntimePoisonRecord {
 }
 
 impl MechRuntime {
+  #[cfg(feature = "invariant_define")]
+  pub(super) fn emit_integrity_failure_audit(
+    &mut self,
+    context: &mut RuntimeContext,
+    audit: Option<IntegrityFailureAudit>,
+  ) {
+    let Some(audit) = audit else {
+      return;
+    };
+    let _ = self.emit_event_immediate_to_context(
+      context,
+      RuntimeEventKind::IntegrityConstraintViolated {
+        transaction_id: audit.transaction_id,
+        task_id: audit.task_id,
+        violations: audit.violations,
+      },
+    );
+  }
+
   fn capture_runtime_program_checkpoint(
     &self,
   ) -> MResult<MechProgramCheckpoint> {
@@ -933,6 +1013,12 @@ impl MechRuntime {
     };
 
     let original_error_text = format!("{:?}", original_error);
+    #[cfg(feature = "invariant_define")]
+    let integrity_audit = integrity_failure_audit(
+      &original_error,
+      transaction_id,
+      context.task,
+    );
     let rollback_failures = self.rollback_program_operation(
       context,
       transaction_id,
@@ -948,6 +1034,11 @@ impl MechRuntime {
           &format!("retained program operation `{}` failed", operation),
         );
         if cleanup_failures.is_empty() {
+          #[cfg(feature = "invariant_define")]
+          self.emit_integrity_failure_audit(
+            context,
+            integrity_audit,
+          );
           return Err(original_error);
         }
         return Err(self.poison_program_operation(
@@ -971,6 +1062,11 @@ impl MechRuntime {
           ));
         }
       }
+      #[cfg(feature = "invariant_define")]
+      self.emit_integrity_failure_audit(
+        context,
+        integrity_audit,
+      );
       return Err(original_error);
     }
 
@@ -1364,7 +1460,7 @@ mod tests {
     let error = runtime
       .run_string_with_context(
         &mut context,
-        "integrity-discarded := 2.0\nintegrity-invalid! := false",
+        "integrity-discarded := 2.0\nintegrity-limit := 1.0\nintegrity-invalid! := integrity-discarded <= integrity-limit",
       )
       .unwrap_err();
 
@@ -1392,6 +1488,39 @@ mod tests {
     assert!(!new_events.iter().any(|event| {
       matches!(event.kind, RuntimeEventKind::ProgramCompleted { .. })
     }));
+    let audit_event = new_events
+      .iter()
+      .find(|event| {
+        matches!(
+          event.kind,
+          RuntimeEventKind::IntegrityConstraintViolated { .. }
+        )
+      })
+      .expect("integrity rollback audit must be durable");
+    let RuntimeEventKind::IntegrityConstraintViolated {
+      violations: audit,
+      ..
+    } = &audit_event.kind
+    else {
+      unreachable!();
+    };
+    assert_eq!(audit.len(), 1);
+    assert_eq!(audit[0].name, "integrity-invalid!");
+    assert_eq!(
+      audit[0].reason,
+      RuntimeIntegrityConstraintFailureReason::EvaluatedFalse,
+    );
+    assert_eq!(audit[0].actual.as_deref(), Some("2"));
+    assert_eq!(audit[0].expected.as_deref(), Some("1"));
+    assert!(!format!("{audit:?}").contains("@0x"));
+    #[cfg(feature = "serde")]
+    {
+      let serialized =
+        serde_json::to_string(&audit_event.kind).unwrap();
+      assert!(!serialized.contains("@0x"));
+      assert!(!serialized.contains("RefCell"));
+      assert!(!serialized.contains("tokens"));
+    }
   }
 
   #[test]
@@ -1433,15 +1562,36 @@ mod tests {
     assert_eq!(context.transaction, Some(transaction_id));
     assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
     assert!(runtime.active_transactions.contains_key(&transaction_id));
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::IntegrityConstraintViolated {
+          transaction_id: id,
+          ..
+        } if id == transaction_id
+      )
+    }));
 
     runtime
-      .commit_runtime_transaction(&mut context)
+      .abort_runtime_transaction(
+        &mut context,
+        "discard explicit integrity test",
+      )
       .unwrap();
     assert_eq!(context.transaction, None);
     assert!(runtime
       .program
       .root_symbol_value("integrity-kept")
-      .is_ok());
+      .is_err());
+    assert!(runtime.list_events(None).unwrap().iter().any(|event| {
+      matches!(
+        event.kind,
+        RuntimeEventKind::IntegrityConstraintViolated {
+          transaction_id: id,
+          ..
+        } if id == transaction_id
+      )
+    }));
   }
 
   #[test]
@@ -1468,6 +1618,17 @@ mod tests {
       panic!("constraint result must be bool");
     }
 
+    let audit_count_before = runtime
+      .list_events(None)
+      .unwrap()
+      .iter()
+      .filter(|event| {
+        matches!(
+          event.kind,
+          RuntimeEventKind::IntegrityConstraintViolated { .. }
+        )
+      })
+      .count();
     let error = runtime
       .commit_runtime_transaction(&mut context)
       .unwrap_err();
@@ -1476,6 +1637,20 @@ mod tests {
     assert_eq!(context.transaction, Some(transaction_id));
     assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
     assert!(runtime.active_transactions.contains_key(&transaction_id));
+    assert_eq!(
+      runtime
+        .list_events(None)
+        .unwrap()
+        .iter()
+        .filter(|event| {
+          matches!(
+            event.kind,
+            RuntimeEventKind::IntegrityConstraintViolated { .. }
+          )
+        })
+        .count(),
+      audit_count_before,
+    );
     if let Value::Bool(value) = &*result.borrow() {
       *value.borrow_mut() = true;
     } else {

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -1497,6 +1497,25 @@ mod tests {
         )
       })
       .expect("integrity rollback audit must be durable");
+    let abort_position = new_events
+      .iter()
+      .position(|event| {
+        matches!(event.kind, RuntimeEventKind::TransactionAborted { .. })
+      })
+      .expect("implicit transaction abort must be durable");
+    let audit_position = new_events
+      .iter()
+      .position(|event| {
+        matches!(
+          event.kind,
+          RuntimeEventKind::IntegrityConstraintViolated { .. }
+        )
+      })
+      .unwrap();
+    assert!(
+      abort_position < audit_position,
+      "integrity audit must follow transaction cleanup",
+    );
     let RuntimeEventKind::IntegrityConstraintViolated {
       violations: audit,
       ..
@@ -1521,6 +1540,53 @@ mod tests {
       assert!(!serialized.contains("RefCell"));
       assert!(!serialized.contains("tokens"));
     }
+  }
+
+  #[test]
+  fn integrity_audit_append_failure_preserves_original_error_and_health() {
+    let mut runtime = MechRuntime::builder()
+      .id_generator(ScriptedEventIdGenerator::new(
+        1,
+        [
+          EventId(100),
+          EventId(101),
+          EventId(102),
+          EventId(103),
+          EventId(104),
+          EventId(100),
+          EventId(105),
+        ],
+      ))
+      .build()
+      .unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .run_string_with_context(
+        &mut context,
+        "audit-invalid! := false",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    assert!(runtime.program.root_symbol_value("audit-invalid!").is_err());
+    assert!(!runtime.is_poisoned());
+    let events = runtime.list_events(None).unwrap();
+    assert!(events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::TransactionAborted { .. }
+    )));
+    assert!(events.iter().any(|event| matches!(
+      event.kind,
+      RuntimeEventKind::ProgramFailed { .. }
+    )));
+    assert!(events.iter().all(|event| !matches!(
+      event.kind,
+      RuntimeEventKind::IntegrityConstraintViolated { .. }
+    )));
   }
 
   #[test]
@@ -1595,12 +1661,125 @@ mod tests {
   }
 
   #[test]
+  fn invalid_explicit_integrity_suffix_discards_only_its_effects() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut builder = MechRuntime::builder();
+    for name in ["integrity/a", "integrity/b", "integrity/c"] {
+      let effect_log = log.clone();
+      builder = builder
+        .host_function(PlannedStagedHostFunction::new(
+          name,
+          |_context, _args| {
+            Ok(Value::F64(mech_core::Ref::new(1.0)).into())
+          },
+          move |_context, _args| {
+            Ok(RuntimePreparedHostCall {
+              value: Value::F64(mech_core::Ref::new(1.0)).into(),
+              effect: PreparedRuntimeEffect::Transactional(Box::new(
+                CommitDecisionEffect {
+                  name,
+                  log: effect_log.clone(),
+                  fail_commit: false,
+                },
+              )),
+            })
+          },
+        ))
+        .unwrap();
+    }
+    let mut runtime = builder.build().unwrap();
+    for (id, name) in [
+      (CapabilityId(810), "integrity/a"),
+      (CapabilityId(811), "integrity/b"),
+      (CapabilityId(812), "integrity/c"),
+    ] {
+      grant_program_host_call(&mut runtime, id, name);
+    }
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "a-result := integrity/a()\na-safe! := true",
+      )
+      .unwrap();
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .effects
+        .len(),
+      1,
+    );
+
+    let error = runtime
+      .run_string_with_context(
+        &mut context,
+        "b-result := integrity/b()\nb-safe! := false",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+    assert!(runtime.program.root_symbol_value("a-result").is_ok());
+    assert!(runtime.program.root_symbol_value("b-result").is_err());
+    assert_eq!(
+      runtime
+        .active_execution_transaction(transaction_id)
+        .unwrap()
+        .effects
+        .len(),
+      1,
+    );
+    assert_eq!(
+      *log.lock().unwrap(),
+      vec!["integrity/b:abort"],
+    );
+    assert!(!runtime.is_poisoned());
+
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "c-result := integrity/c()\nc-safe! := true",
+      )
+      .unwrap();
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+
+    assert_eq!(
+      *log.lock().unwrap(),
+      vec![
+        "integrity/b:abort",
+        "integrity/a:prepare",
+        "integrity/c:prepare",
+        "integrity/a:commit",
+        "integrity/c:commit",
+      ],
+    );
+    assert!(runtime.program.root_symbol_value("a-result").is_ok());
+    assert!(runtime.program.root_symbol_value("c-result").is_ok());
+    assert!(runtime.program.root_symbol_value("b-result").is_err());
+    assert_eq!(context.transaction, None);
+    assert!(runtime.active_transactions.is_empty());
+    assert!(!runtime.is_poisoned());
+  }
+
+  #[test]
   fn final_explicit_commit_revalidates_without_consuming_transaction() {
     let mut runtime = MechRuntime::builder().build().unwrap();
     let mut context = runtime.runtime_context().unwrap();
     let transaction_id = runtime.begin_transaction(&mut context).unwrap();
     runtime
       .run_string_with_context(&mut context, "integrity-final! := true")
+      .unwrap();
+    runtime
+      .stage_runtime_effect_with_context(
+        &mut context,
+        savepoint_effect("integrity-final"),
+      )
       .unwrap();
     let result = runtime
       .program
@@ -1637,6 +1816,10 @@ mod tests {
     assert_eq!(context.transaction, Some(transaction_id));
     assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
     assert!(runtime.active_transactions.contains_key(&transaction_id));
+    let transaction =
+      runtime.active_execution_transaction(transaction_id).unwrap();
+    assert_eq!(transaction.state, RuntimeExecutionTransactionState::Active);
+    assert_eq!(transaction.effects.len(), 1);
     assert_eq!(
       runtime
         .list_events(None)
@@ -1651,25 +1834,24 @@ mod tests {
         .count(),
       audit_count_before,
     );
-    if let Value::Bool(value) = &*result.borrow() {
-      *value.borrow_mut() = true;
-    } else {
-      panic!("constraint result must be bool");
-    }
     runtime
-      .commit_runtime_transaction(&mut context)
+      .abort_runtime_transaction(
+        &mut context,
+        "discard final integrity candidate",
+      )
       .unwrap();
     assert_eq!(context.transaction, None);
     assert_eq!(runtime.program_transaction_owner, None);
+    assert!(runtime.program.root_symbol_value("integrity-final!").is_err());
   }
 
   #[test]
   fn committed_implicit_participant_failure_never_rolls_back_program() {
     let log = Arc::new(Mutex::new(Vec::new()));
     let mut builder = MechRuntime::builder();
-    for (id, name, fail_commit) in [
-      (CapabilityId(800), "round4/first", false),
-      (CapabilityId(801), "round4/second", true),
+    for (name, fail_commit) in [
+      ("round4/first", false),
+      ("round4/second", true),
     ] {
       let effect_log = log.clone();
       builder = builder

--- a/src/runtime/src/runtime/program_transaction.rs
+++ b/src/runtime/src/runtime/program_transaction.rs
@@ -904,7 +904,11 @@ impl MechRuntime {
         operation,
       },
     );
-    let execution_result = execute(self, context);
+    let execution_result = execute(self, context).and_then(|value| {
+      #[cfg(feature = "invariant_define")]
+      self.program.validate_integrity_constraints()?;
+      Ok(value)
+    });
     drop(_operation_guard);
 
     let original_error = match execution_result {
@@ -1348,6 +1352,140 @@ mod tests {
         RuntimeEventKind::TransactionCommitted { .. }
       )
     }));
+  }
+
+  #[test]
+  fn invalid_implicit_program_operation_rolls_back_before_publication() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    runtime.run_string("integrity-anchor := 1.0").unwrap();
+    let events_before = runtime.list_events(None).unwrap().len();
+    let mut context = runtime.runtime_context().unwrap();
+
+    let error = runtime
+      .run_string_with_context(
+        &mut context,
+        "integrity-discarded := 2.0\nintegrity-invalid! := false",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-anchor")
+      .is_ok());
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-discarded")
+      .is_err());
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-invalid!")
+      .is_err());
+    assert!(runtime.active_transactions.is_empty());
+    assert_eq!(runtime.program_transaction_owner, None);
+    assert_eq!(context.transaction, None);
+    let events = runtime.list_events(None).unwrap();
+    let new_events = &events[events_before..];
+    assert!(new_events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::ProgramFailed { .. })
+    }));
+    assert!(!new_events.iter().any(|event| {
+      matches!(event.kind, RuntimeEventKind::ProgramCompleted { .. })
+    }));
+  }
+
+  #[test]
+  fn invalid_explicit_program_operation_rolls_back_only_its_savepoint() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .run_string_with_context(
+        &mut context,
+        "integrity-kept := 1.0\nintegrity-valid! := true",
+      )
+      .unwrap();
+
+    let error = runtime
+      .run_string_with_context(
+        &mut context,
+        "integrity-discarded := 2.0\nintegrity-invalid! := false",
+      )
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-kept")
+      .is_ok());
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-valid!")
+      .is_ok());
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-discarded")
+      .is_err());
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-invalid!")
+      .is_err());
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+    assert!(runtime.active_transactions.contains_key(&transaction_id));
+
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+    assert_eq!(context.transaction, None);
+    assert!(runtime
+      .program
+      .root_symbol_value("integrity-kept")
+      .is_ok());
+  }
+
+  #[test]
+  fn final_explicit_commit_revalidates_without_consuming_transaction() {
+    let mut runtime = MechRuntime::builder().build().unwrap();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+      .run_string_with_context(&mut context, "integrity-final! := true")
+      .unwrap();
+    let result = runtime
+      .program
+      .interpreter()
+      .state
+      .borrow()
+      .integrity_constraints
+      .get(&hash_str("integrity-final!"))
+      .unwrap()
+      .result
+      .clone();
+    if let Value::Bool(value) = &*result.borrow() {
+      *value.borrow_mut() = false;
+    } else {
+      panic!("constraint result must be bool");
+    }
+
+    let error = runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap_err();
+
+    assert_eq!(error.kind_name(), "IntegrityConstraintViolationSet");
+    assert_eq!(context.transaction, Some(transaction_id));
+    assert_eq!(runtime.program_transaction_owner, Some(transaction_id));
+    assert!(runtime.active_transactions.contains_key(&transaction_id));
+    if let Value::Bool(value) = &*result.borrow() {
+      *value.borrow_mut() = true;
+    } else {
+      panic!("constraint result must be bool");
+    }
+    runtime
+      .commit_runtime_transaction(&mut context)
+      .unwrap();
+    assert_eq!(context.transaction, None);
+    assert_eq!(runtime.program_transaction_owner, None);
   }
 
   #[test]

--- a/src/runtime/src/runtime/reactive_transaction.rs
+++ b/src/runtime/src/runtime/reactive_transaction.rs
@@ -452,6 +452,10 @@ impl MechRuntime {
           }
           Err(error) => error,
         };
+        // Integrity validation runs inside the program journal before this
+        // runtime finalizer. A rejected candidate therefore intentionally
+        // leaves finalization pending so the runtime savepoint can discard
+        // provisional effects and context changes.
         self.finish_failed_reactive_runtime_turn(
           context,
           operation,

--- a/src/runtime/src/runtime/reactive_transaction.rs
+++ b/src/runtime/src/runtime/reactive_transaction.rs
@@ -480,6 +480,13 @@ impl MechRuntime {
     newly_acquired_ownership: bool,
   ) -> MResult<T> {
     let original_error_text = format!("{:?}", original_error);
+    #[cfg(feature = "invariant_define")]
+    let integrity_audit =
+      super::program_transaction::integrity_failure_audit(
+        &original_error,
+        transaction_id,
+        context.task,
+      );
     let mut rollback_failures =
       self.rollback_runtime_operation(
         context,
@@ -508,6 +515,11 @@ impl MechRuntime {
     }
 
     if rollback_failures.is_empty() {
+      #[cfg(feature = "invariant_define")]
+      self.emit_integrity_failure_audit(
+        context,
+        integrity_audit,
+      );
       return Err(original_error);
     }
 

--- a/src/runtime/src/runtime/transaction.rs
+++ b/src/runtime/src/runtime/transaction.rs
@@ -321,6 +321,31 @@ impl MechRuntime {
     self.validate_context_for_runtime(context)?;
 
     let transaction_id = Self::context_transaction_id(context)?;
+    let (transaction_mode, has_program_baseline) = {
+      let transaction =
+        self.active_execution_transaction(transaction_id)?;
+      (transaction.mode, transaction.program.is_some())
+    };
+    if has_program_baseline
+      && self.program_transaction_owner != Some(transaction_id)
+    {
+      return self.coordinator_invariant_failure(
+        "commit_runtime_transaction",
+        Some(transaction_id),
+        format!(
+          "transaction {} contains a retained-program baseline but program ownership is {:?}",
+          transaction_id,
+          self.program_transaction_owner,
+        ),
+      );
+    }
+    #[cfg(feature = "invariant_define")]
+    if transaction_mode
+      == super::program_transaction::RuntimeExecutionTransactionMode::Explicit
+      && self.program_transaction_owner == Some(transaction_id)
+    {
+      self.program.validate_integrity_constraints()?;
+    }
     let access = self
       .active_execution_transaction(transaction_id)?
       .context_baseline

--- a/src/runtime/src/snapshot.rs
+++ b/src/runtime/src/snapshot.rs
@@ -75,15 +75,3 @@ pub struct RuntimeCapabilitySnapshot {
   pub attenuable: bool,
   pub max_uses: Option<u64>,
 }
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RuntimeInvariantSnapshot {
-  pub id: u64,
-  pub name: String,
-  pub passed: bool,
-  pub expression: String,
-  pub reason: String,
-  pub evaluated_kind: String,
-  pub actual: String,
-  pub expected: String,
-}

--- a/src/runtime/src/store.rs
+++ b/src/runtime/src/store.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use mech_core::{MResult, MechError, MechErrorKind, MechSourceCode};
 
@@ -896,6 +898,8 @@ pub struct InMemoryStore {
   panic_on_get_object: bool,
   #[cfg(test)]
   panic_on_commit_runtime: bool,
+  #[cfg(test)]
+  commit_runtime_calls: Option<Arc<AtomicUsize>>,
 }
 
 impl InMemoryStore {
@@ -911,6 +915,15 @@ impl InMemoryStore {
   #[cfg(test)]
   pub(crate) fn panic_on_commit_runtime_for_test(&mut self) {
     self.panic_on_commit_runtime = true;
+  }
+
+  #[cfg(test)]
+  pub(crate) fn with_commit_runtime_counter_for_test(
+    mut self,
+    counter: Arc<AtomicUsize>,
+  ) -> Self {
+    self.commit_runtime_calls = Some(counter);
+    self
   }
 
   fn prune_events(&mut self) {
@@ -1522,6 +1535,10 @@ impl MechStore for InMemoryStore {
     &mut self,
     commit: RuntimeStoreCommit,
   ) -> MResult<TransactionId> {
+    #[cfg(test)]
+    if let Some(counter) = &self.commit_runtime_calls {
+      counter.fetch_add(1, Ordering::SeqCst);
+    }
     #[cfg(test)]
     if self.panic_on_commit_runtime {
       panic!("deliberate store commit panic");

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,6 +12,10 @@ use crate::source_discovery::{
   DiscoveryOptions,
   MissingPathPolicy,
 };
+use mech_program::{
+  IntegrityConstraintEvaluation, IntegrityConstraintFailureReason,
+  IntegrityConstraintViolation, IntegrityConstraintViolationSet,
+};
 
 const TEST_EXPLICIT_EXTENSIONS: &[&str] = &["mec", "🤖", "mecb"];
 const TEST_RECURSIVE_EXTENSIONS: &[&str] = &["mec", "🤖"];
@@ -110,6 +114,57 @@ struct CaseDetail {
   evaluated_kind: String,
   actual: String,
   expected: String,
+}
+
+fn integrity_reason(
+  reason: Option<&IntegrityConstraintFailureReason>,
+) -> String {
+  match reason {
+    None => "evaluated to true".to_string(),
+    Some(IntegrityConstraintFailureReason::EvaluatedFalse) => {
+      "evaluated to false".to_string()
+    }
+    Some(IntegrityConstraintFailureReason::ExpectedBool) => {
+      "expected a scalar bool".to_string()
+    }
+    Some(IntegrityConstraintFailureReason::BorrowConflict) => {
+      "could not read the settled constraint result".to_string()
+    }
+  }
+}
+
+fn integrity_evaluation_case(
+  evaluation: &IntegrityConstraintEvaluation,
+) -> CaseDetail {
+  CaseDetail {
+    name: evaluation.name.clone(),
+    expression: evaluation.expression.clone(),
+    reason: integrity_reason(evaluation.reason.as_ref()),
+    evaluated_kind: evaluation
+      .evaluated_kind
+      .as_ref()
+      .map(ToString::to_string)
+      .unwrap_or_else(|| "unknown".to_string()),
+    actual: evaluation.actual.clone().unwrap_or_default(),
+    expected: evaluation.expected.clone().unwrap_or_default(),
+  }
+}
+
+fn integrity_violation_case(
+  violation: &IntegrityConstraintViolation,
+) -> CaseDetail {
+  CaseDetail {
+    name: violation.name.clone(),
+    expression: violation.expression.clone(),
+    reason: integrity_reason(Some(&violation.reason)),
+    evaluated_kind: violation
+      .evaluated_kind
+      .as_ref()
+      .map(ToString::to_string)
+      .unwrap_or_else(|| "unknown".to_string()),
+    actual: violation.actual.clone().unwrap_or_default(),
+    expected: violation.expected.clone().unwrap_or_default(),
+  }
 }
 
 #[derive(Debug, Serialize)]
@@ -317,36 +372,60 @@ pub(crate) fn run_mech_tests_without_tree(
       time_flag,
       10_000,
     )?;
-    let mut runtime = match execute_source_module_roots(config, &[PathBuf::from(path)]) {
+    let runtime = match execute_source_module_roots(config, &[PathBuf::from(path)]) {
       Ok(runtime) => runtime,
       Err(err) => {
+        if let Some(failures) =
+          err.kind_as::<IntegrityConstraintViolationSet>()
+        {
+          let failed_cases = failures
+            .violations
+            .iter()
+            .map(integrity_violation_case)
+            .collect::<Vec<_>>();
+          let failed = failed_cases.len();
+          println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
+          for detail in &failed_cases {
+            println!("{}   ✗", detail.name);
+          }
+          file_reports.push(FileReport {
+            path: path.clone(),
+            result: FileResult {
+              total: failed,
+              passed: 0,
+              failed,
+            },
+            failed: failed_cases,
+            passed: Vec::new(),
+            run_error: None,
+          });
+          continue;
+        }
         eprintln!("{} {}", "[Error]".truecolor(246,98,78), err.display_message());
         file_reports.push(FileReport { path: path.clone(), result: FileResult{total:0,passed:0,failed:0}, failed: vec![], passed: vec![], run_error: Some(err.display_message()) });
         continue;
       }
     };
-    let invariants = runtime.invariant_snapshots();
+    let report = runtime.integrity_constraint_report()?;
     println!("{} {}\n", "[Test]".truecolor(153, 221, 85), path);
 
     let mut passed_cases = Vec::new();
     let mut failed_cases = Vec::new();
-    let width = invariants.iter().map(|case| case.name.len()).max().unwrap_or(0);
-    for invariant in invariants {
+    let width = report
+      .evaluations
+      .iter()
+      .map(|case| case.name.len())
+      .max()
+      .unwrap_or(0);
+    for evaluation in report.evaluations {
       println!(
         "{:<width$}   {}",
-        invariant.name,
-        if invariant.passed { "✓" } else { "✗" },
+        evaluation.name,
+        if evaluation.passed { "✓" } else { "✗" },
         width=width,
       );
-      let detail = CaseDetail {
-        name: invariant.name,
-        expression: invariant.expression,
-        reason: invariant.reason,
-        evaluated_kind: invariant.evaluated_kind,
-        actual: invariant.actual,
-        expected: invariant.expected,
-      };
-      if invariant.passed {
+      let detail = integrity_evaluation_case(&evaluation);
+      if evaluation.passed {
         passed_cases.push(detail);
       } else {
         failed_cases.push(detail);
@@ -517,6 +596,40 @@ mod tests {
     assert_eq!(exit_code, 0);
     assert!(report.contains("\"files-passed\": 1"));
     assert!(report.contains("\"run-error\": null"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn mech_tests_classify_each_integrity_violation_as_a_failed_case() {
+    let root = temp_test_root("integrity-aggregate");
+    let main = root.join("main.mec");
+    let output = root.join("report.json");
+    std::fs::write(
+      &main,
+      "first! := false\nsecond! := 42.0\nthird! := 2.0 < 1.0\n",
+    )
+    .unwrap();
+
+    let exit_code = run_mech_tests(
+      vec![main.display().to_string()],
+      false,
+      false,
+      false,
+      false,
+      Some(output.display().to_string()),
+      true,
+    )
+    .unwrap();
+
+    let report = std::fs::read_to_string(&output).unwrap();
+    assert_eq!(exit_code, 1);
+    assert!(report.contains("\"tests-total\": 3"));
+    assert!(report.contains("\"tests-failed\": 3"));
+    assert!(report.contains("\"run-error\": null"));
+    assert!(report.contains("\"first!\""));
+    assert!(report.contains("\"second!\""));
+    assert!(report.contains("\"third!\""));
+    assert!(!report.contains("@0x"));
     std::fs::remove_dir_all(root).unwrap();
   }
 


### PR DESCRIPTION
## Summary

This stacked PR turns Mech integrity constraints into live, transaction-aware
program state and enforces them at every candidate-state publication boundary.

- Constraint declarations compile once into stable descriptors that retain live
  result and operand cells.
- Program validation walks the complete interpreter hierarchy in deterministic
  order, aggregates every violation, and never uses pointer addresses as
  transaction or diagnostic identities.
- `step`, reactive turns, runtime program operations, module execution, and the
  final explicit commit barrier reject invalid candidate states.
- Failed validation rolls back values, registers, staged store work,
  capabilities, module graph changes, effects, events, and context through the
  existing transaction coordinators.
- Integrity rollback audit events are emitted only after cleanup and retain the
  attempted operation, transaction identity, and complete violation report.
- CLI and `mech test` output expose structured, address-free diagnostics.

Base: `a0486cde5706c8049fef2991777ca0acce517b01`

Previous head: `7a523bd8fbbe621c53955cea54da57fede5c7999`

Final head: `ae8b50e278574460976e8bf64c73ffdbc461d91f`

## Commit stack

1. `2b4995ec2253b49399e27b88782f4698599d4188` — `refactor(program): model live integrity constraints`
2. `0aa834734508bbdbb241ef013e04c450abcc5779` — `feat(program): validate candidate program states`
3. `5aabff304ba5d741b30052c8ab5f19e9ab50f8d6` — `fix(runtime): reject invalid transactional turns`
4. `67d1c33c9855b69782ef7c7f11113ddcfbb562d7` — `feat(runtime): report integrity rollback events`
5. `ae8b50e278574460976e8bf64c73ffdbc461d91f` — `test(runtime): prove transactional integrity enforcement`

## End-to-end staged receiver proof

The acceptance test
`runtime::input_tests::integrity_invalid_host_input_aborts_staged_receiver_before_commit`
drives all three turns through `MechRuntime::apply_host_input`:

| Input | Stage | Abort | Prepare | Commit | Deliver | Store commit | Capability use | Transaction |
| ----- | ----: | ----: | ------: | -----: | ------: | -----------: | -------------: | ----------- |
| 100   |    +1 |     0 |      +1 |     +1 |      +1 |           +1 |             +1 | committed   |
| 150   |    +1 |    +1 |       0 |      0 |       0 |            0 |              0 | aborted     |
| 110   |    +1 |     0 |      +1 |     +1 |      +1 |           +1 |             +1 | committed   |

The rejected payload 150 reached receiver staging but never reached prepare,
commit, delivery, durable store commit, or committed capability accounting.
The abort event precedes the detached integrity audit, live state is already
restored to 100 when that audit is inspected, and the later 110 turn proves the
runtime remains healthy.

Receiver history after the post-installation baseline:

- staged: `[100, 150, 110]`
- aborted: `[150]`
- prepared: `[100, 110]`
- committed: `[100, 110]`
- delivered: `[100, 110]`

The acceptance test passed against the intended production architecture; it did
not expose a production defect.

## Transactional guarantees

- Constraint declarations are structural program state and are included in
  retained checkpoints through the opaque value-state journal.
- Candidate validation is outside the reactive inner loop and runs once at the
  publication barrier.
- Ordinary invalid implicit turns restore their complete pre-turn state and
  leave the runtime healthy.
- Invalid explicit suffixes roll back only to their savepoint; earlier valid
  work remains provisional until outer commit or abort.
- Final explicit commit revalidates before any prepared effect or durable store
  publication.
- Isolated module dependencies validate before root graph materialization,
  export publication, or completion events.
- Validation and diagnostic collection use safe fallible borrows and aggregate
  infrastructure failures without panicking.
- No bypass mode, durable history, arena rewrite, bytecode-format change, or
  provider protocol change is included.

## Example scope

`examples/transactional-integrity/main.mec` is a minimal declaration example:
it evaluates one valid initial candidate and prints scalar `true`. It does not
inject host input or deliver receiver commands. The runtime acceptance test is
the complete host-input, staged-receiver, rollback, and recovery proof.

## Validation

Passed on final head:

- focused staged-receiver acceptance test, filtered and fully qualified
  `--exact`
- existing implicit recovery, explicit suffix rollback, and final explicit
  commit revalidation regressions
- `cargo check --workspace`
- `mech-core`: 154 library tests
- `mech-interpreter`: 163 library tests plus 4 integration tests
- `mech-program`: 95 library tests plus 5 integration tests
- `mech-runtime`: 528 library tests; complete package and integration suites,
  including 235 module-smoke tests and all sealed-API fixtures
- `cargo test --workspace`
- REPL Ctrl-C regression under both `repl` and `repl mika` minimal feature sets
- minimal `base invariant_define` checks for `mech-program` and `mech-runtime`
- REPL-only feature check without `invariant_define`
- runtime-boundary audit
- unsafe-boundary audit and its shell fixtures
- `git diff --check`
- corrected declaration-only example build and run (`bool`, `true`)
- `integrity_constraints` and `reactive_transaction` benchmark compilation

No timing assertions were added. Per explicit maintainer direction, neither
`rustfmt` nor `cargo fmt` was run.

## CI

All nine jobs passed on final head
`ae8b50e278574460976e8bf64c73ffdbc461d91f` in run `30304856048`:

- Cargo language tests
- Cargo runtime and host tests
- Dynamic modules
- Project browser
- Project native
- Run-only CLI
- Windows CLI
- cargo
- macOS runtime tests

The PR remains draft.

## Scope boundary

This is the preliminary transactional-integrity layer stacked directly on
PR #664. It deliberately stops before later integrity work and does not create
another pull request.
