### PR TITLE
[PR-B1] feat(engine): add the resident EKF execution substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "num-traits",
  "paste",
  "serde",
+ "sha2",
  "web-time",
 ]
 

--- a/benchmarks/runtime/gate-b/b1-resident-kernel.json
+++ b/benchmarks/runtime/gate-b/b1-resident-kernel.json
@@ -1,0 +1,635 @@
+{
+  "b1_progression": {
+    "limit_multiplier": 1.05,
+    "limit_ns_per_turn": 233.9171729907655,
+    "passed": true,
+    "resident_kernel_ns_per_turn": 93.0364500306822,
+    "resident_kernel_ratio": 0.9137027361894394,
+    "resident_kernel_vs_raw_epoch": 0.41761907124310543,
+    "rust_epoch_ns_per_turn": 222.77825999120523,
+    "rust_kernel_ns_per_turn": 101.8235432003706
+  },
+  "benchmark_arguments": [
+    "cargo",
+    "bench",
+    "-p",
+    "mech-runtime",
+    "--bench",
+    "resident_ekf",
+    "--features",
+    "source_default,runtime_bench_gate_b",
+    "--",
+    "--noplot",
+    "--sample-size",
+    "10",
+    "--warm-up-time",
+    "1.0",
+    "--measurement-time",
+    "3.0",
+    "--nresamples",
+    "10000"
+  ],
+  "derived": {
+    "legacy_denominator_ns_per_turn": 8307.543502093755,
+    "mech_legacy_atomic_ns_per_turn": 8530.321762084961,
+    "positive": true,
+    "rust_epoch_ns_per_turn": 222.77825999120523
+  },
+  "gate": "B",
+  "git_branch": "feat/engine-resident-ekf-substrate",
+  "git_commit": "9559c46e2bdb32bbc81f10a50127073b5bcabcd4",
+  "lanes": [
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 23161.53125,
+        "allocations_per_turn": 211.01318359375,
+        "episode_allocated_bytes": 94869632,
+        "episode_allocation_count": 864310
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-legacy-atomic",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 4096,
+        "legacy_journal_capture_count": 36864,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 8530.321762084961,
+        "p95_ns_per_turn": 8592.876554478236
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 83361.53125,
+        "allocations_per_turn": 766.01318359375,
+        "episode_allocated_bytes": 341448832,
+        "episode_allocation_count": 3137590
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "mech-legacy-atomic",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 4096,
+        "legacy_journal_capture_count": 294912,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 33671.96651204427,
+        "p95_ns_per_turn": 33792.6252726237
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 568496.234375,
+        "allocations_per_turn": 5049.673095703125,
+        "episode_allocated_bytes": 2328560576,
+        "episode_allocation_count": 20683461
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "mech-legacy-atomic",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 4096,
+        "legacy_journal_capture_count": 2359296,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 307894.35314941406,
+        "p95_ns_per_turn": 308557.2300048828
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 115888.349609375,
+        "allocations_per_turn": 143.013671875,
+        "episode_allocated_bytes": 474678680,
+        "episode_allocation_count": 585784
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-legacy-atomic-full-write",
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 4096,
+        "legacy_journal_capture_count": 12288,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 9134.89859008789,
+        "p95_ns_per_turn": 9178.311638387044
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-kernel",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 93.0364500306822,
+        "p95_ns_per_turn": 93.48869995970826
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "mech-resident-kernel",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 768,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 655.5661223880829,
+        "p95_ns_per_turn": 672.4253380185082
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "mech-resident-kernel",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 6144,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 5145.677699497768,
+        "p95_ns_per_turn": 5153.32011352539
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-kernel-full-write",
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": "c10b5fea1f26905e04b7ca4c90b56710bdebdd356b1936aaf40f55f92675191d",
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 1635.2310256958008,
+        "p95_ns_per_turn": 1635.5747425842285
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": null,
+        "allocations_per_turn": null,
+        "episode_allocated_bytes": null,
+        "episode_allocation_count": null
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "numpy-persistent",
+      "quantized_state_hash": "1b0856ee87055bd50f895f5d8c54f7c29cf6ff6d1530ad3f82332560f392e98f",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": null,
+        "candidate_written_bytes": null,
+        "commit_runtime_call_count": null,
+        "legacy_journal_capture_count": null,
+        "publication_store_count": null,
+        "published_buffer_copy_bytes": null,
+        "receipt_bytes": null
+      },
+      "timing": {
+        "median_ns_per_turn": 20974.344848632812,
+        "p95_ns_per_turn": 21084.435400390626
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": null,
+        "allocations_per_turn": null,
+        "episode_allocated_bytes": null,
+        "episode_allocation_count": null
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "numpy-persistent",
+      "quantized_state_hash": "1b0856ee87055bd50f895f5d8c54f7c29cf6ff6d1530ad3f82332560f392e98f",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": null,
+        "candidate_written_bytes": null,
+        "commit_runtime_call_count": null,
+        "legacy_journal_capture_count": null,
+        "publication_store_count": null,
+        "published_buffer_copy_bytes": null,
+        "receipt_bytes": null
+      },
+      "timing": {
+        "median_ns_per_turn": 162120.01025390625,
+        "p95_ns_per_turn": 164000.80307617187
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": null,
+        "allocations_per_turn": null,
+        "episode_allocated_bytes": null,
+        "episode_allocation_count": null
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "numpy-persistent",
+      "quantized_state_hash": "1b0856ee87055bd50f895f5d8c54f7c29cf6ff6d1530ad3f82332560f392e98f",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": null,
+        "candidate_written_bytes": null,
+        "commit_runtime_call_count": null,
+        "legacy_journal_capture_count": null,
+        "publication_store_count": null,
+        "published_buffer_copy_bytes": null,
+        "receipt_bytes": null
+      },
+      "timing": {
+        "median_ns_per_turn": 1291768.8446044922,
+        "p95_ns_per_turn": 1304901.5584838868
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "rust-epoch",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64
+      },
+      "timing": {
+        "median_ns_per_turn": 222.77825999120523,
+        "p95_ns_per_turn": 223.85623078998768
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "rust-epoch",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 768,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64
+      },
+      "timing": {
+        "median_ns_per_turn": 1368.2243723551433,
+        "p95_ns_per_turn": 1386.0363349260601
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "rust-epoch",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 6144,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64
+      },
+      "timing": {
+        "median_ns_per_turn": 10541.242989095052,
+        "p95_ns_per_turn": 10580.771681213379
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "rust-epoch-full-write",
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": "c10b5fea1f26905e04b7ca4c90b56710bdebdd356b1936aaf40f55f92675191d",
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64
+      },
+      "timing": {
+        "median_ns_per_turn": 34899.83451334636,
+        "p95_ns_per_turn": 34902.4415608724
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "rust-kernel",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 101.8235432003706,
+        "p95_ns_per_turn": 101.94457979642428
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "rust-kernel",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 771.0829800075956,
+        "p95_ns_per_turn": 772.1974242824978
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "rust-kernel",
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 0,
+        "legacy_journal_capture_count": 0,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 6158.123950195312,
+        "p95_ns_per_turn": 6166.115152994792
+      },
+      "turns_per_sample": 4096
+    }
+  ],
+  "machine": {
+    "architecture": "arm64",
+    "identity": "MacBook Air, Mac15,13, Apple M3",
+    "os": "macOS-26.2-arm64-arm-64bit"
+  },
+  "phase": "B1-resident-kernel",
+  "raw_criterion_directory": "/private/tmp/mech-b1-v04/target/criterion",
+  "raw_output": "/private/tmp/mech-b1-v04/target/gate-b-benchmark-runs/9559c46e2bdb32bbc81f10a50127073b5bcabcd4/b0-controls.log",
+  "raw_structural_probe_output": "/private/tmp/mech-b1-v04/target/gate-b-benchmark-runs/9559c46e2bdb32bbc81f10a50127073b5bcabcd4/b0-structural.log",
+  "sample_protocol": {
+    "correctness_included_in_timing": false,
+    "criterion_sample_size": 10,
+    "fixture_setup_included_in_timing": false,
+    "measurement_seconds": 3.0,
+    "numpy_sample_size": 10,
+    "profile": "release",
+    "turns_per_sample": 4096,
+    "warm_up_seconds": 1.0
+  },
+  "schema_version": 1,
+  "stop_condition": {
+    "name": "positive-legacy-denominator",
+    "passed": true
+  },
+  "structural_probe_arguments": [
+    "cargo",
+    "bench",
+    "-p",
+    "mech-runtime",
+    "--bench",
+    "resident_ekf",
+    "--features",
+    "source_default,runtime_bench_gate_b,runtime_bench_probes",
+    "--",
+    "--noplot"
+  ],
+  "thread_environment": {
+    "BLIS_NUM_THREADS": "1",
+    "MKL_NUM_THREADS": "1",
+    "NUMEXPR_NUM_THREADS": "1",
+    "OMP_NUM_THREADS": "1",
+    "OPENBLAS_NUM_THREADS": "1",
+    "RAYON_NUM_THREADS": "1",
+    "VECLIB_MAXIMUM_THREADS": "1"
+  },
+  "toolchain": {
+    "CARGO_ENCODED_RUSTFLAGS": "",
+    "RUSTFLAGS": "",
+    "blas_lapack_provider": "accelerate",
+    "numpy": "2.0.2",
+    "numpy_config": "{\n  \"Compilers\": {\n    \"c\": {\n      \"name\": \"clang\",\n      \"linker\": \"ld64\",\n      \"version\": \"15.0.0\",\n      \"commands\": \"cc\"\n    },\n    \"cython\": {\n      \"name\": \"cython\",\n      \"linker\": \"cython\",\n      \"version\": \"3.0.11\",\n      \"commands\": \"cython\"\n    },\n    \"c++\": {\n      \"name\": \"clang\",\n      \"linker\": \"ld64\",\n      \"version\": \"15.0.0\",\n      \"commands\": \"c++\"\n    }\n  },\n  \"Machine Information\": {\n    \"host\": {\n      \"cpu\": \"aarch64\",\n      \"family\": \"aarch64\",\n      \"endian\": \"little\",\n      \"system\": \"darwin\"\n    },\n    \"build\": {\n      \"cpu\": \"aarch64\",\n      \"family\": \"aarch64\",\n      \"endian\": \"little\",\n      \"system\": \"darwin\"\n    }\n  },\n  \"Build Dependencies\": {\n    \"blas\": {\n      \"name\": \"accelerate\",\n      \"found\": true,\n      \"version\": \"unknown\",\n      \"detection method\": \"system\",\n      \"include directory\": \"unknown\",\n      \"lib directory\": \"unknown\",\n      \"openblas configuration\": \"unknown\",\n      \"pc file directory\": \"unknown\"\n    },\n    \"lapack\": {\n      \"name\": \"accelerate\",\n      \"found\": true,\n      \"version\": \"unknown\",\n      \"detection method\": \"system\",\n      \"include directory\": \"unknown\",\n      \"lib directory\": \"unknown\",\n      \"openblas configuration\": \"unknown\",\n      \"pc file directory\": \"unknown\"\n    }\n  },\n  \"Python Information\": {\n    \"path\": \"/private/var/folders/4d/0gnh84wj53j7wyk695q0tc_80000gn/T/build-env-kq4kuj35/bin/python\",\n    \"version\": \"3.9\"\n  },\n  \"SIMD Extensions\": {\n    \"baseline\": [\n      \"NEON\",\n      \"NEON_FP16\",\n      \"NEON_VFPV4\",\n      \"ASIMD\"\n    ],\n    \"found\": [\n      \"ASIMDHP\"\n    ],\n    \"not found\": [\n      \"ASIMDFHM\"\n    ]\n  }\n}",
+    "python": "3.9.6",
+    "python_executable": "/private/tmp/mech-gate-b-venv/bin/python",
+    "rustc": "rustc 1.96.0-nightly (ec818fda3 2026-03-02)\nbinary: rustc\ncommit-hash: ec818fda361ca216eb186f5cf45131bd9c776bb4\ncommit-date: 2026-03-02\nhost: aarch64-apple-darwin\nrelease: 1.96.0-nightly\nLLVM version: 22.1.0"
+  },
+  "trace": {
+    "file": "ekf-input-v1.bin",
+    "sha256": "ab901e1d115aa92166dc2a6d45a28732e6a548363b829997aa410ae4c2d77c8b"
+  },
+  "workload": {
+    "episode_length": 4096,
+    "matrix_storage": "column-major",
+    "scalar": "f64",
+    "scaled_instances": [
+      1,
+      8,
+      64
+    ],
+    "version": "resident-ekf-v1"
+  }
+}

--- a/benchmarks/runtime/gate-b/result-schema.json
+++ b/benchmarks/runtime/gate-b/result-schema.json
@@ -193,6 +193,30 @@
         "passed": { "type": "boolean" }
       }
     },
+    "b1_progression": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resident_kernel_ns_per_turn",
+        "rust_kernel_ns_per_turn",
+        "rust_epoch_ns_per_turn",
+        "resident_kernel_ratio",
+        "resident_kernel_vs_raw_epoch",
+        "limit_multiplier",
+        "limit_ns_per_turn",
+        "passed"
+      ],
+      "properties": {
+        "resident_kernel_ns_per_turn": { "type": "number", "exclusiveMinimum": 0 },
+        "rust_kernel_ns_per_turn": { "type": "number", "exclusiveMinimum": 0 },
+        "rust_epoch_ns_per_turn": { "type": "number", "exclusiveMinimum": 0 },
+        "resident_kernel_ratio": { "type": "number", "exclusiveMinimum": 0 },
+        "resident_kernel_vs_raw_epoch": { "type": "number", "exclusiveMinimum": 0 },
+        "limit_multiplier": { "const": 1.05 },
+        "limit_ns_per_turn": { "type": "number", "exclusiveMinimum": 0 },
+        "passed": { "type": "boolean" }
+      }
+    },
     "resident_breakdown": { "type": "object" },
     "decision": { "type": "object" }
   },

--- a/scripts/check-gate-b-contract.py
+++ b/scripts/check-gate-b-contract.py
@@ -68,6 +68,16 @@ def required_lane_keys() -> set[tuple[str, int]]:
     return keys
 
 
+def required_phase_lane_keys(phase: str) -> set[tuple[str, int]]:
+    if phase not in {"B0-controls", "B1-resident-kernel"}:
+        raise ValueError(f"unsupported Gate B report phase {phase!r}")
+    keys = required_lane_keys()
+    if phase == "B1-resident-kernel":
+        keys.update(("mech-resident-kernel", instances) for instances in SCALED_INSTANCES)
+        keys.add(("mech-resident-kernel-full-write", 1))
+    return keys
+
+
 def call_occurs_before(source: str, call: str, boundary: str) -> bool:
     call_position = source.find(f"{call}(")
     boundary_position = source.find(boundary)
