### PR TITLE
fix(repl): preserve runtime-backed Mika farewell

### DIFF
--- a/src/cli/commands/repl.rs
+++ b/src/cli/commands/repl.rs
@@ -307,6 +307,21 @@ fn run_runtime_repl_event_loop(
     }
 }
 
+#[cfg(feature = "run")]
+fn finalize_runtime_repl_outcome(
+    interrupt_requested: &AtomicBool,
+    result: MResult<CliOutcome>,
+    farewell: impl FnOnce(),
+) -> MResult<CliOutcome> {
+    // The CLI turns a returned exit outcome into `process::exit`. Complete the
+    // farewell synchronously so process termination cannot cut off its frames.
+    if interrupt_requested.load(Ordering::Acquire) && matches!(&result, Ok(CliOutcome::Exit(0))) {
+        farewell();
+    }
+
+    result
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ReplGreetingVariant {
     Standard,
@@ -406,10 +421,7 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
                 print_prompt();
             }
             ReplInterruptDisposition::GracefulRuntimeExit => {
-                if handler_exit_requested.swap(true, Ordering::AcqRel) {
-                    return;
-                }
-                print_repl_farewell();
+                handler_exit_requested.store(true, Ordering::Release);
             }
             ReplInterruptDisposition::ImmediateProcessExit => {
                 print_repl_farewell();
@@ -485,11 +497,16 @@ pub(crate) fn run(startup: ReplStartup) -> MResult<CliOutcome> {
             // runtime cleanup; normal submitted-line and :quit paths join.
             Ok(())
         };
-        return match (loop_result, worker_result) {
+        let result = match (loop_result, worker_result) {
             (Err(error), _) => Err(error),
             (Ok(_), Err(error)) => Err(error),
             (Ok(outcome), Ok(())) => Ok(outcome),
         };
+        return finalize_runtime_repl_outcome(
+            runtime_exit_requested.as_ref(),
+            result,
+            print_repl_farewell,
+        );
     }
 
     loop {

--- a/src/cli/commands/repl/tests/runtime_live.rs
+++ b/src/cli/commands/repl/tests/runtime_live.rs
@@ -14,8 +14,8 @@ use mech_runtime::{
 use mech_syntax::ReplCommand;
 
 use super::{
-    CliOutcome, MechRepl, ReplInterruptDisposition, RuntimeReplInput, repl_interrupt_disposition,
-    run_runtime_repl_event_loop,
+    CliOutcome, MechRepl, ReplInterruptDisposition, RuntimeReplInput,
+    finalize_runtime_repl_outcome, repl_interrupt_disposition, run_runtime_repl_event_loop,
 };
 
 const TEST_PROVIDER: &str = "replinput";
@@ -503,6 +503,20 @@ fn program_backed_third_interrupt_retains_immediate_exit_policy() {
         repl_interrupt_disposition(false, 3),
         ReplInterruptDisposition::ImmediateProcessExit,
     );
+}
+
+#[test]
+fn runtime_interrupt_finishes_farewell_before_returning_exit_outcome() {
+    let exit_requested = AtomicBool::new(true);
+    let mut events = Vec::new();
+
+    let outcome = finalize_runtime_repl_outcome(&exit_requested, Ok(CliOutcome::Exit(0)), || {
+        events.push("farewell")
+    });
+    events.push("returned");
+
+    assert!(matches!(outcome, Ok(CliOutcome::Exit(0))));
+    assert_eq!(events, ["farewell", "returned"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- request runtime-backed REPL shutdown from the Ctrl-C handler without rendering there
- play Mika's farewell synchronously after runtime cleanup and before returning the exit outcome
- add regression coverage that locks in farewell-before-exit ordering

## Root cause

The runtime-backed Ctrl-C handler set the exit flag and then rendered Mika's farewell on the signal-handler thread. The main REPL thread observed the flag immediately, returned an exit outcome, and called `process::exit` while the animation was still running, usually cutting it off after the first frame.

## Impact

Bare `mech` and `mech run --repl` sessions now complete Mika's full farewell animation before the process exits. The program-backed `mech --repl` behavior remains unchanged.

## Validation

- `cargo test --lib cli::commands::repl::runtime_live_tests`
- `cargo test --lib mika_farewell_remains_visible_after_drop`
- `cargo test --lib --no-default-features --features "repl mika" mika_farewell_remains_visible_after_drop`
- manually reproduced the bare/runtime-backed REPL in a Windows terminal and confirmed all seven wave frames render before exit