### PR TITLE
fix(interpreter): correct multiplicative assignment feature gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,30 @@ jobs:
       - name: Run complete program library suite
         run: cargo test -p mech-program --lib
 
+      - name: Check isolated interpreter feature boundaries
+        run: |
+          cargo check -p mech-interpreter \
+            --no-default-features \
+            --features "program compiler variables variable_define variable_assign f64 math_mul_assign"
+          cargo test -p mech-interpreter \
+            --test op_assign_feature_gates \
+            --no-default-features \
+            --features "program compiler variables variable_define variable_assign f64 math_mul_assign" \
+            whole_mul_assignment_uses_mul_feature_only \
+            -- --exact --nocapture
+          cargo check -p mech-interpreter \
+            --no-default-features \
+            --features "program compiler variables variable_define variable_assign f64 math_div_assign"
+          cargo test -p mech-interpreter \
+            --test op_assign_feature_gates \
+            --no-default-features \
+            --features "program compiler variables variable_define variable_assign f64 math_div_assign" \
+            whole_div_assignment_uses_div_feature_only \
+            -- --exact --nocapture
+          cargo check -p mech-interpreter \
+            --no-default-features \
+            --features "compiler functions formulas string_concat"
+
       - name: Disk report at end
         if: always()
         run: bash scripts/ci-disk-report.sh

--- a/src/interpreter/src/activation/captures.rs
+++ b/src/interpreter/src/activation/captures.rs
@@ -1,7 +1,9 @@
 use crate::{
-    Interpreter, MResult, MechError, MechTuple, PatternBindingSink, PatternMatch, Ref, Value,
-    ValueKind, hash_str,
+    Interpreter, MResult, MechError, PatternBindingSink, PatternMatch, Ref, Value, ValueKind,
+    hash_str,
 };
+#[cfg(feature = "tuple")]
+use crate::MechTuple;
 #[cfg(feature = "matrix")]
 use mech_core::structures::matrix::Matrix;
 #[cfg(feature = "atom")]

