### PR TITLE
feat(syntax): add total document parser and recovery slice

### DIFF
--- a/src/syntax/src/document/ast/document.rs
+++ b/src/syntax/src/document/ast/document.rs
@@ -1,0 +1,22 @@
+use alloc::vec::Vec;
+
+use crate::document::red::{AstNode, DocumentSyntax, SectionSyntax, SyntaxNode};
+use crate::document::SyntaxKind;
+
+impl DocumentSyntax {
+  pub fn sections(&self) -> Vec<SectionSyntax> {
+    let mut sections = Vec::new();
+    collect_sections(self.syntax(), &mut sections);
+    sections
+  }
+}
+
+fn collect_sections(node: &SyntaxNode, output: &mut Vec<SectionSyntax>) {
+  for child in node.children() {
+    if let Some(section) = SectionSyntax::cast(child.clone()) {
+      output.push(section);
+    } else if child.kind() == SyntaxKind::Body {
+      collect_sections(&child, output);
+    }
+  }
+}

--- a/src/syntax/src/document/ast/mech.rs
+++ b/src/syntax/src/document/ast/mech.rs
@@ -1,0 +1,11 @@
+use crate::document::red::{AstNode, MechItemSyntax, VariableDefineSyntax};
+use crate::document::SyntaxKind;
+
+impl MechItemSyntax {
+  pub fn variable_definition(&self) -> Option<VariableDefineSyntax> {
+    self
+      .syntax()
+      .first_child(SyntaxKind::VariableDefine)
+      .and_then(VariableDefineSyntax::cast)
+  }
+}

--- a/src/syntax/src/document/ast/mechdown.rs
+++ b/src/syntax/src/document/ast/mechdown.rs
@@ -1,0 +1,26 @@
+use alloc::vec::Vec;
+
+use crate::document::red::{AstNode, ParagraphSyntax, SectionSyntax, SyntaxNode};
+use crate::document::SyntaxKind;
+
+impl SectionSyntax {
+  pub fn items(&self) -> Vec<SyntaxNode> {
+    self
+      .syntax()
+      .children()
+      .filter(|child| child.kind() == SyntaxKind::SectionElement)
+      .collect()
+  }
+
+  pub fn paragraphs(&self) -> Vec<ParagraphSyntax> {
+    let mut paragraphs = Vec::new();
+    for item in self.items() {
+      for child in item.children() {
+        if let Some(paragraph) = ParagraphSyntax::cast(child) {
+          paragraphs.push(paragraph);
+        }
+      }
+    }
+    paragraphs
+  }
+}

--- a/src/syntax/src/document/ast/mod.rs
+++ b/src/syntax/src/document/ast/mod.rs
@@ -1,0 +1,8 @@
+pub mod document;
+pub mod mech;
+pub mod mechdown;
+
+pub use crate::document::red::{
+  AstNode, DocumentSyntax, ExpressionSyntax, IdentifierSyntax, MechItemSyntax, ParagraphSyntax,
+  SectionSyntax, SyntaxElement, SyntaxNode, SyntaxToken, VariableDefineSyntax,
+};

--- a/src/syntax/src/document/index.rs
+++ b/src/syntax/src/document/index.rs
@@ -69,6 +69,10 @@ impl NodeIndex {
     self.nodes.contains_key(&id)
   }
 
+  pub fn nodes(&self) -> impl Iterator<Item = (NodeId, &NodeRecord)> {
+    self.nodes.iter().map(|(id, record)| (*id, record))
+  }
+
   fn index_node(
     &mut self,
     node: &GreenNode,

--- a/src/syntax/src/document/mod.rs
+++ b/src/syntax/src/document/mod.rs
@@ -8,6 +8,7 @@
 extern crate alloc;
 
 pub mod annotation;
+pub mod ast;
 pub mod builder;
 pub mod diagnostic;
 pub mod edit;
@@ -18,6 +19,7 @@ pub mod index;
 pub mod kind;
 pub mod line_index;
 pub mod pointer;
+pub mod parser;
 pub mod red;
 pub mod source;
 
@@ -25,6 +27,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 pub use annotation::*;
+pub use ast::*;
 pub use builder::*;
 pub use diagnostic::*;
 pub use edit::*;
@@ -35,6 +38,7 @@ pub use index::*;
 pub use kind::*;
 pub use line_index::*;
 pub use pointer::*;
+pub use parser::{ParseConfig, ParseLimits, parse_document};
 pub use red::*;
 pub use source::*;
 

--- a/src/syntax/src/document/parser/checkpoint.rs
+++ b/src/syntax/src/document/parser/checkpoint.rs
@@ -1,0 +1,10 @@
+use super::cursor::CursorCheckpoint;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParserCheckpoint {
+  pub(crate) cursor: CursorCheckpoint,
+  pub(crate) events: usize,
+  pub(crate) diagnostics: usize,
+  pub(crate) rule_depth: usize,
+  pub(crate) nesting: u32,
+}

--- a/src/syntax/src/document/parser/cursor.rs
+++ b/src/syntax/src/document/parser/cursor.rs
@@ -1,0 +1,140 @@
+use core::str;
+
+use crate::document::{TextRange, TextSize, TextSnapshot};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CursorCheckpoint {
+  pub offset: TextSize,
+}
+
+#[derive(Clone, Debug)]
+pub struct Cursor<'a> {
+  source: &'a TextSnapshot,
+  offset: TextSize,
+  end: TextSize,
+}
+
+impl<'a> Cursor<'a> {
+  pub fn new(source: &'a TextSnapshot) -> Self {
+    Self {
+      source,
+      offset: TextSize::ZERO,
+      end: source.byte_len(),
+    }
+  }
+
+  pub fn for_range(source: &'a TextSnapshot, range: TextRange) -> Self {
+    Self {
+      source,
+      offset: range.start,
+      end: range.end,
+    }
+  }
+
+  pub fn offset(&self) -> TextSize {
+    self.offset
+  }
+
+  pub fn end(&self) -> TextSize {
+    self.end
+  }
+
+  pub fn is_eof(&self) -> bool {
+    self.offset.0 >= self.end.0
+  }
+
+  pub fn checkpoint(&self) -> CursorCheckpoint {
+    CursorCheckpoint {
+      offset: self.offset,
+    }
+  }
+
+  pub fn rewind(&mut self, checkpoint: CursorCheckpoint) {
+    self.offset = checkpoint.offset;
+  }
+
+  pub fn byte(&self) -> Option<u8> {
+    (self.offset.0 < self.end.0)
+      .then(|| self.source.byte_at(self.offset))
+      .flatten()
+  }
+
+  pub fn byte_at(&self, relative: u32) -> Option<u8> {
+    let offset = TextSize(self.offset.0.checked_add(relative)?);
+    (offset.0 < self.end.0)
+      .then(|| self.source.byte_at(offset))
+      .flatten()
+  }
+
+  pub fn starts_with(&self, expected: &str) -> bool {
+    if expected.len() > self.remaining().to_usize() {
+      return false;
+    }
+    expected
+      .as_bytes()
+      .iter()
+      .enumerate()
+      .all(|(index, byte)| self.byte_at(index as u32) == Some(*byte))
+  }
+
+  pub fn peek_char(&self) -> Option<char> {
+    let first = self.byte()?;
+    let width = utf8_width(first);
+    if width == 0 || self.offset.0.saturating_add(width as u32) > self.end.0 {
+      return None;
+    }
+    let mut bytes = [0_u8; 4];
+    for (index, slot) in bytes.iter_mut().take(width).enumerate() {
+      *slot = self.byte_at(index as u32)?;
+    }
+    str::from_utf8(&bytes[..width]).ok()?.chars().next()
+  }
+
+  pub fn bump_char(&mut self) -> Option<(char, TextRange)> {
+    let start = self.offset;
+    let character = self.peek_char()?;
+    self.offset = TextSize(
+      self
+        .offset
+        .0
+        .saturating_add(character.len_utf8() as u32)
+        .min(self.end.0),
+    );
+    Some((character, TextRange::new(start, self.offset)))
+  }
+
+  pub fn bump_bytes(&mut self, count: u32) -> Option<TextRange> {
+    let end = self.offset.0.checked_add(count)?;
+    if end > self.end.0 {
+      return None;
+    }
+    let range = TextRange::new(self.offset, TextSize(end));
+    self.offset = TextSize(end);
+    Some(range)
+  }
+
+  pub fn remaining(&self) -> TextSize {
+    self.end - self.offset
+  }
+
+  pub fn is_line_start(&self) -> bool {
+    if self.offset.0 == 0 {
+      return true;
+    }
+    match self.source.byte_at(TextSize(self.offset.0 - 1)) {
+      Some(b'\n') => true,
+      Some(b'\r') => self.byte() != Some(b'\n'),
+      _ => false,
+    }
+  }
+}
+
+const fn utf8_width(first: u8) -> usize {
+  match first {
+    0x00..=0x7f => 1,
+    0xc2..=0xdf => 2,
+    0xe0..=0xef => 3,
+    0xf0..=0xf4 => 4,
+    _ => 0,
+  }
+}

