### PR TITLE
feat(syntax): add revisioned document syntax substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,7 @@ dependencies = [
  "rlibc",
  "serde",
  "serde_derive",
+ "serde_json",
  "tabled",
  "unicode-segmentation",
 ]

--- a/docs/design/incremental-syntax-architecture.mec
+++ b/docs/design/incremental-syntax-architecture.mec
@@ -1,0 +1,213 @@
+Incremental Syntax Architecture
+===============================================================================
+
+Status: Phase 1 experimental architecture.
+
+Stack base: PR 650 at
+`8c2719a8c46ed8225cba5fc58dca789e3a64cc03`.
+
+The legacy parser, public `parse` API, existing `Program` AST, formatter,
+interpreter, runtime, and accepted grammar remain unchanged while this
+architecture is introduced.
+
+1. Goals
+-------------------------------------------------------------------------------
+
+The canonical parsed representation of one source revision is a lossless
+`SyntaxSnapshot`. It is designed for whole `.mec` documents, live incomplete
+input, multiple independent errors, streamed appends, incremental edits, exact
+Unicode preservation, structured diagnostics, and later partial semantic
+analysis.
+
+The persisted canonical artifact remains UTF-8 `.mec` text. The parsed form is
+revisioned derived state.
+
+This phase deliberately implements a narrow grammar slice. It does not port or
+change the complete canonical grammar.
+
+2. Documents, not a host/guest format
+-------------------------------------------------------------------------------
+
+Document mode always parses sibling Mech and Mechdown constructs. Mechdown is
+not an optional wrapper, and parsing does not try a complete Mech program before
+falling back to prose.
+
+The document root contains sections and document items. Items may be paragraphs,
+Mech items, canonical `subtitle` and `ul-subtitle` headings, lists, tables,
+fences, equations, figures, Mika, and other Mechdown forms as their grammar
+families are ported.
+
+Tools may use fragment entry points for isolated productions, but `.mec` always
+selects document mode.
+
+3. Total parsing
+-------------------------------------------------------------------------------
+
+```rust
+pub fn parse_document(
+  source: TextSnapshot,
+  config: ParseConfig,
+) -> SyntaxSnapshot;
+```
+
+Every valid UTF-8 input produces a snapshot. User syntax errors do not produce a
+top-level `Err`. Resource limits create a diagnostic and an `ERROR` node that
+retains the bounded remainder.
+
+Strict validation and lowering are later consumers:
+
+```rust
+parse_document(source, config)
+validate_strict(&snapshot)
+lower_live(&snapshot)
+```
+
+The parser kernel is an event-based ordinary-function parser. It uses explicit
+checkpoints, commitment, recovery, rule context, and fuel. It does not use Nom,
+boxed parser closures, a parser generator, or an external tree framework.
+
+4. Revisioned source
+-------------------------------------------------------------------------------
+
+UTF-8 byte offsets are the primary coordinate system. Rows, byte columns,
+UTF-16 positions, grapheme positions, and display widths are derived views.
+Parser cursors store byte offsets only.
+
+A `TextSnapshot` identifies a `DocumentId` and `Revision`. Its immutable piece
+list references `Arc<str>` chunks and byte ranges within those chunks. Edits
+reuse unchanged chunks. Append is insertion at EOF. Multiple edits in one
+revision are sorted, non-overlapping, and expressed in the old revision.
+
+Edits are rejected when a range is reversed, outside the snapshot, or not on a
+UTF-8 boundary. Input is never normalized. LF, CRLF, and CR remain byte-exact
+and are all recognized by the derived line index.
+
+The current list representation intentionally leaves cursor and tree interfaces
+independent of storage shape so a balanced representation can replace it later.
+
+5. Lossless green and red trees
+-------------------------------------------------------------------------------
+
+Green nodes and tokens are immutable. They store relative lengths, stable
+session-minted identities, flags, structural hashes, and child arrays. They do
+not store absolute offsets or redundant token strings. A red view combines a
+green element with a source revision and derives its range from ancestor and
+sibling lengths.
+
+The lossless invariants are:
+
+- Every source byte belongs to exactly one non-synthetic token.
+- Concatenating non-synthetic token text reproduces the source byte-for-byte.
+- Whitespace, comments, and delimiters are tokens.
+- Missing tokens have zero width and are synthetic.
+- Skipped malformed tokens remain below an `ERROR` node.
+- The tree does not globally intern identical subtrees.
+
+`NodeId` and `TokenId` are minted by a document session. A reused green subtree
+keeps its identities. A reparsed subtree receives new identities. Hashes support
+comparison and caching but never define editor identity.
+
+The `NodeIndex` resolves each identity to its current kind, range, parent, and
+flags. This supports red navigation and diagnostic anchoring without putting
+absolute offsets in green storage.
+
+Typed AST views are zero-copy wrappers over red nodes. Accessors return `Option`
+because live syntax may omit required children.
+
+6. Structural errors and diagnostics
+-------------------------------------------------------------------------------
+
+Absent required syntax is represented by zero-width `MISSING` nodes or tokens.
+Unexpected source is retained as ordinary tokens under an `ERROR` node.
+
+Diagnostic messages are not stored in green nodes. A revisioned
+`DiagnosticStore` contains stable namespaced codes, phases, severity, canonical
+rule IDs, structural or absolute anchors, labels, expected and found syntax,
+fixes, related diagnostics, recovery actions, tags, and display messages.
+
+Structural anchors use an element identity plus a relative range. When an
+unchanged node shifts after an earlier edit, its diagnostics shift with it.
+Absolute anchors are revision-specific and are used when no suitable syntax
+identity exists.
+
+The stable fields, rather than English wording, are the test oracle. Optional
+Serde support supplies JSON for tools. A small plain-text renderer supplies
+human-readable output without coupling the schema to a terminal library.
+
+7. Recovery
+-------------------------------------------------------------------------------
+
+Productions distinguish `NoMatch`, `Match`, and `CommittedFailure`. Once a
+distinctive prefix such as a define operator is recognized, the construct may
+recover but cannot fall back to unrelated prose.
+
+Recovery operations are:
+
+- Insert a missing element at a legitimate boundary.
+- Skip unexpected source into an `ERROR` node.
+- Abandon an incomplete production to an ancestor restart root.
+
+Every parser and recovery loop consumes a source byte, inserts once and changes
+grammar state, returns, or terminates. Fuel, nesting, event, diagnostic, and
+recovery-byte limits enforce this invariant.
+
+Recovery uses contextual restart entries. Document, paragraph, Mech, and fence
+modes record delimiter depth, line-start state, and indentation. Canonical
+headings, matching fence boundaries, and delimiter-aware Mech terminals form
+strong restart points. Recovery never treats a Markdown `#` convention as a
+Mechdown heading.
+
+8. Incremental reparsing
+-------------------------------------------------------------------------------
+
+Edits create a `ChangeMap`, locate the smallest intersecting restart root, and
+expand when boundaries, newlines, composite sigils, delimiters, fence prefixes,
+headings, or relevant indentation change.
+
+A fragment splice is accepted only when it consumes the mapped region, preserves
+the ending boundary, and retains parser mode. Otherwise the reparser ascends.
+Document-root reparsing is the final fallback.
+
+Unaffected green subtrees are reused with their IDs. Full and incremental parses
+are compared after normalization that ignores minted IDs.
+
+9. Annotation substrate and future analysis
+-------------------------------------------------------------------------------
+
+Syntax annotations use typed `NodeMap<T>` values at one revision. Reusing a
+syntax node permits its annotation to be retained; replacing or deleting the
+node invalidates the entry. This is a generic typed map, not a dynamic property
+bag.
+
+Most future semantic facts attach to HIR because one syntax node may lower to
+multiple semantic entities. Origin mappings project them back to syntax:
+
+```rust
+pub struct AnalysisSnapshot {
+  pub document: DocumentId,
+  pub revision: Revision,
+
+  pub origins: HirMap<SyntaxPtr>,
+  pub kinds: HirMap<FactState<KindInfo>>,
+  pub dimensions: HirMap<FactState<DimensionInfo>>,
+  pub effects: HirMap<FactState<EffectInfo>>,
+  pub coeffects: HirMap<FactState<CoeffectInfo>>,
+  pub refinements: HirMap<FactState<RefinementInfo>>,
+  pub liveness: HirMap<FactState<LivenessInfo>>,
+}
+```
+
+`mech-syntax` supplies reusable identities, `SyntaxPtr`, `NodeMap<T>`, and
+`FactState<T>`. It does not define placeholder semantic fact types.
+
+10. Portability
+-------------------------------------------------------------------------------
+
+Production document modules use `core` and `alloc`, forbid unsafe code, and do
+not access filesystems, threads, clocks, terminal coloring, or platform APIs.
+Observable maps are deterministic. Source and diagnostic serialization is
+behind the existing `serde` feature.
+
+The design remains implementable in Mech: piece arrays, immutable nodes, event
+arrays, typed maps, checkpoints, and explicit recovery are concrete data
+structures rather than a Rust-specific framework.

