### PR TITLE
[PR-A3] feat(runtime): add bounded turn-record and effect-outbox primitives

### DIFF
--- a/benchmarks/runtime/gate-a/README.md
+++ b/benchmarks/runtime/gate-a/README.md
@@ -15,6 +15,12 @@ If automatic CPU/model discovery is unavailable, provide the controlled
 machine's stable identity with `--machine-label <model>`; the runner rejects
 generic architecture-only labels.
 
+Run the A3 recording-primitives benchmark with:
+
+```sh
+python scripts/run-gate-a-benchmarks.py --bench recording_primitives
+```
+
 Pass `--output <path>` only when a summary should be written. By default the
 runner writes raw combined output beneath `target/gate-a-benchmark-runs/`,
 keeps Criterion's raw data beneath `target/criterion/`, and prints the summary
@@ -36,6 +42,13 @@ prepare and infallible-apply portions of each in-memory commit separately.
 A1 controlled-machine median and p95 ratios across history sizes are diagnostic
 evidence. A2 controlled-machine timing checks require the largest minimal-store
 history median to be no more than 1.10 times the zero-history median.
+The A3 report covers retained-ledger, owned-queue, record-pool, and effect-outbox
+append at histories 0, 1,000, and 100,000. Its Criterion distribution measures
+the append phase, while probes record reserve and prepare timing, accounted
+bytes, pool reuse, and post-preparation allocations. A3's hard gate is zero
+allocations during every prepared append.
+A3 controlled-machine timing checks require the largest history median to be no
+more than 1.10 times the zero-history median.
 
 Each Criterion sample constructs one fixture with the exact requested history,
 measures exactly one operation, and reports that duration as the per-iteration

--- a/benchmarks/runtime/gate-a/a3-recording-primitives.json
+++ b/benchmarks/runtime/gate-a/a3-recording-primitives.json
@@ -1,0 +1,328 @@
+{
+  "architecture": "arm64",
+  "benchmark_arguments": [
+    "cargo",
+    "bench",
+    "-p",
+    "mech-runtime",
+    "--bench",
+    "recording_primitives",
+    "--features",
+    "runtime_default,runtime_bench_probes",
+    "--",
+    "--noplot",
+    "--sample-size",
+    "10"
+  ],
+  "criterion": [
+    {
+      "benchmark": "gate_a_recording_effect_outbox/0",
+      "median_ns": 42.0,
+      "p95_ns": 156.39999999999978,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_effect_outbox/1000",
+      "median_ns": 42.0,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_effect_outbox/100000",
+      "median_ns": 42.0,
+      "p95_ns": 65.09999999999995,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_owned_queue/0",
+      "median_ns": 41.0,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_owned_queue/1000",
+      "median_ns": 41.0,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_owned_queue/100000",
+      "median_ns": 41.0,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_record_pool/0",
+      "median_ns": 41.0,
+      "p95_ns": 42.00000000000001,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_record_pool/1000",
+      "median_ns": 1.0000000000000002,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_record_pool/100000",
+      "median_ns": 41.5,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_retained_ledger/0",
+      "median_ns": 42.0,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_retained_ledger/1000",
+      "median_ns": 41.0,
+      "p95_ns": 42.0,
+      "sample_count": 10
+    },
+    {
+      "benchmark": "gate_a_recording_retained_ledger/100000",
+      "median_ns": 42.0,
+      "p95_ns": 42.00000000000001,
+      "sample_count": 10
+    }
+  ],
+  "git_commit": "0141a6a8b47b10f391bfbead40fe55a3ff987dec",
+  "hardware": "MacBook Air, Mac15,13, Apple M3",
+  "os": "macOS-26.2-arm64-arm-64bit",
+  "probes": [
+    {
+      "accounted_record_bytes": 27,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 417,
+      "deallocation_count": 1,
+      "history": 0,
+      "operation": "recording_effect_outbox",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 1375,
+      "reserve_time_ns": 1250
+    },
+    {
+      "accounted_record_bytes": 30,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 41,
+      "deallocation_count": 1,
+      "history": 1000,
+      "operation": "recording_effect_outbox",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 84,
+      "reserve_time_ns": 41
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 0,
+      "deallocation_count": 1,
+      "history": 100000,
+      "operation": "recording_effect_outbox",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 83,
+      "reserve_time_ns": 0
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 250,
+      "deallocation_count": 0,
+      "history": 0,
+      "operation": "recording_owned_queue",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 458,
+      "reserve_time_ns": 333
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 0,
+      "deallocation_count": 0,
+      "history": 1000,
+      "operation": "recording_owned_queue",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 41,
+      "reserve_time_ns": 42
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 42,
+      "deallocation_count": 0,
+      "history": 100000,
+      "operation": "recording_owned_queue",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 0,
+      "reserve_time_ns": 0
+    },
+    {
+      "accounted_record_bytes": 64,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 42,
+      "deallocation_count": 0,
+      "history": 0,
+      "operation": "recording_record_pool",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 292,
+      "reserve_time_ns": 333
+    },
+    {
+      "accounted_record_bytes": 64,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 0,
+      "deallocation_count": 0,
+      "history": 1000,
+      "operation": "recording_record_pool",
+      "pool_reuse": true,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 0,
+      "reserve_time_ns": 0
+    },
+    {
+      "accounted_record_bytes": 64,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 0,
+      "deallocation_count": 0,
+      "history": 100000,
+      "operation": "recording_record_pool",
+      "pool_reuse": true,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 0,
+      "reserve_time_ns": 42
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 416,
+      "deallocation_count": 0,
+      "history": 0,
+      "operation": "recording_retained_ledger",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 208,
+      "reserve_time_ns": 542
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 42,
+      "deallocation_count": 0,
+      "history": 1000,
+      "operation": "recording_retained_ledger",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 42,
+      "reserve_time_ns": 41
+    },
+    {
+      "accounted_record_bytes": 32,
+      "allocated_bytes": 0,
+      "allocation_count": 0,
+      "append_time_ns": 0,
+      "deallocation_count": 0,
+      "history": 100000,
+      "operation": "recording_retained_ledger",
+      "pool_reuse": false,
+      "post_publication_failure_branch": false,
+      "prepare_time_ns": 41,
+      "reserve_time_ns": 42
+    }
+  ],
+  "raw_criterion_directory": "/private/tmp/mech-a3-measure-20260807-r3/target/criterion",
+  "raw_output": "/private/tmp/mech-a3-measure-20260807-r3/target/gate-a-benchmark-runs/0141a6a8b47b10f391bfbead40fe55a3ff987dec/recording_primitives.log",
+  "runtime_limits": {
+    "effect_outbox": [
+      {
+        "history": 0,
+        "max_bytes": 64,
+        "max_effects": 1
+      },
+      {
+        "history": 1000,
+        "max_bytes": 64064,
+        "max_effects": 1001
+      },
+      {
+        "history": 100000,
+        "max_bytes": 6400064,
+        "max_effects": 100001
+      }
+    ],
+    "owned_queue": [
+      {
+        "history": 0,
+        "max_bytes": 32,
+        "max_records": 1
+      },
+      {
+        "history": 1000,
+        "max_bytes": 32032,
+        "max_records": 1001
+      },
+      {
+        "history": 100000,
+        "max_bytes": 3200032,
+        "max_records": 100001
+      }
+    ],
+    "record_buffer_pool": {
+      "max_reusable_capacity": 64,
+      "max_segments": 1,
+      "max_total_capacity": 64
+    },
+    "retained_ledger": [
+      {
+        "history": 0,
+        "max_bytes": 32,
+        "max_records": 1
+      },
+      {
+        "history": 1000,
+        "max_bytes": 32032,
+        "max_records": 1001
+      },
+      {
+        "history": 100000,
+        "max_bytes": 3200032,
+        "max_records": 100001
+      }
+    ],
+    "source": "src/runtime/benches/recording_primitives.rs"
+  },
+  "rustc": "rustc 1.96.0-nightly (ec818fda3 2026-03-02)\nbinary: rustc\ncommit-hash: ec818fda361ca216eb186f5cf45131bd9c776bb4\ncommit-date: 2026-03-02\nhost: aarch64-apple-darwin\nrelease: 1.96.0-nightly\nLLVM version: 22.1.0",
+  "sample_protocol": {
+    "criterion_measured_phase": "append",
+    "criterion_sample_size": 10,
+    "extended_direct_store_sweep": false,
+    "fixed_history_per_sample": true,
+    "measured_operations_per_fixture": 1,
+    "profile": "release",
+    "setup_included_in_timing": false
+  },
+  "schema_version": 1,
+  "target_cpu": {
+    "CARGO_ENCODED_RUSTFLAGS": "",
+    "RUSTFLAGS": ""
+  }
+}

--- a/benchmarks/runtime/gate-a/baseline-schema.json
+++ b/benchmarks/runtime/gate-a/baseline-schema.json
@@ -49,22 +49,42 @@
           "history",
           "allocation_count",
           "deallocation_count",
-          "allocated_bytes",
-          "context_event_snapshot_count",
-          "context_event_snapshot_items",
-          "context_event_compaction_count",
-          "context_event_compaction_moved_items",
-          "context_event_visible_len",
-          "context_event_physical_len",
-          "runtime_transaction_savepoint_clone_count",
-          "runtime_transaction_savepoint_items",
-          "in_memory_store_clone_count",
-          "in_memory_store_cloned_records",
-          "commit_runtime_call_count",
-          "program_checkpoint_count",
-          "reactive_journal_cell_count",
-          "events_appended",
-          "transactions_committed"
+          "allocated_bytes"
+        ],
+        "oneOf": [
+          {
+            "title": "runtime transaction probe",
+            "required": [
+              "context_event_snapshot_count",
+              "context_event_snapshot_items",
+              "context_event_compaction_count",
+              "context_event_compaction_moved_items",
+              "context_event_visible_len",
+              "context_event_physical_len",
+              "runtime_transaction_savepoint_clone_count",
+              "runtime_transaction_savepoint_items",
+              "in_memory_store_clone_count",
+              "in_memory_store_cloned_records",
+              "in_memory_store_prepare_duration_ns",
+              "in_memory_store_apply_duration_ns",
+              "commit_runtime_call_count",
+              "program_checkpoint_count",
+              "reactive_journal_cell_count",
+              "events_appended",
+              "transactions_committed"
+            ]
+          },
+          {
+            "title": "recording primitive phase probe",
+            "required": [
+              "reserve_time_ns",
+              "prepare_time_ns",
+              "append_time_ns",
+              "accounted_record_bytes",
+              "pool_reuse",
+              "post_publication_failure_branch"
+            ]
+          }
         ]
       }
     }

--- a/scripts/run-gate-a-benchmarks.py
+++ b/scripts/run-gate-a-benchmarks.py
@@ -158,6 +158,54 @@ def hardware_description(machine_label: str | None = None) -> str:
     )
 
 
+def runtime_limits(bench: str) -> Any:
+    if bench == "history_scaling":
+        return {
+            "default": "RuntimeConfig::default()",
+            "lane_overrides": [
+                {
+                    "operation": "context_event_retention_steady",
+                    "history": limit,
+                    "max_in_memory_events": limit,
+                }
+                for limit in (32, 1_024, 16_384, 100_000)
+            ],
+        }
+    histories = (0, 1_000, 100_000)
+    return {
+        "source": "src/runtime/benches/recording_primitives.rs",
+        "retained_ledger": [
+            {
+                "history": history,
+                "max_records": history + 1,
+                "max_bytes": (history + 1) * 32,
+            }
+            for history in histories
+        ],
+        "owned_queue": [
+            {
+                "history": history,
+                "max_records": history + 1,
+                "max_bytes": (history + 1) * 32,
+            }
+            for history in histories
+        ],
+        "record_buffer_pool": {
+            "max_segments": 1,
+            "max_total_capacity": 64,
+            "max_reusable_capacity": 64,
+        },
+        "effect_outbox": [
+            {
+                "history": history,
+                "max_effects": history + 1,
+                "max_bytes": (history + 1) * 64,
+            }
+            for history in histories
+        ],
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -188,6 +236,12 @@ def parse_args() -> argparse.Namespace:
         "--machine-label",
         help="stable controlled-machine model label when automatic detection is unavailable",
     )
+    parser.add_argument(
+        "--bench",
+        choices=("history_scaling", "recording_primitives"),
+        default="history_scaling",
+        help="controlled Gate A benchmark target",
+    )
     return parser.parse_args()
 
 
@@ -208,11 +262,13 @@ def main() -> int:
         return 2
     commit = command_output(["git", "rev-parse", "HEAD"])
     target_dir = cargo_target_directory(os.environ)
+    raw_name = (
+        "history_scaling-extended.log"
+        if args.bench == "history_scaling" and args.extended
+        else f"{args.bench}.log"
+    )
     raw_output = args.raw_output or (
-        target_dir
-        / "gate-a-benchmark-runs"
-        / commit
-        / ("history_scaling-extended.log" if args.extended else "history_scaling.log")
+        target_dir / "gate-a-benchmark-runs" / commit / raw_name
     )
     if not raw_output.is_absolute():
         raw_output = (ROOT / raw_output).resolve()
@@ -224,12 +280,19 @@ def main() -> int:
         "-p",
         "mech-runtime",
         "--bench",
-        "history_scaling",
-        "--features",
-        "source_default,runtime_bench_probes",
-        "--",
-        "--noplot",
+        args.bench,
     ]
+    if args.bench == "history_scaling":
+        command.extend([
+            "--features",
+            "source_default,runtime_bench_probes",
+        ])
+    else:
+        command.extend([
+            "--features",
+            "runtime_default,runtime_bench_probes",
+        ])
+    command.extend(["--", "--noplot"])
     sample_size = args.sample_size or 10
     if args.filter:
         command.append(args.filter)
@@ -237,7 +300,7 @@ def main() -> int:
 
     clear_gate_a_criterion_results(target_dir)
     environment = os.environ.copy()
-    if args.extended:
+    if args.bench == "history_scaling" and args.extended:
         environment["MECH_GATE_A_EXTENDED"] = "1"
     else:
         environment.pop("MECH_GATE_A_EXTENDED", None)
@@ -265,29 +328,28 @@ def main() -> int:
             "RUSTFLAGS": os.environ.get("RUSTFLAGS", ""),
             "CARGO_ENCODED_RUSTFLAGS": os.environ.get("CARGO_ENCODED_RUSTFLAGS", ""),
         },
-        "runtime_limits": {
-            "default": "RuntimeConfig::default()",
-            "lane_overrides": [
-                {
-                    "operation": "context_event_retention_steady",
-                    "history": limit,
-                    "max_in_memory_events": limit,
-                }
-                for limit in (32, 1_024, 16_384, 100_000)
-            ],
-        },
+        "runtime_limits": runtime_limits(args.bench),
         "sample_protocol": {
             "criterion_sample_size": sample_size,
             "fixed_history_per_sample": True,
-            "measured_operations_per_fixture": {
-                "single_operation_lanes": 1,
-                "context_event_retention_steady": (
-                    "max(criterion_requested_iterations, retention_limit)"
-                ),
-            },
+            "measured_operations_per_fixture": (
+                {
+                    "single_operation_lanes": 1,
+                    "context_event_retention_steady": (
+                        "max(criterion_requested_iterations, retention_limit)"
+                    ),
+                }
+                if args.bench == "history_scaling"
+                else 1
+            ),
             "setup_included_in_timing": False,
+            "criterion_measured_phase": (
+                "append" if args.bench == "recording_primitives" else "operation"
+            ),
             "profile": "release",
-            "extended_direct_store_sweep": args.extended,
+            "extended_direct_store_sweep": (
+                args.extended if args.bench == "history_scaling" else False
+            ),
         },
         "benchmark_arguments": command,
         "raw_criterion_directory": str(target_dir / "criterion"),

--- a/scripts/unsafe-boundaries.allowlist
+++ b/scripts/unsafe-boundaries.allowlist
@@ -121,6 +121,7 @@ src/engine/src/intrinsics/mod.rs|typed-interpreter-kernel|mech-engine|validated 
 src/engine/src/intrinsics/table_ops.rs|typed-interpreter-kernel|mech-engine|validated Value variants match every erased reference and output container|existing typed interpreter dispatch
 src/engine/src/intrinsics/vertcat.rs|typed-interpreter-kernel|mech-engine|validated Value variants match every erased reference and output container|existing typed interpreter dispatch
 src/runtime/benches/history_scaling.rs|benchmark-probe|mech-runtime|the counting allocator forwards the exact pointer and layout to System and retains no allocation pointer|benchmark-only allocation accounting for Gate A evidence
+src/runtime/benches/recording_primitives.rs|benchmark-probe|mech-runtime|the counting allocator forwards the exact pointer and layout to System and retains no allocation pointer|benchmark-only allocation accounting for Gate A evidence
 src/wasm/src/websocket.rs|ffi|mech-wasm|foreign pointers and symbols remain valid only for the documented call or library lifetime|existing native ABI boundary
 tests/fixtures/dynamic-status-module/src/lib.rs|ffi|repository-tests|foreign pointers and symbols remain valid only for the documented call or library lifetime|existing native ABI boundary
 tests/mech_repl_ctrlc.rs|ffi|repository-tests|foreign pointers and symbols remain valid only for the documented call or library lifetime|existing native ABI boundary

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -315,6 +315,11 @@ name = "module_smoke"
 path = "tests/module_smoke.rs"
 required-features = ["source_default"]
 
+[[test]]
+name = "recording_bench_facade"
+path = "tests/recording_bench_facade.rs"
+required-features = ["runtime_default", "runtime_bench_probes"]
+
 [[bench]]
 name = "program_transaction"
 harness = false
@@ -329,3 +334,8 @@ required-features = ["source_default"]
 name = "history_scaling"
 harness = false
 required-features = ["source_default", "runtime_bench_probes"]
+
+[[bench]]
+name = "recording_primitives"
+harness = false
+required-features = ["runtime_default", "runtime_bench_probes"]