--- a/src/syntax/src/document/parser/document.rs
+++ b/src/syntax/src/document/parser/document.rs
@@ -1,0 +1,80 @@
+use crate::document::{NodeFlags, SyntaxKind};
+
+use super::mech;
+use super::mechdown;
+use super::recovery::Attempt;
+use super::terminal::is_newline_start;
+use super::Parser;
+
+pub(crate) fn parse_document_root(parser: &mut Parser<'_>) {
+  parser.enter("document");
+  let document = parser.start();
+  let body = parser.start();
+  let mut section = parser.start();
+  let mut section_has_content = false;
+
+  while !parser.is_eof() {
+    if parser.is_halted() {
+      parser.consume_resource_remainder();
+      section_has_content = true;
+      break;
+    }
+    let before = parser.offset();
+
+    if parser.cursor().is_line_start() && mechdown::is_ul_subtitle(parser.cursor()) {
+      if section_has_content {
+        section.complete_with_flags(
+          parser,
+          SyntaxKind::Section,
+          NodeFlags::REPARSE_ROOT,
+        );
+        section = parser.start();
+      }
+      mechdown::parse_ul_subtitle(parser);
+      section_has_content = true;
+    } else if is_newline_start(parser.cursor()) {
+      let _ = parser.consume_newline();
+      section_has_content = true;
+    } else {
+      let element = parser.start();
+      if mechdown::is_subtitle(parser.cursor()) {
+        mechdown::parse_subtitle(parser);
+      } else if parser.is_fence_start() {
+        mechdown::parse_generic_fence(parser);
+      } else {
+        match mech::parse_mech_item(parser) {
+          Attempt::Match(()) | Attempt::CommittedFailure(_) => {}
+          Attempt::NoMatch => mechdown::parse_paragraph(parser),
+        }
+      }
+      element.complete_with_flags(
+        parser,
+        SyntaxKind::SectionElement,
+        NodeFlags::REPARSE_ROOT,
+      );
+      section_has_content = true;
+    }
+
+    if parser.offset() == before && !parser.is_halted() {
+      parser.consume_resource_remainder();
+      break;
+    }
+  }
+
+  if parser.is_halted() {
+    parser.consume_resource_remainder();
+  }
+
+  section.complete_with_flags(
+    parser,
+    SyntaxKind::Section,
+    NodeFlags::REPARSE_ROOT,
+  );
+  body.complete(parser, SyntaxKind::Body);
+  document.complete_with_flags(
+    parser,
+    SyntaxKind::Document,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parser.leave();
+}

--- a/src/syntax/src/document/parser/event.rs
+++ b/src/syntax/src/document/parser/event.rs
@@ -1,0 +1,62 @@
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use crate::document::{
+  BuildError, GreenBuilder, GreenNode, IdGenerator, NodeFlags, NodeId, SyntaxKind, TextRange,
+  TextSnapshot, TokenFlags,
+};
+
+#[derive(Clone, Debug)]
+pub enum Event {
+  Start {
+    kind: SyntaxKind,
+    flags: NodeFlags,
+  },
+  Token {
+    kind: SyntaxKind,
+    range: TextRange,
+    flags: TokenFlags,
+  },
+  Finish,
+  Tombstone,
+}
+
+pub struct SinkResult {
+  pub root: Arc<GreenNode>,
+  pub event_nodes: BTreeMap<usize, NodeId>,
+}
+
+pub fn sink(
+  events: &[Event],
+  source: &TextSnapshot,
+  ids: &mut IdGenerator,
+) -> Result<SinkResult, BuildError> {
+  let mut builder = GreenBuilder::new(ids);
+  let mut starts = Vec::new();
+  let mut event_nodes = BTreeMap::new();
+  for (index, event) in events.iter().enumerate() {
+    match event {
+      Event::Start { kind, flags } => {
+        builder.start_node_with_flags(*kind, *flags);
+        starts.push(index);
+      }
+      Event::Token { kind, range, flags } => {
+        let text = source
+          .text(*range)
+          .map_err(|_| BuildError::TextTooLarge)?;
+        builder.token_with_flags(*kind, &text, *flags)?;
+      }
+      Event::Finish => {
+        let start = starts.pop().ok_or(BuildError::NoOpenNode)?;
+        let node = builder.finish_node()?;
+        event_nodes.insert(start, node.id);
+      }
+      Event::Tombstone => {}
+    }
+  }
+  Ok(SinkResult {
+    root: builder.finish()?,
+    event_nodes,
+  })
+}

--- a/src/syntax/src/document/parser/limits.rs
+++ b/src/syntax/src/document/parser/limits.rs
@@ -1,0 +1,33 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParseLimits {
+  pub max_nesting: u32,
+  pub max_diagnostics: u32,
+  pub max_events: u32,
+  pub max_recovery_bytes: u32,
+  pub fuel: u64,
+}
+
+impl Default for ParseLimits {
+  fn default() -> Self {
+    Self {
+      max_nesting: 256,
+      max_diagnostics: 128,
+      max_events: 1_000_000,
+      max_recovery_bytes: 64 * 1024,
+      fuel: 4_000_000,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParseConfig {
+  pub limits: ParseLimits,
+}
+
+impl Default for ParseConfig {
+  fn default() -> Self {
+    Self {
+      limits: ParseLimits::default(),
+    }
+  }
+}

--- a/src/syntax/src/document/parser/marker.rs
+++ b/src/syntax/src/document/parser/marker.rs
@@ -1,0 +1,47 @@
+use crate::document::{NodeFlags, SyntaxKind};
+
+use super::Parser;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Marker {
+  pub(crate) position: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CompletedMarker {
+  pub(crate) position: usize,
+  pub(crate) kind: SyntaxKind,
+}
+
+impl Marker {
+  pub fn complete(
+    self,
+    parser: &mut Parser<'_>,
+    kind: SyntaxKind,
+  ) -> CompletedMarker {
+    self.complete_with_flags(parser, kind, NodeFlags::NONE)
+  }
+
+  pub fn complete_with_flags(
+    self,
+    parser: &mut Parser<'_>,
+    kind: SyntaxKind,
+    flags: NodeFlags,
+  ) -> CompletedMarker {
+    parser.complete_marker(self, kind, flags)
+  }
+
+  pub fn abandon(self, parser: &mut Parser<'_>) {
+    parser.abandon_marker(self);
+  }
+}
+
+impl CompletedMarker {
+  pub fn position(self) -> usize {
+    self.position
+  }
+
+  pub fn kind(self) -> SyntaxKind {
+    self.kind
+  }
+}

--- a/src/syntax/src/document/parser/mech.rs
+++ b/src/syntax/src/document/parser/mech.rs
@@ -1,0 +1,411 @@
+use alloc::string::String;
+
+use crate::document::{
+  DiagnosticAnchor, DiagnosticFix, DiagnosticLabel, ExpectedSyntax, FixApplicability, NodeFlags,
+  SyntaxKind, TextEdit, TextRange, TextSize,
+};
+
+use super::recovery::{Attempt, RecoveryClass, insert_missing, nesting_limit, skip_error};
+use super::terminal::{
+  is_horizontal_space, is_identifier_continue, is_identifier_start, is_newline_start,
+};
+use super::{Cursor, Parser};
+
+pub(crate) fn is_mech_item_start(cursor: &Cursor<'_>) -> bool {
+  is_variable_definition_start(cursor) || is_comment_start(cursor)
+}
+
+pub(crate) fn parse_mech_item(parser: &mut Parser<'_>) -> Attempt<()> {
+  if is_variable_definition_start(parser.cursor()) {
+    return parse_variable_definition(parser);
+  }
+  if is_comment_start(parser.cursor()) {
+    parse_comment_item(parser);
+    return Attempt::Match(());
+  }
+  Attempt::NoMatch
+}
+
+fn is_variable_definition_start(cursor: &Cursor<'_>) -> bool {
+  let mut lookahead = cursor.clone();
+  consume_horizontal_lookahead(&mut lookahead);
+  if scan_identifier(&mut lookahead).is_none() {
+    return false;
+  }
+  consume_whitespace_lookahead(&mut lookahead);
+  lookahead.starts_with(":=")
+}
+
+fn is_comment_start(cursor: &Cursor<'_>) -> bool {
+  let mut lookahead = cursor.clone();
+  consume_horizontal_lookahead(&mut lookahead);
+  lookahead.starts_with("--") || lookahead.starts_with("//")
+}
+
+fn parse_variable_definition(parser: &mut Parser<'_>) -> Attempt<()> {
+  parser.enter("variable-define");
+  let item = parser.start();
+  let definition = parser.start();
+  let _ = parser.consume_horizontal_space();
+  parse_identifier(parser);
+  parser.consume_syntax_whitespace();
+
+  let operator = parser.start();
+  let _ = parser.bump_bytes_token(1, SyntaxKind::Colon);
+  let _ = parser.bump_bytes_token(1, SyntaxKind::Equal);
+  operator.complete(parser, SyntaxKind::DefineOperator);
+  parser.consume_syntax_whitespace();
+
+  if at_expression_boundary(parser) {
+    missing_expression(parser, None);
+  } else {
+    match parse_expression(parser) {
+      Attempt::Match(()) => {}
+      Attempt::NoMatch | Attempt::CommittedFailure(_) => {
+        let _ = skip_error(
+          parser,
+          RecoveryClass::MechItem,
+          "syntax/unexpected-token",
+          "unexpected syntax in variable definition",
+        );
+      }
+    }
+  }
+
+  let _ = parser.consume_horizontal_space();
+  if !at_code_terminal(parser)
+    && !parser.is_strong_document_boundary()
+    && !parser.is_halted()
+  {
+    let _ = skip_error(
+      parser,
+      RecoveryClass::MechItem,
+      "syntax/unexpected-token",
+      "unexpected token after expression",
+    );
+  }
+  definition.complete_with_flags(
+    parser,
+    SyntaxKind::VariableDefine,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parse_code_terminal(parser);
+  item.complete_with_flags(parser, SyntaxKind::MechItem, NodeFlags::REPARSE_ROOT);
+  parser.leave();
+  Attempt::Match(())
+}
+
+fn parse_comment_item(parser: &mut Parser<'_>) {
+  parser.enter("comment");
+  let item = parser.start();
+  let _ = parser.consume_horizontal_space();
+  parse_comment(parser);
+  parse_code_terminal(parser);
+  item.complete_with_flags(parser, SyntaxKind::MechItem, NodeFlags::REPARSE_ROOT);
+  parser.leave();
+}
+
+fn parse_expression(parser: &mut Parser<'_>) -> Attempt<()> {
+  parser.enter("expression");
+  let checkpoint = parser.checkpoint();
+  let expression = parser.start();
+  let result = parse_additive(parser);
+  match result {
+    Attempt::Match(()) => {
+      expression.complete(parser, SyntaxKind::Expression);
+      parser.leave();
+      Attempt::Match(())
+    }
+    Attempt::NoMatch => {
+      parser.rewind(checkpoint);
+      Attempt::NoMatch
+    }
+    Attempt::CommittedFailure(failure) => {
+      expression.complete(parser, SyntaxKind::Expression);
+      parser.leave();
+      Attempt::CommittedFailure(failure)
+    }
+  }
+}
+
+fn parse_additive(parser: &mut Parser<'_>) -> Attempt<()> {
+  parser.enter("additive-expression");
+  let checkpoint = parser.checkpoint();
+  let additive = parser.start();
+  if !parse_factor(parser) {
+    parser.rewind(checkpoint);
+    return Attempt::NoMatch;
+  }
+
+  loop {
+    let operator_checkpoint = parser.checkpoint();
+    let _ = parser.consume_horizontal_space();
+    if !parser.cursor().starts_with("+") {
+      parser.rewind(operator_checkpoint);
+      break;
+    }
+    let plus = parser
+      .bump_bytes_token(1, SyntaxKind::Plus)
+      .unwrap_or_else(|| TextRange::empty(parser.offset()));
+    let _ = parser.consume_horizontal_space();
+    if at_expression_boundary(parser) {
+      missing_expression(parser, Some(plus));
+      break;
+    }
+    if !parse_factor(parser) {
+      let _ = skip_error(
+        parser,
+        RecoveryClass::MechItem,
+        "syntax/unexpected-token",
+        "unexpected token where an expression was required",
+      );
+      break;
+    }
+  }
+  additive.complete(parser, SyntaxKind::AdditiveExpression);
+  parser.leave();
+  Attempt::Match(())
+}
+
+fn parse_factor(parser: &mut Parser<'_>) -> bool {
+  if parser
+    .cursor()
+    .peek_char()
+    .is_some_and(|character| character.is_ascii_digit())
+  {
+    parse_integer(parser);
+    return true;
+  }
+  if parser.cursor().starts_with("(") {
+    parse_parenthetical(parser);
+    return true;
+  }
+  if parser
+    .cursor()
+    .peek_char()
+    .is_some_and(is_identifier_start)
+  {
+    parse_identifier(parser);
+    return true;
+  }
+  false
+}
+
+fn parse_integer(parser: &mut Parser<'_>) {
+  parser.enter("integer-literal");
+  let literal = parser.start();
+  let start = parser.offset();
+  while parser
+    .cursor()
+    .peek_char()
+    .is_some_and(|character| character.is_ascii_digit())
+  {
+    let _ = parser.bump_char_raw();
+  }
+  parser.token(
+    SyntaxKind::IntegerToken,
+    TextRange::new(start, parser.offset()),
+  );
+  literal.complete(parser, SyntaxKind::IntegerLiteral);
+  parser.leave();
+}
+
+fn parse_identifier(parser: &mut Parser<'_>) {
+  parser.enter("identifier");
+  let identifier = parser.start();
+  let start = parser.offset();
+  let _ = parser.bump_char_raw();
+  while parser
+    .cursor()
+    .peek_char()
+    .is_some_and(is_identifier_continue)
+  {
+    let _ = parser.bump_char_raw();
+  }
+  parser.token(
+    SyntaxKind::IdentifierToken,
+    TextRange::new(start, parser.offset()),
+  );
+  identifier.complete(parser, SyntaxKind::Identifier);
+  parser.leave();
+}
+
+fn parse_parenthetical(parser: &mut Parser<'_>) {
+  parser.enter("parenthetical-expression");
+  let parenthetical = parser.start();
+  let opening = parser
+    .bump_bytes_token(1, SyntaxKind::LeftParen)
+    .unwrap_or_else(|| TextRange::empty(parser.offset()));
+  if !parser.push_nesting() {
+    nesting_limit(parser);
+  } else {
+    let _ = parser.consume_horizontal_space();
+    if at_expression_boundary(parser) || parser.cursor().starts_with(")") {
+      missing_expression(parser, None);
+    } else if matches!(parse_additive(parser), Attempt::NoMatch) {
+      let _ = skip_error(
+        parser,
+        RecoveryClass::MechItem,
+        "syntax/unexpected-token",
+        "unexpected token inside parenthetical expression",
+      );
+    }
+    let _ = parser.consume_horizontal_space();
+    if parser.cursor().starts_with(")") {
+      let _ = parser.bump_bytes_token(1, SyntaxKind::RightParen);
+    } else {
+      let missing = insert_missing(
+        parser,
+        "syntax/unclosed-delimiter",
+        "missing `)` to close parenthetical expression",
+        ExpectedSyntax::Token(SyntaxKind::RightParen),
+        Some(SyntaxKind::RightParen),
+      );
+      let revision = parser.source().revision();
+      let offset = parser.offset();
+      if let Some(diagnostic) = parser.last_diagnostic_mut() {
+        diagnostic.labels.push(DiagnosticLabel {
+          anchor: DiagnosticAnchor::Absolute {
+            revision,
+            range: opening,
+          },
+          message: String::from("opening `(` is here"),
+        });
+        diagnostic.fixes.push(DiagnosticFix {
+          title: String::from("Insert `)`"),
+          applicability: FixApplicability::MachineApplicable,
+          edits: alloc::vec![TextEdit::insert(offset, ")")],
+        });
+        diagnostic.primary = DiagnosticAnchor::Absolute {
+          revision,
+          range: TextRange::empty(offset),
+        };
+      }
+      let _ = missing;
+    }
+    parser.pop_nesting();
+  }
+  parenthetical.complete_with_flags(
+    parser,
+    SyntaxKind::ParentheticalExpression,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parser.leave();
+}
+
+fn missing_expression(parser: &mut Parser<'_>, operator: Option<TextRange>) {
+  let _ = insert_missing(
+    parser,
+    "syntax/missing-expression",
+    "expected an expression",
+    ExpectedSyntax::Production(String::from("expression")),
+    None,
+  );
+  let revision = parser.source().revision();
+  let offset = parser.offset();
+  if let Some(diagnostic) = parser.last_diagnostic_mut() {
+    if let Some(operator) = operator {
+      diagnostic.labels.push(DiagnosticLabel {
+        anchor: DiagnosticAnchor::Absolute {
+          revision,
+          range: operator,
+        },
+        message: String::from("`+` requires a right operand"),
+      });
+    }
+    diagnostic.fixes.push(DiagnosticFix {
+      title: String::from("Insert an expression"),
+      applicability: FixApplicability::HasPlaceholders,
+      edits: alloc::vec![TextEdit::insert(offset, " _")],
+    });
+  }
+}
+
+fn parse_code_terminal(parser: &mut Parser<'_>) {
+  parser.enter("code-terminal");
+  let _ = parser.consume_horizontal_space();
+  if parser.cursor().starts_with(";") {
+    let _ = parser.bump_bytes_token(1, SyntaxKind::Semicolon);
+    let _ = parser.consume_horizontal_space();
+  }
+  if parser.cursor().starts_with("--") || parser.cursor().starts_with("//") {
+    parse_comment(parser);
+  }
+  let _ = parser.consume_newline();
+
+  loop {
+    let checkpoint = parser.checkpoint();
+    let _ = parser.consume_horizontal_space();
+    if parser.consume_newline().is_none() {
+      parser.rewind(checkpoint);
+      break;
+    }
+  }
+  parser.leave();
+}
+
+fn parse_comment(parser: &mut Parser<'_>) {
+  let comment = parser.start();
+  let start = parser.offset();
+  while !parser.is_eof() && !is_newline_start(parser.cursor()) {
+    let _ = parser.bump_char_raw();
+  }
+  parser.token(
+    SyntaxKind::CommentToken,
+    TextRange::new(start, parser.offset()),
+  );
+  comment.complete(parser, SyntaxKind::Comment);
+}
+
+fn at_code_terminal(parser: &Parser<'_>) -> bool {
+  let mut lookahead = parser.cursor().clone();
+  consume_horizontal_lookahead(&mut lookahead);
+  lookahead.is_eof()
+    || is_newline_start(&lookahead)
+    || lookahead.starts_with(";")
+    || lookahead.starts_with("--")
+    || lookahead.starts_with("//")
+    || lookahead.starts_with(")")
+}
+
+fn at_expression_boundary(parser: &Parser<'_>) -> bool {
+  parser.is_eof()
+    || parser.is_strong_document_boundary()
+    || is_newline_start(parser.cursor())
+    || parser.cursor().starts_with(";")
+    || parser.cursor().starts_with(")")
+    || parser.cursor().starts_with("--")
+    || parser.cursor().starts_with("//")
+}
+
+fn consume_horizontal_lookahead(cursor: &mut Cursor<'_>) {
+  while cursor.peek_char().is_some_and(is_horizontal_space) {
+    let _ = cursor.bump_char();
+  }
+}
+
+fn consume_whitespace_lookahead(cursor: &mut Cursor<'_>) {
+  loop {
+    consume_horizontal_lookahead(cursor);
+    let consumed = match (cursor.byte(), cursor.byte_at(1)) {
+      (Some(b'\r'), Some(b'\n')) => cursor.bump_bytes(2).is_some(),
+      (Some(b'\r' | b'\n'), _) => cursor.bump_bytes(1).is_some(),
+      _ => false,
+    };
+    if !consumed {
+      break;
+    }
+  }
+}
+
+fn scan_identifier(cursor: &mut Cursor<'_>) -> Option<TextRange> {
+  let start = cursor.offset();
+  if !cursor.peek_char().is_some_and(is_identifier_start) {
+    return None;
+  }
+  let _ = cursor.bump_char();
+  while cursor.peek_char().is_some_and(is_identifier_continue) {
+    let _ = cursor.bump_char();
+  }
+  Some(TextRange::new(start, cursor.offset()))
+}

--- a/src/syntax/src/document/parser/mechdown.rs
+++ b/src/syntax/src/document/parser/mechdown.rs
@@ -1,0 +1,415 @@
+use alloc::string::String;
+
+use crate::document::{
+  DiagnosticAnchor, DiagnosticFix, DiagnosticLabel, ExpectedSyntax, FixApplicability, NodeFlags,
+  SyntaxKind, TextEdit, TextRange, TokenFlags,
+};
+
+use super::recovery::{RecoveryClass, insert_missing, skip_error};
+use super::terminal::{
+  is_horizontal_space, is_newline_start, token_kind_for_char,
+};
+use super::{Cursor, Parser};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FenceDelimiter {
+  Grave,
+  Tilde,
+}
+
+impl FenceDelimiter {
+  fn text(self) -> &'static str {
+    match self {
+      Self::Grave => "```",
+      Self::Tilde => "~~~",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct FenceStart {
+  pub delimiter: FenceDelimiter,
+  pub indentation_bytes: u32,
+}
+
+pub(crate) fn fence_delimiter(cursor: &Cursor<'_>) -> Option<FenceStart> {
+  let mut lookahead = cursor.clone();
+  let indentation_start = lookahead.offset();
+  while lookahead.peek_char().is_some_and(is_horizontal_space) {
+    let _ = lookahead.bump_char();
+  }
+  let indentation_bytes = lookahead.offset().0 - indentation_start.0;
+  let delimiter = if lookahead.starts_with("```") {
+    FenceDelimiter::Grave
+  } else if lookahead.starts_with("~~~") {
+    FenceDelimiter::Tilde
+  } else {
+    return None;
+  };
+  Some(FenceStart {
+    delimiter,
+    indentation_bytes,
+  })
+}
+
+pub(crate) fn is_ul_subtitle(cursor: &Cursor<'_>) -> bool {
+  let mut lookahead = cursor.clone();
+  if !lookahead.is_line_start() {
+    return false;
+  }
+  let mut count = 0;
+  while lookahead
+    .peek_char()
+    .is_some_and(|character| character.is_alphanumeric())
+  {
+    count += 1;
+    let _ = lookahead.bump_char();
+  }
+  if count == 0 || !lookahead.starts_with(".") {
+    return false;
+  }
+  let _ = lookahead.bump_bytes(1);
+  consume_horizontal_lookahead(&mut lookahead);
+  let title_start = lookahead.offset();
+  while !lookahead.is_eof() && !is_newline_start(&lookahead) {
+    let _ = lookahead.bump_char();
+  }
+  if lookahead.offset() == title_start || consume_newline_lookahead(&mut lookahead).is_none() {
+    return false;
+  }
+  let mut dashes = 0;
+  while lookahead.starts_with("-") {
+    dashes += 1;
+    let _ = lookahead.bump_bytes(1);
+  }
+  if dashes == 0 {
+    return false;
+  }
+  consume_horizontal_lookahead(&mut lookahead);
+  consume_newline_lookahead(&mut lookahead).is_some() || lookahead.is_eof()
+}
+
+pub(crate) fn is_subtitle(cursor: &Cursor<'_>) -> bool {
+  let mut lookahead = cursor.clone();
+  consume_horizontal_lookahead(&mut lookahead);
+  if !lookahead.starts_with("(") {
+    return false;
+  }
+  let _ = lookahead.bump_bytes(1);
+  if !consume_subtitle_segment(&mut lookahead) {
+    return false;
+  }
+  while lookahead.starts_with(".") {
+    let _ = lookahead.bump_bytes(1);
+    if !consume_subtitle_segment(&mut lookahead) {
+      return false;
+    }
+  }
+  if !lookahead.starts_with(")") {
+    return false;
+  }
+  let _ = lookahead.bump_bytes(1);
+  consume_horizontal_lookahead(&mut lookahead);
+  let title_start = lookahead.offset();
+  while !lookahead.is_eof() && !is_newline_start(&lookahead) {
+    let _ = lookahead.bump_char();
+  }
+  lookahead.offset() != title_start
+    && (consume_newline_lookahead(&mut lookahead).is_some() || lookahead.is_eof())
+}
+
+pub(crate) fn parse_ul_subtitle(parser: &mut Parser<'_>) {
+  parser.enter("ul-subtitle");
+  let heading = parser.start();
+  consume_line_tokens(parser);
+  consume_line_tokens(parser);
+  heading.complete_with_flags(
+    parser,
+    SyntaxKind::UlSubtitle,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parser.leave();
+}
+
+pub(crate) fn parse_subtitle(parser: &mut Parser<'_>) {
+  parser.enter("subtitle");
+  let heading = parser.start();
+  consume_line_tokens(parser);
+  heading.complete_with_flags(
+    parser,
+    SyntaxKind::Subtitle,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parser.leave();
+}
+
+pub(crate) fn parse_generic_fence(parser: &mut Parser<'_>) {
+  parser.enter("generic-code-fence");
+  let fence_start = fence_delimiter(parser.cursor()).expect("fence was checked");
+  let fence = parser.start();
+  let _ = parser.consume_horizontal_space();
+  let opening = parser
+    .bump_bytes_token(3, SyntaxKind::FenceDelimiter)
+    .unwrap_or_else(|| TextRange::empty(parser.offset()));
+  consume_line_tokens(parser);
+
+  let content = parser.start();
+  while !parser.is_eof() && !parser.is_halted() {
+    if parser.cursor().is_line_start()
+      && matching_fence(parser.cursor(), fence_start.delimiter)
+    {
+      break;
+    }
+    consume_content_token(parser);
+  }
+  content.complete(parser, SyntaxKind::FenceContent);
+
+  if matching_fence(parser.cursor(), fence_start.delimiter) {
+    let _ = parser.consume_horizontal_space();
+    let _ = parser.bump_bytes_token(3, SyntaxKind::FenceDelimiter);
+    consume_line_tokens(parser);
+  } else if !parser.is_halted() {
+    let _ = insert_missing(
+      parser,
+      "syntax/unclosed-fence",
+      "missing closing code fence",
+      ExpectedSyntax::Token(SyntaxKind::FenceDelimiter),
+      Some(SyntaxKind::FenceDelimiter),
+    );
+    let revision = parser.source().revision();
+    let offset = parser.offset();
+    if let Some(diagnostic) = parser.last_diagnostic_mut() {
+      diagnostic.labels.push(DiagnosticLabel {
+        anchor: DiagnosticAnchor::Absolute {
+          revision,
+          range: opening,
+        },
+        message: String::from("opening fence is here"),
+      });
+      diagnostic.fixes.push(DiagnosticFix {
+        title: String::from("Insert the matching closing fence"),
+        applicability: FixApplicability::MachineApplicable,
+        edits: alloc::vec![TextEdit::insert(
+          offset,
+          String::from(fence_start.delimiter.text()),
+        )],
+      });
+    }
+  }
+  fence.complete_with_flags(
+    parser,
+    SyntaxKind::GenericFence,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parser.leave();
+}
+
+pub(crate) fn parse_paragraph(parser: &mut Parser<'_>) {
+  parser.enter("paragraph");
+  let paragraph = parser.start();
+  while !parser.is_eof() && !is_newline_start(parser.cursor()) && !parser.is_halted() {
+    if parser.cursor().starts_with(":=") {
+      let _ = skip_exact_paragraph_error(
+        parser,
+        2,
+        "syntax/invalid-paragraph-element",
+        "define operator is not valid paragraph text",
+      );
+      continue;
+    }
+    if parser
+      .cursor()
+      .peek_char()
+      .is_some_and(is_horizontal_space)
+    {
+      let _ = parser.consume_horizontal_space();
+      continue;
+    }
+    if parser
+      .cursor()
+      .peek_char()
+      .is_some_and(|character| matches!(character, '`' | '[' | ']' | '{' | '}' | '*' | '_' | '~'))
+    {
+      let _ = skip_error(
+        parser,
+        RecoveryClass::Paragraph,
+        "syntax/invalid-paragraph-element",
+        "invalid or incomplete paragraph element",
+      );
+      continue;
+    }
+
+    let element = parser.start();
+    let text = parser.start();
+    let start = parser.offset();
+    while !parser.is_eof()
+      && !is_newline_start(parser.cursor())
+      && !parser.cursor().starts_with(":=")
+      && !parser
+        .cursor()
+        .peek_char()
+        .is_some_and(is_horizontal_space)
+      && !parser
+        .cursor()
+        .peek_char()
+        .is_some_and(|character| matches!(character, '`' | '[' | ']' | '{' | '}' | '*' | '_' | '~'))
+    {
+      let _ = parser.bump_char_raw();
+    }
+    if parser.offset() == start {
+      let _ = parser.bump_char_raw();
+    }
+    parser.token(SyntaxKind::Text, TextRange::new(start, parser.offset()));
+    text.complete(parser, SyntaxKind::ParagraphText);
+    element.complete(parser, SyntaxKind::ParagraphElement);
+  }
+  let _ = parser.consume_newline();
+  paragraph.complete_with_flags(
+    parser,
+    SyntaxKind::Paragraph,
+    NodeFlags::REPARSE_ROOT,
+  );
+  parser.leave();
+}
+
+fn matching_fence(cursor: &Cursor<'_>, delimiter: FenceDelimiter) -> bool {
+  let Some(found) = fence_delimiter(cursor) else {
+    return false;
+  };
+  found.delimiter == delimiter
+}
+
+fn consume_content_token(parser: &mut Parser<'_>) {
+  if parser.consume_newline().is_some() {
+    return;
+  }
+  if parser
+    .cursor()
+    .peek_char()
+    .is_some_and(is_horizontal_space)
+  {
+    let _ = parser.consume_horizontal_space();
+    return;
+  }
+  let start = parser.offset();
+  while !parser.is_eof()
+    && !is_newline_start(parser.cursor())
+    && !parser
+      .cursor()
+      .peek_char()
+      .is_some_and(is_horizontal_space)
+  {
+    let _ = parser.bump_char_raw();
+  }
+  if parser.offset() > start {
+    parser.token(SyntaxKind::Text, TextRange::new(start, parser.offset()));
+  }
+}
+
+fn consume_line_tokens(parser: &mut Parser<'_>) {
+  while !parser.is_eof() && !is_newline_start(parser.cursor()) && !parser.is_halted() {
+    if parser
+      .cursor()
+      .peek_char()
+      .is_some_and(is_horizontal_space)
+    {
+      let _ = parser.consume_horizontal_space();
+      continue;
+    }
+    let Some((character, range)) = parser.bump_char_raw() else {
+      break;
+    };
+    parser.token(token_kind_for_char(character), range);
+  }
+  let _ = parser.consume_newline();
+}
+
+fn skip_exact_paragraph_error(
+  parser: &mut Parser<'_>,
+  bytes: u32,
+  code: &str,
+  message: &str,
+) -> Option<()> {
+  let marker = parser.start();
+  let start = parser.offset();
+  for _ in 0..bytes {
+    let Some((character, range)) = parser.bump_char_raw() else {
+      break;
+    };
+    parser.token_with_flags(
+      token_kind_for_char(character),
+      range,
+      TokenFlags::ERROR,
+    );
+  }
+  if parser.offset() == start {
+    marker.abandon(parser);
+    return None;
+  }
+  let error = marker.complete_with_flags(parser, SyntaxKind::Error, NodeFlags::ERROR);
+  let range = TextRange::new(start, parser.offset());
+  let diagnostic = crate::document::Diagnostic {
+    id: parser.next_diagnostic_id(),
+    code: crate::document::DiagnosticCode::from(code),
+    phase: crate::document::DiagnosticPhase::Syntax,
+    severity: crate::document::Severity::Error,
+    rule: parser.current_rule(),
+    primary: DiagnosticAnchor::Absolute {
+      revision: parser.source().revision(),
+      range,
+    },
+    labels: alloc::vec![],
+    expected: alloc::vec![ExpectedSyntax::Production(String::from(
+      "paragraph-element",
+    ))],
+    found: Some(crate::document::FoundSyntax {
+      kind: Some(SyntaxKind::DefineOperator),
+      text: parser.source().text(range).ok(),
+    }),
+    fixes: alloc::vec![],
+    related: alloc::vec![],
+    recovery: Some(crate::document::RecoveryAction::Skip { range }),
+    tags: crate::document::DiagnosticTags::NONE,
+    message: String::from(message),
+  };
+  parser.push_diagnostic(
+    diagnostic,
+    Some(error.position()),
+    TextRange::new(crate::document::TextSize::ZERO, range.len()),
+  );
+  Some(())
+}
+
+fn consume_horizontal_lookahead(cursor: &mut Cursor<'_>) {
+  while cursor.peek_char().is_some_and(is_horizontal_space) {
+    let _ = cursor.bump_char();
+  }
+}
+
+fn consume_newline_lookahead(cursor: &mut Cursor<'_>) -> Option<TextRange> {
+  match (cursor.byte(), cursor.byte_at(1)) {
+    (Some(b'\r'), Some(b'\n')) => cursor.bump_bytes(2),
+    (Some(b'\r' | b'\n'), _) => cursor.bump_bytes(1),
+    _ => None,
+  }
+}
+
+fn consume_subtitle_segment(cursor: &mut Cursor<'_>) -> bool {
+  let Some(first) = cursor.peek_char() else {
+    return false;
+  };
+  let alphabetic = first.is_alphabetic();
+  let numeric = first.is_numeric();
+  if !alphabetic && !numeric {
+    return false;
+  }
+  let mut consumed = false;
+  while cursor.peek_char().is_some_and(|character| {
+    (alphabetic && character.is_alphabetic())
+      || (numeric && character.is_numeric())
+  }) {
+    consumed = true;
+    let _ = cursor.bump_char();
+  }
+  consumed
+}

--- a/src/syntax/src/document/parser/mod.rs
+++ b/src/syntax/src/document/parser/mod.rs
@@ -1,0 +1,506 @@
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use crate::document::{
+  Diagnostic, DiagnosticAnchor, DiagnosticCode, DiagnosticPhase, DiagnosticStore, DiagnosticTags,
+  DocumentId, ExpectedSyntax, FoundSyntax, GreenBuilder, GreenNode, IdGenerator, NodeFlags,
+  ParseStats, RecoveryAction, RestartEntry, RestartIndex, RestartMode, Revision, RuleId, Severity,
+  SyntaxKind, SyntaxSnapshot, TextRange, TextSize, TextSnapshot, TokenFlags,
+};
+
+pub mod checkpoint;
+pub mod cursor;
+pub mod document;
+pub mod event;
+pub mod limits;
+pub mod marker;
+pub mod mech;
+pub mod mechdown;
+pub mod recovery;
+pub mod rule;
+pub mod terminal;
+
+pub use checkpoint::*;
+pub use cursor::*;
+pub use event::*;
+pub use limits::*;
+pub use marker::*;
+pub use recovery::*;
+pub use rule::*;
+
+struct PendingDiagnostic {
+  diagnostic: Diagnostic,
+  event: Option<usize>,
+  relative: TextRange,
+}
+
+struct ParserOutput {
+  events: Vec<Event>,
+  diagnostics: Vec<PendingDiagnostic>,
+  stats: ParseStats,
+}
+
+pub(crate) struct Parser<'a> {
+  source: &'a TextSnapshot,
+  cursor: Cursor<'a>,
+  events: Vec<Event>,
+  diagnostics: Vec<PendingDiagnostic>,
+  rules: RuleStack,
+  config: ParseConfig,
+  fuel: u64,
+  nesting: u32,
+  halted: bool,
+  resource_diagnostic_emitted: bool,
+  ids: &'a mut IdGenerator,
+  stats: ParseStats,
+}
+
+impl<'a> Parser<'a> {
+  fn new(
+    source: &'a TextSnapshot,
+    config: ParseConfig,
+    ids: &'a mut IdGenerator,
+  ) -> Self {
+    Self {
+      source,
+      cursor: Cursor::new(source),
+      events: Vec::new(),
+      diagnostics: Vec::new(),
+      rules: RuleStack::default(),
+      config,
+      fuel: config.limits.fuel,
+      nesting: 0,
+      halted: false,
+      resource_diagnostic_emitted: false,
+      ids,
+      stats: ParseStats {
+        source_bytes: u64::from(source.byte_len().0),
+        ..ParseStats::default()
+      },
+    }
+  }
+
+  pub(crate) fn source(&self) -> &TextSnapshot {
+    self.source
+  }
+
+  pub(crate) fn cursor(&self) -> &Cursor<'a> {
+    &self.cursor
+  }
+
+  pub(crate) fn config(&self) -> ParseConfig {
+    self.config
+  }
+
+  pub(crate) fn offset(&self) -> TextSize {
+    self.cursor.offset()
+  }
+
+  pub(crate) fn is_eof(&self) -> bool {
+    self.cursor.is_eof()
+  }
+
+  pub(crate) fn is_halted(&self) -> bool {
+    self.halted
+  }
+
+  pub(crate) fn halt(&mut self) {
+    self.halted = true;
+  }
+
+  pub(crate) fn stats(&self) -> ParseStats {
+    self.stats
+  }
+
+  pub(crate) fn stats_mut(&mut self) -> &mut ParseStats {
+    &mut self.stats
+  }
+
+  pub(crate) fn start(&mut self) -> Marker {
+    let position = self.events.len();
+    self.events.push(Event::Tombstone);
+    Marker { position }
+  }
+
+  pub(crate) fn complete_marker(
+    &mut self,
+    marker: Marker,
+    kind: SyntaxKind,
+    flags: NodeFlags,
+  ) -> CompletedMarker {
+    if let Some(event) = self.events.get_mut(marker.position) {
+      *event = Event::Start { kind, flags };
+    }
+    self.events.push(Event::Finish);
+    CompletedMarker {
+      position: marker.position,
+      kind,
+    }
+  }
+
+  pub(crate) fn abandon_marker(&mut self, marker: Marker) {
+    if marker.position + 1 == self.events.len() {
+      self.events.pop();
+    } else if let Some(event) = self.events.get_mut(marker.position) {
+      *event = Event::Tombstone;
+    }
+  }
+
+  pub(crate) fn checkpoint(&self) -> ParserCheckpoint {
+    ParserCheckpoint {
+      cursor: self.cursor.checkpoint(),
+      events: self.events.len(),
+      diagnostics: self.diagnostics.len(),
+      rule_depth: self.rules.len(),
+      nesting: self.nesting,
+    }
+  }
+
+  pub(crate) fn rewind(&mut self, checkpoint: ParserCheckpoint) {
+    self.cursor.rewind(checkpoint.cursor);
+    self.events.truncate(checkpoint.events);
+    self.diagnostics.truncate(checkpoint.diagnostics);
+    self.rules.truncate(checkpoint.rule_depth);
+    self.nesting = checkpoint.nesting;
+  }
+
+  pub(crate) fn enter(&mut self, name: &str) {
+    self.rules.push(rule_id(name));
+  }
+
+  pub(crate) fn leave(&mut self) {
+    self.rules.pop();
+  }
+
+  pub(crate) fn current_rule(&self) -> Option<RuleId> {
+    self.rules.current()
+  }
+
+  pub(crate) fn bump_char_raw(&mut self) -> Option<(char, TextRange)> {
+    if !self.charge() {
+      return None;
+    }
+    self.cursor.bump_char()
+  }
+
+  pub(crate) fn bump_bytes_token(
+    &mut self,
+    count: u32,
+    kind: SyntaxKind,
+  ) -> Option<TextRange> {
+    if !self.charge() {
+      return None;
+    }
+    let range = self.cursor.bump_bytes(count)?;
+    self.token(kind, range);
+    Some(range)
+  }
+
+  pub(crate) fn bump_char_token(&mut self, kind: SyntaxKind) -> Option<TextRange> {
+    let (_, range) = self.bump_char_raw()?;
+    self.token(kind, range);
+    Some(range)
+  }
+
+  pub(crate) fn token(&mut self, kind: SyntaxKind, range: TextRange) {
+    self.token_with_flags(kind, range, TokenFlags::NONE);
+  }
+
+  pub(crate) fn token_with_flags(
+    &mut self,
+    kind: SyntaxKind,
+    range: TextRange,
+    flags: TokenFlags,
+  ) {
+    if self.events.len() >= self.config.limits.max_events as usize {
+      self.halted = true;
+    }
+    self.events.push(Event::Token { kind, range, flags });
+  }
+
+  pub(crate) fn missing_token(&mut self, kind: SyntaxKind) {
+    self.events.push(Event::Token {
+      kind,
+      range: TextRange::empty(self.offset()),
+      flags: TokenFlags::SYNTHETIC | TokenFlags::MISSING,
+    });
+  }
+
+  pub(crate) fn next_diagnostic_id(&mut self) -> crate::document::DiagnosticId {
+    self.ids.diagnostic()
+  }
+
+  pub(crate) fn push_diagnostic(
+    &mut self,
+    diagnostic: Diagnostic,
+    event: Option<usize>,
+    relative: TextRange,
+  ) {
+    if self.diagnostics.len() >= self.config.limits.max_diagnostics as usize {
+      return;
+    }
+    self.diagnostics.push(PendingDiagnostic {
+      diagnostic,
+      event,
+      relative,
+    });
+  }
+
+  pub(crate) fn last_diagnostic_mut(&mut self) -> Option<&mut Diagnostic> {
+    self
+      .diagnostics
+      .last_mut()
+      .map(|pending| &mut pending.diagnostic)
+  }
+
+  pub(crate) fn consume_horizontal_space(&mut self) -> Option<TextRange> {
+    let start = self.offset();
+    while self
+      .cursor
+      .peek_char()
+      .is_some_and(terminal::is_horizontal_space)
+    {
+      let _ = self.bump_char_raw()?;
+    }
+    if self.offset() == start {
+      return None;
+    }
+    let range = TextRange::new(start, self.offset());
+    self.token(SyntaxKind::Whitespace, range);
+    Some(range)
+  }
+
+  pub(crate) fn consume_newline(&mut self) -> Option<TextRange> {
+    let count = match (self.cursor.byte(), self.cursor.byte_at(1)) {
+      (Some(b'\r'), Some(b'\n')) => 2,
+      (Some(b'\r' | b'\n'), _) => 1,
+      _ => return None,
+    };
+    self.bump_bytes_token(count, SyntaxKind::Newline)
+  }
+
+  pub(crate) fn consume_syntax_whitespace(&mut self) {
+    loop {
+      if self.consume_horizontal_space().is_some() {
+        continue;
+      }
+      if self.consume_newline().is_some() {
+        continue;
+      }
+      break;
+    }
+  }
+
+  pub(crate) fn found_syntax(&self) -> FoundSyntax {
+    if self.is_eof() {
+      return FoundSyntax {
+        kind: Some(SyntaxKind::Eof),
+        text: None,
+      };
+    }
+    let character = self.cursor.peek_char();
+    FoundSyntax {
+      kind: character.map(terminal::token_kind_for_char),
+      text: character.map(|character| character.to_string()),
+    }
+  }
+
+  pub(crate) fn nesting(&self) -> u32 {
+    self.nesting
+  }
+
+  pub(crate) fn push_nesting(&mut self) -> bool {
+    if self.nesting >= self.config.limits.max_nesting {
+      return false;
+    }
+    self.nesting += 1;
+    true
+  }
+
+  pub(crate) fn pop_nesting(&mut self) {
+    self.nesting = self.nesting.saturating_sub(1);
+  }
+
+  pub(crate) fn is_fence_start(&self) -> bool {
+    mechdown::fence_delimiter(self.cursor()).is_some()
+  }
+
+  pub(crate) fn is_strong_document_boundary(&self) -> bool {
+    self.cursor.is_line_start()
+      && (mechdown::is_ul_subtitle(self.cursor()) || self.is_fence_start())
+  }
+
+  pub(crate) fn consume_resource_remainder(&mut self) {
+    let start = self.offset();
+    let marker = self.start();
+    let range = TextRange::new(start, self.cursor.end());
+    self.cursor.rewind(CursorCheckpoint { offset: range.end });
+    if !range.is_empty() {
+      self.events.push(Event::Token {
+        kind: SyntaxKind::Unknown,
+        range,
+        flags: TokenFlags::ERROR,
+      });
+    }
+    let error =
+      marker.complete_with_flags(self, SyntaxKind::Error, NodeFlags::ERROR);
+    if !self.resource_diagnostic_emitted
+      && self.diagnostics.len() < self.config.limits.max_diagnostics as usize
+    {
+      self.resource_diagnostic_emitted = true;
+      let diagnostic = Diagnostic {
+        id: self.next_diagnostic_id(),
+        code: DiagnosticCode::syntax("recovery-limit"),
+        phase: DiagnosticPhase::Syntax,
+        severity: Severity::Error,
+        rule: Some(recovery::recovery_limit_rule()),
+        primary: DiagnosticAnchor::Absolute {
+          revision: self.source.revision(),
+          range,
+        },
+        labels: Vec::new(),
+        expected: Vec::new(),
+        found: Some(FoundSyntax {
+          kind: Some(SyntaxKind::Unknown),
+          text: None,
+        }),
+        fixes: Vec::new(),
+        related: Vec::new(),
+        recovery: Some(RecoveryAction::ResourceLimit { range }),
+        tags: DiagnosticTags::NONE,
+        message: String::from("parser resource limit reached"),
+      };
+      self.push_diagnostic(
+        diagnostic,
+        Some(error.position()),
+        TextRange::new(TextSize::ZERO, range.len()),
+      );
+    }
+    self.halted = false;
+  }
+
+  fn charge(&mut self) -> bool {
+    if self.fuel == 0 {
+      self.halted = true;
+      return false;
+    }
+    self.fuel -= 1;
+    self.stats.parser_steps = self.stats.parser_steps.saturating_add(1);
+    true
+  }
+
+  fn finish(mut self) -> ParserOutput {
+    self.stats.events_emitted = self.events.len() as u64;
+    self.stats.diagnostics_emitted = self.diagnostics.len() as u64;
+    ParserOutput {
+      events: self.events,
+      diagnostics: self.diagnostics,
+      stats: self.stats,
+    }
+  }
+}
+
+pub fn parse_document(source: TextSnapshot, config: ParseConfig) -> SyntaxSnapshot {
+  let mut ids = IdGenerator::new();
+  parse_document_with_ids(source, config, &mut ids)
+}
+
+pub(crate) fn parse_document_with_ids(
+  source: TextSnapshot,
+  config: ParseConfig,
+  ids: &mut IdGenerator,
+) -> SyntaxSnapshot {
+  let mut parser = Parser::new(&source, config, ids);
+  document::parse_document_root(&mut parser);
+  let output = parser.finish();
+  let sink_result = sink(&output.events, &source, ids)
+    .unwrap_or_else(|_| fallback_tree(&source, ids));
+
+  let mut diagnostics = DiagnosticStore::new(source.revision());
+  for mut pending in output.diagnostics {
+    if let Some(event) = pending.event
+      && let Some(node) = sink_result.event_nodes.get(&event)
+    {
+      pending.diagnostic.primary = DiagnosticAnchor::Element {
+        element: crate::document::SyntaxElementId::Node(*node),
+        relative: pending.relative,
+      };
+    }
+    diagnostics.push(pending.diagnostic);
+  }
+
+  let mut snapshot =
+    SyntaxSnapshot::new(source, sink_result.root, diagnostics);
+  snapshot.stats = output.stats;
+  snapshot.stats.new_node_count = snapshot.nodes.node_count() as u64;
+  snapshot.restarts = build_restart_index(&snapshot);
+  snapshot
+}
+
+fn fallback_tree(source: &TextSnapshot, ids: &mut IdGenerator) -> SinkResult {
+  let mut builder = GreenBuilder::new(ids);
+  builder.start_node(SyntaxKind::Document);
+  if !source.is_empty() {
+    builder.start_node_with_flags(SyntaxKind::Error, NodeFlags::ERROR);
+    let text = source.to_contiguous_string();
+    let _ = builder.token_with_flags(
+      SyntaxKind::Unknown,
+      &text,
+      TokenFlags::ERROR,
+    );
+    let _ = builder.finish_node();
+  }
+  let _ = builder.finish_node();
+  let root = builder.finish().unwrap_or_else(|_| {
+    Arc::new(GreenNode {
+      id: ids.node(),
+      kind: SyntaxKind::Document,
+      text_len: TextSize::ZERO,
+      children: Arc::from([]),
+      flags: NodeFlags::ERROR,
+      structural_hash: 0,
+    })
+  });
+  SinkResult {
+    root,
+    event_nodes: BTreeMap::new(),
+  }
+}
+
+fn build_restart_index(snapshot: &SyntaxSnapshot) -> RestartIndex {
+  let mut restarts = RestartIndex::default();
+  for (node, record) in snapshot.nodes.nodes() {
+    let mode = match record.kind {
+      SyntaxKind::Paragraph | SyntaxKind::ParagraphElement => RestartMode::Paragraph,
+      SyntaxKind::MechItem
+      | SyntaxKind::VariableDefine
+      | SyntaxKind::ParentheticalExpression => RestartMode::Mech,
+      SyntaxKind::GenericFence => RestartMode::Fence,
+      SyntaxKind::Document
+      | SyntaxKind::Section
+      | SyntaxKind::SectionElement
+      | SyntaxKind::Subtitle
+      | SyntaxKind::UlSubtitle => RestartMode::Document,
+      _ => continue,
+    };
+    restarts.push(RestartEntry {
+      node,
+      range: record.range,
+      mode,
+      delimiter_depth: if record.kind == SyntaxKind::ParentheticalExpression {
+        1
+      } else {
+        0
+      },
+      line_start: snapshot
+        .source
+        .line_index()
+        .line_start(snapshot.source.line_index().line_of(record.range.start))
+        == Some(record.range.start),
+      indentation: 0,
+    });
+  }
+  restarts
+}

--- a/src/syntax/src/document/parser/recovery.rs
+++ b/src/syntax/src/document/parser/recovery.rs
@@ -1,0 +1,192 @@
+use alloc::string::String;
+
+use crate::document::{
+  Diagnostic, DiagnosticAnchor, DiagnosticCode, DiagnosticPhase, DiagnosticTags, ExpectedSyntax,
+  FoundSyntax, NodeFlags, RecoveryAction, Severity, SyntaxKind, TextRange, TokenFlags,
+};
+
+use super::terminal::{is_newline_start, token_kind_for_char};
+use super::{CompletedMarker, Parser, rule_id};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParseFailure {
+  pub rule: crate::document::RuleId,
+  pub range: TextRange,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Attempt<T> {
+  NoMatch,
+  Match(T),
+  CommittedFailure(ParseFailure),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecoveryClass {
+  MechItem,
+  Paragraph,
+  Fence,
+}
+
+pub(crate) fn skip_error(
+  parser: &mut Parser<'_>,
+  class: RecoveryClass,
+  code: &str,
+  message: &str,
+) -> Option<CompletedMarker> {
+  let start = parser.offset();
+  let marker = parser.start();
+  let mut recovered = 0_u32;
+  while !parser.is_eof() && recovered < parser.config().limits.max_recovery_bytes {
+    if should_stop(parser, class, start) {
+      break;
+    }
+    let Some((character, range)) = parser.bump_char_raw() else {
+      break;
+    };
+    recovered = recovered.saturating_add(range.len().0);
+    parser.token_with_flags(
+      token_kind_for_char(character),
+      range,
+      TokenFlags::ERROR,
+    );
+  }
+  if recovered >= parser.config().limits.max_recovery_bytes
+    && !parser.is_eof()
+    && !should_stop(parser, class, start)
+  {
+    parser.halt();
+  }
+  if parser.offset() == start {
+    marker.abandon(parser);
+    return None;
+  }
+  parser.stats_mut().recovery_bytes = parser
+    .stats()
+    .recovery_bytes
+    .saturating_add(u64::from(recovered));
+  let error = marker.complete_with_flags(parser, SyntaxKind::Error, NodeFlags::ERROR);
+  let range = TextRange::new(start, parser.offset());
+  let found = parser
+    .source()
+    .text(range)
+    .ok()
+    .map(|text| FoundSyntax {
+      kind: Some(SyntaxKind::Unknown),
+      text: Some(text),
+    });
+  let diagnostic = Diagnostic {
+    id: parser.next_diagnostic_id(),
+    code: DiagnosticCode::from(code),
+    phase: DiagnosticPhase::Syntax,
+    severity: Severity::Error,
+    rule: parser.current_rule(),
+    primary: DiagnosticAnchor::Absolute {
+      revision: parser.source().revision(),
+      range,
+    },
+    labels: alloc::vec![],
+    expected: alloc::vec![],
+    found,
+    fixes: alloc::vec![],
+    related: alloc::vec![],
+    recovery: Some(RecoveryAction::Skip { range }),
+    tags: DiagnosticTags::NONE,
+    message: String::from(message),
+  };
+  parser.push_diagnostic(
+    diagnostic,
+    Some(error.position()),
+    TextRange::new(crate::document::TextSize::ZERO, range.len()),
+  );
+  Some(error)
+}
+
+pub(crate) fn insert_missing(
+  parser: &mut Parser<'_>,
+  code: &str,
+  message: &str,
+  expected: ExpectedSyntax,
+  token: Option<SyntaxKind>,
+) -> CompletedMarker {
+  let at = parser.offset();
+  let marker = parser.start();
+  if let Some(token) = token {
+    parser.missing_token(token);
+  }
+  let missing =
+    marker.complete_with_flags(parser, SyntaxKind::Missing, NodeFlags::MISSING);
+  let range = TextRange::empty(at);
+  let diagnostic = Diagnostic {
+    id: parser.next_diagnostic_id(),
+    code: DiagnosticCode::from(code),
+    phase: DiagnosticPhase::Syntax,
+    severity: Severity::Error,
+    rule: parser.current_rule(),
+    primary: DiagnosticAnchor::Absolute {
+      revision: parser.source().revision(),
+      range,
+    },
+    labels: alloc::vec![],
+    expected: alloc::vec![expected.clone()],
+    found: Some(parser.found_syntax()),
+    fixes: alloc::vec![],
+    related: alloc::vec![],
+    recovery: Some(RecoveryAction::Insert {
+      syntax: expected,
+      at,
+    }),
+    tags: DiagnosticTags::NONE,
+    message: String::from(message),
+  };
+  parser.push_diagnostic(
+    diagnostic,
+    Some(missing.position()),
+    TextRange::empty(crate::document::TextSize::ZERO),
+  );
+  missing
+}
+
+fn should_stop(
+  parser: &Parser<'_>,
+  class: RecoveryClass,
+  start: crate::document::TextSize,
+) -> bool {
+  if parser.offset() == start {
+    return false;
+  }
+  match class {
+    RecoveryClass::MechItem => {
+      is_newline_start(parser.cursor())
+        || parser.cursor().starts_with(";")
+        || parser.is_strong_document_boundary()
+    }
+    RecoveryClass::Paragraph => {
+      is_newline_start(parser.cursor()) || parser.is_fence_start()
+    }
+    RecoveryClass::Fence => false,
+  }
+}
+
+pub(crate) fn nesting_limit(parser: &mut Parser<'_>) {
+  let start = parser.offset();
+  let _ = skip_error(
+    parser,
+    RecoveryClass::MechItem,
+    "syntax/nesting-limit",
+    "syntax nesting limit reached",
+  );
+  if start == parser.offset() {
+    let _ = insert_missing(
+      parser,
+      "syntax/nesting-limit",
+      "syntax nesting limit reached",
+      ExpectedSyntax::Production(String::from("expression")),
+      None,
+    );
+  }
+}
+
+pub(crate) fn recovery_limit_rule() -> crate::document::RuleId {
+  rule_id("recovery-limit")
+}

--- a/src/syntax/src/document/parser/rule.rs
+++ b/src/syntax/src/document/parser/rule.rs
@@ -1,0 +1,77 @@
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::document::RuleId;
+
+pub const fn rule_id(name: &str) -> RuleId {
+  let bytes = name.as_bytes();
+  let mut hash = 0x811c_9dc5_u32;
+  let mut index = 0;
+  while index < bytes.len() {
+    hash ^= bytes[index] as u32;
+    hash = hash.wrapping_mul(0x0100_0193);
+    index += 1;
+  }
+  RuleId(hash)
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RuleStack {
+  rules: Vec<RuleId>,
+}
+
+impl RuleStack {
+  pub fn push(&mut self, rule: RuleId) {
+    self.rules.push(rule);
+  }
+
+  pub fn pop(&mut self) {
+    self.rules.pop();
+  }
+
+  pub fn current(&self) -> Option<RuleId> {
+    self.rules.last().copied()
+  }
+
+  pub fn len(&self) -> usize {
+    self.rules.len()
+  }
+
+  pub fn truncate(&mut self, len: usize) {
+    self.rules.truncate(len);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn canonical_specification_rule_hashes_do_not_collide() {
+    let specification = include_str!("../../../../../docs/design/specification.mec");
+    let mut names = BTreeSet::new();
+    for line in specification.lines() {
+      let Some((left, _)) = line.split_once(":=") else {
+        continue;
+      };
+      let candidate = left.trim();
+      if !candidate.is_empty()
+        && candidate
+          .chars()
+          .all(|character| character.is_ascii_alphanumeric() || character == '-')
+      {
+        names.insert(String::from(candidate));
+      }
+    }
+    assert!(names.len() > 100, "canonical grammar inventory was not found");
+
+    let mut hashes = BTreeMap::new();
+    for name in names {
+      let id = rule_id(&name);
+      if let Some(previous) = hashes.insert(id, name.clone()) {
+        panic!("RuleId collision between {previous} and {name}: {id}");
+      }
+    }
+  }
+}

--- a/src/syntax/src/document/parser/terminal.rs
+++ b/src/syntax/src/document/parser/terminal.rs
@@ -1,0 +1,68 @@
+use crate::document::{SyntaxKind, TextRange, TextSize};
+
+use super::Cursor;
+
+pub fn is_horizontal_space(character: char) -> bool {
+  matches!(character, ' ' | '\t' | '\u{00a0}' | '\u{2009}')
+}
+
+pub fn is_newline_start(cursor: &Cursor<'_>) -> bool {
+  matches!(cursor.byte(), Some(b'\r' | b'\n'))
+}
+
+pub fn newline_range(cursor: &mut Cursor<'_>) -> Option<TextRange> {
+  let start = cursor.offset();
+  match cursor.byte()? {
+    b'\r' if cursor.byte_at(1) == Some(b'\n') => cursor.bump_bytes(2),
+    b'\r' | b'\n' => cursor.bump_bytes(1),
+    _ => None,
+  }
+  .or_else(|| Some(TextRange::empty(start)))
+}
+
+pub fn is_identifier_start(character: char) -> bool {
+  character.is_alphabetic() || is_emoji_like(character)
+}
+
+pub fn is_identifier_continue(character: char) -> bool {
+  character.is_alphanumeric()
+    || is_emoji_like(character)
+    || matches!(
+      character,
+      '&' | '$' | '%' | '/' | '#' | '\\' | '~' | '+' | '-' | '*' | '^'
+    )
+}
+
+fn is_emoji_like(character: char) -> bool {
+  !character.is_ascii()
+    && !character.is_whitespace()
+    && !matches!(
+      character,
+      '(' | ')' | '[' | ']' | '{' | '}' | ':' | '=' | ';' | '`'
+    )
+}
+
+pub fn token_kind_for_char(character: char) -> SyntaxKind {
+  match character {
+    ' ' | '\t' | '\u{00a0}' | '\u{2009}' => SyntaxKind::Whitespace,
+    '\r' | '\n' => SyntaxKind::Newline,
+    ':' => SyntaxKind::Colon,
+    '=' => SyntaxKind::Equal,
+    '+' => SyntaxKind::Plus,
+    '(' => SyntaxKind::LeftParen,
+    ')' => SyntaxKind::RightParen,
+    '.' => SyntaxKind::Period,
+    '-' => SyntaxKind::Dash,
+    ';' => SyntaxKind::Semicolon,
+    character if character.is_ascii_digit() => SyntaxKind::IntegerToken,
+    character if is_identifier_start(character) => SyntaxKind::IdentifierToken,
+    _ => SyntaxKind::Text,
+  }
+}
+
+pub fn line_end(source_len: TextSize, mut cursor: Cursor<'_>) -> TextSize {
+  while !cursor.is_eof() && !is_newline_start(&cursor) {
+    let _ = cursor.bump_char();
+  }
+  TextSize(cursor.offset().0.min(source_len.0))
+}

--- a/src/syntax/src/document/red.rs
+++ b/src/syntax/src/document/red.rs
@@ -1,6 +1,7 @@
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::fmt::Write;
 
 use super::edit::{SourceError, TextRange, TextSize};
 use super::flags::{NodeFlags, TokenFlags};
@@ -139,6 +140,35 @@ impl SyntaxToken {
 pub enum SyntaxElement {
   Node(SyntaxNode),
   Token(SyntaxToken),
+}
+
+pub fn compact_debug_tree(root: &SyntaxNode) -> String {
+  let mut output = String::new();
+  write_debug_node(root, 0, &mut output);
+  output
+}
+
+fn write_debug_node(node: &SyntaxNode, depth: usize, output: &mut String) {
+  for _ in 0..depth {
+    output.push_str("  ");
+  }
+  let _ = writeln!(output, "{:?}", node.kind());
+  for child in node.children_with_tokens() {
+    match child {
+      SyntaxElement::Node(child) => write_debug_node(&child, depth + 1, output),
+      SyntaxElement::Token(token) => {
+        for _ in 0..=depth {
+          output.push_str("  ");
+        }
+        if token.flags().contains(TokenFlags::MISSING) {
+          let _ = writeln!(output, "{:?} <missing>", token.kind());
+        } else {
+          let text = token.text().unwrap_or_default();
+          let _ = writeln!(output, "{:?} {text:?}", token.kind());
+        }
+      }
+    }
+  }
 }
 
 pub trait AstNode: Clone {

--- a/src/syntax/tests/document_parser.rs
+++ b/src/syntax/tests/document_parser.rs
@@ -1,0 +1,246 @@
+use mech_syntax::document::{
+  AstNode, DiagnosticAnchor, DocumentId, DocumentSyntax, NodeFlags, ParseConfig, Revision,
+  SyntaxKind, SyntaxNode, TextSnapshot, compact_debug_tree, parse_document, reconstruct_source,
+  validate_lossless,
+};
+
+fn parse(text: &str) -> mech_syntax::document::SyntaxSnapshot {
+  let source = TextSnapshot::new(DocumentId(42), Revision(0), text).unwrap();
+  parse_document(source, ParseConfig::default())
+}
+
+fn nodes_of_kind(root: &SyntaxNode, kind: SyntaxKind) -> Vec<SyntaxNode> {
+  let mut nodes = Vec::new();
+  if root.kind() == kind {
+    nodes.push(root.clone());
+  }
+  for child in root.children() {
+    nodes.extend(nodes_of_kind(&child, kind));
+  }
+  nodes
+}
+
+fn assert_lossless(text: &str, snapshot: &mech_syntax::document::SyntaxSnapshot) {
+  validate_lossless(&snapshot.root, &snapshot.source).unwrap();
+  assert_eq!(reconstruct_source(&snapshot.root, &snapshot.source).unwrap(), text);
+}
+
+fn diagnostic_codes(
+  snapshot: &mech_syntax::document::SyntaxSnapshot,
+) -> Vec<&str> {
+  snapshot
+    .diagnostics
+    .iter()
+    .map(|diagnostic| diagnostic.code.as_str())
+    .collect()
+}
+
+#[test]
+fn missing_variable_rhs_is_structural_and_lossless() {
+  let snapshot = parse("x :=\n");
+  assert_lossless("x :=\n", &snapshot);
+  assert_eq!(
+    diagnostic_codes(&snapshot),
+    vec!["syntax/missing-expression"]
+  );
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Missing).len(), 1);
+  assert!(snapshot.root.flags.contains(NodeFlags::CONTAINS_MISSING));
+
+  let tree = compact_debug_tree(&snapshot.syntax());
+  let expected = r#"Document
+  Body
+    Section
+      SectionElement
+        MechItem
+          VariableDefine
+            Identifier
+              IdentifierToken "x"
+            Whitespace " "
+            DefineOperator
+              Colon ":"
+              Equal "="
+            Newline "\n"
+            Missing
+"#;
+  assert_eq!(tree, expected);
+
+  let document = DocumentSyntax::cast(snapshot.syntax()).unwrap();
+  assert_eq!(document.sections().len(), 1);
+}
+
+#[test]
+fn missing_right_operand_after_plus_uses_additive_rule() {
+  let snapshot = parse("x := 1 +\n");
+  assert_lossless("x := 1 +\n", &snapshot);
+  let diagnostic = snapshot.diagnostics.iter().next().unwrap();
+  assert_eq!(diagnostic.code.as_str(), "syntax/missing-expression");
+  assert_eq!(
+    diagnostic.rule,
+    Some(mech_syntax::document::parser::rule_id(
+      "additive-expression"
+    ))
+  );
+  assert_eq!(diagnostic.expected.len(), 1);
+  assert!(diagnostic.recovery.is_some());
+  assert_eq!(diagnostic.labels.len(), 1);
+  assert_eq!(diagnostic.fixes.len(), 1);
+  let json = snapshot.diagnostics.to_json().unwrap();
+  assert!(json.contains("\"syntax/missing-expression\""));
+  assert!(json.contains("\"recovery\""));
+  assert!(json.contains("\"expected\""));
+}
+
+#[test]
+fn missing_right_parenthesis_has_opening_label_and_safe_fix() {
+  let snapshot = parse("x := (1 + 2\n");
+  assert_lossless("x := (1 + 2\n", &snapshot);
+  let diagnostic = snapshot
+    .diagnostics
+    .iter()
+    .find(|diagnostic| diagnostic.code.as_str() == "syntax/unclosed-delimiter")
+    .unwrap();
+  assert_eq!(diagnostic.labels.len(), 1);
+  assert_eq!(diagnostic.fixes.len(), 1);
+  assert!(matches!(
+    diagnostic.primary,
+    DiagnosticAnchor::Element { .. }
+  ));
+  assert_eq!(
+    nodes_of_kind(&snapshot.syntax(), SyntaxKind::ParentheticalExpression).len(),
+    1
+  );
+}
+
+#[test]
+fn unexpected_mech_source_is_retained_under_error_node() {
+  let snapshot = parse("x := 1 @@@\n");
+  assert_lossless("x := 1 @@@\n", &snapshot);
+  assert_eq!(
+    diagnostic_codes(&snapshot),
+    vec!["syntax/unexpected-token"]
+  );
+  let errors = nodes_of_kind(&snapshot.syntax(), SyntaxKind::Error);
+  assert_eq!(errors.len(), 1);
+  assert_eq!(errors[0].text().unwrap(), "@@@");
+}
+
+#[test]
+fn recovery_preserves_later_paragraph_and_canonical_heading() {
+  let text =
+    "x := @@@\nordinary prose\n1. Recovered Section\n-------------------\nlater prose\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::MechItem).len(), 1);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::UlSubtitle).len(), 1);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Paragraph).len(), 2);
+  assert_eq!(
+    DocumentSyntax::cast(snapshot.syntax())
+      .unwrap()
+      .sections()
+      .len(),
+    2
+  );
+}
+
+#[test]
+fn malformed_paragraph_element_recovers_before_generic_fence() {
+  let text = "`unterminated inline\n```text\nopaque := content\n```\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert!(diagnostic_codes(&snapshot)
+    .contains(&"syntax/invalid-paragraph-element"));
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::GenericFence).len(), 1);
+}
+
+#[test]
+fn unclosed_generic_fence_keeps_opaque_content() {
+  let text = "~~~text\nx := not parsed here\n1. Not a heading\n----------------\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert_eq!(
+    diagnostic_codes(&snapshot),
+    vec!["syntax/unclosed-fence"]
+  );
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::FenceContent).len(), 1);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Missing).len(), 1);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::UlSubtitle).len(), 0);
+}
+
+#[test]
+fn two_independent_errors_survive_across_heading_restart() {
+  let text = "x :=\n1. Next\n--------\ny := (1\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert_eq!(
+    diagnostic_codes(&snapshot),
+    vec![
+      "syntax/missing-expression",
+      "syntax/unclosed-delimiter"
+    ]
+  );
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::UlSubtitle).len(), 1);
+}
+
+#[test]
+fn unicode_and_emoji_do_not_corrupt_primary_error_span() {
+  let text = "💡 := 1 +\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  let diagnostic = snapshot.diagnostics.iter().next().unwrap();
+  let range = diagnostic
+    .primary
+    .resolve(snapshot.revision, &snapshot.nodes)
+    .unwrap();
+  assert_eq!(range.start.0, "💡 := 1 +".len() as u32);
+  assert!(range.is_empty());
+}
+
+#[test]
+fn eof_error_is_total_for_streamed_input() {
+  let text = "x := 1 +";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert_eq!(
+    diagnostic_codes(&snapshot),
+    vec!["syntax/missing-expression"]
+  );
+}
+
+#[test]
+fn committed_mech_prefix_never_becomes_paragraph() {
+  let snapshot = parse("x := @\n");
+  assert_lossless("x := @\n", &snapshot);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::MechItem).len(), 1);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Paragraph).len(), 0);
+}
+
+#[test]
+fn separate_colon_and_equal_are_paragraph_text() {
+  let text = "ordinary : = prose\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert!(snapshot.diagnostics.is_empty());
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Paragraph).len(), 1);
+}
+
+#[test]
+fn raw_define_operator_is_excluded_from_paragraph_text() {
+  let text = " := raw\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert_eq!(
+    diagnostic_codes(&snapshot),
+    vec!["syntax/invalid-paragraph-element"]
+  );
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::MechItem).len(), 0);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Error).len(), 1);
+}
+
+#[test]
+fn parenthesized_canonical_subtitle_is_not_markdown_heading() {
+  let text = "(1.1) Canonical subtitle\n# ordinary paragraph\n";
+  let snapshot = parse(text);
+  assert_lossless(text, &snapshot);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Subtitle).len(), 1);
+  assert_eq!(nodes_of_kind(&snapshot.syntax(), SyntaxKind::Paragraph).len(), 1);
+}