@@ -183,6 +193,15 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
         root / "src/runtime/benches/support/gate_b/raw_epoch.rs",
         root / "src/runtime/benches/support/gate_b/full_write.rs",
         root / "src/runtime/benches/support/gate_b/legacy_atomic.rs",
+        root / "src/runtime/benches/support/gate_b/resident_kernel.rs",
+        root / "src/engine/src/resident/artifact.rs",
+        root / "src/engine/src/resident/activation.rs",
+        root / "src/engine/src/resident/arena.rs",
+        root / "src/engine/src/resident/workspace.rs",
+        root / "src/engine/src/resident/candidate.rs",
+        root / "src/engine/src/resident/full_write.rs",
+        root / "src/engine/src/resident/kernel.rs",
+        root / "src/engine/src/resident/efficacy/ekf.rs",
     )
     errors = [f"missing required Gate B fixture: {path.relative_to(root)}" for path in required if not path.is_file()]
     if errors:
@@ -252,6 +271,68 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
     full_write = read_text(root / "src/runtime/benches/support/gate_b/full_write.rs")
     legacy = read_text(root / "src/runtime/benches/support/gate_b/legacy_atomic.rs")
     benchmark = read_text(root / "src/runtime/benches/resident_ekf.rs")
+    resident_root = root / "src/engine/src/resident"
+    resident_sources = {
+        source: read_text(source) for source in resident_root.rglob("*.rs")
+    }
+    forbidden_resident_identifiers = {
+        "Value", "Ref", "ValRef", "ReactiveCellId", "ReactiveTurnJournal",
+        "ValueStateJournal", "RuntimeExecutionTransaction",
+        "transaction_state_values", "capture_runtime_operation_savepoint",
+        "commit_runtime",
+    }
+    for source, text in resident_sources.items():
+        identifiers = set(re.split(r"[^A-Za-z0-9_]+", text))
+        forbidden = forbidden_resident_identifiers.intersection(identifiers)
+        if forbidden:
+            errors.append(
+                f"resident source {source.relative_to(root)} uses legacy state: "
+                + ", ".join(sorted(forbidden))
+            )
+    resident_text = "\n".join(resident_sources.values())
+    forbidden_resident_source = (
+        "slots: Box<[Versioned<Box<[f64]>>]>",
+        "plan.slot(",
+        "left_rows",
+        "left_columns",
+        "right_columns",
+        "Vec<ResidentEkf>",
+        "raw_kernel::step",
+        "ekf_step",
+    )
+    for forbidden in forbidden_resident_source:
+        if forbidden in resident_text:
+            errors.append(f"resident timed implementation contains forbidden {forbidden}")
+    full_write_path = root / "src/engine/src/resident/full_write.rs"
+    for source, text in resident_sources.items():
+        if source != full_write_path and "Box<[f64]>" in text:
+            errors.append(
+                "resident typed EKF storage is erased in "
+                f"{source.relative_to(root)}"
+            )
+    if sum(text.count(".store(") for text in resident_sources.values()) != 1:
+        errors.append("resident execution must contain exactly one publication store site")
+    candidate_source = resident_sources[root / "src/engine/src/resident/candidate.rs"]
+    if "next_epoch: Option<InstanceEpoch>" not in candidate_source or "checked_next()" not in candidate_source:
+        errors.append("resident candidate epochs do not use checked exhaustion")
+    artifact_source = resident_sources[root / "src/engine/src/resident/artifact.rs"]
+    if artifact_source.count("node(") < 15:
+        errors.append("resident EKF artifact lost its explicit node manifest")
+    activation_source = resident_sources[root / "src/engine/src/resident/activation.rs"]
+    for required_topology in (
+        "consumer_offsets",
+        "consumer_nodes",
+        "downstream_offsets",
+        "downstream_nodes",
+        "linear_node_order",
+    ):
+        if required_topology not in activation_source:
+            errors.append(f"resident activation lost {required_topology}")
+    resident_fixture = read_text(
+        root / "src/runtime/benches/support/gate_b/resident_kernel.rs"
+    )
+    if "resident: ResidentEkfBatch" not in resident_fixture:
+        errors.append("scaled resident lanes do not use one ResidentEkfBatch")
     if "raw_kernel::step(" not in raw_epoch or "raw_kernel::step(" not in legacy:
         errors.append("raw epoch and legacy controls must call the shared raw EKF kernel")
     if raw_epoch.count("published_epoch.store(") != 1:
@@ -416,7 +497,12 @@ def report_contract_errors(
         errors.append("Gate B report includes correctness work in timing")
 
     lanes = _lane_map(report, errors)
-    missing = required_lane_keys().difference(lanes)
+    try:
+        required_lanes = required_phase_lane_keys(report["phase"])
+    except ValueError as error:
+        errors.append(str(error))
+        required_lanes = set()
+    missing = required_lanes.difference(lanes)
     if missing:
         errors.append(
             "Gate B report is missing lanes: "
@@ -462,6 +548,66 @@ def report_contract_errors(
         if structural.get("receipt_bytes") != 64:
             errors.append(f"raw epoch {instances} reports the wrong receipt size")
 
+    if report["phase"] == "B1-resident-kernel":
+        if report["git_branch"] != "feat/engine-resident-ekf-substrate":
+            errors.append("B1 evidence is attributed to the wrong branch")
+        for instances in SCALED_INSTANCES:
+            key = ("mech-resident-kernel", instances)
+            if key not in lanes:
+                continue
+            lane = lanes[key]
+            allocation = lane.get("allocation", {})
+            structural = lane.get("structural", {})
+            if allocation.get("episode_allocation_count") != 0 or allocation.get("episode_allocated_bytes") != 0:
+                errors.append(f"resident kernel {instances} allocates during the timed episode")
+            if structural.get("candidate_seed_bytes") != 0:
+                errors.append(f"resident kernel {instances} seeds candidate storage")
+            if structural.get("published_buffer_copy_bytes") != 0:
+                errors.append(f"resident kernel {instances} copies published storage")
+            if structural.get("publication_store_count") != 1:
+                errors.append(f"resident kernel {instances} does not use one publication store")
+            if structural.get("candidate_written_bytes") != instances * 96:
+                errors.append(
+                    f"resident kernel {instances} reports the wrong written-byte count"
+                )
+            if structural.get("receipt_bytes") != 0:
+                errors.append(f"resident kernel {instances} constructs a receipt in B1")
+            if structural.get("commit_runtime_call_count") != 0:
+                errors.append(f"resident kernel {instances} calls the runtime commit path")
+            if structural.get("legacy_journal_capture_count") != 0:
+                errors.append(f"resident kernel {instances} captures a legacy journal")
+
+        resident_full_key = ("mech-resident-kernel-full-write", 1)
+        if resident_full_key in lanes:
+            lane = lanes[resident_full_key]
+            allocation = lane.get("allocation", {})
+            structural = lane.get("structural", {})
+            if allocation.get("episode_allocation_count") != 0 or allocation.get("episode_allocated_bytes") != 0:
+                errors.append("resident full-write allocates during the timed episode")
+            for field in (
+                "candidate_seed_bytes",
+                "published_buffer_copy_bytes",
+                "receipt_bytes",
+                "commit_runtime_call_count",
+                "legacy_journal_capture_count",
+            ):
+                if structural.get(field) != 0:
+                    errors.append(f"resident full-write reports nonzero {field}")
+            if structural.get("candidate_written_bytes") != 64 * 64 * 8:
+                errors.append("resident full-write reports the wrong written-byte count")
+            if structural.get("publication_store_count") != 1:
+                errors.append("resident full-write does not use one publication store")
+            if not structural.get("abort_output_hash"):
+                errors.append("resident full-write has no forced-abort output hash")
+            raw_full = lanes.get(("rust-epoch-full-write", 1))
+            if raw_full is not None:
+                if lane.get("quantized_state_hash") != raw_full.get("quantized_state_hash"):
+                    errors.append("resident full-write terminal hash differs from raw epoch")
+                if structural.get("abort_output_hash") != raw_full.get("structural", {}).get(
+                    "abort_output_hash"
+                ):
+                    errors.append("resident full-write forced-abort hash differs from raw epoch")
+
     full_key = ("rust-epoch-full-write", 1)
     if full_key in lanes:
         lane = lanes[full_key]
@@ -505,6 +651,40 @@ def report_contract_errors(
             errors.append("Gate B derived positive flag disagrees with the denominator")
         if report["stop_condition"].get("passed") is not (denominator > 0.0):
             errors.append("Gate B stop-condition result disagrees with the denominator")
+
+    if report["phase"] == "B1-resident-kernel":
+        progression = report.get("b1_progression")
+        if not isinstance(progression, dict):
+            errors.append("B1 report is missing b1_progression")
+        elif all(
+            key in lanes
+            for key in (
+                ("mech-resident-kernel", 1),
+                ("rust-kernel", 1),
+                ("rust-epoch", 1),
+            )
+        ):
+            resident = lanes[("mech-resident-kernel", 1)]["timing"]["median_ns_per_turn"]
+            rust_kernel = lanes[("rust-kernel", 1)]["timing"]["median_ns_per_turn"]
+            rust_epoch = lanes[("rust-epoch", 1)]["timing"]["median_ns_per_turn"]
+            expected = {
+                "resident_kernel_ns_per_turn": resident,
+                "rust_kernel_ns_per_turn": rust_kernel,
+                "rust_epoch_ns_per_turn": rust_epoch,
+                "resident_kernel_ratio": resident / rust_kernel,
+                "resident_kernel_vs_raw_epoch": resident / rust_epoch,
+                "limit_multiplier": 1.05,
+                "limit_ns_per_turn": 1.05 * rust_epoch,
+            }
+            for field, value in expected.items():
+                reported = progression.get(field)
+                if not isinstance(reported, (int, float)) or not math.isclose(
+                    float(reported), float(value), rel_tol=1.0e-12, abs_tol=1.0e-9
+                ):
+                    errors.append(f"B1 progression {field} is inconsistent with lane medians")
+            passed = resident <= 1.05 * rust_epoch
+            if progression.get("passed") is not passed:
+                errors.append("B1 progression passed flag disagrees with the unchanged limit")
     return errors
 
 

--- a/scripts/run-gate-b-benchmarks.py
+++ b/scripts/run-gate-b-benchmarks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run and summarize the controlled Gate B B0 benchmark lanes."""
+"""Run and summarize the controlled Gate B benchmark lanes."""
 
 from __future__ import annotations
 
@@ -20,6 +20,8 @@ ROOT = Path(__file__).resolve().parents[1]
 SAMPLE_PREFIX = "GATE_B_SAMPLE "
 FROZEN_BASE = "437f6c6c636d9818729597342165dfc9af5eb4a7"
 FROZEN_B0_BRANCH = "test/resident-ekf-efficacy-contract"
+FROZEN_B1_BRANCH = "feat/engine-resident-ekf-substrate"
+FROZEN_B1_BASE = "c4f7cb1d27b9645b3f669d944c7e49bcd0829ccc"
 EPISODE_LENGTH = 4_096
 SCALED_INSTANCES = (1, 8, 64)
 THREAD_VARIABLES = (
@@ -121,24 +123,30 @@ def parse_probe_samples(output: str) -> dict[tuple[str, int], dict[str, Any]]:
     return samples
 
 
-def merge_legacy_structural_probes(
+def merge_structural_probes(
     timed: dict[tuple[str, int], dict[str, Any]],
     structural: dict[tuple[str, int], dict[str, Any]],
 ) -> dict[tuple[str, int], dict[str, Any]]:
     merged = {key: value.copy() for key, value in timed.items()}
-    required = {
+    legacy = {
         *(("mech-legacy-atomic", instances) for instances in SCALED_INSTANCES),
         ("mech-legacy-atomic-full-write", 1),
     }
-    for key in required:
+    resident = {
+        *(("mech-resident-kernel", instances) for instances in SCALED_INSTANCES),
+        ("mech-resident-kernel-full-write", 1),
+    }
+    for key in legacy | resident:
         if key not in merged:
-            raise ValueError(f"missing timed legacy probe {key[0]}/{key[1]}")
+            raise ValueError(f"missing timed structural probe {key[0]}/{key[1]}")
         if key not in structural:
-            raise ValueError(f"missing untimed legacy probe {key[0]}/{key[1]}")
-        for field in (
-            "commit_runtime_call_count",
-            "legacy_journal_capture_count",
-        ):
+            raise ValueError(f"missing untimed structural probe {key[0]}/{key[1]}")
+        fields = (
+            ("commit_runtime_call_count", "legacy_journal_capture_count")
+            if key in legacy
+            else STRUCTURAL_FIELDS
+        )
+        for field in fields:
             merged[key][field] = structural[key].get(field)
     return merged
 
@@ -327,6 +335,7 @@ def assemble_lanes(
     rust_lanes = (
         ("rust-kernel", "gate_b/rust-kernel/{instances}"),
         ("rust-epoch", "gate_b/rust-epoch/{instances}"),
+        ("mech-resident-kernel", "gate_b/mech-resident-kernel/{instances}"),
         ("mech-legacy-atomic", "gate_b/mech-legacy-atomic/{instances}"),
     )
     for lane, benchmark_template in rust_lanes:
@@ -352,6 +361,7 @@ def assemble_lanes(
     for lane, benchmark in (
         ("rust-epoch-full-write", "gate_b/full-write/rust-epoch"),
         ("mech-legacy-atomic-full-write", "gate_b/full-write/mech-legacy-atomic"),
+        ("mech-resident-kernel-full-write", "gate_b/full-write/mech-resident-kernel"),
     ):
         if benchmark not in criterion:
             raise ValueError(f"missing Criterion result {benchmark}")
@@ -414,18 +424,40 @@ def legacy_denominator(lanes: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def b1_progression(lanes: list[dict[str, Any]]) -> dict[str, Any]:
+    resident = primary_median(lanes, "mech-resident-kernel")
+    rust_kernel = primary_median(lanes, "rust-kernel")
+    rust_epoch = primary_median(lanes, "rust-epoch")
+    multiplier = 1.05
+    limit = multiplier * rust_epoch
+    return {
+        "resident_kernel_ns_per_turn": resident,
+        "rust_kernel_ns_per_turn": rust_kernel,
+        "rust_epoch_ns_per_turn": rust_epoch,
+        "resident_kernel_ratio": resident / rust_kernel,
+        "resident_kernel_vs_raw_epoch": resident / rust_epoch,
+        "limit_multiplier": multiplier,
+        "limit_ns_per_turn": limit,
+        "passed": resident <= limit,
+    }
+
+
 def worktree_changes() -> str:
     return command_output(["git", "status", "--porcelain=v1", "--untracked-files=all"])
 
 
 def frozen_base_error(commit: str, branch: str) -> str | None:
-    if branch != FROZEN_B0_BRANCH:
-        return f"Gate B B0 must run on {FROZEN_B0_BRANCH}, not {branch}"
-    merge_base = command_output(["git", "merge-base", commit, FROZEN_BASE])
-    if merge_base != FROZEN_BASE:
+    expected_base = {
+        FROZEN_B0_BRANCH: FROZEN_BASE,
+        FROZEN_B1_BRANCH: FROZEN_B1_BASE,
+    }.get(branch)
+    if expected_base is None:
+        return f"Gate B controls cannot run on unapproved branch {branch}"
+    merge_base = command_output(["git", "merge-base", commit, expected_base])
+    if merge_base != expected_base:
         return (
-            f"Gate B B0 commit {commit} is not based on frozen base "
-            f"{FROZEN_BASE}; merge-base is {merge_base}"
+            f"Gate B commit {commit} is not based on frozen base "
+            f"{expected_base}; merge-base is {merge_base}"
         )
     return None
 
@@ -577,7 +609,7 @@ def main() -> int:
                 encoding="utf-8"
             )
         )
-        probes = merge_legacy_structural_probes(
+        probes = merge_structural_probes(
             parse_probe_samples(process.stdout),
             parse_probe_samples(structural_process.stdout),
         )
@@ -595,7 +627,7 @@ def main() -> int:
     summary = {
         "schema_version": 1,
         "gate": "B",
-        "phase": "B0-controls",
+        "phase": "B0-controls" if branch == FROZEN_B0_BRANCH else "B1-resident-kernel",
         "git_commit": commit,
         "git_branch": branch,
         "machine": {
@@ -651,6 +683,8 @@ def main() -> int:
             "passed": bool(derived["positive"]),
         },
     }
+    if branch == FROZEN_B1_BRANCH:
+        summary["b1_progression"] = b1_progression(lanes)
     rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
     if args.output:
         output = args.output if args.output.is_absolute() else ROOT / args.output
@@ -664,6 +698,12 @@ def main() -> int:
             file=sys.stderr,
         )
         return 3
+    if branch == FROZEN_B1_BRANCH and not summary["b1_progression"]["passed"]:
+        print(
+            "Gate B B1 stop: mech-resident-kernel exceeds 1.05 x rust-epoch",
+            file=sys.stderr,
+        )
+        return 4
     return 0
 
 

--- a/scripts/tests/test_check_gate_b_contract.py
+++ b/scripts/tests/test_check_gate_b_contract.py
@@ -17,6 +17,8 @@ def lane(name, instances):
     is_numpy = name == "numpy-persistent"
     is_epoch = name == "rust-epoch"
     is_full_epoch = name == "rust-epoch-full-write"
+    is_resident = name == "mech-resident-kernel"
+    is_resident_full = name == "mech-resident-kernel-full-write"
     is_legacy = name.startswith("mech-legacy-atomic")
     allocation_count = None if is_numpy else (1 if is_legacy else 0)
     allocated_bytes = None if is_numpy else (8 if is_legacy else 0)
@@ -44,6 +46,21 @@ def lane(name, instances):
                 "candidate_written_bytes": 64 * 64 * 8,
                 "publication_store_count": 1,
                 "receipt_bytes": 64,
+                "abort_output_hash": "c" * 64,
+            }
+        )
+    if is_resident:
+        structural.update(
+            {
+                "candidate_written_bytes": instances * 96,
+                "publication_store_count": 1,
+            }
+        )
+    if is_resident_full:
+        structural.update(
+            {
+                "candidate_written_bytes": 64 * 64 * 8,
+                "publication_store_count": 1,
                 "abort_output_hash": "c" * 64,
             }
         )
@@ -168,12 +185,66 @@ def valid_report():
     }
 
 
+def valid_b1_report():
+    report = valid_report()
+    report["phase"] = "B1-resident-kernel"
+    report["git_branch"] = "feat/engine-resident-ekf-substrate"
+    for instances in (1, 8, 64):
+        resident = lane("mech-resident-kernel", instances)
+        report["lanes"].append(resident)
+    report["lanes"].append(lane("mech-resident-kernel-full-write", 1))
+    report["b1_progression"] = {
+        "resident_kernel_ns_per_turn": 25.0,
+        "rust_kernel_ns_per_turn": 25.0,
+        "rust_epoch_ns_per_turn": 25.0,
+        "resident_kernel_ratio": 1.0,
+        "resident_kernel_vs_raw_epoch": 1.0,
+        "limit_multiplier": 1.05,
+        "limit_ns_per_turn": 26.25,
+        "passed": True,
+    }
+    return report
+
+
 class GateBContractCheckerTests(unittest.TestCase):
     def test_committed_static_contract_passes(self):
         self.assertEqual(CHECKER.static_contract_errors(), [])
 
     def test_valid_b0_report_passes(self):
         self.assertEqual(CHECKER.report_contract_errors(valid_report()), [])
+
+    def test_valid_b1_report_requires_resident_kernel_lanes(self):
+        self.assertEqual(CHECKER.report_contract_errors(valid_b1_report()), [])
+
+    def test_unknown_phase_is_rejected(self):
+        report = valid_report()
+        report["phase"] = "B1-resident-kernel-typo"
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("unsupported Gate B report phase" in error for error in errors))
+
+    def test_empty_and_unknown_future_phases_are_rejected(self):
+        for phase in ("", "B2-dirty-scheduler"):
+            report = valid_report()
+            report["phase"] = phase
+            errors = CHECKER.report_contract_errors(report)
+            self.assertTrue(any("unsupported Gate B report phase" in error for error in errors))
+
+    def test_b1_progression_is_recomputed_from_primary_medians(self):
+        report = valid_b1_report()
+        report["b1_progression"]["resident_kernel_vs_raw_epoch"] = 0.5
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("resident_kernel_vs_raw_epoch" in error for error in errors))
+
+    def test_scaled_resident_requires_one_batch_publication(self):
+        report = valid_b1_report()
+        result = next(
+            lane
+            for lane in report["lanes"]
+            if lane["lane"] == "mech-resident-kernel" and lane["instances"] == 64
+        )
+        result["structural"]["publication_store_count"] = 64
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("does not use one publication store" in error for error in errors))
 
     def test_nonpositive_denominator_is_a_hard_error(self):
         report = valid_report()

--- a/scripts/tests/test_run_gate_b_benchmarks.py
+++ b/scripts/tests/test_run_gate_b_benchmarks.py
@@ -80,7 +80,7 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
             RUNNER.parse_probe_samples(output)[("rust-epoch", 8)], payload
         )
 
-    def test_untimed_legacy_probe_merge_preserves_timed_allocation(self):
+    def test_untimed_probe_merge_preserves_timed_allocation(self):
         timed = {}
         structural = {}
         for instances in RUNNER.SCALED_INSTANCES:
@@ -96,9 +96,25 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
             "commit_runtime_call_count": 4096,
             "legacy_journal_capture_count": 13,
         }
-        merged = RUNNER.merge_legacy_structural_probes(timed, structural)
+        for instances in RUNNER.SCALED_INSTANCES:
+            key = ("mech-resident-kernel", instances)
+            timed[key] = {"allocation_count": 0}
+            structural[key] = {
+                field: (1 if field == "publication_store_count" else 0)
+                for field in RUNNER.STRUCTURAL_FIELDS
+            }
+        resident_full = ("mech-resident-kernel-full-write", 1)
+        timed[resident_full] = {"allocation_count": 0}
+        structural[resident_full] = {
+            field: (1 if field == "publication_store_count" else 0)
+            for field in RUNNER.STRUCTURAL_FIELDS
+        }
+        merged = RUNNER.merge_structural_probes(timed, structural)
         self.assertEqual(merged[full_key]["allocation_count"], 9)
         self.assertEqual(merged[full_key]["commit_runtime_call_count"], 4096)
+        self.assertEqual(
+            merged[("mech-resident-kernel", 64)]["publication_store_count"], 1
+        )
 
     def test_frozen_base_requires_exact_merge_base(self):
         with patch.object(
@@ -114,6 +130,13 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
                 "a" * 40, RUNNER.FROZEN_B0_BRANCH
             )
         self.assertIn("not based on frozen base", error)
+
+        with patch.object(
+            RUNNER, "command_output", return_value=RUNNER.FROZEN_B1_BASE
+        ):
+            self.assertIsNone(
+                RUNNER.frozen_base_error("c" * 40, RUNNER.FROZEN_B1_BRANCH)
+            )
 
     def test_lane_record_normalizes_by_host_turn_not_instance(self):
         probe = {
@@ -150,6 +173,28 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
         derived = RUNNER.legacy_denominator(lanes)
         self.assertEqual(derived["legacy_denominator_ns_per_turn"], 75.0)
         self.assertTrue(derived["positive"])
+
+    def test_b1_progression_uses_same_session_primary_medians(self):
+        lanes = [
+            {
+                "lane": "mech-resident-kernel",
+                "instances": 1,
+                "timing": {"median_ns_per_turn": 21.0},
+            },
+            {
+                "lane": "rust-kernel",
+                "instances": 1,
+                "timing": {"median_ns_per_turn": 20.0},
+            },
+            {
+                "lane": "rust-epoch",
+                "instances": 1,
+                "timing": {"median_ns_per_turn": 22.0},
+            },
+        ]
+        progression = RUNNER.b1_progression(lanes)
+        self.assertEqual(progression["limit_ns_per_turn"], 23.1)
+        self.assertTrue(progression["passed"])
 
     def test_explicit_machine_label_is_preserved(self):
         self.assertEqual(

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -22,6 +22,7 @@ std = []
 no_std = ["rlibc", "hashbrown", "embedded-io", "fxhash"]
 
 default = []
+resident-execution = []
 full = ["baselib", "pretty_print", "serde", "compiler", "mika", "program",
           "u8", "u16", "u32", "u64", "u128",
           "i8", "i16", "i32", "i64", "i128", 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -118,6 +118,9 @@ pub mod kind;
 pub mod nodes;
 #[cfg(feature = "functions")]
 pub mod reactive_transaction;
+#[cfg(feature = "resident-execution")]
+#[doc(hidden)]
+pub mod resident_execution;
 pub mod state_journal;
 pub mod structures;
 pub mod value;
@@ -144,6 +147,9 @@ pub use self::nodes::*;
 pub use self::program::*;
 #[cfg(feature = "functions")]
 pub use self::reactive_transaction::*;
+#[cfg(feature = "resident-execution")]
+#[doc(hidden)]
+pub use self::resident_execution::*;
 pub use self::state_journal::*;
 pub use self::stdlib::*;
 pub use self::structures::*;

--- a/src/core/src/resident_execution.rs
+++ b/src/core/src/resident_execution.rs
@@ -1,0 +1,47 @@
+//! Dependency-neutral identities for the experimental resident executor.
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct CellSlotId(pub u32);
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct SlotIndex(pub u32);
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct InstanceEpoch(pub u64);
+
+impl InstanceEpoch {
+    /// Returns the next unique resident epoch, or `None` after `u64::MAX`.
+    #[inline]
+    pub const fn checked_next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(next) => Some(Self(next)),
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identities_are_transparent_dependency_free_scalars() {
+        assert_eq!(
+            core::mem::size_of::<CellSlotId>(),
+            core::mem::size_of::<u32>()
+        );
+        assert_eq!(
+            core::mem::size_of::<SlotIndex>(),
+            core::mem::size_of::<u32>()
+        );
+        assert_eq!(
+            core::mem::size_of::<InstanceEpoch>(),
+            core::mem::size_of::<u64>()
+        );
+        assert_eq!(InstanceEpoch(41).checked_next(), Some(InstanceEpoch(42)));
+        assert_eq!(InstanceEpoch(u64::MAX).checked_next(), None);
+    }
+}

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -479,6 +479,7 @@ optional = true
 
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
+sha2 = "0.10"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 web-time = "1.1.0"

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -24,6 +24,7 @@ no_std = ["mech-core/no_std", "mech-syntax?/no_std"]
 runtime = ["program", "functions"]
 # Runtime-only diagnostic hook consumed by mech-runtime's non-default Gate A probes.
 runtime_bench_probes = ["runtime"]
+resident-ekf = ["mech-core/resident-execution"]
 native-plan = ["runtime", "mech-core/native-plan"]
 native-link = ["runtime"]
 source = ["runtime", "dep:mech-syntax"]

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -90,6 +90,8 @@ pub mod mechdown;
 #[cfg(feature = "source")]
 pub mod patterns;
 pub mod program;
+#[cfg(feature = "resident-ekf")]
+mod resident;
 #[cfg(all(feature = "source", feature = "state_machines"))]
 pub mod state_machines;
 #[cfg(feature = "source")]

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -92,6 +92,14 @@ pub mod patterns;
 pub mod program;
 #[cfg(feature = "resident-ekf")]
 mod resident;
+#[cfg(feature = "resident-ekf")]
+#[doc(hidden)]
+pub mod __gate_b_resident {
+    #[cfg(feature = "runtime_bench_probes")]
+    pub use crate::resident::bench::ResidentTurnProbe;
+    pub use crate::resident::bench::{ResidentEkfBatch, ResidentEkfState};
+    pub use crate::resident::{FULL_WRITE_ELEMENTS, ResidentExecutionError, ResidentFullWrite};
+}
 #[cfg(all(feature = "source", feature = "state_machines"))]
 pub mod state_machines;
 #[cfg(feature = "source")]

--- a/src/engine/src/resident/activation.rs
+++ b/src/engine/src/resident/activation.rs
@@ -1,0 +1,227 @@
+use mech_core::{CellSlotId, SlotIndex};
+
+use super::artifact::{
+    EkfConstants, EkfOp, LOGICAL_SLOTS_PER_EKF, NODES_PER_EKF, ProgramArtifact, SlotKind, SlotRole,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub(crate) struct NodeIndex(pub(crate) u32);
+
+pub(crate) type ActivatedKernel = EkfOp;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ResolvedSlot {
+    pub(crate) id: CellSlotId,
+    pub(crate) index: SlotIndex,
+    pub(crate) kind: SlotKind,
+    pub(crate) role: SlotRole,
+    pub(crate) instance: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ActivatedNode {
+    pub(crate) kernel: ActivatedKernel,
+    pub(crate) instance: u32,
+    pub(crate) downstream_start: u32,
+    pub(crate) downstream_len: u16,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DependencyTopology {
+    pub(crate) linear_node_order: Box<[NodeIndex]>,
+    pub(crate) consumer_offsets: Box<[u32]>,
+    pub(crate) consumer_nodes: Box<[NodeIndex]>,
+    pub(crate) downstream_offsets: Box<[u32]>,
+    pub(crate) downstream_nodes: Box<[NodeIndex]>,
+}
+
+impl DependencyTopology {
+    pub(crate) fn consumers(&self, slot: CellSlotId) -> &[NodeIndex] {
+        let index = slot.0 as usize;
+        let start = self.consumer_offsets[index] as usize;
+        let end = self.consumer_offsets[index + 1] as usize;
+        &self.consumer_nodes[start..end]
+    }
+
+    pub(crate) fn downstream(&self, node: NodeIndex) -> &[NodeIndex] {
+        let index = node.0 as usize;
+        let start = self.downstream_offsets[index] as usize;
+        let end = self.downstream_offsets[index + 1] as usize;
+        &self.downstream_nodes[start..end]
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ActivatedPlan {
+    pub(crate) instances: usize,
+    pub(crate) slots: Box<[ResolvedSlot]>,
+    pub(crate) nodes: Box<[ActivatedNode]>,
+    pub(crate) topology: DependencyTopology,
+    pub(crate) constants: EkfConstants,
+}
+
+fn flatten<T: Copy>(lists: &[Vec<T>]) -> (Box<[u32]>, Box<[T]>) {
+    let mut offsets = Vec::with_capacity(lists.len() + 1);
+    let total = lists.iter().map(Vec::len).sum();
+    let mut values = Vec::with_capacity(total);
+    offsets.push(0);
+    for list in lists {
+        values.extend_from_slice(list);
+        offsets.push(u32::try_from(values.len()).expect("resident topology fits u32"));
+    }
+    (offsets.into_boxed_slice(), values.into_boxed_slice())
+}
+
+impl ActivatedPlan {
+    pub(crate) fn activate(artifact: ProgramArtifact) -> Self {
+        let logical_slot_count = artifact.slots.len();
+        let slots: Box<[_]> = artifact
+            .slots
+            .iter()
+            .enumerate()
+            .map(|(index, slot)| {
+                assert_eq!(slot.id.0 as usize, index, "logical slot IDs are dense");
+                ResolvedSlot {
+                    id: slot.id,
+                    index: SlotIndex(index.try_into().expect("resident slot count fits u32")),
+                    kind: slot.kind,
+                    role: slot.role,
+                    instance: slot.instance,
+                }
+            })
+            .collect();
+
+        let mut consumers = vec![Vec::<NodeIndex>::new(); logical_slot_count];
+        for (node, declaration) in artifact.nodes.iter().enumerate() {
+            let node = NodeIndex(node.try_into().expect("resident node count fits u32"));
+            for slot in &declaration.reads {
+                consumers[slot.0 as usize].push(node);
+            }
+        }
+        let (consumer_offsets, consumer_nodes) = flatten(&consumers);
+
+        let mut downstream = vec![Vec::<NodeIndex>::new(); artifact.nodes.len()];
+        for (node, declaration) in artifact.nodes.iter().enumerate() {
+            for output in &declaration.writes {
+                for consumer in &consumers[output.0 as usize] {
+                    if !downstream[node].contains(consumer) {
+                        downstream[node].push(*consumer);
+                    }
+                }
+            }
+            downstream[node].sort_by_key(|index| index.0);
+        }
+        let (downstream_offsets, downstream_nodes) = flatten(&downstream);
+        let nodes: Box<[_]> = artifact
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(index, declaration)| {
+                let start = downstream_offsets[index];
+                let end = downstream_offsets[index + 1];
+                ActivatedNode {
+                    kernel: declaration.op,
+                    instance: declaration.instance,
+                    downstream_start: start,
+                    downstream_len: u16::try_from(end - start)
+                        .expect("resident node fanout fits u16"),
+                }
+            })
+            .collect();
+        let topology = DependencyTopology {
+            linear_node_order: (0..nodes.len())
+                .map(|index| NodeIndex(index as u32))
+                .collect(),
+            consumer_offsets,
+            consumer_nodes,
+            downstream_offsets,
+            downstream_nodes,
+        };
+        debug_assert_eq!(artifact.instances * NODES_PER_EKF, nodes.len());
+        debug_assert_eq!(
+            artifact.instances * LOGICAL_SLOTS_PER_EKF as usize,
+            slots.len()
+        );
+        Self {
+            instances: artifact.instances,
+            slots,
+            nodes,
+            topology,
+            constants: artifact.constants,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resident::slot;
+
+    #[test]
+    fn scaled_activation_is_deterministic_and_topologically_complete() {
+        for instances in [1, 8, 64] {
+            let artifact = ProgramArtifact::frozen_ekf_batch(instances);
+            let declarations = artifact.nodes.clone();
+            let left = ActivatedPlan::activate(artifact);
+            let right = ActivatedPlan::activate(ProgramArtifact::frozen_ekf_batch(instances));
+            assert_eq!(left.nodes.len(), NODES_PER_EKF * instances);
+            assert_eq!(left.slots.len(), LOGICAL_SLOTS_PER_EKF as usize * instances);
+            assert_eq!(left.topology.linear_node_order.len(), left.nodes.len());
+            assert_eq!(
+                left.topology.consumer_offsets,
+                right.topology.consumer_offsets
+            );
+            assert_eq!(left.topology.consumer_nodes, right.topology.consumer_nodes);
+            assert_eq!(
+                left.topology.downstream_offsets,
+                right.topology.downstream_offsets
+            );
+            assert_eq!(
+                left.topology.downstream_nodes,
+                right.topology.downstream_nodes
+            );
+            for (expected, node) in left.nodes.iter().enumerate() {
+                assert_eq!(node.instance as usize, expected / NODES_PER_EKF);
+                let downstream = left.topology.downstream(NodeIndex(expected as u32));
+                assert_eq!(
+                    node.downstream_start,
+                    left.topology.downstream_offsets[expected]
+                );
+                assert_eq!(node.downstream_len as usize, downstream.len());
+            }
+            for instance in 0..instances as u32 {
+                assert_eq!(
+                    left.topology
+                        .consumers(slot::id(instance, slot::INPUT))
+                        .len(),
+                    3
+                );
+                assert_eq!(
+                    left.topology
+                        .consumers(slot::id(instance, slot::STATE))
+                        .len(),
+                    3
+                );
+                assert_eq!(
+                    left.topology
+                        .consumers(slot::id(instance, slot::CORRECTED_STATE))
+                        .len(),
+                    1
+                );
+            }
+            for (node, declaration) in declarations.iter().enumerate() {
+                let node = NodeIndex(node as u32);
+                for input in &declaration.reads {
+                    assert!(left.topology.consumers(*input).contains(&node));
+                }
+                let downstream = left.topology.downstream(node);
+                for output in &declaration.writes {
+                    for consumer in left.topology.consumers(*output) {
+                        assert!(downstream.contains(consumer));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/engine/src/resident/arena.rs
+++ b/src/engine/src/resident/arena.rs
@@ -1,0 +1,130 @@
+use mech_core::InstanceEpoch;
+
+#[derive(Clone, Debug)]
+pub(crate) struct VersionedBatch<T> {
+    pub(crate) buffers: [Box<[T]>; 2],
+    pub(crate) epochs: [Option<InstanceEpoch>; 2],
+}
+
+impl<T: Copy> VersionedBatch<T> {
+    fn activate(instances: usize, initial: T) -> Self {
+        Self {
+            buffers: [
+                vec![initial; instances].into_boxed_slice(),
+                vec![initial; instances].into_boxed_slice(),
+            ],
+            epochs: [Some(InstanceEpoch(0)), None],
+        }
+    }
+
+    #[inline]
+    fn published_index(&self, epoch: InstanceEpoch) -> usize {
+        match self.epochs {
+            [Some(left), _] if left == epoch => 0,
+            [_, Some(right)] if right == epoch => 1,
+            _ => panic!("published resident epoch has no typed buffer"),
+        }
+    }
+
+    #[inline]
+    fn begin_candidate(&mut self, base: InstanceEpoch, working: InstanceEpoch) -> (usize, usize) {
+        let published = self.published_index(base);
+        debug_assert_eq!(self.epochs[published], Some(base));
+        let candidate = 1 - published;
+        self.epochs[candidate] = Some(working);
+        (published, candidate)
+    }
+
+    #[inline]
+    fn reject(&mut self, candidate: usize, working: InstanceEpoch) {
+        debug_assert_eq!(self.epochs[candidate], Some(working));
+        self.epochs[candidate] = None;
+    }
+
+    fn split_buffers(&mut self, published: usize, candidate: usize) -> (&[T], &mut [T]) {
+        debug_assert_ne!(published, candidate);
+        if published == 0 {
+            let (published_buffers, candidate_buffers) = self.buffers.split_at_mut(1);
+            (&published_buffers[0], &mut candidate_buffers[0])
+        } else {
+            let (candidate_buffers, published_buffers) = self.buffers.split_at_mut(1);
+            (&published_buffers[0], &mut candidate_buffers[0])
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StateArena {
+    pub(crate) states: VersionedBatch<[f64; 3]>,
+    pub(crate) covariances: VersionedBatch<[f64; 9]>,
+}
+
+impl StateArena {
+    pub(crate) fn activate(instances: usize) -> Self {
+        Self {
+            states: VersionedBatch::activate(instances, [2.0, 1.0, 0.15]),
+            covariances: VersionedBatch::activate(
+                instances,
+                [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.05],
+            ),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn begin_candidate(
+        &mut self,
+        base: InstanceEpoch,
+        working: InstanceEpoch,
+    ) -> (usize, usize) {
+        let state = self.states.begin_candidate(base, working);
+        let covariance = self.covariances.begin_candidate(base, working);
+        debug_assert_eq!(state, covariance);
+        state
+    }
+
+    #[inline]
+    pub(crate) fn reject_candidate(&mut self, candidate: usize, working: InstanceEpoch) {
+        self.states.reject(candidate, working);
+        self.covariances.reject(candidate, working);
+    }
+
+    pub(crate) fn split_buffers(
+        &mut self,
+        published: usize,
+        candidate: usize,
+    ) -> (&[[f64; 3]], &mut [[f64; 3]], &[[f64; 9]], &mut [[f64; 9]]) {
+        let (states, candidate_states) = self.states.split_buffers(published, candidate);
+        let (covariances, candidate_covariances) =
+            self.covariances.split_buffers(published, candidate);
+        (states, candidate_states, covariances, candidate_covariances)
+    }
+
+    #[inline]
+    pub(crate) fn published_state(&self, epoch: InstanceEpoch, instance: usize) -> [f64; 3] {
+        self.states.buffers[self.states.published_index(epoch)][instance]
+    }
+
+    #[inline]
+    pub(crate) fn published_covariance(&self, epoch: InstanceEpoch, instance: usize) -> [f64; 9] {
+        self.covariances.buffers[self.covariances.published_index(epoch)][instance]
+    }
+
+    #[cfg(test)]
+    pub(crate) fn candidate_state(&self, candidate: usize, instance: usize) -> [f64; 3] {
+        self.states.buffers[candidate][instance]
+    }
+
+    #[cfg(test)]
+    pub(crate) fn buffer_addresses(&self) -> ([usize; 2], [usize; 2]) {
+        (
+            [
+                self.states.buffers[0].as_ptr() as usize,
+                self.states.buffers[1].as_ptr() as usize,
+            ],
+            [
+                self.covariances.buffers[0].as_ptr() as usize,
+                self.covariances.buffers[1].as_ptr() as usize,
+            ],
+        )
+    }
+}

--- a/src/engine/src/resident/artifact.rs
+++ b/src/engine/src/resident/artifact.rs
@@ -1,0 +1,276 @@
+use mech_core::CellSlotId;
+
+pub(crate) const LOGICAL_SLOTS_PER_EKF: u32 = 17;
+pub(crate) const NODES_PER_EKF: usize = 15;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SlotKind {
+    Matrix2,
+    Vector2,
+    Vector3,
+    Matrix3,
+    Matrix2x3,
+    Matrix3x2,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SlotRole {
+    Input,
+    Stateful,
+    Intermediate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SlotDecl {
+    pub(crate) id: CellSlotId,
+    pub(crate) kind: SlotKind,
+    pub(crate) role: SlotRole,
+    pub(crate) instance: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EkfOp {
+    TrigonometricState,
+    MotionJacobian,
+    ControlJacobian,
+    PredictedState,
+    PredictedCovariance,
+    LandmarkDeltaAndRange,
+    PredictedMeasurement,
+    MeasurementJacobian,
+    InnovationCovariance,
+    Solve2x2,
+    KalmanGain,
+    Innovation,
+    CorrectedState,
+    JosephCovarianceUpdate,
+    CovarianceSymmetrization,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct NodeDecl {
+    pub(crate) op: EkfOp,
+    pub(crate) instance: u32,
+    pub(crate) reads: Box<[CellSlotId]>,
+    pub(crate) writes: Box<[CellSlotId]>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct EkfConstants {
+    pub(crate) dt: f64,
+    pub(crate) landmark: [f64; 2],
+    pub(crate) process_covariance: [f64; 4],
+    pub(crate) measurement_covariance: [f64; 4],
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProgramArtifact {
+    pub(crate) instances: usize,
+    pub(crate) slots: Box<[SlotDecl]>,
+    pub(crate) nodes: Box<[NodeDecl]>,
+    pub(crate) constants: EkfConstants,
+}
+
+pub(crate) mod slot {
+    use mech_core::{CellSlotId, SlotIndex};
+
+    use super::LOGICAL_SLOTS_PER_EKF;
+
+    pub(crate) const STATE: u32 = 0;
+    pub(crate) const COVARIANCE: u32 = 1;
+    pub(crate) const INPUT: u32 = 2;
+    pub(crate) const TRIG: u32 = 3;
+    pub(crate) const MOTION_JACOBIAN: u32 = 4;
+    pub(crate) const CONTROL_JACOBIAN: u32 = 5;
+    pub(crate) const PREDICTED_STATE: u32 = 6;
+    pub(crate) const PREDICTED_COVARIANCE: u32 = 7;
+    pub(crate) const DELTA_RANGE: u32 = 8;
+    pub(crate) const PREDICTED_MEASUREMENT: u32 = 9;
+    pub(crate) const MEASUREMENT_JACOBIAN: u32 = 10;
+    pub(crate) const INNOVATION_COVARIANCE: u32 = 11;
+    pub(crate) const INVERSE_INNOVATION: u32 = 12;
+    pub(crate) const GAIN: u32 = 13;
+    pub(crate) const INNOVATION: u32 = 14;
+    pub(crate) const CORRECTED_STATE: u32 = 15;
+    pub(crate) const CORRECTED_COVARIANCE: u32 = 16;
+
+    #[inline]
+    pub(crate) const fn id(instance: u32, local: u32) -> CellSlotId {
+        CellSlotId(instance * LOGICAL_SLOTS_PER_EKF + local)
+    }
+
+    #[inline]
+    pub(crate) const fn index(instance: u32, local: u32) -> SlotIndex {
+        SlotIndex(id(instance, local).0)
+    }
+}
+
+fn node(instance: u32, op: EkfOp, reads: &[u32], writes: &[u32]) -> NodeDecl {
+    NodeDecl {
+        op,
+        instance,
+        reads: reads
+            .iter()
+            .map(|local| slot::id(instance, *local))
+            .collect(),
+        writes: writes
+            .iter()
+            .map(|local| slot::id(instance, *local))
+            .collect(),
+    }
+}
+
+fn append_ekf_nodes(nodes: &mut Vec<NodeDecl>, instance: u32) {
+    use EkfOp::*;
+    use slot::*;
+
+    nodes.extend([
+        node(instance, TrigonometricState, &[STATE], &[TRIG]),
+        node(
+            instance,
+            MotionJacobian,
+            &[STATE, INPUT, TRIG],
+            &[MOTION_JACOBIAN],
+        ),
+        node(instance, ControlJacobian, &[TRIG], &[CONTROL_JACOBIAN]),
+        node(
+            instance,
+            PredictedState,
+            &[STATE, INPUT, TRIG],
+            &[PREDICTED_STATE],
+        ),
+        node(
+            instance,
+            PredictedCovariance,
+            &[COVARIANCE, MOTION_JACOBIAN, CONTROL_JACOBIAN],
+            &[PREDICTED_COVARIANCE],
+        ),
+        node(
+            instance,
+            LandmarkDeltaAndRange,
+            &[PREDICTED_STATE],
+            &[DELTA_RANGE],
+        ),
+        node(
+            instance,
+            PredictedMeasurement,
+            &[PREDICTED_STATE, DELTA_RANGE],
+            &[PREDICTED_MEASUREMENT],
+        ),
+        node(
+            instance,
+            MeasurementJacobian,
+            &[DELTA_RANGE],
+            &[MEASUREMENT_JACOBIAN],
+        ),
+        node(
+            instance,
+            InnovationCovariance,
+            &[PREDICTED_COVARIANCE, MEASUREMENT_JACOBIAN],
+            &[INNOVATION_COVARIANCE],
+        ),
+        node(
+            instance,
+            Solve2x2,
+            &[INNOVATION_COVARIANCE],
+            &[INVERSE_INNOVATION],
+        ),
+        node(
+            instance,
+            KalmanGain,
+            &[
+                PREDICTED_COVARIANCE,
+                MEASUREMENT_JACOBIAN,
+                INVERSE_INNOVATION,
+            ],
+            &[GAIN],
+        ),
+        node(
+            instance,
+            Innovation,
+            &[INPUT, PREDICTED_MEASUREMENT],
+            &[INNOVATION],
+        ),
+        node(
+            instance,
+            CorrectedState,
+            &[PREDICTED_STATE, GAIN, INNOVATION],
+            &[CORRECTED_STATE],
+        ),
+        node(
+            instance,
+            JosephCovarianceUpdate,
+            &[PREDICTED_COVARIANCE, MEASUREMENT_JACOBIAN, GAIN],
+            &[CORRECTED_COVARIANCE],
+        ),
+        node(
+            instance,
+            CovarianceSymmetrization,
+            &[CORRECTED_STATE, CORRECTED_COVARIANCE],
+            &[STATE, COVARIANCE],
+        ),
+    ]);
+}
+
+impl ProgramArtifact {
+    pub(crate) fn frozen_ekf_batch(instances: usize) -> Self {
+        assert!(instances > 0, "resident EKF batch must not be empty");
+        let slot_capacity = instances
+            .checked_mul(LOGICAL_SLOTS_PER_EKF as usize)
+            .expect("resident logical slot count");
+        let node_capacity = instances
+            .checked_mul(NODES_PER_EKF)
+            .expect("resident node count");
+        let mut slots = Vec::with_capacity(slot_capacity);
+        let mut nodes = Vec::with_capacity(node_capacity);
+        for instance in 0..instances {
+            let instance = u32::try_from(instance).expect("resident instance count fits u32");
+            use SlotKind::*;
+            use SlotRole::*;
+            let declarations = [
+                (Vector3, Stateful),
+                (Matrix3, Stateful),
+                (Matrix2, Input),
+                (Vector2, Intermediate),
+                (Matrix3, Intermediate),
+                (Matrix3x2, Intermediate),
+                (Vector3, Intermediate),
+                (Matrix3, Intermediate),
+                (Vector3, Intermediate),
+                (Vector2, Intermediate),
+                (Matrix2x3, Intermediate),
+                (Matrix2, Intermediate),
+                (Matrix2, Intermediate),
+                (Matrix3x2, Intermediate),
+                (Vector2, Intermediate),
+                (Vector3, Intermediate),
+                (Matrix3, Intermediate),
+            ];
+            slots.extend(
+                declarations
+                    .into_iter()
+                    .enumerate()
+                    .map(|(local, (kind, role))| SlotDecl {
+                        id: slot::id(instance, local as u32),
+                        kind,
+                        role,
+                        instance,
+                    }),
+            );
+            append_ekf_nodes(&mut nodes, instance);
+        }
+        debug_assert_eq!(slots.len(), slot_capacity);
+        debug_assert_eq!(nodes.len(), node_capacity);
+        Self {
+            instances,
+            slots: slots.into_boxed_slice(),
+            nodes: nodes.into_boxed_slice(),
+            constants: EkfConstants {
+                dt: 0.05,
+                landmark: [25.0, -10.0],
+                process_covariance: [0.04, 0.0, 0.0, 0.0025],
+                measurement_covariance: [0.25, 0.0, 0.0, 0.0009],
+            },
+        }
+    }
+}

--- a/src/engine/src/resident/bench.rs
+++ b/src/engine/src/resident/bench.rs
@@ -1,0 +1,93 @@
+use super::{ReactiveInstance, ResidentExecutionError, execute_ekf_candidate};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResidentEkfState {
+    pub state: [f64; 3],
+    pub covariance: [f64; 9],
+}
+
+#[cfg(feature = "runtime_bench_probes")]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ResidentTurnProbe {
+    pub candidate_seed_bytes: usize,
+    pub candidate_written_bytes: usize,
+    pub published_buffer_copy_bytes: usize,
+    pub publication_store_count: usize,
+}
+
+pub struct ResidentEkfBatch {
+    instance: ReactiveInstance,
+}
+
+impl ResidentEkfBatch {
+    pub fn new(instances: usize) -> Self {
+        Self {
+            instance: ReactiveInstance::frozen_ekf_batch(instances),
+        }
+    }
+
+    #[inline]
+    pub fn turn(&mut self, input: [f64; 4]) -> Result<(), ResidentExecutionError> {
+        let mut candidate = self.instance.begin_candidate(input)?;
+        if let Err(error) = execute_ekf_candidate(&mut candidate) {
+            candidate.abort();
+            return Err(error);
+        }
+        candidate.publish();
+        Ok(())
+    }
+
+    pub fn execute_then_abort(&mut self, input: [f64; 4]) -> Result<(), ResidentExecutionError> {
+        let mut candidate = self.instance.begin_candidate(input)?;
+        let result = execute_ekf_candidate(&mut candidate);
+        candidate.abort();
+        result
+    }
+
+    pub fn state(&self, index: usize) -> ResidentEkfState {
+        let published = self.instance.published_epoch();
+        ResidentEkfState {
+            state: self.instance.state.published_state(published, index),
+            covariance: self.instance.state.published_covariance(published, index),
+        }
+    }
+
+    pub fn instances(&self) -> usize {
+        self.instance.plan.instances
+    }
+
+    pub fn published_epoch(&self) -> u64 {
+        self.instance.published_epoch().0
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn structural_probe(&self) -> ResidentTurnProbe {
+        debug_assert_eq!(
+            self.instance.workspace.touched_slots.len(),
+            self.instances() * 2
+        );
+        debug_assert_eq!(
+            self.instance.workspace.changed_slots.len(),
+            self.instances() * 2
+        );
+        debug_assert_eq!(
+            self.instance.workspace.invalidated_slots.len(),
+            self.instances() * 2
+        );
+        ResidentTurnProbe {
+            candidate_seed_bytes: 0,
+            candidate_written_bytes: self.instances() * 96,
+            published_buffer_copy_bytes: 0,
+            publication_store_count: 1,
+        }
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn turn_with_probe(
+        &mut self,
+        input: [f64; 4],
+    ) -> Result<ResidentTurnProbe, ResidentExecutionError> {
+        self.turn(input)?;
+        Ok(self.structural_probe())
+    }
+}

--- a/src/engine/src/resident/candidate.rs
+++ b/src/engine/src/resident/candidate.rs
@@ -1,0 +1,110 @@
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use mech_core::InstanceEpoch;
+
+use super::{ActivatedPlan, ProgramArtifact, StateArena, TurnWorkspace};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResidentExecutionError {
+    EpochExhausted,
+    LandmarkDistance,
+    InnovationDeterminant,
+    NonFiniteState,
+    CovarianceDiagonal,
+    CovarianceSymmetry,
+}
+
+#[inline]
+pub(crate) fn publish_epoch(target: &AtomicU64, epoch: InstanceEpoch) {
+    target.store(epoch.0, Ordering::Release);
+}
+
+#[derive(Debug)]
+pub(crate) struct ReactiveInstance {
+    pub(crate) plan: ActivatedPlan,
+    pub(crate) state: StateArena,
+    pub(crate) workspace: TurnWorkspace,
+    pub(crate) published_epoch: AtomicU64,
+    pub(crate) next_epoch: Option<InstanceEpoch>,
+    #[cfg(feature = "runtime_bench_probes")]
+    pub(crate) publication_store_count: u64,
+}
+
+impl ReactiveInstance {
+    pub(crate) fn frozen_ekf_batch(instances: usize) -> Self {
+        let plan = ActivatedPlan::activate(ProgramArtifact::frozen_ekf_batch(instances));
+        let state = StateArena::activate(instances);
+        let workspace = TurnWorkspace::activate(&plan);
+        Self {
+            plan,
+            state,
+            workspace,
+            published_epoch: AtomicU64::new(0),
+            next_epoch: Some(InstanceEpoch(1)),
+            #[cfg(feature = "runtime_bench_probes")]
+            publication_store_count: 0,
+        }
+    }
+
+    pub(crate) fn begin_candidate(
+        &mut self,
+        input: [f64; 4],
+    ) -> Result<Candidate<'_>, ResidentExecutionError> {
+        let working_epoch = self
+            .next_epoch
+            .ok_or(ResidentExecutionError::EpochExhausted)?;
+        self.next_epoch = working_epoch.checked_next();
+        let base_epoch = InstanceEpoch(self.published_epoch.load(Ordering::Acquire));
+        let (published_buffer, candidate_buffer) =
+            self.state.begin_candidate(base_epoch, working_epoch);
+        self.workspace.begin(input);
+        Ok(Candidate {
+            instance: self,
+            base_epoch,
+            working_epoch,
+            published_buffer,
+            candidate_buffer,
+            finished: false,
+        })
+    }
+
+    #[inline]
+    pub(crate) fn published_epoch(&self) -> InstanceEpoch {
+        InstanceEpoch(self.published_epoch.load(Ordering::Acquire))
+    }
+}
+
+pub(crate) struct Candidate<'a> {
+    pub(crate) instance: &'a mut ReactiveInstance,
+    pub(crate) base_epoch: InstanceEpoch,
+    pub(crate) working_epoch: InstanceEpoch,
+    pub(crate) published_buffer: usize,
+    pub(crate) candidate_buffer: usize,
+    finished: bool,
+}
+
+impl Candidate<'_> {
+    #[inline]
+    pub(crate) fn publish(mut self) {
+        publish_epoch(&self.instance.published_epoch, self.working_epoch);
+        #[cfg(feature = "runtime_bench_probes")]
+        {
+            self.instance.publication_store_count += 1;
+        }
+        self.finished = true;
+    }
+
+    #[inline]
+    pub(crate) fn abort(mut self) {
+        self.instance
+            .state
+            .reject_candidate(self.candidate_buffer, self.working_epoch);
+        self.finished = true;
+    }
+}
+
+impl Drop for Candidate<'_> {
+    fn drop(&mut self) {
+        debug_assert!(self.finished, "candidate must publish or abort explicitly");
+    }
+}

--- a/src/engine/src/resident/efficacy/ekf.rs
+++ b/src/engine/src/resident/efficacy/ekf.rs
@@ -1,0 +1,294 @@
+use super::super::{ActivatedKernel, EkfConstants, EkfScratch, ResidentExecutionError};
+
+#[inline(always)]
+fn mat3_mul(a: &[f64; 9], b: &[f64; 9]) -> [f64; 9] {
+    let mut result = [0.0; 9];
+    for column in 0..3 {
+        for row in 0..3 {
+            let mut total = 0.0;
+            for inner in 0..3 {
+                total += a[inner * 3 + row] * b[column * 3 + inner];
+            }
+            result[column * 3 + row] = total;
+        }
+    }
+    result
+}
+
+#[inline(always)]
+fn mat3_mul_mat3x2(a: &[f64; 9], b: &[f64; 6]) -> [f64; 6] {
+    let mut result = [0.0; 6];
+    for column in 0..2 {
+        for row in 0..3 {
+            let mut total = 0.0;
+            for inner in 0..3 {
+                total += a[inner * 3 + row] * b[column * 3 + inner];
+            }
+            result[column * 3 + row] = total;
+        }
+    }
+    result
+}
+
+#[inline(always)]
+fn mat3x2_mul_mat2(a: &[f64; 6], b: &[f64; 4]) -> [f64; 6] {
+    let mut result = [0.0; 6];
+    for column in 0..2 {
+        for row in 0..3 {
+            let mut total = 0.0;
+            for inner in 0..2 {
+                total += a[inner * 3 + row] * b[column * 2 + inner];
+            }
+            result[column * 3 + row] = total;
+        }
+    }
+    result
+}
+
+#[inline(always)]
+fn mat3x2_mul_vec2(a: &[f64; 6], b: &[f64; 2]) -> [f64; 3] {
+    let mut result = [0.0; 3];
+    for row in 0..3 {
+        let mut total = 0.0;
+        for inner in 0..2 {
+            total += a[inner * 3 + row] * b[inner];
+        }
+        result[row] = total;
+    }
+    result
+}
+
+#[inline(always)]
+fn mat3x2_mul_mat2x3(a: &[f64; 6], b: &[f64; 6]) -> [f64; 9] {
+    let mut result = [0.0; 9];
+    for column in 0..3 {
+        for row in 0..3 {
+            let mut total = 0.0;
+            for inner in 0..2 {
+                total += a[inner * 3 + row] * b[column * 2 + inner];
+            }
+            result[column * 3 + row] = total;
+        }
+    }
+    result
+}
+
+#[inline(always)]
+fn mat2x3_mul_mat3(a: &[f64; 6], b: &[f64; 9]) -> [f64; 6] {
+    let mut result = [0.0; 6];
+    for column in 0..3 {
+        for row in 0..2 {
+            let mut total = 0.0;
+            for inner in 0..3 {
+                total += a[inner * 2 + row] * b[column * 3 + inner];
+            }
+            result[column * 2 + row] = total;
+        }
+    }
+    result
+}
+
+#[inline(always)]
+fn mat2x3_mul_mat3x2(a: &[f64; 6], b: &[f64; 6]) -> [f64; 4] {
+    let mut result = [0.0; 4];
+    for column in 0..2 {
+        for row in 0..2 {
+            let mut total = 0.0;
+            for inner in 0..3 {
+                total += a[inner * 2 + row] * b[column * 3 + inner];
+            }
+            result[column * 2 + row] = total;
+        }
+    }
+    result
+}
+
+#[inline(always)]
+fn transpose3(a: &[f64; 9]) -> [f64; 9] {
+    [a[0], a[3], a[6], a[1], a[4], a[7], a[2], a[5], a[8]]
+}
+
+#[inline(always)]
+fn transpose3x2(a: &[f64; 6]) -> [f64; 6] {
+    [a[0], a[3], a[1], a[4], a[2], a[5]]
+}
+
+#[inline(always)]
+fn transpose2x3(a: &[f64; 6]) -> [f64; 6] {
+    [a[0], a[2], a[4], a[1], a[3], a[5]]
+}
+
+#[inline(always)]
+fn add<const N: usize>(left: [f64; N], right: [f64; N]) -> [f64; N] {
+    let mut result = [0.0; N];
+    for index in 0..N {
+        result[index] = left[index] + right[index];
+    }
+    result
+}
+
+#[inline(always)]
+pub(crate) fn execute(
+    kernel: ActivatedKernel,
+    input: &[f64; 4],
+    state: &[f64; 3],
+    covariance: &[f64; 9],
+    candidate_state: &mut [f64; 3],
+    candidate_covariance: &mut [f64; 9],
+    scratch: &mut EkfScratch,
+    constants: &EkfConstants,
+) -> Result<(), ResidentExecutionError> {
+    use super::super::EkfOp::*;
+    match kernel {
+        TrigonometricState => {
+            scratch.trig = [state[2].cos(), state[2].sin()];
+        }
+        MotionJacobian => {
+            scratch.motion_jacobian = [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                -input[0] * scratch.trig[1] * constants.dt,
+                input[0] * scratch.trig[0] * constants.dt,
+                1.0,
+            ];
+        }
+        ControlJacobian => {
+            scratch.control_jacobian = [
+                scratch.trig[0] * constants.dt,
+                scratch.trig[1] * constants.dt,
+                0.0,
+                0.0,
+                0.0,
+                constants.dt,
+            ];
+        }
+        PredictedState => {
+            scratch.predicted_state = [
+                state[0] + input[0] * scratch.trig[0] * constants.dt,
+                state[1] + input[0] * scratch.trig[1] * constants.dt,
+                state[2] + input[1] * constants.dt,
+            ];
+        }
+        PredictedCovariance => {
+            let gp = mat3_mul(&scratch.motion_jacobian, covariance);
+            let predicted = mat3_mul(&gp, &transpose3(&scratch.motion_jacobian));
+            let vq = mat3x2_mul_mat2(&scratch.control_jacobian, &constants.process_covariance);
+            let process = mat3x2_mul_mat2x3(&vq, &transpose3x2(&scratch.control_jacobian));
+            scratch.predicted_covariance = add(predicted, process);
+        }
+        LandmarkDeltaAndRange => {
+            let dx = constants.landmark[0] - scratch.predicted_state[0];
+            let dy = constants.landmark[1] - scratch.predicted_state[1];
+            let q = dx * dx + dy * dy;
+            if q <= 1.0e-12 {
+                return Err(ResidentExecutionError::LandmarkDistance);
+            }
+            scratch.delta_range = [dx, dy, q.sqrt()];
+        }
+        PredictedMeasurement => {
+            scratch.predicted_measurement = [
+                scratch.delta_range[2],
+                scratch.delta_range[1].atan2(scratch.delta_range[0]) - scratch.predicted_state[2],
+            ];
+        }
+        MeasurementJacobian => {
+            let q = scratch.delta_range[0] * scratch.delta_range[0]
+                + scratch.delta_range[1] * scratch.delta_range[1];
+            scratch.measurement_jacobian = [
+                -scratch.delta_range[0] / scratch.delta_range[2],
+                scratch.delta_range[1] / q,
+                -scratch.delta_range[1] / scratch.delta_range[2],
+                -scratch.delta_range[0] / q,
+                0.0,
+                -1.0,
+            ];
+        }
+        InnovationCovariance => {
+            let hp = mat2x3_mul_mat3(&scratch.measurement_jacobian, &scratch.predicted_covariance);
+            let measurement_transpose = transpose2x3(&scratch.measurement_jacobian);
+            scratch.innovation_covariance = add(
+                mat2x3_mul_mat3x2(&hp, &measurement_transpose),
+                constants.measurement_covariance,
+            );
+        }
+        Solve2x2 => {
+            let matrix = scratch.innovation_covariance;
+            let determinant = matrix[0] * matrix[3] - matrix[2] * matrix[1];
+            if determinant.abs() <= 1.0e-12 {
+                return Err(ResidentExecutionError::InnovationDeterminant);
+            }
+            scratch.inverse_innovation = [
+                matrix[3] / determinant,
+                -matrix[1] / determinant,
+                -matrix[2] / determinant,
+                matrix[0] / determinant,
+            ];
+        }
+        KalmanGain => {
+            let measurement_transpose = transpose2x3(&scratch.measurement_jacobian);
+            let pht = mat3_mul_mat3x2(&scratch.predicted_covariance, &measurement_transpose);
+            scratch.gain = mat3x2_mul_mat2(&pht, &scratch.inverse_innovation);
+        }
+        Innovation => {
+            scratch.innovation = [
+                input[2] - scratch.predicted_measurement[0],
+                input[3] - scratch.predicted_measurement[1],
+            ];
+        }
+        CorrectedState => {
+            let correction = mat3x2_mul_vec2(&scratch.gain, &scratch.innovation);
+            scratch.corrected_state = [
+                scratch.predicted_state[0] + correction[0],
+                scratch.predicted_state[1] + correction[1],
+                scratch.predicted_state[2] + correction[2],
+            ];
+        }
+        JosephCovarianceUpdate => {
+            let kh = mat3x2_mul_mat2x3(&scratch.gain, &scratch.measurement_jacobian);
+            let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+            let mut a = [0.0; 9];
+            for index in 0..9 {
+                a[index] = identity[index] - kh[index];
+            }
+            let ap = mat3_mul(&a, &scratch.predicted_covariance);
+            let joseph = mat3_mul(&ap, &transpose3(&a));
+            let kr = mat3x2_mul_mat2(&scratch.gain, &constants.measurement_covariance);
+            let measurement = mat3x2_mul_mat2x3(&kr, &transpose3x2(&scratch.gain));
+            scratch.corrected_covariance = add(joseph, measurement);
+        }
+        CovarianceSymmetrization => {
+            let transposed = transpose3(&scratch.corrected_covariance);
+            for index in 0..9 {
+                candidate_covariance[index] =
+                    0.5 * (scratch.corrected_covariance[index] + transposed[index]);
+            }
+            *candidate_state = scratch.corrected_state;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_shape_transposes_preserve_column_major_layout() {
+        assert_eq!(
+            transpose3(&[0., 1., 2., 3., 4., 5., 6., 7., 8.]),
+            [0., 3., 6., 1., 4., 7., 2., 5., 8.]
+        );
+        assert_eq!(
+            transpose3x2(&[0., 1., 2., 3., 4., 5.]),
+            [0., 3., 1., 4., 2., 5.]
+        );
+        assert_eq!(
+            transpose2x3(&[0., 1., 2., 3., 4., 5.]),
+            [0., 2., 4., 1., 3., 5.]
+        );
+    }
+}

--- a/src/engine/src/resident/full_write.rs
+++ b/src/engine/src/resident/full_write.rs
@@ -1,0 +1,129 @@
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use mech_core::InstanceEpoch;
+
+use super::{ResidentExecutionError, publish_epoch};
+
+pub const FULL_WRITE_ELEMENTS: usize = 64 * 64;
+
+pub struct ResidentFullWrite {
+    versions: [Box<[f64]>; 2],
+    coefficient: Box<[f64]>,
+    buffer_epochs: [Option<InstanceEpoch>; 2],
+    published_epoch: AtomicU64,
+    next_epoch: Option<InstanceEpoch>,
+    #[cfg(feature = "runtime_bench_probes")]
+    publication_store_count: u64,
+}
+
+impl ResidentFullWrite {
+    pub fn new() -> Self {
+        let initial: Box<[f64]> = (0..FULL_WRITE_ELEMENTS)
+            .map(|index| (index as f64 + 1.0) * 0.0001)
+            .collect();
+        let coefficient: Box<[f64]> = (0..FULL_WRITE_ELEMENTS)
+            .map(|index| ((index % 127) as f64 + 1.0) * 0.000001)
+            .collect();
+        Self {
+            versions: [initial.clone(), initial],
+            coefficient,
+            buffer_epochs: [Some(InstanceEpoch(0)), None],
+            published_epoch: AtomicU64::new(0),
+            next_epoch: Some(InstanceEpoch(1)),
+            #[cfg(feature = "runtime_bench_probes")]
+            publication_store_count: 0,
+        }
+    }
+
+    #[inline]
+    fn published_index(&self, epoch: InstanceEpoch) -> usize {
+        if self.buffer_epochs[0] == Some(epoch) {
+            0
+        } else {
+            1
+        }
+    }
+
+    fn execute(&mut self, input: f64, publish: bool) -> Result<(), ResidentExecutionError> {
+        let working_epoch = self
+            .next_epoch
+            .ok_or(ResidentExecutionError::EpochExhausted)?;
+        self.next_epoch = working_epoch.checked_next();
+        let published_epoch = InstanceEpoch(self.published_epoch.load(Ordering::Acquire));
+        let published = self.published_index(published_epoch);
+        debug_assert_eq!(self.buffer_epochs[published], Some(published_epoch));
+        let candidate = 1 - published;
+        self.buffer_epochs[candidate] = Some(working_epoch);
+        if published == 0 {
+            let (current, next) = self.versions.split_at_mut(1);
+            for index in 0..FULL_WRITE_ELEMENTS {
+                next[0][index] = current[0][index] * 1.000001 + self.coefficient[index] * input;
+            }
+        } else {
+            let (next, current) = self.versions.split_at_mut(1);
+            for index in 0..FULL_WRITE_ELEMENTS {
+                next[0][index] = current[0][index] * 1.000001 + self.coefficient[index] * input;
+            }
+        }
+        if !self.versions[candidate]
+            .iter()
+            .all(|value| value.is_finite())
+        {
+            self.buffer_epochs[candidate] = None;
+            return Err(ResidentExecutionError::NonFiniteState);
+        }
+        if publish {
+            publish_epoch(&self.published_epoch, working_epoch);
+            #[cfg(feature = "runtime_bench_probes")]
+            {
+                self.publication_store_count += 1;
+            }
+        } else {
+            self.buffer_epochs[candidate] = None;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn turn(&mut self, input: f64) -> Result<(), ResidentExecutionError> {
+        self.execute(input, true)
+    }
+
+    pub fn execute_then_abort(&mut self, input: f64) -> Result<(), ResidentExecutionError> {
+        self.execute(input, false)
+    }
+
+    pub fn published(&self) -> &[f64] {
+        let epoch = InstanceEpoch(self.published_epoch.load(Ordering::Acquire));
+        &self.versions[self.published_index(epoch)]
+    }
+
+    pub fn published_epoch(&self) -> u64 {
+        self.published_epoch.load(Ordering::Acquire)
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn structural_probe(&self) -> super::bench::ResidentTurnProbe {
+        super::bench::ResidentTurnProbe {
+            candidate_seed_bytes: 0,
+            candidate_written_bytes: FULL_WRITE_ELEMENTS * size_of::<f64>(),
+            published_buffer_copy_bytes: 0,
+            publication_store_count: 1,
+        }
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn turn_with_probe(
+        &mut self,
+        input: f64,
+    ) -> Result<super::bench::ResidentTurnProbe, ResidentExecutionError> {
+        self.turn(input)?;
+        Ok(self.structural_probe())
+    }
+}
+
+impl Default for ResidentFullWrite {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/engine/src/resident/kernel.rs
+++ b/src/engine/src/resident/kernel.rs
@@ -1,0 +1,86 @@
+use mech_core::InstanceEpoch;
+
+use super::{Candidate, NODES_PER_EKF, ResidentExecutionError, efficacy::ekf};
+
+#[inline]
+fn validate_candidate(
+    state: &[f64; 3],
+    covariance: &[f64; 9],
+) -> Result<(), ResidentExecutionError> {
+    if !state
+        .iter()
+        .chain(covariance)
+        .all(|value| value.is_finite())
+    {
+        return Err(ResidentExecutionError::NonFiniteState);
+    }
+    if ![0, 4, 8].into_iter().all(|index| covariance[index] > 0.0) {
+        return Err(ResidentExecutionError::CovarianceDiagonal);
+    }
+    let mut symmetry_error = 0.0_f64;
+    for column in 0..3 {
+        for row in 0..3 {
+            symmetry_error = symmetry_error
+                .max((covariance[column * 3 + row] - covariance[row * 3 + column]).abs());
+        }
+    }
+    if symmetry_error > 1.0e-10 {
+        return Err(ResidentExecutionError::CovarianceSymmetry);
+    }
+    Ok(())
+}
+
+pub(crate) fn execute_ekf_candidate(
+    candidate: &mut Candidate<'_>,
+) -> Result<(), ResidentExecutionError> {
+    let working_epoch = candidate.working_epoch;
+    let published_buffer = candidate.published_buffer;
+    let candidate_buffer = candidate.candidate_buffer;
+    let resident = &mut *candidate.instance;
+    let plan = &resident.plan;
+    let input = resident.workspace.input;
+    {
+        let (states, candidate_states, covariances, candidate_covariances) = resident
+            .state
+            .split_buffers(published_buffer, candidate_buffer);
+        let scratch = &mut resident.workspace.scratch;
+        let marks = &mut resident.workspace.node_execution_marks;
+        let order = &resident.workspace.linear_node_order;
+        for instance in 0..plan.instances {
+            let node_start = instance * NODES_PER_EKF;
+            for offset in 0..NODES_PER_EKF {
+                let node_index = order[node_start + offset];
+                let node = plan.nodes[node_index.0 as usize];
+                debug_assert_eq!(node.instance as usize, instance);
+                ekf::execute(
+                    node.kernel,
+                    &input,
+                    &states[instance],
+                    &covariances[instance],
+                    &mut candidate_states[instance],
+                    &mut candidate_covariances[instance],
+                    &mut scratch[instance],
+                    &plan.constants,
+                )?;
+                marks[node_index.0 as usize] = working_epoch;
+            }
+            validate_candidate(
+                &candidate_states[instance],
+                &candidate_covariances[instance],
+            )?;
+        }
+    }
+    for instance in 0..plan.instances as u32 {
+        resident
+            .workspace
+            .record_candidate_outputs(instance, working_epoch);
+        resident.workspace.record_changed_outputs(instance);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn node_executed(candidate: &Candidate<'_>, node: usize) -> bool {
+    candidate.instance.workspace.node_execution_marks[node]
+        == InstanceEpoch(candidate.working_epoch.0)
+}

--- a/src/engine/src/resident/mod.rs
+++ b/src/engine/src/resident/mod.rs
@@ -1,5 +1,12 @@
 mod activation;
+mod arena;
 mod artifact;
+mod candidate;
+mod workspace;
 
 pub(crate) use activation::*;
+pub(crate) use arena::*;
 pub(crate) use artifact::*;
+pub use candidate::ResidentExecutionError;
+pub(crate) use candidate::{Candidate, ReactiveInstance, publish_epoch};
+pub(crate) use workspace::*;

--- a/src/engine/src/resident/mod.rs
+++ b/src/engine/src/resident/mod.rs
@@ -1,0 +1,5 @@
+mod activation;
+mod artifact;
+
+pub(crate) use activation::*;
+pub(crate) use artifact::*;

--- a/src/engine/src/resident/mod.rs
+++ b/src/engine/src/resident/mod.rs
@@ -18,3 +18,6 @@ pub(crate) use candidate::{Candidate, ReactiveInstance, publish_epoch};
 pub use full_write::{FULL_WRITE_ELEMENTS, ResidentFullWrite};
 pub(crate) use kernel::*;
 pub(crate) use workspace::*;
+
+#[cfg(test)]
+mod tests;

--- a/src/engine/src/resident/mod.rs
+++ b/src/engine/src/resident/mod.rs
@@ -1,12 +1,20 @@
 mod activation;
 mod arena;
 mod artifact;
+pub(crate) mod bench;
 mod candidate;
+mod full_write;
+mod kernel;
 mod workspace;
+mod efficacy {
+    pub(crate) mod ekf;
+}
 
 pub(crate) use activation::*;
 pub(crate) use arena::*;
 pub(crate) use artifact::*;
 pub use candidate::ResidentExecutionError;
 pub(crate) use candidate::{Candidate, ReactiveInstance, publish_epoch};
+pub use full_write::{FULL_WRITE_ELEMENTS, ResidentFullWrite};
+pub(crate) use kernel::*;
 pub(crate) use workspace::*;

--- a/src/engine/src/resident/tests.rs
+++ b/src/engine/src/resident/tests.rs
@@ -1,0 +1,89 @@
+use mech_core::InstanceEpoch;
+
+use super::*;
+
+#[test]
+fn candidate_reads_observe_own_writes_before_publication() {
+    let mut instance = ReactiveInstance::frozen_ekf_batch(1);
+    let published = instance.state.published_state(InstanceEpoch(0), 0);
+    let mut candidate = instance.begin_candidate([1.0, 0.1, 24.0, -0.6]).unwrap();
+    execute_ekf_candidate(&mut candidate).unwrap();
+    assert_ne!(
+        candidate
+            .instance
+            .state
+            .candidate_state(candidate.candidate_buffer, 0),
+        published
+    );
+    assert!(node_executed(
+        &candidate,
+        candidate.instance.plan.nodes.len() - 1
+    ));
+    candidate.abort();
+    assert_eq!(
+        instance.state.published_state(InstanceEpoch(0), 0),
+        published
+    );
+}
+
+#[test]
+fn aborts_reuse_the_same_two_buffers() {
+    let mut instance = ReactiveInstance::frozen_ekf_batch(1);
+    let addresses = instance.state.buffer_addresses();
+    for _ in 0..10_000 {
+        let mut candidate = instance.begin_candidate([1.0, 0.1, 24.0, -0.6]).unwrap();
+        execute_ekf_candidate(&mut candidate).unwrap();
+        candidate.abort();
+    }
+    assert_eq!(instance.state.buffer_addresses(), addresses);
+    assert_eq!(instance.state.states.epochs.iter().flatten().count(), 1);
+    assert_eq!(
+        instance.state.covariances.epochs.iter().flatten().count(),
+        1
+    );
+}
+
+#[test]
+fn maximum_epoch_is_legal_once_and_never_reused() {
+    let mut instance = ReactiveInstance::frozen_ekf_batch(1);
+    instance.next_epoch = Some(InstanceEpoch(u64::MAX));
+    let mut candidate = instance.begin_candidate([1.0, 0.1, 24.0, -0.6]).unwrap();
+    assert_eq!(candidate.working_epoch, InstanceEpoch(u64::MAX));
+    execute_ekf_candidate(&mut candidate).unwrap();
+    candidate.publish();
+    assert_eq!(instance.published_epoch(), InstanceEpoch(u64::MAX));
+    assert_eq!(instance.next_epoch, None);
+    assert!(matches!(
+        instance.begin_candidate([1.0, 0.1, 24.0, -0.6]),
+        Err(ResidentExecutionError::EpochExhausted)
+    ));
+}
+
+#[test]
+fn accepted_candidate_tracks_touched_invalidated_and_changed_outputs() {
+    let mut instance = ReactiveInstance::frozen_ekf_batch(8);
+    let mut candidate = instance.begin_candidate([1.0, 0.1, 24.0, -0.6]).unwrap();
+    execute_ekf_candidate(&mut candidate).unwrap();
+    assert_eq!(candidate.instance.workspace.touched_slots.len(), 16);
+    assert_eq!(candidate.instance.workspace.invalidated_slots.len(), 16);
+    assert_eq!(candidate.instance.workspace.changed_slots.len(), 16);
+    candidate.publish();
+}
+
+#[test]
+fn aborted_and_accepted_epochs_are_never_reused() {
+    let input = [1.0, 0.1, 24.0, -0.6];
+    let mut instance = ReactiveInstance::frozen_ekf_batch(1);
+    let first = instance.begin_candidate(input).unwrap();
+    let rejected_epoch = first.working_epoch;
+    first.abort();
+    let mut second = instance.begin_candidate(input).unwrap();
+    let accepted_epoch = second.working_epoch;
+    assert!(accepted_epoch.0 > rejected_epoch.0);
+    execute_ekf_candidate(&mut second).unwrap();
+    second.publish();
+    let third = instance.begin_candidate(input).unwrap();
+    assert!(third.working_epoch.0 > accepted_epoch.0);
+    third.abort();
+    assert_eq!(instance.published_epoch(), accepted_epoch);
+}

--- a/src/engine/src/resident/workspace.rs
+++ b/src/engine/src/resident/workspace.rs
@@ -1,0 +1,77 @@
+use mech_core::{InstanceEpoch, SlotIndex};
+
+use super::{ActivatedPlan, NodeIndex, slot};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct EkfScratch {
+    pub(crate) trig: [f64; 2],
+    pub(crate) motion_jacobian: [f64; 9],
+    pub(crate) control_jacobian: [f64; 6],
+    pub(crate) predicted_state: [f64; 3],
+    pub(crate) predicted_covariance: [f64; 9],
+    pub(crate) delta_range: [f64; 3],
+    pub(crate) predicted_measurement: [f64; 2],
+    pub(crate) measurement_jacobian: [f64; 6],
+    pub(crate) innovation_covariance: [f64; 4],
+    pub(crate) inverse_innovation: [f64; 4],
+    pub(crate) gain: [f64; 6],
+    pub(crate) innovation: [f64; 2],
+    pub(crate) corrected_state: [f64; 3],
+    pub(crate) corrected_covariance: [f64; 9],
+}
+
+#[derive(Debug)]
+pub(crate) struct TurnWorkspace {
+    pub(crate) input: [f64; 4],
+    pub(crate) scratch: Box<[EkfScratch]>,
+    pub(crate) slot_epoch_marks: Box<[InstanceEpoch]>,
+    pub(crate) touched_slots: Vec<SlotIndex>,
+    pub(crate) invalidated_slots: Vec<SlotIndex>,
+    pub(crate) changed_slots: Vec<SlotIndex>,
+    pub(crate) node_execution_marks: Box<[InstanceEpoch]>,
+    pub(crate) linear_node_order: Box<[NodeIndex]>,
+}
+
+impl TurnWorkspace {
+    pub(crate) fn activate(plan: &ActivatedPlan) -> Self {
+        let persistent_capacity = plan.instances * 2;
+        Self {
+            input: [0.0; 4],
+            scratch: vec![EkfScratch::default(); plan.instances].into_boxed_slice(),
+            slot_epoch_marks: vec![InstanceEpoch(0); plan.slots.len()].into_boxed_slice(),
+            touched_slots: Vec::with_capacity(persistent_capacity),
+            invalidated_slots: Vec::with_capacity(persistent_capacity),
+            changed_slots: Vec::with_capacity(persistent_capacity),
+            node_execution_marks: vec![InstanceEpoch(0); plan.nodes.len()].into_boxed_slice(),
+            linear_node_order: plan.topology.linear_node_order.clone(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn begin(&mut self, input: [f64; 4]) {
+        self.input = input;
+        self.touched_slots.clear();
+        self.invalidated_slots.clear();
+        self.changed_slots.clear();
+    }
+
+    #[inline]
+    pub(crate) fn record_candidate_outputs(&mut self, instance: u32, epoch: InstanceEpoch) {
+        for local in [slot::STATE, slot::COVARIANCE] {
+            let index = slot::index(instance, local);
+            let mark = &mut self.slot_epoch_marks[index.0 as usize];
+            if *mark != epoch {
+                *mark = epoch;
+                self.touched_slots.push(index);
+                self.invalidated_slots.push(index);
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn record_changed_outputs(&mut self, instance: u32) {
+        self.changed_slots.push(slot::index(instance, slot::STATE));
+        self.changed_slots
+            .push(slot::index(instance, slot::COVARIANCE));
+    }
+}

--- a/src/engine/tests/resident_ekf_contract.rs
+++ b/src/engine/tests/resident_ekf_contract.rs
@@ -1,0 +1,136 @@
+#![cfg(feature = "resident-ekf")]
+
+use mech_engine::__gate_b_resident::{FULL_WRITE_ELEMENTS, ResidentEkfBatch, ResidentFullWrite};
+use sha2::{Digest, Sha256};
+
+const TRACE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../benchmarks/runtime/gate-b/ekf-input-v1.bin"
+));
+const TURNS: usize = 4_096;
+const EXPECTED_HASH: &str = "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758";
+
+fn inputs() -> impl Iterator<Item = [f64; 4]> {
+    assert_eq!(TRACE.len(), TURNS * 32);
+    TRACE.chunks_exact(32).map(|row| {
+        let number = |start| f64::from_le_bytes(row[start..start + 8].try_into().unwrap());
+        [number(0), number(8), number(16), number(24)]
+    })
+}
+
+fn quantized_hash(states: impl IntoIterator<Item = [f64; 12]>) -> String {
+    let mut hash = Sha256::new();
+    for state in states {
+        for value in state {
+            hash.update(((value / 1.0e-10).round() as i64).to_le_bytes());
+        }
+    }
+    format!("{:x}", hash.finalize())
+}
+
+fn state_values(resident: &ResidentEkfBatch, instance: usize) -> [f64; 12] {
+    let state = resident.state(instance);
+    let mut values = [0.0; 12];
+    values[..3].copy_from_slice(&state.state);
+    values[3..].copy_from_slice(&state.covariance);
+    values
+}
+
+#[test]
+fn frozen_trace_matches_every_scaled_resident_instance() {
+    for instances in [1, 8, 64] {
+        let mut resident = ResidentEkfBatch::new(instances);
+        let mut trajectory = Vec::with_capacity(TURNS);
+        for input in inputs() {
+            resident
+                .turn(input)
+                .expect("frozen trace must pass integrity");
+            let first = state_values(&resident, 0);
+            for instance in 1..instances {
+                assert_eq!(state_values(&resident, instance), first);
+            }
+            trajectory.push(first);
+        }
+        assert_eq!(quantized_hash(trajectory), EXPECTED_HASH);
+        assert_eq!(resident.published_epoch(), TURNS as u64);
+    }
+}
+
+#[test]
+fn rejected_batches_never_escape_and_repeated_aborts_stay_bounded() {
+    let input = inputs().next().unwrap();
+    let mut resident = ResidentEkfBatch::new(8);
+    resident.turn(input).unwrap();
+    let published: Vec<_> = (0..8).map(|instance| resident.state(instance)).collect();
+    let epoch = resident.published_epoch();
+    for _ in 0..10_000 {
+        resident.execute_then_abort(input).unwrap();
+        assert_eq!(resident.published_epoch(), epoch);
+        for (instance, expected) in published.iter().enumerate() {
+            assert_eq!(resident.state(instance), *expected);
+        }
+    }
+}
+
+#[test]
+fn full_write_uses_the_exact_frozen_recurrence_and_abort_is_invisible() {
+    let mut resident = ResidentFullWrite::new();
+    let mut expected: Vec<_> = (0..FULL_WRITE_ELEMENTS)
+        .map(|index| (index as f64 + 1.0) * 0.0001)
+        .collect();
+    for input in inputs() {
+        resident.turn(input[0]).unwrap();
+        for (index, value) in expected.iter_mut().enumerate() {
+            let coefficient = ((index % 127) as f64 + 1.0) * 0.000001;
+            *value = *value * 1.000001 + coefficient * input[0];
+        }
+    }
+    assert_eq!(resident.published(), expected);
+    let published = resident.published().to_vec();
+    let epoch = resident.published_epoch();
+    resident.execute_then_abort(1.0).unwrap();
+    assert_eq!(resident.published_epoch(), epoch);
+    assert_eq!(resident.published(), published);
+}
+
+#[test]
+fn resident_source_has_no_erased_or_legacy_turn_dependencies() {
+    let resident_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/resident");
+    let mut pending = vec![resident_root];
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if path.extension().and_then(|value| value.to_str()) != Some("rs") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&path).unwrap();
+            for forbidden in [
+                "plan.slot(",
+                "raw_kernel::step",
+                "ekf_step",
+                "RuntimeExecutionTransaction",
+                "ValueStateJournal",
+                "ReactiveTurnJournal",
+                "ValRef",
+                "ReactiveCellId",
+            ] {
+                assert!(
+                    !source.contains(forbidden),
+                    "{} contains forbidden {forbidden}",
+                    path.display()
+                );
+            }
+            if path.file_name().and_then(|value| value.to_str()) != Some("full_write.rs") {
+                assert!(
+                    !source.contains("Box<[f64]>"),
+                    "{} erases typed resident storage",
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -19,7 +19,7 @@ no_std = ["mech-core/no_std", "mech-engine/no_std", "mech-syntax?/no_std"]
 
 runtime = ["mech-engine/runtime"]
 runtime_bench_probes = ["mech-engine/runtime_bench_probes"]
-runtime_bench_gate_b = []
+runtime_bench_gate_b = ["mech-engine/resident-ekf"]
 native-link = ["runtime", "string"]
 source = ["runtime", "mech-engine/source", "dep:mech-syntax"]
 compiler = ["source", "mech-engine/compiler"]

--- a/src/runtime/benches/resident_ekf.rs
+++ b/src/runtime/benches/resident_ekf.rs
@@ -19,6 +19,9 @@ use support::gate_b::full_write::{FullWriteEpochFixture, FullWriteProbe, buffer_
 use support::gate_b::legacy_atomic::{LegacyEkfFixture, LegacyFullWriteFixture};
 use support::gate_b::raw_epoch::{EpochFixture, EpochProbe};
 use support::gate_b::raw_kernel::KernelFixture;
+use support::gate_b::resident_kernel::{
+    ResidentFullWriteFixture, ResidentKernelFixture, ResidentKernelProbe,
+};
 
 struct CountingAllocator;
 
@@ -114,6 +117,18 @@ impl From<FullWriteProbe> for StructuralProbe {
     }
 }
 
+impl From<ResidentKernelProbe> for StructuralProbe {
+    fn from(probe: ResidentKernelProbe) -> Self {
+        Self {
+            candidate_seed_bytes: probe.candidate_seed_bytes,
+            candidate_written_bytes: probe.candidate_written_bytes,
+            published_buffer_copy_bytes: probe.published_buffer_copy_bytes,
+            publication_store_count: probe.publication_store_count,
+            ..Self::default()
+        }
+    }
+}
+
 fn report(
     lane: &str,
     instances: usize,
@@ -185,6 +200,15 @@ fn validate_controls() {
     let mut rejected = EpochFixture::new(1);
     rejected.force_rejected_turn_preserves_publication();
 
+    let mut resident = ResidentKernelFixture::new(1);
+    assert_eq!(
+        resident.run_and_validate_every_turn(),
+        REFERENCE_TRAJECTORY_SHA256
+    );
+    resident.validate_final();
+    let mut resident_rejected = ResidentKernelFixture::new(1);
+    resident_rejected.force_rejected_turn_preserves_publication();
+
     let mut legacy = LegacyEkfFixture::new(1);
     assert_eq!(
         legacy.run_and_validate_every_turn(),
@@ -198,6 +222,9 @@ fn validate_controls() {
     let mut full_legacy = LegacyFullWriteFixture::new();
     full_legacy.run_episode();
     assert_eq!(buffer_hash(&full_legacy.published()), full_hash);
+    let mut full_resident = ResidentFullWriteFixture::new();
+    full_resident.run_episode();
+    assert_eq!(buffer_hash(full_resident.published()), full_hash);
     let mut full_rejected = FullWriteEpochFixture::new();
     assert_eq!(
         full_rejected.abort_output_hash(),
@@ -262,6 +289,40 @@ fn rust_epoch(c: &mut Criterion) {
                         instances,
                         allocations,
                         fixture.probe().into(),
+                        &trajectory_hash,
+                        None,
+                    );
+                }
+                elapsed
+            });
+        });
+    }
+    group.finish();
+}
+
+fn resident_kernel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gate_b/mech-resident-kernel");
+    for instances in SCALED_INSTANCES {
+        let mut correctness = ResidentKernelFixture::new(instances);
+        let trajectory_hash = correctness.run_and_validate_every_turn();
+        assert_eq!(trajectory_hash, REFERENCE_TRAJECTORY_SHA256);
+        group.bench_function(BenchmarkId::from_parameter(instances), |benchmark| {
+            benchmark.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let mut fixture = ResidentKernelFixture::new(instances);
+                    reset_allocations();
+                    let started = Instant::now();
+                    fixture.run_episode();
+                    elapsed += started.elapsed();
+                    let allocations = allocation_snapshot();
+                    fixture.validate_final();
+                    black_box(fixture.state(0));
+                    report(
+                        "mech-resident-kernel",
+                        instances,
+                        allocations,
+                        StructuralProbe::default(),
                         &trajectory_hash,
                         None,
                     );
@@ -364,7 +425,63 @@ fn full_write(c: &mut Criterion) {
             elapsed
         });
     });
+    group.bench_function("mech-resident-kernel", |benchmark| {
+        benchmark.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let mut fixture = ResidentFullWriteFixture::new();
+                reset_allocations();
+                let started = Instant::now();
+                fixture.run_episode();
+                elapsed += started.elapsed();
+                let allocations = allocation_snapshot();
+                let output_hash = buffer_hash(fixture.published());
+                let mut rejected = ResidentFullWriteFixture::new();
+                let abort_hash = rejected.abort_output_hash();
+                black_box(fixture.published());
+                report(
+                    "mech-resident-kernel-full-write",
+                    1,
+                    allocations,
+                    StructuralProbe::default(),
+                    &output_hash,
+                    Some(&abort_hash),
+                );
+            }
+            elapsed
+        });
+    });
     group.finish();
+}
+
+#[cfg(feature = "runtime_bench_probes")]
+fn resident_structural_samples() {
+    for instances in SCALED_INSTANCES {
+        let mut fixture = ResidentKernelFixture::new(instances);
+        let trajectory_hash = fixture.run_and_validate_every_turn();
+        report(
+            "mech-resident-kernel",
+            instances,
+            AllocationSnapshot::default(),
+            fixture.probe().into(),
+            &trajectory_hash,
+            None,
+        );
+    }
+
+    let mut fixture = ResidentFullWriteFixture::new();
+    fixture.run_episode();
+    let output_hash = buffer_hash(fixture.published());
+    let mut rejected = ResidentFullWriteFixture::new();
+    let abort_hash = rejected.abort_output_hash();
+    report(
+        "mech-resident-kernel-full-write",
+        1,
+        AllocationSnapshot::default(),
+        fixture.probe().into(),
+        &output_hash,
+        Some(&abort_hash),
+    );
 }
 
 #[cfg(feature = "runtime_bench_probes")]
@@ -417,11 +534,13 @@ fn gate_b_controls(c: &mut Criterion) {
     validate_controls();
     #[cfg(feature = "runtime_bench_probes")]
     if std::env::var_os("MECH_GATE_B_STRUCTURAL_ONLY").is_some() {
+        resident_structural_samples();
         legacy_structural_samples();
         return;
     }
     rust_kernel(c);
     rust_epoch(c);
+    resident_kernel(c);
     legacy_atomic(c);
     full_write(c);
 }

--- a/src/runtime/benches/support/gate_b/mod.rs
+++ b/src/runtime/benches/support/gate_b/mod.rs
@@ -3,3 +3,4 @@ pub mod full_write;
 pub mod legacy_atomic;
 pub mod raw_epoch;
 pub mod raw_kernel;
+pub mod resident_kernel;

--- a/src/runtime/benches/support/gate_b/resident_kernel.rs
+++ b/src/runtime/benches/support/gate_b/resident_kernel.rs
@@ -1,0 +1,153 @@
+use mech_engine::__gate_b_resident::{ResidentEkfBatch, ResidentFullWrite};
+
+#[cfg(feature = "runtime_bench_probes")]
+use mech_engine::__gate_b_resident::ResidentTurnProbe;
+
+use super::contract::{
+    EPISODE_LENGTH, EkfState, assert_state_close, quantized_trajectory_hash, reference_trajectory,
+    trace,
+};
+use super::full_write::buffer_hash;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ResidentKernelProbe {
+    pub candidate_seed_bytes: usize,
+    pub candidate_written_bytes: usize,
+    pub published_buffer_copy_bytes: usize,
+    pub publication_store_count: usize,
+}
+
+#[cfg(feature = "runtime_bench_probes")]
+impl From<ResidentTurnProbe> for ResidentKernelProbe {
+    fn from(probe: ResidentTurnProbe) -> Self {
+        Self {
+            candidate_seed_bytes: probe.candidate_seed_bytes,
+            candidate_written_bytes: probe.candidate_written_bytes,
+            published_buffer_copy_bytes: probe.published_buffer_copy_bytes,
+            publication_store_count: probe.publication_store_count,
+        }
+    }
+}
+
+pub struct ResidentKernelFixture {
+    resident: ResidentEkfBatch,
+}
+
+impl ResidentKernelFixture {
+    pub fn new(instances: usize) -> Self {
+        Self {
+            resident: ResidentEkfBatch::new(instances),
+        }
+    }
+
+    pub fn run_episode(&mut self) {
+        for input in trace() {
+            self.resident
+                .turn([
+                    input.velocity,
+                    input.angular_velocity,
+                    input.measured_range,
+                    input.measured_bearing,
+                ])
+                .expect("frozen resident EKF turn");
+        }
+    }
+
+    pub fn run_and_validate_every_turn(&mut self) -> String {
+        let mut trajectory = Vec::with_capacity(EPISODE_LENGTH);
+        for (turn, (input, expected)) in trace().iter().zip(reference_trajectory()).enumerate() {
+            self.resident
+                .turn([
+                    input.velocity,
+                    input.angular_velocity,
+                    input.measured_range,
+                    input.measured_bearing,
+                ])
+                .expect("frozen resident EKF turn");
+            for instance in 0..self.resident.instances() {
+                assert_state_close(self.state(instance), *expected, turn + 1);
+            }
+            trajectory.push(self.state(0));
+        }
+        quantized_trajectory_hash(&trajectory)
+    }
+
+    pub fn state(&self, index: usize) -> EkfState {
+        let state = self.resident.state(index);
+        EkfState {
+            state: state.state,
+            covariance: state.covariance,
+        }
+    }
+
+    pub fn validate_final(&self) {
+        for index in 0..self.resident.instances() {
+            assert_state_close(self.state(index), EkfState::REFERENCE_FINAL, EPISODE_LENGTH);
+        }
+    }
+
+    pub fn force_rejected_turn_preserves_publication(&mut self) {
+        let before: Vec<_> = (0..self.resident.instances())
+            .map(|index| self.resident.state(index))
+            .collect();
+        let epoch = self.resident.published_epoch();
+        let input = trace()[0];
+        self.resident
+            .execute_then_abort([
+                input.velocity,
+                input.angular_velocity,
+                input.measured_range,
+                input.measured_bearing,
+            ])
+            .expect("valid candidate before forced abort");
+        for (index, state) in before.into_iter().enumerate() {
+            assert_eq!(self.resident.state(index), state);
+        }
+        assert_eq!(self.resident.published_epoch(), epoch);
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn probe(&self) -> ResidentKernelProbe {
+        self.resident.structural_probe().into()
+    }
+}
+
+pub struct ResidentFullWriteFixture {
+    resident: ResidentFullWrite,
+}
+
+impl ResidentFullWriteFixture {
+    pub fn new() -> Self {
+        Self {
+            resident: ResidentFullWrite::new(),
+        }
+    }
+
+    pub fn run_episode(&mut self) {
+        for input in trace() {
+            self.resident
+                .turn(input.velocity)
+                .expect("frozen resident full-write turn");
+        }
+    }
+
+    pub fn published(&self) -> &[f64] {
+        self.resident.published()
+    }
+
+    pub fn abort_output_hash(&mut self) -> String {
+        let before_epoch = self.resident.published_epoch();
+        let before_hash = buffer_hash(self.resident.published());
+        self.resident
+            .execute_then_abort(1.0)
+            .expect("valid resident full-write candidate before abort");
+        assert_eq!(self.resident.published_epoch(), before_epoch);
+        assert_eq!(buffer_hash(self.resident.published()), before_hash);
+        before_hash
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn probe(&self) -> ResidentKernelProbe {
+        self.resident.structural_probe().into()
+    }
+}


### PR DESCRIPTION
## Scope

Replaces B1 with one faithful private resident implementation for the frozen Gate B EKF workload. This PR intentionally excludes dirty scheduling, receipt preparation, ledger append, production routing, and every B2 concern.

## Architecture

- Uses one `ResidentEkfBatch` for the 1/8/64 scaled workloads and publishes one batch epoch with one release store per external turn.
- Stores persistent EKF state in typed `VersionedBatch<[f64; 3]>` and `VersionedBatch<[f64; 9]>` buffers. Inputs and intermediates live in preallocated typed workspace scratch.
- Activates a deterministic 15 x instances node manifest with precomputed consumer and downstream topology. Timed execution performs no logical slot lookup or runtime shape discovery.
- Uses checked `Option<InstanceEpoch>` allocation: `u64::MAX` is legal once, and the following candidate returns `EpochExhausted` without wrapping or reuse.
- Tracks touched, invalidated, and changed persistent outputs separately and truthfully.
- Keeps the 64 x 64 full-write workload in a separate two-version control using the exact frozen recurrence.
- Keeps structural probing out of the timed build and performs it in the separate non-default probe process.
- Contains no legacy value, reference, journal, or runtime transaction-coordinator dependency.

## Controlled evidence

Report: `benchmarks/runtime/gate-b/b1-resident-kernel.json`

Exact pre-report SHA: `9559c46e2bdb32bbc81f10a50127073b5bcabcd4`

Primary same-session medians:

- `mech-resident-kernel`: 93.036 ns/turn
- `rust-kernel`: 101.824 ns/turn
- `rust-epoch`: 222.778 ns/turn
- unchanged B1 limit (`1.05 x rust-epoch`): 233.917 ns/turn
- resident vs raw epoch: 0.417619
- B1 progression: **passed**

Resident scaled results:

- 1 instance: 93.036 ns/turn, 96 candidate bytes, 1 publication store
- 8 instances: 655.566 ns/turn, 768 candidate bytes, 1 publication store
- 64 instances: 5,145.678 ns/turn, 6,144 candidate bytes, 1 publication store

Every resident scale has zero timed allocations, zero candidate seed bytes, zero published-buffer copy bytes, zero receipt bytes, zero runtime commit calls, zero legacy journal captures, and the frozen trajectory hash.

The resident full-write lane has zero timed allocations, writes 32,768 candidate bytes, performs one publication store, and matches the raw epoch terminal and forced-abort hashes.

## Review findings resolved

The existing single scoped review's findings are resolved by this rewrite: unsupported phases are rejected, candidate epochs cannot wrap, scaled workloads use one truthful batch publication, the exact full-write recurrence reads published storage, dependency topology includes corrected state, and aborted candidates cannot become visible later.

## Validation

- `cargo test -p mech-runtime --lib --features source_default` — 660 passed
- `cargo test -p mech-engine --test resident_ekf_contract --features resident-ekf` — 4 passed
- `cargo test -p mech-engine --lib --features compiler_default,resident-ekf resident::` — 7 passed
- Gate B checker/runner script suites — 27 passed
- timed and probe-enabled resident benchmark builds passed
- `scripts/check-unsafe-boundaries.sh` passed
- `cargo fmt --all -- --check` passed
- Gate B controlled benchmark and exact pre-report evidence validation passed

## Commit structure

Exactly the six commits prescribed by B1, above frozen B0 head `c4f7cb1d27b9645b3f669d944c7e49bcd0829ccc`.