--- a/src/interpreter/src/expressions/formulas.rs
+++ b/src/interpreter/src/expressions/formulas.rs
@@ -161,14 +161,12 @@ pub fn term(trm: &Term, env: Option<&Environment>, p: &InterpreterExecution<'_>)
       || string_access_input_is_live(&rhs, p);
     let new_fxn: Box<dyn MechFunction> = match op {
       // Math
-      FormulaOperator::AddSub(AddSubOp::Add) => match (&lhs, &rhs) {
-        #[cfg(feature = "string_concat")]
-        (_, value) | (value, _) if value.is_string() => {
-          StringConcat {}.compile(&vec![lhs, rhs])?
-        }
-        #[cfg(feature = "math_add")]
-        _ => MathAdd {}.compile(&vec![lhs, rhs])?,
-      },
+      #[cfg(feature = "string_concat")]
+      FormulaOperator::AddSub(AddSubOp::Add) if lhs.is_string() || rhs.is_string() => {
+        StringConcat {}.compile(&vec![lhs, rhs])?
+      }
+      #[cfg(feature = "math_add")]
+      FormulaOperator::AddSub(AddSubOp::Add) => MathAdd {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "math_sub")]
       FormulaOperator::AddSub(AddSubOp::Sub) => MathSub {}.compile(&vec![lhs, rhs])?,
       #[cfg(feature = "math_mul")]

--- a/src/interpreter/src/expressions/variables.rs
+++ b/src/interpreter/src/expressions/variables.rs
@@ -1,7 +1,46 @@
 use super::{Environment, UndefinedVariableError};
-#[cfg(feature = "kind_annotation")]
+#[cfg(all(feature = "kind_annotation", feature = "convert"))]
 use crate::{ConvertKind, execute_initialized_indexed_compiler, kind_annotation};
-use crate::{Identifier, InterpreterExecution, MResult, MutableReference, Value, Var, hash_str};
+use crate::{
+    Identifier, InterpreterExecution, MResult, MutableReference, Value, Var, hash_str,
+};
+#[cfg(not(all(feature = "kind_annotation", feature = "convert")))]
+use crate::{FeatureNotEnabledError, MechError};
+
+fn maybe_cast_variable_to_kind(
+    variable: &Var,
+    value: Value,
+    interpreter: &InterpreterExecution<'_>,
+) -> MResult<Value> {
+    let Some(annotation) = &variable.kind else {
+        return Ok(value);
+    };
+
+    #[cfg(all(feature = "kind_annotation", feature = "convert"))]
+    {
+        let target_kind = {
+            let state = interpreter.state.borrow();
+            kind_annotation(&annotation.kind, interpreter)?.to_value_kind(&state.kinds)?
+        };
+
+        return execute_initialized_indexed_compiler(
+            interpreter,
+            &interpreter.plan(),
+            &ConvertKind {},
+            vec![value, Value::Kind(target_kind)],
+        );
+    }
+
+    #[cfg(not(all(feature = "kind_annotation", feature = "convert")))]
+    {
+        let _ = value;
+        Err(
+            MechError::new(FeatureNotEnabledError, None)
+                .with_compiler_loc()
+                .with_tokens(annotation.tokens()),
+        )
+    }
+}
 
 pub(super) fn addressed_identifier_name(name: &Identifier, context: &Option<Identifier>) -> String {
     match context {
@@ -19,25 +58,6 @@ pub(super) fn addressed_identifier_hash(name: &Identifier, context: &Option<Iden
 
 #[cfg(feature = "symbol_table")]
 pub fn var(v: &Var, env: Option<&Environment>, p: &InterpreterExecution<'_>) -> MResult<Value> {
-    let plan = p.plan();
-    let maybe_cast_to_kind = |value: Value| -> MResult<Value> {
-        match &v.kind {
-            Some(kind_anntn) => {
-                let target_kind = {
-                    let state_brrw = p.state.borrow();
-                    kind_annotation(&kind_anntn.kind, p)?.to_value_kind(&state_brrw.kinds)?
-                };
-                execute_initialized_indexed_compiler(
-                    p,
-                    &plan,
-                    &ConvertKind {},
-                    vec![value, Value::Kind(target_kind)],
-                )
-            }
-            None => Ok(value),
-        }
-    };
-
     let id = addressed_identifier_hash(&v.name, &v.context);
     let name = addressed_identifier_name(&v.name, &v.context);
     let mark_if_live_symbol = |value: &MutableReference| {
@@ -62,7 +82,7 @@ pub fn var(v: &Var, env: Option<&Environment>, p: &InterpreterExecution<'_>) -> 
     };
     match env {
         Some(env) => match env.get(&id) {
-            Some(value) => maybe_cast_to_kind(value.clone()),
+            Some(value) => maybe_cast_variable_to_kind(v, value.clone(), p),
             None => {
                 let state_brrw = p.state.borrow();
                 let symbols_brrw = state_brrw.symbol_table.borrow();
@@ -72,7 +92,7 @@ pub fn var(v: &Var, env: Option<&Environment>, p: &InterpreterExecution<'_>) -> 
                 match symbol_value {
                     Some(value) => {
                         mark_if_live_symbol(&value);
-                        maybe_cast_to_kind(Value::MutableReference(value))
+                        maybe_cast_variable_to_kind(v, Value::MutableReference(value), p)
                     }
                     None => Err(crate::MechError::new(
                         UndefinedVariableError {
@@ -95,7 +115,7 @@ pub fn var(v: &Var, env: Option<&Environment>, p: &InterpreterExecution<'_>) -> 
             match symbol_value {
                 Some(value) => {
                     mark_if_live_symbol(&value);
-                    maybe_cast_to_kind(Value::MutableReference(value))
+                    maybe_cast_variable_to_kind(v, Value::MutableReference(value), p)
                 }
                 None => Err(crate::MechError::new(
                     UndefinedVariableError {

--- a/src/interpreter/src/functions.rs
+++ b/src/interpreter/src/functions.rs
@@ -506,8 +506,9 @@ fn execute_function_match_arms(
         }
       }
       // Normal arm: evaluate the expression and coerce to the declared output kind.
-      let out = expression(&arm.expression, Some(&env), p)?;
-      let coerced = coerce_function_output_kind(detach_value(&out), fxn_def, p)?;
+      let coerced = detach_value(&expression(&arm.expression, Some(&env), p)?);
+      #[cfg(feature = "kind_annotation")]
+      let coerced = coerce_function_output_kind(coerced, fxn_def, p)?;
       trace_println!(
         p,
         "{}",
@@ -859,7 +860,16 @@ fn collect_function_output(p: &InterpreterExecution<'_>, fxn_def: &FunctionDefin
   Ok(match outputs.len() {
     0 => Value::Empty,
     1 => outputs.remove(0),
+    #[cfg(feature = "tuple")]
     _ => Value::Tuple(Ref::new(MechTuple::from_vec(outputs))),
+    #[cfg(not(feature = "tuple"))]
+    _ => {
+      return Err(
+        MechError::new(FeatureNotEnabledError, None)
+          .with_compiler_loc()
+          .with_tokens(fxn_def.code.name.tokens()),
+      );
+    }
   })
 }
 

--- a/src/interpreter/src/statements/mod.rs
+++ b/src/interpreter/src/statements/mod.rs
@@ -42,9 +42,9 @@ pub use op_assign::op_assign;
 pub use op_assign::add_assign;
 #[cfg(feature = "math_sub_assign")]
 pub use op_assign::sub_assign;
-#[cfg(feature = "math_div_assign")]
-pub use op_assign::mul_assign;
 #[cfg(feature = "math_mul_assign")]
+pub use op_assign::mul_assign;
+#[cfg(feature = "math_div_assign")]
 pub use op_assign::div_assign;
 #[cfg(feature = "variable_assign")]
 pub use variable_assign::variable_assign;

--- a/src/interpreter/src/statements/op_assign.rs
+++ b/src/interpreter/src/statements/op_assign.rs
@@ -22,10 +22,37 @@ use crate::{MulAssignRange, MulAssignRangeAll, MulAssignValue};
   feature = "math_div_assign",
   feature = "math_mul_assign"
 ))]
-use crate::{
-  MatrixAssignScalar, MatrixAssignScalarAll, NativeFunctionCompiler, Subscript,
-  subscript_formula_ix, subscript_range,
-};
+use crate::Subscript;
+#[cfg(all(
+  any(
+    feature = "math_add_assign",
+    feature = "math_sub_assign",
+    feature = "math_div_assign",
+    feature = "math_mul_assign"
+  ),
+  any(feature = "subscript_formula", feature = "subscript_range")
+))]
+use crate::NativeFunctionCompiler;
+#[cfg(all(
+  any(
+    feature = "math_add_assign",
+    feature = "math_sub_assign",
+    feature = "math_div_assign",
+    feature = "math_mul_assign"
+  ),
+  feature = "subscript_formula"
+))]
+use crate::{MatrixAssignScalar, MatrixAssignScalarAll, subscript_formula_ix};
+#[cfg(all(
+  any(
+    feature = "math_add_assign",
+    feature = "math_sub_assign",
+    feature = "math_div_assign",
+    feature = "math_mul_assign"
+  ),
+  feature = "subscript_range"
+))]
+use crate::subscript_range;
 #[cfg(any(
   feature = "math_add_assign",
   feature = "math_sub_assign",
@@ -120,6 +147,7 @@ macro_rules! op_assign {
           Subscript::Bracket(subs) => {
             let mut fxn_input = vec![sink.clone()];
             match &subs[..] {
+              #[cfg(feature = "subscript_formula")]
               [Subscript::Formula(ix)] => {
                 fxn_input.push(source.clone());
                 let ixes = subscript_formula_ix(&subs[0], env, p)?;
@@ -132,6 +160,7 @@ macro_rules! op_assign {
                   _ => todo!(),
                 }
               },
+              #[cfg(feature = "subscript_formula")]
               [Subscript::Formula(ix1),Subscript::All] => {
                 fxn_input.push(source.clone());
                 let ix = subscript_formula_ix(&subs[0], env, p)?;
@@ -145,12 +174,14 @@ macro_rules! op_assign {
                   _ => todo!(),
                 }
               },
+              #[cfg(feature = "subscript_range")]
               [Subscript::Range(ix)] => {
                 fxn_input.push(source.clone());
                 let ixes = subscript_range(&subs[0], env, p)?;
                 fxn_input.push(ixes);
                 plan.borrow_mut().push([<$op AssignRange>]{}.compile(&fxn_input)?);
               },
+              #[cfg(feature = "subscript_range")]
               [Subscript::Range(ix), Subscript::All] => {
                 fxn_input.push(source.clone());
                 let ixes = subscript_range(&subs[0], env, p)?;
@@ -179,9 +210,9 @@ macro_rules! op_assign {
 op_assign!(add_assign, Add);
 #[cfg(feature = "math_sub_assign")]
 op_assign!(sub_assign, Sub);
-#[cfg(feature = "math_div_assign")]
-op_assign!(mul_assign, Mul);
 #[cfg(feature = "math_mul_assign")]
+op_assign!(mul_assign, Mul);
+#[cfg(feature = "math_div_assign")]
 op_assign!(div_assign, Div);
 //#[cfg(feature = "math_pow")]
 //op_assign!(pow_assign, Pow);

--- a/src/interpreter/tests/op_assign_feature_gates.rs
+++ b/src/interpreter/tests/op_assign_feature_gates.rs
@@ -1,0 +1,44 @@
+#[cfg(any(
+  feature = "math_mul_assign",
+  feature = "math_div_assign",
+))]
+use mech_interpreter::Interpreter;
+
+#[cfg(any(
+  feature = "math_mul_assign",
+  feature = "math_div_assign",
+))]
+fn evaluate_f64(source: &str) -> f64 {
+  let tree = mech_syntax::parser::parse(source).unwrap();
+  let mut interpreter = Interpreter::new_with_full_stdlib(0);
+  let output = interpreter.interpret(&tree).unwrap();
+  *output.as_f64().unwrap().borrow()
+}
+
+#[cfg(feature = "math_mul_assign")]
+#[test]
+fn whole_mul_assignment_uses_mul_feature_only() {
+  assert_eq!(
+    evaluate_f64(
+      "~x := 6.0\n\
+       y := 3.0\n\
+       x *= y\n\
+       x",
+    ),
+    18.0,
+  );
+}
+
+#[cfg(feature = "math_div_assign")]
+#[test]
+fn whole_div_assignment_uses_div_feature_only() {
+  assert_eq!(
+    evaluate_f64(
+      "~x := 6.0\n\
+       y := 3.0\n\
+       x /= y\n\
+       x",
+    ),
+    2.0,
+  );
+}


### PR DESCRIPTION
## Summary

Corrects the multiplication/division assignment gates while preserving the narrow Cargo feature graph from the runtime-shell base.

- Base branch: `refactor/651-runtime-shell-topology`
- Base SHA: `4c1bc65d340a0387f274ab63095878a7346bfa69`
- Head branch: `fix/651-mul-div-assignment-feature-gates`
- Head SHA: `74990457896ce633deda2cb5bb247466fcc8f419`
- Commit: `74990457896ce633deda2cb5bb247466fcc8f419` — `fix(interpreter): correct multiplicative assignment feature gates`

## Changes

- Gates `mul_assign` exclusively with `math_mul_assign` and `div_assign` exclusively with `math_div_assign`.
- Gates tuple activation capture imports, variable kind conversion, subscript formula assignment, and subscript range assignment at their exact feature boundaries.
- Returns `FeatureNotEnabledError` with compiler location and annotation tokens when a variable annotation is present without both conversion features.
- Moves the isolated multiplication and division checks to the public `op_assign_feature_gates` integration target.
- Keeps the Cargo feature graph, activation test module, and prior private statement tests identical to the #679 base.
- Updates Cargo language CI to run the public assignment tests and a string-concatenation-only formula check under narrow configurations.

Two additional production files are required by the truly narrow feature closure:

- `expressions/formulas.rs` uses separate dispatch arms for string concatenation and numeric addition. The guarded concatenation arm is enabled only by `string_concat`; the exhaustive numeric arm is enabled only by `math_add`; the existing unsupported-operator fallback handles non-string addition when numeric addition is absent.
- `functions.rs` gates kind-output coercion and tuple construction on their actual features, returning `FeatureNotEnabledError` for multi-output tuple construction when tuple support is absent.

## Feature-boundary design

The Cargo feature graph is unchanged from the runtime-shell base.

- `variables` does not imply tuple or kind conversion.
- `math_op_assign` does not imply addition, Boolean values, or subscript modes.
- Optional production imports and branches use their exact feature gates.
- `string_concat` can compile formula dispatch without enabling `math_add`.
- The isolated multiplication and division tests are public integration tests,
  so they do not suppress or require unrelated private activation fixtures.
- The full default activation suite remains enabled and unchanged.

## Validation

Narrow multiplication and division configurations:

- Both prescribed `cargo check` commands passed.
- Public multiplication integration test: 1 passed, 0 failed, 0 ignored.
- Public division integration test: 1 passed, 0 failed, 0 ignored.
- Captured interpreter cfg proves multiplication enables `math_mul_assign` but not `math_div_assign`.
- Captured interpreter cfg proves division enables `math_div_assign` but not `math_mul_assign`.
- Both cfg captures exclude `tuple`, `kind_annotation`, `convert`, `math_add`, `bool`, `subscript_formula`, and `subscript_range`.

Formula feature matrix:

- `compiler functions formulas string`: passed with neither addition implementation enabled.
- `compiler functions formulas string_concat`: passed with string concatenation enabled and `math_add` absent.
- `compiler f64 math_add string`: passed with numeric addition enabled and `string_concat` absent.
- `compiler f64 math_add string_concat`: passed with both implementations enabled.
- Captured interpreter cfg confirms the string-concatenation-only configuration contains `formulas` and `string_concat`, but not `math_add`.

Focused and full coverage:

- Activation suite: 69 passed, 0 failed, 0 ignored.
- Statement suite: 29 passed, 0 failed, 0 ignored.
- `cargo test -p mech-interpreter`: 171 passed across package targets, 0 failed, 0 ignored.
- `cargo check --workspace`: passed.
- `cargo test -p mech-core`: passed.
- `cargo test -p mech-program`: passed.
- `cargo test -p mech-runtime`: passed.
- `cargo test --workspace`: passed.
- Runtime wildcard, runtime boundary, and unsafe-boundary audits and fixtures: passed.
- `git diff --check`: passed.

Final diff remains one commit and has no changes to `src/interpreter/Cargo.toml`, `src/interpreter/src/activation/mod.rs`, or `src/interpreter/src/statements/tests/op_assign.rs` relative to #679.

## CI

GitHub Actions run `30395422616`: all nine jobs passed on amended head `74990457896ce633deda2cb5bb247466fcc8f419`.

- Cargo language tests: passed, including both isolated multiplicative assignment configurations and the string-concatenation-only formula configuration
- Cargo runtime and host tests: passed
- Dynamic modules: passed
- Project browser: passed
- Project native: passed
- Run-only CLI: passed
- Windows CLI: passed
- cargo: passed
- macOS runtime tests: passed