--- a/src/syntax/tests/document_parser_limits.rs
+++ b/src/syntax/tests/document_parser_limits.rs
@@ -1,0 +1,98 @@
+use mech_syntax::document::{
+  DocumentId, ParseConfig, ParseLimits, Revision, TextSnapshot, parse_document,
+  reconstruct_source, validate_lossless,
+};
+
+fn parse_with_limits(text: &str, limits: ParseLimits) -> mech_syntax::document::SyntaxSnapshot {
+  parse_document(
+    TextSnapshot::new(DocumentId(88), Revision(0), text).unwrap(),
+    ParseConfig { limits },
+  )
+}
+
+#[test]
+fn nesting_limit_returns_a_complete_snapshot() {
+  let text = "x := (((((((1\nlater prose\n";
+  let snapshot = parse_with_limits(
+    text,
+    ParseLimits {
+      max_nesting: 2,
+      ..ParseLimits::default()
+    },
+  );
+  validate_lossless(&snapshot.root, &snapshot.source).unwrap();
+  assert_eq!(reconstruct_source(&snapshot.root, &snapshot.source).unwrap(), text);
+  assert!(snapshot
+    .diagnostics
+    .iter()
+    .any(|diagnostic| diagnostic.code.as_str() == "syntax/nesting-limit"));
+}
+
+#[test]
+fn fuel_limit_consumes_remainder_and_never_panics() {
+  let text = "x := 123456789\nlater prose\n";
+  let snapshot = parse_with_limits(
+    text,
+    ParseLimits {
+      fuel: 3,
+      ..ParseLimits::default()
+    },
+  );
+  validate_lossless(&snapshot.root, &snapshot.source).unwrap();
+  assert_eq!(reconstruct_source(&snapshot.root, &snapshot.source).unwrap(), text);
+  assert_eq!(snapshot.diagnostics.len(), 1);
+  assert_eq!(
+    snapshot.diagnostics.iter().next().unwrap().code.as_str(),
+    "syntax/recovery-limit"
+  );
+}
+
+#[test]
+fn diagnostic_limit_suppresses_cascades_and_later_excess() {
+  let text = "x :=\n1. Next\n--------\ny :=\n";
+  let snapshot = parse_with_limits(
+    text,
+    ParseLimits {
+      max_diagnostics: 1,
+      ..ParseLimits::default()
+    },
+  );
+  validate_lossless(&snapshot.root, &snapshot.source).unwrap();
+  assert_eq!(snapshot.diagnostics.len(), 1);
+}
+
+#[test]
+fn event_limit_produces_structural_resource_error() {
+  let text = "ordinary prose with many tokens\nx := 1\n";
+  let snapshot = parse_with_limits(
+    text,
+    ParseLimits {
+      max_events: 8,
+      ..ParseLimits::default()
+    },
+  );
+  validate_lossless(&snapshot.root, &snapshot.source).unwrap();
+  assert_eq!(reconstruct_source(&snapshot.root, &snapshot.source).unwrap(), text);
+  assert!(snapshot
+    .diagnostics
+    .iter()
+    .any(|diagnostic| diagnostic.code.as_str() == "syntax/recovery-limit"));
+}
+
+#[test]
+fn recovery_byte_limit_abandons_to_resource_error_without_losing_bytes() {
+  let text = "x := @@@@@@@@@@\nlater prose\n";
+  let snapshot = parse_with_limits(
+    text,
+    ParseLimits {
+      max_recovery_bytes: 2,
+      ..ParseLimits::default()
+    },
+  );
+  validate_lossless(&snapshot.root, &snapshot.source).unwrap();
+  assert_eq!(reconstruct_source(&snapshot.root, &snapshot.source).unwrap(), text);
+  assert!(snapshot
+    .diagnostics
+    .iter()
+    .any(|diagnostic| diagnostic.code.as_str() == "syntax/recovery-limit"));
+}