--- a/src/syntax/Cargo.toml
+++ b/src/syntax/Cargo.toml
@@ -76,7 +76,7 @@ baselib = ["bool", "string",
 compiler = ["mech-core/compiler"]
 program = ["mech-core/program"]
 pretty_print = ["mech-core/pretty_print"]
-serde = ["mech-core/serde"]
+serde = ["mech-core/serde", "dep:serde_json"]
 
 statements = ["mech-core/statements"]
 variables = ["variable_define", "symbol_table", "mech-core/variables"]
@@ -169,6 +169,7 @@ unicode-segmentation = "1.12.0"
 rlibc = { version = "=1.0", optional = true }
 serde = "1.0.228"
 serde_derive = "1.0.228"
+serde_json = { version = "1.0.149", default-features = false, features = ["alloc"], optional = true }
 colored = "3.1.1"
 indexmap = "2.13.0"
 tabled = "0.20.0"

--- a/src/syntax/src/document/annotation.rs
+++ b/src/syntax/src/document/annotation.rs
@@ -1,0 +1,65 @@
+use alloc::collections::BTreeMap;
+
+use super::ids::{DiagnosticId, NodeId, Revision};
+use super::index::NodeIndex;
+
+#[derive(Clone, Debug)]
+pub struct NodeMap<T> {
+  pub revision: Revision,
+  values: BTreeMap<NodeId, T>,
+}
+
+impl<T> NodeMap<T> {
+  pub fn new(revision: Revision) -> Self {
+    Self {
+      revision,
+      values: BTreeMap::new(),
+    }
+  }
+
+  pub fn insert(&mut self, node: NodeId, value: T) -> Option<T> {
+    self.values.insert(node, value)
+  }
+
+  pub fn get(&self, node: NodeId) -> Option<&T> {
+    self.values.get(&node)
+  }
+
+  pub fn get_mut(&mut self, node: NodeId) -> Option<&mut T> {
+    self.values.get_mut(&node)
+  }
+
+  pub fn remove(&mut self, node: NodeId) -> Option<T> {
+    self.values.remove(&node)
+  }
+
+  pub fn contains_key(&self, node: NodeId) -> bool {
+    self.values.contains_key(&node)
+  }
+
+  pub fn len(&self) -> usize {
+    self.values.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.values.is_empty()
+  }
+
+  pub fn iter(&self) -> impl Iterator<Item = (NodeId, &T)> {
+    self.values.iter().map(|(id, value)| (*id, value))
+  }
+
+  pub fn retain_reused(mut self, revision: Revision, index: &NodeIndex) -> Self {
+    self.values.retain(|id, _| index.contains_node(*id));
+    self.revision = revision;
+    self
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FactState<T> {
+  Unknown,
+  Partial(T),
+  Complete(T),
+  Invalid(DiagnosticId),
+}

--- a/src/syntax/src/document/builder.rs
+++ b/src/syntax/src/document/builder.rs
@@ -1,0 +1,143 @@
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt;
+
+use super::edit::TextSize;
+use super::flags::{NodeFlags, TokenFlags};
+use super::green::{
+  GreenElement, GreenNode, GreenToken, child_text_len, hash_node, propagated_flags, text_hash,
+};
+use super::ids::IdGenerator;
+use super::kind::SyntaxKind;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BuildError {
+  NoOpenNode,
+  UnclosedNodes(usize),
+  MultipleRoots(usize),
+  TokenKindExpected(SyntaxKind),
+  TextTooLarge,
+}
+
+impl fmt::Display for BuildError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::NoOpenNode => f.write_str("tree builder has no open node"),
+      Self::UnclosedNodes(count) => write!(f, "tree builder has {count} unclosed nodes"),
+      Self::MultipleRoots(count) => write!(f, "tree builder produced {count} roots"),
+      Self::TokenKindExpected(kind) => write!(f, "{kind:?} is not a token kind"),
+      Self::TextTooLarge => f.write_str("token text exceeds the 32-bit text range"),
+    }
+  }
+}
+
+struct Frame {
+  kind: SyntaxKind,
+  flags: NodeFlags,
+  children: Vec<GreenElement>,
+}
+
+pub struct GreenBuilder<'a> {
+  ids: &'a mut IdGenerator,
+  frames: Vec<Frame>,
+  roots: Vec<Arc<GreenNode>>,
+}
+
+impl<'a> GreenBuilder<'a> {
+  pub fn new(ids: &'a mut IdGenerator) -> Self {
+    Self {
+      ids,
+      frames: Vec::new(),
+      roots: Vec::new(),
+    }
+  }
+
+  pub fn start_node(&mut self, kind: SyntaxKind) {
+    self.start_node_with_flags(kind, NodeFlags::NONE);
+  }
+
+  pub fn start_node_with_flags(&mut self, kind: SyntaxKind, flags: NodeFlags) {
+    self.frames.push(Frame {
+      kind,
+      flags,
+      children: Vec::new(),
+    });
+  }
+
+  pub fn token(&mut self, kind: SyntaxKind, text: &str) -> Result<(), BuildError> {
+    self.token_with_flags(kind, text, TokenFlags::NONE)
+  }
+
+  pub fn token_with_flags(
+    &mut self,
+    kind: SyntaxKind,
+    text: &str,
+    flags: TokenFlags,
+  ) -> Result<(), BuildError> {
+    if !kind.is_token() {
+      return Err(BuildError::TokenKindExpected(kind));
+    }
+    let text_len = TextSize::checked_from_usize(text.len()).map_err(|_| BuildError::TextTooLarge)?;
+    let id = self.ids.token();
+    self.push_element(GreenElement::Token(GreenToken {
+      id,
+      kind,
+      text_len,
+      flags,
+      text_hash: text_hash(text),
+    }))
+  }
+
+  pub fn missing_token(&mut self, expected: SyntaxKind) -> Result<(), BuildError> {
+    if !expected.is_token() {
+      return Err(BuildError::TokenKindExpected(expected));
+    }
+    let id = self.ids.token();
+    self.push_element(GreenElement::Token(GreenToken {
+      id,
+      kind: expected,
+      text_len: TextSize::ZERO,
+      flags: TokenFlags::SYNTHETIC | TokenFlags::MISSING,
+      text_hash: text_hash(""),
+    }))
+  }
+
+  pub fn reuse_node(&mut self, node: Arc<GreenNode>) -> Result<(), BuildError> {
+    self.push_element(GreenElement::Node(node))
+  }
+
+  pub fn finish_node(&mut self) -> Result<Arc<GreenNode>, BuildError> {
+    let frame = self.frames.pop().ok_or(BuildError::NoOpenNode)?;
+    let flags = propagated_flags(frame.kind, frame.flags, &frame.children);
+    let node = Arc::new(GreenNode {
+      id: self.ids.node(),
+      kind: frame.kind,
+      text_len: child_text_len(&frame.children),
+      structural_hash: hash_node(frame.kind, &frame.children),
+      children: frame.children.into(),
+      flags,
+    });
+    if let Some(parent) = self.frames.last_mut() {
+      parent.children.push(GreenElement::Node(node.clone()));
+    } else {
+      self.roots.push(node.clone());
+    }
+    Ok(node)
+  }
+
+  pub fn finish(self) -> Result<Arc<GreenNode>, BuildError> {
+    if !self.frames.is_empty() {
+      return Err(BuildError::UnclosedNodes(self.frames.len()));
+    }
+    if self.roots.len() != 1 {
+      return Err(BuildError::MultipleRoots(self.roots.len()));
+    }
+    Ok(self.roots.into_iter().next().expect("one root was checked"))
+  }
+
+  fn push_element(&mut self, element: GreenElement) -> Result<(), BuildError> {
+    let frame = self.frames.last_mut().ok_or(BuildError::NoOpenNode)?;
+    frame.children.push(element);
+    Ok(())
+  }
+}

