### PR TITLE
docs(syntax): extract implemented grammar [Phase 0B]

### DIFF
--- a/docs/design/grammar-audit/current-grammar.mec
+++ b/docs/design/grammar-audit/current-grammar.mec
@@ -1,0 +1,2115 @@
+Current Parser Grammar Candidate
+===============================================================================
+
+Status: mechanically extracted Phase 0 candidate, not the normative
+specification.
+
+Baseline: `75bb213f42a0f8116ca1299d1d39a5cf14fc0303`, the merge commit for
+PR 680.
+
+Authority: the parser implementation at that baseline is law. Comments, the
+existing specification, formatter output, and examples are evidence only.
+
+The formal rules below use the notation already present in
+`docs/design/specification.mec`: prefix `?`, `*`, `+`, `>`, and `¬`; comma
+sequences; bar choices; parenthesized groups; `[separator, element]` separated
+lists; and quoted terminals. Every formal rule ends in a semicolon. Text such
+as `?Unicode alphabetic grapheme?` names an implementation primitive in the
+same style as the existing specification. The current `grammar.rs` parser
+does not accept that descriptive primitive notation and cannot escape a quote
+inside a quoted terminal; those are meta-grammar discrepancies, not changes
+to this candidate.
+
+Cardinality rule:
+In this candidate, `[separator, element]` denotes one-or-more elements with
+the separator between them. `?[separator, element]` denotes the corresponding
+zero-or-more form. This uses the existing optional and separated-list
+operators together so the implementation's `separated_list1` and
+`separated_list0` calls remain distinguishable.
+
+The older Phase 0 module list predated PR 680. This extraction also includes
+`activation.rs` and `imports.rs`, because `parser.rs::mech_code_alt` selects
+`activation_scope` and `module_import` at this baseline.
+
+1. Source representation and entry normalization
+-------------------------------------------------------------------------------
+
+Source rule:
+`graphemes::init_source` segments the supplied UTF-8 string with
+`UnicodeSegmentation::graphemes(text, true)` and then unconditionally appends
+one synthetic `"\n"` grapheme. It does this even when the supplied text
+already ends in a newline. `parse`, `parse_grammar`, rich-comment reparsing,
+and fenced-Mech reparsing use this initializer. Lower-level parsers receiving
+a `ParseString` do not add a newline themselves. `graphemes::init_tag`, used
+by lower-level tests, does not append one.
+
+Source rule:
+`parse_grammar` first deletes every ASCII space, line feed, carriage return,
+and tab from the entire source, including from quoted terminals, and only then
+uses `init_source`.
+
+Implementation primitive:
+`parse-string` is a cursor over extended grapheme clusters with a shared
+diagnostic log. `eof` succeeds without consuming only when that cursor has no
+remaining graphemes.
+
+2. Character classes and implementation primitives
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+tag := ?exact grapheme-sequence supplied by the caller? ;
+emoji-grapheme := ?one grapheme classified by consume-emoji? ;
+alpha := ?one grapheme whose first scalar is alphabetic? ;
+digit := ?one grapheme whose first scalar is numeric? ;
+any := ?one extended grapheme cluster? ;
+any-token := any ;
+alpha-token := alpha ;
+digit-token := digit ;
+alphanumeric := alpha-token
+              | digit-token ;
+underscore-digit := underscore, digit-token ;
+digit-sequence := digit-token, *(underscore-digit | digit-token) ;
+forbidden-emoji := box-drawing-emoji
+                 | nbsp
+                 | thin-space
+                 | mika-section-open
+                 | mika-section-close
+                 | left-angle2
+                 | right-angle2 ;
+emoji := ¬forbidden-emoji, emoji-grapheme ;
+```
+
+Implementation primitive:
+`tag(x)` compares and consumes the exact grapheme sequence in `x`.
+`range(p)` preserves the source range consumed by `p`; `null(p)` discards its
+value. `is(p)` is positive lookahead and `is-not(p)` is negative lookahead.
+These implementation helpers do not add accepted syntax.
+
+Implementation anomaly:
+`consume_emoji` accepts a grapheme whenever its first scalar is neither
+alphanumeric nor ASCII. `forbidden-emoji` removes only the listed shapes, so
+the class is broader than Unicode emoji.
+
+3. Whitespace and separators
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+new-line := carriage-return-new-line
+          | new-line-char
+          | carriage-return ;
+whitespace := space
+            | tab
+            | new-line ;
+whitespace0 := *whitespace ;
+whitespace1 := +whitespace ;
+newline-indent := new-line, *space-tab ;
+ws1e := +space-tab ;
+ws0e := *space-tab ;
+space-tab := space
+           | tab
+           | nbsp
+           | thin-space ;
+space-tab0 := *space-tab ;
+space-tab1 := +space-tab ;
+list-separator := whitespace0, comma, whitespace0 ;
+enum-separator := whitespace0, bar, whitespace0 ;
+statement-separator := whitespace0, semicolon, whitespace0 ;
+```
+
+Whitespace rule:
+Despite their stale inline comments, `ws0e` and `ws1e` consume only
+`space-tab`; they do not consume a newline or call `newline-indent`.
+`space-tab` includes ordinary space, tab, no-break space, and thin space.
+`whitespace` includes ordinary space, tab, and all three newline forms, but
+does not include no-break or thin space.
+
+Whitespace rule:
+The twelve `ws0-leaf` operators below consume `whitespace0` on both sides.
+Consequently they can consume newlines. Raw punctuation terminals consume no
+surrounding whitespace.
+
+4. Terminals, punctuation, symbols, and sigils
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+ampersand := "&" ;
+apostrophe := "'" ;
+asterisk := "*" ;
+at := "@" ;
+bar := "|" ;
+backslash := "\\" ;
+caret := "^" ;
+colon := ":" ;
+comma := "," ;
+dash := "-" ;
+dollar := "$" ;
+equal := "=" ;
+exclamation := "!" ;
+grave := "`" ;
+hashtag := "#" ;
+negate := "¬" ;
+percent := "%" ;
+period := "." ;
+plus := "+" ;
+question := "?" ;
+quote := ?U+0022 quotation mark? ;
+semicolon := ";" ;
+slash := "/" ;
+tilde := "~" ;
+underscore := "_" ;
+
+check-mark := "✓" ;
+cross := "✗" ;
+english-true-literal := "true" ;
+english-false-literal := "false" ;
+
+space := " " ;
+nbsp := ?U+00A0 no-break space? ;
+thin-space := ?U+2009 thin space? ;
+new-line-char := ?U+000A line feed? ;
+carriage-return := ?U+000D carriage return? ;
+carriage-return-new-line := ?U+000D followed by U+000A? ;
+tab := ?U+0009 tab? ;
+
+left-bracket := "[" ;
+left-parenthesis := "(" ;
+left-brace := "{" ;
+left-angle1 := "<" ;
+left-angle2 := "⟨" ;
+right-bracket := "]" ;
+right-parenthesis := ")" ;
+right-brace := "}" ;
+right-angle1 := ">" ;
+right-angle2 := "⟩" ;
+
+box-tl-round := "╭" ;
+box-tr-round := "╮" ;
+box-bl-round := "╰" ;
+box-br-round := "╯" ;
+box-tl-bold := "┏" ;
+box-tr-bold := "┓" ;
+box-bl-bold := "┗" ;
+box-br-bold := "┛" ;
+box-tl := "┌" ;
+box-tr := "┐" ;
+box-bl := "└" ;
+box-br := "┘" ;
+box-cross := "┼" ;
+box-horz := "─" ;
+box-t-left := "├" ;
+box-t-right := "┤" ;
+box-t-top := "┬" ;
+box-t-bottom := "┴" ;
+box-vert := "│" ;
+box-vert-bold := "┃" ;
+
+abstract-sigil := "%%" ;
+emphasis-sigil := "*" ;
+equation-sigil := "$$" ;
+footnote-prefix := "[^" ;
+float-left := "<<:" ;
+float-right := ":>>" ;
+http-prefix := "http" ;
+highlight-sigil := "!!" ;
+img-prefix := "![" ;
+quote-sigil := ">" ;
+question-sigil := "(?)>" ;
+info-sigil := "(i)>" ;
+idea-sigil := "(*)>" ;
+warning-sigil := "(!)>" ;
+error-sigil := "(x)>" ;
+error-alt-sigil := "(✗)>" ;
+success-check-sigil := "(✓)>" ;
+success-sigil := "(+)>" ;
+strike-sigil := "~~" ;
+strong-sigil := "**" ;
+grave-codeblock-sigil := ?three consecutive U+0060 grave accents? ;
+tilde-codeblock-sigil := "~~~" ;
+underline-sigil := "__" ;
+section-sigil := "§" ;
+mika-section-open := "⸢" ;
+mika-section-close := "⸥" ;
+prompt-sigil := ">:" ;
+module-import-sigil := "+>" ;
+module-export-sigil := "<+" ;
+
+assign-operator := whitespace0, "=", whitespace0 ;
+async-transition-operator := whitespace0, "~>", whitespace0 ;
+define-operator := whitespace0, ":=", whitespace0 ;
+synth-operator := whitespace0, "?=", whitespace0 ;
+gen-operator := whitespace0, "@=", whitespace0 ;
+output-operator-a := whitespace0, "=>", whitespace0 ;
+output-operator-u := whitespace0, "⇒", whitespace0 ;
+transition-operator-a := whitespace0, "->", whitespace0 ;
+transition-operator-u := whitespace0, "→", whitespace0 ;
+generator-arrow := whitespace0, "<-", whitespace0 ;
+generator-arrow-u := whitespace0, "←", whitespace0 ;
+spread-operator-a := whitespace0, "...", whitespace0 ;
+spread-operator-u := whitespace0, "…", whitespace0 ;
+transition-operator := transition-operator-a
+                     | transition-operator-u ;
+output-operator := output-operator-a
+                 | output-operator-u ;
+
+grouping-symbol := left-parenthesis
+                 | right-parenthesis
+                 | left-angle
+                 | right-angle
+                 | left-brace
+                 | right-brace
+                 | left-bracket
+                 | right-bracket ;
+punctuation := period
+             | exclamation
+             | question
+             | comma
+             | colon
+             | semicolon
+             | quote
+             | apostrophe ;
+symbol := ampersand
+        | grave
+        | dollar
+        | bar
+        | percent
+        | at
+        | slash
+        | hashtag
+        | equal
+        | backslash
+        | tilde
+        | plus
+        | dash
+        | asterisk
+        | caret
+        | underscore ;
+identifier-symbol := ampersand
+                   | dollar
+                   | percent
+                   | slash
+                   | hashtag
+                   | backslash
+                   | tilde
+                   | plus
+                   | dash
+                   | asterisk
+                   | caret ;
+escaped-char := backslash, (alpha-token | symbol | punctuation) ;
+text := alpha-token
+      | digit-token
+      | emoji
+      | forbidden-emoji
+      | space
+      | tab
+      | escaped-char
+      | punctuation
+      | grouping-symbol
+      | symbol ;
+raw-text := alpha-token
+          | digit-token
+          | emoji
+          | forbidden-emoji
+          | space
+          | tab
+          | punctuation
+          | grouping-symbol
+          | symbol ;
+```
+
+Selection rule:
+All choices in this section use ordinary ordered `alt`. Multi-character sigils
+are separate callers; `symbol` itself tries the one-character alternatives in
+the displayed order.
+
+5. Identifiers
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+identifier := (alpha-token | emoji),
+              *(alpha-token | digit-token | identifier-symbol | emoji) ;
+identifier-path-segment-emoji :=
+  ¬(slash | asterisk | comma | colon | equal | left-brace | right-brace
+    | underscore | space | tab | new-line),
+  emoji ;
+identifier-path-segment :=
+  (alpha-token | identifier-path-segment-emoji),
+  *(alpha-token | digit-token | dash | identifier-path-segment-emoji) ;
+context-address-path-token := alpha-token
+                            | digit-token
+                            | dash
+                            | slash
+                            | underscore
+                            | period ;
+context-address-path := +context-address-path-token ;
+prefixed-context-path := at, identifier-path-segment, slash,
+                         context-address-path ;
+var := prefixed-context-path, ?kind-annotation
+     | identifier, ?kind-annotation ;
+```
+
+Selection rule:
+`var`, `slice`, and `slice-ref` manually try the addressed-context form first
+and fall back to the unqualified identifier form on any failure.
+
+6. Literals
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+literal := (number
+          | string
+          | atom
+          | boolean
+          | empty
+          | kind-annotation),
+          ?kind-annotation ;
+empty := +underscore ;
+atom := colon, identifier ;
+string := raw-string
+        | utf8-string ;
+utf8-string := quote, *(¬quote, (text | new-line)), quote ;
+raw-string := quote, quote, quote,
+              *(¬(quote, quote, quote), (raw-text | new-line)),
+              quote, quote, quote ;
+boolean := true-literal
+         | false-literal ;
+true-literal := english-true-literal
+              | check-mark ;
+false-literal := english-false-literal
+               | cross ;
+
+number := complex-number
+        | real-number ;
+complex-number := untyped-real-number, ("i" | "j")
+                | untyped-real-number, (plus | dash),
+                  untyped-real-number, ("i" | "j") ;
+real-number := ?dash,
+               (hexadecimal-literal
+              | decimal-literal
+              | octal-literal
+              | binary-literal
+              | scientific-literal
+              | rational-literal
+              | float-literal
+              | integer-literal) ;
+untyped-real-number := ?dash,
+                       (hexadecimal-literal
+                      | decimal-literal
+                      | octal-literal
+                      | binary-literal
+                      | scientific-literal
+                      | rational-literal
+                      | float-literal
+                      | untyped-integer) ;
+rational-literal := integer-literal, slash, integer-literal ;
+scientific-literal := (float-literal | integer-literal),
+                      ("e" | "E"),
+                      ?plus,
+                      ?dash,
+                      (float-literal | integer-literal) ;
+float-decimal-start := period, digit-sequence ;
+float-full := digit-sequence, period, digit-sequence ;
+float-literal := float-decimal-start
+               | float-full ;
+integer-literal := typed-integer
+                 | untyped-integer ;
+typed-integer := digit-sequence, identifier ;
+untyped-integer := digit-sequence ;
+decimal-literal := "0d", digit-sequence ;
+hexadecimal-literal := "0x", +(digit-token | underscore | alpha-token) ;
+octal-literal := "0o", digit-sequence ;
+binary-literal := "0b", digit-sequence ;
+```
+
+Selection rule:
+`complex-number` first parses an `untyped-real-number`. It succeeds only if an
+`i`/`j` follows immediately, or if an immediately adjacent plus/dash,
+untyped-real-number, and `i`/`j` follow. `number` then falls back to
+`real-number`.
+
+Implementation anomaly:
+The hexadecimal, octal, binary, and explicit decimal parsers enforce their
+prefixes but do not validate the digit alphabet beyond the displayed parser.
+Thus hexadecimal accepts any alphabetic grapheme, and octal/binary accept any
+numeric grapheme recognized by `digit`.
+
+Implementation anomaly:
+Because `integer-literal` tries `typed-integer` first, adjacent alphabetic
+text is consumed as a kind suffix. Because `rational-literal` itself calls
+`integer-literal`, either side can consume such a suffix.
+
+Implementation anomaly:
+The same typed-integer priority means an integer-base scientific spelling
+such as `1e2` consumes `e2` as the integer kind suffix before
+`scientific-literal` can match its `e`. A floating base such as `1.0e2`
+reaches the scientific branch. A typed exponent reaches an `unreachable!()`
+arm in the current implementation rather than producing a parse result.
+
+7. Kinds
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+left-angle := left-angle1
+            | left-angle2 ;
+right-angle := right-angle1
+             | right-angle2 ;
+kind-annotation := left-angle, kind-with-option, right-angle ;
+kind-with-option := kind, ?question ;
+kind := kind-any
+      | kind-atom
+      | kind-empty
+      | kind-map
+      | kind-matrix
+      | kind-record
+      | kind-scalar
+      | kind-set
+      | kind-table
+      | kind-tuple
+      | kind-kind ;
+kind-kind := left-angle, kind-with-option, right-angle ;
+kind-table := bar,
+              [(list-separator | space-tab1),
+               (identifier, ?kind-annotation)],
+              bar,
+              ?(colon, literal) ;
+kind-any := asterisk ;
+kind-empty := +underscore ;
+kind-atom := colon, identifier ;
+kind-set := left-brace, kind, right-brace,
+            ?(colon, literal), ?":N" ;
+kind-map := left-brace, kind, colon, kind, right-brace ;
+kind-record := left-brace, whitespace0,
+               [(list-separator | whitespace1),
+                (identifier, kind-annotation)],
+               ?(",…"), whitespace0, right-brace ;
+kind-matrix := left-bracket, kind-with-option, right-bracket,
+               ?colon, ?[list-separator, literal] ;
+kind-tuple := left-parenthesis, [list-separator, kind],
+              right-parenthesis ;
+kind-scalar := identifier, ?(colon, range-expression) ;
+```
+
+Selection rule:
+`kind` uses ordinary ordered `alt` exactly in the displayed order.
+`kind-table` and `kind-record` use the one-or-more separated-list form and
+therefore require at least one field.
+
+Whitespace rule:
+`kind-table` separators are either `list-separator` or `space-tab1` in the
+implementation (not `whitespace1`); `kind-record` separators are either
+`list-separator` or `whitespace1`, so record fields can be newline-separated.
+
+Implementation anomaly:
+`kind-set` parses an optional `":" literal` and then independently parses an
+optional literal `":N"`, even when the first size was present. `kind-matrix`
+allows a size list without a colon and accepts an empty size list.
+
+8. Expressions and operator precedence
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+expression := fsm-pipe
+            | set-comprehension
+            | matrix-comprehension
+            | range-expression
+            | formula, ?(question, whitespace0, +match-arm, ?period) ;
+formula := l1 ;
+l1 := l2, *(logic-operator, l2) ;
+l2 := l3, *(comparison-operator, l3) ;
+l3 := l4, *(add-sub-operator, l4) ;
+l4 := l5, *((mul-div-operator | matrix-operator), l5) ;
+l5 := l6, *(power-operator, l6) ;
+l6 := l7, *(table-operator, l7) ;
+l7 := factor, *(set-operator, factor) ;
+factor := (parenthetical-term
+         | negate-factor
+         | not-factor
+         | matrix-comprehension
+         | structure
+         | function-call
+         | literal
+         | slice
+         | var),
+         ?transpose ;
+parenthetical-term := left-parenthesis, space-tab0, formula,
+                      space-tab0, right-parenthesis ;
+negate-factor := dash, factor ;
+not-factor := not, factor ;
+transpose := apostrophe ;
+
+add-sub-operator := add
+                  | subtract ;
+mul-div-operator := multiply
+                  | divide
+                  | modulus ;
+power-operator := power ;
+add := ws0e, plus, ws0e ;
+subtract := spaced-subtract
+          | raw-subtract ;
+raw-subtract := ¬comment-sigil, dash ;
+spaced-subtract := ws1e, raw-subtract, ws1e ;
+multiply := ws0e, ¬matrix-multiply, ("*" | "×"), ws0e ;
+divide := ws0e, ¬comment-sigil, (slash | "÷"), ws0e ;
+modulus := ws0e, percent, ws0e ;
+power := ws0e, caret, ws0e ;
+
+matrix-operator := matrix-multiply
+                 | matrix-solve
+                 | dot-product
+                 | cross-product ;
+matrix-multiply := ws0e, "**", ws0e ;
+matrix-solve := ws0e, backslash, ws0e ;
+dot-product := ws0e, ("·" | "•"), ws0e ;
+cross-product := ws0e, "⨯", ws0e ;
+
+range-expression := formula, range-operator, formula,
+                    ?(range-operator, formula) ;
+range-inclusive := "..=" ;
+range-exclusive := ".." ;
+range-operator := range-inclusive
+                | range-exclusive ;
+
+comparison-operator := strict-equal
+                     | strict-not-equal
+                     | not-equal
+                     | equal-to
+                     | greater-than-equal
+                     | greater-than
+                     | less-than-equal
+                     | less-than ;
+not-equal := ws0e, ("!=" | "¬=" | "≠"), ws0e ;
+equal-to := ws0e, ("==" | "⩵"), ws0e ;
+strict-not-equal := ws0e, ("!==" | "!≡" | "¬≡" | "¬=="), ws0e ;
+strict-equal := ws0e, ("===" | "≡"), ws0e ;
+greater-than := ws0e, right-angle1, ws0e ;
+less-than := ws0e, ¬generator-arrow, left-angle1, ws0e ;
+greater-than-equal := ws0e, (">=" | "≥"), ws0e ;
+less-than-equal := ws0e, ("<=" | "≤"), ws0e ;
+
+logic-operator := and
+                | or
+                | xor ;
+or := ws0e, ("||" | "∨" | "⋁"), ws0e ;
+and := ws0e, ("&&" | "∧" | "⋀"), ws0e ;
+not := exclamation
+     | negate ;
+xor := ws0e, ("^^" | "⊕" | "⊻"), ws0e ;
+
+table-operator := join
+                | left-join
+                | right-join
+                | full-join
+                | left-semi-join
+                | left-anti-join ;
+join := ws0e, "⋈", ws0e ;
+left-join := ws0e, "⟕", ws0e ;
+right-join := ws0e, "⟖", ws0e ;
+full-join := ws0e, "⟗", ws0e ;
+left-semi-join := ws0e, "⋉", ws0e ;
+left-anti-join := ws0e, "▷", ws0e ;
+
+set-operator := union-op
+              | intersection
+              | difference
+              | complement
+              | subset
+              | superset
+              | proper-subset
+              | proper-superset
+              | element-of
+              | not-element-of
+              | symmetric-difference ;
+union-op := ws0e, "∪", ws0e ;
+intersection := ws0e, "∩", ws0e ;
+difference := ws0e, "∖", ws0e ;
+complement := ws0e, "∁", ws0e ;
+subset := ws0e, "⊆", ws0e ;
+superset := ws0e, "⊇", ws0e ;
+proper-subset := ws0e, ("⊊" | "⊂"), ws0e ;
+proper-superset := ws0e, ("⊋" | "⊃"), ws0e ;
+element-of := ws0e, "∈", ws0e ;
+not-element-of := ws0e, "∉", ws0e ;
+symmetric-difference := ws1e, "Δ", ws1e ;
+
+set-comprehension := left-brace, space-tab0, expression, space-tab0,
+                     bar, space-tab0,
+                     [list-separator, comprehension-qualifier],
+                     space-tab0, right-brace ;
+matrix-comprehension := left-bracket, space-tab0, expression, space-tab0,
+                        bar, space-tab0,
+                        [list-separator, comprehension-qualifier],
+                        space-tab0, right-bracket ;
+comprehension-qualifier := generator
+                         | variable-define
+                         | expression ;
+generator := pattern, space-tab0,
+             (generator-arrow | generator-arrow-u),
+             space-tab0, expression ;
+```
+
+Selection rule:
+`expression` is manual ordered fallback in the displayed order. The formula
+branch then manually recognizes the trailing question/arms form and changes
+the AST to a match expression. `factor` is also manual ordered fallback in the
+displayed order. `comprehension-qualifier` manually tries generator, then
+variable definition, then filter expression. Errors from rejected earlier
+forms are discarded.
+
+Selection rule:
+The match suffix is optional only while its leading `question` is absent.
+Once `question` succeeds, `whitespace0`, one-or-more `match-arm` values, and
+the optional final period are parsed on the already-advanced input; their
+failure is returned rather than falling back to the preceding formula
+prefix. Thus `a?` does not succeed as the shorter expression `a`.
+
+Selection rule:
+Each precedence function constructs a left-associated term containing its
+ordered right-hand operator/operand pairs. This includes `power`; the current
+parser does not make exponentiation right-associative. Once an operator is
+recognized, the following operand is committed by `cut`.
+
+Whitespace rule:
+Formula operators using `ws0e` can have only horizontal `space-tab` around
+them. `raw-subtract` consumes no surrounding space. `spaced-subtract` requires
+at least one `space-tab` on both sides. `symmetric-difference` likewise
+requires horizontal space on both sides.
+
+Implementation anomaly:
+`identifier` includes dash and slash. Therefore `a-b` and `a/b` are single
+identifiers, while `a - b` and `a / b` are formulas. Numeric parsing wins for
+`1/2`, producing a rational literal; `1 / 2` is division.
+
+Validation rule:
+After parsing a `matrix-comprehension`, the implementation rejects it unless
+at least one qualifier produced a generator (`<-` or `←`) or a variable
+definition (`:=`). A set comprehension has no equivalent validation.
+
+9. Structures
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+structure := empty-set
+           | empty-map
+           | table
+           | matrix
+           | tuple
+           | tuple-struct
+           | record
+           | map
+           | set ;
+
+matrix := matrix-start,
+          *(box-drawing-char | whitespace),
+          *(matrix-row, *(box-drawing-char | whitespace)),
+          whitespace0,
+          matrix-end ;
+matrix-column := space-tab0, expression,
+                 space-tab0, ?(comma | box-vert | box-vert-bold),
+                 space-tab0 ;
+matrix-row := space-tab0, ?table-separator, space-tab0,
+              +matrix-column, ?semicolon, ?new-line,
+              ?(+box-drawing-char, new-line) ;
+matrix-start := box-tl-round
+              | box-tl
+              | box-tl-bold
+              | left-bracket ;
+matrix-end := box-br-round
+            | box-br
+            | box-br-bold
+            | right-bracket ;
+
+table := inline-table
+       | regular-table
+       | fancy-table ;
+fancy-table := table-top, table-separator, fancy-table-header,
+               [new-line, (table-row2 | row-separator)] ;
+fancy-table-header := [table-separator, field],
+                      table-separator, whitespace0 ;
+row-separator := space-tab0,
+                 +(box-drawing-char | table-end | space-tab),
+                 space-tab0 ;
+table-top := table-start, *box-drawing-char, new-line ;
+inline-table := table-separator, space-tab0, inline-table-header,
+                space-tab0, +inline-table-row ;
+inline-table-row := space-tab0, +(space-tab0, expression),
+                    space-tab0, table-separator ;
+regular-table := table-separator, whitespace0, table-header,
+                 [whitespace0, table-row] ;
+table-header := [space-tab1, header-field],
+                space-tab0, table-separator, whitespace0 ;
+inline-table-header := [space-tab1, header-field],
+                       space-tab0, table-separator, space-tab0 ;
+table-row2 := table-separator,
+              [(space-tab0, table-separator, space-tab0), expression],
+              space-tab0, table-separator, space-tab0 ;
+table-row := table-separator, [space-tab1, expression],
+             space-tab0, table-separator, space-tab0 ;
+table-column := space-tab0, expression, space-tab0,
+                ?(comma | table-separator), space-tab0 ;
+header-field := identifier, kind-annotation ;
+field := identifier, ?kind-annotation ;
+box-drawing-char := box-tl
+                  | box-bl
+                  | box-tr
+                  | box-tl-bold
+                  | box-bl-bold
+                  | box-tr-bold
+                  | box-tr-round
+                  | box-bl-round
+                  | box-vert
+                  | box-cross
+                  | box-horz
+                  | box-t-left
+                  | box-t-right
+                  | box-t-top
+                  | box-t-bottom ;
+box-drawing-emoji := box-vert-bold
+                   | box-tl
+                   | box-bl
+                   | box-tr
+                   | box-tl-bold
+                   | box-bl-bold
+                   | box-tr-bold
+                   | box-tl-round
+                   | box-br-round
+                   | box-tr-round
+                   | box-bl-round
+                   | box-vert
+                   | box-cross
+                   | box-horz
+                   | box-t-left
+                   | box-t-right
+                   | box-t-top
+                   | box-t-bottom ;
+table-start := box-tl-round
+             | box-tl
+             | box-tl-bold
+             | left-brace
+             | table-separator ;
+table-end := box-br-round
+           | box-br
+           | box-br-bold
+           | right-brace
+           | table-separator ;
+table-separator := space-tab0, (box-vert | box-vert-bold | bar),
+                   space-tab0 ;
+table-horz := dash
+            | box-horz ;
+
+empty-map := left-brace, whitespace0, colon, whitespace0, right-brace ;
+map := left-brace, whitespace0, +mapping, whitespace0, right-brace ;
+mapping := whitespace0, expression, whitespace0, colon, whitespace0,
+           expression, whitespace0, ?comma, whitespace0 ;
+record := table-start, whitespace0, +binding, whitespace0, table-end ;
+binding := whitespace0, identifier, ?kind-annotation, whitespace0,
+           colon, whitespace0, expression, whitespace0, ?comma,
+           whitespace0 ;
+empty-set := left-brace, whitespace0, ?empty, whitespace0, right-brace ;
+set := left-brace, whitespace0,
+       [(list-separator | whitespace1), expression],
+       whitespace0, right-brace ;
+tuple := left-parenthesis, whitespace0,
+         ?[list-separator, expression],
+         whitespace0, right-parenthesis ;
+tuple-struct := colon, identifier, left-parenthesis, whitespace0,
+                expression, whitespace0, right-parenthesis ;
+```
+
+Selection rule:
+`structure` manually tries the displayed alternatives, discarding every
+failure until `set`, whose error is returned. `table` uses ordinary ordered
+`alt`: inline, regular, then fancy. This ordering is observable for shared
+`|`/brace/bracket prefixes.
+
+Completion rule:
+`matrix` loops until `matrix-end` is visible and requires each successful row
+to advance the cursor. The private Rust `table_bottom` function has no caller:
+`fancy-table` does not invoke it, so it is classified as a non-grammar helper
+and is intentionally absent from the formal rules.
+
+Whitespace rule:
+`table-separator` consumes `space-tab0` on both sides. `matrix-column` and
+`table-column` also consume horizontal whitespace around their optional
+trailing separators. Map, set, tuple, record, and binding interiors use
+`whitespace0`, so their separators may cross newlines.
+
+10. Subscripts
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+subscript := +(swizzle-subscript
+             | dot-subscript
+             | dot-subscript-int
+             | bracket-subscript
+             | brace-subscript) ;
+slice := prefixed-context-path, subscript
+       | identifier, subscript ;
+slice-ref := prefixed-context-path, ?subscript
+           | identifier, ?subscript ;
+swizzle-subscript := period, identifier, comma,
+                     [comma, identifier] ;
+dot-subscript := period, identifier ;
+dot-subscript-int := period, integer-literal ;
+bracket-subscript := left-bracket,
+                     [list-separator,
+                      (select-all | range-subscript | formula-subscript)],
+                     right-bracket ;
+brace-subscript := left-brace,
+                   [list-separator,
+                    (select-all | range-subscript | formula-subscript)],
+                   right-brace ;
+select-all := colon ;
+formula-subscript := formula ;
+range-subscript := range-expression ;
+```
+
+Selection rule:
+The repeated subscript alternatives are ordered swizzle, dot identifier, dot
+integer, bracket, brace. Because dot identifier precedes dot integer, a typed
+integer-like suffix that begins alphabetically follows the identifier path.
+Within brackets/braces, select-all precedes range, which precedes formula.
+
+Feature rule:
+The parser functions are compiled without per-rule `cfg` gates at this
+baseline. Cargo feature names such as `subscript_slice`, `subscript_range`,
+`logical_indexing`, `swizzle`, `subscript_formula`, and `dot_indexing` govern
+downstream capabilities, not whether these syntax functions recognize text.
+
+11. Patterns
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+pattern := pattern-atom-struct
+         | pattern-tuple-struct
+         | wildcard
+         | pattern-array
+         | pattern-tuple
+         | expression ;
+wildcard := asterisk ;
+pattern-tuple-struct := grave, identifier, left-parenthesis,
+                        whitespace0, [list-separator, pattern],
+                        whitespace0, right-parenthesis ;
+spread-operator := spread-operator-a
+                 | spread-operator-u ;
+pattern-array-item := pattern ;
+pattern-array-token := spread-operator
+                     | enum-separator
+                     | pattern-array-item ;
+pattern-array := left-bracket, whitespace0,
+                 *(pattern-array-token, whitespace0, ?list-separator),
+                 right-bracket ;
+pattern-atom-struct := colon, identifier, left-parenthesis,
+                       whitespace0, [list-separator, pattern],
+                       whitespace0, right-parenthesis ;
+pattern-tuple := left-parenthesis, whitespace0,
+                 [list-separator, pattern],
+                 whitespace0, right-parenthesis ;
+```
+
+Selection rule:
+`pattern` is manual ordered fallback in the displayed order. The array parser
+is a hand-written token loop: it stops only when `right-bracket` succeeds and
+otherwise parses a token, optional whitespace, and consumes a comma separator
+when present.
+
+Validation rule:
+An array pattern permits at most one `enum-separator` rest marker and then
+requires exactly one pattern after it. It rejects mixing that marker with a
+spread operator. Without a rest marker it permits at most one spread.
+Spread-binding AST selection depends on the prefix ending in wildcard and on
+the number of suffix patterns; this semantic reshaping does not change the
+formal token language.
+
+12. Statements
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+comment-sigil := "--"
+               | "//" ;
+comment := *space-tab, comment-sigil, *(¬new-line, any-token) ;
+op-assign-operator := add-assign-operator
+                    | sub-assign-operator
+                    | mul-assign-operator
+                    | div-assign-operator
+                    | exp-assign-operator ;
+add-assign-operator := whitespace0, "+=", whitespace0 ;
+sub-assign-operator := whitespace0, "-=", whitespace0 ;
+mul-assign-operator := whitespace0, "*=", whitespace0 ;
+div-assign-operator := whitespace0, "/=", whitespace0 ;
+exp-assign-operator := whitespace0, "^=", whitespace0 ;
+send-operator := whitespace0, "<-", whitespace0 ;
+context-send := var, send-operator, expression ;
+variable-define := ?tilde, var, ¬assign-operator,
+                   define-operator, expression ;
+invariant-define := identifier, exclamation, ¬assign-operator,
+                    define-operator, expression ;
+variable-assign := slice-ref, ¬define-operator,
+                   assign-operator, expression ;
+op-assign := slice-ref, ¬define-operator,
+             op-assign-operator, expression ;
+tuple-destructure := left-parenthesis,
+                     [list-separator, identifier],
+                     right-parenthesis, define-operator, expression ;
+
+source-import-tail := +(¬(new-line | semicolon), any-token) ;
+source-path-component-token := alpha-token
+                             | digit-token
+                             | dash
+                             | underscore
+                             | period ;
+source-path-component := +source-path-component-token ;
+source-mec-path := source-path-component,
+                   *(slash, source-path-component) ;
+source-mec-path-wildcard-suffix := ?(slash, asterisk) ;
+relative-source-import-specifier :=
+  ((period, period, slash) | (period, slash)),
+  source-mec-path, source-mec-path-wildcard-suffix ;
+absolute-source-import-specifier :=
+  slash, source-mec-path, source-mec-path-wildcard-suffix ;
+bare-source-import-specifier :=
+  source-mec-path, source-mec-path-wildcard-suffix ;
+uri-scheme-part := alpha-token
+                 | digit-token
+                 | plus
+                 | dash
+                 | period ;
+source-import-uri-scheme := alpha-token, *uri-scheme-part ;
+uri-source-import-specifier :=
+  source-import-uri-scheme, "://", source-import-tail ;
+source-import-specifier := relative-source-import-specifier
+                         | absolute-source-import-specifier
+                         | uri-source-import-specifier
+                         | bare-source-import-specifier ;
+import-declaration := whitespace0, module-import-sigil, whitespace1,
+                      source-import-specifier ;
+export-declaration := whitespace0, module-export-sigil, whitespace1,
+                      identifier ;
+
+context-declaration := whitespace0, at, identifier, define-operator,
+                       (context-base-resource-uri | context-base-context),
+                       ?(left-brace,
+                         [list-separator, context-capability-declaration],
+                         ?list-separator, right-brace) ;
+context-base-context := at, identifier ;
+context-base-resource-uri :=
+  +(alpha-token | digit-token | dash | period),
+  "://",
+  +(alpha-token | digit-token | dash | period | slash | underscore) ;
+context-capability-declaration :=
+  colon, identifier, left-parenthesis, context-capability-scope,
+  right-parenthesis ;
+context-capability-path-token := alpha-token
+                               | digit-token
+                               | dash
+                               | slash
+                               | underscore
+                               | period
+                               | asterisk ;
+context-capability-path := +context-capability-path-token ;
+context-capability-scope := asterisk
+                          | context-capability-path ;
+
+statement := import-declaration
+           | export-declaration
+           | context-declaration
+           | fsm-declare
+           | invariant-define
+           | context-send
+           | variable-define
+           | variable-assign
+           | op-assign
+           | enum-define
+           | tuple-destructure
+           | kind-define ;
+enum-define := left-angle, identifier, right-angle,
+               define-operator, [enum-separator, enum-variant] ;
+enum-variant := ?grave, ?colon, identifier,
+                ?(enum-variant-kind | enum-variant-inline-kind) ;
+enum-variant-kind := left-parenthesis, kind-annotation,
+                     right-parenthesis ;
+enum-variant-inline-kind := kind-annotation ;
+kind-define := left-angle, identifier, right-angle,
+               define-operator, kind-annotation ;
+```
+
+Selection rule:
+`statement` uses `alt_best`, not ordinary ordered `alt`. It runs all enabled
+alternatives from the same input and chooses the successful parse consuming
+the most input; ties keep the earlier displayed alternative. Failures are
+ranked for diagnostics only. `source-import-specifier` uses ordinary ordered
+`alt`.
+
+Validation rule:
+`context-send` requires the parsed `var` to have a context and no kind.
+`variable-define` rejects an addressed context path. `source-mec-path`
+validates that its merged text ends in `.mec`. Source-import wildcards are
+valid only when absent or when the sole `*` is the final `/*`. A context
+capability path accepts no wildcard or one final nonempty `/*`; a lone
+wildcard is represented by the separate `asterisk` scope.
+
+Whitespace rule:
+The `source-import-tail` URI parser stops before newline or semicolon and
+trims trailing Unicode whitespace from the token after parsing. Source
+declarations require `whitespace1` after `+>`/`<+`, which can include
+newlines.
+
+Completion rule:
+Rich comments first capture through but not including newline. The captured
+line is reparsed with `inline-paragraph` and accepted as rich content only if
+that parser leaves the synthetic newline next. Otherwise the raw captured
+token is retained and an error is logged.
+
+The `imports.rs` module selected directly by `mech-code-alt` implements a
+second, structured `+>` family:
+
+```ebnf:phase-0
+module-import-name-segment := identifier-path-segment ;
+module-import-intrinsic-segment := underscore, module-import-name-segment ;
+module-import-path-segment := module-import-intrinsic-segment
+                            | module-import-name-segment ;
+module-import-path := module-import-path-segment,
+                      *(slash, module-import-path-segment) ;
+module-import-alias-segment := identifier-path-segment ;
+module-import-alias-path := module-import-alias-segment,
+                            *(slash, module-import-alias-segment) ;
+module-import-value-alias := module-import-alias-path ;
+context-import-alias-segment :=
+  alpha-token, *(alpha-token | digit-token | dash) ;
+module-import-context-alias := at, context-import-alias-segment, ¬slash ;
+module-import-alias := module-import-context-alias
+                     | module-import-value-alias ;
+module-root := identifier-path-segment ;
+import-alias-operator := space-tab0, colon, equal, space-tab0 ;
+import-group-separator := list-separator
+                        | whitespace1 ;
+import-group-item := module-import-path ;
+import-group-items := whitespace0, import-group-item,
+                      *(import-group-separator, import-group-item),
+                      whitespace0 ;
+module-import-end := space-tab0, ?new-line ;
+aliased-item-import := module-import-alias, import-alias-operator,
+                       module-root, slash, module-import-path ;
+module-suffix-import :=
+  module-root, slash,
+  (asterisk
+   | (left-brace, import-group-items, right-brace)
+   | module-import-path) ;
+module-only-import := module-root ;
+module-import := whitespace0, plus, right-angle, space-tab0,
+                 (aliased-item-import
+                  | module-suffix-import
+                  | module-only-import),
+                 >module-import-end ;
+```
+
+Selection rule:
+Intrinsic `_segment` precedes a normal path segment. A context alias beginning
+with `@` commits to `aliased-item-import`; otherwise alias, suffix, and
+module-only forms use ordinary ordered `alt`. `module-only-import` explicitly
+fails if a slash is next.
+
+Completion rule:
+`module-import` calls `module-import-end` on a clone solely to extend the
+module token's source range, then mistakenly returns the input from before
+that call. Trailing horizontal space and optional newline are therefore not
+consumed by `module-import` itself. The formal rule records the actually
+consumed language; `module-import-end` is shown separately as the implemented
+lookahead-like helper.
+
+13. Functions
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+function-define := identifier, left-parenthesis,
+                   ?[list-separator, function-arg],
+                   right-parenthesis, whitespace0,
+                   (function-define-match-arms
+                  | function-define-statements) ;
+function-define-statements :=
+  equal, whitespace0,
+  (function-out-args | function-out-arg),
+  define-operator,
+  [(whitespace1 | statement-separator), statement],
+  period ;
+function-define-match-arms :=
+  output-operator, whitespace0, kind-annotation,
+  +(whitespace1 | statement-separator),
+  +function-match-arm, ?period ;
+function-match-arm :=
+  whitespace0, (box-t-left | box-bl | bar), whitespace0,
+  ((pattern, whitespace0, output-operator, whitespace0, expression)
+   | expression),
+  ?(whitespace1 | statement-separator) ;
+function-out-args := left-parenthesis,
+                     [list-separator, function-arg],
+                     right-parenthesis ;
+function-out-arg := function-arg ;
+function-arg := identifier, kind-annotation ;
+argument-list := left-parenthesis,
+                 ?[list-separator, (call-arg-with-binding | call-arg)],
+                 right-parenthesis ;
+function-call := identifier, argument-list ;
+call-arg-with-binding := identifier, whitespace0, colon, whitespace0,
+                         expression ;
+call-arg := expression ;
+```
+
+Selection rule:
+After the shared name and input argument list, `function-define` manually
+tries the match-arm form first and on any error retries the statement form.
+Within an arm, it manually attempts `pattern => expression`; if that sequence
+does not complete, it restarts at the arm payload as a wildcard-associated
+expression. Call arguments use ordinary ordered `alt`, named before unnamed.
+
+Completion rule:
+Statement-body function definitions require a final period. Match-arm
+definitions make the final period optional.
+
+14. Match expressions
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+match-expression := factor, question, whitespace0, +match-arm, ?period ;
+match-arm := guard-operator, pattern,
+             ?(list-separator, whitespace0, expression),
+             output-operator, expression,
+             ?(whitespace1 | statement-separator) ;
+```
+
+Selection rule:
+`match-expression` is a public lower-level parser but is not called by
+`expression`. The reachable match implementation is duplicated in
+`expression`: it first parses a complete `formula` and then, when a question
+follows, parses the same arm list. Thus the reachable source expression can
+be a full formula, while direct `match-expression` begins with one `factor`.
+
+Whitespace rule:
+`guard-operator`, `output-operator`, and `list-separator` each consume their
+own `whitespace0`. The explicit `whitespace0` after the optional comma is
+therefore redundant but implemented.
+
+15. State machines
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+fsm-value := pattern ;
+guard-operator := whitespace0, (bar | box-vert | box-t-left | box-bl),
+                  whitespace0 ;
+fsm-implementation := hashtag, identifier, left-parenthesis,
+                      ?[list-separator, var], right-parenthesis,
+                      transition-operator, fsm-value, whitespace0,
+                      +fsm-arm, period ;
+fsm-arm := (fsm-guard-arm | fsm-transition | fsm-comment-arm),
+           whitespace0 ;
+fsm-guard-arm := pattern, +fsm-guard ;
+fsm-comment-arm := comment ;
+fsm-guard := guard-operator, pattern,
+             +(fsm-statement-transition
+             | fsm-state-transition
+             | fsm-output
+             | fsm-async-transition
+             | fsm-block-transition) ;
+fsm-transition := pattern,
+                  +(fsm-block-transition
+                  | fsm-statement-transition
+                  | fsm-state-transition
+                  | fsm-output
+                  | fsm-async-transition) ;
+fsm-state-transition := transition-operator, fsm-value ;
+fsm-async-transition := async-transition-operator, fsm-value ;
+fsm-statement-transition := transition-operator, statement ;
+fsm-block-transition := transition-operator, left-brace,
+                        *(whitespace0, mech-code-alt, ?code-terminal),
+                        whitespace0, right-brace ;
+fsm-output := output-operator, fsm-value ;
+
+fsm-specification := hashtag, identifier, left-parenthesis,
+                     ?[list-separator, var], right-parenthesis,
+                     ?output-operator, ?kind-annotation, ?define-operator,
+                     +fsm-state-definition, period ;
+fsm-state-definition := guard-operator, whitespace0, atom,
+                        ?fsm-state-definition-variables ;
+fsm-state-definition-variables :=
+  left-parenthesis, [list-separator, var], right-parenthesis ;
+
+fsm-pipe := fsm-instance,
+            *(fsm-state-transition | fsm-async-transition | fsm-output) ;
+fsm-declare := fsm, define-operator, fsm-pipe ;
+fsm := hashtag, identifier, ?argument-list, ?kind-annotation ;
+fsm-instance := hashtag, identifier, ?fsm-args ;
+fsm-args := left-parenthesis,
+            ?[list-separator, (call-arg-with-binding | call-arg)],
+            right-parenthesis ;
+```
+
+Selection rule:
+`fsm-arm` tries guard arm, transition, then comment. Transition alternatives
+have deliberately different orders: `fsm-guard` tries statement before state
+and block last; `fsm-transition` tries block first, then statement, state,
+output, and async. `fsm-pipe` tries state, async, then output. These are
+ordinary ordered alternatives.
+
+Validation rule:
+`fsm-value` parses a general pattern and then rejects wildcard patterns and
+array spread/rest recursively, including when nested in tuples or tuple
+structures. This applies to implementation start values, next/async values,
+and outputs. Guard/match positions continue to accept those pattern forms.
+
+Completion rule:
+`fsm-block-transition` is a manual brace loop. Empty blocks are accepted.
+Nonempty iterations use `mech-code-alt` and then attempt `code-terminal`; a
+failed terminal is ignored for that iteration. The closing right brace is
+required. FSM implementations and specifications require their final period.
+
+16. Reactive and braced regions
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+activation-scope := async-transition-operator, expression, whitespace0,
+                    ((left-brace, whitespace0,
+                      ?mech-code, right-brace)
+                     | (+activation-arm, ?period)) ;
+activation-arm := guard-operator, pattern,
+                  ?(list-separator, whitespace0, expression),
+                  output-operator, whitespace0,
+                  ((left-brace, whitespace0, ?mech-code, right-brace)
+                   | (expression,
+                      ?(whitespace1 | statement-separator))) ;
+```
+
+Selection rule:
+After `~>` the trigger expression is committed. A following left brace
+selects the fixed block form; otherwise one or more pattern arms are
+committed. Within each arm, a left brace selects the block body; otherwise an
+expression body is required. Empty fixed blocks and empty arm blocks are
+accepted.
+
+Selection rule:
+The leading `~>` here is an activation operator only when followed by a
+trigger expression. Consequently bare `~> { ... }` is not an activation.
+In an FSM, `~>` instead introduces an asynchronous value transition, while a
+braced FSM transition is introduced only by `->`.
+
+Whitespace rule:
+`async-transition-operator` itself consumes `whitespace0` on both sides, then
+the parser consumes another `whitespace0` after the trigger and after an
+opening brace.
+
+Completion rule:
+`mech-code` is a prefix parser, but in a braced activation its remainder must
+be positioned at the required right brace. The block parser therefore bounds
+the prefix even though `mech-code` has no independent EOF requirement.
+
+17. Mech code items
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+mech-code-alt := whitespace0,
+                 (activation-scope
+                | fsm-specification
+                | fsm-implementation
+                | function-define
+                | module-import
+                | statement
+                | expression
+                | comment) ;
+code-terminal := space-tab0,
+                 ?(?semicolon, space-tab0, comment),
+                 (new-line | semicolon | >right-brace | >eof
+                  | >mika-section-close),
+                 whitespace0 ;
+mech-code := +(¬not-mech-code, mech-code-alt, code-terminal) ;
+```
+
+Selection rule:
+`mech-code-alt` uses `alt_best`: all displayed candidates run from the same
+post-whitespace cursor and the longest successful parse wins, with displayed
+order breaking ties. This is especially significant for the shared `#`
+specification/implementation prefix, function versus expression prefixes,
+structured module imports versus statement imports, and activation `~>`
+versus other expression-like prefixes.
+
+Selection rule:
+The arrow families are context-sensitive: `=>` introduces outputs, `->`
+introduces ordinary state/statement/block transitions, and `~>` introduces
+FSM asynchronous transitions or a top-level activation when followed by its
+required trigger expression.
+
+Completion rule:
+`mech-code` is a manual prefix loop. It returns accumulated items when a
+Mechdown stop form is ahead, when a later item fails with the generic
+unexpected-character error, or when a later code terminal fails. It consumes
+the entire input only when its caller supplies no non-code suffix. A terminal
+can be newline, semicolon, or zero-width lookahead for right brace, EOF, or
+Mika close; trailing `whitespace0` is then consumed.
+
+Recovery note:
+Non-generic soft errors and hard failures are logged and converted to an AST
+error item after skipping to newline, semicolon, or Mika close. Recovery is
+not an alternative in the accepted-language rule above.
+
+Recovery note:
+`label!` upgrades selected errors to hard failure. `labelr!` logs and invokes
+a synchronization parser. `alt_best` failure ranking and all diagnostic
+messages affect diagnostics, not the formal choice language.
+
+18. Mechdown inline elements
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+strong := strong-sigil, paragraph-element, strong-sigil ;
+emphasis := emphasis-sigil, paragraph-element, emphasis-sigil ;
+strikethrough := tilde, paragraph-element, tilde ;
+underline := underscore, paragraph-element, underscore ;
+highlight := highlight-sigil, paragraph-element, highlight-sigil ;
+inline-code := ¬grave-codeblock-sigil, grave,
+               *(¬grave, text), grave ;
+inline-equation := equation-sigil,
+                   +(¬equation-sigil, (backslash | text)),
+                   equation-sigil ;
+hyperlink := left-bracket, inline-paragraph, right-bracket,
+             left-parenthesis, +(¬right-parenthesis, text),
+             right-parenthesis ;
+raw-hyperlink := >http-prefix, +(¬space, text) ;
+
+option-map := left-brace, whitespace0, +option-mapping,
+              whitespace0, right-brace ;
+option-mapping := whitespace0, identifier, whitespace0, colon,
+                  whitespace0, option-value, whitespace0, ?comma,
+                  whitespace0 ;
+option-value := string
+              | identifier ;
+img := img-prefix, ?inline-paragraph, right-bracket, left-parenthesis,
+       +(¬right-parenthesis, text), right-parenthesis, ?option-map ;
+figure-item := img ;
+figures-row := whitespace0, bar,
+               +(space-tab0, figure-item, space-tab0, bar),
+               whitespace0 ;
+figures := +figures-row ;
+
+paragraph-text :=
+  +(¬(section-sigil
+      | footnote-prefix
+      | highlight-sigil
+      | equation-sigil
+      | img-prefix
+      | http-prefix
+      | left-brace
+      | left-bracket
+      | left-angle
+      | right-bracket
+      | tilde
+      | asterisk
+      | underscore
+      | grave
+      | define-operator
+      | bar
+      | mika-section-open
+      | mika-section-close),
+    text) ;
+eval-inline-mech-code := left-brace, whitespace0, expression,
+                         whitespace0, right-brace ;
+inline-mech-code := left-brace, left-brace, whitespace0,
+                    mech-code-alt, whitespace0,
+                    right-brace, right-brace ;
+footnote-reference := footnote-prefix,
+                      +(¬right-bracket, text), right-bracket ;
+reference := left-bracket, +alphanumeric, right-bracket ;
+section-reference := section-sigil, +(alphanumeric | period) ;
+
+paragraph-element := hyperlink
+                   | reference
+                   | section-reference
+                   | raw-hyperlink
+                   | highlight
+                   | footnote-reference
+                   | inline-mech-code
+                   | eval-inline-mech-code
+                   | inline-equation
+                   | paragraph-text
+                   | strong
+                   | emphasis
+                   | inline-code
+                   | strikethrough
+                   | underline ;
+inline-paragraph := +(¬new-line, paragraph-element) ;
+paragraph := +(¬(new-line | mika-section-close | idea-sigil),
+               paragraph-element) ;
+paragraph-newline := paragraph, new-line ;
+```
+
+Selection rule:
+`paragraph-element` uses ordinary ordered `alt` in the displayed order. The
+implementation contains `highlight` a second time between `strong` and
+`emphasis`; the duplicate is behaviorally redundant and is not represented
+as a second formal alternative. `option-value` manually tries string then
+identifier.
+
+Whitespace rule:
+`paragraph-text` uses the exact negative-lookahead set shown above. In
+particular it excludes `:=` through `define-operator`, every left brace,
+section and Mika delimiters, `![`, `[^`, `!!`, `$$`, both bracket directions
+listed, and `|`. It does not generically exclude colon, equal, exclamation, or
+dollar when they occur separately.
+
+Selection rule:
+Because `define-operator` includes its leading `whitespace0`,
+`paragraph-text` can stop at whitespace immediately preceding `:=`, rather
+than only at the colon.
+
+Completion rule:
+`inline-paragraph` stops before newline but does not itself require newline or
+EOF. `paragraph` stops before newline, Mika close, or the idea-block sigil.
+Inline Mech accepts exactly one `mech-code-alt` bounded by `}}`; evaluated
+inline Mech accepts one expression bounded by `}`.
+
+Implementation anomaly:
+`inline-equation` uses `many0` internally and then unwraps token merging, so
+an empty `$$$$` body panics instead of returning a parse result. The formal
+rule uses `+` to describe successful, non-panicking parses. The same class of
+empty-token panic exists in the meta-grammar terminal parser.
+
+Recovery note:
+`paragraph` wraps each element with `labelr!`; a failed element can log an
+error and synchronize at the next paragraph element. `inline-paragraph` has
+no such recovery. Recovery placeholders are not formal alternatives.
+
+19. Mechdown block elements
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+title := +text, new-line, +equal, whitespace0, ?title-front-matter ;
+title-front-matter :=
+  *(identifier, space-tab0, colon, space-tab0,
+    ((img | figures), whitespace0
+     | (inline-paragraph, new-line))),
+  +equal, whitespace0 ;
+
+no-alignment := +dash ;
+left-alignment := colon, +dash ;
+right-alignment := +dash, colon ;
+center-alignment := colon, +dash, colon ;
+alignment-separator := space-tab0,
+                       (center-alignment
+                        | left-alignment
+                        | right-alignment
+                        | no-alignment),
+                       space-tab0 ;
+mechdown-table := whitespace0,
+                  (mechdown-table-with-header
+                   | mechdown-table-no-header) ;
+mechdown-table-with-header := mechdown-table-header,
+                              +mechdown-table-row ;
+mechdown-table-no-header := +mechdown-table-row ;
+mechdown-table-header :=
+  whitespace0,
+  +(bar, space-tab0, inline-paragraph), bar, whitespace0,
+  +(bar, space-tab0, alignment-separator), bar, whitespace0 ;
+empty-paragraph := ?empty-input? ;
+mechdown-table-row :=
+  whitespace0, bar,
+  +(((space-tab0, inline-paragraph)
+     | (space-tab1, empty-paragraph)),
+    bar),
+  whitespace0 ;
+
+ul-subtitle := +(digit-token | alpha-token), period, space-tab0,
+               paragraph-newline, +dash, space-tab0, new-line,
+               space-tab0, whitespace0 ;
+subtitle := ¬(error-sigil | info-sigil), space-tab0,
+            left-parenthesis,
+            [period, (+alpha | +digit)],
+            right-parenthesis, space-tab0, paragraph-newline,
+            space-tab0, whitespace0 ;
+
+ordered-list-item := number, period, paragraph-newline ;
+checked-item := dash, left-bracket, ("x" | "✓" | "✗"),
+                right-bracket, paragraph-newline, paragraph-newline ;
+unchecked-item := dash, left-bracket, whitespace0, right-bracket,
+                  paragraph-newline ;
+check-list-item := checked-item
+                 | unchecked-item ;
+unordered-list-item := dash,
+                       ?(left-parenthesis, emoji, right-parenthesis),
+                       +space, paragraph-newline, *new-line ;
+check-list := check-list-item, *(check-list-item | sublist) ;
+unordered-list := unordered-list-item, *(unordered-list-item | sublist) ;
+ordered-list := ordered-list-item, *(ordered-list-item | sublist) ;
+sublist := ordered-list
+         | check-list
+         | unordered-list ;
+mechdown-list := ordered-list
+               | check-list
+               | unordered-list ;
+
+codeblock-sigil := grave-codeblock-sigil
+                 | tilde-codeblock-sigil ;
+code-block := codeblock-sigil, space-tab0,
+              *(¬left-brace, text), ?option-map, space-tab0, new-line,
+              *(¬matching-codeblock-sigil, any),
+              matching-codeblock-sigil, whitespace0 ;
+thematic-break := +asterisk, space-tab0, new-line ;
+footnote := footnote-prefix, +(¬right-bracket, text), right-bracket,
+            colon, whitespace0, +paragraph-newline ;
+prompt := prompt-sigil, space-tab0, section-element ;
+blank-line := space-tab0, new-line ;
+question-block := question-sigil, space-tab0, +paragraph-newline ;
+info-block := info-sigil, space-tab0, +paragraph-newline ;
+quote-block := ¬float-sigil, ¬prompt-sigil, quote-sigil,
+               space-tab0, +paragraph-newline ;
+warning-block := ¬float-sigil, warning-sigil,
+                 space-tab0, +paragraph-newline ;
+success-block := ¬float-sigil, (success-sigil | success-check-sigil),
+                 space-tab0, +paragraph-newline ;
+error-block := ¬float-sigil, (error-sigil | error-alt-sigil),
+               space-tab0, +paragraph-newline ;
+idea-block := idea-sigil, space-tab0, +paragraph-newline ;
+abstract-el := abstract-sigil, space-tab0, +paragraph-newline ;
+equation := equation-sigil, +(backslash | text) ;
+citation := left-bracket, +alphanumeric, right-bracket, colon,
+            whitespace0, paragraph, whitespace0 ;
+float-sigil := float-left
+             | float-right ;
+float := float-sigil, space-tab0, section-element ;
+not-mech-code := question-block
+               | info-block
+               | success-block
+               | warning-block
+               | error-block
+               | idea-block
+               | img
+               | mika-section-close
+               | float ;
+
+section-element := mechdown-list
+                 | prompt
+                 | footnote
+                 | citation
+                 | abstract-el
+                 | img
+                 | figures
+                 | equation
+                 | mechdown-table
+                 | float
+                 | quote-block
+                 | code-block
+                 | thematic-break
+                 | subtitle
+                 | question-block
+                 | info-block
+                 | success-block
+                 | warning-block
+                 | error-block
+                 | idea-block
+                 | paragraph ;
+section := ?ul-subtitle,
+           *(mika | mech-code | (section-element, *blank-line)) ;
+body := whitespace0, *section ;
+```
+
+Selection rule:
+`mechdown-table` uses ordinary ordered choice with-header before no-header.
+Alignment tries center, left, right, then none. `sublist` and `mechdown-list`
+manually try ordered, checklist, then unordered. `section-element` uses
+`alt_best` with the displayed order as its tie breaker. The implementation
+contains the paragraph candidate twice at the end; the duplicate has no
+language effect.
+
+Selection rule:
+`section` does not call `section-content` as an ordinary alternative. Its
+manual loop first tries feature-gated Mika, then `mech-code`, then
+`section-element`. It stops before the next `ul-subtitle`, before Mika close
+when Mika is enabled, or at cursor end. This top-level precedence is
+observable because paragraph is the last broad fallback.
+
+Whitespace rule:
+List nesting is calculated by counting only consecutive ordinary space and
+tab graphemes at each line start. The list-item parser then consumes
+`space-tab` (which additionally includes no-break and thin space), but its
+indent comparison does not count those two characters. An unordered marker
+requires one or more ordinary spaces after the dash; a tab does not satisfy
+that requirement.
+
+Validation rule:
+The list functions are manual indentation state machines. A lower indent
+returns to the parent, equal indent continues the current list, and greater
+indent recursively selects a sublist. These column comparisons are semantic
+validation adjacent to the formal item grammar.
+
+Implementation anomaly:
+Immediately after every `ordered-list-item`, the ordered-list state machine
+rejects a next cursor beginning with `--`. On the first item that rejection
+causes the ordered-list candidate to fail; after earlier items it ends the
+current list before the rejected item. Indented `--` does not trigger this
+lookahead because it begins with whitespace.
+
+Implementation anomaly:
+`checked-item` invokes `paragraph-newline` twice and returns only the second
+paragraph. Current successful syntax therefore requires two paragraph lines
+after a checked marker. `unchecked-item` requires one.
+
+Completion rule:
+A code block must close with the same grave or tilde sigil chosen by its
+opener. Content consumes any grapheme until that exact sigil. The opening info
+string is text up to a left brace or newline; an optional brace option map can
+follow. `code-block` consumes `whitespace0` after the closing fence.
+
+Implementation primitive:
+`matching-codeblock-sigil` means the function value returned by
+`codeblock-sigil`; it is not a separately selectable terminal.
+
+20. Mika
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+mika-section := mika-section-open, section, mika-section-close ;
+mika-arm-left := "Ɔ∞"
+               | "›─"
+               | "›⌣"
+               | "·¬"
+               | "-◡"
+               | "ᗑ"
+               | "ᕦ"
+               | "~"
+               | "⌣"
+               | "╭"
+               | "⸌"
+               | "⸸"
+               | "─"
+               | "ᓂ"
+               | "ᓇ"
+               | "╰" ;
+mika-arm-right := "∞C"
+                | "─‹"
+                | "⌣‹"
+                | "⌐·"
+                | "◡-"
+                | "ᗑ"
+                | "ᕤ"
+                | "~"
+                | "⌣"
+                | "╮"
+                | "⸍"
+                | "ᗢ"
+                | "─"
+                | "ᓀ"
+                | "ᓄ"
+                | "╯" ;
+mika-eye-left := "⌐▰"
+               | "ˆ"
+               | "ಠ"
+               | "╥"
+               | "⋇"
+               | "✖"
+               | "≻"
+               | "ᗒ"
+               | "ㆆ"
+               | "◜"
+               | "˙"
+               | "⚆"
+               | "☉"
+               | "◠"
+               | "◡̀"
+               | "◕"
+               | "◞"
+               | "Ͼ"
+               | "⹇"
+               | "ᗣ"
+               | "≖"
+               | "°"
+               | "ᗩ"
+               | "¬"
+               | "◉" ;
+mika-eye-right := "ˆ"
+                | "ಠ"
+                | "╥"
+                | "⋇"
+                | "✖"
+                | "≺"
+                | "ᗕ"
+                | "ㆆ"
+                | "◝"
+                | "˙"
+                | "⚆"
+                | "☉"
+                | "◠"
+                | "◡́"
+                | "◕"
+                | "◟"
+                | "Ͽ"
+                | "▰"
+                | "⹇"
+                | "ᗣ"
+                | "≖"
+                | "°"
+                | "ᗩ"
+                | "¬"
+                | "◉" ;
+mika-nose := "⦿"
+           | "◯"
+           | "⊕"
+           | "∘"
+           | "⦾"
+           | "⊖"
+           | "⦵"
+           | "⊗"
+           | "⏺"
+           | "⍜"
+           | "⬢"
+           | "⬟"
+           | "⬣"
+           | "⎔" ;
+mika-expression-inner := mika-eye-left, mika-nose, mika-eye-right ;
+micro-mika := mika-arm-left, mika-nose, mika-arm-right ;
+mini-mika := ?mika-arm-left, left-parenthesis, ?mika-arm-right,
+             mika-expression-inner, ?mika-arm-left, right-parenthesis,
+             ?mika-arm-right ;
+mika := (mini-mika | micro-mika), whitespace0, ?mika-section,
+        whitespace0 ;
+```
+
+Selection rule:
+Mika arm alternatives are tried longest/specialized first exactly as shown.
+Eye and nose functions iterate fixed variant arrays in the displayed order.
+`mika-expression-inner` does not accept an arbitrary left/nose/right product:
+it parses left and nose, selects the one registered expression with that
+pair, and then requires that expression's exact right eye. At the audited
+head the accepted triples are `ˆ◯ˆ`, `ಠ◯ಠ`, `╥◯╥`, `⋇◯⋇`, `✖◯✖`, `≻◯≺`,
+`ᗒ◯ᗕ`, `ㆆ⍜ㆆ`, `◜◯◝`, `˙◯˙`, `⚆◯⚆`, `☉◯☉`, `◠◯◠`, `◡̀◯◡́`, `◕◯◕`,
+`◞◯◟`, `Ͼ◯Ͽ`, `⌐▰◯▰`, `⹇◯⹇`, `ᗣ◯ᗣ`, `≖◯≖`, `°◯°`, `ᗩ◯ᗩ`, `¬◯¬`,
+and `◉◯◉`.
+
+Feature rule:
+The `mika` module and its public rules exist only with Cargo feature `mika`.
+The base terminals for Mika section delimiters exist in every feature set.
+The `section` loop attempts `mika` and stops before `mika-section-close` only
+when the feature is enabled.
+
+21. Sections, bodies, and programs
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+program := whitespace0, ?title, body, whitespace0 ;
+```
+
+Selection rule:
+`program` delegates document content to the `body`/`section` manual loops from
+section 19. Within each section the current order is Mika when enabled, Mech
+code, then the remaining `section-element` candidates. `section-element`
+ultimately includes paragraph.
+
+Completion rule:
+`program` has no explicit `eof` combinator. In practice `body` loops until the
+`ParseString` cursor reaches its length and returns an error if a nonempty
+cursor cannot form a section. Direct lower-level calls still expose the
+remaining cursor.
+
+Implementation anomaly:
+With feature `mika`, a top-level unmatched `mika-section-close` is an
+exception to that progress description. `section` sees the close delimiter
+and returns an empty section without consuming it; `body` then calls
+`section` again at the same cursor indefinitely. This nontermination is
+canonical evidence for Phase 0, not an accepted formal production. A
+conformance check must exercise the zero-consumption `section` boundary
+without invoking the hanging public root.
+
+22. Embedded and fenced Mech
+-------------------------------------------------------------------------------
+
+Completion rule:
+Evaluated inline Mech `{ expression }` requires its expression to leave the
+cursor at optional `whitespace0` followed by the single closing brace. Inline
+Mech `{{ mech-code-alt }}` similarly requires exactly one selected code item
+to leave the cursor at optional whitespace and `}}`. Neither form invokes
+source normalization.
+
+Completion rule:
+For a code fence whose info string starts with `mech`, `mec`, or `🤖`,
+`code-block` creates a fresh normalized source (thereby adding a synthetic
+newline), calls `mech-code`, and accepts any success while discarding its
+remaining cursor. Fenced Mech is therefore prefix-complete, not
+complete-consumption checked. Its AST stores only the parsed prefix.
+
+Selection rule:
+The remainder of the Mech fence info string, after removing repeated leading
+`mech`, then `mec`, then `🤖`, and one leading colon, selects the block
+configuration: empty, `disabled`, `hidden`, or an arbitrary namespace.
+An option-map entry named `output` disables output for case-insensitive
+values `false`, `no`, `off`, or `0`.
+
+Completion rule:
+An exact `ebnf` fence calls the complete `parse-grammar` string API. On error,
+the current branch prints the error and executes `todo!()`, so invalid exact
+EBNF fences panic. For that reason this audit document labels its inert
+candidate fences `ebnf:phase-0`; only the exact info string `ebnf` is
+executable. Equation/math and diagram/chart info prefixes classify their
+content without reparsing it. All other fences remain generic code blocks.
+
+23. EBNF grammar syntax
+-------------------------------------------------------------------------------
+
+Private meta-grammar rules are prefixed `grammar-` here to avoid collisions
+with Mech expression rules such as `factor` and `not`.
+
+```ebnf:phase-0
+grammar := +grammar-rule, new-line ;
+grammar-identifier := alpha-token,
+                      *(alpha-token | digit-token | dash) ;
+grammar-rule := grammar-identifier, define-operator,
+                grammar-expression, semicolon ;
+grammar-expression := grammar-term, *(bar, grammar-term) ;
+grammar-term := grammar-factor, *(comma, grammar-factor) ;
+grammar-definition := grammar-identifier ;
+grammar-repeat0 := asterisk, grammar-factor ;
+grammar-repeat1 := plus, grammar-factor ;
+grammar-optional := question, grammar-factor ;
+grammar-peek := right-angle, grammar-factor ;
+grammar-not := negate, grammar-factor ;
+grammar-list := left-bracket, grammar-factor, comma,
+                grammar-factor, right-bracket ;
+grammar-range := grammar-terminal-token, period, period,
+                 grammar-terminal-token ;
+grammar-factor := grammar-repeat0
+                | grammar-repeat1
+                | grammar-optional
+                | grammar-peek
+                | grammar-not
+                | grammar-group
+                | grammar-list
+                | grammar-definition
+                | grammar-range
+                | grammar-terminal ;
+grammar-group := left-parenthesis, grammar-expression,
+                 right-parenthesis ;
+grammar-terminal := grammar-terminal-token ;
+grammar-terminal-token := quote, +(¬quote, any-token), quote ;
+```
+
+Selection rule:
+`grammar-factor` uses ordinary ordered `alt` exactly as displayed. Prefix
+operators recurse into `grammar-factor`, so they bind to one following factor.
+Choice is built above sequence. The separated-list form always has exactly
+two factors: separator first, element second.
+
+Source rule:
+The public `parse-grammar` wrapper deletes all ASCII spaces, tabs, carriage
+returns, and line feeds before this grammar runs, then appends a synthetic
+newline. This makes formatting whitespace insignificant but also deletes
+those characters inside quoted terminals.
+
+Completion rule:
+Direct `grammar` requires at least one rule followed by one newline and can
+leave a suffix. `parse-grammar` rejects any remaining graphemes. The terminal
+implementation uses `many0` followed by an unconditional token merge; an
+empty `""` terminal therefore panics. The formal successful-return rule uses
+`+`.
+
+Implementation anomaly:
+The descriptive implementation-primitives used by the specification, such as
+`?emoji-grapheme-literal?`, are not a factor form in this meta-grammar.
+Escaped quotes are also unsupported because terminal content stops at the
+first quote. This audit records, rather than changes, those discrepancies.
+
+24. REPL commands
+-------------------------------------------------------------------------------
+
+The REPL module parses `&str` bytes/chars with Nom's complete string parsers,
+not `ParseString`; its space primitives mean ASCII space only.
+
+```ebnf:phase-0
+parse-repl-command := colon,
+                      (cd-rpl
+                     | step-rpl
+                     | clear-rpl
+                     | clc-rpl
+                     | load-rpl
+                     | code-rpl
+                     | help-rpl
+                     | quit-rpl
+                     | save-rpl
+                     | symbols-rpl
+                     | profile-rpl
+                     | plan-rpl
+                     | ls-rpl
+                     | whos-rpl
+                     | docs-rpl),
+                      ?repl-carriage-return, ?repl-line-feed, repl-eof ;
+save-rpl := "save", repl-space1, *repl-path-character ;
+code-rpl := ("code" | "c"), repl-space0, *repl-any-character ;
+profile-rpl := "profile", repl-space0, ("on" | "off") ;
+docs-rpl := ("docs" | "d"), repl-space0,
+            ?repl-nonempty-through-line-ending ;
+help-rpl := "help"
+          | "h" ;
+quit-rpl := "quit"
+          | "exit"
+          | "q" ;
+cd-rpl := "cd", repl-space0, repl-through-crlf ;
+symbols-rpl := ("symbols" | "s"), repl-space0, *repl-alphanumeric ;
+plan-rpl := "plan"
+          | "p" ;
+repl-identifier := +repl-non-space-line-ending-character ;
+whos-rpl := ("whos" | "w"), repl-space0,
+            ?[repl-space1, repl-identifier] ;
+clear-rpl := "clear" ;
+clc-rpl := "clc" ;
+ls-rpl := "ls" ;
+load-rpl := "load", repl-space1,
+            [repl-space1, repl-load-path] ;
+step-rpl := "step", repl-space1,
+            ?(hashtag, repl-digit1, repl-space1), ?repl-digit1 ;
+```
+
+Implementation primitive:
+`repl-space0`/`repl-space1` are zero-or-more/one-or-more ASCII spaces.
+`repl-digit1` is one-or-more ASCII digits. `repl-path-character` is
+alphanumeric, slash, period, or underscore. `repl-through-crlf` consumes up
+to but not including a required CRLF marker. `repl-load-path` is the current
+`take_until(" ")` or `take_until("\r\n")` behavior.
+
+Selection rule:
+Command names use ordinary ordered `alt` in the order shown by
+`parse-repl-command`. Short aliases can parse a prefix, but the root's final
+empty-input check rejects any unconsumed suffix.
+
+Completion rule:
+The root optionally consumes one CR and then one LF and explicitly rejects
+all remaining input. `code-rpl` consumes every remaining character itself.
+`cd-rpl` and the final branch of `load-rpl` require a CRLF delimiter because
+they use `take_until("\r\n")`; a lone LF does not satisfy that lower-level
+parser. `save-rpl` permits an empty path after its required space because it
+uses `take_while`.
+
+25. Public entry points
+-------------------------------------------------------------------------------
+
+```ebnf:phase-0
+parse-mech := program ;
+parse := parse-mech ;
+parse-grammar := grammar ;
+```
+
+Separate roots:
+`parse`, `parse-mech`, `program`, `mech-code`, `grammar`, `parse-grammar`, and
+`parse-repl-command` are independently callable public roots. Fenced Mech and
+inline Mech are bounded embedded roots implemented inside `code-block` and
+`inline-mech-code`, respectively.
+
+Separate lower-level roots:
+The public `gen-operator`, `synth-operator`, `match-expression`,
+`mika-eye-right`, and parameterized `tag` parsers have no caller in the
+accepted-language graph but remain independently callable. They are retained
+as explicit separate lower-level roots.
+
+Implementation anomaly:
+`newline-indent`, `strike-sigil`, `underline-sigil`, `table-column`,
+and `table-horz` have no accepted-language caller at this baseline. They are
+explicit legacy/dead graph nodes. The private, uncalled `table_bottom`
+function is inventoried separately as a non-grammar helper; no parser code is
+removed in Phase 0.
+
+Source rule:
+`parse(&str)` uses `init-source`, calls `parse-mech`, aggregates logged
+diagnostics, and rejects any remainder. `parse-mech(ParseString)` and
+`program(ParseString)` do not themselves add a newline or run an explicit
+remainder check.
+
+Completion rule:
+`parse-grammar(&str)` performs its whitespace-deleting normalization and
+rejects any remainder. Direct `grammar(ParseString)` is prefix-capable except
+for its required trailing newline. `parse-repl-command(&str)` performs its
+own complete-input check without synthetic normalization. `mech-code` is
+prefix-capable. Fenced Mech ignores the `mech-code` remainder; inline Mech
+requires its single code item to meet `}}`.
+
+26. Feature-set differences
+-------------------------------------------------------------------------------
+
+Feature rule:
+`mika-section`, Mika arm/eye/nose/expression rules, `micro-mika`, `mini-mika`,
+and `mika` are compiled only with feature `mika`. The `section` loop's Mika
+candidate and Mika-close stop check are compiled only with that feature.
+
+Feature rule:
+`invariant-define` and its `statement` candidate are compiled only with
+feature `invariant_define`.
+
+Feature rule:
+At this baseline both the crate's `default` feature set and its documented
+`base` feature set include `mika` and include `invariant_define` through
+`statements_default`; their accepted grammar is the same for these gates.
+Custom feature sets can omit them. The `mechdown` feature exists but
+`mechdown.rs` is currently compiled and re-exported unconditionally.
+
+Feature rule:
+Other fine-grained Cargo features describe core data/runtime capabilities.
+The syntax functions for literals, structures, formulas, and subscripts are
+not individually `cfg`-gated in these parser modules, so this candidate does
+not remove their productions when those downstream features are absent.
+
+27. Disambiguation and completion rules
+-------------------------------------------------------------------------------
+
+Selection rule:
+There are three distinct selection mechanisms.
+
+- Ordinary Nom `alt` is ordered first-success.
+- Manual fallback in `expression`, `factor`, `structure`, `pattern`,
+  comprehension qualifiers, function forms, lists, and context-qualified
+  paths retries from a clone and discards specified earlier failures.
+- `alt_best` in `statement`, `mech-code-alt`, and `section-element` runs every
+  candidate and selects the longest success, using declaration order for
+  ties.
+
+Selection rule:
+The document parser is a fourth, caller-controlled layer: `section` tries
+Mika first when enabled, then `mech-code`, then `section-element`. This means
+a successful Mech prefix can win before the paragraph fallback. The parser
+does not require the paragraph candidate to prove complete paragraph success
+before that choice.
+
+Whitespace rule:
+Do not collapse `space`, `space-tab`, `space-tab0`, `space-tab1`,
+`whitespace`, `whitespace0`, `whitespace1`, `ws0e`, `ws1e`, `new-line`, and
+`newline-indent`. Their exact definitions in section 3 are normative for this
+candidate. In particular `whitespace0` can cross lines, while `ws0e` cannot.
+
+Completion rule:
+Final periods are inconsistent by implementation and remain so:
+FSM specification/implementation and statement-body functions require one;
+match expressions, match-arm functions, and activation pattern bodies make
+one optional; ordinary statements and expressions rely on `code-terminal`
+and do not include a period production.
+
+Completion rule:
+The outer `parse` and `parse-grammar` string APIs check all normalized input;
+the direct lower-level roots generally return a remainder. `mech-code` is a
+prefix parser. Inline braces bound its one-item variant. Fenced Mech accepts a
+parsed prefix and ignores the remainder. Exact EBNF fences are complete
+checked but panic on parse error in the current `code-block` branch.
+
+Source rule:
+Every use of `init-source` adds one final newline unconditionally. This is an
+entry normalization rule and is not hidden in `program`, `mech-code`, or
+`grammar`.
+
+Validation rule:
+Matrix comprehensions require a generator or let qualifier. FSM value
+positions reject wildcard and array spread/rest patterns. Context paths,
+source import paths, wildcard placement, context sends, and variable
+definitions apply the validations recorded next to their grammar families.
+These validations are not new EBNF operators.
+
+Recovery note:
+Paragraph element recovery and Mech item recovery can return AST placeholders
+with logged errors. The accepted-language productions above describe
+successful parsing before recovery; the recovery synchronization boundaries
+are recorded in prose and in `productions.tsv`.
+
+Implementation anomaly:
+The current language intentionally frozen here includes the broad
+emoji-classification heuristic, permissive based-number digit alphabets,
+left-associated power, dash/slash identifiers, rational-versus-division
+spacing, the dead non-grammar `table_bottom` helper, double-parsed checked-list
+paragraphs, prefix-complete fenced Mech, source whitespace deletion in
+`parse-grammar`, and empty inline-equation/meta-terminal panics. Phase 0
+records these facts; it does not repair them.

--- a/docs/design/grammar-audit/discrepancies.mec
+++ b/docs/design/grammar-audit/discrepancies.mec
@@ -7,7 +7,7 @@ PR 680.
 Authority for every entry in this Phase 0 ledger: current parser behavior is
 canonical for this phase. The ledger records behavior; it does not fix it.
 
-Known discrepancies and required investigations at this baseline: 30.
+Known discrepancies and required investigations at this baseline: 32.
 
 IDs are stable and append-only. Do not renumber or reuse an ID. When a later
 design change resolves an entry, retain the entry, add the resolution commit
@@ -1157,3 +1157,81 @@ emoji-like non-ASCII graphemes, and complete consumption.
 Future design question:
 Which symbols are intended identifier characters, and should the spec use an
 explicit positive set rather than exclusion from `symbol`?
+
+GRAM-0031 — Unmatched Mika close prevents public-root progress
+-------------------------------------------------------------------------------
+
+Current parser behavior:
+With feature `mika`, `section` checks `mika_section_close` before parsing an
+element and returns a successful empty `Section` without consuming the close
+delimiter. At the top level, `body` treats that success as progress, pushes
+the empty section, and invokes `section` again at the same cursor forever.
+The public `parse` root therefore does not terminate on a top-level unmatched
+`⸥`. Inside a Mika section the same stop behavior is required so the enclosing
+`mika_section` parser can consume its delimiter.
+
+Inline EBNF/comment:
+`src/syntax/src/mechdown.rs:1048-1051` implements the zero-consumption stop,
+while the `body` comment and loop at lines 1104-1121 do not state or guard the
+progress invariant.
+
+Specification text:
+`docs/design/specification.mec` describes the Mika close delimiter only as
+the end of a Mika section and does not define unmatched-close behavior or
+top-level nontermination.
+
+Documentation/example evidence:
+Mika examples use balanced `⸢ ... ⸥` sections. No example contains a
+top-level unmatched close delimiter, so the hang is not visible in the
+documentation corpus.
+
+Phase 0 ruling:
+Current parser behavior recorded as canonical for this phase. Do not add a
+progress guard or change delimiter handling in Phase 0.
+
+Conformance case:
+`grammar-conformance::gram_0031_unmatched_mika_close` calls the lower-level
+`section` parser and records its successful zero-consumption result. It must
+not call `body` or `parse` on this source in-process.
+
+Future design question:
+Should an unmatched Mika close be rejected at the document root, and where
+should parser loops enforce mandatory cursor progress?
+
+GRAM-0032 — Private table-bottom parser has no caller
+-------------------------------------------------------------------------------
+
+Current parser behavior:
+`structures.rs::table_bottom` can parse a run of box-drawing characters and a
+table-end token, but it is private and no parser calls it. In particular,
+`fancy_table` returns after its row list. A bottom border that is accepted by
+that path is consumed by `row_separator`, whose alternatives include
+`table_end`.
+
+Inline EBNF/comment:
+The inline comment above `table_bottom` presents it as `table-bottom`, and the
+comment above `fancy_table` says that a fancy table ends with
+`table-bottom`. The implementation of `fancy_table` does not contain that
+call.
+
+Specification text:
+The prior specification describes fancy-table border syntax but does not
+identify this private implementation function as dead.
+
+Documentation/example evidence:
+Fancy-table examples can contain bottom-border glyphs, but their accepted
+parse path is `row_separator`; they provide no call path to `table_bottom`.
+
+Phase 0 ruling:
+The parser call graph is canonical for this phase. The private uncalled
+function is inventoried as `helper/not-grammar`; no `table-bottom` formal rule
+is published and no production visibility is widened.
+
+Conformance case:
+Not applicable to accepted-language conformance. Inventory and rule-graph
+tests assert that the function remains inventoried without a canonical rule,
+while `TABLE-FANCY` snapshots the actual accepted bottom-border path.
+
+Future design question:
+Should a future parser delete the dead helper, call it explicitly, or continue
+to treat a bottom border as a row separator?

--- a/src/syntax/tests/grammar_rule_graph.rs
+++ b/src/syntax/tests/grammar_rule_graph.rs
@@ -1,0 +1,592 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const INVENTORY_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/design/grammar-audit/productions.tsv"
+);
+const GRAMMAR_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/design/grammar-audit/current-grammar.mec"
+);
+
+// Public, independently useful lower-level parsers which are not called by
+// any of the seven complete/prefix roots in the candidate rule graph.
+const DECLARED_SEPARATE_ROOTS: &[&str] = &[
+    "gen-operator",
+    "match-expression",
+    "synth-operator",
+    "tag",
+];
+
+// Implemented baseline rules with no accepted-language caller at PR 680's
+// audited head. Keeping this list explicit makes accidental reachability drift
+// visible without rejecting expected recursion elsewhere in the graph.
+const DECLARED_LEGACY_OR_DEAD: &[&str] = &[
+    "newline-indent",
+    "strike-sigil",
+    "table-column",
+    "table-horz",
+    "underline-sigil",
+];
+
+const DECLARED_PRIMITIVES: &[&str] = &[
+    "eof",
+    "matching-codeblock-sigil",
+    "repl-alphanumeric",
+    "repl-any-character",
+    "repl-carriage-return",
+    "repl-digit1",
+    "repl-eof",
+    "repl-line-feed",
+    "repl-load-path",
+    "repl-non-space-line-ending-character",
+    "repl-nonempty-through-line-ending",
+    "repl-path-character",
+    "repl-space0",
+    "repl-space1",
+    "repl-through-crlf",
+];
+
+// These names occur in the Rust-derived child graph but do not denote formal
+// grammar edges at every call site:
+//
+// - `map`, `tag`, and `tuple` are nom combinators whose Rust identifiers
+//   collide with inventoried grammar rules;
+// - `grammar-peek` is parser control used to choose a parser without consuming;
+// - the remaining names are embedded-parser or paragraph implementation calls
+//   which the candidate describes as prose mechanics at their call sites.
+const DECLARED_IMPLEMENTATION_ONLY_CHILDREN: &[&str] = &[
+    "grammar-peek",
+    "inline-paragraph",
+    "map",
+    "mech-code",
+    "parse-grammar",
+    "tag",
+    "tuple",
+];
+
+#[derive(Debug)]
+struct InventoryRow {
+    line: usize,
+    id: String,
+    grammar_name: String,
+    module: String,
+    rust_function: String,
+    classification: String,
+    feature_gate: String,
+    child_rules: String,
+    implementation_path: String,
+}
+
+fn inventory_rows() -> Vec<InventoryRow> {
+    let source = fs::read_to_string(INVENTORY_PATH)
+        .unwrap_or_else(|err| panic!("failed to read {INVENTORY_PATH}: {err}"));
+    let mut lines = source.lines();
+    let header = lines
+        .next()
+        .unwrap_or_else(|| panic!("{INVENTORY_PATH} is empty"))
+        .split('\t')
+        .collect::<Vec<_>>();
+
+    let index = |name: &str| {
+        header
+            .iter()
+            .position(|column| *column == name)
+            .unwrap_or_else(|| panic!("{INVENTORY_PATH} is missing column {name:?}"))
+    };
+    let id = index("id");
+    let grammar_name = index("grammar-name");
+    let module = index("module");
+    let rust_function = index("rust-function");
+    let classification = index("classification");
+    let feature_gate = index("feature-gate");
+    let child_rules = index("child-rules");
+    let implementation_path = index("implementation-path");
+
+    lines
+        .enumerate()
+        .filter(|(_, line)| !line.trim().is_empty())
+        .map(|(offset, line)| {
+            let fields = line.split('\t').collect::<Vec<_>>();
+            assert_eq!(
+                fields.len(),
+                header.len(),
+                "{INVENTORY_PATH}:{} has {} fields; expected {}",
+                offset + 2,
+                fields.len(),
+                header.len(),
+            );
+            InventoryRow {
+                line: offset + 2,
+                id: fields[id].to_owned(),
+                grammar_name: fields[grammar_name].to_owned(),
+                module: fields[module].to_owned(),
+                rust_function: fields[rust_function].to_owned(),
+                classification: fields[classification].to_owned(),
+                feature_gate: fields[feature_gate].to_owned(),
+                child_rules: fields[child_rules].to_owned(),
+                implementation_path: fields[implementation_path].to_owned(),
+            }
+        })
+        .collect()
+}
+
+fn is_rule_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    if !matches!(chars.next(), Some('a'..='z')) {
+        return false;
+    }
+    let mut previous_hyphen = false;
+    for ch in chars {
+        if ch == '-' {
+            if previous_hyphen {
+                return false;
+            }
+            previous_hyphen = true;
+        } else if ch.is_ascii_lowercase() || ch.is_ascii_digit() {
+            previous_hyphen = false;
+        } else {
+            return false;
+        }
+    }
+    !previous_hyphen
+}
+
+/// This deliberately is not an EBNF parser. It only finds the stable
+/// `kebab-name := ... ;` declarations inside inert Phase 0 grammar fences.
+fn candidate_rules() -> BTreeMap<String, String> {
+    let source = fs::read_to_string(GRAMMAR_PATH)
+        .unwrap_or_else(|err| panic!("failed to read {GRAMMAR_PATH}: {err}"));
+    candidate_rules_from(&source)
+}
+
+fn candidate_rules_from(source: &str) -> BTreeMap<String, String> {
+    let mut rules = BTreeMap::new();
+    let mut in_candidate_fence = false;
+    let mut current: Option<(String, usize, String)> = None;
+
+    for (offset, line) in source.lines().enumerate() {
+        let line_number = offset + 1;
+        if line == "```ebnf:phase-0" {
+            assert!(
+                !in_candidate_fence,
+                "{GRAMMAR_PATH}:{line_number}: nested grammar fence"
+            );
+            in_candidate_fence = true;
+            continue;
+        }
+        if in_candidate_fence && line == "```" {
+            assert!(
+                current.is_none(),
+                "{GRAMMAR_PATH}:{line_number}: grammar fence closed inside a rule"
+            );
+            in_candidate_fence = false;
+            continue;
+        }
+        if !in_candidate_fence {
+            continue;
+        }
+
+        if let Some((_, _, body)) = current.as_mut() {
+            body.push(' ');
+            body.push_str(line.trim());
+            if line.trim_end().ends_with(';') {
+                let (name, start, body) = current.take().unwrap();
+                assert!(
+                    rules.insert(name.clone(), body).is_none(),
+                    "{GRAMMAR_PATH}:{start}: duplicate rule {name:?}"
+                );
+            }
+            continue;
+        }
+
+        if line.trim().is_empty() {
+            continue;
+        }
+        assert!(
+            !line.starts_with(char::is_whitespace),
+            "{GRAMMAR_PATH}:{line_number}: indented grammar line has no active declaration"
+        );
+        let Some((lhs, rhs)) = line.split_once(":=") else {
+            panic!(
+                "{GRAMMAR_PATH}:{line_number}: unindented grammar-fence line is not a rule declaration"
+            );
+        };
+        let name = lhs.trim();
+        assert!(
+            is_rule_name(name),
+            "{GRAMMAR_PATH}:{line_number}: rule name {name:?} is not kebab-case"
+        );
+        current = Some((name.to_owned(), line_number, rhs.trim().to_owned()));
+        if line.trim_end().ends_with(';') {
+            let (name, start, body) = current.take().unwrap();
+            assert!(
+                rules.insert(name.clone(), body).is_none(),
+                "{GRAMMAR_PATH}:{start}: duplicate rule {name:?}"
+            );
+        }
+    }
+
+    assert!(
+        !in_candidate_fence,
+        "{GRAMMAR_PATH}: unclosed grammar fence"
+    );
+    assert!(
+        current.is_none(),
+        "{GRAMMAR_PATH}: unterminated grammar rule"
+    );
+    rules
+}
+
+fn classification_has(classification: &str, role: &str) -> bool {
+    classification.split('/').any(|part| part == role)
+}
+
+fn grammar_bearing(classification: &str) -> bool {
+    ["root", "production", "terminal", "lexical-primitive"]
+        .iter()
+        .any(|role| classification_has(classification, role))
+}
+
+fn comma_names(field: &str) -> impl Iterator<Item = &str> {
+    field
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty() && *name != "none")
+}
+
+fn unquoted_ascii_words(body: &str) -> Vec<String> {
+    let trimmed = body.trim();
+    let before_semicolon = trimmed.strip_suffix(';').unwrap_or(trimmed).trim();
+    // A whole-rule `?descriptive implementation primitive?` has no graph edge.
+    if before_semicolon.starts_with('?') && before_semicolon.ends_with('?') {
+        return vec![];
+    }
+
+    let mut visible = String::with_capacity(body.len());
+    let mut quoted = false;
+    let mut escaped = false;
+    for ch in body.chars() {
+        if quoted {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                quoted = false;
+            }
+            visible.push(' ');
+        } else if ch == '"' {
+            quoted = true;
+            visible.push(' ');
+        } else {
+            visible.push(ch);
+        }
+    }
+
+    visible
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_'))
+        .filter(|word| word.chars().any(|ch| ch.is_ascii_alphabetic()))
+        .map(|word| {
+            assert!(
+                is_rule_name(word),
+                "{GRAMMAR_PATH}: malformed unquoted grammar name {word:?}"
+            );
+            word.to_owned()
+        })
+        .collect()
+}
+
+fn workspace_path(implementation_path: &str) -> PathBuf {
+    let relative = implementation_path
+        .split("::")
+        .next()
+        .unwrap_or(implementation_path);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn recursive_components(graph: &BTreeMap<String, BTreeSet<String>>) -> Vec<Vec<String>> {
+    fn visit(
+        node: &str,
+        graph: &BTreeMap<String, BTreeSet<String>>,
+        seen: &mut BTreeSet<String>,
+        order: &mut Vec<String>,
+    ) {
+        if !seen.insert(node.to_owned()) {
+            return;
+        }
+        for child in graph.get(node).into_iter().flatten() {
+            visit(child, graph, seen, order);
+        }
+        order.push(node.to_owned());
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut order = vec![];
+    for node in graph.keys() {
+        visit(node, graph, &mut seen, &mut order);
+    }
+
+    let mut reverse: BTreeMap<String, BTreeSet<String>> = graph
+        .keys()
+        .map(|node| (node.clone(), BTreeSet::new()))
+        .collect();
+    for (parent, children) in graph {
+        for child in children {
+            reverse
+                .entry(child.clone())
+                .or_default()
+                .insert(parent.clone());
+        }
+    }
+
+    let mut assigned = BTreeSet::new();
+    let mut recursive = vec![];
+    while let Some(node) = order.pop() {
+        if assigned.contains(&node) {
+            continue;
+        }
+        let mut component = vec![];
+        let mut queue = vec![node];
+        while let Some(next) = queue.pop() {
+            if !assigned.insert(next.clone()) {
+                continue;
+            }
+            component.push(next.clone());
+            queue.extend(reverse.get(&next).into_iter().flatten().cloned());
+        }
+        component.sort();
+        let self_recursive = component.len() == 1
+            && graph
+                .get(&component[0])
+                .is_some_and(|children| children.contains(&component[0]));
+        if component.len() > 1 || self_recursive {
+            recursive.push(component);
+        }
+    }
+    recursive
+}
+
+#[test]
+fn candidate_grammar_and_inventory_form_a_closed_rule_graph() {
+    let rows = inventory_rows();
+    let rules = candidate_rules();
+    let declared_primitives = DECLARED_PRIMITIVES.iter().copied().collect::<BTreeSet<_>>();
+
+    let mut manifest_names: BTreeMap<String, Vec<&InventoryRow>> = BTreeMap::new();
+    let mut module_functions = BTreeSet::new();
+    for row in &rows {
+        assert!(
+            module_functions.insert((row.module.as_str(), row.rust_function.as_str())),
+            "{INVENTORY_PATH}:{} duplicates {}::{}",
+            row.line,
+            row.module,
+            row.rust_function,
+        );
+        assert!(
+            !row.id.is_empty(),
+            "{INVENTORY_PATH}:{} has no stable id",
+            row.line
+        );
+        assert!(
+            !row.feature_gate.is_empty(),
+            "{INVENTORY_PATH}:{} has no feature-gate classification",
+            row.line,
+        );
+        if grammar_bearing(&row.classification) {
+            assert!(
+                !row.grammar_name.is_empty(),
+                "{INVENTORY_PATH}:{} grammar-bearing {}::{} has no grammar name",
+                row.line,
+                row.module,
+                row.rust_function,
+            );
+        }
+        if !row.grammar_name.is_empty() {
+            assert!(
+                is_rule_name(&row.grammar_name),
+                "{INVENTORY_PATH}:{} has invalid grammar name {:?}",
+                row.line,
+                row.grammar_name,
+            );
+            assert!(
+                !row.implementation_path.is_empty(),
+                "{INVENTORY_PATH}:{} rule {:?} has no implementation path",
+                row.line,
+                row.grammar_name,
+            );
+            assert!(
+                workspace_path(&row.implementation_path).is_file(),
+                "{INVENTORY_PATH}:{} implementation path {:?} does not name a file",
+                row.line,
+                row.implementation_path,
+            );
+            manifest_names
+                .entry(row.grammar_name.clone())
+                .or_default()
+                .push(row);
+        }
+    }
+
+    let defined = rules.keys().cloned().collect::<BTreeSet<_>>();
+    let inventoried = manifest_names.keys().cloned().collect::<BTreeSet<_>>();
+    assert_eq!(
+        defined, inventoried,
+        "candidate rules and inventoried canonical grammar names differ"
+    );
+
+    // `child-rules` is the manifest-driven implementation graph. It must never
+    // point at an undeclared production.
+    for row in &rows {
+        for child in comma_names(&row.child_rules) {
+            assert!(
+                inventoried.contains(child) || declared_primitives.contains(child),
+                "{INVENTORY_PATH}:{} rule {:?} references undefined child {:?}",
+                row.line,
+                row.grammar_name,
+                child,
+            );
+        }
+    }
+
+    // Scan only names from the inert formal rule bodies. This catches candidate
+    // transcription typos while intentionally avoiding a generalized EBNF AST.
+    let mut graph: BTreeMap<String, BTreeSet<String>> = rules
+        .keys()
+        .map(|name| (name.clone(), BTreeSet::new()))
+        .collect();
+    for (name, body) in &rules {
+        for reference in unquoted_ascii_words(body) {
+            if defined.contains(&reference) {
+                graph.get_mut(name).unwrap().insert(reference);
+            } else {
+                assert!(
+                    declared_primitives.contains(reference.as_str()),
+                    "{GRAMMAR_PATH}: rule {name:?} references undefined name {reference:?}",
+                );
+            }
+        }
+    }
+
+    // The inventory graph is Rust-call-shaped while the formal graph may inline
+    // wrappers or spell combinators as operators. Nevertheless, every named
+    // language child recorded by the inventory must be reachable from the
+    // corresponding formal rule. This one-way cross-check catches transcription
+    // drift (for example `right-angle1` versus the implemented `right-angle`)
+    // without pretending the two graphs have identical abstraction boundaries.
+    // It is deliberately a coarse reachability guard, not proof of direct-edge
+    // equivalence: formal-only edges and alternate paths inside recursive
+    // components remain review responsibilities.
+    let implementation_only = DECLARED_IMPLEMENTATION_ONLY_CHILDREN
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let edge_drift = rows
+        .iter()
+        .filter(|row| !row.grammar_name.is_empty())
+        .flat_map(|row| {
+            let mut reachable = BTreeSet::new();
+            let mut queue =
+                VecDeque::from_iter(graph.get(&row.grammar_name).into_iter().flatten().cloned());
+            while let Some(rule) = queue.pop_front() {
+                if !reachable.insert(rule.clone()) {
+                    continue;
+                }
+                queue.extend(graph.get(&rule).into_iter().flatten().cloned());
+            }
+            comma_names(&row.child_rules)
+                .filter(|child| {
+                    defined.contains(*child)
+                        && !implementation_only.contains(*child)
+                        && !reachable.contains(*child)
+                })
+                .map(|child| {
+                    (
+                        row.line,
+                        row.grammar_name.clone(),
+                        child.to_owned(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        edge_drift.is_empty(),
+        "inventory language children missing from candidate reachability: {edge_drift:#?}"
+    );
+
+    let roots = rows
+        .iter()
+        .filter(|row| classification_has(&row.classification, "root"))
+        .map(|row| row.grammar_name.clone())
+        .collect::<BTreeSet<_>>();
+    let mut reachable = BTreeSet::new();
+    let mut queue = VecDeque::from_iter(roots.iter().cloned());
+    while let Some(rule) = queue.pop_front() {
+        if !reachable.insert(rule.clone()) {
+            continue;
+        }
+        queue.extend(graph.get(&rule).into_iter().flatten().cloned());
+    }
+
+    let unreachable = defined
+        .difference(&reachable)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let classified_unreachable = DECLARED_SEPARATE_ROOTS
+        .iter()
+        .chain(DECLARED_LEGACY_OR_DEAD)
+        .map(|name| (*name).to_owned())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        unreachable, classified_unreachable,
+        "unreachable rules must be declared as a separate root or legacy/dead"
+    );
+
+    let cycles = recursive_components(&graph);
+    let cycle_sizes = cycles.iter().map(Vec::len).collect::<Vec<_>>();
+    eprintln!(
+        "grammar rule graph: rules={}, primitives={}, roots={}, feature-gated={}, \
+     undefined=0, duplicate-definitions=0, unmapped-canonical=0, \
+     unclassified-implementation=0, recursive-components={} {:?}",
+        rules.len(),
+        rows.iter()
+            .filter(|row| classification_has(&row.classification, "lexical-primitive"))
+            .count(),
+        roots.len(),
+        rows.iter()
+            .filter(|row| row.feature_gate != "always")
+            .count(),
+        cycles.len(),
+        cycle_sizes,
+    );
+}
+
+#[test]
+fn candidate_grammar_is_inert_parseable_mechdown() {
+    let source = fs::read_to_string(GRAMMAR_PATH)
+        .unwrap_or_else(|err| panic!("failed to read {GRAMMAR_PATH}: {err}"));
+    mech_syntax::parse(&source)
+        .unwrap_or_else(|err| panic!("{GRAMMAR_PATH} must parse as inert Mechdown: {err:?}"));
+}
+
+#[test]
+fn candidate_scanner_rejects_malformed_declarations_and_references() {
+    let indented = "```ebnf:phase-0\n  bad-name := \"x\" ;\n```\n";
+    assert!(
+        std::panic::catch_unwind(|| candidate_rules_from(indented)).is_err(),
+        "an orphaned indented declaration must not disappear from the rule graph"
+    );
+
+    assert!(
+        std::panic::catch_unwind(|| unquoted_ascii_words("BAR ;")).is_err(),
+        "an uppercase bare reference must not disappear from the rule graph"
+    );
+    assert!(!is_rule_name("bad_name"));
+    assert!(!is_rule_name("bad--name"));
+    assert!(!is_rule_name("bad-name-"));
+}


### PR DESCRIPTION
## Stack

Phase 0B of 4: mechanically extract the grammar implemented by the parser.

- Base: `codex/phase-0a-grammar-inventory`
- Next: `codex/phase-0c-grammar-conformance`
- Recorded parser baseline: PR #680 merge commit `75bb213f42a0f8116ca1299d1d39a5cf14fc0303`

## Summary

- Extracts the accepted language from Rust implementation structure into specification notation.
- Organizes all grammar families from source normalization through REPL roots.
- Keeps source normalization, feature gates, selection, completion, validation, recovery, and implementation anomalies in adjacent prose instead of inventing EBNF operators.
- Adds a manifest-driven rule-graph test for mapping closure, reachability, recursion, duplicate definitions, and undefined references.
- Expands the discrepancy ledger to 32 stable entries.

## Extraction summary

```text
canonical candidate rules: 540
implementation primitives: 10
separate roots: 7
feature-gated rules: 11
undefined references: 0
duplicate rule definitions: 0
unclassified implementation productions: 0
unmapped canonical productions: 0
```

The graph has four expected recursive strongly connected components. The private, uncalled `table_bottom` helper is classified as non-grammar and is not published as a formal rule.

## Validation

- Inventory tests pass.
- Rule-graph tests pass.
- `git diff --check` passes.
- No parser behavior changed.