--- a/src/syntax/tests/document_parser_render.rs
+++ b/src/syntax/tests/document_parser_render.rs
@@ -1,0 +1,42 @@
+use mech_syntax::document::{
+  DocumentId, ParseConfig, Revision, TextSnapshot, parse_document, render_plain,
+};
+
+fn render(text: &str) -> Vec<String> {
+  let snapshot = parse_document(
+    TextSnapshot::new(DocumentId(5), Revision(0), text).unwrap(),
+    ParseConfig::default(),
+  );
+  snapshot
+    .diagnostics
+    .iter()
+    .map(|diagnostic| render_plain(diagnostic, &snapshot.source, &snapshot.nodes))
+    .collect()
+}
+
+#[test]
+fn renders_missing_expression_with_operator_context() {
+  assert_eq!(
+    render("x := 1 +\n"),
+    vec![String::from(
+      "Error[syntax/missing-expression] at 1:9: expected an expression\n  1:8: `+` requires a right operand\n"
+    )]
+  );
+}
+
+#[test]
+fn renders_malformed_mech_before_heading_without_losing_heading() {
+  let rendered = render("x := @\n1. Next\n--------\n");
+  assert_eq!(rendered.len(), 1);
+  assert!(rendered[0].contains("syntax/unexpected-token"));
+  assert!(rendered[0].contains("1:6"));
+}
+
+#[test]
+fn renders_multiple_independent_errors() {
+  let rendered = render("x :=\n1. Next\n--------\ny := (1\n");
+  assert_eq!(rendered.len(), 2);
+  assert!(rendered[0].contains("syntax/missing-expression"));
+  assert!(rendered[1].contains("syntax/unclosed-delimiter"));
+  assert!(rendered[1].contains("opening `(` is here"));
+}