--- a/src/runtime/benches/recording_primitives.rs
+++ b/src/runtime/benches/recording_primitives.rs
@@ -1,0 +1,345 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::BTreeSet;
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use mech_runtime::__gate_a_recording::{
+    AccountedRecord, OutboxDeliveryPolicy, OutboxEffectId, OwnedEffectIntent, OwnedTurnRecordQueue,
+    RecordBufferPool, RecordEstimate, RetainedEffectOutbox, RetainedTurnLedger, TurnId,
+    prepare_outbox, prepare_queue, prepare_retained, reserve_outbox, reserve_queue,
+    reserve_retained,
+};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static DEALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static REPORTED: OnceLock<Mutex<BTreeSet<(String, usize)>>> = OnceLock::new();
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        DEALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, old: Layout, size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        DEALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(size as u64, Ordering::Relaxed);
+        unsafe { System.realloc(pointer, old, size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct AllocationSnapshot {
+    allocations: u64,
+    deallocations: u64,
+    allocated_bytes: u64,
+}
+
+fn reset_allocations() {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    DEALLOCATIONS.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn allocation_snapshot() -> AllocationSnapshot {
+    AllocationSnapshot {
+        allocations: ALLOCATIONS.load(Ordering::Relaxed),
+        deallocations: DEALLOCATIONS.load(Ordering::Relaxed),
+        allocated_bytes: ALLOCATED_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PhaseSample {
+    reserve: Duration,
+    prepare: Duration,
+    append: Duration,
+    bytes: usize,
+    pool_reuse: bool,
+    allocations: AllocationSnapshot,
+}
+
+fn report(operation: &str, history: usize, sample: PhaseSample) {
+    let mut reported = REPORTED
+        .get_or_init(|| Mutex::new(BTreeSet::new()))
+        .lock()
+        .unwrap();
+    if !reported.insert((operation.to_string(), history)) {
+        return;
+    }
+    eprintln!(
+        "GATE_A_SAMPLE {{\"operation\":\"{operation}\",\"history\":{history},\"reserve_time_ns\":{},\"prepare_time_ns\":{},\"append_time_ns\":{},\"accounted_record_bytes\":{},\"pool_reuse\":{},\"allocation_count\":{},\"deallocation_count\":{},\"allocated_bytes\":{},\"post_publication_failure_branch\":false}}",
+        sample.reserve.as_nanos(),
+        sample.prepare.as_nanos(),
+        sample.append.as_nanos(),
+        sample.bytes,
+        sample.pool_reuse,
+        sample.allocations.allocations,
+        sample.allocations.deallocations,
+        sample.allocations.allocated_bytes,
+    );
+}
+
+fn scaled_append(sample: PhaseSample, iterations: u64) -> Duration {
+    sample
+        .append
+        .max(Duration::from_nanos(1))
+        .mul_f64(iterations as f64)
+}
+
+fn boxed_record() -> Box<[u8]> {
+    vec![0_u8; 32].into_boxed_slice()
+}
+
+fn append_retained(ledger: &mut RetainedTurnLedger<Box<[u8]>>) {
+    let record = boxed_record();
+    let permit = reserve_retained(
+        ledger,
+        RecordEstimate {
+            records: 1,
+            bytes: record.retained_bytes(),
+        },
+    )
+    .unwrap();
+    prepare_retained(ledger, permit, record).unwrap().append();
+}
+
+fn retained_fixture(history: usize) -> RetainedTurnLedger<Box<[u8]>> {
+    let capacity = history + 1;
+    let mut ledger = RetainedTurnLedger::new(capacity, capacity * 32).unwrap();
+    for _ in 0..history {
+        append_retained(&mut ledger);
+    }
+    ledger
+}
+
+fn retained_ledger_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gate_a_recording/retained_ledger");
+    for history in [0_usize, 1_000, 100_000] {
+        group.bench_function(BenchmarkId::from_parameter(history), |b| {
+            b.iter_custom(|iterations| {
+                let mut ledger = retained_fixture(history);
+                let record = boxed_record();
+                let bytes = record.retained_bytes();
+                let started = Instant::now();
+                let permit =
+                    reserve_retained(&ledger, RecordEstimate { records: 1, bytes }).unwrap();
+                let reserve = started.elapsed();
+                let started = Instant::now();
+                let prepared = prepare_retained(&mut ledger, permit, record).unwrap();
+                let prepare = started.elapsed();
+                reset_allocations();
+                let started = Instant::now();
+                black_box(prepared.append());
+                let append = started.elapsed();
+                let sample = PhaseSample {
+                    reserve,
+                    prepare,
+                    append,
+                    bytes,
+                    pool_reuse: false,
+                    allocations: allocation_snapshot(),
+                };
+                report("recording_retained_ledger", history, sample);
+                scaled_append(sample, iterations)
+            });
+        });
+    }
+    group.finish();
+}
+
+fn append_queued(queue: &OwnedTurnRecordQueue<Box<[u8]>>) {
+    let record = boxed_record();
+    let permit = reserve_queue(
+        queue,
+        RecordEstimate {
+            records: 1,
+            bytes: record.retained_bytes(),
+        },
+    )
+    .unwrap();
+    prepare_queue(queue, permit, record).unwrap().append();
+}
+
+fn queue_fixture(history: usize) -> OwnedTurnRecordQueue<Box<[u8]>> {
+    let capacity = history + 1;
+    let queue = OwnedTurnRecordQueue::new(capacity, capacity * 32).unwrap();
+    for _ in 0..history {
+        append_queued(&queue);
+    }
+    queue
+}
+
+fn owned_queue_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gate_a_recording/owned_queue");
+    for history in [0_usize, 1_000, 100_000] {
+        group.bench_function(BenchmarkId::from_parameter(history), |b| {
+            b.iter_custom(|iterations| {
+                let queue = queue_fixture(history);
+                let record = boxed_record();
+                let bytes = record.retained_bytes();
+                let started = Instant::now();
+                let permit = reserve_queue(&queue, RecordEstimate { records: 1, bytes }).unwrap();
+                let reserve = started.elapsed();
+                let started = Instant::now();
+                let prepared = prepare_queue(&queue, permit, record).unwrap();
+                let prepare = started.elapsed();
+                reset_allocations();
+                let started = Instant::now();
+                black_box(prepared.append());
+                let append = started.elapsed();
+                let sample = PhaseSample {
+                    reserve,
+                    prepare,
+                    append,
+                    bytes,
+                    pool_reuse: false,
+                    allocations: allocation_snapshot(),
+                };
+                report("recording_owned_queue", history, sample);
+                scaled_append(sample, iterations)
+            });
+        });
+    }
+    group.finish();
+}
+
+fn pool_fixture(history: usize) -> RecordBufferPool {
+    let pool = RecordBufferPool::new(1, 64, 64).unwrap();
+    for _ in 0..history {
+        let mut segment = pool.acquire(64).unwrap();
+        segment.try_extend_from_slice(&[0_u8; 32]).unwrap();
+        drop(segment);
+    }
+    pool
+}
+
+fn record_pool_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gate_a_recording/record_pool");
+    for history in [0_usize, 1_000, 100_000] {
+        group.bench_function(BenchmarkId::from_parameter(history), |b| {
+            b.iter_custom(|iterations| {
+                let pool = pool_fixture(history);
+                let allocations_before = pool.stats().allocations;
+                let started = Instant::now();
+                let mut segment = pool.acquire(64).unwrap();
+                let reserve = started.elapsed();
+                let started = Instant::now();
+                segment.try_extend_from_slice(&[0_u8; 32]).unwrap();
+                let prepare = started.elapsed();
+                let bytes = segment.retained_bytes();
+                reset_allocations();
+                let started = Instant::now();
+                drop(segment);
+                let append = started.elapsed();
+                let sample = PhaseSample {
+                    reserve,
+                    prepare,
+                    append,
+                    bytes,
+                    pool_reuse: pool.stats().allocations == allocations_before,
+                    allocations: allocation_snapshot(),
+                };
+                report("recording_record_pool", history, sample);
+                scaled_append(sample, iterations)
+            });
+        });
+    }
+    group.finish();
+}
+
+fn effect(turn: u64) -> OwnedEffectIntent<Box<[u8]>> {
+    OwnedEffectIntent {
+        id: OutboxEffectId {
+            turn_id: TurnId::new(turn).unwrap(),
+            ordinal: 0,
+        },
+        operation: String::from("write"),
+        target: String::from("bench"),
+        payload: vec![0_u8; 16].into_boxed_slice(),
+        idempotency_key: turn.to_string(),
+        delivery: OutboxDeliveryPolicy::AtLeastOnce,
+    }
+}
+
+fn append_effect(outbox: &mut RetainedEffectOutbox<Box<[u8]>>, turn: u64) {
+    let effect = effect(turn);
+    let bytes = effect.retained_bytes();
+    let permit = reserve_outbox(outbox, RecordEstimate { records: 1, bytes }).unwrap();
+    prepare_outbox(outbox, permit, vec![effect])
+        .unwrap()
+        .append();
+}
+
+fn outbox_fixture(history: usize) -> RetainedEffectOutbox<Box<[u8]>> {
+    let capacity = history + 1;
+    let mut outbox = RetainedEffectOutbox::new(capacity, capacity * 64).unwrap();
+    for turn in 1..=history {
+        append_effect(&mut outbox, turn as u64);
+    }
+    outbox
+}
+
+fn effect_outbox_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gate_a_recording/effect_outbox");
+    for history in [0_usize, 1_000, 100_000] {
+        group.bench_function(BenchmarkId::from_parameter(history), |b| {
+            b.iter_custom(|iterations| {
+                let mut outbox = outbox_fixture(history);
+                let effect = effect(history as u64 + 1);
+                let bytes = effect.retained_bytes();
+                let started = Instant::now();
+                let permit = reserve_outbox(&outbox, RecordEstimate { records: 1, bytes }).unwrap();
+                let reserve = started.elapsed();
+                let started = Instant::now();
+                let prepared = prepare_outbox(&mut outbox, permit, vec![effect]).unwrap();
+                let prepare = started.elapsed();
+                reset_allocations();
+                let started = Instant::now();
+                prepared.append();
+                let append = started.elapsed();
+                let sample = PhaseSample {
+                    reserve,
+                    prepare,
+                    append,
+                    bytes,
+                    pool_reuse: false,
+                    allocations: allocation_snapshot(),
+                };
+                report("recording_effect_outbox", history, sample);
+                scaled_append(sample, iterations)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    retained_ledger_benchmark,
+    owned_queue_benchmark,
+    record_pool_benchmark,
+    effect_outbox_benchmark,
+);
+criterion_main!(benches);

--- a/src/runtime/src/ledger/capacity.rs
+++ b/src/runtime/src/ledger/capacity.rs
@@ -147,6 +147,7 @@ impl CapacityController {
         ledger_generation: u64,
         consumed: bool,
         mut reservation: CapacityReservation,
+        actual_records: usize,
         actual_bytes: usize,
     ) -> MResult<CapacityReservation> {
         if consumed {
@@ -161,8 +162,20 @@ impl CapacityController {
         if ledger_generation != state.generation.get() {
             return Err(invalid_permit("ledger permit generation is stale"));
         }
-        if reservation.records < 1 {
-            return Err(invalid_permit("ledger permit does not reserve a record"));
+        if actual_records == 0 {
+            return Err(invalid_permit("prepared append must contain a record"));
+        }
+        if actual_records > reservation.records {
+            return Err(MechError::new(
+                LedgerCapacityExceeded {
+                    resource: "prepared record count",
+                    maximum: reservation.records,
+                    retained: 0,
+                    reserved: 0,
+                    requested: actual_records,
+                },
+                None,
+            ));
         }
         if state.prepared_sequence.is_some() {
             return Err(invalid_permit(
@@ -189,11 +202,11 @@ impl CapacityController {
                 None,
             ));
         }
-        let unused_records = reservation.records - 1;
+        let unused_records = reservation.records - actual_records;
         let unused_bytes = reservation.bytes - actual_bytes;
         state.reserved_records -= unused_records;
         state.reserved_bytes -= unused_bytes;
-        reservation.records = 1;
+        reservation.records = actual_records;
         reservation.bytes = actual_bytes;
         state.prepared_sequence = Some(reservation.sequence);
         Ok(reservation)
@@ -299,13 +312,6 @@ impl CapacityController {
 
     pub(crate) fn is_healthy(&self) -> bool {
         self.lock().healthy
-    }
-
-    pub(crate) fn assert_owner(&self, owner: &Self) {
-        assert!(
-            self.identity == owner.identity && Arc::ptr_eq(&self.state, &owner.state),
-            "prepared append belongs to a different ledger"
-        );
     }
 
     #[cfg(test)]

--- a/src/runtime/src/ledger/capacity.rs
+++ b/src/runtime/src/ledger/capacity.rs
@@ -297,6 +297,17 @@ impl CapacityController {
         self.lock().healthy = false;
     }
 
+    pub(crate) fn is_healthy(&self) -> bool {
+        self.lock().healthy
+    }
+
+    pub(crate) fn assert_owner(&self, owner: &Self) {
+        assert!(
+            self.identity == owner.identity && Arc::ptr_eq(&self.state, &owner.state),
+            "prepared append belongs to a different ledger"
+        );
+    }
+
     #[cfg(test)]
     pub(super) fn force_generation_for_test(&self, generation: NonZeroU64) {
         self.lock().generation = generation;

--- a/src/runtime/src/ledger/capacity.rs
+++ b/src/runtime/src/ledger/capacity.rs
@@ -1,0 +1,417 @@
+use core::{fmt, num::NonZeroU64};
+use std::sync::{
+    Arc, Mutex, MutexGuard,
+    atomic::{AtomicU64, Ordering},
+};
+
+use mech_core::{MResult, MechError, MechErrorKind};
+
+use crate::turn_record::{CheckedSequenceAllocator, LedgerSequence};
+
+static NEXT_LEDGER_IDENTITY: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecordEstimate {
+    pub records: usize,
+    pub bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CapacityReservation {
+    pub(crate) sequence: LedgerSequence,
+    pub(crate) records: usize,
+    pub(crate) bytes: usize,
+}
+
+#[derive(Debug)]
+struct CapacityState {
+    generation: NonZeroU64,
+    max_records: usize,
+    max_bytes: usize,
+    retained_records: usize,
+    retained_bytes: usize,
+    reserved_records: usize,
+    reserved_bytes: usize,
+    prepared_sequence: Option<LedgerSequence>,
+    last_appended_sequence: Option<LedgerSequence>,
+    healthy: bool,
+    sequences: CheckedSequenceAllocator<LedgerSequence>,
+}
+
+#[derive(Clone)]
+pub(crate) struct CapacityController {
+    identity: u64,
+    state: Arc<Mutex<CapacityState>>,
+}
+
+impl fmt::Debug for CapacityController {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CapacityController")
+            .field("identity", &self.identity)
+            .field("generation", &self.generation())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CapacityController {
+    pub(crate) fn new(max_records: usize, max_bytes: usize) -> MResult<Self> {
+        if max_records == 0 {
+            return Err(MechError::new(
+                LedgerCapacityExceeded {
+                    resource: "records",
+                    maximum: max_records,
+                    retained: 0,
+                    reserved: 0,
+                    requested: 1,
+                },
+                None,
+            ));
+        }
+        let identity = NEXT_LEDGER_IDENTITY
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |identity| {
+                identity.checked_add(1)
+            })
+            .map_err(|_| {
+                MechError::new(
+                    LedgerAllocationFailed {
+                        resource: "ledger identity",
+                    },
+                    None,
+                )
+            })?;
+        Ok(Self {
+            identity,
+            state: Arc::new(Mutex::new(CapacityState {
+                generation: NonZeroU64::MIN,
+                max_records,
+                max_bytes,
+                retained_records: 0,
+                retained_bytes: 0,
+                reserved_records: 0,
+                reserved_bytes: 0,
+                prepared_sequence: None,
+                last_appended_sequence: None,
+                healthy: true,
+                sequences: CheckedSequenceAllocator::new(),
+            })),
+        })
+    }
+
+    pub(crate) const fn identity(&self) -> u64 {
+        self.identity
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.lock().generation.get()
+    }
+
+    pub(crate) fn reserve(&self, estimate: RecordEstimate) -> MResult<CapacityReservation> {
+        if estimate.records == 0 {
+            return Err(invalid_permit(
+                "record estimate must reserve at least one record",
+            ));
+        }
+        let mut state = self.lock();
+        if !state.healthy {
+            return Err(invalid_permit("ledger writer is unhealthy"));
+        }
+        ensure_capacity(
+            "records",
+            state.max_records,
+            state.retained_records,
+            state.reserved_records,
+            estimate.records,
+        )?;
+        ensure_capacity(
+            "bytes",
+            state.max_bytes,
+            state.retained_bytes,
+            state.reserved_bytes,
+            estimate.bytes,
+        )?;
+        let sequence = state.sequences.allocate()?;
+        state.reserved_records += estimate.records;
+        state.reserved_bytes += estimate.bytes;
+        Ok(CapacityReservation {
+            sequence,
+            records: estimate.records,
+            bytes: estimate.bytes,
+        })
+    }
+
+    pub(crate) fn bind(
+        &self,
+        permit_controller: &Self,
+        ledger_identity: u64,
+        ledger_generation: u64,
+        consumed: bool,
+        mut reservation: CapacityReservation,
+        actual_bytes: usize,
+    ) -> MResult<CapacityReservation> {
+        if consumed {
+            return Err(invalid_permit("ledger permit has already been consumed"));
+        }
+        if ledger_identity != self.identity || !Arc::ptr_eq(&permit_controller.state, &self.state) {
+            return Err(invalid_permit(
+                "ledger permit belongs to a different ledger",
+            ));
+        }
+        let mut state = self.lock();
+        if ledger_generation != state.generation.get() {
+            return Err(invalid_permit("ledger permit generation is stale"));
+        }
+        if reservation.records < 1 {
+            return Err(invalid_permit("ledger permit does not reserve a record"));
+        }
+        if state.prepared_sequence.is_some() {
+            return Err(invalid_permit(
+                "another prepared append is already active for this ledger",
+            ));
+        }
+        if state
+            .last_appended_sequence
+            .is_some_and(|last| reservation.sequence <= last)
+        {
+            return Err(invalid_permit(
+                "ledger permit sequence does not follow the append watermark",
+            ));
+        }
+        if actual_bytes > reservation.bytes {
+            return Err(MechError::new(
+                LedgerCapacityExceeded {
+                    resource: "prepared record bytes",
+                    maximum: reservation.bytes,
+                    retained: 0,
+                    reserved: 0,
+                    requested: actual_bytes,
+                },
+                None,
+            ));
+        }
+        let unused_records = reservation.records - 1;
+        let unused_bytes = reservation.bytes - actual_bytes;
+        state.reserved_records -= unused_records;
+        state.reserved_bytes -= unused_bytes;
+        reservation.records = 1;
+        reservation.bytes = actual_bytes;
+        state.prepared_sequence = Some(reservation.sequence);
+        Ok(reservation)
+    }
+
+    pub(crate) fn release_reserved(&self, reservation: CapacityReservation) {
+        let mut state = self.lock();
+        state.reserved_records = state
+            .reserved_records
+            .checked_sub(reservation.records)
+            .expect("reservation record accounting underflow");
+        state.reserved_bytes = state
+            .reserved_bytes
+            .checked_sub(reservation.bytes)
+            .expect("reservation byte accounting underflow");
+    }
+
+    pub(crate) fn release_prepared(&self, reservation: CapacityReservation) {
+        let mut state = self.lock();
+        assert_eq!(
+            state.prepared_sequence,
+            Some(reservation.sequence),
+            "dropped prepared append must own the active preparation lease"
+        );
+        state.prepared_sequence = None;
+        state.reserved_records = state
+            .reserved_records
+            .checked_sub(reservation.records)
+            .expect("prepared reservation record accounting underflow");
+        state.reserved_bytes = state
+            .reserved_bytes
+            .checked_sub(reservation.bytes)
+            .expect("prepared reservation byte accounting underflow");
+    }
+
+    pub(crate) fn commit_prepared(
+        &self,
+        prepared_controller: &Self,
+        reservation: CapacityReservation,
+    ) {
+        assert!(
+            self.identity == prepared_controller.identity
+                && Arc::ptr_eq(&self.state, &prepared_controller.state),
+            "prepared append must retain its originating ledger controller"
+        );
+        let mut state = self.lock();
+        assert_eq!(
+            state.prepared_sequence,
+            Some(reservation.sequence),
+            "prepared append sequence must match the active preparation lease"
+        );
+        state.prepared_sequence = None;
+        state.last_appended_sequence = Some(reservation.sequence);
+        state.reserved_records = state
+            .reserved_records
+            .checked_sub(reservation.records)
+            .expect("committed reservation record accounting underflow");
+        state.reserved_bytes = state
+            .reserved_bytes
+            .checked_sub(reservation.bytes)
+            .expect("committed reservation byte accounting underflow");
+        state.retained_records = state
+            .retained_records
+            .checked_add(reservation.records)
+            .expect("retained record accounting overflow");
+        state.retained_bytes = state
+            .retained_bytes
+            .checked_add(reservation.bytes)
+            .expect("retained byte accounting overflow");
+    }
+
+    pub(crate) fn release_retained(&self, records: usize, bytes: usize) {
+        let mut state = self.lock();
+        state.retained_records = state
+            .retained_records
+            .checked_sub(records)
+            .expect("retained record accounting underflow");
+        state.retained_bytes = state
+            .retained_bytes
+            .checked_sub(bytes)
+            .expect("retained byte accounting underflow");
+    }
+
+    pub(crate) fn retained(&self) -> RecordEstimate {
+        let state = self.lock();
+        RecordEstimate {
+            records: state.retained_records,
+            bytes: state.retained_bytes,
+        }
+    }
+
+    pub(crate) fn reserved(&self) -> RecordEstimate {
+        let state = self.lock();
+        RecordEstimate {
+            records: state.reserved_records,
+            bytes: state.reserved_bytes,
+        }
+    }
+
+    pub(crate) fn mark_unhealthy(&self) {
+        self.lock().healthy = false;
+    }
+
+    #[cfg(test)]
+    pub(super) fn force_generation_for_test(&self, generation: NonZeroU64) {
+        self.lock().generation = generation;
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_sequence_for_test(&self, next: NonZeroU64) {
+        self.lock().sequences = CheckedSequenceAllocator::starting_at(next);
+    }
+
+    fn lock(&self) -> MutexGuard<'_, CapacityState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+fn ensure_capacity(
+    resource: &'static str,
+    maximum: usize,
+    retained: usize,
+    reserved: usize,
+    requested: usize,
+) -> MResult<()> {
+    let used = retained.checked_add(reserved).ok_or_else(|| {
+        MechError::new(
+            LedgerCapacityExceeded {
+                resource,
+                maximum,
+                retained,
+                reserved,
+                requested,
+            },
+            None,
+        )
+    })?;
+    let total = used.checked_add(requested).ok_or_else(|| {
+        MechError::new(
+            LedgerCapacityExceeded {
+                resource,
+                maximum,
+                retained,
+                reserved,
+                requested,
+            },
+            None,
+        )
+    })?;
+    if total > maximum {
+        return Err(MechError::new(
+            LedgerCapacityExceeded {
+                resource,
+                maximum,
+                retained,
+                reserved,
+                requested,
+            },
+            None,
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn invalid_permit(reason: &'static str) -> MechError {
+    MechError::new(LedgerPermitInvalid { reason }, None)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LedgerCapacityExceeded {
+    pub resource: &'static str,
+    pub maximum: usize,
+    pub retained: usize,
+    pub reserved: usize,
+    pub requested: usize,
+}
+
+impl MechErrorKind for LedgerCapacityExceeded {
+    fn name(&self) -> &str {
+        "LedgerCapacityExceeded"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "ledger {} capacity exceeded: retained {}, reserved {}, requested {}, maximum {}",
+            self.resource, self.retained, self.reserved, self.requested, self.maximum
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LedgerPermitInvalid {
+    pub reason: &'static str,
+}
+
+impl MechErrorKind for LedgerPermitInvalid {
+    fn name(&self) -> &str {
+        "LedgerPermitInvalid"
+    }
+
+    fn message(&self) -> String {
+        format!("invalid ledger permit: {}", self.reason)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LedgerAllocationFailed {
+    pub resource: &'static str,
+}
+
+impl MechErrorKind for LedgerAllocationFailed {
+    fn name(&self) -> &str {
+        "LedgerAllocationFailed"
+    }
+
+    fn message(&self) -> String {
+        format!("failed to allocate bounded ledger {}", self.resource)
+    }
+}

--- a/src/runtime/src/ledger/mod.rs
+++ b/src/runtime/src/ledger/mod.rs
@@ -1,6 +1,8 @@
 //! Bounded owned turn-record storage primitives.
 
 mod capacity;
+mod queue;
+mod retained;
 #[cfg(test)]
 mod tests;
 
@@ -12,6 +14,8 @@ pub(crate) use capacity::{CapacityController, CapacityReservation};
 pub use capacity::{
     LedgerAllocationFailed, LedgerCapacityExceeded, LedgerPermitInvalid, RecordEstimate,
 };
+pub use queue::OwnedTurnRecordQueue;
+pub use retained::{RetainedLedgerDrain, RetainedTurnLedger};
 
 /// An unused reservation for one future ledger append.
 #[derive(Debug)]
@@ -98,6 +102,10 @@ impl<R> PreparedLedgerAppend<R> {
             .take()
             .expect("prepared append record consumed once");
         (reservation, record)
+    }
+
+    pub(crate) fn controller(&self) -> &CapacityController {
+        &self.controller
     }
 }
 

--- a/src/runtime/src/ledger/mod.rs
+++ b/src/runtime/src/ledger/mod.rs
@@ -1,6 +1,7 @@
 //! Bounded owned turn-record storage primitives.
 
 mod capacity;
+mod pool;
 mod queue;
 mod retained;
 #[cfg(test)]
@@ -13,6 +14,10 @@ use crate::turn_record::{AccountedRecord, LedgerSequence};
 pub(crate) use capacity::{CapacityController, CapacityReservation};
 pub use capacity::{
     LedgerAllocationFailed, LedgerCapacityExceeded, LedgerPermitInvalid, RecordEstimate,
+};
+pub use pool::{
+    PooledRecordBuffer, RecordBufferCapacityExceeded, RecordBufferPool, RecordBufferPoolExhausted,
+    RecordBufferPoolStats,
 };
 pub use queue::OwnedTurnRecordQueue;
 pub use retained::{RetainedLedgerDrain, RetainedTurnLedger};

--- a/src/runtime/src/ledger/mod.rs
+++ b/src/runtime/src/ledger/mod.rs
@@ -1,0 +1,163 @@
+//! Bounded owned turn-record storage primitives.
+
+mod capacity;
+#[cfg(test)]
+mod tests;
+
+use mech_core::MResult;
+
+use crate::turn_record::{AccountedRecord, LedgerSequence};
+
+pub(crate) use capacity::{CapacityController, CapacityReservation};
+pub use capacity::{
+    LedgerAllocationFailed, LedgerCapacityExceeded, LedgerPermitInvalid, RecordEstimate,
+};
+
+/// An unused reservation for one future ledger append.
+#[derive(Debug)]
+pub struct LedgerPermit {
+    controller: CapacityController,
+    ledger_identity: u64,
+    ledger_generation: u64,
+    reservation: Option<CapacityReservation>,
+    consumed: bool,
+}
+
+impl LedgerPermit {
+    pub fn sequence(&self) -> LedgerSequence {
+        self.reservation
+            .as_ref()
+            .expect("live ledger permit reservation")
+            .sequence
+    }
+
+    pub fn reserved_records(&self) -> usize {
+        self.reservation
+            .as_ref()
+            .map_or(0, |reservation| reservation.records)
+    }
+
+    pub fn reserved_bytes(&self) -> usize {
+        self.reservation
+            .as_ref()
+            .map_or(0, |reservation| reservation.bytes)
+    }
+
+    pub fn is_consumed(&self) -> bool {
+        self.consumed
+    }
+
+    fn new(controller: CapacityController, reservation: CapacityReservation) -> Self {
+        Self {
+            ledger_identity: controller.identity(),
+            ledger_generation: controller.generation(),
+            controller,
+            reservation: Some(reservation),
+            consumed: false,
+        }
+    }
+}
+
+impl Drop for LedgerPermit {
+    fn drop(&mut self) {
+        if let Some(reservation) = self.reservation.take() {
+            self.controller.release_reserved(reservation);
+        }
+    }
+}
+
+/// An owned record bound to already-reserved ledger capacity.
+#[derive(Debug)]
+pub struct PreparedLedgerAppend<R> {
+    controller: CapacityController,
+    reservation: Option<CapacityReservation>,
+    record: Option<R>,
+}
+
+impl<R> PreparedLedgerAppend<R> {
+    pub fn sequence(&self) -> LedgerSequence {
+        self.reservation
+            .as_ref()
+            .expect("live prepared ledger append reservation")
+            .sequence
+    }
+
+    pub fn retained_bytes(&self) -> usize {
+        self.reservation
+            .as_ref()
+            .map_or(0, |reservation| reservation.bytes)
+    }
+
+    pub(crate) fn into_parts(mut self) -> (CapacityReservation, R) {
+        let reservation = self
+            .reservation
+            .take()
+            .expect("prepared append reservation consumed once");
+        let record = self
+            .record
+            .take()
+            .expect("prepared append record consumed once");
+        (reservation, record)
+    }
+}
+
+impl<R> Drop for PreparedLedgerAppend<R> {
+    fn drop(&mut self) {
+        if let Some(reservation) = self.reservation.take() {
+            self.controller.release_prepared(reservation);
+        }
+    }
+}
+
+/// Reserve, prepare, then infallibly append an owned record.
+pub trait TurnLedger<R>
+where
+    R: AccountedRecord,
+{
+    fn reserve(&self, estimate: RecordEstimate) -> MResult<LedgerPermit>;
+
+    fn prepare_append(&self, permit: LedgerPermit, record: R) -> MResult<PreparedLedgerAppend<R>>;
+
+    fn append(&mut self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence;
+}
+
+pub(crate) fn reserve(
+    controller: &CapacityController,
+    estimate: RecordEstimate,
+) -> MResult<LedgerPermit> {
+    let reservation = controller.reserve(estimate)?;
+    Ok(LedgerPermit::new(controller.clone(), reservation))
+}
+
+pub(crate) fn prepare<R: AccountedRecord>(
+    controller: &CapacityController,
+    mut permit: LedgerPermit,
+    record: R,
+) -> MResult<PreparedLedgerAppend<R>> {
+    let actual_bytes = record.retained_bytes();
+    let reservation = permit
+        .reservation
+        .take()
+        .ok_or_else(|| capacity::invalid_permit("permit reservation has already been consumed"))?;
+    let bound = controller.bind(
+        &permit.controller,
+        permit.ledger_identity,
+        permit.ledger_generation,
+        permit.consumed,
+        reservation,
+        actual_bytes,
+    );
+    let reservation = match bound {
+        Ok(reservation) => reservation,
+        Err(error) => {
+            permit.controller.release_reserved(reservation);
+            return Err(error);
+        }
+    };
+    permit.consumed = true;
+    Ok(PreparedLedgerAppend {
+        controller: controller.clone(),
+        reservation: Some(reservation),
+        record: Some(record),
+    })
+}

--- a/src/runtime/src/ledger/mod.rs
+++ b/src/runtime/src/ledger/mod.rs
@@ -11,7 +11,7 @@ use mech_core::MResult;
 
 use crate::turn_record::{AccountedRecord, LedgerSequence};
 
-pub(crate) use capacity::{CapacityController, CapacityReservation};
+pub(crate) use capacity::{CapacityController, CapacityReservation, invalid_permit};
 pub use capacity::{
     LedgerAllocationFailed, LedgerCapacityExceeded, LedgerPermitInvalid, RecordEstimate,
 };
@@ -144,10 +144,25 @@ pub(crate) fn reserve(
 
 pub(crate) fn prepare<R: AccountedRecord>(
     controller: &CapacityController,
-    mut permit: LedgerPermit,
+    permit: LedgerPermit,
     record: R,
 ) -> MResult<PreparedLedgerAppend<R>> {
     let actual_bytes = record.retained_bytes();
+    let (prepared_controller, reservation) =
+        prepare_reservation(controller, permit, 1, actual_bytes)?;
+    Ok(PreparedLedgerAppend {
+        controller: prepared_controller,
+        reservation: Some(reservation),
+        record: Some(record),
+    })
+}
+
+pub(crate) fn prepare_reservation(
+    controller: &CapacityController,
+    mut permit: LedgerPermit,
+    actual_records: usize,
+    actual_bytes: usize,
+) -> MResult<(CapacityController, CapacityReservation)> {
     let reservation = permit
         .reservation
         .take()
@@ -158,6 +173,7 @@ pub(crate) fn prepare<R: AccountedRecord>(
         permit.ledger_generation,
         permit.consumed,
         reservation,
+        actual_records,
         actual_bytes,
     );
     let reservation = match bound {
@@ -168,9 +184,5 @@ pub(crate) fn prepare<R: AccountedRecord>(
         }
     };
     permit.consumed = true;
-    Ok(PreparedLedgerAppend {
-        controller: controller.clone(),
-        reservation: Some(reservation),
-        record: Some(record),
-    })
+    Ok((controller.clone(), reservation))
 }

--- a/src/runtime/src/ledger/mod.rs
+++ b/src/runtime/src/ledger/mod.rs
@@ -84,6 +84,13 @@ pub struct PreparedLedgerAppend<R> {
 }
 
 impl<R> PreparedLedgerAppend<R> {
+    pub(crate) fn reservation(&self) -> CapacityReservation {
+        *self
+            .reservation
+            .as_ref()
+            .expect("live prepared ledger append reservation")
+    }
+
     pub fn sequence(&self) -> LedgerSequence {
         self.reservation
             .as_ref()
@@ -123,7 +130,7 @@ impl<R> Drop for PreparedLedgerAppend<R> {
 }
 
 /// Reserve, prepare, then infallibly append an owned record.
-pub trait TurnLedger<R>
+pub(crate) trait TurnLedger<R>
 where
     R: AccountedRecord,
 {
@@ -147,6 +154,7 @@ pub(crate) fn prepare<R: AccountedRecord>(
     permit: LedgerPermit,
     record: R,
 ) -> MResult<PreparedLedgerAppend<R>> {
+    record.validate_for_recording()?;
     let actual_bytes = record.retained_bytes();
     let (prepared_controller, reservation) =
         prepare_reservation(controller, permit, 1, actual_bytes)?;

--- a/src/runtime/src/ledger/pool.rs
+++ b/src/runtime/src/ledger/pool.rs
@@ -1,0 +1,319 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use mech_core::{MResult, MechError, MechErrorKind};
+
+use crate::AccountedRecord;
+
+#[derive(Debug)]
+struct PoolState {
+    available: Vec<Vec<u8>>,
+    in_use_segments: usize,
+    total_capacity: usize,
+    reuses: u64,
+    allocations: u64,
+    dropped_oversized: u64,
+}
+
+#[derive(Debug)]
+struct PoolInner {
+    max_segments: usize,
+    max_total_capacity: usize,
+    max_reusable_capacity: usize,
+    state: Mutex<PoolState>,
+}
+
+/// A bounded owner of reusable byte sections for typed turn records.
+#[derive(Clone, Debug)]
+pub struct RecordBufferPool {
+    inner: Arc<PoolInner>,
+}
+
+impl RecordBufferPool {
+    pub fn new(
+        max_segments: usize,
+        max_total_capacity: usize,
+        max_reusable_capacity: usize,
+    ) -> MResult<Self> {
+        if max_segments == 0 {
+            return Err(pool_exhausted(
+                "segment limit must allow at least one segment",
+            ));
+        }
+        if max_reusable_capacity > max_total_capacity {
+            return Err(pool_exhausted(
+                "reusable segment limit exceeds total pool capacity",
+            ));
+        }
+        let mut available = Vec::new();
+        available.try_reserve_exact(max_segments).map_err(|_| {
+            MechError::new(
+                RecordBufferPoolExhausted {
+                    reason: "failed to allocate pool segment slots",
+                },
+                None,
+            )
+        })?;
+        Ok(Self {
+            inner: Arc::new(PoolInner {
+                max_segments,
+                max_total_capacity,
+                max_reusable_capacity,
+                state: Mutex::new(PoolState {
+                    available,
+                    in_use_segments: 0,
+                    total_capacity: 0,
+                    reuses: 0,
+                    allocations: 0,
+                    dropped_oversized: 0,
+                }),
+            }),
+        })
+    }
+
+    pub fn acquire(&self, minimum_capacity: usize) -> MResult<PooledRecordBuffer> {
+        if minimum_capacity > self.inner.max_total_capacity {
+            return Err(pool_exhausted(
+                "requested segment exceeds total pool capacity",
+            ));
+        }
+        let mut state = self.lock();
+        if let Some(index) = state
+            .available
+            .iter()
+            .enumerate()
+            .filter(|(_, buffer)| buffer.capacity() >= minimum_capacity)
+            .min_by_key(|(_, buffer)| buffer.capacity())
+            .map(|(index, _)| index)
+        {
+            let mut buffer = state.available.swap_remove(index);
+            buffer.clear();
+            state.in_use_segments += 1;
+            state.reuses += 1;
+            return Ok(PooledRecordBuffer {
+                pool: Arc::clone(&self.inner),
+                buffer: Some(buffer),
+            });
+        }
+
+        let owned_segments = state
+            .available
+            .len()
+            .checked_add(state.in_use_segments)
+            .expect("bounded pool segment accounting overflow");
+        let segment_replacement_required = owned_segments >= self.inner.max_segments;
+
+        let mut buffer = Vec::new();
+        buffer
+            .try_reserve_exact(minimum_capacity)
+            .map_err(|_| pool_exhausted("failed to allocate requested record buffer capacity"))?;
+        let new_capacity = buffer.capacity();
+        let capacity_replacement_required = state
+            .total_capacity
+            .checked_add(new_capacity)
+            .is_none_or(|total| total > self.inner.max_total_capacity);
+        let replace_index = if segment_replacement_required || capacity_replacement_required {
+            state
+                .available
+                .iter()
+                .enumerate()
+                .max_by_key(|(_, buffer)| buffer.capacity())
+                .map(|(index, _)| index)
+                .ok_or_else(|| {
+                    pool_exhausted("all bounded pool segments are currently owned by records")
+                })?
+                .into()
+        } else {
+            None
+        };
+        let replaced_capacity = replace_index
+            .map(|index| state.available[index].capacity())
+            .unwrap_or(0);
+
+        let retained_capacity = state
+            .total_capacity
+            .checked_sub(replaced_capacity)
+            .expect("pool replacement capacity accounting underflow");
+        let new_total = retained_capacity
+            .checked_add(new_capacity)
+            .ok_or_else(|| pool_exhausted("pool capacity accounting overflow"))?;
+        if new_total > self.inner.max_total_capacity {
+            return Err(pool_exhausted(
+                "requested segment would exceed total pool capacity",
+            ));
+        }
+
+        if let Some(index) = replace_index {
+            let replaced = state.available.swap_remove(index);
+            drop(replaced);
+        }
+        state.total_capacity = new_total;
+        state.in_use_segments += 1;
+        state.allocations += 1;
+        Ok(PooledRecordBuffer {
+            pool: Arc::clone(&self.inner),
+            buffer: Some(buffer),
+        })
+    }
+
+    pub fn stats(&self) -> RecordBufferPoolStats {
+        let state = self.lock();
+        RecordBufferPoolStats {
+            available_segments: state.available.len(),
+            in_use_segments: state.in_use_segments,
+            total_capacity: state.total_capacity,
+            reuses: state.reuses,
+            allocations: state.allocations,
+            dropped_oversized: state.dropped_oversized,
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, PoolState> {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecordBufferPoolStats {
+    pub available_segments: usize,
+    pub in_use_segments: usize,
+    pub total_capacity: usize,
+    pub reuses: u64,
+    pub allocations: u64,
+    pub dropped_oversized: u64,
+}
+
+/// An exclusively owned pool segment. It recycles only when this owner drops.
+#[derive(Debug)]
+pub struct PooledRecordBuffer {
+    pool: Arc<PoolInner>,
+    buffer: Option<Vec<u8>>,
+}
+
+impl PooledRecordBuffer {
+    pub fn len(&self) -> usize {
+        self.buffer().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buffer().is_empty()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.buffer().capacity()
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.buffer().as_slice()
+    }
+
+    pub fn clear(&mut self) {
+        self.buffer_mut().clear();
+    }
+
+    pub fn try_extend_from_slice(&mut self, bytes: &[u8]) -> MResult<()> {
+        let buffer = self.buffer_mut();
+        let requested = buffer.len().checked_add(bytes.len()).ok_or_else(|| {
+            MechError::new(
+                RecordBufferCapacityExceeded {
+                    capacity: buffer.capacity(),
+                    requested: usize::MAX,
+                },
+                None,
+            )
+        })?;
+        if requested > buffer.capacity() {
+            return Err(MechError::new(
+                RecordBufferCapacityExceeded {
+                    capacity: buffer.capacity(),
+                    requested,
+                },
+                None,
+            ));
+        }
+        buffer.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn buffer(&self) -> &Vec<u8> {
+        self.buffer.as_ref().expect("live pooled record buffer")
+    }
+
+    fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        self.buffer.as_mut().expect("live pooled record buffer")
+    }
+}
+
+impl AccountedRecord for PooledRecordBuffer {
+    fn retained_bytes(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl Drop for PooledRecordBuffer {
+    fn drop(&mut self) {
+        let Some(mut buffer) = self.buffer.take() else {
+            return;
+        };
+        buffer.clear();
+        let capacity = buffer.capacity();
+        let mut state = self
+            .pool
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.in_use_segments = state
+            .in_use_segments
+            .checked_sub(1)
+            .expect("pool in-use segment accounting underflow");
+        if capacity > self.pool.max_reusable_capacity {
+            state.total_capacity = state
+                .total_capacity
+                .checked_sub(capacity)
+                .expect("pool oversized capacity accounting underflow");
+            state.dropped_oversized += 1;
+            return;
+        }
+        state.available.push(buffer);
+    }
+}
+
+fn pool_exhausted(reason: &'static str) -> MechError {
+    MechError::new(RecordBufferPoolExhausted { reason }, None)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordBufferPoolExhausted {
+    pub reason: &'static str,
+}
+
+impl MechErrorKind for RecordBufferPoolExhausted {
+    fn name(&self) -> &str {
+        "RecordBufferPoolExhausted"
+    }
+
+    fn message(&self) -> String {
+        format!("record buffer pool exhausted: {}", self.reason)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordBufferCapacityExceeded {
+    pub capacity: usize,
+    pub requested: usize,
+}
+
+impl MechErrorKind for RecordBufferCapacityExceeded {
+    fn name(&self) -> &str {
+        "RecordBufferCapacityExceeded"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "record buffer capacity exceeded: requested {}, capacity {}",
+            self.requested, self.capacity
+        )
+    }
+}

--- a/src/runtime/src/ledger/pool.rs
+++ b/src/runtime/src/ledger/pool.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use mech_core::{MResult, MechError, MechErrorKind};
 
-use crate::AccountedRecord;
+use crate::turn_record::AccountedRecord;
 
 #[derive(Debug)]
 struct PoolState {

--- a/src/runtime/src/ledger/queue.rs
+++ b/src/runtime/src/ledger/queue.rs
@@ -87,11 +87,11 @@ impl<R> OwnedTurnRecordQueue<R> {
         self.controller.mark_unhealthy();
     }
 
-    pub fn reserve(&self, estimate: RecordEstimate) -> MResult<LedgerPermit> {
+    pub(crate) fn reserve(&self, estimate: RecordEstimate) -> MResult<LedgerPermit> {
         reserve(&self.controller, estimate)
     }
 
-    pub fn prepare_append(
+    pub(crate) fn prepare_append(
         &self,
         permit: LedgerPermit,
         record: R,
@@ -103,16 +103,16 @@ impl<R> OwnedTurnRecordQueue<R> {
     }
 
     /// Appends a valid prepared record without allocation or a recoverable failure branch.
-    pub fn append(&self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence
+    pub(crate) fn append(&self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence
     where
         R: Send + 'static,
     {
-        let prepared_controller = prepared.controller().clone();
-        let (reservation, record) = prepared.into_parts();
+        let reservation = prepared.reservation();
         let sequence = reservation.sequence;
         let mut state = self.lock();
         self.controller
-            .commit_prepared(&prepared_controller, reservation);
+            .commit_prepared(prepared.controller(), reservation);
+        let (_, record) = prepared.into_parts();
         state.records.push_back((sequence, record));
         state.record_bytes.push_back(reservation.bytes);
         sequence

--- a/src/runtime/src/ledger/queue.rs
+++ b/src/runtime/src/ledger/queue.rs
@@ -1,0 +1,157 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use mech_core::{MResult, MechError};
+
+use crate::turn_record::{AccountedRecord, LedgerSequence};
+
+use super::{
+    CapacityController, LedgerPermit, PreparedLedgerAppend, RecordEstimate,
+    capacity::LedgerAllocationFailed, prepare, reserve,
+};
+
+#[derive(Debug)]
+struct QueueState<R> {
+    records: VecDeque<(LedgerSequence, R)>,
+    record_bytes: VecDeque<usize>,
+}
+
+/// A bounded, cloneable producer handle for cross-thread owned records.
+#[derive(Debug)]
+pub struct OwnedTurnRecordQueue<R> {
+    state: Arc<Mutex<QueueState<R>>>,
+    controller: CapacityController,
+}
+
+impl<R> Clone for OwnedTurnRecordQueue<R> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            controller: self.controller.clone(),
+        }
+    }
+}
+
+impl<R> OwnedTurnRecordQueue<R> {
+    pub fn new(max_records: usize, max_bytes: usize) -> MResult<Self> {
+        let controller = CapacityController::new(max_records, max_bytes)?;
+        let mut records = VecDeque::new();
+        records.try_reserve_exact(max_records).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "queue record slots",
+                },
+                None,
+            )
+        })?;
+        let mut record_bytes = VecDeque::new();
+        record_bytes.try_reserve_exact(max_records).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "queue accounting slots",
+                },
+                None,
+            )
+        })?;
+        let queue = Self {
+            state: Arc::new(Mutex::new(QueueState {
+                records,
+                record_bytes,
+            })),
+            controller,
+        };
+        // Initialize any platform mutex state while construction is still fallible.
+        drop(queue.lock());
+        Ok(queue)
+    }
+
+    pub fn len(&self) -> usize {
+        self.lock().records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn retained_bytes(&self) -> usize {
+        self.controller.retained().bytes
+    }
+
+    pub fn writer_is_healthy(&self) -> bool {
+        self.controller.is_healthy()
+    }
+
+    pub fn mark_writer_unhealthy(&self) {
+        self.controller.mark_unhealthy();
+    }
+
+    pub fn reserve(&self, estimate: RecordEstimate) -> MResult<LedgerPermit> {
+        reserve(&self.controller, estimate)
+    }
+
+    pub fn prepare_append(
+        &self,
+        permit: LedgerPermit,
+        record: R,
+    ) -> MResult<PreparedLedgerAppend<R>>
+    where
+        R: AccountedRecord + Send + 'static,
+    {
+        prepare(&self.controller, permit, record)
+    }
+
+    /// Appends a valid prepared record without allocation or a recoverable failure branch.
+    pub fn append(&self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence
+    where
+        R: Send + 'static,
+    {
+        let prepared_controller = prepared.controller().clone();
+        let (reservation, record) = prepared.into_parts();
+        let sequence = reservation.sequence;
+        let mut state = self.lock();
+        self.controller
+            .commit_prepared(&prepared_controller, reservation);
+        state.records.push_back((sequence, record));
+        state.record_bytes.push_back(reservation.bytes);
+        sequence
+    }
+
+    pub fn pop_front(&self) -> Option<(LedgerSequence, R)> {
+        let mut state = self.lock();
+        let entry = state.records.pop_front()?;
+        let bytes = state
+            .record_bytes
+            .pop_front()
+            .expect("queued record byte accounting entry");
+        self.controller.release_retained(1, bytes);
+        Some(entry)
+    }
+
+    pub fn drain(&self) -> Vec<(LedgerSequence, R)> {
+        let queued = self.len();
+        let mut drained = Vec::with_capacity(queued);
+        for _ in 0..queued {
+            if let Some(record) = self.pop_front() {
+                drained.push(record);
+            }
+        }
+        drained
+    }
+
+    #[cfg(test)]
+    pub(super) fn poison_mutex_for_test(&self) {
+        let state = Arc::clone(&self.state);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _guard = state.lock().unwrap();
+            panic!("poison queue mutex for recovery test");
+        }));
+    }
+
+    fn lock(&self) -> MutexGuard<'_, QueueState<R>> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}

--- a/src/runtime/src/ledger/retained.rs
+++ b/src/runtime/src/ledger/retained.rs
@@ -93,11 +93,11 @@ impl<R: AccountedRecord> TurnLedger<R> for RetainedTurnLedger<R> {
     }
 
     fn append(&mut self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence {
-        let prepared_controller = prepared.controller().clone();
-        let (reservation, record) = prepared.into_parts();
+        let reservation = prepared.reservation();
         let sequence = reservation.sequence;
         self.controller
-            .commit_prepared(&prepared_controller, reservation);
+            .commit_prepared(prepared.controller(), reservation);
+        let (_, record) = prepared.into_parts();
         self.records.push_back((sequence, record));
         self.record_bytes.push_back(reservation.bytes);
         sequence

--- a/src/runtime/src/ledger/retained.rs
+++ b/src/runtime/src/ledger/retained.rs
@@ -1,0 +1,130 @@
+use std::collections::VecDeque;
+
+use mech_core::{MResult, MechError};
+
+use crate::turn_record::{AccountedRecord, LedgerSequence};
+
+use super::{
+    CapacityController, LedgerPermit, PreparedLedgerAppend, RecordEstimate, TurnLedger,
+    capacity::LedgerAllocationFailed, prepare, reserve,
+};
+
+/// A bounded FIFO ledger that retains owned records until explicitly drained.
+#[derive(Debug)]
+pub struct RetainedTurnLedger<R> {
+    records: VecDeque<(LedgerSequence, R)>,
+    record_bytes: VecDeque<usize>,
+    controller: CapacityController,
+}
+
+impl<R> RetainedTurnLedger<R> {
+    pub fn new(max_records: usize, max_bytes: usize) -> MResult<Self> {
+        let controller = CapacityController::new(max_records, max_bytes)?;
+        let mut records = VecDeque::new();
+        records.try_reserve_exact(max_records).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "record slots",
+                },
+                None,
+            )
+        })?;
+        let mut record_bytes = VecDeque::new();
+        record_bytes.try_reserve_exact(max_records).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "record accounting slots",
+                },
+                None,
+            )
+        })?;
+        Ok(Self {
+            records,
+            record_bytes,
+            controller,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub fn retained_bytes(&self) -> usize {
+        self.controller.retained().bytes
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (LedgerSequence, &R)> {
+        self.records
+            .iter()
+            .map(|(sequence, record)| (*sequence, record))
+    }
+
+    pub fn pop_front(&mut self) -> Option<(LedgerSequence, R)> {
+        let entry = self.records.pop_front()?;
+        let bytes = self
+            .record_bytes
+            .pop_front()
+            .expect("retained record byte accounting entry");
+        self.controller.release_retained(1, bytes);
+        Some(entry)
+    }
+
+    pub fn drain(&mut self) -> RetainedLedgerDrain<'_, R> {
+        RetainedLedgerDrain { ledger: self }
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_sequence_for_test(&self, next: core::num::NonZeroU64) {
+        self.controller.set_sequence_for_test(next);
+    }
+}
+
+impl<R: AccountedRecord> TurnLedger<R> for RetainedTurnLedger<R> {
+    fn reserve(&self, estimate: RecordEstimate) -> MResult<LedgerPermit> {
+        reserve(&self.controller, estimate)
+    }
+
+    fn prepare_append(&self, permit: LedgerPermit, record: R) -> MResult<PreparedLedgerAppend<R>> {
+        prepare(&self.controller, permit, record)
+    }
+
+    fn append(&mut self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence {
+        let prepared_controller = prepared.controller().clone();
+        let (reservation, record) = prepared.into_parts();
+        let sequence = reservation.sequence;
+        self.controller
+            .commit_prepared(&prepared_controller, reservation);
+        self.records.push_back((sequence, record));
+        self.record_bytes.push_back(reservation.bytes);
+        sequence
+    }
+}
+
+pub struct RetainedLedgerDrain<'a, R> {
+    ledger: &'a mut RetainedTurnLedger<R>,
+}
+
+impl<R> Iterator for RetainedLedgerDrain<'_, R> {
+    type Item = (LedgerSequence, R);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ledger.pop_front()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.ledger.len();
+        (len, Some(len))
+    }
+}
+
+impl<R> ExactSizeIterator for RetainedLedgerDrain<'_, R> {}
+
+impl<R> Drop for RetainedLedgerDrain<'_, R> {
+    fn drop(&mut self) {
+        while self.ledger.pop_front().is_some() {}
+    }
+}

--- a/src/runtime/src/ledger/tests.rs
+++ b/src/runtime/src/ledger/tests.rs
@@ -1,0 +1,125 @@
+use core::num::NonZeroU64;
+
+use super::*;
+
+fn capacity(records: usize, bytes: usize) -> CapacityController {
+    CapacityController::new(records, bytes).unwrap()
+}
+
+#[test]
+fn reservation_assigns_a_sequence_and_drop_returns_capacity() {
+    let controller = capacity(1, 8);
+    let permit = reserve(
+        &controller,
+        RecordEstimate {
+            records: 1,
+            bytes: 8,
+        },
+    )
+    .unwrap();
+    assert_eq!(permit.sequence().get(), 1);
+    assert_eq!(controller.reserved().records, 1);
+    drop(permit);
+    assert_eq!(controller.reserved(), RecordEstimate::default());
+}
+
+#[test]
+fn prepare_binds_actual_bytes_and_returns_overestimate() {
+    let controller = capacity(2, 32);
+    let permit = reserve(
+        &controller,
+        RecordEstimate {
+            records: 2,
+            bytes: 32,
+        },
+    )
+    .unwrap();
+    let prepared = prepare(&controller, permit, vec![1_u8; 8]).unwrap();
+    assert_eq!(prepared.retained_bytes(), 8);
+    assert_eq!(controller.reserved().records, 1);
+    assert_eq!(controller.reserved().bytes, 8);
+    drop(prepared);
+    assert_eq!(controller.reserved(), RecordEstimate::default());
+}
+
+#[test]
+fn underestimated_and_wrong_ledger_permits_release_capacity() {
+    let first = capacity(1, 8);
+    let second = capacity(1, 8);
+    let underestimated = reserve(
+        &first,
+        RecordEstimate {
+            records: 1,
+            bytes: 4,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        prepare(&first, underestimated, vec![0_u8; 8])
+            .unwrap_err()
+            .kind_name(),
+        "LedgerCapacityExceeded"
+    );
+    assert_eq!(first.reserved(), RecordEstimate::default());
+
+    let wrong_ledger = reserve(
+        &first,
+        RecordEstimate {
+            records: 1,
+            bytes: 8,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        prepare(&second, wrong_ledger, vec![0_u8; 8])
+            .unwrap_err()
+            .kind_name(),
+        "LedgerPermitInvalid"
+    );
+    assert_eq!(first.reserved(), RecordEstimate::default());
+}
+
+#[test]
+fn generation_and_sequence_exhaustion_are_checked() {
+    let controller = capacity(1, 8);
+    let stale = reserve(
+        &controller,
+        RecordEstimate {
+            records: 1,
+            bytes: 8,
+        },
+    )
+    .unwrap();
+    controller.force_generation_for_test(NonZeroU64::new(2).unwrap());
+    assert_eq!(
+        prepare(&controller, stale, vec![0_u8; 8])
+            .unwrap_err()
+            .kind_name(),
+        "LedgerPermitInvalid"
+    );
+
+    let exhausted = capacity(1, 8);
+    exhausted.set_sequence_for_test(NonZeroU64::MAX);
+    let last = reserve(
+        &exhausted,
+        RecordEstimate {
+            records: 1,
+            bytes: 8,
+        },
+    )
+    .unwrap();
+    assert_eq!(last.sequence().get(), u64::MAX);
+    drop(last);
+    assert_eq!(
+        reserve(
+            &exhausted,
+            RecordEstimate {
+                records: 1,
+                bytes: 8,
+            },
+        )
+        .unwrap_err()
+        .kind_name(),
+        "SequenceExhausted"
+    );
+}

--- a/src/runtime/src/ledger/tests.rs
+++ b/src/runtime/src/ledger/tests.rs
@@ -228,3 +228,67 @@ fn prepared_queue_append_survives_health_change_and_poison_recovery() {
     queue.append(prepared);
     assert_eq!(queue.len(), 1);
 }
+
+#[test]
+fn pool_segments_are_exclusive_bounded_and_reused() {
+    let pool = RecordBufferPool::new(1, 8, 8).unwrap();
+    let mut segment = pool.acquire(8).unwrap();
+    segment.try_extend_from_slice(&[1, 2, 3, 4]).unwrap();
+    assert_eq!(segment.as_slice(), &[1, 2, 3, 4]);
+    assert_eq!(
+        pool.acquire(1).unwrap_err().kind_name(),
+        "RecordBufferPoolExhausted"
+    );
+    drop(segment);
+    let recycled = pool.acquire(4).unwrap();
+    assert!(recycled.is_empty());
+    assert_eq!(pool.stats().allocations, 1);
+    assert_eq!(pool.stats().reuses, 1);
+}
+
+#[test]
+fn oversized_pool_segments_are_dropped_instead_of_retained() {
+    let pool = RecordBufferPool::new(1, 16, 4).unwrap();
+    let segment = pool.acquire(8).unwrap();
+    assert_eq!(pool.stats().total_capacity, 8);
+    drop(segment);
+    assert_eq!(pool.stats().available_segments, 0);
+    assert_eq!(pool.stats().total_capacity, 0);
+    assert_eq!(pool.stats().dropped_oversized, 1);
+}
+
+#[test]
+fn pool_replaces_the_largest_undersized_available_segment() {
+    let pool = RecordBufferPool::new(2, 9, 9).unwrap();
+    let small = pool.acquire(2).unwrap();
+    let large = pool.acquire(6).unwrap();
+    drop(small);
+    drop(large);
+
+    let replacement = pool.acquire(7).unwrap();
+    assert_eq!(replacement.capacity(), 7);
+    assert_eq!(pool.stats().total_capacity, 9);
+}
+
+#[test]
+fn pool_replaces_an_available_segment_when_bytes_are_exhausted_first() {
+    let pool = RecordBufferPool::new(3, 9, 9).unwrap();
+    let available = pool.acquire(6).unwrap();
+    drop(available);
+
+    let replacement = pool.acquire(7).unwrap();
+    assert_eq!(replacement.capacity(), 7);
+    assert_eq!(pool.stats().total_capacity, 7);
+}
+
+#[test]
+fn pool_fill_never_grows_a_segment_implicitly() {
+    let pool = RecordBufferPool::new(1, 4, 4).unwrap();
+    let mut segment = pool.acquire(4).unwrap();
+    segment.try_extend_from_slice(&[1, 2, 3, 4]).unwrap();
+    assert_eq!(
+        segment.try_extend_from_slice(&[5]).unwrap_err().kind_name(),
+        "RecordBufferCapacityExceeded"
+    );
+    assert_eq!(segment.capacity(), 4);
+}

--- a/src/runtime/src/ledger/tests.rs
+++ b/src/runtime/src/ledger/tests.rs
@@ -1,4 +1,5 @@
 use core::num::NonZeroU64;
+use std::sync::{Arc, Barrier};
 
 use super::*;
 
@@ -227,6 +228,254 @@ fn prepared_queue_append_survives_health_change_and_poison_recovery() {
     queue.poison_mutex_for_test();
     queue.append(prepared);
     assert_eq!(queue.len(), 1);
+}
+
+#[test]
+fn multiple_unused_permits_are_allowed_but_only_one_append_may_be_prepared() {
+    let mut ledger = RetainedTurnLedger::new(2, 8).unwrap();
+    let first = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let second = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    assert_eq!(first.sequence().get(), 1);
+    assert_eq!(second.sequence().get(), 2);
+
+    let prepared_first = ledger.prepare_append(first, boxed(4)).unwrap();
+    let error = ledger.prepare_append(second, boxed(4)).unwrap_err();
+    assert_eq!(error.kind_name(), "LedgerPermitInvalid");
+    assert_eq!(ledger.append(prepared_first).get(), 1);
+    assert_eq!(
+        ledger
+            .iter()
+            .map(|(sequence, _)| sequence.get())
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+}
+
+#[test]
+fn wrong_ledger_preparation_is_rejected_before_append() {
+    let first = RetainedTurnLedger::<Box<[u8]>>::new(1, 4).unwrap();
+    let second = RetainedTurnLedger::<Box<[u8]>>::new(1, 4).unwrap();
+    let permit = first
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+
+    assert_eq!(
+        second
+            .prepare_append(permit, boxed(4))
+            .unwrap_err()
+            .kind_name(),
+        "LedgerPermitInvalid"
+    );
+    assert!(
+        first
+            .reserve(RecordEstimate {
+                records: 1,
+                bytes: 4,
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn invalid_owned_turn_record_is_rejected_during_preparation() {
+    let ledger = RetainedTurnLedger::new(1, 4).unwrap();
+    let permit = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let invalid = crate::turn_record::OwnedTurnRecord {
+        header: crate::turn_record::TurnRecordHeader {
+            turn_id: crate::turn_record::TurnId::new(1).unwrap(),
+            transaction_id: crate::TransactionId::ZERO,
+            input_range: None,
+            status: crate::turn_record::TurnRecordStatus::Accepted,
+            failure: None,
+        },
+        body: boxed(4),
+    };
+
+    assert_eq!(
+        ledger
+            .prepare_append(permit, invalid)
+            .unwrap_err()
+            .kind_name(),
+        "InvalidTurnRecord"
+    );
+    assert!(ledger.is_empty());
+    assert!(
+        ledger
+            .reserve(RecordEstimate {
+                records: 1,
+                bytes: 4,
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn internal_wrong_destination_assertion_preserves_origin_capacity() {
+    let first = OwnedTurnRecordQueue::new(1, 4).unwrap();
+    let second = OwnedTurnRecordQueue::new(1, 4).unwrap();
+    let permit = first
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = first.prepare_append(permit, boxed(4)).unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        second.append(prepared);
+    }));
+    assert!(result.is_err());
+    assert!(first.is_empty());
+    assert!(second.is_empty());
+    assert!(
+        first
+            .reserve(RecordEstimate {
+                records: 1,
+                bytes: 4,
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn dropping_prepared_record_releases_lease_and_bound_capacity() {
+    let mut ledger = RetainedTurnLedger::new(1, 4).unwrap();
+    let permit = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = ledger.prepare_append(permit, boxed(4)).unwrap();
+    drop(prepared);
+
+    let retry = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = ledger.prepare_append(retry, boxed(4)).unwrap();
+    assert_eq!(ledger.append(prepared).get(), 2);
+}
+
+#[test]
+fn older_and_duplicate_sequences_are_rejected_after_drain_but_newer_appends() {
+    let mut ledger = RetainedTurnLedger::new(2, 8).unwrap();
+    let older = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let newer = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = ledger.prepare_append(newer, boxed(4)).unwrap();
+    assert_eq!(ledger.append(prepared).get(), 2);
+    assert_eq!(ledger.drain().count(), 1);
+
+    assert_eq!(
+        ledger
+            .prepare_append(older, boxed(4))
+            .unwrap_err()
+            .kind_name(),
+        "LedgerPermitInvalid"
+    );
+
+    ledger.set_sequence_for_test(NonZeroU64::new(2).unwrap());
+    let duplicate = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    assert_eq!(
+        ledger
+            .prepare_append(duplicate, boxed(4))
+            .unwrap_err()
+            .kind_name(),
+        "LedgerPermitInvalid"
+    );
+
+    let next = ledger
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = ledger.prepare_append(next, boxed(4)).unwrap();
+    assert_eq!(ledger.append(prepared).get(), 3);
+}
+
+#[test]
+fn cloned_queue_producers_race_for_one_preparation_lease() {
+    let queue = OwnedTurnRecordQueue::new(2, 8).unwrap();
+    let first = queue
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let second = queue
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let start = Arc::new(Barrier::new(2));
+    let finish = Arc::new(Barrier::new(2));
+
+    let handles = [(queue.clone(), first), (queue.clone(), second)]
+        .into_iter()
+        .map(|(producer, permit)| {
+            let start = Arc::clone(&start);
+            let finish = Arc::clone(&finish);
+            std::thread::spawn(move || {
+                start.wait();
+                let prepared = producer.prepare_append(permit, boxed(4));
+                finish.wait();
+                prepared.is_ok()
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let successes = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .filter(|success| *success)
+        .count();
+    assert_eq!(successes, 1);
+    assert!(queue.is_empty());
+    assert!(
+        queue
+            .reserve(RecordEstimate {
+                records: 2,
+                bytes: 8,
+            })
+            .is_ok()
+    );
 }
 
 #[test]

--- a/src/runtime/src/ledger/tests.rs
+++ b/src/runtime/src/ledger/tests.rs
@@ -123,3 +123,108 @@ fn generation_and_sequence_exhaustion_are_checked() {
         "SequenceExhausted"
     );
 }
+
+fn boxed(bytes: usize) -> Box<[u8]> {
+    vec![0_u8; bytes].into_boxed_slice()
+}
+
+fn append_retained(ledger: &mut RetainedTurnLedger<Box<[u8]>>, bytes: usize) -> LedgerSequence {
+    let permit = ledger
+        .reserve(RecordEstimate { records: 1, bytes })
+        .unwrap();
+    let prepared = ledger.prepare_append(permit, boxed(bytes)).unwrap();
+    ledger.append(prepared)
+}
+
+#[test]
+fn retained_ledger_is_fifo_exact_and_never_silently_evicts() {
+    let mut ledger = RetainedTurnLedger::new(2, 5).unwrap();
+    let first = append_retained(&mut ledger, 2);
+    let second = append_retained(&mut ledger, 3);
+    assert_eq!(ledger.len(), 2);
+    assert_eq!(ledger.retained_bytes(), 5);
+    assert_eq!(
+        ledger
+            .reserve(RecordEstimate {
+                records: 1,
+                bytes: 1,
+            })
+            .unwrap_err()
+            .kind_name(),
+        "LedgerCapacityExceeded"
+    );
+    assert_eq!(
+        ledger.iter().map(|(id, _)| id).collect::<Vec<_>>(),
+        vec![first, second]
+    );
+    assert_eq!(ledger.pop_front().unwrap().0, first);
+    assert_eq!(ledger.retained_bytes(), 3);
+    let drained = ledger.drain().collect::<Vec<_>>();
+    assert_eq!(drained[0].0, second);
+    assert!(ledger.is_empty());
+    assert_eq!(ledger.retained_bytes(), 0);
+    assert!(
+        ledger
+            .reserve(RecordEstimate {
+                records: 2,
+                bytes: 5,
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn queued_record_crosses_threads_and_drain_returns_capacity() {
+    let queue = OwnedTurnRecordQueue::new(2, 8).unwrap();
+    let permit = queue
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = queue.prepare_append(permit, boxed(4)).unwrap();
+    let sequence = queue.append(prepared);
+
+    let consumer = queue.clone();
+    let drained = std::thread::spawn(move || consumer.drain()).join().unwrap();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].0, sequence);
+    assert_eq!(&*drained[0].1, &[0_u8; 4]);
+    assert!(queue.is_empty());
+    assert_eq!(queue.retained_bytes(), 0);
+    assert!(
+        queue
+            .reserve(RecordEstimate {
+                records: 2,
+                bytes: 8,
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn prepared_queue_append_survives_health_change_and_poison_recovery() {
+    let queue = OwnedTurnRecordQueue::new(1, 4).unwrap();
+    let permit = queue
+        .reserve(RecordEstimate {
+            records: 1,
+            bytes: 4,
+        })
+        .unwrap();
+    let prepared = queue.prepare_append(permit, boxed(4)).unwrap();
+    queue.mark_writer_unhealthy();
+    assert!(!queue.writer_is_healthy());
+    assert_eq!(
+        queue
+            .reserve(RecordEstimate {
+                records: 1,
+                bytes: 1,
+            })
+            .unwrap_err()
+            .kind_name(),
+        "LedgerPermitInvalid"
+    );
+    queue.poison_mutex_for_test();
+    queue.append(prepared);
+    assert_eq!(queue.len(), 1);
+}

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -10,6 +10,8 @@ pub mod input;
 #[cfg(feature = "runtime")]
 pub mod ledger;
 pub mod operation;
+#[cfg(feature = "runtime")]
+pub mod outbox;
 mod resource;
 #[cfg(feature = "runtime")]
 mod snapshot;
@@ -55,6 +57,8 @@ pub use self::input::*;
 #[cfg(feature = "runtime")]
 pub use self::ledger::*;
 pub use self::operation::*;
+#[cfg(feature = "runtime")]
+pub use self::outbox::*;
 pub use self::resource::*;
 #[cfg(feature = "runtime")]
 pub use self::snapshot::*;

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -8,10 +8,10 @@ pub mod id;
 #[cfg(feature = "runtime")]
 pub mod input;
 #[cfg(feature = "runtime")]
-pub mod ledger;
+mod ledger;
 pub mod operation;
 #[cfg(feature = "runtime")]
-pub mod outbox;
+mod outbox;
 mod resource;
 #[cfg(feature = "runtime")]
 mod snapshot;
@@ -44,7 +44,7 @@ pub mod store;
 #[cfg(feature = "runtime")]
 pub mod transaction;
 #[cfg(feature = "runtime")]
-pub mod turn_record;
+mod turn_record;
 #[cfg(all(feature = "watcher", feature = "source"))]
 mod workspace;
 
@@ -54,11 +54,7 @@ pub use self::extension::{RuntimeExtensionPanicked, RuntimeStoreCommitIndetermin
 pub use self::id::*;
 #[cfg(feature = "runtime")]
 pub use self::input::*;
-#[cfg(feature = "runtime")]
-pub use self::ledger::*;
 pub use self::operation::*;
-#[cfg(feature = "runtime")]
-pub use self::outbox::*;
 pub use self::resource::*;
 #[cfg(feature = "runtime")]
 pub use self::snapshot::*;
@@ -88,10 +84,122 @@ pub use self::service::*;
 pub use self::store::*;
 #[cfg(feature = "runtime")]
 pub use self::transaction::*;
-#[cfg(feature = "runtime")]
-pub use self::turn_record::*;
 #[cfg(all(feature = "watcher", feature = "source"))]
 pub use self::workspace::*;
+
+/// Provisional Gate A recording primitives for controlled benchmarks only.
+///
+/// This facade is intentionally hidden behind a non-default probe feature. The
+/// normal runtime API does not expose these types while the canonical receipt,
+/// value, slot, schema, and epoch model is still under design.
+#[doc(hidden)]
+#[cfg(all(feature = "runtime", feature = "runtime_bench_probes"))]
+pub mod __gate_a_recording {
+    use mech_core::MResult;
+
+    pub use crate::ledger::{
+        LedgerPermit, OwnedTurnRecordQueue, RecordBufferPool, RecordEstimate, RetainedTurnLedger,
+    };
+    pub use crate::outbox::{
+        OutboxDeliveryPolicy, OutboxEffectId, OutboxPermit, OwnedEffectIntent, RetainedEffectOutbox,
+    };
+    pub use crate::turn_record::{AccountedRecord, LedgerSequence, TurnId};
+
+    use crate::{
+        ledger::{PreparedLedgerAppend, TurnLedger},
+        outbox::PreparedOutboxBatch,
+    };
+
+    /// A prepared retained-ledger append bound to its originating destination.
+    #[must_use = "prepared records must be appended or dropped"]
+    pub struct PreparedRetainedAppend<'a, R: AccountedRecord> {
+        ledger: &'a mut RetainedTurnLedger<R>,
+        prepared: PreparedLedgerAppend<R>,
+    }
+
+    impl<R: AccountedRecord> PreparedRetainedAppend<'_, R> {
+        pub fn append(self) -> LedgerSequence {
+            TurnLedger::append(self.ledger, self.prepared)
+        }
+    }
+
+    pub fn reserve_retained<R: AccountedRecord>(
+        ledger: &RetainedTurnLedger<R>,
+        estimate: RecordEstimate,
+    ) -> MResult<LedgerPermit> {
+        TurnLedger::reserve(ledger, estimate)
+    }
+
+    pub fn prepare_retained<'a, R: AccountedRecord>(
+        ledger: &'a mut RetainedTurnLedger<R>,
+        permit: LedgerPermit,
+        record: R,
+    ) -> MResult<PreparedRetainedAppend<'a, R>> {
+        let prepared = TurnLedger::prepare_append(ledger, permit, record)?;
+        Ok(PreparedRetainedAppend { ledger, prepared })
+    }
+
+    /// A prepared queue append that publishes only to its originating queue.
+    #[must_use = "prepared records must be appended or dropped"]
+    pub struct PreparedQueueAppend<R> {
+        queue: OwnedTurnRecordQueue<R>,
+        prepared: PreparedLedgerAppend<R>,
+    }
+
+    impl<R: Send + 'static> PreparedQueueAppend<R> {
+        pub fn append(self) -> LedgerSequence {
+            self.queue.append(self.prepared)
+        }
+    }
+
+    pub fn reserve_queue<R>(
+        queue: &OwnedTurnRecordQueue<R>,
+        estimate: RecordEstimate,
+    ) -> MResult<LedgerPermit> {
+        queue.reserve(estimate)
+    }
+
+    pub fn prepare_queue<R: AccountedRecord + Send + 'static>(
+        queue: &OwnedTurnRecordQueue<R>,
+        permit: LedgerPermit,
+        record: R,
+    ) -> MResult<PreparedQueueAppend<R>> {
+        let prepared = queue.prepare_append(permit, record)?;
+        Ok(PreparedQueueAppend {
+            queue: queue.clone(),
+            prepared,
+        })
+    }
+
+    /// A prepared effect batch bound to its originating outbox.
+    #[must_use = "prepared effect batches must be appended or dropped"]
+    pub struct PreparedEffectBatch<'a, P> {
+        outbox: &'a mut RetainedEffectOutbox<P>,
+        prepared: PreparedOutboxBatch<P>,
+    }
+
+    impl<P> PreparedEffectBatch<'_, P> {
+        pub fn append(self) {
+            self.outbox.append(self.prepared);
+        }
+    }
+
+    pub fn reserve_outbox<P>(
+        outbox: &RetainedEffectOutbox<P>,
+        estimate: RecordEstimate,
+    ) -> MResult<OutboxPermit> {
+        outbox.reserve(estimate)
+    }
+
+    pub fn prepare_outbox<'a, P: AccountedRecord + Send + 'static>(
+        outbox: &'a mut RetainedEffectOutbox<P>,
+        permit: OutboxPermit,
+        effects: Vec<OwnedEffectIntent<P>>,
+    ) -> MResult<PreparedEffectBatch<'a, P>> {
+        let prepared = outbox.prepare_batch(permit, effects)?;
+        Ok(PreparedEffectBatch { outbox, prepared })
+    }
+}
 
 #[doc(hidden)]
 #[cfg(feature = "native-link")]

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -7,6 +7,8 @@ mod extension;
 pub mod id;
 #[cfg(feature = "runtime")]
 pub mod input;
+#[cfg(feature = "runtime")]
+pub mod ledger;
 pub mod operation;
 mod resource;
 #[cfg(feature = "runtime")]
@@ -50,6 +52,8 @@ pub use self::extension::{RuntimeExtensionPanicked, RuntimeStoreCommitIndetermin
 pub use self::id::*;
 #[cfg(feature = "runtime")]
 pub use self::input::*;
+#[cfg(feature = "runtime")]
+pub use self::ledger::*;
 pub use self::operation::*;
 pub use self::resource::*;
 #[cfg(feature = "runtime")]

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -39,6 +39,8 @@ pub mod service;
 pub mod store;
 #[cfg(feature = "runtime")]
 pub mod transaction;
+#[cfg(feature = "runtime")]
+pub mod turn_record;
 #[cfg(all(feature = "watcher", feature = "source"))]
 mod workspace;
 
@@ -78,6 +80,8 @@ pub use self::service::*;
 pub use self::store::*;
 #[cfg(feature = "runtime")]
 pub use self::transaction::*;
+#[cfg(feature = "runtime")]
+pub use self::turn_record::*;
 #[cfg(all(feature = "watcher", feature = "source"))]
 pub use self::workspace::*;
 

--- a/src/runtime/src/outbox/mod.rs
+++ b/src/runtime/src/outbox/mod.rs
@@ -8,7 +8,10 @@ use mech_core::{MResult, MechError, MechErrorKind};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{AccountedRecord, TurnId};
+use crate::{
+    ledger::LedgerPermit,
+    turn_record::{AccountedRecord, TurnId},
+};
 
 pub use retained::{PreparedOutboxBatch, RetainedEffectOutbox};
 
@@ -74,6 +77,10 @@ impl<P: AccountedRecord> OwnedEffectIntent<P> {
 }
 
 impl<P: AccountedRecord> AccountedRecord for OwnedEffectIntent<P> {
+    fn validate_for_recording(&self) -> MResult<()> {
+        self.validate()
+    }
+
     fn retained_bytes(&self) -> usize {
         self.accounted_bytes()
             .expect("validated owned effect byte accounting")
@@ -82,20 +89,18 @@ impl<P: AccountedRecord> AccountedRecord for OwnedEffectIntent<P> {
 
 #[derive(Debug)]
 pub struct OutboxPermit {
-    pub(crate) inner: Option<crate::LedgerPermit>,
+    pub(crate) inner: Option<LedgerPermit>,
 }
 
 impl OutboxPermit {
     pub fn reserved_effects(&self) -> usize {
         self.inner
             .as_ref()
-            .map_or(0, crate::LedgerPermit::reserved_records)
+            .map_or(0, LedgerPermit::reserved_records)
     }
 
     pub fn reserved_bytes(&self) -> usize {
-        self.inner
-            .as_ref()
-            .map_or(0, crate::LedgerPermit::reserved_bytes)
+        self.inner.as_ref().map_or(0, LedgerPermit::reserved_bytes)
     }
 }
 

--- a/src/runtime/src/outbox/mod.rs
+++ b/src/runtime/src/outbox/mod.rs
@@ -1,0 +1,160 @@
+//! Bounded owned effect intents prepared before turn publication.
+
+mod retained;
+#[cfg(test)]
+mod tests;
+
+use mech_core::{MResult, MechError, MechErrorKind};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::{AccountedRecord, TurnId};
+
+pub use retained::{PreparedOutboxBatch, RetainedEffectOutbox};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OutboxEffectId {
+    pub turn_id: TurnId,
+    pub ordinal: u32,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum OutboxDeliveryPolicy {
+    #[default]
+    AtLeastOnce,
+    ProviderTransactional,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedEffectIntent<P> {
+    pub id: OutboxEffectId,
+    pub operation: String,
+    pub target: String,
+    pub payload: P,
+    pub idempotency_key: String,
+    pub delivery: OutboxDeliveryPolicy,
+}
+
+impl<P: AccountedRecord> OwnedEffectIntent<P> {
+    pub fn validate(&self) -> MResult<()> {
+        self.validated_retained_bytes().map(|_| ())
+    }
+
+    pub(super) fn validated_retained_bytes(&self) -> MResult<usize> {
+        if self.operation.is_empty() {
+            return invalid_effect_intent("operation", "operation must not be empty");
+        }
+        if self.target.is_empty() {
+            return invalid_effect_intent("target", "target must not be empty");
+        }
+        if self.idempotency_key.is_empty() {
+            return invalid_effect_intent("idempotency_key", "idempotency key must not be empty");
+        }
+        self.accounted_bytes().ok_or_else(|| {
+            MechError::new(
+                InvalidEffectIntent {
+                    field: "effect",
+                    reason: "owned effect byte accounting overflowed",
+                },
+                None,
+            )
+        })
+    }
+
+    fn accounted_bytes(&self) -> Option<usize> {
+        self.operation
+            .capacity()
+            .checked_add(self.target.capacity())?
+            .checked_add(self.idempotency_key.capacity())?
+            .checked_add(self.payload.retained_bytes())
+    }
+}
+
+impl<P: AccountedRecord> AccountedRecord for OwnedEffectIntent<P> {
+    fn retained_bytes(&self) -> usize {
+        self.accounted_bytes()
+            .expect("validated owned effect byte accounting")
+    }
+}
+
+#[derive(Debug)]
+pub struct OutboxPermit {
+    pub(crate) inner: Option<crate::LedgerPermit>,
+}
+
+impl OutboxPermit {
+    pub fn reserved_effects(&self) -> usize {
+        self.inner
+            .as_ref()
+            .map_or(0, crate::LedgerPermit::reserved_records)
+    }
+
+    pub fn reserved_bytes(&self) -> usize {
+        self.inner
+            .as_ref()
+            .map_or(0, crate::LedgerPermit::reserved_bytes)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DuplicateOutboxEffectId {
+    pub id: OutboxEffectId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidOutboxEffectOrder {
+    pub previous: OutboxEffectId,
+    pub next: OutboxEffectId,
+}
+
+impl MechErrorKind for InvalidOutboxEffectOrder {
+    fn name(&self) -> &str {
+        "InvalidOutboxEffectOrder"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "outbox effect {:?} must follow retained effect {:?}",
+            self.next, self.previous
+        )
+    }
+}
+
+impl MechErrorKind for DuplicateOutboxEffectId {
+    fn name(&self) -> &str {
+        "DuplicateOutboxEffectId"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "duplicate outbox effect ID for turn {} ordinal {}",
+            self.id.turn_id, self.id.ordinal
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidEffectIntent {
+    pub field: &'static str,
+    pub reason: &'static str,
+}
+
+impl MechErrorKind for InvalidEffectIntent {
+    fn name(&self) -> &str {
+        "InvalidEffectIntent"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "invalid owned effect field `{}`: {}",
+            self.field, self.reason
+        )
+    }
+}
+
+fn invalid_effect_intent<T>(field: &'static str, reason: &'static str) -> MResult<T> {
+    Err(MechError::new(InvalidEffectIntent { field, reason }, None))
+}

--- a/src/runtime/src/outbox/retained.rs
+++ b/src/runtime/src/outbox/retained.rs
@@ -1,0 +1,209 @@
+use std::collections::VecDeque;
+
+use mech_core::{MResult, MechError};
+
+use crate::{
+    ledger::{
+        CapacityController, CapacityReservation, LedgerAllocationFailed, RecordEstimate,
+        invalid_permit, prepare_reservation, reserve,
+    },
+    turn_record::AccountedRecord,
+};
+
+use super::{
+    DuplicateOutboxEffectId, InvalidOutboxEffectOrder, OutboxEffectId, OutboxPermit,
+    OwnedEffectIntent,
+};
+
+#[derive(Debug)]
+pub struct PreparedOutboxBatch<P> {
+    controller: CapacityController,
+    reservation: Option<CapacityReservation>,
+    effects: Option<Vec<(usize, OwnedEffectIntent<P>)>>,
+}
+
+impl<P> PreparedOutboxBatch<P> {
+    pub fn len(&self) -> usize {
+        self.effects.as_ref().map_or(0, Vec::len)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn into_parts(mut self) -> (CapacityReservation, Vec<(usize, OwnedEffectIntent<P>)>) {
+        let reservation = self
+            .reservation
+            .take()
+            .expect("prepared outbox reservation consumed once");
+        let effects = self
+            .effects
+            .take()
+            .expect("prepared outbox effects consumed once");
+        (reservation, effects)
+    }
+}
+
+impl<P> Drop for PreparedOutboxBatch<P> {
+    fn drop(&mut self) {
+        if let Some(reservation) = self.reservation.take() {
+            self.controller.release_prepared(reservation);
+        }
+    }
+}
+
+/// A bounded FIFO outbox retaining effect intents in deterministic ID order.
+#[derive(Debug)]
+pub struct RetainedEffectOutbox<P> {
+    effects: VecDeque<OwnedEffectIntent<P>>,
+    effect_bytes: VecDeque<usize>,
+    controller: CapacityController,
+    last_appended_id: Option<OutboxEffectId>,
+}
+
+impl<P> RetainedEffectOutbox<P> {
+    pub fn new(max_effects: usize, max_bytes: usize) -> MResult<Self> {
+        let controller = CapacityController::new(max_effects, max_bytes)?;
+        let mut effects = VecDeque::new();
+        effects.try_reserve_exact(max_effects).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "outbox effect slots",
+                },
+                None,
+            )
+        })?;
+        let mut effect_bytes = VecDeque::new();
+        effect_bytes.try_reserve_exact(max_effects).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "outbox accounting slots",
+                },
+                None,
+            )
+        })?;
+        Ok(Self {
+            effects,
+            effect_bytes,
+            controller,
+            last_appended_id: None,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.effects.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.effects.is_empty()
+    }
+
+    pub fn retained_bytes(&self) -> usize {
+        self.controller.retained().bytes
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &OwnedEffectIntent<P>> {
+        self.effects.iter()
+    }
+
+    pub fn reserve(&self, estimate: RecordEstimate) -> MResult<OutboxPermit> {
+        Ok(OutboxPermit {
+            inner: Some(reserve(&self.controller, estimate)?),
+        })
+    }
+
+    pub fn prepare_batch(
+        &self,
+        mut permit: OutboxPermit,
+        mut effects: Vec<OwnedEffectIntent<P>>,
+    ) -> MResult<PreparedOutboxBatch<P>>
+    where
+        P: AccountedRecord + Send + 'static,
+    {
+        effects.sort_unstable_by_key(|effect| effect.id);
+        if let Some(duplicate) = effects
+            .windows(2)
+            .find(|pair| pair[0].id == pair[1].id)
+            .map(|pair| pair[0].id)
+        {
+            return Err(MechError::new(
+                DuplicateOutboxEffectId { id: duplicate },
+                None,
+            ));
+        }
+        let expected_previous = self.last_appended_id;
+        if let (Some(previous), Some(next)) =
+            (expected_previous, effects.first().map(|effect| effect.id))
+        {
+            if next <= previous {
+                return Err(MechError::new(
+                    InvalidOutboxEffectOrder { previous, next },
+                    None,
+                ));
+            }
+        }
+        let mut accounted = Vec::new();
+        accounted.try_reserve_exact(effects.len()).map_err(|_| {
+            MechError::new(
+                LedgerAllocationFailed {
+                    resource: "prepared outbox batch",
+                },
+                None,
+            )
+        })?;
+        let mut total_bytes = 0_usize;
+        for effect in effects {
+            let bytes = effect.validated_retained_bytes()?;
+            total_bytes = total_bytes.checked_add(bytes).ok_or_else(|| {
+                MechError::new(
+                    LedgerAllocationFailed {
+                        resource: "outbox byte accounting",
+                    },
+                    None,
+                )
+            })?;
+            accounted.push((bytes, effect));
+        }
+        let permit = permit
+            .inner
+            .take()
+            .ok_or_else(|| invalid_permit("outbox permit has already been consumed"))?;
+        let (controller, reservation) =
+            prepare_reservation(&self.controller, permit, accounted.len(), total_bytes)?;
+        Ok(PreparedOutboxBatch {
+            controller,
+            reservation: Some(reservation),
+            effects: Some(accounted),
+        })
+    }
+
+    /// Transfers a prepared batch without allocation or a recoverable failure branch.
+    pub fn append(&mut self, prepared: PreparedOutboxBatch<P>) {
+        let prepared_controller = prepared.controller.clone();
+        let (reservation, effects) = prepared.into_parts();
+        let last_appended_id = effects.last().map(|(_, effect)| effect.id);
+        self.controller
+            .commit_prepared(&prepared_controller, reservation);
+        for (bytes, effect) in effects {
+            self.effects.push_back(effect);
+            self.effect_bytes.push_back(bytes);
+        }
+        if let Some(last_appended_id) = last_appended_id {
+            self.last_appended_id = Some(last_appended_id);
+        }
+    }
+
+    pub fn pop_front(&mut self) -> Option<OwnedEffectIntent<P>> {
+        let effect = self.effects.pop_front()?;
+        let bytes = self
+            .effect_bytes
+            .pop_front()
+            .expect("retained outbox byte accounting entry");
+        self.controller.release_retained(1, bytes);
+        Some(effect)
+    }
+
+    pub fn drain(&mut self) -> impl Iterator<Item = OwnedEffectIntent<P>> + '_ {
+        std::iter::from_fn(|| self.pop_front())
+    }
+}

--- a/src/runtime/src/outbox/retained.rs
+++ b/src/runtime/src/outbox/retained.rs
@@ -106,13 +106,13 @@ impl<P> RetainedEffectOutbox<P> {
         self.effects.iter()
     }
 
-    pub fn reserve(&self, estimate: RecordEstimate) -> MResult<OutboxPermit> {
+    pub(crate) fn reserve(&self, estimate: RecordEstimate) -> MResult<OutboxPermit> {
         Ok(OutboxPermit {
             inner: Some(reserve(&self.controller, estimate)?),
         })
     }
 
-    pub fn prepare_batch(
+    pub(crate) fn prepare_batch(
         &self,
         mut permit: OutboxPermit,
         mut effects: Vec<OwnedEffectIntent<P>>,
@@ -178,12 +178,15 @@ impl<P> RetainedEffectOutbox<P> {
     }
 
     /// Transfers a prepared batch without allocation or a recoverable failure branch.
-    pub fn append(&mut self, prepared: PreparedOutboxBatch<P>) {
-        let prepared_controller = prepared.controller.clone();
-        let (reservation, effects) = prepared.into_parts();
-        let last_appended_id = effects.last().map(|(_, effect)| effect.id);
+    pub(crate) fn append(&mut self, prepared: PreparedOutboxBatch<P>) {
+        let reservation = *prepared
+            .reservation
+            .as_ref()
+            .expect("live prepared outbox reservation");
         self.controller
-            .commit_prepared(&prepared_controller, reservation);
+            .commit_prepared(&prepared.controller, reservation);
+        let (_, effects) = prepared.into_parts();
+        let last_appended_id = effects.last().map(|(_, effect)| effect.id);
         for (bytes, effect) in effects {
             self.effects.push_back(effect);
             self.effect_bytes.push_back(bytes);

--- a/src/runtime/src/outbox/tests.rs
+++ b/src/runtime/src/outbox/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::RecordEstimate;
+use crate::{ledger::RecordEstimate, turn_record::AccountedRecord};
 
 fn effect(turn: u64, ordinal: u32, payload: &'static [u8]) -> OwnedEffectIntent<Box<[u8]>> {
     OwnedEffectIntent {
@@ -115,4 +115,58 @@ fn dropping_prepared_batch_releases_capacity_and_owned_payloads() {
     let prepared = outbox.prepare_batch(permit, effects).unwrap();
     drop(prepared);
     assert!(outbox.reserve(estimate).is_ok());
+}
+
+#[test]
+fn overlapping_batch_preparation_is_rejected_before_publication() {
+    let mut outbox = RetainedEffectOutbox::new(2, 256).unwrap();
+    let first = vec![effect(1, 0, b"first")];
+    let second = vec![effect(2, 0, b"second")];
+    let first_permit = outbox.reserve(estimate(&first)).unwrap();
+    let second_permit = outbox.reserve(estimate(&second)).unwrap();
+
+    let prepared_first = outbox.prepare_batch(first_permit, first).unwrap();
+    let error = outbox.prepare_batch(second_permit, second).unwrap_err();
+    assert_eq!(error.kind_name(), "LedgerPermitInvalid");
+    outbox.append(prepared_first);
+    assert_eq!(outbox.len(), 1);
+    assert_eq!(outbox.iter().next().unwrap().id.turn_id.get(), 1);
+}
+
+#[test]
+fn dropped_batch_releases_preparation_lease_for_retry() {
+    let mut outbox = RetainedEffectOutbox::new(1, 128).unwrap();
+    let first = vec![effect(1, 0, b"first")];
+    let permit = outbox.reserve(estimate(&first)).unwrap();
+    let prepared = outbox.prepare_batch(permit, first).unwrap();
+    drop(prepared);
+
+    let retry = vec![effect(1, 0, b"retry")];
+    let permit = outbox.reserve(estimate(&retry)).unwrap();
+    let prepared = outbox.prepare_batch(permit, retry).unwrap();
+    outbox.append(prepared);
+    assert_eq!(outbox.len(), 1);
+}
+
+#[test]
+fn effect_payload_outlives_its_builder_storage() {
+    fn build() -> OwnedEffectIntent<Box<[u8]>> {
+        let temporary = vec![4_u8, 3, 2, 1];
+        OwnedEffectIntent {
+            id: OutboxEffectId {
+                turn_id: TurnId::new(1).unwrap(),
+                ordinal: 0,
+            },
+            operation: String::from("write"),
+            target: String::from("test"),
+            payload: temporary.into_boxed_slice(),
+            idempotency_key: String::from("1:0"),
+            delivery: OutboxDeliveryPolicy::AtLeastOnce,
+        }
+    }
+
+    fn assert_owned_effect<T: Send + 'static>() {}
+    assert_owned_effect::<OwnedEffectIntent<Box<[u8]>>>();
+    let effect = build();
+    assert_eq!(&*effect.payload, &[4, 3, 2, 1]);
 }

--- a/src/runtime/src/outbox/tests.rs
+++ b/src/runtime/src/outbox/tests.rs
@@ -1,0 +1,118 @@
+use super::*;
+use crate::RecordEstimate;
+
+fn effect(turn: u64, ordinal: u32, payload: &'static [u8]) -> OwnedEffectIntent<Box<[u8]>> {
+    OwnedEffectIntent {
+        id: OutboxEffectId {
+            turn_id: TurnId::new(turn).unwrap(),
+            ordinal,
+        },
+        operation: "write".to_string(),
+        target: "test".to_string(),
+        payload: payload.into(),
+        idempotency_key: format!("{turn}:{ordinal}"),
+        delivery: OutboxDeliveryPolicy::default(),
+    }
+}
+
+fn estimate(effects: &[OwnedEffectIntent<Box<[u8]>>]) -> RecordEstimate {
+    RecordEstimate {
+        records: effects.len(),
+        bytes: effects.iter().map(AccountedRecord::retained_bytes).sum(),
+    }
+}
+
+#[test]
+fn batch_is_sorted_by_turn_then_ordinal_and_transferred_once() {
+    let mut outbox = RetainedEffectOutbox::new(3, 256).unwrap();
+    let effects = vec![effect(2, 0, b"c"), effect(1, 1, b"b"), effect(1, 0, b"a")];
+    let permit = outbox.reserve(estimate(&effects)).unwrap();
+    let prepared = outbox.prepare_batch(permit, effects).unwrap();
+    outbox.append(prepared);
+    let ids = outbox.iter().map(|effect| effect.id).collect::<Vec<_>>();
+    assert_eq!(ids[0].turn_id.get(), 1);
+    assert_eq!(ids[0].ordinal, 0);
+    assert_eq!(ids[1].ordinal, 1);
+    assert_eq!(ids[2].turn_id.get(), 2);
+    assert!(
+        outbox
+            .iter()
+            .all(|effect| effect.delivery == OutboxDeliveryPolicy::AtLeastOnce)
+    );
+    assert_eq!(outbox.drain().count(), 3);
+    assert!(outbox.is_empty());
+}
+
+#[test]
+fn duplicate_effect_id_is_rejected_before_publication() {
+    let outbox = RetainedEffectOutbox::new(2, 256).unwrap();
+    let effects = vec![effect(1, 0, b"a"), effect(1, 0, b"b")];
+    let permit = outbox.reserve(estimate(&effects)).unwrap();
+    assert_eq!(
+        outbox
+            .prepare_batch(permit, effects)
+            .unwrap_err()
+            .kind_name(),
+        "DuplicateOutboxEffectId"
+    );
+    assert!(outbox.is_empty());
+}
+
+#[test]
+fn later_batch_cannot_break_retained_effect_order() {
+    let mut outbox = RetainedEffectOutbox::new(2, 256).unwrap();
+    let retained = vec![effect(2, 0, b"retained")];
+    let permit = outbox.reserve(estimate(&retained)).unwrap();
+    let prepared = outbox.prepare_batch(permit, retained).unwrap();
+    outbox.append(prepared);
+
+    let earlier = vec![effect(1, 0, b"earlier")];
+    let permit = outbox.reserve(estimate(&earlier)).unwrap();
+    assert_eq!(
+        outbox
+            .prepare_batch(permit, earlier)
+            .unwrap_err()
+            .kind_name(),
+        "InvalidOutboxEffectOrder"
+    );
+    assert_eq!(outbox.len(), 1);
+}
+
+#[test]
+fn delivery_does_not_erase_the_effect_ordering_watermark() {
+    let mut outbox = RetainedEffectOutbox::new(2, 256).unwrap();
+    let delivered = vec![effect(2, 0, b"delivered")];
+    let permit = outbox.reserve(estimate(&delivered)).unwrap();
+    let prepared = outbox.prepare_batch(permit, delivered).unwrap();
+    outbox.append(prepared);
+    assert_eq!(outbox.drain().count(), 1);
+
+    for stale in [effect(1, 0, b"older"), effect(2, 0, b"duplicate")] {
+        let effects = vec![stale];
+        let permit = outbox.reserve(estimate(&effects)).unwrap();
+        assert_eq!(
+            outbox
+                .prepare_batch(permit, effects)
+                .unwrap_err()
+                .kind_name(),
+            "InvalidOutboxEffectOrder"
+        );
+    }
+
+    let newer = vec![effect(3, 0, b"newer")];
+    let permit = outbox.reserve(estimate(&newer)).unwrap();
+    let prepared = outbox.prepare_batch(permit, newer).unwrap();
+    outbox.append(prepared);
+    assert_eq!(outbox.iter().next().unwrap().id.turn_id.get(), 3);
+}
+
+#[test]
+fn dropping_prepared_batch_releases_capacity_and_owned_payloads() {
+    let outbox = RetainedEffectOutbox::new(1, 128).unwrap();
+    let effects = vec![effect(1, 0, b"payload")];
+    let estimate = estimate(&effects);
+    let permit = outbox.reserve(estimate).unwrap();
+    let prepared = outbox.prepare_batch(permit, effects).unwrap();
+    drop(prepared);
+    assert!(outbox.reserve(estimate).is_ok());
+}

--- a/src/runtime/src/runtime/transaction/tests/store/mod.rs
+++ b/src/runtime/src/runtime/transaction/tests/store/mod.rs
@@ -7,6 +7,7 @@ mod commit;
 mod context_identity;
 mod event_publication;
 mod indeterminate;
+mod projection;
 mod store_failure;
 
 fn new_runtime() -> MechRuntime {

--- a/src/runtime/src/runtime/transaction/tests/store/projection.rs
+++ b/src/runtime/src/runtime/transaction/tests/store/projection.rs
@@ -1,0 +1,83 @@
+use super::new_runtime;
+use crate::{
+    RuntimeEventKind,
+    turn_record::{
+        TurnFailurePhase, TurnFailureRecord, TurnId, TurnRecordHeader, TurnRecordStatus,
+        project_transaction_lifecycle_events,
+    },
+};
+
+fn lifecycle(events: Vec<crate::RuntimeEvent>) -> Vec<RuntimeEventKind> {
+    events
+        .into_iter()
+        .map(|event| event.kind)
+        .filter(|kind| {
+            matches!(
+                kind,
+                RuntimeEventKind::TransactionStarted { .. }
+                    | RuntimeEventKind::TransactionCommitted { .. }
+                    | RuntimeEventKind::TransactionAborted { .. }
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn accepted_projection_matches_current_standalone_lifecycle_order() {
+    let mut runtime = new_runtime();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime.commit_runtime_transaction(&mut context).unwrap();
+
+    let header = TurnRecordHeader {
+        turn_id: TurnId::new(1).unwrap(),
+        transaction_id,
+        input_range: None,
+        status: TurnRecordStatus::Accepted,
+        failure: None,
+    };
+    let projected = project_transaction_lifecycle_events(&header)
+        .unwrap()
+        .collect::<Vec<_>>();
+    assert_eq!(projected, lifecycle(runtime.list_events(None).unwrap()));
+    assert_eq!(
+        projected
+            .iter()
+            .filter(|kind| matches!(kind, RuntimeEventKind::TransactionCommitted { .. }))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn rejected_projection_matches_current_standalone_lifecycle_order() {
+    let mut runtime = new_runtime();
+    let mut context = runtime.runtime_context().unwrap();
+    let transaction_id = runtime.begin_transaction(&mut context).unwrap();
+    runtime
+        .abort_runtime_transaction(&mut context, "rejected")
+        .unwrap();
+
+    let header = TurnRecordHeader {
+        turn_id: TurnId::new(1).unwrap(),
+        transaction_id,
+        input_range: None,
+        status: TurnRecordStatus::Rejected,
+        failure: Some(TurnFailureRecord {
+            phase: TurnFailurePhase::Execution,
+            kind: "Rejected".to_string(),
+            message: "rejected".to_string(),
+        }),
+    };
+    let projected = project_transaction_lifecycle_events(&header)
+        .unwrap()
+        .collect::<Vec<_>>();
+    assert_eq!(projected, lifecycle(runtime.list_events(None).unwrap()));
+    assert_eq!(
+        projected
+            .iter()
+            .filter(|kind| matches!(kind, RuntimeEventKind::TransactionAborted { .. }))
+            .count(),
+        1
+    );
+}

--- a/src/runtime/src/turn_record.rs
+++ b/src/runtime/src/turn_record.rs
@@ -6,6 +6,8 @@ use mech_core::{MResult, MechError, MechErrorKind};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use crate::RuntimeEventKind;
 use crate::TransactionId;
 
 macro_rules! sequence_id {
@@ -158,8 +160,34 @@ pub struct TurnRecordHeader {
     pub failure: Option<TurnFailureRecord>,
 }
 
+/// Projects only the existing standalone transaction lifecycle for compatibility tests.
+#[cfg(test)]
+pub(crate) fn project_transaction_lifecycle_events(
+    header: &TurnRecordHeader,
+) -> MResult<impl Iterator<Item = RuntimeEventKind>> {
+    header.validate()?;
+    let started = RuntimeEventKind::TransactionStarted {
+        transaction_id: header.transaction_id,
+    };
+    let completed = match (&header.status, &header.failure) {
+        (TurnRecordStatus::Accepted, None) => Some(RuntimeEventKind::TransactionCommitted {
+            transaction_id: header.transaction_id,
+        }),
+        (TurnRecordStatus::Rejected, Some(failure)) => Some(RuntimeEventKind::TransactionAborted {
+            transaction_id: header.transaction_id,
+            message: failure.message.clone(),
+        }),
+        (TurnRecordStatus::Staged, None) => None,
+        _ => unreachable!("TurnRecordHeader::validate accepted an invalid status/failure pair"),
+    };
+    Ok([Some(started), completed].into_iter().flatten())
+}
+
 impl TurnRecordHeader {
     pub fn validate(&self) -> MResult<()> {
+        if self.transaction_id.is_zero() {
+            return invalid_turn_record("transaction_id", "transaction ID must be non-zero");
+        }
         if let Some(range) = self.input_range {
             InputSequenceRange::new(range.first, range.last)?;
         }
@@ -169,6 +197,9 @@ impl TurnRecordHeader {
             }
             (TurnRecordStatus::Rejected, None) => {
                 return invalid_turn_record("failure", "rejected turns require a failure");
+            }
+            (TurnRecordStatus::Staged, Some(_)) => {
+                return invalid_turn_record("failure", "staged turns may not contain a failure");
             }
             _ => {}
         }
@@ -185,28 +216,47 @@ impl TurnRecordHeader {
     }
 }
 
-/// Reports the owned heap bytes retained by a record body.
-pub trait AccountedRecord {
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Reports the owned heap bytes retained by a trusted record representation.
+///
+/// The private supertrait prevents callers of the benchmark facade from
+/// supplying unaccounted payload implementations.
+pub trait AccountedRecord: sealed::Sealed {
+    /// Validates trusted semantic structure before byte accounting is bound.
+    fn validate_for_recording(&self) -> MResult<()> {
+        Ok(())
+    }
+
     fn retained_bytes(&self) -> usize;
 }
 
+impl sealed::Sealed for Vec<u8> {}
 impl AccountedRecord for Vec<u8> {
     fn retained_bytes(&self) -> usize {
         self.capacity()
     }
 }
 
+impl sealed::Sealed for String {}
 impl AccountedRecord for String {
     fn retained_bytes(&self) -> usize {
         self.capacity()
     }
 }
 
+impl sealed::Sealed for Box<[u8]> {}
 impl AccountedRecord for Box<[u8]> {
     fn retained_bytes(&self) -> usize {
         self.len()
     }
 }
+
+impl sealed::Sealed for crate::ledger::PooledRecordBuffer {}
+
+impl<P: AccountedRecord> sealed::Sealed for crate::outbox::OwnedEffectIntent<P> {}
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -234,7 +284,13 @@ impl<B: AccountedRecord> OwnedTurnRecord<B> {
     }
 }
 
+impl<B: AccountedRecord> sealed::Sealed for OwnedTurnRecord<B> {}
+
 impl<B: AccountedRecord> AccountedRecord for OwnedTurnRecord<B> {
+    fn validate_for_recording(&self) -> MResult<()> {
+        self.validate()
+    }
+
     fn retained_bytes(&self) -> usize {
         self.header
             .retained_bytes()
@@ -380,5 +436,100 @@ mod tests {
             header.validate().unwrap_err().kind_name(),
             "InvalidTurnRecord"
         );
+    }
+
+    fn assert_owned_record<T: Send + 'static>() {}
+
+    fn build_owned_record() -> OwnedTurnRecord<String> {
+        let builder_text = String::from("owned after builder drop");
+        OwnedTurnRecord {
+            header: TurnRecordHeader {
+                turn_id: TurnId::new(1).unwrap(),
+                transaction_id: TransactionId::new(1),
+                input_range: None,
+                status: TurnRecordStatus::Accepted,
+                failure: None,
+            },
+            body: builder_text,
+        }
+    }
+
+    #[test]
+    fn owned_record_outlives_builder_and_workspace_reuse() {
+        assert_owned_record::<OwnedTurnRecord<String>>();
+        let record = build_owned_record();
+        assert_eq!(record.body, "owned after builder drop");
+
+        let mut workspace = vec![1_u8, 2, 3, 4];
+        let record = OwnedTurnRecord {
+            header: record.header,
+            body: workspace.clone().into_boxed_slice(),
+        };
+        workspace.fill(0);
+        drop(workspace);
+        assert_eq!(&*record.body, &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn staged_projection_has_no_final_lifecycle_event() {
+        let header = TurnRecordHeader {
+            turn_id: TurnId::new(1).unwrap(),
+            transaction_id: TransactionId::new(1),
+            input_range: None,
+            status: TurnRecordStatus::Staged,
+            failure: None,
+        };
+        assert_eq!(
+            project_transaction_lifecycle_events(&header)
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn header_rejects_zero_transaction_and_staged_failure() {
+        let zero_transaction = TurnRecordHeader {
+            turn_id: TurnId::new(1).unwrap(),
+            transaction_id: TransactionId::ZERO,
+            input_range: None,
+            status: TurnRecordStatus::Accepted,
+            failure: None,
+        };
+        assert_eq!(
+            zero_transaction.validate().unwrap_err().kind_name(),
+            "InvalidTurnRecord"
+        );
+
+        let staged_failure = TurnRecordHeader {
+            turn_id: TurnId::new(1).unwrap(),
+            transaction_id: TransactionId::new(1),
+            input_range: None,
+            status: TurnRecordStatus::Staged,
+            failure: Some(TurnFailureRecord {
+                phase: TurnFailurePhase::Execution,
+                kind: "Rejected".to_string(),
+                message: "not valid for staged".to_string(),
+            }),
+        };
+        assert_eq!(
+            staged_failure.validate().unwrap_err().kind_name(),
+            "InvalidTurnRecord"
+        );
+    }
+
+    #[test]
+    fn failure_accounting_includes_retained_string_capacity() {
+        let mut kind = String::with_capacity(128);
+        kind.push('k');
+        let mut message = String::with_capacity(256);
+        message.push('m');
+        let failure = TurnFailureRecord {
+            phase: TurnFailurePhase::Execution,
+            kind,
+            message,
+        };
+        failure.validate().unwrap();
+        assert!(failure.retained_bytes() >= 384);
     }
 }

--- a/src/runtime/src/turn_record.rs
+++ b/src/runtime/src/turn_record.rs
@@ -1,0 +1,384 @@
+//! Owned turn-record identities and status metadata.
+
+use core::{fmt, num::NonZeroU64};
+
+use mech_core::{MResult, MechError, MechErrorKind};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::TransactionId;
+
+macro_rules! sequence_id {
+    ($name:ident) => {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(transparent)]
+        pub struct $name(NonZeroU64);
+
+        impl $name {
+            pub const fn new(value: u64) -> Option<Self> {
+                match NonZeroU64::new(value) {
+                    Some(value) => Some(Self(value)),
+                    None => None,
+                }
+            }
+
+            pub const fn get(self) -> u64 {
+                self.0.get()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_tuple(stringify!($name))
+                    .field(&self.get())
+                    .finish()
+            }
+        }
+
+        impl TryFrom<u64> for $name {
+            type Error = InvalidTurnRecord;
+
+            fn try_from(value: u64) -> Result<Self, Self::Error> {
+                Self::new(value).ok_or(InvalidTurnRecord {
+                    field: stringify!($name),
+                    reason: "sequence identifiers must be non-zero".to_string(),
+                })
+            }
+        }
+
+        impl From<$name> for u64 {
+            fn from(value: $name) -> Self {
+                value.get()
+            }
+        }
+    };
+}
+
+sequence_id!(TurnId);
+sequence_id!(InputSequence);
+sequence_id!(LedgerSequence);
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct InputSequenceRange {
+    pub first: InputSequence,
+    pub last: InputSequence,
+}
+
+impl InputSequenceRange {
+    pub fn new(first: InputSequence, last: InputSequence) -> MResult<Self> {
+        if first > last {
+            return invalid_turn_record("input_range", "first input follows last input");
+        }
+        Ok(Self { first, last })
+    }
+
+    pub const fn first(self) -> InputSequence {
+        self.first
+    }
+
+    pub const fn last(self) -> InputSequence {
+        self.last
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TurnRecordStatus {
+    Accepted,
+    Rejected,
+    Staged,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TurnFailurePhase {
+    Admission,
+    InputInstallation,
+    Execution,
+    Integrity,
+    Finalization,
+    Recording,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TurnFailureRecord {
+    pub phase: TurnFailurePhase,
+    pub kind: String,
+    pub message: String,
+}
+
+impl TurnFailureRecord {
+    pub fn validate(&self) -> MResult<()> {
+        if self.kind.is_empty() {
+            return invalid_turn_record("failure.kind", "failure kind must not be empty");
+        }
+        if self.message.is_empty() {
+            return invalid_turn_record("failure.message", "failure message must not be empty");
+        }
+        self.kind
+            .capacity()
+            .checked_add(self.message.capacity())
+            .ok_or_else(|| {
+                MechError::new(
+                    InvalidTurnRecord {
+                        field: "failure",
+                        reason: "failure text byte accounting overflowed".to_string(),
+                    },
+                    None,
+                )
+            })?;
+        Ok(())
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.kind
+            .capacity()
+            .checked_add(self.message.capacity())
+            .expect("validated turn failure byte accounting")
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TurnRecordHeader {
+    pub turn_id: TurnId,
+    pub transaction_id: TransactionId,
+    pub input_range: Option<InputSequenceRange>,
+    pub status: TurnRecordStatus,
+    pub failure: Option<TurnFailureRecord>,
+}
+
+impl TurnRecordHeader {
+    pub fn validate(&self) -> MResult<()> {
+        if let Some(range) = self.input_range {
+            InputSequenceRange::new(range.first, range.last)?;
+        }
+        match (&self.status, &self.failure) {
+            (TurnRecordStatus::Accepted, Some(_)) => {
+                return invalid_turn_record("failure", "accepted turns may not contain a failure");
+            }
+            (TurnRecordStatus::Rejected, None) => {
+                return invalid_turn_record("failure", "rejected turns require a failure");
+            }
+            _ => {}
+        }
+        if let Some(failure) = &self.failure {
+            failure.validate()?;
+        }
+        Ok(())
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.failure
+            .as_ref()
+            .map_or(0, TurnFailureRecord::retained_bytes)
+    }
+}
+
+/// Reports the owned heap bytes retained by a record body.
+pub trait AccountedRecord {
+    fn retained_bytes(&self) -> usize;
+}
+
+impl AccountedRecord for Vec<u8> {
+    fn retained_bytes(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl AccountedRecord for String {
+    fn retained_bytes(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl AccountedRecord for Box<[u8]> {
+    fn retained_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedTurnRecord<B> {
+    pub header: TurnRecordHeader,
+    pub body: B,
+}
+
+impl<B: AccountedRecord> OwnedTurnRecord<B> {
+    pub fn validate(&self) -> MResult<()> {
+        self.header.validate()?;
+        self.header
+            .retained_bytes()
+            .checked_add(self.body.retained_bytes())
+            .ok_or_else(|| {
+                MechError::new(
+                    InvalidTurnRecord {
+                        field: "record",
+                        reason: "record byte accounting overflowed".to_string(),
+                    },
+                    None,
+                )
+            })?;
+        Ok(())
+    }
+}
+
+impl<B: AccountedRecord> AccountedRecord for OwnedTurnRecord<B> {
+    fn retained_bytes(&self) -> usize {
+        self.header
+            .retained_bytes()
+            .checked_add(self.body.retained_bytes())
+            .expect("validated owned turn record byte accounting")
+    }
+}
+
+pub(crate) trait CheckedSequence: Copy {
+    const NAME: &'static str;
+    fn from_non_zero(value: NonZeroU64) -> Self;
+}
+
+impl CheckedSequence for TurnId {
+    const NAME: &'static str = "TurnId";
+
+    fn from_non_zero(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+}
+
+impl CheckedSequence for InputSequence {
+    const NAME: &'static str = "InputSequence";
+
+    fn from_non_zero(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+}
+
+impl CheckedSequence for LedgerSequence {
+    const NAME: &'static str = "LedgerSequence";
+
+    fn from_non_zero(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CheckedSequenceAllocator<S> {
+    next: Option<NonZeroU64>,
+    marker: core::marker::PhantomData<S>,
+}
+
+impl<S: CheckedSequence> CheckedSequenceAllocator<S> {
+    pub(crate) fn new() -> Self {
+        Self::starting_at(NonZeroU64::MIN)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn starting_at(next: NonZeroU64) -> Self {
+        Self {
+            next: Some(next),
+            marker: core::marker::PhantomData,
+        }
+    }
+
+    #[cfg(not(test))]
+    fn starting_at(next: NonZeroU64) -> Self {
+        Self {
+            next: Some(next),
+            marker: core::marker::PhantomData,
+        }
+    }
+
+    pub(crate) fn allocate(&mut self) -> MResult<S> {
+        let next = self
+            .next
+            .ok_or_else(|| MechError::new(SequenceExhausted { sequence: S::NAME }, None))?;
+        self.next = next.get().checked_add(1).and_then(NonZeroU64::new);
+        Ok(S::from_non_zero(next))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidTurnRecord {
+    pub field: &'static str,
+    pub reason: String,
+}
+
+impl MechErrorKind for InvalidTurnRecord {
+    fn name(&self) -> &str {
+        "InvalidTurnRecord"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "invalid turn record field `{}`: {}",
+            self.field, self.reason
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SequenceExhausted {
+    pub sequence: &'static str,
+}
+
+impl MechErrorKind for SequenceExhausted {
+    fn name(&self) -> &str {
+        "SequenceExhausted"
+    }
+
+    fn message(&self) -> String {
+        format!("{} sequence is exhausted", self.sequence)
+    }
+}
+
+fn invalid_turn_record<T>(field: &'static str, reason: impl Into<String>) -> MResult<T> {
+    Err(MechError::new(
+        InvalidTurnRecord {
+            field,
+            reason: reason.into(),
+        },
+        None,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_sequence_allocation_never_wraps() {
+        let mut allocator = CheckedSequenceAllocator::<TurnId>::starting_at(NonZeroU64::MAX);
+        assert_eq!(allocator.allocate().unwrap().get(), u64::MAX);
+        let error = allocator.allocate().unwrap_err();
+        assert_eq!(error.kind_name(), "SequenceExhausted");
+    }
+
+    #[test]
+    fn header_status_and_input_range_are_validated() {
+        let header = TurnRecordHeader {
+            turn_id: TurnId::new(1).unwrap(),
+            transaction_id: TransactionId::new(1),
+            input_range: Some(InputSequenceRange {
+                first: InputSequence::new(2).unwrap(),
+                last: InputSequence::new(1).unwrap(),
+            }),
+            status: TurnRecordStatus::Accepted,
+            failure: None,
+        };
+        assert_eq!(
+            header.validate().unwrap_err().kind_name(),
+            "InvalidTurnRecord"
+        );
+    }
+}

--- a/src/runtime/tests/recording_bench_facade.rs
+++ b/src/runtime/tests/recording_bench_facade.rs
@@ -1,0 +1,30 @@
+use mech_runtime::__gate_a_recording::{
+    AccountedRecord, OwnedTurnRecordQueue, RecordEstimate, RetainedTurnLedger, prepare_retained,
+    reserve_retained,
+};
+
+#[test]
+fn hidden_probe_facade_exposes_the_minimum_recording_surface() {
+    let mut ledger = RetainedTurnLedger::new(1, 4).unwrap();
+    let record = vec![1_u8, 2, 3, 4].into_boxed_slice();
+    let permit = reserve_retained(
+        &ledger,
+        RecordEstimate {
+            records: 1,
+            bytes: record.retained_bytes(),
+        },
+    )
+    .unwrap();
+    let prepared = prepare_retained(&mut ledger, permit, record).unwrap();
+    assert_eq!(prepared.append().get(), 1);
+
+    let queue = OwnedTurnRecordQueue::<Box<[u8]>>::new(1, 4).unwrap();
+    assert!(queue.is_empty());
+}
+
+#[test]
+fn hidden_probe_facade_rejects_unapproved_external_operations() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/recording_bench/accounted_record_external.rs");
+    tests.compile_fail("tests/ui/recording_bench/cross_destination_append.rs");
+}

--- a/src/runtime/tests/ui/recording_bench/accounted_record_external.rs
+++ b/src/runtime/tests/ui/recording_bench/accounted_record_external.rs
@@ -1,0 +1,11 @@
+use mech_runtime::__gate_a_recording::AccountedRecord;
+
+struct HugePayload(Vec<u8>);
+
+impl AccountedRecord for HugePayload {
+    fn retained_bytes(&self) -> usize {
+        0
+    }
+}
+
+fn main() {}

--- a/src/runtime/tests/ui/recording_bench/accounted_record_external.stderr
+++ b/src/runtime/tests/ui/recording_bench/accounted_record_external.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the trait bound `HugePayload: mech_runtime::turn_record::sealed::Sealed` is not satisfied
+ --> tests/ui/recording_bench/accounted_record_external.rs:5:26
+  |
+5 | impl AccountedRecord for HugePayload {
+  |                          ^^^^^^^^^^^ unsatisfied trait bound
+  |
+help: the trait `mech_runtime::turn_record::sealed::Sealed` is not implemented for `HugePayload`
+ --> tests/ui/recording_bench/accounted_record_external.rs:3:1
+  |
+3 | struct HugePayload(Vec<u8>);
+  | ^^^^^^^^^^^^^^^^^^
+  = help: the following other types implement trait `mech_runtime::turn_record::sealed::Sealed`:
+            Box<[u8]>
+            Vec<u8>
+            mech_runtime::ledger::pool::PooledRecordBuffer
+            mech_runtime::turn_record::OwnedTurnRecord<B>
+            std::string::String
+note: required by a bound in `mech_runtime::__gate_a_recording::AccountedRecord`
+ --> src/turn_record.rs
+  |
+  | pub trait AccountedRecord: sealed::Sealed {
+  |                            ^^^^^^^^^^^^^^ required by this bound in `AccountedRecord`
+  = note: `AccountedRecord` is a "sealed trait", because to implement it you also need to implement `mech_runtime::turn_record::sealed::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following types implement the trait:
+            std::vec::Vec<u8>
+            std::string::String
+            std::boxed::Box<[u8]>
+            mech_runtime::ledger::pool::PooledRecordBuffer
+            mech_runtime::__gate_a_recording::OwnedEffectIntent<P>
+            mech_runtime::turn_record::OwnedTurnRecord<B>

--- a/src/runtime/tests/ui/recording_bench/cross_destination_append.rs
+++ b/src/runtime/tests/ui/recording_bench/cross_destination_append.rs
@@ -1,0 +1,20 @@
+use mech_runtime::__gate_a_recording::{
+    AccountedRecord, OwnedTurnRecordQueue, RecordEstimate, prepare_queue, reserve_queue,
+};
+
+fn main() {
+    let first = OwnedTurnRecordQueue::<Box<[u8]>>::new(1, 4).unwrap();
+    let second = OwnedTurnRecordQueue::<Box<[u8]>>::new(1, 4).unwrap();
+    let record = vec![1_u8, 2, 3, 4].into_boxed_slice();
+    let permit = reserve_queue(
+        &first,
+        RecordEstimate {
+            records: 1,
+            bytes: record.retained_bytes(),
+        },
+    )
+    .unwrap();
+    let prepared = prepare_queue(&first, permit, record).unwrap();
+
+    second.append(prepared);
+}

--- a/src/runtime/tests/ui/recording_bench/cross_destination_append.stderr
+++ b/src/runtime/tests/ui/recording_bench/cross_destination_append.stderr
@@ -1,0 +1,12 @@
+error[E0624]: method `append` is private
+  --> tests/ui/recording_bench/cross_destination_append.rs:19:12
+   |
+19 |       second.append(prepared);
+   |              ^^^^^^ private method
+   |
+  ::: src/ledger/queue.rs
+   |
+   | /     pub(crate) fn append(&self, prepared: PreparedLedgerAppend<R>) -> LedgerSequence
+   | |     where
+   | |         R: Send + 'static,
+   | |__________________________- private method defined here

--- a/src/runtime/tests/ui/sealed/recording_api_private.rs
+++ b/src/runtime/tests/ui/sealed/recording_api_private.rs
@@ -1,0 +1,13 @@
+use mech_runtime::ledger::RetainedTurnLedger;
+use mech_runtime::outbox::RetainedEffectOutbox;
+use mech_runtime::turn_record::{AccountedRecord, LedgerSequence, TurnId, TurnRecordHeader};
+
+fn main() {
+    let _ = core::mem::size_of::<RetainedTurnLedger<Box<[u8]>>>();
+    let _ = core::mem::size_of::<RetainedEffectOutbox<Box<[u8]>>>();
+    let _ = core::mem::size_of::<LedgerSequence>();
+    let _ = core::mem::size_of::<TurnId>();
+    let _ = core::mem::size_of::<TurnRecordHeader>();
+    fn require_accounting<T: AccountedRecord>() {}
+    require_accounting::<Box<[u8]>>();
+}

--- a/src/runtime/tests/ui/sealed/recording_api_private.stderr
+++ b/src/runtime/tests/ui/sealed/recording_api_private.stderr
@@ -1,0 +1,49 @@
+error[E0603]: module `ledger` is private
+ --> tests/ui/sealed/recording_api_private.rs:1:19
+  |
+1 | use mech_runtime::ledger::RetainedTurnLedger;
+  |                   ^^^^^^ private module
+  |
+note: the module `ledger` is defined here
+ --> src/lib.rs
+  |
+  | mod ledger;
+  | ^^^^^^^^^^
+
+error[E0603]: module `outbox` is private
+ --> tests/ui/sealed/recording_api_private.rs:2:19
+  |
+2 | use mech_runtime::outbox::RetainedEffectOutbox;
+  |                   ^^^^^^ private module
+  |
+note: the module `outbox` is defined here
+ --> src/lib.rs
+  |
+  | mod outbox;
+  | ^^^^^^^^^^
+
+error[E0603]: module `turn_record` is private
+ --> tests/ui/sealed/recording_api_private.rs:3:19
+  |
+3 | use mech_runtime::turn_record::{AccountedRecord, LedgerSequence, TurnId, TurnRecordHeader};
+  |                   ^^^^^^^^^^^   --------------- trait `AccountedRecord` is not publicly re-exported
+  |                   |
+  |                   private module
+  |
+note: the module `turn_record` is defined here
+ --> src/lib.rs
+  |
+  | mod turn_record;
+  | ^^^^^^^^^^^^^^^
+
+error[E0603]: module `turn_record` is private
+ --> tests/ui/sealed/recording_api_private.rs:3:19
+  |
+3 | use mech_runtime::turn_record::{AccountedRecord, LedgerSequence, TurnId, TurnRecordHeader};
+  |                   ^^^^^^^^^^^ private module
+  |
+note: the module `turn_record` is defined here
+ --> src/lib.rs
+  |
+  | mod turn_record;
+  | ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Stack

Base branch: `refactor/store-prepare-apply-commit`
Exact base SHA: `cca4ec3daa207819c663ec1d710a908b034a7405`
Head branch: `feat/runtime-bounded-turn-recording`
Exact head SHA: `5fb4354fcb7a3e9067d82575fae2599b56c57a29`
Target: `integration/value-executor-v0.4`

This is a draft stacked PR. Do not merge, mark ready, retarget, or enable auto-merge.

## Scope

- Adds checked non-zero turn, input, and ledger sequencing plus validated owned turn-record headers.
- Adds count/byte-bounded reserve → prepare → infallible-append primitives for retained and cross-thread ledgers.
- Enforces a single active preparation lease and a durable append-sequence watermark for each ledger or outbox.
- Adds bounded owned buffer recycling and a generic owned effect outbox with deterministic `TurnId` then ordinal ordering.
- Keeps all provisional recording modules private and exposes only the minimum controlled-benchmark surface through the hidden, non-default `runtime_bench_probes` facade.
- Seals byte accounting to trusted owned representations.
- Freezes ownership and current standalone transaction-lifecycle projection contracts without changing production event emission.
- Adds controlled 0 / 1,000 / 100,000-history benchmarks for retained ledger, owned queue, buffer pool, and effect outbox append.

## Explicit non-goals

- No final receipt body or permanent schema that depends on legacy `Value`.
- No `StateArena`, `CellSlotId`, `InstanceEpoch`, dependent shapes, immutable replacement-value architecture, or pointer-identity redesign.
- No production turn routing through a resident executor and no change to explicit transactions or the existing program rollback journal.
- No bytecode, native-code-generation, matrix-solver, feature-closure, fixture, or unrelated warning repair.

## Commits

1. `523dd733c2f5e0dc22a5c527fa301693f9216d18 feat(runtime): add turn-record ordering and status primitives`
2. `5f2633a117ee4ef67c1a5648a879a485bfa6645c feat(runtime): add bounded ledger reservations`
3. `89fc99bc4a53b7b0353e8587bb512e823fe2b09c feat(runtime): add retained and queued record storage`
4. `6daff0a4c7f14de1eb9d32ec37527c1e93f41303 feat(runtime): add bounded record buffer recycling`
5. `8534ad5c77dacd5f90ed865f6622b187994d62b8 feat(runtime): add owned effect outbox`
6. `0141a6a8b47b10f391bfbead40fe55a3ff987dec test(runtime): freeze recording ownership and projection`
7. `5fb4354fcb7a3e9067d82575fae2599b56c57a29 bench(runtime): verify history-independent record append`

The A3 stack is rebased onto finalized A2 and remains exactly seven commits. Commit 7 is report-only; its committed `git_commit` is its exact measurable parent, commit 6.

## Review resolution

- The earlier two scoped rounds resolved the pool-replacement, durable outbox-watermark, schema-variant, and benchmark-capacity findings.
- The subsequent architecture review identified the remaining preparation-ordering, ownership, API-visibility, sealed-accounting, and header/projection gaps. This rewrite addresses all of them and adds the requested regressions.
- The required final scoped review of `569e2e070c2504e79e41fa2fd46b3ac7f53421a3` found two remaining issues: the hidden benchmark facade still admitted a cross-destination append, and generic ledger preparation did not validate semantic owned records.
- This exact head resolves both findings: prepared facade values now publish only to their captured origin, external cross-destination append is compile-fail tested, the internal ownership invariant runs before token consumption so unwind releases the origin lease/capacity, and generic preparation invokes sealed semantic validation before accounting is bound.
- No additional review has been requested.

## Semantic contracts

- Records and effect intents own every payload; no record borrows a context, program, journal, workspace, or temporary buffer.
- Multiple permits may be reserved, but only one prepared append may hold the ledger/outbox preparation lease.
- Preparation verifies owner and generation, exact record/effect counts and retained bytes, active-lease state, and sequence monotonicity before publication.
- Dropping prepared work releases both its lease and bound capacity without advancing the append watermark.
- Append matches the active sequence as an internal invariant, advances the durable watermark, transfers accounting, and publishes without allocation, callbacks, validation, a `Result`, or a legal-use failure branch.
- Retained and queued records preserve FIFO order and return capacity on drain; exhaustion is rejected before publication and no silent eviction occurs.
- Buffer-pool segment count and retained capacity are bounded; ownership is exclusive until return, and replacement minimizes retained capacity when limits require eviction.
- Outbox insertion sorts by `TurnId` then ordinal, rejects duplicate, overlapping, or non-monotonic IDs before publication, and preserves its ordering watermark after delivery.
- Normal runtime builds expose none of the provisional recording API. The benchmark-only facade is hidden behind `runtime_bench_probes`, and `AccountedRecord` cannot be implemented externally.
- `TurnRecordHeader` rejects zero transaction IDs and invalid status/failure pairs. Transaction-lifecycle projection is internal/test-only compatibility infrastructure and validates before projecting.

## Performance evidence

Report: `benchmarks/runtime/gate-a/a3-recording-primitives.json`

- Measured clean pre-report head: `0141a6a8b47b10f391bfbead40fe55a3ff987dec`.
- Four operations × three retained histories produced 12 Criterion cases and 12 phase probes.
- Every append probe reports zero post-preparation allocations and no post-publication recoverable failure branch.
- Criterion medians at retained histories 0 / 1,000 / 100,000 ns: effect outbox `42 / 42 / 42`; owned queue `41 / 41 / 41`; record pool `41 / 1 / 41.5`; retained ledger `42 / 41 / 42`.
- Pool reuse is false for the empty-history fixture and true for the 1,000/100,000-history fixtures.
- The report records exact per-history ledger, queue, outbox, and pool capacity limits and conforms to the committed recording-probe schema variant.
- Absolute latency remains informational until Gate B provides the representative receipt workload.

## Validation

Passed locally on exact head `5fb4354fcb7a3e9067d82575fae2599b56c57a29`:

```text
cargo fmt --all -- --check
cargo test -p mech-core --all-features                         # 276 passed
cargo test -p mech-runtime --lib --no-default-features \
  --features source_default                                    # 660 passed
cargo test -p mech-runtime --test sealed_api \
  --no-default-features --features source_default              # passed
cargo test -p mech-runtime --test recording_bench_facade \
  --no-default-features \
  --features runtime_default,runtime_bench_probes              # 2 passed
python3 -B -m unittest \
  scripts/tests/test_check_value_execution_boundary.py         # 16 passed
python3 -B -m unittest \
  scripts/tests/test_run_gate_a_benchmarks.py                   # 7 passed
cargo bench -p mech-runtime --bench reactive_transaction \
  --no-run --features source_default
cargo bench -p mech-runtime --bench history_scaling \
  --features source_default,runtime_bench_probes --no-run
cargo bench -p mech-runtime --bench recording_primitives \
  --no-run --no-default-features \
  --features runtime_default,runtime_bench_probes
python3 scripts/run-gate-a-benchmarks.py \
  --bench recording_primitives \
  --output benchmarks/runtime/gate-a/a3-recording-primitives.json
python3 scripts/check-value-execution-boundary.py
python3 scripts/check-rust-module-layout.py
scripts/check-unsafe-boundaries.sh
git diff --check
```

The controlled recording benchmark completed all 12 Criterion cases and all 12 probes. Exact-head GitHub CI run `31223504576` passed Impact, Static contracts, Standard Linux, Standard Windows, Browser canary, every owner job, and the final PR gate.

The final stack smoke confirms that restacking retained A1's zero-use event-clone boundaries and A2's zero-use `in-memory-store-clone-commit` boundary.

### Protected inherited base failures

`cargo test -p mech-runtime --lib` reproduces the documented inherited failure: the `native-live-host` fixture compiles `Value::Tuple` / `Value::Record` paths without the feature closure required by that fixture.

`cargo test -p mech-runtime --lib --no-default-features --features runtime_default` reproduces the inherited v0.4 test-closure failure: source-only runtime tests compile without the `source` surface.

Both failures predate Gate A. This PR makes no fixture, production, test-boundary, or feature-boundary changes to repair them.

## Remaining legacy boundary

- implicit standalone `RuntimeExecutionTransaction`
- `RuntimeTransaction` operation-savepoint cloning
- `ReactiveTurnJournal`
- `ValueStateJournal`
- `transaction_state_values()`
- `ValRef`
- `ReactiveCellId`
- pointer-derived cell and live-binding identity
- standalone coordinator calls to `commit_runtime`

These remain explicit deletion targets for later gates.

## Review scope

Review only the changes introduced by this PR relative to `refactor/store-prepare-apply-commit` at exact SHA `cca4ec3daa207819c663ec1d710a908b034a7405`. Do not review or report unrelated changes inherited from the stacked base.

The final scoped review should specifically cover preparation leases, sequence monotonicity, drop accounting, outbox overlap, public API visibility, sealed byte accounting, post-publication panic freedom, and header validation.