--- a/src/syntax/src/document/diagnostic.rs
+++ b/src/syntax/src/document/diagnostic.rs
@@ -1,0 +1,288 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::Write;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::edit::{TextEdit, TextRange, TextSize};
+use super::flags::NodeFlags;
+use super::ids::{DiagnosticId, Revision, RuleId, SyntaxElementId};
+use super::index::NodeIndex;
+use super::kind::SyntaxKind;
+use super::source::TextSnapshot;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct DiagnosticCode(pub String);
+
+impl DiagnosticCode {
+  pub fn syntax(name: &str) -> Self {
+    Self(format!("syntax/{name}"))
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+}
+
+impl From<&str> for DiagnosticCode {
+  fn from(value: &str) -> Self {
+    Self(value.to_string())
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum DiagnosticPhase {
+  Syntax,
+  SyntaxValidation,
+  Lowering,
+  Kind,
+  Dimension,
+  Effect,
+  Coeffect,
+  Refinement,
+  Liveness,
+  Document,
+  Runtime,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum Severity {
+  Error,
+  Warning,
+  Information,
+  Hint,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind", rename_all = "kebab-case"))]
+pub enum DiagnosticAnchor {
+  Element {
+    element: SyntaxElementId,
+    relative: TextRange,
+  },
+  Absolute {
+    revision: Revision,
+    range: TextRange,
+  },
+}
+
+impl DiagnosticAnchor {
+  pub fn resolve(&self, revision: Revision, nodes: &NodeIndex) -> Option<TextRange> {
+    match self {
+      Self::Element { element, relative } => {
+        let base = nodes.range(*element)?;
+        if relative.end.0 > base.len().0 {
+          return None;
+        }
+        Some(TextRange::new(
+          base.start + relative.start,
+          base.start + relative.end,
+        ))
+      }
+      Self::Absolute {
+        revision: anchor_revision,
+        range,
+      } => (*anchor_revision == revision).then_some(*range),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct DiagnosticLabel {
+  pub anchor: DiagnosticAnchor,
+  pub message: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind", content = "value", rename_all = "kebab-case"))]
+pub enum ExpectedSyntax {
+  Token(SyntaxKind),
+  Production(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct FoundSyntax {
+  pub kind: Option<SyntaxKind>,
+  pub text: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum FixApplicability {
+  MachineApplicable,
+  MaybeIncorrect,
+  HasPlaceholders,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct DiagnosticFix {
+  pub title: String,
+  pub applicability: FixApplicability,
+  pub edits: Vec<TextEdit>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind", rename_all = "kebab-case"))]
+pub enum RecoveryAction {
+  Insert {
+    syntax: ExpectedSyntax,
+    at: TextSize,
+  },
+  Skip {
+    range: TextRange,
+  },
+  Abandon {
+    rule: RuleId,
+    at: TextSize,
+  },
+  ResourceLimit {
+    range: TextRange,
+  },
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct DiagnosticTags(pub u16);
+
+impl DiagnosticTags {
+  pub const NONE: Self = Self(0);
+  pub const UNNECESSARY: Self = Self(1 << 0);
+  pub const DEPRECATED: Self = Self(1 << 1);
+  pub const SUPPRESSED_CASCADE: Self = Self(1 << 2);
+
+  pub const fn contains(self, other: Self) -> bool {
+    self.0 & other.0 == other.0
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct Diagnostic {
+  pub id: DiagnosticId,
+  pub code: DiagnosticCode,
+  pub phase: DiagnosticPhase,
+  pub severity: Severity,
+  pub rule: Option<RuleId>,
+  pub primary: DiagnosticAnchor,
+  pub labels: Vec<DiagnosticLabel>,
+  pub expected: Vec<ExpectedSyntax>,
+  pub found: Option<FoundSyntax>,
+  pub fixes: Vec<DiagnosticFix>,
+  pub related: Vec<DiagnosticId>,
+  pub recovery: Option<RecoveryAction>,
+  pub tags: DiagnosticTags,
+  pub message: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct DiagnosticStore {
+  pub revision: Revision,
+  diagnostics: Vec<Diagnostic>,
+}
+
+impl DiagnosticStore {
+  pub fn new(revision: Revision) -> Self {
+    Self {
+      revision,
+      diagnostics: Vec::new(),
+    }
+  }
+
+  pub fn push(&mut self, diagnostic: Diagnostic) {
+    self.diagnostics.push(diagnostic);
+  }
+
+  pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> {
+    self.diagnostics.iter()
+  }
+
+  pub fn as_slice(&self) -> &[Diagnostic] {
+    &self.diagnostics
+  }
+
+  pub fn len(&self) -> usize {
+    self.diagnostics.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.diagnostics.is_empty()
+  }
+
+  pub fn retain_resolvable(mut self, revision: Revision, nodes: &NodeIndex) -> Self {
+    self.diagnostics.retain(|diagnostic| {
+      diagnostic.primary.resolve(revision, nodes).is_some()
+    });
+    self.revision = revision;
+    self
+  }
+
+  #[cfg(feature = "serde")]
+  pub fn to_json(&self) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(self)
+  }
+}
+
+pub fn render_plain(
+  diagnostic: &Diagnostic,
+  source: &TextSnapshot,
+  nodes: &NodeIndex,
+) -> String {
+  let range = diagnostic
+    .primary
+    .resolve(source.revision(), nodes)
+    .unwrap_or_else(|| TextRange::empty(TextSize::ZERO));
+  let (line, column) = source.line_index().line_and_byte_column(range.start);
+  let mut output = String::new();
+  let _ = writeln!(
+    output,
+    "{:?}[{}] at {}:{}: {}",
+    diagnostic.severity,
+    diagnostic.code.as_str(),
+    line + 1,
+    column.0 + 1,
+    diagnostic.message
+  );
+  for label in &diagnostic.labels {
+    if let Some(label_range) = label.anchor.resolve(source.revision(), nodes) {
+      let (label_line, label_column) =
+        source.line_index().line_and_byte_column(label_range.start);
+      let _ = writeln!(
+        output,
+        "  {}:{}: {}",
+        label_line + 1,
+        label_column.0 + 1,
+        label.message
+      );
+    }
+  }
+  output
+}
+
+pub fn anchor_flags(anchor: &DiagnosticAnchor, nodes: &NodeIndex) -> Option<NodeFlags> {
+  let DiagnosticAnchor::Element { element, .. } = anchor else {
+    return None;
+  };
+  match element {
+    SyntaxElementId::Node(id) => nodes.node(*id).map(|record| record.flags),
+    SyntaxElementId::Token(id) => nodes
+      .token(*id)
+      .and_then(|record| nodes.node(record.parent))
+      .map(|record| record.flags),
+  }
+}

--- a/src/syntax/src/document/edit.rs
+++ b/src/syntax/src/document/edit.rs
@@ -1,0 +1,172 @@
+use alloc::string::String;
+use core::fmt;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct TextSize(pub u32);
+
+impl TextSize {
+  pub const ZERO: Self = Self(0);
+
+  pub const fn from_u32(value: u32) -> Self {
+    Self(value)
+  }
+
+  pub const fn to_u32(self) -> u32 {
+    self.0
+  }
+
+  pub const fn to_usize(self) -> usize {
+    self.0 as usize
+  }
+
+  pub fn checked_from_usize(value: usize) -> Result<Self, SourceError> {
+    u32::try_from(value)
+      .map(Self)
+      .map_err(|_| SourceError::SourceTooLarge)
+  }
+}
+
+impl Add for TextSize {
+  type Output = Self;
+
+  fn add(self, rhs: Self) -> Self::Output {
+    Self(self.0.saturating_add(rhs.0))
+  }
+}
+
+impl AddAssign for TextSize {
+  fn add_assign(&mut self, rhs: Self) {
+    *self = *self + rhs;
+  }
+}
+
+impl Sub for TextSize {
+  type Output = Self;
+
+  fn sub(self, rhs: Self) -> Self::Output {
+    Self(self.0.saturating_sub(rhs.0))
+  }
+}
+
+impl SubAssign for TextSize {
+  fn sub_assign(&mut self, rhs: Self) {
+    *self = *self - rhs;
+  }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct TextRange {
+  pub start: TextSize,
+  pub end: TextSize,
+}
+
+impl TextRange {
+  pub const fn new(start: TextSize, end: TextSize) -> Self {
+    Self { start, end }
+  }
+
+  pub const fn empty(offset: TextSize) -> Self {
+    Self {
+      start: offset,
+      end: offset,
+    }
+  }
+
+  pub const fn at(start: TextSize, len: TextSize) -> Self {
+    Self {
+      start,
+      end: TextSize(start.0.saturating_add(len.0)),
+    }
+  }
+
+  pub const fn len(self) -> TextSize {
+    TextSize(self.end.0.saturating_sub(self.start.0))
+  }
+
+  pub const fn is_empty(self) -> bool {
+    self.start.0 == self.end.0
+  }
+
+  pub const fn contains(self, offset: TextSize) -> bool {
+    self.start.0 <= offset.0 && offset.0 < self.end.0
+  }
+
+  pub const fn contains_inclusive(self, offset: TextSize) -> bool {
+    self.start.0 <= offset.0 && offset.0 <= self.end.0
+  }
+
+  pub const fn contains_range(self, other: Self) -> bool {
+    self.start.0 <= other.start.0 && other.end.0 <= self.end.0
+  }
+
+  pub const fn intersects(self, other: Self) -> bool {
+    self.start.0 < other.end.0 && other.start.0 < self.end.0
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct TextEdit {
+  pub delete: TextRange,
+  pub insert: String,
+}
+
+impl TextEdit {
+  pub fn insert(offset: TextSize, text: impl Into<String>) -> Self {
+    Self {
+      delete: TextRange::empty(offset),
+      insert: text.into(),
+    }
+  }
+
+  pub fn delete(range: TextRange) -> Self {
+    Self {
+      delete: range,
+      insert: String::new(),
+    }
+  }
+
+  pub fn replace(range: TextRange, text: impl Into<String>) -> Self {
+    Self {
+      delete: range,
+      insert: text.into(),
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SourceError {
+  InvalidRange(TextRange),
+  InvalidUtf8Boundary(TextSize),
+  UnsortedEdits,
+  OverlappingEdits,
+  SourceTooLarge,
+  WrongDocumentRevision,
+}
+
+impl fmt::Display for SourceError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::InvalidRange(range) => write!(
+        f,
+        "invalid source range {}..{}",
+        range.start.0, range.end.0
+      ),
+      Self::InvalidUtf8Boundary(offset) => {
+        write!(f, "offset {} is not a UTF-8 boundary", offset.0)
+      }
+      Self::UnsortedEdits => f.write_str("edits must be sorted by source range"),
+      Self::OverlappingEdits => f.write_str("edit ranges must not overlap"),
+      Self::SourceTooLarge => f.write_str("source exceeds the 32-bit text range"),
+      Self::WrongDocumentRevision => {
+        f.write_str("source snapshot belongs to another document revision")
+      }
+    }
+  }
+}

--- a/src/syntax/src/document/flags.rs
+++ b/src/syntax/src/document/flags.rs
@@ -1,0 +1,55 @@
+use core::ops::{BitOr, BitOrAssign};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+macro_rules! flags {
+  ($name:ident, $storage:ty) => {
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    pub struct $name(pub $storage);
+
+    impl $name {
+      pub const NONE: Self = Self(0);
+
+      pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+      }
+
+      pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+      }
+    }
+
+    impl BitOr for $name {
+      type Output = Self;
+
+      fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+      }
+    }
+
+    impl BitOrAssign for $name {
+      fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+      }
+    }
+  };
+}
+
+flags!(NodeFlags, u16);
+flags!(TokenFlags, u16);
+
+impl NodeFlags {
+  pub const ERROR: Self = Self(1 << 0);
+  pub const MISSING: Self = Self(1 << 1);
+  pub const REPARSE_ROOT: Self = Self(1 << 2);
+  pub const CONTAINS_ERROR: Self = Self(1 << 3);
+  pub const CONTAINS_MISSING: Self = Self(1 << 4);
+}
+
+impl TokenFlags {
+  pub const SYNTHETIC: Self = Self(1 << 0);
+  pub const MISSING: Self = Self(1 << 1);
+  pub const ERROR: Self = Self(1 << 2);
+}

--- a/src/syntax/src/document/green.rs
+++ b/src/syntax/src/document/green.rs
@@ -1,0 +1,297 @@
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt;
+
+use super::edit::{TextRange, TextSize};
+use super::flags::{NodeFlags, TokenFlags};
+use super::ids::{NodeId, TokenId};
+use super::kind::SyntaxKind;
+use super::source::TextSnapshot;
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+#[derive(Clone, Debug)]
+pub struct GreenNode {
+  pub id: NodeId,
+  pub kind: SyntaxKind,
+  pub text_len: TextSize,
+  pub children: Arc<[GreenElement]>,
+  pub flags: NodeFlags,
+  pub structural_hash: u64,
+}
+
+#[derive(Clone, Debug)]
+pub enum GreenElement {
+  Node(Arc<GreenNode>),
+  Token(GreenToken),
+}
+
+impl GreenElement {
+  pub fn text_len(&self) -> TextSize {
+    match self {
+      Self::Node(node) => node.text_len,
+      Self::Token(token) => token.text_len,
+    }
+  }
+
+  pub fn kind(&self) -> SyntaxKind {
+    match self {
+      Self::Node(node) => node.kind,
+      Self::Token(token) => token.kind,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct GreenToken {
+  pub id: TokenId,
+  pub kind: SyntaxKind,
+  pub text_len: TextSize,
+  pub flags: TokenFlags,
+  pub text_hash: u64,
+}
+
+impl GreenToken {
+  pub fn is_synthetic(self) -> bool {
+    self.flags.contains(TokenFlags::SYNTHETIC)
+  }
+}
+
+pub fn text_hash(text: &str) -> u64 {
+  let mut hash = FNV_OFFSET;
+  for byte in text.as_bytes() {
+    hash ^= u64::from(*byte);
+    hash = hash.wrapping_mul(FNV_PRIME);
+  }
+  hash
+}
+
+pub(crate) fn hash_node(kind: SyntaxKind, children: &[GreenElement]) -> u64 {
+  let mut hash = hash_u64(FNV_OFFSET, kind as u64);
+  for child in children {
+    hash = hash_u64(hash, child.kind() as u64);
+    hash = hash_u64(hash, u64::from(child.text_len().0));
+    hash = hash_u64(
+      hash,
+      match child {
+        GreenElement::Node(node) => node.structural_hash,
+        GreenElement::Token(token) => token.text_hash,
+      },
+    );
+  }
+  hash
+}
+
+fn hash_u64(mut hash: u64, value: u64) -> u64 {
+  for byte in value.to_le_bytes() {
+    hash ^= u64::from(byte);
+    hash = hash.wrapping_mul(FNV_PRIME);
+  }
+  hash
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TreeInvariantError {
+  RootLength {
+    tree: TextSize,
+    source: TextSize,
+  },
+  SyntheticTokenHasWidth {
+    token: TokenId,
+    len: TextSize,
+  },
+  TokenOutsideSource {
+    token: TokenId,
+    range: TextRange,
+  },
+  TokenTextHash {
+    token: TokenId,
+    range: TextRange,
+  },
+  NonTokenKind {
+    token: TokenId,
+    kind: SyntaxKind,
+  },
+}
+
+impl fmt::Display for TreeInvariantError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::RootLength { tree, source } => {
+        write!(f, "tree length {} differs from source length {}", tree.0, source.0)
+      }
+      Self::SyntheticTokenHasWidth { token, len } => {
+        write!(f, "synthetic token {} has width {}", token.0, len.0)
+      }
+      Self::TokenOutsideSource { token, range } => write!(
+        f,
+        "token {} range {}..{} is outside the source",
+        token.0, range.start.0, range.end.0
+      ),
+      Self::TokenTextHash { token, range } => write!(
+        f,
+        "token {} does not match source bytes {}..{}",
+        token.0, range.start.0, range.end.0
+      ),
+      Self::NonTokenKind { token, kind } => {
+        write!(f, "token {} uses node kind {kind:?}", token.0)
+      }
+    }
+  }
+}
+
+pub fn validate_lossless(
+  root: &GreenNode,
+  source: &TextSnapshot,
+) -> Result<(), TreeInvariantError> {
+  if root.text_len != source.byte_len() {
+    return Err(TreeInvariantError::RootLength {
+      tree: root.text_len,
+      source: source.byte_len(),
+    });
+  }
+  let mut offset = TextSize::ZERO;
+  validate_node(root, source, &mut offset)?;
+  if offset != source.byte_len() {
+    return Err(TreeInvariantError::RootLength {
+      tree: offset,
+      source: source.byte_len(),
+    });
+  }
+  Ok(())
+}
+
+pub fn reconstruct_source(
+  root: &GreenNode,
+  source: &TextSnapshot,
+) -> Result<alloc::string::String, TreeInvariantError> {
+  validate_lossless(root, source)?;
+  let mut output = alloc::string::String::with_capacity(source.byte_len().to_usize());
+  let mut offset = TextSize::ZERO;
+  collect_text(root, source, &mut offset, &mut output);
+  Ok(output)
+}
+
+fn validate_node(
+  node: &GreenNode,
+  source: &TextSnapshot,
+  offset: &mut TextSize,
+) -> Result<(), TreeInvariantError> {
+  for child in node.children.iter() {
+    match child {
+      GreenElement::Node(node) => validate_node(node, source, offset)?,
+      GreenElement::Token(token) => {
+        if !token.kind.is_token() {
+          return Err(TreeInvariantError::NonTokenKind {
+            token: token.id,
+            kind: token.kind,
+          });
+        }
+        if token.is_synthetic() {
+          if token.text_len.0 != 0 {
+            return Err(TreeInvariantError::SyntheticTokenHasWidth {
+              token: token.id,
+              len: token.text_len,
+            });
+          }
+          continue;
+        }
+        let range = TextRange::at(*offset, token.text_len);
+        if range.end.0 > source.byte_len().0 {
+          return Err(TreeInvariantError::TokenOutsideSource {
+            token: token.id,
+            range,
+          });
+        }
+        let text = source
+          .text(range)
+          .map_err(|_| TreeInvariantError::TokenOutsideSource {
+            token: token.id,
+            range,
+          })?;
+        if text_hash(&text) != token.text_hash {
+          return Err(TreeInvariantError::TokenTextHash {
+            token: token.id,
+            range,
+          });
+        }
+        *offset += token.text_len;
+      }
+    }
+  }
+  Ok(())
+}
+
+fn collect_text(
+  node: &GreenNode,
+  source: &TextSnapshot,
+  offset: &mut TextSize,
+  output: &mut alloc::string::String,
+) {
+  for child in node.children.iter() {
+    match child {
+      GreenElement::Node(node) => collect_text(node, source, offset, output),
+      GreenElement::Token(token) => {
+        if !token.is_synthetic() {
+          let range = TextRange::at(*offset, token.text_len);
+          source.for_each_slice(range, |slice| output.push_str(slice));
+          *offset += token.text_len;
+        }
+      }
+    }
+  }
+}
+
+pub(crate) fn propagated_flags(
+  kind: SyntaxKind,
+  explicit: NodeFlags,
+  children: &[GreenElement],
+) -> NodeFlags {
+  let mut flags = explicit;
+  if kind == SyntaxKind::Error {
+    flags |= NodeFlags::ERROR;
+  }
+  if kind == SyntaxKind::Missing {
+    flags |= NodeFlags::MISSING;
+  }
+  for child in children {
+    match child {
+      GreenElement::Node(node) => {
+        if node.flags.intersects(NodeFlags::ERROR | NodeFlags::CONTAINS_ERROR) {
+          flags |= NodeFlags::CONTAINS_ERROR;
+        }
+        if node
+          .flags
+          .intersects(NodeFlags::MISSING | NodeFlags::CONTAINS_MISSING)
+        {
+          flags |= NodeFlags::CONTAINS_MISSING;
+        }
+      }
+      GreenElement::Token(token) => {
+        if token.flags.contains(TokenFlags::ERROR) {
+          flags |= NodeFlags::CONTAINS_ERROR;
+        }
+        if token.flags.contains(TokenFlags::MISSING) {
+          flags |= NodeFlags::CONTAINS_MISSING;
+        }
+      }
+    }
+  }
+  flags
+}
+
+pub(crate) fn child_text_len(children: &[GreenElement]) -> TextSize {
+  children
+    .iter()
+    .fold(TextSize::ZERO, |total, child| total + child.text_len())
+}
+
+pub(crate) fn collect_tokens<'a>(node: &'a GreenNode, output: &mut Vec<&'a GreenToken>) {
+  for child in node.children.iter() {
+    match child {
+      GreenElement::Node(node) => collect_tokens(node, output),
+      GreenElement::Token(token) => output.push(token),
+    }
+  }
+}

--- a/src/syntax/src/document/ids.rs
+++ b/src/syntax/src/document/ids.rs
@@ -1,0 +1,102 @@
+use core::fmt;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+macro_rules! id_type {
+  ($name:ident) => {
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    pub struct $name(pub u64);
+
+    impl fmt::Display for $name {
+      fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+      }
+    }
+  };
+}
+
+id_type!(DocumentId);
+id_type!(Revision);
+id_type!(NodeId);
+id_type!(TokenId);
+id_type!(DiagnosticId);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct RuleId(pub u32);
+
+impl fmt::Display for RuleId {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{:08x}", self.0)
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub enum SyntaxElementId {
+  Node(NodeId),
+  Token(TokenId),
+}
+
+#[derive(Clone, Debug)]
+pub struct IdGenerator {
+  next_node: u64,
+  next_token: u64,
+  next_diagnostic: u64,
+}
+
+impl Default for IdGenerator {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl IdGenerator {
+  pub const fn new() -> Self {
+    Self {
+      next_node: 1,
+      next_token: 1,
+      next_diagnostic: 1,
+    }
+  }
+
+  pub const fn with_next(next_node: u64, next_token: u64, next_diagnostic: u64) -> Self {
+    Self {
+      next_node,
+      next_token,
+      next_diagnostic,
+    }
+  }
+
+  pub fn node(&mut self) -> NodeId {
+    let id = NodeId(self.next_node);
+    self.next_node = self.next_node.saturating_add(1);
+    id
+  }
+
+  pub fn token(&mut self) -> TokenId {
+    let id = TokenId(self.next_token);
+    self.next_token = self.next_token.saturating_add(1);
+    id
+  }
+
+  pub fn diagnostic(&mut self) -> DiagnosticId {
+    let id = DiagnosticId(self.next_diagnostic);
+    self.next_diagnostic = self.next_diagnostic.saturating_add(1);
+    id
+  }
+
+  pub const fn next_node(&self) -> u64 {
+    self.next_node
+  }
+
+  pub const fn next_token(&self) -> u64 {
+    self.next_token
+  }
+
+  pub const fn next_diagnostic(&self) -> u64 {
+    self.next_diagnostic
+  }
+}

--- a/src/syntax/src/document/index.rs
+++ b/src/syntax/src/document/index.rs
@@ -1,0 +1,109 @@
+use alloc::collections::BTreeMap;
+
+use super::edit::{TextRange, TextSize};
+use super::flags::{NodeFlags, TokenFlags};
+use super::green::{GreenElement, GreenNode};
+use super::ids::{NodeId, SyntaxElementId, TokenId};
+use super::kind::SyntaxKind;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NodeRecord {
+  pub kind: SyntaxKind,
+  pub range: TextRange,
+  pub parent: Option<NodeId>,
+  pub flags: NodeFlags,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TokenRecord {
+  pub kind: SyntaxKind,
+  pub range: TextRange,
+  pub parent: NodeId,
+  pub flags: TokenFlags,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NodeIndex {
+  nodes: BTreeMap<NodeId, NodeRecord>,
+  tokens: BTreeMap<TokenId, TokenRecord>,
+}
+
+impl NodeIndex {
+  pub fn build(root: &GreenNode) -> Self {
+    let mut index = Self::default();
+    index.index_node(root, None, TextSize::ZERO);
+    index
+  }
+
+  pub fn node(&self, id: NodeId) -> Option<&NodeRecord> {
+    self.nodes.get(&id)
+  }
+
+  pub fn token(&self, id: TokenId) -> Option<&TokenRecord> {
+    self.tokens.get(&id)
+  }
+
+  pub fn range(&self, id: SyntaxElementId) -> Option<TextRange> {
+    match id {
+      SyntaxElementId::Node(id) => self.node(id).map(|record| record.range),
+      SyntaxElementId::Token(id) => self.token(id).map(|record| record.range),
+    }
+  }
+
+  pub fn parent(&self, id: SyntaxElementId) -> Option<NodeId> {
+    match id {
+      SyntaxElementId::Node(id) => self.node(id).and_then(|record| record.parent),
+      SyntaxElementId::Token(id) => self.token(id).map(|record| record.parent),
+    }
+  }
+
+  pub fn node_count(&self) -> usize {
+    self.nodes.len()
+  }
+
+  pub fn token_count(&self) -> usize {
+    self.tokens.len()
+  }
+
+  pub fn contains_node(&self, id: NodeId) -> bool {
+    self.nodes.contains_key(&id)
+  }
+
+  fn index_node(
+    &mut self,
+    node: &GreenNode,
+    parent: Option<NodeId>,
+    start: TextSize,
+  ) {
+    self.nodes.insert(
+      node.id,
+      NodeRecord {
+        kind: node.kind,
+        range: TextRange::at(start, node.text_len),
+        parent,
+        flags: node.flags,
+      },
+    );
+    let mut offset = start;
+    for child in node.children.iter() {
+      match child {
+        GreenElement::Node(child) => {
+          self.index_node(child, Some(node.id), offset);
+          offset += child.text_len;
+        }
+        GreenElement::Token(token) => {
+          self.tokens.insert(
+            token.id,
+            TokenRecord {
+              kind: token.kind,
+              range: TextRange::at(offset, token.text_len),
+              parent: node.id,
+              flags: token.flags,
+            },
+          );
+          offset += token.text_len;
+        }
+      }
+    }
+  }
+}

--- a/src/syntax/src/document/kind.rs
+++ b/src/syntax/src/document/kind.rs
@@ -1,0 +1,74 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[repr(u16)]
+pub enum SyntaxKind {
+  Document,
+  Body,
+  Section,
+  SectionElement,
+  Title,
+  Subtitle,
+  UlSubtitle,
+  Paragraph,
+  ParagraphElement,
+  ParagraphText,
+  GenericFence,
+  FenceContent,
+  MechItem,
+  VariableDefine,
+  Identifier,
+  Expression,
+  AdditiveExpression,
+  ParentheticalExpression,
+  IntegerLiteral,
+  DefineOperator,
+  Comment,
+  Error,
+  Missing,
+
+  Text,
+  Whitespace,
+  Newline,
+  IdentifierToken,
+  IntegerToken,
+  Colon,
+  Equal,
+  Plus,
+  LeftParen,
+  RightParen,
+  Period,
+  Dash,
+  Semicolon,
+  FenceDelimiter,
+  CommentToken,
+  Unknown,
+  Eof,
+}
+
+impl SyntaxKind {
+  pub const fn is_token(self) -> bool {
+    matches!(
+      self,
+      Self::Text
+        | Self::Whitespace
+        | Self::Newline
+        | Self::IdentifierToken
+        | Self::IntegerToken
+        | Self::Colon
+        | Self::Equal
+        | Self::Plus
+        | Self::LeftParen
+        | Self::RightParen
+        | Self::Period
+        | Self::Dash
+        | Self::Semicolon
+        | Self::FenceDelimiter
+        | Self::CommentToken
+        | Self::Unknown
+        | Self::Eof
+    )
+  }
+}

--- a/src/syntax/src/document/line_index.rs
+++ b/src/syntax/src/document/line_index.rs
@@ -1,0 +1,199 @@
+use alloc::sync::Arc;
+
+use super::edit::{TextEdit, TextSize};
+use super::source::{Piece, TextSnapshot};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LineIndex {
+  starts: Arc<[TextSize]>,
+}
+
+impl Default for LineIndex {
+  fn default() -> Self {
+    Self {
+      starts: Arc::from([TextSize::ZERO]),
+    }
+  }
+}
+
+impl LineIndex {
+  pub fn from_str(source: &str) -> Self {
+    let mut starts = alloc::vec![TextSize::ZERO];
+    scan_line_starts(
+      TextSize::ZERO,
+      TextSize(source.len() as u32),
+      |offset| source.as_bytes().get(offset.to_usize()).copied(),
+      &mut starts,
+    );
+    Self {
+      starts: starts.into(),
+    }
+  }
+
+  pub(crate) fn from_pieces(pieces: &[Piece], byte_len: TextSize) -> Self {
+    let mut starts = alloc::vec![TextSize::ZERO];
+    scan_line_starts(
+      TextSize::ZERO,
+      byte_len,
+      |offset| byte_from_pieces(pieces, offset),
+      &mut starts,
+    );
+    Self {
+      starts: starts.into(),
+    }
+  }
+
+  pub(crate) fn updated(
+    &self,
+    old: &TextSnapshot,
+    new_pieces: &[Piece],
+    new_len: TextSize,
+    edits: &[TextEdit],
+  ) -> Self {
+    if edits.is_empty() {
+      return self.clone();
+    }
+
+    let first = edits[0].delete.start;
+    let last = edits[edits.len() - 1].delete.end;
+    let first_line = self.line_of(first).saturating_sub(1);
+    let last_line = self.line_of(last);
+    let scan_start = self.starts[first_line];
+    let old_scan_end = self
+      .starts
+      .get(last_line.saturating_add(2))
+      .copied()
+      .unwrap_or_else(|| old.byte_len());
+    let new_scan_end = map_old_offset(old_scan_end, edits);
+
+    let mut starts = self
+      .starts
+      .iter()
+      .copied()
+      .take_while(|start| start.0 < scan_start.0)
+      .collect::<alloc::vec::Vec<_>>();
+    starts.push(scan_start);
+    scan_line_starts(
+      scan_start,
+      new_scan_end,
+      |offset| byte_from_pieces(new_pieces, offset),
+      &mut starts,
+    );
+
+    for old_start in self
+      .starts
+      .iter()
+      .copied()
+      .filter(|start| start.0 > old_scan_end.0)
+    {
+      let mapped = map_old_offset(old_start, edits);
+      if starts.last().copied() != Some(mapped) {
+        starts.push(mapped);
+      }
+    }
+
+    if starts.is_empty() {
+      starts.push(TextSize::ZERO);
+    }
+    debug_assert!(starts.windows(2).all(|pair| pair[0].0 < pair[1].0));
+    debug_assert!(starts.iter().all(|start| start.0 <= new_len.0));
+    Self {
+      starts: starts.into(),
+    }
+  }
+
+  pub fn line_count(&self) -> usize {
+    self.starts.len()
+  }
+
+  pub fn line_starts(&self) -> &[TextSize] {
+    &self.starts
+  }
+
+  pub fn line_start(&self, line: usize) -> Option<TextSize> {
+    self.starts.get(line).copied()
+  }
+
+  pub fn line_of(&self, offset: TextSize) -> usize {
+    match self
+      .starts
+      .binary_search_by_key(&offset.0, |start| start.0)
+    {
+      Ok(line) => line,
+      Err(next) => next.saturating_sub(1),
+    }
+  }
+
+  pub fn line_and_byte_column(&self, offset: TextSize) -> (usize, TextSize) {
+    let line = self.line_of(offset);
+    let start = self.starts[line];
+    (line, offset - start)
+  }
+}
+
+fn map_old_offset(offset: TextSize, edits: &[TextEdit]) -> TextSize {
+  let mut delta = 0_i64;
+  for edit in edits {
+    if offset.0 < edit.delete.start.0 {
+      break;
+    }
+    if offset.0 <= edit.delete.end.0 {
+      let mapped = i64::from(edit.delete.start.0)
+        + delta
+        + i64::try_from(edit.insert.len()).unwrap_or(i64::MAX);
+      return TextSize(mapped.clamp(0, i64::from(u32::MAX)) as u32);
+    }
+    delta += i64::try_from(edit.insert.len()).unwrap_or(i64::MAX)
+      - i64::from(edit.delete.len().0);
+  }
+  let mapped = i64::from(offset.0) + delta;
+  TextSize(mapped.clamp(0, i64::from(u32::MAX)) as u32)
+}
+
+fn byte_from_pieces(pieces: &[Piece], offset: TextSize) -> Option<u8> {
+  let mut absolute = 0_u32;
+  for piece in pieces {
+    let len = piece.len().0;
+    if offset.0 < absolute.saturating_add(len) {
+      let local = piece.range_in_chunk.start.0 + (offset.0 - absolute);
+      return piece.chunk.as_bytes().get(local as usize).copied();
+    }
+    absolute = absolute.saturating_add(len);
+  }
+  None
+}
+
+fn scan_line_starts(
+  start: TextSize,
+  end: TextSize,
+  mut byte_at: impl FnMut(TextSize) -> Option<u8>,
+  starts: &mut alloc::vec::Vec<TextSize>,
+) {
+  let mut offset = start.0;
+  while offset < end.0 {
+    match byte_at(TextSize(offset)) {
+      Some(b'\r') => {
+        if offset.saturating_add(1) < end.0
+          && byte_at(TextSize(offset + 1)) == Some(b'\n')
+        {
+          offset = offset.saturating_add(2);
+        } else {
+          offset = offset.saturating_add(1);
+        }
+        let next = TextSize(offset);
+        if starts.last().copied() != Some(next) {
+          starts.push(next);
+        }
+      }
+      Some(b'\n') => {
+        offset = offset.saturating_add(1);
+        let next = TextSize(offset);
+        if starts.last().copied() != Some(next) {
+          starts.push(next);
+        }
+      }
+      Some(_) => offset = offset.saturating_add(1),
+      None => break,
+    }
+  }
+}

--- a/src/syntax/src/document/mod.rs
+++ b/src/syntax/src/document/mod.rs
@@ -1,0 +1,134 @@
+#![forbid(unsafe_code)]
+
+//! Experimental, lossless document syntax infrastructure.
+//!
+//! Production parsing still uses the legacy Nom parser and existing `Program`
+//! AST. Nothing in this module is called by the public legacy `parse` path.
+
+extern crate alloc;
+
+pub mod annotation;
+pub mod builder;
+pub mod diagnostic;
+pub mod edit;
+pub mod flags;
+pub mod green;
+pub mod ids;
+pub mod index;
+pub mod kind;
+pub mod line_index;
+pub mod pointer;
+pub mod red;
+pub mod source;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+pub use annotation::*;
+pub use builder::*;
+pub use diagnostic::*;
+pub use edit::*;
+pub use flags::*;
+pub use green::*;
+pub use ids::*;
+pub use index::*;
+pub use kind::*;
+pub use line_index::*;
+pub use pointer::*;
+pub use red::*;
+pub use source::*;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RestartMode {
+  Document,
+  Paragraph,
+  Mech,
+  Fence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RestartEntry {
+  pub node: NodeId,
+  pub range: TextRange,
+  pub mode: RestartMode,
+  pub delimiter_depth: u32,
+  pub line_start: bool,
+  pub indentation: u32,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RestartIndex {
+  entries: Vec<RestartEntry>,
+}
+
+impl RestartIndex {
+  pub fn push(&mut self, entry: RestartEntry) {
+    self.entries.push(entry);
+  }
+
+  pub fn iter(&self) -> impl Iterator<Item = &RestartEntry> {
+    self.entries.iter()
+  }
+
+  pub fn as_slice(&self) -> &[RestartEntry] {
+    &self.entries
+  }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ParseStats {
+  pub source_bytes: u64,
+  pub parser_steps: u64,
+  pub events_emitted: u64,
+  pub diagnostics_emitted: u64,
+  pub recovery_bytes: u64,
+  pub reparse_root_count: u64,
+  pub reused_node_count: u64,
+  pub new_node_count: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SyntaxSnapshot {
+  pub document: DocumentId,
+  pub revision: Revision,
+  pub source: TextSnapshot,
+  pub root: Arc<GreenNode>,
+  pub diagnostics: DiagnosticStore,
+  pub nodes: NodeIndex,
+  pub restarts: RestartIndex,
+  pub stats: ParseStats,
+}
+
+impl SyntaxSnapshot {
+  pub fn new(
+    source: TextSnapshot,
+    root: Arc<GreenNode>,
+    diagnostics: DiagnosticStore,
+  ) -> Self {
+    let document = source.document();
+    let revision = source.revision();
+    let nodes = NodeIndex::build(&root);
+    Self {
+      document,
+      revision,
+      source,
+      root,
+      diagnostics,
+      nodes,
+      restarts: RestartIndex::default(),
+      stats: ParseStats::default(),
+    }
+  }
+
+  pub fn syntax(&self) -> SyntaxNode {
+    SyntaxNode::new_root(self.root.clone(), self.source.clone())
+  }
+
+  pub fn is_strictly_clean(&self) -> bool {
+    self.diagnostics.is_empty()
+      && !self
+        .root
+        .flags
+        .intersects(NodeFlags::CONTAINS_ERROR | NodeFlags::CONTAINS_MISSING)
+  }
+}

--- a/src/syntax/src/document/pointer.rs
+++ b/src/syntax/src/document/pointer.rs
@@ -1,0 +1,11 @@
+use super::ids::{DocumentId, NodeId};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct SyntaxPtr {
+  pub document: DocumentId,
+  pub node: NodeId,
+}

--- a/src/syntax/src/document/red.rs
+++ b/src/syntax/src/document/red.rs
@@ -1,0 +1,206 @@
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use super::edit::{SourceError, TextRange, TextSize};
+use super::flags::{NodeFlags, TokenFlags};
+use super::green::{GreenElement, GreenNode, GreenToken};
+use super::ids::{NodeId, TokenId};
+use super::kind::SyntaxKind;
+use super::source::TextSnapshot;
+
+#[derive(Clone, Debug)]
+pub struct SyntaxNode {
+  green: Arc<GreenNode>,
+  source: TextSnapshot,
+  offset: TextSize,
+}
+
+impl SyntaxNode {
+  pub fn new_root(green: Arc<GreenNode>, source: TextSnapshot) -> Self {
+    Self {
+      green,
+      source,
+      offset: TextSize::ZERO,
+    }
+  }
+
+  pub fn id(&self) -> NodeId {
+    self.green.id
+  }
+
+  pub fn kind(&self) -> SyntaxKind {
+    self.green.kind
+  }
+
+  pub fn flags(&self) -> NodeFlags {
+    self.green.flags
+  }
+
+  pub fn range(&self) -> TextRange {
+    TextRange::at(self.offset, self.green.text_len)
+  }
+
+  pub fn text(&self) -> Result<String, SourceError> {
+    self.source.text(self.range())
+  }
+
+  pub fn green(&self) -> &Arc<GreenNode> {
+    &self.green
+  }
+
+  pub fn source(&self) -> &TextSnapshot {
+    &self.source
+  }
+
+  pub fn children_with_tokens(&self) -> Vec<SyntaxElement> {
+    let mut children = Vec::with_capacity(self.green.children.len());
+    let mut offset = self.offset;
+    for child in self.green.children.iter() {
+      match child {
+        GreenElement::Node(node) => {
+          children.push(SyntaxElement::Node(Self {
+            green: node.clone(),
+            source: self.source.clone(),
+            offset,
+          }));
+          offset += node.text_len;
+        }
+        GreenElement::Token(token) => {
+          children.push(SyntaxElement::Token(SyntaxToken {
+            green: *token,
+            source: self.source.clone(),
+            offset,
+          }));
+          offset += token.text_len;
+        }
+      }
+    }
+    children
+  }
+
+  pub fn children(&self) -> impl Iterator<Item = SyntaxNode> {
+    self.children_with_tokens().into_iter().filter_map(|child| match child {
+      SyntaxElement::Node(node) => Some(node),
+      SyntaxElement::Token(_) => None,
+    })
+  }
+
+  pub fn tokens(&self) -> Vec<SyntaxToken> {
+    let mut tokens = Vec::new();
+    self.collect_tokens(&mut tokens);
+    tokens
+  }
+
+  pub fn first_child(&self, kind: SyntaxKind) -> Option<SyntaxNode> {
+    self.children().find(|child| child.kind() == kind)
+  }
+
+  fn collect_tokens(&self, output: &mut Vec<SyntaxToken>) {
+    for child in self.children_with_tokens() {
+      match child {
+        SyntaxElement::Node(node) => node.collect_tokens(output),
+        SyntaxElement::Token(token) => output.push(token),
+      }
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct SyntaxToken {
+  green: GreenToken,
+  source: TextSnapshot,
+  offset: TextSize,
+}
+
+impl SyntaxToken {
+  pub fn id(&self) -> TokenId {
+    self.green.id
+  }
+
+  pub fn kind(&self) -> SyntaxKind {
+    self.green.kind
+  }
+
+  pub fn flags(&self) -> TokenFlags {
+    self.green.flags
+  }
+
+  pub fn range(&self) -> TextRange {
+    TextRange::at(self.offset, self.green.text_len)
+  }
+
+  pub fn text(&self) -> Result<String, SourceError> {
+    self.source.text(self.range())
+  }
+}
+
+#[derive(Clone, Debug)]
+pub enum SyntaxElement {
+  Node(SyntaxNode),
+  Token(SyntaxToken),
+}
+
+pub trait AstNode: Clone {
+  fn can_cast(kind: SyntaxKind) -> bool;
+  fn cast(syntax: SyntaxNode) -> Option<Self>;
+  fn syntax(&self) -> &SyntaxNode;
+}
+
+macro_rules! ast_node {
+  ($name:ident, $($kind:pat_param)|+) => {
+    #[derive(Clone, Debug)]
+    pub struct $name(pub(crate) SyntaxNode);
+
+    impl AstNode for $name {
+      fn can_cast(kind: SyntaxKind) -> bool {
+        matches!(kind, $($kind)|+)
+      }
+
+      fn cast(syntax: SyntaxNode) -> Option<Self> {
+        Self::can_cast(syntax.kind()).then_some(Self(syntax))
+      }
+
+      fn syntax(&self) -> &SyntaxNode {
+        &self.0
+      }
+    }
+  };
+}
+
+ast_node!(DocumentSyntax, SyntaxKind::Document);
+ast_node!(SectionSyntax, SyntaxKind::Section);
+ast_node!(ParagraphSyntax, SyntaxKind::Paragraph);
+ast_node!(MechItemSyntax, SyntaxKind::MechItem);
+ast_node!(VariableDefineSyntax, SyntaxKind::VariableDefine);
+ast_node!(IdentifierSyntax, SyntaxKind::Identifier);
+ast_node!(
+  ExpressionSyntax,
+  SyntaxKind::Expression
+    | SyntaxKind::AdditiveExpression
+    | SyntaxKind::ParentheticalExpression
+    | SyntaxKind::IntegerLiteral
+    | SyntaxKind::Missing
+);
+
+impl VariableDefineSyntax {
+  pub fn name(&self) -> Option<IdentifierSyntax> {
+    self.0
+      .first_child(SyntaxKind::Identifier)
+      .and_then(IdentifierSyntax::cast)
+  }
+
+  pub fn define_operator(&self) -> Option<SyntaxToken> {
+    self
+      .0
+      .first_child(SyntaxKind::DefineOperator)
+      .and_then(|node| node.tokens().into_iter().next())
+  }
+
+  pub fn value(&self) -> Option<ExpressionSyntax> {
+    self
+      .0
+      .children()
+      .find_map(ExpressionSyntax::cast)
+  }
+}

--- a/src/syntax/src/document/source.rs
+++ b/src/syntax/src/document/source.rs
@@ -1,0 +1,286 @@
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use super::edit::{SourceError, TextEdit, TextRange, TextSize};
+use super::ids::{DocumentId, Revision};
+use super::line_index::LineIndex;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Piece {
+  pub(crate) chunk: Arc<str>,
+  pub(crate) range_in_chunk: TextRange,
+}
+
+impl Piece {
+  pub(crate) fn len(&self) -> TextSize {
+    self.range_in_chunk.len()
+  }
+
+  fn text(&self) -> &str {
+    &self.chunk
+      [self.range_in_chunk.start.to_usize()..self.range_in_chunk.end.to_usize()]
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct TextSnapshot {
+  document: DocumentId,
+  revision: Revision,
+  pub(crate) pieces: Arc<[Piece]>,
+  byte_len: TextSize,
+  line_index: LineIndex,
+}
+
+impl TextSnapshot {
+  pub fn new(
+    document: DocumentId,
+    revision: Revision,
+    source: impl Into<Arc<str>>,
+  ) -> Result<Self, SourceError> {
+    let source = source.into();
+    let byte_len = TextSize::checked_from_usize(source.len())?;
+    let line_index = LineIndex::from_str(&source);
+    let pieces: Arc<[Piece]> = if source.is_empty() {
+      Arc::from([])
+    } else {
+      Arc::from([Piece {
+        chunk: source,
+        range_in_chunk: TextRange::new(TextSize::ZERO, byte_len),
+      }])
+    };
+    Ok(Self {
+      document,
+      revision,
+      pieces,
+      byte_len,
+      line_index,
+    })
+  }
+
+  pub fn document(&self) -> DocumentId {
+    self.document
+  }
+
+  pub fn revision(&self) -> Revision {
+    self.revision
+  }
+
+  pub fn byte_len(&self) -> TextSize {
+    self.byte_len
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.byte_len.0 == 0
+  }
+
+  pub fn full_range(&self) -> TextRange {
+    TextRange::new(TextSize::ZERO, self.byte_len)
+  }
+
+  pub fn line_index(&self) -> &LineIndex {
+    &self.line_index
+  }
+
+  pub fn piece_count(&self) -> usize {
+    self.pieces.len()
+  }
+
+  pub fn chunks(&self) -> impl Iterator<Item = &str> {
+    self.pieces.iter().map(Piece::text)
+  }
+
+  pub fn text(&self, range: TextRange) -> Result<String, SourceError> {
+    self.validate_range(range)?;
+    let mut text = String::with_capacity(range.len().to_usize());
+    self.for_each_slice(range, |slice| text.push_str(slice));
+    Ok(text)
+  }
+
+  pub fn to_contiguous_string(&self) -> String {
+    let mut text = String::with_capacity(self.byte_len.to_usize());
+    for piece in self.pieces.iter() {
+      text.push_str(piece.text());
+    }
+    text
+  }
+
+  pub fn byte_at(&self, offset: TextSize) -> Option<u8> {
+    if offset.0 >= self.byte_len.0 {
+      return None;
+    }
+    let mut absolute = 0_u32;
+    for piece in self.pieces.iter() {
+      let end = absolute + piece.len().0;
+      if offset.0 < end {
+        let local = piece.range_in_chunk.start.0 + (offset.0 - absolute);
+        return piece.chunk.as_bytes().get(local as usize).copied();
+      }
+      absolute = end;
+    }
+    None
+  }
+
+  pub fn is_char_boundary(&self, offset: TextSize) -> bool {
+    if offset.0 == 0 || offset.0 == self.byte_len.0 {
+      return true;
+    }
+    self
+      .byte_at(offset)
+      .map(|byte| byte & 0b1100_0000 != 0b1000_0000)
+      .unwrap_or(false)
+  }
+
+  pub fn validate_range(&self, range: TextRange) -> Result<(), SourceError> {
+    if range.start.0 > range.end.0 || range.end.0 > self.byte_len.0 {
+      return Err(SourceError::InvalidRange(range));
+    }
+    if !self.is_char_boundary(range.start) {
+      return Err(SourceError::InvalidUtf8Boundary(range.start));
+    }
+    if !self.is_char_boundary(range.end) {
+      return Err(SourceError::InvalidUtf8Boundary(range.end));
+    }
+    Ok(())
+  }
+
+  pub fn append(&self, text: impl Into<String>) -> Result<Self, SourceError> {
+    self.apply_edits(&[TextEdit::insert(self.byte_len, text)])
+  }
+
+  pub fn apply_edits(&self, edits: &[TextEdit]) -> Result<Self, SourceError> {
+    self.validate_edits(edits)?;
+    if edits.is_empty() {
+      return Ok(self.clone());
+    }
+
+    let mut pieces = Vec::with_capacity(self.pieces.len() + edits.len() * 2);
+    let mut copied_until = TextSize::ZERO;
+    let mut new_len = i64::from(self.byte_len.0);
+    for edit in edits {
+      self.copy_range(
+        TextRange::new(copied_until, edit.delete.start),
+        &mut pieces,
+      );
+      push_insert(&mut pieces, &edit.insert)?;
+      copied_until = edit.delete.end;
+      new_len += i64::try_from(edit.insert.len()).map_err(|_| SourceError::SourceTooLarge)?
+        - i64::from(edit.delete.len().0);
+    }
+    self.copy_range(
+      TextRange::new(copied_until, self.byte_len),
+      &mut pieces,
+    );
+    let byte_len = TextSize::checked_from_usize(
+      usize::try_from(new_len).map_err(|_| SourceError::SourceTooLarge)?,
+    )?;
+    let line_index = self
+      .line_index
+      .updated(self, &pieces, byte_len, edits);
+    Ok(Self {
+      document: self.document,
+      revision: Revision(self.revision.0.saturating_add(1)),
+      pieces: pieces.into(),
+      byte_len,
+      line_index,
+    })
+  }
+
+  pub(crate) fn with_revision(mut self, revision: Revision) -> Self {
+    self.revision = revision;
+    self
+  }
+
+  pub(crate) fn for_each_slice(&self, range: TextRange, mut f: impl FnMut(&str)) {
+    if range.is_empty() {
+      return;
+    }
+    let mut absolute = 0_u32;
+    for piece in self.pieces.iter() {
+      let piece_start = absolute;
+      let piece_end = absolute + piece.len().0;
+      absolute = piece_end;
+      let start = range.start.0.max(piece_start);
+      let end = range.end.0.min(piece_end);
+      if start >= end {
+        continue;
+      }
+      let local_start = piece.range_in_chunk.start.0 + start - piece_start;
+      let local_end = piece.range_in_chunk.start.0 + end - piece_start;
+      f(&piece.chunk[local_start as usize..local_end as usize]);
+    }
+  }
+
+  fn validate_edits(&self, edits: &[TextEdit]) -> Result<(), SourceError> {
+    let mut previous: Option<TextRange> = None;
+    for edit in edits {
+      self.validate_range(edit.delete)?;
+      TextSize::checked_from_usize(edit.insert.len())?;
+      if let Some(prior) = previous {
+        if edit.delete.start.0 < prior.start.0 {
+          return Err(SourceError::UnsortedEdits);
+        }
+        if edit.delete.start.0 < prior.end.0 {
+          return Err(SourceError::OverlappingEdits);
+        }
+      }
+      previous = Some(edit.delete);
+    }
+    Ok(())
+  }
+
+  fn copy_range(&self, range: TextRange, output: &mut Vec<Piece>) {
+    if range.is_empty() {
+      return;
+    }
+    let mut absolute = 0_u32;
+    for piece in self.pieces.iter() {
+      let piece_start = absolute;
+      let piece_end = absolute + piece.len().0;
+      absolute = piece_end;
+      let start = range.start.0.max(piece_start);
+      let end = range.end.0.min(piece_end);
+      if start >= end {
+        continue;
+      }
+      let local_start = piece.range_in_chunk.start.0 + start - piece_start;
+      let local_end = piece.range_in_chunk.start.0 + end - piece_start;
+      push_piece(
+        output,
+        Piece {
+          chunk: piece.chunk.clone(),
+          range_in_chunk: TextRange::new(TextSize(local_start), TextSize(local_end)),
+        },
+      );
+    }
+  }
+}
+
+fn push_insert(output: &mut Vec<Piece>, insert: &str) -> Result<(), SourceError> {
+  if insert.is_empty() {
+    return Ok(());
+  }
+  let len = TextSize::checked_from_usize(insert.len())?;
+  push_piece(
+    output,
+    Piece {
+      chunk: Arc::<str>::from(insert),
+      range_in_chunk: TextRange::new(TextSize::ZERO, len),
+    },
+  );
+  Ok(())
+}
+
+fn push_piece(output: &mut Vec<Piece>, piece: Piece) {
+  if piece.len().0 == 0 {
+    return;
+  }
+  if let Some(previous) = output.last_mut()
+    && Arc::ptr_eq(&previous.chunk, &piece.chunk)
+    && previous.range_in_chunk.end == piece.range_in_chunk.start
+  {
+    previous.range_in_chunk.end = piece.range_in_chunk.end;
+    return;
+  }
+  output.push(piece);
+}

--- a/src/syntax/src/lib.rs
+++ b/src/syntax/src/lib.rs
@@ -7,7 +7,7 @@
 #![allow(warnings)]
 
 extern crate mech_core;
-#[cfg(feature="no-std")] #[macro_use] extern crate alloc;
+#[macro_use] extern crate alloc;
 #[cfg(not(feature = "no-std"))] extern crate core;
 extern crate nom;
 extern crate nom_unicode;
@@ -58,6 +58,9 @@ pub mod patterns;
 pub mod state_machines;
 pub mod functions;
 pub mod repl;
+/// Experimental lossless document syntax. Production parsing remains on the
+/// legacy parser during migration.
+pub mod document;
 
 pub use crate::imports::*;
 pub use crate::parser::*;

--- a/src/syntax/tests/document_annotations.rs
+++ b/src/syntax/tests/document_annotations.rs
@@ -1,0 +1,44 @@
+use mech_syntax::document::{
+  DocumentId, GreenBuilder, IdGenerator, NodeIndex, NodeMap, Revision, SyntaxKind, TextSnapshot,
+  validate_lossless,
+};
+
+#[test]
+fn typed_annotations_survive_reuse_and_deleted_nodes_are_dropped() {
+  let mut ids = IdGenerator::new();
+  let mut paragraph_builder = GreenBuilder::new(&mut ids);
+  paragraph_builder.start_node(SyntaxKind::Paragraph);
+  paragraph_builder.token(SyntaxKind::Text, "stable").unwrap();
+  paragraph_builder.finish_node().unwrap();
+  let paragraph = paragraph_builder.finish().unwrap();
+
+  let mut annotations = NodeMap::new(Revision(0));
+  annotations.insert(paragraph.id, String::from("dimension checked"));
+
+  let mut reused_builder = GreenBuilder::new(&mut ids);
+  reused_builder.start_node(SyntaxKind::Document);
+  reused_builder.token(SyntaxKind::Text, "prefix ").unwrap();
+  reused_builder.reuse_node(paragraph.clone()).unwrap();
+  reused_builder.finish_node().unwrap();
+  let reused_root = reused_builder.finish().unwrap();
+  let reused_index = NodeIndex::build(&reused_root);
+  let annotations = annotations.retain_reused(Revision(1), &reused_index);
+
+  assert_eq!(
+    annotations.get(paragraph.id).map(String::as_str),
+    Some("dimension checked")
+  );
+  assert_eq!(annotations.revision, Revision(1));
+  let source =
+    TextSnapshot::new(DocumentId(1), Revision(1), "prefix stable").unwrap();
+  validate_lossless(&reused_root, &source).unwrap();
+
+  let mut replaced_builder = GreenBuilder::new(&mut ids);
+  replaced_builder.start_node(SyntaxKind::Document);
+  replaced_builder.token(SyntaxKind::Text, "replacement").unwrap();
+  replaced_builder.finish_node().unwrap();
+  let replaced_root = replaced_builder.finish().unwrap();
+  let replaced_index = NodeIndex::build(&replaced_root);
+  let annotations = annotations.retain_reused(Revision(2), &replaced_index);
+  assert!(annotations.is_empty());
+}

--- a/src/syntax/tests/document_diagnostics.rs
+++ b/src/syntax/tests/document_diagnostics.rs
@@ -1,0 +1,92 @@
+use mech_syntax::document::{
+  Diagnostic, DiagnosticAnchor, DiagnosticCode, DiagnosticFix, DiagnosticId, DiagnosticLabel,
+  DiagnosticPhase, DiagnosticStore, DiagnosticTags, DocumentId, ExpectedSyntax, FixApplicability,
+  FoundSyntax, GreenBuilder, IdGenerator, NodeIndex, RecoveryAction, Revision, RuleId, Severity,
+  SyntaxElementId, SyntaxKind, TextEdit, TextRange, TextSize, TextSnapshot, render_plain,
+};
+
+fn paragraph_tree(text: &str) -> (std::sync::Arc<mech_syntax::document::GreenNode>, IdGenerator) {
+  let mut ids = IdGenerator::new();
+  let mut builder = GreenBuilder::new(&mut ids);
+  builder.start_node(SyntaxKind::Paragraph);
+  builder.token(SyntaxKind::Text, text).unwrap();
+  builder.finish_node().unwrap();
+  (builder.finish().unwrap(), ids)
+}
+
+#[test]
+fn structural_anchor_moves_with_reused_node() {
+  let (paragraph, mut ids) = paragraph_tree("later");
+  let mut root_builder = GreenBuilder::new(&mut ids);
+  root_builder.start_node(SyntaxKind::Document);
+  root_builder.token(SyntaxKind::Text, "💡 ").unwrap();
+  root_builder.reuse_node(paragraph.clone()).unwrap();
+  root_builder.finish_node().unwrap();
+  let root = root_builder.finish().unwrap();
+  let index = NodeIndex::build(&root);
+  let anchor = DiagnosticAnchor::Element {
+    element: SyntaxElementId::Node(paragraph.id),
+    relative: TextRange::new(TextSize(1), TextSize(3)),
+  };
+
+  assert_eq!(
+    anchor.resolve(Revision(1), &index),
+    Some(TextRange::new(TextSize(6), TextSize(8)))
+  );
+}
+
+#[test]
+fn structured_diagnostic_serializes_and_renders() {
+  let text = "x := 1 +";
+  let source =
+    TextSnapshot::new(DocumentId(9), Revision(2), text).unwrap();
+  let (root, _) = paragraph_tree(text);
+  let index = NodeIndex::build(&root);
+  let diagnostic = Diagnostic {
+    id: DiagnosticId(1),
+    code: DiagnosticCode::syntax("missing-expression"),
+    phase: DiagnosticPhase::Syntax,
+    severity: Severity::Error,
+    rule: Some(RuleId(0xa11d_171e)),
+    primary: DiagnosticAnchor::Absolute {
+      revision: Revision(2),
+      range: TextRange::empty(TextSize(text.len() as u32)),
+    },
+    labels: vec![DiagnosticLabel {
+      anchor: DiagnosticAnchor::Absolute {
+        revision: Revision(2),
+        range: TextRange::new(TextSize(7), TextSize(8)),
+      },
+      message: "`+` requires a right operand".into(),
+    }],
+    expected: vec![ExpectedSyntax::Production("expression".into())],
+    found: Some(FoundSyntax {
+      kind: Some(SyntaxKind::Eof),
+      text: None,
+    }),
+    fixes: vec![DiagnosticFix {
+      title: "Insert an expression".into(),
+      applicability: FixApplicability::HasPlaceholders,
+      edits: vec![TextEdit::insert(TextSize(text.len() as u32), " _")],
+    }],
+    related: vec![],
+    recovery: Some(RecoveryAction::Insert {
+      syntax: ExpectedSyntax::Production("expression".into()),
+      at: TextSize(text.len() as u32),
+    }),
+    tags: DiagnosticTags::NONE,
+    message: "expected an expression after `+`".into(),
+  };
+  let mut store = DiagnosticStore::new(Revision(2));
+  store.push(diagnostic.clone());
+
+  let json = store.to_json().unwrap();
+  assert!(json.contains("\"syntax/missing-expression\""));
+  assert!(json.contains("\"machine-applicable\"") || json.contains("\"has-placeholders\""));
+  assert!(json.contains("\"recovery\""));
+
+  let rendered = render_plain(&diagnostic, &source, &index);
+  assert!(rendered.contains("syntax/missing-expression"));
+  assert!(rendered.contains("1:9"));
+  assert!(rendered.contains("right operand"));
+}

--- a/src/syntax/tests/document_green_tree.rs
+++ b/src/syntax/tests/document_green_tree.rs
@@ -1,0 +1,108 @@
+use mech_syntax::document::{
+  DocumentId, GreenBuilder, IdGenerator, NodeFlags, NodeIndex, Revision, SyntaxElementId,
+  SyntaxKind, TextSnapshot, TokenFlags, reconstruct_source, validate_lossless,
+};
+
+fn source(text: &str) -> TextSnapshot {
+  TextSnapshot::new(DocumentId(3), Revision(0), text).unwrap()
+}
+
+#[test]
+fn reconstructs_unicode_whitespace_comments_and_delimiters() {
+  let text = "x := 💡 -- note\r\n";
+  let source = source(text);
+  let mut ids = IdGenerator::new();
+  let mut builder = GreenBuilder::new(&mut ids);
+  builder.start_node(SyntaxKind::Document);
+  builder.start_node(SyntaxKind::MechItem);
+  builder.start_node(SyntaxKind::VariableDefine);
+  builder.start_node(SyntaxKind::Identifier);
+  builder.token(SyntaxKind::IdentifierToken, "x").unwrap();
+  builder.finish_node().unwrap();
+  builder.token(SyntaxKind::Whitespace, " ").unwrap();
+  builder.start_node(SyntaxKind::DefineOperator);
+  builder.token(SyntaxKind::Colon, ":").unwrap();
+  builder.token(SyntaxKind::Equal, "=").unwrap();
+  builder.finish_node().unwrap();
+  builder.token(SyntaxKind::Whitespace, " ").unwrap();
+  builder.start_node(SyntaxKind::Expression);
+  builder.token(SyntaxKind::Text, "💡").unwrap();
+  builder.finish_node().unwrap();
+  builder.token(SyntaxKind::Whitespace, " ").unwrap();
+  builder.start_node(SyntaxKind::Comment);
+  builder.token(SyntaxKind::CommentToken, "-- note").unwrap();
+  builder.finish_node().unwrap();
+  builder.token(SyntaxKind::Newline, "\r\n").unwrap();
+  builder.finish_node().unwrap();
+  builder.finish_node().unwrap();
+  builder.finish_node().unwrap();
+  let root = builder.finish().unwrap();
+
+  validate_lossless(&root, &source).unwrap();
+  assert_eq!(reconstruct_source(&root, &source).unwrap(), text);
+  assert_eq!(root.text_len, source.byte_len());
+}
+
+#[test]
+fn missing_tokens_are_zero_width_and_error_nodes_retain_source() {
+  let source = source("x := @");
+  let mut ids = IdGenerator::new();
+  let mut builder = GreenBuilder::new(&mut ids);
+  builder.start_node(SyntaxKind::Document);
+  builder.token(SyntaxKind::IdentifierToken, "x").unwrap();
+  builder.token(SyntaxKind::Whitespace, " ").unwrap();
+  builder.token(SyntaxKind::Colon, ":").unwrap();
+  builder.token(SyntaxKind::Equal, "=").unwrap();
+  builder.token(SyntaxKind::Whitespace, " ").unwrap();
+  builder.start_node_with_flags(SyntaxKind::Error, NodeFlags::ERROR);
+  builder
+    .token_with_flags(SyntaxKind::Unknown, "@", TokenFlags::ERROR)
+    .unwrap();
+  builder.finish_node().unwrap();
+  builder.start_node_with_flags(SyntaxKind::Missing, NodeFlags::MISSING);
+  builder.missing_token(SyntaxKind::IdentifierToken).unwrap();
+  let missing = builder.finish_node().unwrap();
+  builder.finish_node().unwrap();
+  let root = builder.finish().unwrap();
+
+  assert_eq!(missing.text_len.0, 0);
+  assert!(missing.flags.contains(NodeFlags::MISSING));
+  assert!(root.flags.contains(NodeFlags::CONTAINS_ERROR));
+  assert!(root.flags.contains(NodeFlags::CONTAINS_MISSING));
+  validate_lossless(&root, &source).unwrap();
+  assert_eq!(reconstruct_source(&root, &source).unwrap(), "x := @");
+}
+
+#[test]
+fn reused_green_nodes_keep_ids_and_shift_in_the_red_index() {
+  let mut ids = IdGenerator::new();
+  let mut paragraph_builder = GreenBuilder::new(&mut ids);
+  paragraph_builder.start_node(SyntaxKind::Paragraph);
+  paragraph_builder.token(SyntaxKind::Text, "later").unwrap();
+  paragraph_builder.finish_node().unwrap();
+  let paragraph = paragraph_builder.finish().unwrap();
+  let paragraph_id = paragraph.id;
+  let token_id = match &paragraph.children[0] {
+    mech_syntax::document::GreenElement::Token(token) => token.id,
+    _ => unreachable!(),
+  };
+
+  let mut root_builder = GreenBuilder::new(&mut ids);
+  root_builder.start_node(SyntaxKind::Document);
+  root_builder.token(SyntaxKind::Text, "x ").unwrap();
+  root_builder.reuse_node(paragraph.clone()).unwrap();
+  root_builder.finish_node().unwrap();
+  let root = root_builder.finish().unwrap();
+  let index = NodeIndex::build(&root);
+
+  assert_eq!(paragraph.id, paragraph_id);
+  assert_eq!(
+    index.range(SyntaxElementId::Node(paragraph_id)).unwrap().start.0,
+    2
+  );
+  assert_eq!(
+    index.range(SyntaxElementId::Token(token_id)).unwrap().start.0,
+    2
+  );
+  validate_lossless(&root, &source("x later")).unwrap();
+}

--- a/src/syntax/tests/document_line_index.rs
+++ b/src/syntax/tests/document_line_index.rs
@@ -1,0 +1,81 @@
+use mech_syntax::document::{
+  DocumentId, LineIndex, Revision, TextEdit, TextRange, TextSize, TextSnapshot,
+};
+
+fn snapshot(text: &str) -> TextSnapshot {
+  TextSnapshot::new(DocumentId(1), Revision(0), text).unwrap()
+}
+
+fn expected_starts(text: &str) -> Vec<TextSize> {
+  let mut starts = vec![TextSize::ZERO];
+  let bytes = text.as_bytes();
+  let mut offset = 0;
+  while offset < bytes.len() {
+    match bytes[offset] {
+      b'\r' if bytes.get(offset + 1) == Some(&b'\n') => {
+        offset += 2;
+        starts.push(TextSize(offset as u32));
+      }
+      b'\r' | b'\n' => {
+        offset += 1;
+        starts.push(TextSize(offset as u32));
+      }
+      _ => offset += 1,
+    }
+  }
+  starts
+}
+
+fn assert_index(text: &str, index: &LineIndex) {
+  assert_eq!(index.line_starts(), expected_starts(text));
+  for boundary in text
+    .char_indices()
+    .map(|(offset, _)| offset)
+    .chain(core::iter::once(text.len()))
+  {
+    let (line, column) = index.line_and_byte_column(TextSize(boundary as u32));
+    assert_eq!(
+      index.line_start(line).unwrap().0 + column.0,
+      boundary as u32
+    );
+  }
+}
+
+#[test]
+fn indexes_lf_crlf_and_cr_without_normalizing() {
+  let text = "a\nb\r\nc\rd\n";
+  let source = snapshot(text);
+  assert_eq!(
+    source.line_index().line_starts(),
+    &[TextSize(0), TextSize(2), TextSize(5), TextSize(7), TextSize(9)]
+  );
+  assert_eq!(source.to_contiguous_string(), text);
+}
+
+#[test]
+fn edits_update_line_boundaries_around_piece_edges() {
+  let mut source = snapshot("a\rb\nc\r\nd");
+  let cases = [
+    (TextRange::empty(TextSize(2)), "\n"),
+    (TextRange::new(TextSize(1), TextSize(3)), "\r\n"),
+    (TextRange::new(TextSize(5), TextSize(6)), ""),
+    (TextRange::empty(TextSize(0)), "💡\n"),
+  ];
+  for (delete, insert) in cases {
+    source = source
+      .apply_edits(&[TextEdit::replace(delete, insert)])
+      .unwrap();
+    let text = source.to_contiguous_string();
+    assert_index(&text, source.line_index());
+  }
+}
+
+#[test]
+fn line_index_handles_unicode_as_byte_columns() {
+  let source = snapshot("💡e\u{301}\r\n終");
+  assert_eq!(source.line_index().line_starts(), &[TextSize(0), TextSize(9)]);
+  assert_eq!(
+    source.line_index().line_and_byte_column(TextSize(7)),
+    (0, TextSize(7))
+  );
+}

--- a/src/syntax/tests/document_source_edits.rs
+++ b/src/syntax/tests/document_source_edits.rs
@@ -1,0 +1,126 @@
+use mech_syntax::document::{
+  DocumentId, Revision, SourceError, TextEdit, TextRange, TextSize, TextSnapshot,
+};
+
+fn snapshot(text: &str) -> TextSnapshot {
+  TextSnapshot::new(DocumentId(7), Revision(0), text).unwrap()
+}
+
+fn range(start: u32, end: u32) -> TextRange {
+  TextRange::new(TextSize(start), TextSize(end))
+}
+
+#[test]
+fn insert_delete_replace_and_append_preserve_exact_bytes() {
+  let source = snapshot("alpha 💡 omega");
+  let inserted = source
+    .apply_edits(&[TextEdit::insert(TextSize(6), "bright ")])
+    .unwrap();
+  assert_eq!(inserted.to_contiguous_string(), "alpha bright 💡 omega");
+  assert!(inserted.piece_count() > 1);
+
+  let deleted = inserted
+    .apply_edits(&[TextEdit::delete(range(6, 13))])
+    .unwrap();
+  assert_eq!(deleted.to_contiguous_string(), "alpha 💡 omega");
+
+  let replaced = deleted
+    .apply_edits(&[TextEdit::replace(range(6, 10), "🦀")])
+    .unwrap();
+  assert_eq!(replaced.to_contiguous_string(), "alpha 🦀 omega");
+
+  let appended = replaced.append("\r\n終").unwrap();
+  assert_eq!(appended.to_contiguous_string(), "alpha 🦀 omega\r\n終");
+  assert_eq!(appended.revision(), Revision(4));
+}
+
+#[test]
+fn multiple_edits_share_one_revision_and_cross_piece_boundaries() {
+  let first = snapshot("abcdef")
+    .apply_edits(&[
+      TextEdit::insert(TextSize(2), "12"),
+      TextEdit::insert(TextSize(4), "34"),
+    ])
+    .unwrap();
+  assert_eq!(first.to_contiguous_string(), "ab12cd34ef");
+
+  let second = first
+    .apply_edits(&[
+      TextEdit::replace(range(1, 5), "B"),
+      TextEdit::replace(range(7, 9), "E"),
+    ])
+    .unwrap();
+  assert_eq!(second.to_contiguous_string(), "aBd3Ef");
+  assert_eq!(second.revision(), Revision(2));
+}
+
+#[test]
+fn rejects_invalid_ranges_order_overlap_and_utf8_boundaries() {
+  let source = snapshot("a💡e\u{301}");
+  assert!(matches!(
+    source.apply_edits(&[TextEdit::delete(range(2, 3))]),
+    Err(SourceError::InvalidUtf8Boundary(TextSize(2)))
+  ));
+  assert!(matches!(
+    source.apply_edits(&[TextEdit::delete(range(8, 7))]),
+    Err(SourceError::InvalidRange(invalid)) if invalid == range(8, 7)
+  ));
+  let ascii = snapshot("abcdefgh");
+  assert!(matches!(
+    ascii.apply_edits(&[
+      TextEdit::delete(range(5, 7)),
+      TextEdit::delete(range(0, 1)),
+    ]),
+    Err(SourceError::UnsortedEdits)
+  ));
+  assert!(matches!(
+    ascii.apply_edits(&[
+      TextEdit::delete(range(0, 5)),
+      TextEdit::delete(range(4, 7)),
+    ]),
+    Err(SourceError::OverlappingEdits)
+  ));
+}
+
+#[test]
+fn deterministic_random_edit_sequences_match_string_model() {
+  let mut state = 0x6d65_6368_5f31_6101_u64;
+  for case in 0..128 {
+    let initial = match case % 4 {
+      0 => "hello\r\nworld".to_string(),
+      1 => "emoji 💡 and 🦀".to_string(),
+      2 => "e\u{301}\rline\n終".to_string(),
+      _ => String::new(),
+    };
+    let mut expected = initial.clone();
+    let mut actual = snapshot(&initial);
+    for _ in 0..32 {
+      state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+      let boundaries = expected
+        .char_indices()
+        .map(|(offset, _)| offset)
+        .chain(core::iter::once(expected.len()))
+        .collect::<Vec<_>>();
+      let a = boundaries[(state as usize) % boundaries.len()];
+      state = state.rotate_left(17).wrapping_add(0x9e37_79b9);
+      let b = boundaries[(state as usize) % boundaries.len()];
+      let (start, end) = if a <= b { (a, b) } else { (b, a) };
+      let insert = match (state >> 8) % 7 {
+        0 => "💡",
+        1 => "\r\n",
+        2 => "e\u{301}",
+        3 => "x",
+        4 => "\n",
+        _ => "",
+      };
+      expected.replace_range(start..end, insert);
+      actual = actual
+        .apply_edits(&[TextEdit::replace(
+          range(start as u32, end as u32),
+          insert,
+        )])
+        .unwrap();
+      assert_eq!(actual.to_contiguous_string(), expected);
+    }
+  }
+}


### PR DESCRIPTION
## Stack

- Phase 1A of 4
- Targets `fix/581-build-test-modules` (PR #650)
- Verified live base SHA: `45a8acf1d1ee457a40340f17b9dc009ae781dfce`
- Next: `codex/phase-1b-total-document-parser`

## Summary

- Add an exact, persistent UTF-8 document source model with immutable revisions, byte edits, CR/LF/CRLF-aware line indexing, and stable source IDs.
- Add lossless green/red syntax tree infrastructure, typed annotations, structured diagnostics, syntax pointers, and indexing/building primitives.
- Document the incremental parser architecture and invariants.
- Keep the new implementation behind the experimental `document` module. The legacy parser, public parse API, existing `Program` AST, formatter, interpreter, runtime, and accepted grammar are unchanged.
- Add no unsafe blocks and no external parser, tree, or rope dependency.

## Validation

- `cargo test -p mech-syntax --tests`
- `cargo test -p mech-syntax`
- `cargo test -p mech-syntax --tests --no-default-features --features base`
- `cargo check -p mech-syntax --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cargo build --no-default-features`
- Interpreter and bytecode filtered test matrices with the requested numeric feature set

All passed on the recorded base SHA.