### PR DESCRIPTION
## Stack

- Phase 1B of 4
- Depends on draft PR #687 (`codex/phase-1a-revisioned-syntax`)
- Original PR #650 live base SHA: `45a8acf1d1ee457a40340f17b9dc009ae781dfce`
- Next: `codex/phase-1c-incremental-reparse`

## Summary

- Add a total event-based document parser with markers, checkpoints, explicit recovery sets, and bounded resource limits.
- Add a typed experimental AST and a narrow vertical grammar slice covering canonical headings, paragraphs, fenced sections, variable definitions, expressions, comments, and code terminals.
- Preserve every source byte in the syntax tree while representing absent required syntax with structural `MISSING` nodes and malformed input with `ERROR` nodes and structured diagnostics.
- Keep parser progress and diagnostic production bounded under arbitrary UTF-8 input.
- The new path does not use Nom. The legacy parser, public parse API, existing `Program` AST, formatter, interpreter, runtime, and accepted grammar are unchanged.

## Validation

- `cargo test -p mech-syntax --tests`
- `cargo test -p mech-syntax`
- `cargo test -p mech-syntax --tests --no-default-features --features base`
- `cargo check -p mech-syntax --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cargo build --no-default-features`
- Phase 0 compatibility-oracle inventory, graph, corpus, and conformance suites

All passed on the recorded base SHA.