### PR TITLE
[PR-B2] perf(runtime): prove resident epoch efficacy on the retained EKF

### DIFF
--- a/benchmarks/runtime/gate-b/b2-resident-turn.json
+++ b/benchmarks/runtime/gate-b/b2-resident-turn.json
@@ -1,0 +1,1052 @@
+{
+  "b1_progression": {
+    "limit_multiplier": 1.05,
+    "limit_ns_per_turn": 259.0853160184973,
+    "passed": true,
+    "resident_kernel_ns_per_turn": 90.26945949245143,
+    "resident_kernel_ratio": 0.8801083173121869,
+    "resident_kernel_vs_raw_epoch": 0.36583675958041184,
+    "rust_epoch_ns_per_turn": 246.74792001761642,
+    "rust_kernel_ns_per_turn": 102.56630657477537
+  },
+  "b2_decision": {
+    "conditional_attribution": null,
+    "decision": "Pass",
+    "executor_tax_ns": 202.0937852074259,
+    "hard_gates": {
+      "constant_publication": true,
+      "correctness": true,
+      "executor_tax": true,
+      "history_independent": true,
+      "legacy_gap_closure": true,
+      "no_full_clone": true,
+      "post_publication_append_infallible": true,
+      "raw_epoch_ratio": true,
+      "tail_stability": true,
+      "zero_allocation": true
+    },
+    "high_epoch_over_low_epoch_median_ratio": 1.0006389195929932,
+    "history_100k_over_history_0_median_ratio": 1.0020690289853063,
+    "history_1k_over_history_0_median_ratio": 1.0003214859048637,
+    "legacy_gap_closure": 0.9945923105078902,
+    "numpy_ratio": 0.014056930367226172,
+    "numpy_target": true,
+    "raw_epoch_ratio": 1.1848660960505937,
+    "recording_tax_ns": 173.67423775432567,
+    "scheduler_tax_ns": 28.419547453100222,
+    "tail_ratio": 1.0015773771153091
+  },
+  "benchmark_arguments": [
+    "cargo",
+    "bench",
+    "-p",
+    "mech-runtime",
+    "--bench",
+    "resident_ekf",
+    "--features",
+    "source_default,runtime_bench_gate_b",
+    "--",
+    "--noplot",
+    "--sample-size",
+    "10",
+    "--warm-up-time",
+    "1.0",
+    "--measurement-time",
+    "3.0",
+    "--nresamples",
+    "10000"
+  ],
+  "derived": {
+    "legacy_denominator_ns_per_turn": 8435.27069163603,
+    "mech_legacy_atomic_ns_per_turn": 8682.018611653646,
+    "positive": true,
+    "rust_epoch_ns_per_turn": 246.74792001761642
+  },
+  "gate": "B",
+  "git_branch": "perf/runtime-resident-ekf-efficacy",
+  "git_commit": "bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd",
+  "lanes": [
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 23161.53125,
+        "allocations_per_turn": 211.01318359375,
+        "episode_allocated_bytes": 94869632,
+        "episode_allocation_count": 864310
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-legacy-atomic",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 4096,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 36864,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 8682.018611653646,
+        "p95_ns_per_turn": 8755.59219909668
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 83361.53125,
+        "allocations_per_turn": 766.01318359375,
+        "episode_allocated_bytes": 341448832,
+        "episode_allocation_count": 3137590
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "mech-legacy-atomic",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 4096,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 294912,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 34547.00895182292,
+        "p95_ns_per_turn": 34713.677779134116
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 568014.171875,
+        "allocations_per_turn": 5047.662353515625,
+        "episode_allocated_bytes": 2326586048,
+        "episode_allocation_count": 20675225
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "mech-legacy-atomic",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 4096,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 2359296,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 315144.41931152344,
+        "p95_ns_per_turn": 316674.3144897461
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 115888.349609375,
+        "allocations_per_turn": 143.013671875,
+        "episode_allocated_bytes": 474678680,
+        "episode_allocation_count": 585784
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-legacy-atomic-full-write",
+      "next_epoch": 1,
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 4096,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 12288,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 8820.038592529298,
+        "p95_ns_per_turn": 8879.694102478028
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-kernel",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 90.26945949245143,
+        "p95_ns_per_turn": 90.67700541728252
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "mech-resident-kernel",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 768,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 658.670415969122,
+        "p95_ns_per_turn": 662.6643672252836
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "mech-resident-kernel",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 6144,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 5074.559934828016,
+        "p95_ns_per_turn": 5078.158612060547
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-kernel-full-write",
+      "next_epoch": 1,
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": "c10b5fea1f26905e04b7ca4c90b56710bdebdd356b1936aaf40f55f92675191d",
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 3857.809248352051,
+        "p95_ns_per_turn": 3860.495324707031
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-scheduled",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 15,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 118.68900694555165,
+        "p95_ns_per_turn": 119.55135901314871
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-turn",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 15,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 292.3632446998773,
+        "p95_ns_per_turn": 292.82441179142444
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-turn",
+      "next_epoch": 1000000001,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 15,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 292.55004130518716,
+        "p95_ns_per_turn": 292.74378769985464
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-turn",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 1000,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 15,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 1000
+      },
+      "timing": {
+        "median_ns_per_turn": 292.45723536214854,
+        "p95_ns_per_turn": 292.72996307266715
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-turn",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 100000,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 15,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 100000
+      },
+      "timing": {
+        "median_ns_per_turn": 292.96815272739957,
+        "p95_ns_per_turn": 293.2680892944336
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "mech-resident-turn-full-write",
+      "next_epoch": 1,
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": "c10b5fea1f26905e04b7ca4c90b56710bdebdd356b1936aaf40f55f92675191d",
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 1,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 37040.43572998047,
+        "p95_ns_per_turn": 37046.10489501953
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": null,
+        "allocations_per_turn": null,
+        "episode_allocated_bytes": null,
+        "episode_allocation_count": null
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "numpy-persistent",
+      "next_epoch": 1,
+      "quantized_state_hash": "1b0856ee87055bd50f895f5d8c54f7c29cf6ff6d1530ad3f82332560f392e98f",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": null,
+        "candidate_written_bytes": null,
+        "commit_runtime_call_count": null,
+        "dirty_node_count": null,
+        "ledger_records_inspected": null,
+        "legacy_journal_capture_count": null,
+        "post_publication_append_infallible": null,
+        "publication_store_count": null,
+        "published_buffer_copy_bytes": null,
+        "receipt_bytes": null,
+        "record_append_count": null,
+        "record_preparation_count": null,
+        "records_appended": null,
+        "records_retained_before_timing": null
+      },
+      "timing": {
+        "median_ns_per_turn": 20798.5126953125,
+        "p95_ns_per_turn": 20875.262451171875
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": null,
+        "allocations_per_turn": null,
+        "episode_allocated_bytes": null,
+        "episode_allocation_count": null
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "numpy-persistent",
+      "next_epoch": 1,
+      "quantized_state_hash": "1b0856ee87055bd50f895f5d8c54f7c29cf6ff6d1530ad3f82332560f392e98f",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": null,
+        "candidate_written_bytes": null,
+        "commit_runtime_call_count": null,
+        "dirty_node_count": null,
+        "ledger_records_inspected": null,
+        "legacy_journal_capture_count": null,
+        "post_publication_append_infallible": null,
+        "publication_store_count": null,
+        "published_buffer_copy_bytes": null,
+        "receipt_bytes": null,
+        "record_append_count": null,
+        "record_preparation_count": null,
+        "records_appended": null,
+        "records_retained_before_timing": null
+      },
+      "timing": {
+        "median_ns_per_turn": 161391.0421142578,
+        "p95_ns_per_turn": 162486.77113037108
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": null,
+        "allocations_per_turn": null,
+        "episode_allocated_bytes": null,
+        "episode_allocation_count": null
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "numpy-persistent",
+      "next_epoch": 1,
+      "quantized_state_hash": "1b0856ee87055bd50f895f5d8c54f7c29cf6ff6d1530ad3f82332560f392e98f",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": null,
+        "candidate_written_bytes": null,
+        "commit_runtime_call_count": null,
+        "dirty_node_count": null,
+        "ledger_records_inspected": null,
+        "legacy_journal_capture_count": null,
+        "post_publication_append_infallible": null,
+        "publication_store_count": null,
+        "published_buffer_copy_bytes": null,
+        "receipt_bytes": null,
+        "record_append_count": null,
+        "record_preparation_count": null,
+        "records_appended": null,
+        "records_retained_before_timing": null
+      },
+      "timing": {
+        "median_ns_per_turn": 1295971.2575683594,
+        "p95_ns_per_turn": 1302969.670666504
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "rust-epoch",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 96,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 246.74792001761642,
+        "p95_ns_per_turn": 246.99667886305997
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "rust-epoch",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 768,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 1393.8555859375,
+        "p95_ns_per_turn": 1394.712113647461
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "rust-epoch",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 6144,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 10573.925255475726,
+        "p95_ns_per_turn": 10584.814434814452
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "rust-epoch-full-write",
+      "next_epoch": 1,
+      "quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "reference_quantized_state_hash": "da2a7736565a2cfc2b9d33e66f81b757c82766cea69f216a060fdc5b24a91ff2",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": "c10b5fea1f26905e04b7ca4c90b56710bdebdd356b1936aaf40f55f92675191d",
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 32768,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": true,
+        "publication_store_count": 1,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 64,
+        "record_append_count": 1,
+        "record_preparation_count": 1,
+        "records_appended": 4096,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 34928.34480794271,
+        "p95_ns_per_turn": 35209.873962402344
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 1,
+      "lane": "rust-kernel",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 102.56630657477537,
+        "p95_ns_per_turn": 102.71644867952847
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 8,
+      "lane": "rust-kernel",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 775.4906441824777,
+        "p95_ns_per_turn": 801.4443363613552
+      },
+      "turns_per_sample": 4096
+    },
+    {
+      "allocation": {
+        "allocated_bytes_per_turn": 0.0,
+        "allocations_per_turn": 0.0,
+        "episode_allocated_bytes": 0,
+        "episode_allocation_count": 0
+      },
+      "correctness": true,
+      "instances": 64,
+      "lane": "rust-kernel",
+      "next_epoch": 1,
+      "quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "reference_quantized_state_hash": "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758",
+      "retained_history": 0,
+      "sample_count": 10,
+      "structural": {
+        "abort_output_hash": null,
+        "candidate_seed_bytes": 0,
+        "candidate_written_bytes": 0,
+        "commit_runtime_call_count": 0,
+        "dirty_node_count": 0,
+        "ledger_records_inspected": 0,
+        "legacy_journal_capture_count": 0,
+        "post_publication_append_infallible": false,
+        "publication_store_count": 0,
+        "published_buffer_copy_bytes": 0,
+        "receipt_bytes": 0,
+        "record_append_count": 0,
+        "record_preparation_count": 0,
+        "records_appended": 0,
+        "records_retained_before_timing": 0
+      },
+      "timing": {
+        "median_ns_per_turn": 6181.268360279224,
+        "p95_ns_per_turn": 6273.83397623698
+      },
+      "turns_per_sample": 4096
+    }
+  ],
+  "machine": {
+    "architecture": "arm64",
+    "identity": "MacBook Air, Mac15,13, Apple M3",
+    "os": "macOS-26.2-arm64-arm-64bit"
+  },
+  "phase": "B2-resident-turn",
+  "raw_criterion_directory": "/private/tmp/mech-b2-v04/target/criterion",
+  "raw_output": "/private/tmp/mech-b2-v04/target/gate-b-benchmark-runs/bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd/b0-controls.log",
+  "raw_structural_probe_output": "/private/tmp/mech-b2-v04/target/gate-b-benchmark-runs/bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd/b0-structural.log",
+  "sample_protocol": {
+    "correctness_included_in_timing": false,
+    "criterion_sample_size": 10,
+    "fixture_setup_included_in_timing": false,
+    "measurement_seconds": 3.0,
+    "numpy_sample_size": 10,
+    "profile": "release",
+    "turns_per_sample": 4096,
+    "warm_up_seconds": 1.0
+  },
+  "schema_version": 1,
+  "stop_condition": {
+    "name": "positive-legacy-denominator",
+    "passed": true
+  },
+  "structural_probe_arguments": [
+    "cargo",
+    "bench",
+    "-p",
+    "mech-runtime",
+    "--bench",
+    "resident_ekf",
+    "--features",
+    "source_default,runtime_bench_gate_b,runtime_bench_probes",
+    "--",
+    "--noplot"
+  ],
+  "thread_environment": {
+    "BLIS_NUM_THREADS": "1",
+    "MKL_NUM_THREADS": "1",
+    "NUMEXPR_NUM_THREADS": "1",
+    "OMP_NUM_THREADS": "1",
+    "OPENBLAS_NUM_THREADS": "1",
+    "RAYON_NUM_THREADS": "1",
+    "VECLIB_MAXIMUM_THREADS": "1"
+  },
+  "toolchain": {
+    "CARGO_ENCODED_RUSTFLAGS": "",
+    "RUSTFLAGS": "",
+    "blas_lapack_provider": "accelerate",
+    "numpy": "2.0.2",
+    "numpy_config": "{\n  \"Compilers\": {\n    \"c\": {\n      \"name\": \"clang\",\n      \"linker\": \"ld64\",\n      \"version\": \"15.0.0\",\n      \"commands\": \"cc\"\n    },\n    \"cython\": {\n      \"name\": \"cython\",\n      \"linker\": \"cython\",\n      \"version\": \"3.0.11\",\n      \"commands\": \"cython\"\n    },\n    \"c++\": {\n      \"name\": \"clang\",\n      \"linker\": \"ld64\",\n      \"version\": \"15.0.0\",\n      \"commands\": \"c++\"\n    }\n  },\n  \"Machine Information\": {\n    \"host\": {\n      \"cpu\": \"aarch64\",\n      \"family\": \"aarch64\",\n      \"endian\": \"little\",\n      \"system\": \"darwin\"\n    },\n    \"build\": {\n      \"cpu\": \"aarch64\",\n      \"family\": \"aarch64\",\n      \"endian\": \"little\",\n      \"system\": \"darwin\"\n    }\n  },\n  \"Build Dependencies\": {\n    \"blas\": {\n      \"name\": \"accelerate\",\n      \"found\": true,\n      \"version\": \"unknown\",\n      \"detection method\": \"system\",\n      \"include directory\": \"unknown\",\n      \"lib directory\": \"unknown\",\n      \"openblas configuration\": \"unknown\",\n      \"pc file directory\": \"unknown\"\n    },\n    \"lapack\": {\n      \"name\": \"accelerate\",\n      \"found\": true,\n      \"version\": \"unknown\",\n      \"detection method\": \"system\",\n      \"include directory\": \"unknown\",\n      \"lib directory\": \"unknown\",\n      \"openblas configuration\": \"unknown\",\n      \"pc file directory\": \"unknown\"\n    }\n  },\n  \"Python Information\": {\n    \"path\": \"/private/var/folders/4d/0gnh84wj53j7wyk695q0tc_80000gn/T/build-env-kq4kuj35/bin/python\",\n    \"version\": \"3.9\"\n  },\n  \"SIMD Extensions\": {\n    \"baseline\": [\n      \"NEON\",\n      \"NEON_FP16\",\n      \"NEON_VFPV4\",\n      \"ASIMD\"\n    ],\n    \"found\": [\n      \"ASIMDHP\"\n    ],\n    \"not found\": [\n      \"ASIMDFHM\"\n    ]\n  }\n}",
+    "python": "3.9.6",
+    "python_executable": "/private/tmp/mech-gate-b-venv/bin/python",
+    "rustc": "rustc 1.96.0-nightly (ec818fda3 2026-03-02)\nbinary: rustc\ncommit-hash: ec818fda361ca216eb186f5cf45131bd9c776bb4\ncommit-date: 2026-03-02\nhost: aarch64-apple-darwin\nrelease: 1.96.0-nightly\nLLVM version: 22.1.0"
+  },
+  "trace": {
+    "file": "ekf-input-v1.bin",
+    "sha256": "ab901e1d115aa92166dc2a6d45a28732e6a548363b829997aa410ae4c2d77c8b"
+  },
+  "workload": {
+    "episode_length": 4096,
+    "matrix_storage": "column-major",
+    "scalar": "f64",
+    "scaled_instances": [
+      1,
+      8,
+      64
+    ],
+    "version": "resident-ekf-v1"
+  }
+}

--- a/benchmarks/runtime/gate-b/result-schema.json
+++ b/benchmarks/runtime/gate-b/result-schema.json
@@ -218,7 +218,8 @@
       }
     },
     "resident_breakdown": { "type": "object" },
-    "decision": { "type": "object" }
+    "decision": { "type": "object" },
+    "b2_decision": { "type": "object" }
   },
   "$defs": {
     "lane": {
@@ -239,6 +240,8 @@
       "properties": {
         "lane": { "type": "string", "minLength": 1 },
         "instances": { "enum": [1, 8, 64] },
+        "retained_history": { "type": "integer", "minimum": 0 },
+        "next_epoch": { "type": "integer", "minimum": 1 },
         "sample_count": { "type": "integer", "minimum": 10 },
         "turns_per_sample": { "const": 4096 },
         "timing": {
@@ -293,6 +296,13 @@
             "receipt_bytes": { "type": ["integer", "null"], "minimum": 0 },
             "commit_runtime_call_count": { "type": ["integer", "null"], "minimum": 0 },
             "legacy_journal_capture_count": { "type": ["integer", "null"], "minimum": 0 },
+            "dirty_node_count": { "type": ["integer", "null"], "minimum": 0 },
+            "record_preparation_count": { "type": ["integer", "null"], "minimum": 0 },
+            "record_append_count": { "type": ["integer", "null"], "minimum": 0 },
+            "records_retained_before_timing": { "type": ["integer", "null"], "minimum": 0 },
+            "records_appended": { "type": ["integer", "null"], "minimum": 0 },
+            "ledger_records_inspected": { "type": ["integer", "null"], "minimum": 0 },
+            "post_publication_append_infallible": { "type": ["boolean", "null"] },
             "abort_output_hash": {
               "type": ["string", "null"],
               "pattern": "^[0-9a-f]{64}$"

--- a/scripts/check-gate-b-contract.py
+++ b/scripts/check-gate-b-contract.py
@@ -48,9 +48,12 @@ def import_roots(source: str) -> set[str]:
     return roots
 
 
-def required_lane_keys() -> set[tuple[str, int]]:
+LaneKey = tuple[str, int, int, int]
+
+
+def required_lane_keys() -> set[LaneKey]:
     keys = {
-        (lane, instances)
+        (lane, instances, 0, 1)
         for lane in (
             "rust-kernel",
             "rust-epoch",
@@ -61,20 +64,34 @@ def required_lane_keys() -> set[tuple[str, int]]:
     }
     keys.update(
         {
-            ("rust-epoch-full-write", 1),
-            ("mech-legacy-atomic-full-write", 1),
+            ("rust-epoch-full-write", 1, 0, 1),
+            ("mech-legacy-atomic-full-write", 1, 0, 1),
         }
     )
     return keys
 
 
-def required_phase_lane_keys(phase: str) -> set[tuple[str, int]]:
-    if phase not in {"B0-controls", "B1-resident-kernel"}:
+def required_phase_lane_keys(phase: str) -> set[LaneKey]:
+    if phase not in {"B0-controls", "B1-resident-kernel", "B2-resident-turn"}:
         raise ValueError(f"unsupported Gate B report phase {phase!r}")
     keys = required_lane_keys()
-    if phase == "B1-resident-kernel":
-        keys.update(("mech-resident-kernel", instances) for instances in SCALED_INSTANCES)
-        keys.add(("mech-resident-kernel-full-write", 1))
+    if phase in {"B1-resident-kernel", "B2-resident-turn"}:
+        keys.update(
+            ("mech-resident-kernel", instances, 0, 1)
+            for instances in SCALED_INSTANCES
+        )
+        keys.add(("mech-resident-kernel-full-write", 1, 0, 1))
+    if phase == "B2-resident-turn":
+        keys.update(
+            {
+                ("mech-resident-scheduled", 1, 0, 1),
+                ("mech-resident-turn", 1, 0, 1),
+                ("mech-resident-turn", 1, 1_000, 1),
+                ("mech-resident-turn", 1, 100_000, 1),
+                ("mech-resident-turn", 1, 0, 1_000_000_001),
+                ("mech-resident-turn-full-write", 1, 0, 1),
+            }
+        )
     return keys
 
 
@@ -194,6 +211,8 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
         root / "src/runtime/benches/support/gate_b/full_write.rs",
         root / "src/runtime/benches/support/gate_b/legacy_atomic.rs",
         root / "src/runtime/benches/support/gate_b/resident_kernel.rs",
+        root / "src/runtime/benches/support/gate_b/resident_turn.rs",
+        root / "src/runtime/src/resident_gate_b.rs",
         root / "src/engine/src/resident/artifact.rs",
         root / "src/engine/src/resident/activation.rs",
         root / "src/engine/src/resident/arena.rs",
@@ -331,8 +350,82 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
     resident_fixture = read_text(
         root / "src/runtime/benches/support/gate_b/resident_kernel.rs"
     )
+    resident_turn_fixture = read_text(
+        root / "src/runtime/benches/support/gate_b/resident_turn.rs"
+    )
+    resident_recorder = read_text(root / "src/runtime/src/resident_gate_b.rs")
     if "resident: ResidentEkfBatch" not in resident_fixture:
         errors.append("scaled resident lanes do not use one ResidentEkfBatch")
+    complete_path = resident_turn_fixture + "\n" + resident_recorder
+    forbidden_complete_identifiers = forbidden_resident_identifiers | {
+        "RuntimeContext",
+        "HashSet",
+        "BinaryHeap",
+    }
+    complete_identifiers = set(re.split(r"[^A-Za-z0-9_]+", complete_path))
+    forbidden_complete = forbidden_complete_identifiers.intersection(
+        complete_identifiers
+    )
+    if forbidden_complete:
+        errors.append(
+            "resident complete path uses forbidden legacy or variable-work state: "
+            + ", ".join(sorted(forbidden_complete))
+        )
+    if re.search(r"GateBFixedReceipt\s*[<&]", complete_path):
+        errors.append("resident complete path retains a receipt payload reference")
+    for frozen in (
+        "pub fn prepare_commit<'instance>",
+        "pub fn prepare_full_write_commit<'instance>",
+        "let summary = turn.summary();",
+        "self.prepare_accepted_append(permit, summary)",
+        "PreparedResidentPublication::Ekf(turn)",
+        "PreparedResidentPublication::FullWrite(turn)",
+        "turn.abort();",
+    ):
+        if frozen not in resident_recorder:
+            errors.append(f"resident candidate/receipt binding contract lost: {frozen}")
+    for forbidden in (
+        "pub fn prepare_accepted(",
+        "pub fn new_full_write(",
+        "pub fn new(\n        turn: PreparedResidentTurn",
+    ):
+        if forbidden in resident_recorder:
+            errors.append(f"resident mismatched receipt construction remains public: {forbidden}")
+    for frozen in (
+        ".prepare_commit(permit, prepared)",
+        ".prepare_full_write_commit(permit, prepared)",
+    ):
+        if frozen not in resident_turn_fixture:
+            errors.append(f"resident benchmark bypasses bound commit preparation: {frozen}")
+    commit_body = resident_recorder[
+        resident_recorder.find("pub fn commit(self)") :
+    ]
+    if not call_occurs_before(commit_body, "self.turn.publish", "self.append.append"):
+        errors.append("resident commit does not publish before retained append")
+    if "fn append(self) -> LedgerSequence" not in resident_recorder:
+        errors.append("resident post-publication append is not statically infallible")
+    if "pub fn commit(self) -> LedgerSequence" not in resident_recorder:
+        errors.append("resident complete commit exposes post-publication failure")
+    if "OwnedTurnRecord<GateBFixedReceipt>" not in raw_epoch:
+        errors.append("raw epoch does not use the fixed resident receipt type")
+    if "OwnedTurnRecord<GateBFixedReceipt>" not in resident_recorder:
+        errors.append("resident turn does not use the fixed raw-epoch receipt type")
+    resident_full_write = resident_sources[full_write_path]
+    if "self.execute_candidate(input)?.publish();" not in resident_full_write:
+        errors.append("resident kernel full-write lane computes complete receipt summary")
+    if not call_occurs_before(
+        resident_full_write, "self.execute_candidate", "let summary = candidate.summary();"
+    ):
+        errors.append("resident complete full-write summary is not derived after execution")
+    for frozen in (
+        "EdgeTiming::SameTurn",
+        "EdgeTiming::NextTurn",
+        "same_turn_downstream",
+        "next_turn_consumers",
+        "timing == EdgeTiming::SameTurn",
+    ):
+        if frozen not in activation_source:
+            errors.append(f"resident temporal topology contract lost: {frozen}")
     if "raw_kernel::step(" not in raw_epoch or "raw_kernel::step(" not in legacy:
         errors.append("raw epoch and legacy controls must call the shared raw EKF kernel")
     if raw_epoch.count("published_epoch.store(") != 1:
@@ -401,10 +494,15 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
 
     allowed_production = {
         root / "src/runtime/src/lib.rs",
+        root / "src/runtime/src/resident_gate_b.rs",
         root / "src/runtime/src/turn_record.rs",
     }
     for source in (root / "src").rglob("*.rs"):
-        if "/benches/" in source.as_posix() or source in allowed_production:
+        if (
+            "/benches/" in source.as_posix()
+            or "/tests/" in source.as_posix()
+            or source in allowed_production
+        ):
             continue
         text = read_text(source)
         if "GateBFixedReceipt" in text or "__gate_b_recording" in text:
@@ -421,16 +519,21 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
     return errors
 
 
-def _lane_map(report: dict[str, Any], errors: list[str]) -> dict[tuple[str, int], dict[str, Any]]:
-    lanes: dict[tuple[str, int], dict[str, Any]] = {}
+def _lane_map(report: dict[str, Any], errors: list[str]) -> dict[LaneKey, dict[str, Any]]:
+    lanes: dict[LaneKey, dict[str, Any]] = {}
     for lane in report.get("lanes", []):
         try:
-            key = (str(lane["lane"]), int(lane["instances"]))
+            key = (
+                str(lane["lane"]),
+                int(lane["instances"]),
+                int(lane.get("retained_history", 0)),
+                int(lane.get("next_epoch", 1)),
+            )
         except (KeyError, TypeError, ValueError):
             errors.append("Gate B report contains an invalid lane identity")
             continue
         if key in lanes:
-            errors.append(f"Gate B report duplicates lane {key[0]}/{key[1]}")
+            errors.append(f"Gate B report duplicates lane {key}")
         lanes[key] = lane
     return lanes
 
@@ -506,7 +609,16 @@ def report_contract_errors(
     if missing:
         errors.append(
             "Gate B report is missing lanes: "
-            + ", ".join(f"{lane}/{instances}" for lane, instances in sorted(missing))
+            + ", ".join(
+                f"{lane}/{instances}/history-{history}/epoch-{epoch}"
+                for lane, instances, history, epoch in sorted(missing)
+            )
+        )
+    unexpected = set(lanes).difference(required_lanes)
+    if required_lanes and unexpected:
+        errors.append(
+            "Gate B report contains unexpected lanes: "
+            + ", ".join(str(key) for key in sorted(unexpected))
         )
     for key, lane in lanes.items():
         if lane.get("sample_count", 0) < 10:
@@ -529,7 +641,7 @@ def report_contract_errors(
                 errors.append(f"Gate B Rust EKF lane {key[0]}/{key[1]} changed its trajectory hash")
 
     for instances in SCALED_INSTANCES:
-        key = ("rust-epoch", instances)
+        key = ("rust-epoch", instances, 0, 1)
         if key not in lanes:
             continue
         lane = lanes[key]
@@ -547,12 +659,27 @@ def report_contract_errors(
             errors.append(f"raw epoch {instances} reports the wrong written-byte count")
         if structural.get("receipt_bytes") != 64:
             errors.append(f"raw epoch {instances} reports the wrong receipt size")
+        if report["phase"] == "B2-resident-turn":
+            for field, expected_value in {
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_appended": EPISODE_LENGTH,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+            }.items():
+                if structural.get(field) != expected_value:
+                    errors.append(f"raw epoch {instances} reports wrong {field}")
 
-    if report["phase"] == "B1-resident-kernel":
-        if report["git_branch"] != "feat/engine-resident-ekf-substrate":
+    if report["phase"] in {"B1-resident-kernel", "B2-resident-turn"}:
+        expected_branch = (
+            "feat/engine-resident-ekf-substrate"
+            if report["phase"] == "B1-resident-kernel"
+            else "perf/runtime-resident-ekf-efficacy"
+        )
+        if report["git_branch"] != expected_branch:
             errors.append("B1 evidence is attributed to the wrong branch")
         for instances in SCALED_INSTANCES:
-            key = ("mech-resident-kernel", instances)
+            key = ("mech-resident-kernel", instances, 0, 1)
             if key not in lanes:
                 continue
             lane = lanes[key]
@@ -577,7 +704,7 @@ def report_contract_errors(
             if structural.get("legacy_journal_capture_count") != 0:
                 errors.append(f"resident kernel {instances} captures a legacy journal")
 
-        resident_full_key = ("mech-resident-kernel-full-write", 1)
+        resident_full_key = ("mech-resident-kernel-full-write", 1, 0, 1)
         if resident_full_key in lanes:
             lane = lanes[resident_full_key]
             allocation = lane.get("allocation", {})
@@ -599,7 +726,7 @@ def report_contract_errors(
                 errors.append("resident full-write does not use one publication store")
             if not structural.get("abort_output_hash"):
                 errors.append("resident full-write has no forced-abort output hash")
-            raw_full = lanes.get(("rust-epoch-full-write", 1))
+            raw_full = lanes.get(("rust-epoch-full-write", 1, 0, 1))
             if raw_full is not None:
                 if lane.get("quantized_state_hash") != raw_full.get("quantized_state_hash"):
                     errors.append("resident full-write terminal hash differs from raw epoch")
@@ -608,7 +735,7 @@ def report_contract_errors(
                 ):
                     errors.append("resident full-write forced-abort hash differs from raw epoch")
 
-    full_key = ("rust-epoch-full-write", 1)
+    full_key = ("rust-epoch-full-write", 1, 0, 1)
     if full_key in lanes:
         lane = lanes[full_key]
         allocation = lane.get("allocation", {})
@@ -624,6 +751,16 @@ def report_contract_errors(
             errors.append("raw full-write epoch does not use one publication store")
         if not structural.get("abort_output_hash"):
             errors.append("raw full-write epoch has no forced-abort output hash")
+        if report["phase"] == "B2-resident-turn":
+            for field, expected_value in {
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_appended": EPISODE_LENGTH,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+            }.items():
+                if structural.get(field) != expected_value:
+                    errors.append(f"raw full-write epoch reports wrong {field}")
 
     for lane_name in ("mech-legacy-atomic", "mech-legacy-atomic-full-write"):
         for key, lane in lanes.items():
@@ -635,9 +772,11 @@ def report_contract_errors(
             if structural.get("legacy_journal_capture_count", 0) <= 0:
                 errors.append(f"legacy lane {key[0]}/{key[1]} did not capture journal state")
 
-    if ("mech-legacy-atomic", 1) in lanes and ("rust-epoch", 1) in lanes:
-        legacy = lanes[("mech-legacy-atomic", 1)]["timing"]["median_ns_per_turn"]
-        raw_epoch = lanes[("rust-epoch", 1)]["timing"]["median_ns_per_turn"]
+    legacy_key = ("mech-legacy-atomic", 1, 0, 1)
+    raw_epoch_key = ("rust-epoch", 1, 0, 1)
+    if legacy_key in lanes and raw_epoch_key in lanes:
+        legacy = lanes[legacy_key]["timing"]["median_ns_per_turn"]
+        raw_epoch = lanes[raw_epoch_key]["timing"]["median_ns_per_turn"]
         denominator = legacy - raw_epoch
         derived = report["derived"]
         reported = derived.get("legacy_denominator_ns_per_turn")
@@ -652,21 +791,21 @@ def report_contract_errors(
         if report["stop_condition"].get("passed") is not (denominator > 0.0):
             errors.append("Gate B stop-condition result disagrees with the denominator")
 
-    if report["phase"] == "B1-resident-kernel":
+    if report["phase"] in {"B1-resident-kernel", "B2-resident-turn"}:
         progression = report.get("b1_progression")
         if not isinstance(progression, dict):
             errors.append("B1 report is missing b1_progression")
         elif all(
             key in lanes
             for key in (
-                ("mech-resident-kernel", 1),
-                ("rust-kernel", 1),
-                ("rust-epoch", 1),
+                ("mech-resident-kernel", 1, 0, 1),
+                ("rust-kernel", 1, 0, 1),
+                ("rust-epoch", 1, 0, 1),
             )
         ):
-            resident = lanes[("mech-resident-kernel", 1)]["timing"]["median_ns_per_turn"]
-            rust_kernel = lanes[("rust-kernel", 1)]["timing"]["median_ns_per_turn"]
-            rust_epoch = lanes[("rust-epoch", 1)]["timing"]["median_ns_per_turn"]
+            resident = lanes[("mech-resident-kernel", 1, 0, 1)]["timing"]["median_ns_per_turn"]
+            rust_kernel = lanes[("rust-kernel", 1, 0, 1)]["timing"]["median_ns_per_turn"]
+            rust_epoch = lanes[("rust-epoch", 1, 0, 1)]["timing"]["median_ns_per_turn"]
             expected = {
                 "resident_kernel_ns_per_turn": resident,
                 "rust_kernel_ns_per_turn": rust_kernel,
@@ -685,6 +824,198 @@ def report_contract_errors(
             passed = resident <= 1.05 * rust_epoch
             if progression.get("passed") is not passed:
                 errors.append("B1 progression passed flag disagrees with the unchanged limit")
+
+    if report["phase"] == "B2-resident-turn":
+        turn_keys = [
+            ("mech-resident-turn", 1, 0, 1),
+            ("mech-resident-turn", 1, 1_000, 1),
+            ("mech-resident-turn", 1, 100_000, 1),
+            ("mech-resident-turn", 1, 0, 1_000_000_001),
+        ]
+        complete_keys = [
+            ("mech-resident-scheduled", 1, 0, 1),
+            *turn_keys,
+            ("mech-resident-turn-full-write", 1, 0, 1),
+        ]
+        for key in complete_keys:
+            if key not in lanes:
+                continue
+            lane = lanes[key]
+            allocation = lane.get("allocation", {})
+            structural = lane.get("structural", {})
+            if (
+                allocation.get("episode_allocation_count") != 0
+                or allocation.get("episode_allocated_bytes") != 0
+            ):
+                errors.append(f"B2 resident lane {key} allocates during the timed episode")
+            if structural.get("publication_store_count") != 1:
+                errors.append(f"B2 resident lane {key} does not use one publication store")
+            if structural.get("candidate_seed_bytes") != 0:
+                errors.append(f"B2 resident lane {key} seeds candidate storage")
+            if structural.get("published_buffer_copy_bytes") != 0:
+                errors.append(f"B2 resident lane {key} copies published storage")
+
+        for key in turn_keys:
+            if key not in lanes:
+                continue
+            structural = lanes[key].get("structural", {})
+            expected_structural = {
+                "candidate_written_bytes": 96,
+                "receipt_bytes": 64,
+                "dirty_node_count": 15,
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_retained_before_timing": key[2],
+                "records_appended": EPISODE_LENGTH,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+            }
+            for field, expected_value in expected_structural.items():
+                if structural.get(field) != expected_value:
+                    errors.append(
+                        f"B2 resident lane {key} reports wrong {field}"
+                    )
+
+        full_turn_key = ("mech-resident-turn-full-write", 1, 0, 1)
+        if full_turn_key in lanes:
+            full = lanes[full_turn_key]
+            structural = full.get("structural", {})
+            expected_structural = {
+                "candidate_written_bytes": 32_768,
+                "receipt_bytes": 64,
+                "dirty_node_count": 1,
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_retained_before_timing": 0,
+                "records_appended": EPISODE_LENGTH,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+            }
+            for field, expected_value in expected_structural.items():
+                if structural.get(field) != expected_value:
+                    errors.append(f"B2 full-write lane reports wrong {field}")
+            if not structural.get("abort_output_hash"):
+                errors.append("B2 full-write lane has no forced-rejection output hash")
+
+        decision_keys = {
+            ("mech-legacy-atomic", 1, 0, 1),
+            ("rust-epoch", 1, 0, 1),
+            ("numpy-persistent", 1, 0, 1),
+            ("mech-resident-kernel", 1, 0, 1),
+            ("mech-resident-scheduled", 1, 0, 1),
+            ("mech-resident-turn", 1, 0, 1),
+            ("mech-resident-turn", 1, 1_000, 1),
+            ("mech-resident-turn", 1, 100_000, 1),
+            ("mech-resident-turn", 1, 0, 1_000_000_001),
+            full_turn_key,
+        }
+        b2 = report.get("b2_decision")
+        if not isinstance(b2, dict):
+            errors.append("B2 report is missing b2_decision")
+        elif decision_keys.issubset(lanes):
+            median = lambda key: float(lanes[key]["timing"]["median_ns_per_turn"])
+            legacy = median(("mech-legacy-atomic", 1, 0, 1))
+            raw_epoch = median(("rust-epoch", 1, 0, 1))
+            numpy = median(("numpy-persistent", 1, 0, 1))
+            kernel = median(("mech-resident-kernel", 1, 0, 1))
+            scheduled = median(("mech-resident-scheduled", 1, 0, 1))
+            turn_key = ("mech-resident-turn", 1, 0, 1)
+            turn = median(turn_key)
+            turn_p95 = float(lanes[turn_key]["timing"]["p95_ns_per_turn"])
+            history_ratio = median(("mech-resident-turn", 1, 100_000, 1)) / turn
+            history_1k_ratio = median(("mech-resident-turn", 1, 1_000, 1)) / turn
+            high_epoch_ratio = median(
+                ("mech-resident-turn", 1, 0, 1_000_000_001)
+            ) / turn
+            metrics = {
+                "legacy_gap_closure": (legacy - turn) / (legacy - raw_epoch),
+                "raw_epoch_ratio": turn / raw_epoch,
+                "executor_tax_ns": turn - kernel,
+                "scheduler_tax_ns": scheduled - kernel,
+                "recording_tax_ns": turn - scheduled,
+                "numpy_ratio": turn / numpy,
+                "tail_ratio": turn_p95 / turn,
+                "history_1k_over_history_0_median_ratio": history_1k_ratio,
+                "history_100k_over_history_0_median_ratio": history_ratio,
+                "high_epoch_over_low_epoch_median_ratio": high_epoch_ratio,
+            }
+            for field, expected_value in metrics.items():
+                reported = b2.get(field)
+                if not isinstance(reported, (int, float)) or not math.isclose(
+                    float(reported), expected_value, rel_tol=1.0e-12, abs_tol=1.0e-9
+                ):
+                    errors.append(f"B2 decision {field} is inconsistent with lane evidence")
+
+            resident_decision_lanes = [
+                lanes[key]
+                for key in complete_keys
+                if key in lanes
+            ]
+            primary_structural = lanes[turn_key]["structural"]
+            full_structural = lanes[full_turn_key]["structural"]
+            hard_gates = {
+                "correctness": all(
+                    lane.get("correctness") is True
+                    and lane.get("quantized_state_hash")
+                    == lane.get("reference_quantized_state_hash")
+                    for lane in resident_decision_lanes
+                ),
+                "zero_allocation": all(
+                    lane.get("allocation", {}).get("episode_allocation_count") == 0
+                    for lane in resident_decision_lanes
+                ),
+                "constant_publication": (
+                    primary_structural.get("publication_store_count") == 1
+                    and full_structural.get("publication_store_count") == 1
+                ),
+                "no_full_clone": (
+                    primary_structural.get("candidate_seed_bytes") == 0
+                    and primary_structural.get("published_buffer_copy_bytes") == 0
+                    and full_structural.get("candidate_seed_bytes") == 0
+                    and full_structural.get("candidate_written_bytes") == 32_768
+                    and full_structural.get("published_buffer_copy_bytes") == 0
+                ),
+                "history_independent": (
+                    history_1k_ratio <= 1.05
+                    and history_ratio <= 1.05
+                    and high_epoch_ratio <= 1.05
+                    and all(
+                        lanes[key]["structural"].get("ledger_records_inspected") == 0
+                        for key in turn_keys
+                    )
+                ),
+                "legacy_gap_closure": metrics["legacy_gap_closure"] >= 0.80,
+                "raw_epoch_ratio": metrics["raw_epoch_ratio"] <= 1.25,
+                "executor_tax": metrics["executor_tax_ns"]
+                <= (1.25 * raw_epoch - kernel),
+                "tail_stability": metrics["tail_ratio"] <= 1.50,
+                "post_publication_append_infallible": (
+                    primary_structural.get("post_publication_append_infallible") is True
+                    and full_structural.get("post_publication_append_infallible") is True
+                ),
+            }
+            if b2.get("hard_gates") != hard_gates:
+                errors.append("B2 decision hard gates are inconsistent with lane evidence")
+            numpy_target = turn <= 1.10 * numpy
+            if b2.get("numpy_target") is not numpy_target:
+                errors.append("B2 decision NumPy target is inconsistent with lane evidence")
+            hard_pass = all(hard_gates.values())
+            expected_decision = (
+                "Pass"
+                if hard_pass and numpy_target
+                else "ConditionalPass"
+                if hard_pass
+                else "Fail"
+            )
+            expected_attribution = (
+                "kernel selection, numerical backend, or data layout"
+                if expected_decision == "ConditionalPass"
+                else None
+            )
+            if b2.get("decision") != expected_decision:
+                errors.append("B2 final decision is inconsistent with recomputed gates")
+            if b2.get("conditional_attribution") != expected_attribution:
+                errors.append("B2 conditional attribution is inconsistent with its decision")
     return errors
 
 

--- a/scripts/run-gate-b-benchmarks.py
+++ b/scripts/run-gate-b-benchmarks.py
@@ -22,6 +22,8 @@ FROZEN_BASE = "437f6c6c636d9818729597342165dfc9af5eb4a7"
 FROZEN_B0_BRANCH = "test/resident-ekf-efficacy-contract"
 FROZEN_B1_BRANCH = "feat/engine-resident-ekf-substrate"
 FROZEN_B1_BASE = "c4f7cb1d27b9645b3f669d944c7e49bcd0829ccc"
+B2_BRANCH = "perf/runtime-resident-ekf-efficacy"
+FROZEN_B2_BASE = "75d0775209c8ee0eae5480facba3a9b2c9c12143"
 EPISODE_LENGTH = 4_096
 SCALED_INSTANCES = (1, 8, 64)
 THREAD_VARIABLES = (
@@ -112,35 +114,58 @@ def criterion_samples(target_dir: Path) -> dict[str, dict[str, Any]]:
     return summaries
 
 
-def parse_probe_samples(output: str) -> dict[tuple[str, int], dict[str, Any]]:
-    samples: dict[tuple[str, int], dict[str, Any]] = {}
+ProbeKey = tuple[str, int, int, int]
+
+
+def probe_key(sample: dict[str, Any]) -> ProbeKey:
+    return (
+        str(sample["lane"]),
+        int(sample["instances"]),
+        int(sample.get("retained_history", 0)),
+        int(sample.get("next_epoch", 1)),
+    )
+
+
+def parse_probe_samples(output: str) -> dict[ProbeKey, dict[str, Any]]:
+    samples: dict[ProbeKey, dict[str, Any]] = {}
     for line in output.splitlines():
         marker = line.find(SAMPLE_PREFIX)
         if marker < 0:
             continue
         sample = json.loads(line[marker + len(SAMPLE_PREFIX) :])
-        samples[(sample["lane"], int(sample["instances"]))] = sample
+        samples[probe_key(sample)] = sample
     return samples
 
 
 def merge_structural_probes(
-    timed: dict[tuple[str, int], dict[str, Any]],
-    structural: dict[tuple[str, int], dict[str, Any]],
-) -> dict[tuple[str, int], dict[str, Any]]:
+    timed: dict[ProbeKey, dict[str, Any]],
+    structural: dict[ProbeKey, dict[str, Any]],
+) -> dict[ProbeKey, dict[str, Any]]:
     merged = {key: value.copy() for key, value in timed.items()}
     legacy = {
-        *(("mech-legacy-atomic", instances) for instances in SCALED_INSTANCES),
-        ("mech-legacy-atomic-full-write", 1),
+        *(("mech-legacy-atomic", instances, 0, 1) for instances in SCALED_INSTANCES),
+        ("mech-legacy-atomic-full-write", 1, 0, 1),
     }
     resident = {
-        *(("mech-resident-kernel", instances) for instances in SCALED_INSTANCES),
-        ("mech-resident-kernel-full-write", 1),
+        *(("mech-resident-kernel", instances, 0, 1) for instances in SCALED_INSTANCES),
+        ("mech-resident-kernel-full-write", 1, 0, 1),
     }
+    if any(key[0] == "mech-resident-turn" for key in timed):
+        resident.update(
+            {
+                ("mech-resident-scheduled", 1, 0, 1),
+                ("mech-resident-turn", 1, 0, 1),
+                ("mech-resident-turn", 1, 1_000, 1),
+                ("mech-resident-turn", 1, 100_000, 1),
+                ("mech-resident-turn", 1, 0, 1_000_000_001),
+                ("mech-resident-turn-full-write", 1, 0, 1),
+            }
+        )
     for key in legacy | resident:
         if key not in merged:
-            raise ValueError(f"missing timed structural probe {key[0]}/{key[1]}")
+            raise ValueError(f"missing timed structural probe {key}")
         if key not in structural:
-            raise ValueError(f"missing untimed structural probe {key[0]}/{key[1]}")
+            raise ValueError(f"missing untimed structural probe {key}")
         fields = (
             ("commit_runtime_call_count", "legacy_journal_capture_count")
             if key in legacy
@@ -282,6 +307,13 @@ STRUCTURAL_FIELDS = (
     "commit_runtime_call_count",
     "legacy_journal_capture_count",
     "abort_output_hash",
+    "dirty_node_count",
+    "record_preparation_count",
+    "record_append_count",
+    "records_retained_before_timing",
+    "records_appended",
+    "ledger_records_inspected",
+    "post_publication_append_infallible",
 )
 
 
@@ -300,6 +332,8 @@ def lane_record(
     return {
         "lane": lane,
         "instances": instances,
+        "retained_history": int(probe.get("retained_history", 0)),
+        "next_epoch": int(probe.get("next_epoch", 1)),
         "sample_count": sample_count,
         "turns_per_sample": turns,
         "timing": {
@@ -327,7 +361,7 @@ def lane_record(
 
 def assemble_lanes(
     criterion: dict[str, dict[str, Any]],
-    probes: dict[tuple[str, int], dict[str, Any]],
+    probes: dict[ProbeKey, dict[str, Any]],
     numpy_results: list[dict[str, Any]],
     reference_hash: str,
 ) -> list[dict[str, Any]]:
@@ -343,7 +377,7 @@ def assemble_lanes(
             benchmark = benchmark_template.format(instances=instances)
             if benchmark not in criterion:
                 raise ValueError(f"missing Criterion result {benchmark}")
-            key = (lane, instances)
+            key = (lane, instances, 0, 1)
             if key not in probes:
                 raise ValueError(f"missing structural probe {lane}/{instances}")
             timing = criterion[benchmark]
@@ -365,7 +399,7 @@ def assemble_lanes(
     ):
         if benchmark not in criterion:
             raise ValueError(f"missing Criterion result {benchmark}")
-        key = (lane, 1)
+        key = (lane, 1, 0, 1)
         if key not in probes:
             raise ValueError(f"missing structural probe {lane}/1")
         timing = criterion[benchmark]
@@ -380,6 +414,66 @@ def assemble_lanes(
                 probes[key]["quantized_state_hash"],
             )
         )
+    if ("mech-resident-turn", 1, 0, 1) in probes:
+        for lane, benchmark, history, next_epoch in (
+            (
+                "mech-resident-scheduled",
+                "gate_b/mech-resident-scheduled/1",
+                0,
+                1,
+            ),
+            (
+                "mech-resident-turn",
+                "gate_b/mech-resident-turn/history-0-low-epoch",
+                0,
+                1,
+            ),
+            (
+                "mech-resident-turn",
+                "gate_b/mech-resident-turn/history-1000-low-epoch",
+                1_000,
+                1,
+            ),
+            (
+                "mech-resident-turn",
+                "gate_b/mech-resident-turn/history-100000-low-epoch",
+                100_000,
+                1,
+            ),
+            (
+                "mech-resident-turn",
+                "gate_b/mech-resident-turn/history-0-high-epoch",
+                0,
+                1_000_000_001,
+            ),
+            (
+                "mech-resident-turn-full-write",
+                "gate_b/full-write/mech-resident-turn",
+                0,
+                1,
+            ),
+        ):
+            if benchmark not in criterion:
+                raise ValueError(f"missing Criterion result {benchmark}")
+            key = (lane, 1, history, next_epoch)
+            if key not in probes:
+                raise ValueError(f"missing structural probe {key}")
+            timing = criterion[benchmark]
+            lanes.append(
+                lane_record(
+                    lane,
+                    1,
+                    int(timing["sample_count"]),
+                    float(timing["median_episode_ns"]),
+                    float(timing["p95_episode_ns"]),
+                    probes[key],
+                    (
+                        probes[key]["quantized_state_hash"]
+                        if lane == "mech-resident-turn-full-write"
+                        else reference_hash
+                    ),
+                )
+            )
     for result in numpy_results:
         durations = [float(value) for value in result["samples_ns"]]
         probe = {
@@ -398,14 +492,25 @@ def assemble_lanes(
                 result["reference_quantized_state_hash"],
             )
         )
-    return sorted(lanes, key=lambda lane: (lane["lane"], lane["instances"]))
+    return sorted(
+        lanes,
+        key=lambda lane: (
+            lane["lane"],
+            lane["instances"],
+            lane["retained_history"],
+            lane["next_epoch"],
+        ),
+    )
 
 
 def primary_median(lanes: list[dict[str, Any]], name: str) -> float:
     matches = [
         lane
         for lane in lanes
-        if lane["lane"] == name and lane["instances"] == 1
+        if lane["lane"] == name
+        and lane["instances"] == 1
+        and lane.get("retained_history", 0) == 0
+        and lane.get("next_epoch", 1) == 1
     ]
     if len(matches) != 1:
         raise ValueError(f"expected exactly one primary {name} lane")
@@ -442,6 +547,145 @@ def b1_progression(lanes: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def selected_lane(
+    lanes: list[dict[str, Any]],
+    name: str,
+    *,
+    history: int = 0,
+    next_epoch: int = 1,
+) -> dict[str, Any]:
+    matches = [
+        lane
+        for lane in lanes
+        if lane["lane"] == name
+        and lane["instances"] == 1
+        and lane.get("retained_history", 0) == history
+        and lane.get("next_epoch", 1) == next_epoch
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one {name} lane for history={history}, "
+            f"next_epoch={next_epoch}"
+        )
+    return matches[0]
+
+
+def b2_decision(lanes: list[dict[str, Any]]) -> dict[str, Any]:
+    legacy = primary_median(lanes, "mech-legacy-atomic")
+    raw_epoch = primary_median(lanes, "rust-epoch")
+    numpy = primary_median(lanes, "numpy-persistent")
+    kernel = primary_median(lanes, "mech-resident-kernel")
+    scheduled = primary_median(lanes, "mech-resident-scheduled")
+    turn = selected_lane(lanes, "mech-resident-turn")
+    turn_median = float(turn["timing"]["median_ns_per_turn"])
+    turn_p95 = float(turn["timing"]["p95_ns_per_turn"])
+    history_100k = selected_lane(
+        lanes, "mech-resident-turn", history=100_000
+    )
+    history_1k = selected_lane(lanes, "mech-resident-turn", history=1_000)
+    high_epoch = selected_lane(
+        lanes, "mech-resident-turn", next_epoch=1_000_000_001
+    )
+    full_write = selected_lane(lanes, "mech-resident-turn-full-write")
+    resident_lanes = [
+        lane
+        for lane in lanes
+        if lane["lane"]
+        in {
+            "mech-resident-scheduled",
+            "mech-resident-turn",
+            "mech-resident-turn-full-write",
+        }
+    ]
+    legacy_gap_closure = (legacy - turn_median) / (legacy - raw_epoch)
+    raw_epoch_ratio = turn_median / raw_epoch
+    executor_tax = turn_median - kernel
+    scheduler_tax = scheduled - kernel
+    recording_tax = turn_median - scheduled
+    numpy_ratio = turn_median / numpy
+    tail_ratio = turn_p95 / turn_median
+    history_ratio = (
+        float(history_100k["timing"]["median_ns_per_turn"]) / turn_median
+    )
+    history_1k_ratio = (
+        float(history_1k["timing"]["median_ns_per_turn"]) / turn_median
+    )
+    high_epoch_ratio = (
+        float(high_epoch["timing"]["median_ns_per_turn"]) / turn_median
+    )
+
+    structural = turn["structural"]
+    full_structural = full_write["structural"]
+    hard_gates = {
+        "correctness": all(
+            lane["correctness"]
+            and lane["quantized_state_hash"]
+            == lane["reference_quantized_state_hash"]
+            for lane in resident_lanes
+        ),
+        "zero_allocation": all(
+            lane["allocation"]["episode_allocation_count"] == 0
+            for lane in resident_lanes
+        ),
+        "constant_publication": (
+            structural["publication_store_count"] == 1
+            and full_structural["publication_store_count"] == 1
+        ),
+        "no_full_clone": (
+            structural["candidate_seed_bytes"] == 0
+            and structural["published_buffer_copy_bytes"] == 0
+            and full_structural["candidate_seed_bytes"] == 0
+            and full_structural["candidate_written_bytes"] == 32_768
+            and full_structural["published_buffer_copy_bytes"] == 0
+        ),
+        "history_independent": (
+            history_1k_ratio <= 1.05
+            and history_ratio <= 1.05
+            and high_epoch_ratio <= 1.05
+            and all(
+                lane["structural"]["ledger_records_inspected"] == 0
+                for lane in resident_lanes
+                if lane["lane"] == "mech-resident-turn"
+            )
+        ),
+        "legacy_gap_closure": legacy_gap_closure >= 0.80,
+        "raw_epoch_ratio": raw_epoch_ratio <= 1.25,
+        "executor_tax": executor_tax <= (1.25 * raw_epoch - kernel),
+        "tail_stability": tail_ratio <= 1.50,
+        "post_publication_append_infallible": (
+            structural["post_publication_append_infallible"] is True
+            and full_structural["post_publication_append_infallible"] is True
+        ),
+    }
+    numpy_target = turn_median <= 1.10 * numpy
+    hard_pass = all(hard_gates.values())
+    if hard_pass and numpy_target:
+        decision = "Pass"
+        attribution = None
+    elif hard_pass:
+        decision = "ConditionalPass"
+        attribution = "kernel selection, numerical backend, or data layout"
+    else:
+        decision = "Fail"
+        attribution = None
+    return {
+        "legacy_gap_closure": legacy_gap_closure,
+        "raw_epoch_ratio": raw_epoch_ratio,
+        "executor_tax_ns": executor_tax,
+        "scheduler_tax_ns": scheduler_tax,
+        "recording_tax_ns": recording_tax,
+        "numpy_ratio": numpy_ratio,
+        "tail_ratio": tail_ratio,
+        "history_1k_over_history_0_median_ratio": history_1k_ratio,
+        "history_100k_over_history_0_median_ratio": history_ratio,
+        "high_epoch_over_low_epoch_median_ratio": high_epoch_ratio,
+        "hard_gates": hard_gates,
+        "numpy_target": numpy_target,
+        "decision": decision,
+        "conditional_attribution": attribution,
+    }
+
+
 def worktree_changes() -> str:
     return command_output(["git", "status", "--porcelain=v1", "--untracked-files=all"])
 
@@ -450,6 +694,7 @@ def frozen_base_error(commit: str, branch: str) -> str | None:
     expected_base = {
         FROZEN_B0_BRANCH: FROZEN_BASE,
         FROZEN_B1_BRANCH: FROZEN_B1_BASE,
+        B2_BRANCH: FROZEN_B2_BASE,
     }.get(branch)
     if expected_base is None:
         return f"Gate B controls cannot run on unapproved branch {branch}"
@@ -627,7 +872,13 @@ def main() -> int:
     summary = {
         "schema_version": 1,
         "gate": "B",
-        "phase": "B0-controls" if branch == FROZEN_B0_BRANCH else "B1-resident-kernel",
+        "phase": (
+            "B0-controls"
+            if branch == FROZEN_B0_BRANCH
+            else "B1-resident-kernel"
+            if branch == FROZEN_B1_BRANCH
+            else "B2-resident-turn"
+        ),
         "git_commit": commit,
         "git_branch": branch,
         "machine": {
@@ -685,6 +936,9 @@ def main() -> int:
     }
     if branch == FROZEN_B1_BRANCH:
         summary["b1_progression"] = b1_progression(lanes)
+    if branch == B2_BRANCH:
+        summary["b1_progression"] = b1_progression(lanes)
+        summary["b2_decision"] = b2_decision(lanes)
     rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
     if args.output:
         output = args.output if args.output.is_absolute() else ROOT / args.output
@@ -704,6 +958,12 @@ def main() -> int:
             file=sys.stderr,
         )
         return 4
+    if branch == B2_BRANCH and summary["b2_decision"]["decision"] == "Fail":
+        print(
+            "Gate B B2 stop: complete resident turn failed one or more hard gates",
+            file=sys.stderr,
+        )
+        return 5
     return 0
 
 

--- a/scripts/tests/test_check_gate_b_contract.py
+++ b/scripts/tests/test_check_gate_b_contract.py
@@ -13,12 +13,15 @@ sys.modules[SPEC.name] = CHECKER
 SPEC.loader.exec_module(CHECKER)
 
 
-def lane(name, instances):
+def lane(name, instances, retained_history=0, next_epoch=1):
     is_numpy = name == "numpy-persistent"
     is_epoch = name == "rust-epoch"
     is_full_epoch = name == "rust-epoch-full-write"
     is_resident = name == "mech-resident-kernel"
     is_resident_full = name == "mech-resident-kernel-full-write"
+    is_scheduled = name == "mech-resident-scheduled"
+    is_turn = name == "mech-resident-turn"
+    is_turn_full = name == "mech-resident-turn-full-write"
     is_legacy = name.startswith("mech-legacy-atomic")
     allocation_count = None if is_numpy else (1 if is_legacy else 0)
     allocated_bytes = None if is_numpy else (8 if is_legacy else 0)
@@ -31,6 +34,13 @@ def lane(name, instances):
         "commit_runtime_call_count": None if is_numpy else 0,
         "legacy_journal_capture_count": None if is_numpy else 0,
         "abort_output_hash": None,
+        "dirty_node_count": None,
+        "record_preparation_count": None,
+        "record_append_count": None,
+        "records_retained_before_timing": None,
+        "records_appended": None,
+        "ledger_records_inspected": None,
+        "post_publication_append_infallible": None,
     }
     if is_epoch:
         structural.update(
@@ -38,6 +48,11 @@ def lane(name, instances):
                 "candidate_written_bytes": instances * 96,
                 "publication_store_count": 1,
                 "receipt_bytes": 64,
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_appended": 4096,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
             }
         )
     if is_full_epoch:
@@ -47,6 +62,11 @@ def lane(name, instances):
                 "publication_store_count": 1,
                 "receipt_bytes": 64,
                 "abort_output_hash": "c" * 64,
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_appended": 4096,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
             }
         )
     if is_resident:
@@ -54,6 +74,44 @@ def lane(name, instances):
             {
                 "candidate_written_bytes": instances * 96,
                 "publication_store_count": 1,
+            }
+        )
+    if is_scheduled:
+        structural.update(
+            {
+                "candidate_written_bytes": 96,
+                "publication_store_count": 1,
+            }
+        )
+    if is_turn:
+        structural.update(
+            {
+                "candidate_written_bytes": 96,
+                "publication_store_count": 1,
+                "receipt_bytes": 64,
+                "dirty_node_count": 15,
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_retained_before_timing": retained_history,
+                "records_appended": 4096,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+            }
+        )
+    if is_turn_full:
+        structural.update(
+            {
+                "candidate_written_bytes": 64 * 64 * 8,
+                "publication_store_count": 1,
+                "receipt_bytes": 64,
+                "dirty_node_count": 1,
+                "record_preparation_count": 1,
+                "record_append_count": 1,
+                "records_retained_before_timing": 0,
+                "records_appended": 4096,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+                "abort_output_hash": "c" * 64,
             }
         )
     if is_resident_full:
@@ -77,13 +135,15 @@ def lane(name, instances):
     return {
         "lane": name,
         "instances": instances,
+        "retained_history": retained_history,
+        "next_epoch": next_epoch,
         "sample_count": 10,
         "turns_per_sample": 4096,
         "timing": {
             "median_ns_per_turn": 100.0
             if name == "mech-legacy-atomic"
             else 25.0,
-            "p95_ns_per_turn": 125.0,
+            "p95_ns_per_turn": 30.0 if is_turn else 125.0,
         },
         "allocation": {
             "allocations_per_turn": None
@@ -101,7 +161,9 @@ def lane(name, instances):
             if is_numpy or name.endswith("full-write")
             else CHECKER.REFERENCE_HASH
         ),
-        "reference_quantized_state_hash": CHECKER.REFERENCE_HASH,
+        "reference_quantized_state_hash": (
+            "d" * 64 if name.endswith("full-write") else CHECKER.REFERENCE_HASH
+        ),
         "structural": structural,
     }
 
@@ -206,6 +268,50 @@ def valid_b1_report():
     return report
 
 
+def valid_b2_report():
+    report = valid_b1_report()
+    report["phase"] = "B2-resident-turn"
+    report["git_branch"] = "perf/runtime-resident-ekf-efficacy"
+    report["lanes"].extend(
+        [
+            lane("mech-resident-scheduled", 1),
+            lane("mech-resident-turn", 1),
+            lane("mech-resident-turn", 1, retained_history=1_000),
+            lane("mech-resident-turn", 1, retained_history=100_000),
+            lane("mech-resident-turn", 1, next_epoch=1_000_000_001),
+            lane("mech-resident-turn-full-write", 1),
+        ]
+    )
+    report["b2_decision"] = {
+        "legacy_gap_closure": 1.0,
+        "raw_epoch_ratio": 1.0,
+        "executor_tax_ns": 0.0,
+        "scheduler_tax_ns": 0.0,
+        "recording_tax_ns": 0.0,
+        "numpy_ratio": 1.0,
+        "tail_ratio": 1.2,
+        "history_1k_over_history_0_median_ratio": 1.0,
+        "history_100k_over_history_0_median_ratio": 1.0,
+        "high_epoch_over_low_epoch_median_ratio": 1.0,
+        "hard_gates": {
+            "correctness": True,
+            "zero_allocation": True,
+            "constant_publication": True,
+            "no_full_clone": True,
+            "history_independent": True,
+            "legacy_gap_closure": True,
+            "raw_epoch_ratio": True,
+            "executor_tax": True,
+            "tail_stability": True,
+            "post_publication_append_infallible": True,
+        },
+        "numpy_target": True,
+        "decision": "Pass",
+        "conditional_attribution": None,
+    }
+    return report
+
+
 class GateBContractCheckerTests(unittest.TestCase):
     def test_committed_static_contract_passes(self):
         self.assertEqual(CHECKER.static_contract_errors(), [])
@@ -215,6 +321,50 @@ class GateBContractCheckerTests(unittest.TestCase):
 
     def test_valid_b1_report_requires_resident_kernel_lanes(self):
         self.assertEqual(CHECKER.report_contract_errors(valid_b1_report()), [])
+
+    def test_valid_b2_report_recomputes_complete_turn_decision(self):
+        self.assertEqual(CHECKER.report_contract_errors(valid_b2_report()), [])
+
+    def test_b2_rejects_forged_decision_metric(self):
+        report = valid_b2_report()
+        report["b2_decision"]["raw_epoch_ratio"] = 0.1
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("raw_epoch_ratio" in error for error in errors))
+
+    def test_b2_rejects_history_iteration(self):
+        report = valid_b2_report()
+        result = next(
+            lane
+            for lane in report["lanes"]
+            if lane["lane"] == "mech-resident-turn"
+            and lane["retained_history"] == 100_000
+        )
+        result["structural"]["ledger_records_inspected"] = 100_000
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("ledger_records_inspected" in error for error in errors))
+
+    def test_b2_history_independence_uses_five_percent_ceiling(self):
+        report = valid_b2_report()
+        result = next(
+            lane
+            for lane in report["lanes"]
+            if lane["lane"] == "mech-resident-turn"
+            and lane["retained_history"] == 1_000
+        )
+        result["timing"]["median_ns_per_turn"] = 26.5
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("hard gates" in error for error in errors))
+
+    def test_b2_raw_epoch_requires_equivalent_record_evidence(self):
+        report = valid_b2_report()
+        result = next(
+            lane
+            for lane in report["lanes"]
+            if lane["lane"] == "rust-epoch" and lane["instances"] == 8
+        )
+        result["structural"]["record_append_count"] = 0
+        errors = CHECKER.report_contract_errors(report)
+        self.assertTrue(any("raw epoch 8 reports wrong record_append_count" in error for error in errors))
 
     def test_unknown_phase_is_rejected(self):
         report = valid_report()

--- a/scripts/tests/test_run_gate_b_benchmarks.py
+++ b/scripts/tests/test_run_gate_b_benchmarks.py
@@ -77,33 +77,33 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
         }
         output = "prefix\nGATE_B_SAMPLE " + json.dumps(payload) + "\n"
         self.assertEqual(
-            RUNNER.parse_probe_samples(output)[("rust-epoch", 8)], payload
+            RUNNER.parse_probe_samples(output)[("rust-epoch", 8, 0, 1)], payload
         )
 
     def test_untimed_probe_merge_preserves_timed_allocation(self):
         timed = {}
         structural = {}
         for instances in RUNNER.SCALED_INSTANCES:
-            key = ("mech-legacy-atomic", instances)
+            key = ("mech-legacy-atomic", instances, 0, 1)
             timed[key] = {"allocation_count": 7}
             structural[key] = {
                 "commit_runtime_call_count": 4096,
                 "legacy_journal_capture_count": 12,
             }
-        full_key = ("mech-legacy-atomic-full-write", 1)
+        full_key = ("mech-legacy-atomic-full-write", 1, 0, 1)
         timed[full_key] = {"allocation_count": 9}
         structural[full_key] = {
             "commit_runtime_call_count": 4096,
             "legacy_journal_capture_count": 13,
         }
         for instances in RUNNER.SCALED_INSTANCES:
-            key = ("mech-resident-kernel", instances)
+            key = ("mech-resident-kernel", instances, 0, 1)
             timed[key] = {"allocation_count": 0}
             structural[key] = {
                 field: (1 if field == "publication_store_count" else 0)
                 for field in RUNNER.STRUCTURAL_FIELDS
             }
-        resident_full = ("mech-resident-kernel-full-write", 1)
+        resident_full = ("mech-resident-kernel-full-write", 1, 0, 1)
         timed[resident_full] = {"allocation_count": 0}
         structural[resident_full] = {
             field: (1 if field == "publication_store_count" else 0)
@@ -113,7 +113,7 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
         self.assertEqual(merged[full_key]["allocation_count"], 9)
         self.assertEqual(merged[full_key]["commit_runtime_call_count"], 4096)
         self.assertEqual(
-            merged[("mech-resident-kernel", 64)]["publication_store_count"], 1
+            merged[("mech-resident-kernel", 64, 0, 1)]["publication_store_count"], 1
         )
 
     def test_frozen_base_requires_exact_merge_base(self):
@@ -195,6 +195,49 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
         progression = RUNNER.b1_progression(lanes)
         self.assertEqual(progression["limit_ns_per_turn"], 23.1)
         self.assertTrue(progression["passed"])
+
+    def test_b2_history_independence_uses_five_percent_ceiling(self):
+        def lane(name, median, *, history=0, next_epoch=1, full_write=False):
+            structural = {
+                "candidate_seed_bytes": 0,
+                "candidate_written_bytes": 32_768 if full_write else 96,
+                "published_buffer_copy_bytes": 0,
+                "publication_store_count": 1,
+                "ledger_records_inspected": 0,
+                "post_publication_append_infallible": True,
+            }
+            return {
+                "lane": name,
+                "instances": 1,
+                "retained_history": history,
+                "next_epoch": next_epoch,
+                "timing": {
+                    "median_ns_per_turn": median,
+                    "p95_ns_per_turn": median,
+                },
+                "allocation": {"episode_allocation_count": 0},
+                "structural": structural,
+                "correctness": True,
+                "quantized_state_hash": "a" * 64,
+                "reference_quantized_state_hash": "a" * 64,
+            }
+
+        lanes = [
+            lane("mech-legacy-atomic", 100.0),
+            lane("rust-epoch", 20.0),
+            lane("numpy-persistent", 30.0),
+            lane("mech-resident-kernel", 19.0),
+            lane("mech-resident-scheduled", 20.0),
+            lane("mech-resident-turn", 21.0),
+            lane("mech-resident-turn", 22.1, history=1_000),
+            lane("mech-resident-turn", 21.0, history=100_000),
+            lane("mech-resident-turn", 21.0, next_epoch=1_000_000_001),
+            lane("mech-resident-turn-full-write", 21.0, full_write=True),
+        ]
+
+        decision = RUNNER.b2_decision(lanes)
+        self.assertGreater(decision["history_1k_over_history_0_median_ratio"], 1.05)
+        self.assertFalse(decision["hard_gates"]["history_independent"])
 
     def test_explicit_machine_label_is_preserved(self):
         self.assertEqual(

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -97,8 +97,12 @@ mod resident;
 pub mod __gate_b_resident {
     #[cfg(feature = "runtime_bench_probes")]
     pub use crate::resident::bench::ResidentTurnProbe;
-    pub use crate::resident::bench::{ResidentEkfBatch, ResidentEkfState};
-    pub use crate::resident::{FULL_WRITE_ELEMENTS, ResidentExecutionError, ResidentFullWrite};
+    pub use crate::resident::bench::{
+        PreparedResidentTurn, ResidentEkfBatch, ResidentEkfState, ResidentTurnSummary,
+    };
+    pub use crate::resident::{
+        FULL_WRITE_ELEMENTS, PreparedResidentFullWrite, ResidentExecutionError, ResidentFullWrite,
+    };
 }
 #[cfg(all(feature = "source", feature = "state_machines"))]
 pub mod state_machines;

--- a/src/engine/src/resident/activation.rs
+++ b/src/engine/src/resident/activation.rs
@@ -8,6 +8,12 @@ use super::artifact::{
 #[repr(transparent)]
 pub(crate) struct NodeIndex(pub(crate) u32);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EdgeTiming {
+    SameTurn,
+    NextTurn,
+}
+
 pub(crate) type ActivatedKernel = EkfOp;
 
 #[derive(Clone, Copy, Debug)]
@@ -23,8 +29,8 @@ pub(crate) struct ResolvedSlot {
 pub(crate) struct ActivatedNode {
     pub(crate) kernel: ActivatedKernel,
     pub(crate) instance: u32,
-    pub(crate) downstream_start: u32,
-    pub(crate) downstream_len: u16,
+    pub(crate) same_turn_downstream_start: u32,
+    pub(crate) same_turn_downstream_len: u16,
 }
 
 #[derive(Clone, Debug)]
@@ -32,8 +38,11 @@ pub(crate) struct DependencyTopology {
     pub(crate) linear_node_order: Box<[NodeIndex]>,
     pub(crate) consumer_offsets: Box<[u32]>,
     pub(crate) consumer_nodes: Box<[NodeIndex]>,
-    pub(crate) downstream_offsets: Box<[u32]>,
-    pub(crate) downstream_nodes: Box<[NodeIndex]>,
+    pub(crate) same_turn_downstream_offsets: Box<[u32]>,
+    pub(crate) same_turn_downstream_nodes: Box<[NodeIndex]>,
+    pub(crate) next_turn_consumer_offsets: Box<[u32]>,
+    pub(crate) next_turn_consumer_nodes: Box<[NodeIndex]>,
+    pub(crate) turn_root_nodes: Box<[NodeIndex]>,
 }
 
 impl DependencyTopology {
@@ -44,11 +53,18 @@ impl DependencyTopology {
         &self.consumer_nodes[start..end]
     }
 
-    pub(crate) fn downstream(&self, node: NodeIndex) -> &[NodeIndex] {
+    pub(crate) fn same_turn_downstream(&self, node: NodeIndex) -> &[NodeIndex] {
         let index = node.0 as usize;
-        let start = self.downstream_offsets[index] as usize;
-        let end = self.downstream_offsets[index + 1] as usize;
-        &self.downstream_nodes[start..end]
+        let start = self.same_turn_downstream_offsets[index] as usize;
+        let end = self.same_turn_downstream_offsets[index + 1] as usize;
+        &self.same_turn_downstream_nodes[start..end]
+    }
+
+    pub(crate) fn next_turn_consumers(&self, slot: CellSlotId) -> &[NodeIndex] {
+        let index = slot.0 as usize;
+        let start = self.next_turn_consumer_offsets[index] as usize;
+        let end = self.next_turn_consumer_offsets[index + 1] as usize;
+        &self.next_turn_consumer_nodes[start..end]
     }
 }
 
@@ -101,30 +117,53 @@ impl ActivatedPlan {
         }
         let (consumer_offsets, consumer_nodes) = flatten(&consumers);
 
-        let mut downstream = vec![Vec::<NodeIndex>::new(); artifact.nodes.len()];
+        let mut same_turn_downstream = vec![Vec::<NodeIndex>::new(); artifact.nodes.len()];
+        let mut next_turn_consumers = vec![Vec::<NodeIndex>::new(); logical_slot_count];
+        let mut turn_roots = Vec::<NodeIndex>::new();
+        for slot in &artifact.slots {
+            if matches!(slot.role, SlotRole::Input | SlotRole::Stateful) {
+                turn_roots.extend_from_slice(&consumers[slot.id.0 as usize]);
+            }
+            if slot.role == SlotRole::Stateful {
+                next_turn_consumers[slot.id.0 as usize]
+                    .extend_from_slice(&consumers[slot.id.0 as usize]);
+            }
+        }
+        turn_roots.sort_by_key(|index| index.0);
+        turn_roots.dedup();
+
         for (node, declaration) in artifact.nodes.iter().enumerate() {
             for output in &declaration.writes {
+                let timing = if artifact.slots[output.0 as usize].role == SlotRole::Stateful {
+                    EdgeTiming::NextTurn
+                } else {
+                    EdgeTiming::SameTurn
+                };
                 for consumer in &consumers[output.0 as usize] {
-                    if !downstream[node].contains(consumer) {
-                        downstream[node].push(*consumer);
+                    if timing == EdgeTiming::SameTurn
+                        && !same_turn_downstream[node].contains(consumer)
+                    {
+                        same_turn_downstream[node].push(*consumer);
                     }
                 }
             }
-            downstream[node].sort_by_key(|index| index.0);
+            same_turn_downstream[node].sort_by_key(|index| index.0);
         }
-        let (downstream_offsets, downstream_nodes) = flatten(&downstream);
+        let (same_turn_downstream_offsets, same_turn_downstream_nodes) =
+            flatten(&same_turn_downstream);
+        let (next_turn_consumer_offsets, next_turn_consumer_nodes) = flatten(&next_turn_consumers);
         let nodes: Box<[_]> = artifact
             .nodes
             .iter()
             .enumerate()
             .map(|(index, declaration)| {
-                let start = downstream_offsets[index];
-                let end = downstream_offsets[index + 1];
+                let start = same_turn_downstream_offsets[index];
+                let end = same_turn_downstream_offsets[index + 1];
                 ActivatedNode {
                     kernel: declaration.op,
                     instance: declaration.instance,
-                    downstream_start: start,
-                    downstream_len: u16::try_from(end - start)
+                    same_turn_downstream_start: start,
+                    same_turn_downstream_len: u16::try_from(end - start)
                         .expect("resident node fanout fits u16"),
                 }
             })
@@ -135,9 +174,39 @@ impl ActivatedPlan {
                 .collect(),
             consumer_offsets,
             consumer_nodes,
-            downstream_offsets,
-            downstream_nodes,
+            same_turn_downstream_offsets,
+            same_turn_downstream_nodes,
+            next_turn_consumer_offsets,
+            next_turn_consumer_nodes,
+            turn_root_nodes: turn_roots.into_boxed_slice(),
         };
+        for node in topology.linear_node_order.iter().copied() {
+            for downstream in topology.same_turn_downstream(node) {
+                assert!(
+                    downstream.0 > node.0,
+                    "same-turn resident edges must point forward"
+                );
+            }
+        }
+        for slot in artifact
+            .slots
+            .iter()
+            .filter(|slot| slot.role == SlotRole::Stateful)
+        {
+            for consumer in topology.next_turn_consumers(slot.id) {
+                assert!(
+                    topology.turn_root_nodes.contains(consumer),
+                    "next-turn feedback must target a legal turn root"
+                );
+            }
+        }
+        for instance in 0..artifact.instances {
+            let final_node = NodeIndex((instance * NODES_PER_EKF + NODES_PER_EKF - 1) as u32);
+            assert!(
+                topology.same_turn_downstream(final_node).is_empty(),
+                "final state publication node must not feed back in the same turn"
+            );
+        }
         debug_assert_eq!(artifact.instances * NODES_PER_EKF, nodes.len());
         debug_assert_eq!(
             artifact.instances * LOGICAL_SLOTS_PER_EKF as usize,
@@ -174,21 +243,27 @@ mod tests {
             );
             assert_eq!(left.topology.consumer_nodes, right.topology.consumer_nodes);
             assert_eq!(
-                left.topology.downstream_offsets,
-                right.topology.downstream_offsets
+                left.topology.same_turn_downstream_offsets,
+                right.topology.same_turn_downstream_offsets
             );
             assert_eq!(
-                left.topology.downstream_nodes,
-                right.topology.downstream_nodes
+                left.topology.same_turn_downstream_nodes,
+                right.topology.same_turn_downstream_nodes
+            );
+            assert_eq!(
+                left.topology.turn_root_nodes,
+                right.topology.turn_root_nodes
             );
             for (expected, node) in left.nodes.iter().enumerate() {
                 assert_eq!(node.instance as usize, expected / NODES_PER_EKF);
-                let downstream = left.topology.downstream(NodeIndex(expected as u32));
+                let downstream = left
+                    .topology
+                    .same_turn_downstream(NodeIndex(expected as u32));
                 assert_eq!(
-                    node.downstream_start,
-                    left.topology.downstream_offsets[expected]
+                    node.same_turn_downstream_start,
+                    left.topology.same_turn_downstream_offsets[expected]
                 );
-                assert_eq!(node.downstream_len as usize, downstream.len());
+                assert_eq!(node.same_turn_downstream_len as usize, downstream.len());
             }
             for instance in 0..instances as u32 {
                 assert_eq!(
@@ -215,10 +290,20 @@ mod tests {
                 for input in &declaration.reads {
                     assert!(left.topology.consumers(*input).contains(&node));
                 }
-                let downstream = left.topology.downstream(node);
+                let downstream = left.topology.same_turn_downstream(node);
                 for output in &declaration.writes {
                     for consumer in left.topology.consumers(*output) {
-                        assert!(downstream.contains(consumer));
+                        let role = left.slots[output.0 as usize].role;
+                        if role == SlotRole::Stateful {
+                            assert!(!downstream.contains(consumer));
+                            assert!(
+                                left.topology
+                                    .next_turn_consumers(*output)
+                                    .contains(consumer)
+                            );
+                        } else {
+                            assert!(downstream.contains(consumer));
+                        }
                     }
                 }
             }

--- a/src/engine/src/resident/arena.rs
+++ b/src/engine/src/resident/arena.rs
@@ -99,6 +99,29 @@ impl StateArena {
         (states, candidate_states, covariances, candidate_covariances)
     }
 
+    pub(crate) fn candidate_state_hash(&self, candidate: usize) -> u64 {
+        let mut batch_hash = 0xcbf29ce484222325_u64;
+        for (state, covariance) in self.states.buffers[candidate]
+            .iter()
+            .zip(self.covariances.buffers[candidate].iter())
+        {
+            let mut state_hash = 0xcbf29ce484222325_u64;
+            for value in state.iter().chain(covariance.iter()) {
+                for byte in value.to_bits().to_le_bytes() {
+                    state_hash ^= u64::from(byte);
+                    state_hash = state_hash.wrapping_mul(0x100000001b3);
+                }
+            }
+            batch_hash ^= state_hash;
+            batch_hash = batch_hash.wrapping_mul(0x100000001b3);
+        }
+        batch_hash
+    }
+
+    pub(crate) fn contains_epoch(&self, epoch: InstanceEpoch) -> bool {
+        self.states.epochs.contains(&Some(epoch)) || self.covariances.epochs.contains(&Some(epoch))
+    }
+
     #[inline]
     pub(crate) fn published_state(&self, epoch: InstanceEpoch, instance: usize) -> [f64; 3] {
         self.states.buffers[self.states.published_index(epoch)][instance]

--- a/src/engine/src/resident/bench.rs
+++ b/src/engine/src/resident/bench.rs
@@ -1,4 +1,7 @@
-use super::{ReactiveInstance, ResidentExecutionError, execute_ekf_candidate};
+use super::{
+    Candidate, NODES_PER_EKF, ReactiveInstance, ResidentExecutionError, execute_ekf_candidate,
+    execute_scheduled_ekf_candidate,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ResidentEkfState {
@@ -19,6 +22,78 @@ pub struct ResidentEkfBatch {
     instance: ReactiveInstance,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResidentTurnSummary {
+    pub before_epoch: u64,
+    pub after_epoch: u64,
+    pub state_hash: u64,
+    pub touched_slots: u16,
+    pub changed_slots: u16,
+    pub dirty_nodes: u16,
+}
+
+#[must_use = "prepared resident turns must be published or aborted"]
+pub struct PreparedResidentTurn<'a> {
+    candidate: Option<Candidate<'a>>,
+    summary: ResidentTurnSummary,
+}
+
+impl PreparedResidentTurn<'_> {
+    pub fn summary(&self) -> ResidentTurnSummary {
+        self.summary
+    }
+
+    pub fn published_epoch(&self) -> u64 {
+        self.candidate
+            .as_ref()
+            .expect("live prepared resident turn")
+            .instance
+            .published_epoch()
+            .0
+    }
+
+    pub fn published_state(&self, index: usize) -> ResidentEkfState {
+        let candidate = self
+            .candidate
+            .as_ref()
+            .expect("live prepared resident turn");
+        ResidentEkfState {
+            state: candidate
+                .instance
+                .state
+                .published_state(candidate.base_epoch, index),
+            covariance: candidate
+                .instance
+                .state
+                .published_covariance(candidate.base_epoch, index),
+        }
+    }
+
+    #[inline]
+    pub fn publish(mut self) {
+        self.candidate
+            .take()
+            .expect("live prepared resident turn")
+            .publish();
+    }
+
+    pub fn abort(mut self) {
+        self.candidate
+            .take()
+            .expect("live prepared resident turn")
+            .abort();
+    }
+}
+
+impl Drop for PreparedResidentTurn<'_> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.candidate.is_none(),
+            "prepared resident turn must publish or abort explicitly"
+        );
+    }
+}
+
 impl ResidentEkfBatch {
     pub fn new(instances: usize) -> Self {
         Self {
@@ -35,6 +110,51 @@ impl ResidentEkfBatch {
         }
         candidate.publish();
         Ok(())
+    }
+
+    #[inline]
+    pub fn scheduled_turn(&mut self, input: [f64; 4]) -> Result<(), ResidentExecutionError> {
+        let mut candidate = self.instance.begin_candidate(input)?;
+        if let Err(error) = execute_scheduled_ekf_candidate(&mut candidate) {
+            candidate.abort();
+            return Err(error);
+        }
+        candidate.publish();
+        Ok(())
+    }
+
+    pub fn prepare_scheduled_turn(
+        &mut self,
+        input: [f64; 4],
+    ) -> Result<PreparedResidentTurn<'_>, ResidentExecutionError> {
+        let instances = self.instance.plan.instances;
+        let mut candidate = self.instance.begin_candidate(input)?;
+        if let Err(error) = execute_scheduled_ekf_candidate(&mut candidate) {
+            candidate.abort();
+            return Err(error);
+        }
+        let workspace = &candidate.instance.workspace;
+        let summary = ResidentTurnSummary {
+            before_epoch: candidate.base_epoch.0,
+            after_epoch: candidate.working_epoch.0,
+            state_hash: candidate
+                .instance
+                .state
+                .candidate_state_hash(candidate.candidate_buffer),
+            touched_slots: u16::try_from(workspace.touched_slots.len())
+                .expect("resident touched count fits u16"),
+            changed_slots: u16::try_from(workspace.changed_slots.len())
+                .expect("resident changed count fits u16"),
+            dirty_nodes: u16::try_from(workspace.executed_nodes.len())
+                .expect("resident dirty-node count fits u16"),
+        };
+        debug_assert_eq!(summary.touched_slots as usize, instances * 2);
+        debug_assert_eq!(summary.changed_slots as usize, instances * 2);
+        debug_assert_eq!(summary.dirty_nodes as usize, instances * NODES_PER_EKF);
+        Ok(PreparedResidentTurn {
+            candidate: Some(candidate),
+            summary,
+        })
     }
 
     pub fn execute_then_abort(&mut self, input: [f64; 4]) -> Result<(), ResidentExecutionError> {
@@ -58,6 +178,19 @@ impl ResidentEkfBatch {
 
     pub fn published_epoch(&self) -> u64 {
         self.instance.published_epoch().0
+    }
+
+    #[doc(hidden)]
+    pub fn set_next_epoch_for_gate_b(&mut self, next_epoch: u64) {
+        assert_ne!(next_epoch, 0, "resident candidate epochs are non-zero");
+        self.instance.next_epoch = Some(mech_core::InstanceEpoch(next_epoch));
+    }
+
+    #[doc(hidden)]
+    pub fn candidate_epoch_is_active_for_gate_b(&self, epoch: u64) -> bool {
+        self.instance
+            .state
+            .contains_epoch(mech_core::InstanceEpoch(epoch))
     }
 
     #[cfg(feature = "runtime_bench_probes")]
@@ -88,6 +221,15 @@ impl ResidentEkfBatch {
         input: [f64; 4],
     ) -> Result<ResidentTurnProbe, ResidentExecutionError> {
         self.turn(input)?;
+        Ok(self.structural_probe())
+    }
+
+    #[cfg(feature = "runtime_bench_probes")]
+    pub fn scheduled_turn_with_probe(
+        &mut self,
+        input: [f64; 4],
+    ) -> Result<ResidentTurnProbe, ResidentExecutionError> {
+        self.scheduled_turn(input)?;
         Ok(self.structural_probe())
     }
 }

--- a/src/engine/src/resident/full_write.rs
+++ b/src/engine/src/resident/full_write.rs
@@ -2,7 +2,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use mech_core::InstanceEpoch;
 
-use super::{ResidentExecutionError, publish_epoch};
+use super::{ResidentExecutionError, bench::ResidentTurnSummary, publish_epoch};
 
 pub const FULL_WRITE_ELEMENTS: usize = 64 * 64;
 
@@ -14,6 +14,104 @@ pub struct ResidentFullWrite {
     next_epoch: Option<InstanceEpoch>,
     #[cfg(feature = "runtime_bench_probes")]
     publication_store_count: u64,
+}
+
+#[must_use = "prepared resident full writes must be published or aborted"]
+pub struct PreparedResidentFullWrite<'a> {
+    candidate: Option<PreparedFullWriteCandidate<'a>>,
+    summary: ResidentTurnSummary,
+}
+
+#[must_use = "resident full-write candidates must be published or aborted"]
+struct PreparedFullWriteCandidate<'a> {
+    resident: Option<&'a mut ResidentFullWrite>,
+    candidate: usize,
+    before_epoch: InstanceEpoch,
+    working_epoch: InstanceEpoch,
+}
+
+impl PreparedResidentFullWrite<'_> {
+    pub fn summary(&self) -> ResidentTurnSummary {
+        self.summary
+    }
+
+    #[inline]
+    pub fn publish(mut self) {
+        self.candidate
+            .take()
+            .expect("live prepared resident full write")
+            .publish();
+    }
+
+    pub fn abort(mut self) {
+        self.candidate
+            .take()
+            .expect("live prepared resident full write")
+            .abort();
+    }
+}
+
+impl Drop for PreparedResidentFullWrite<'_> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.candidate.is_none(),
+            "prepared resident full write must publish or abort explicitly"
+        );
+    }
+}
+
+impl PreparedFullWriteCandidate<'_> {
+    fn summary(&self) -> ResidentTurnSummary {
+        let resident = self
+            .resident
+            .as_deref()
+            .expect("live resident full-write candidate");
+        let mut state_hash = 0xcbf29ce484222325_u64;
+        for value in &resident.versions[self.candidate] {
+            for byte in value.to_bits().to_le_bytes() {
+                state_hash ^= u64::from(byte);
+                state_hash = state_hash.wrapping_mul(0x100000001b3);
+            }
+        }
+        ResidentTurnSummary {
+            before_epoch: self.before_epoch.0,
+            after_epoch: self.working_epoch.0,
+            state_hash,
+            touched_slots: 1,
+            changed_slots: 1,
+            dirty_nodes: 1,
+        }
+    }
+
+    #[inline]
+    fn publish(mut self) {
+        let resident = self
+            .resident
+            .take()
+            .expect("live resident full-write candidate");
+        publish_epoch(&resident.published_epoch, self.working_epoch);
+        #[cfg(feature = "runtime_bench_probes")]
+        {
+            resident.publication_store_count += 1;
+        }
+    }
+
+    fn abort(mut self) {
+        let resident = self
+            .resident
+            .take()
+            .expect("live resident full-write candidate");
+        resident.buffer_epochs[self.candidate] = None;
+    }
+}
+
+impl Drop for PreparedFullWriteCandidate<'_> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.resident.is_none(),
+            "resident full-write candidate must publish or abort explicitly"
+        );
+    }
 }
 
 impl ResidentFullWrite {
@@ -44,7 +142,10 @@ impl ResidentFullWrite {
         }
     }
 
-    fn execute(&mut self, input: f64, publish: bool) -> Result<(), ResidentExecutionError> {
+    fn execute_candidate(
+        &mut self,
+        input: f64,
+    ) -> Result<PreparedFullWriteCandidate<'_>, ResidentExecutionError> {
         let working_epoch = self
             .next_epoch
             .ok_or(ResidentExecutionError::EpochExhausted)?;
@@ -72,25 +173,35 @@ impl ResidentFullWrite {
             self.buffer_epochs[candidate] = None;
             return Err(ResidentExecutionError::NonFiniteState);
         }
-        if publish {
-            publish_epoch(&self.published_epoch, working_epoch);
-            #[cfg(feature = "runtime_bench_probes")]
-            {
-                self.publication_store_count += 1;
-            }
-        } else {
-            self.buffer_epochs[candidate] = None;
-        }
-        Ok(())
+        Ok(PreparedFullWriteCandidate {
+            resident: Some(self),
+            candidate,
+            before_epoch: published_epoch,
+            working_epoch,
+        })
+    }
+
+    pub fn prepare_turn(
+        &mut self,
+        input: f64,
+    ) -> Result<PreparedResidentFullWrite<'_>, ResidentExecutionError> {
+        let candidate = self.execute_candidate(input)?;
+        let summary = candidate.summary();
+        Ok(PreparedResidentFullWrite {
+            candidate: Some(candidate),
+            summary,
+        })
     }
 
     #[inline]
     pub fn turn(&mut self, input: f64) -> Result<(), ResidentExecutionError> {
-        self.execute(input, true)
+        self.execute_candidate(input)?.publish();
+        Ok(())
     }
 
     pub fn execute_then_abort(&mut self, input: f64) -> Result<(), ResidentExecutionError> {
-        self.execute(input, false)
+        self.execute_candidate(input)?.abort();
+        Ok(())
     }
 
     pub fn published(&self) -> &[f64] {

--- a/src/engine/src/resident/kernel.rs
+++ b/src/engine/src/resident/kernel.rs
@@ -79,6 +79,66 @@ pub(crate) fn execute_ekf_candidate(
     Ok(())
 }
 
+pub(crate) fn execute_scheduled_ekf_candidate(
+    candidate: &mut Candidate<'_>,
+) -> Result<(), ResidentExecutionError> {
+    let working_epoch = candidate.working_epoch;
+    let published_buffer = candidate.published_buffer;
+    let candidate_buffer = candidate.candidate_buffer;
+    let resident = &mut *candidate.instance;
+    let plan = &resident.plan;
+    let input = resident.workspace.input;
+    resident
+        .workspace
+        .seed_turn_roots(&plan.topology.turn_root_nodes, working_epoch);
+    {
+        let (states, candidate_states, covariances, candidate_covariances) = resident
+            .state
+            .split_buffers(published_buffer, candidate_buffer);
+        for order_index in 0..resident.workspace.linear_node_order.len() {
+            let node_index = resident.workspace.linear_node_order[order_index];
+            if !resident.workspace.is_dirty(node_index, working_epoch) {
+                continue;
+            }
+            let node = plan.nodes[node_index.0 as usize];
+            let instance = node.instance as usize;
+            ekf::execute(
+                node.kernel,
+                &input,
+                &states[instance],
+                &covariances[instance],
+                &mut candidate_states[instance],
+                &mut candidate_covariances[instance],
+                &mut resident.workspace.scratch[instance],
+                &plan.constants,
+            )?;
+            resident
+                .workspace
+                .record_node_execution(node_index, working_epoch);
+            for downstream in plan.topology.same_turn_downstream(node_index) {
+                resident.workspace.mark_dirty(*downstream, working_epoch);
+            }
+        }
+        for instance in 0..plan.instances {
+            validate_candidate(
+                &candidate_states[instance],
+                &candidate_covariances[instance],
+            )?;
+        }
+    }
+    for instance in 0..plan.instances as u32 {
+        resident
+            .workspace
+            .record_candidate_outputs(instance, working_epoch);
+        resident.workspace.record_changed_outputs(instance);
+    }
+    debug_assert_eq!(
+        resident.workspace.executed_nodes.len(),
+        plan.instances * NODES_PER_EKF
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 pub(crate) fn node_executed(candidate: &Candidate<'_>, node: usize) -> bool {
     candidate.instance.workspace.node_execution_marks[node]

--- a/src/engine/src/resident/mod.rs
+++ b/src/engine/src/resident/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use arena::*;
 pub(crate) use artifact::*;
 pub use candidate::ResidentExecutionError;
 pub(crate) use candidate::{Candidate, ReactiveInstance, publish_epoch};
-pub use full_write::{FULL_WRITE_ELEMENTS, ResidentFullWrite};
+pub use full_write::{FULL_WRITE_ELEMENTS, PreparedResidentFullWrite, ResidentFullWrite};
 pub(crate) use kernel::*;
 pub(crate) use workspace::*;
 

--- a/src/engine/src/resident/workspace.rs
+++ b/src/engine/src/resident/workspace.rs
@@ -28,7 +28,10 @@ pub(crate) struct TurnWorkspace {
     pub(crate) touched_slots: Vec<SlotIndex>,
     pub(crate) invalidated_slots: Vec<SlotIndex>,
     pub(crate) changed_slots: Vec<SlotIndex>,
+    pub(crate) dirty_node_marks: Box<[InstanceEpoch]>,
     pub(crate) node_execution_marks: Box<[InstanceEpoch]>,
+    pub(crate) dirty_nodes: Vec<NodeIndex>,
+    pub(crate) executed_nodes: Vec<NodeIndex>,
     pub(crate) linear_node_order: Box<[NodeIndex]>,
 }
 
@@ -42,7 +45,10 @@ impl TurnWorkspace {
             touched_slots: Vec::with_capacity(persistent_capacity),
             invalidated_slots: Vec::with_capacity(persistent_capacity),
             changed_slots: Vec::with_capacity(persistent_capacity),
+            dirty_node_marks: vec![InstanceEpoch(0); plan.nodes.len()].into_boxed_slice(),
             node_execution_marks: vec![InstanceEpoch(0); plan.nodes.len()].into_boxed_slice(),
+            dirty_nodes: Vec::with_capacity(plan.nodes.len()),
+            executed_nodes: Vec::with_capacity(plan.nodes.len()),
             linear_node_order: plan.topology.linear_node_order.clone(),
         }
     }
@@ -53,6 +59,36 @@ impl TurnWorkspace {
         self.touched_slots.clear();
         self.invalidated_slots.clear();
         self.changed_slots.clear();
+        self.dirty_nodes.clear();
+        self.executed_nodes.clear();
+    }
+
+    #[inline]
+    pub(crate) fn mark_dirty(&mut self, node: NodeIndex, epoch: InstanceEpoch) {
+        let mark = &mut self.dirty_node_marks[node.0 as usize];
+        if *mark != epoch {
+            *mark = epoch;
+            self.dirty_nodes.push(node);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn seed_turn_roots(&mut self, roots: &[NodeIndex], epoch: InstanceEpoch) {
+        for node in roots.iter().copied() {
+            self.mark_dirty(node, epoch);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_dirty(&self, node: NodeIndex, epoch: InstanceEpoch) -> bool {
+        self.dirty_node_marks[node.0 as usize] == epoch
+    }
+
+    #[inline]
+    pub(crate) fn record_node_execution(&mut self, node: NodeIndex, epoch: InstanceEpoch) {
+        debug_assert_ne!(self.node_execution_marks[node.0 as usize], epoch);
+        self.node_execution_marks[node.0 as usize] = epoch;
+        self.executed_nodes.push(node);
     }
 
     #[inline]

--- a/src/engine/src/resident/workspace.rs
+++ b/src/engine/src/resident/workspace.rs
@@ -111,3 +111,45 @@ impl TurnWorkspace {
             .push(slot::index(instance, slot::COVARIANCE));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_marks_skip_a_clean_branch_and_deduplicate_invalidations() {
+        let plan = ActivatedPlan::activate(super::super::ProgramArtifact::frozen_ekf_batch(1));
+        let mut workspace = TurnWorkspace::activate(&plan);
+        let epoch = InstanceEpoch(7);
+        let order = [
+            NodeIndex(0),
+            NodeIndex(1),
+            NodeIndex(2),
+            NodeIndex(3),
+            NodeIndex(4),
+        ];
+        let downstream: [&[NodeIndex]; 5] =
+            [&[NodeIndex(1)], &[NodeIndex(3)], &[NodeIndex(4)], &[], &[]];
+
+        workspace.begin([0.0; 4]);
+        workspace.mark_dirty(NodeIndex(0), epoch);
+        workspace.mark_dirty(NodeIndex(0), epoch);
+        assert_eq!(workspace.dirty_nodes, [NodeIndex(0)]);
+        for node in order {
+            if !workspace.is_dirty(node, epoch) {
+                continue;
+            }
+            workspace.record_node_execution(node, epoch);
+            for child in downstream[node.0 as usize] {
+                workspace.mark_dirty(*child, epoch);
+            }
+        }
+
+        assert_eq!(
+            workspace.executed_nodes,
+            [NodeIndex(0), NodeIndex(1), NodeIndex(3)]
+        );
+        assert!(!workspace.is_dirty(NodeIndex(2), epoch));
+        assert!(!workspace.is_dirty(NodeIndex(4), epoch));
+    }
+}

--- a/src/runtime/benches/resident_ekf.rs
+++ b/src/runtime/benches/resident_ekf.rs
@@ -22,13 +22,17 @@ use support::gate_b::raw_kernel::KernelFixture;
 use support::gate_b::resident_kernel::{
     ResidentFullWriteFixture, ResidentKernelFixture, ResidentKernelProbe,
 };
+use support::gate_b::resident_turn::{
+    ResidentCompleteProbe, ResidentFullWriteTurnFixture, ResidentScheduledFixture,
+    ResidentTurnFixture,
+};
 
 struct CountingAllocator;
 
 static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
 static DEALLOCATIONS: AtomicU64 = AtomicU64::new(0);
 static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
-static REPORTED: OnceLock<Mutex<BTreeSet<(String, usize)>>> = OnceLock::new();
+static REPORTED: OnceLock<Mutex<BTreeSet<(String, usize, usize, u64)>>> = OnceLock::new();
 
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -89,6 +93,13 @@ struct StructuralProbe {
     receipt_bytes: usize,
     commit_runtime_call_count: u64,
     legacy_journal_capture_count: u64,
+    dirty_node_count: usize,
+    record_preparation_count: usize,
+    record_append_count: usize,
+    records_retained_before_timing: usize,
+    records_appended: usize,
+    ledger_records_inspected: usize,
+    post_publication_append_infallible: bool,
 }
 
 impl From<EpochProbe> for StructuralProbe {
@@ -99,6 +110,11 @@ impl From<EpochProbe> for StructuralProbe {
             published_buffer_copy_bytes: probe.published_buffer_copy_bytes,
             publication_store_count: probe.publication_store_count,
             receipt_bytes: probe.receipt_bytes,
+            record_preparation_count: probe.record_preparation_count,
+            record_append_count: probe.record_append_count,
+            records_appended: probe.records_appended,
+            ledger_records_inspected: probe.ledger_records_inspected,
+            post_publication_append_infallible: probe.post_publication_append_infallible,
             ..Self::default()
         }
     }
@@ -112,6 +128,11 @@ impl From<FullWriteProbe> for StructuralProbe {
             published_buffer_copy_bytes: probe.published_buffer_copy_bytes,
             publication_store_count: probe.publication_store_count,
             receipt_bytes: probe.receipt_bytes,
+            record_preparation_count: probe.record_preparation_count,
+            record_append_count: probe.record_append_count,
+            records_appended: probe.records_appended,
+            ledger_records_inspected: probe.ledger_records_inspected,
+            post_publication_append_infallible: probe.post_publication_append_infallible,
             ..Self::default()
         }
     }
@@ -129,9 +150,52 @@ impl From<ResidentKernelProbe> for StructuralProbe {
     }
 }
 
+impl From<ResidentCompleteProbe> for StructuralProbe {
+    fn from(probe: ResidentCompleteProbe) -> Self {
+        Self {
+            candidate_seed_bytes: probe.candidate_seed_bytes,
+            candidate_written_bytes: probe.candidate_written_bytes,
+            published_buffer_copy_bytes: probe.published_buffer_copy_bytes,
+            publication_store_count: probe.publication_store_count,
+            receipt_bytes: probe.receipt_bytes,
+            dirty_node_count: probe.dirty_nodes,
+            record_preparation_count: probe.record_preparation_count,
+            record_append_count: probe.record_append_count,
+            records_retained_before_timing: probe.records_retained_before_timing,
+            records_appended: probe.records_appended,
+            ledger_records_inspected: probe.ledger_records_inspected,
+            post_publication_append_infallible: true,
+            ..Self::default()
+        }
+    }
+}
+
 fn report(
     lane: &str,
     instances: usize,
+    allocations: AllocationSnapshot,
+    probe: StructuralProbe,
+    output_hash: &str,
+    abort_output_hash: Option<&str>,
+) {
+    report_dimensions(
+        lane,
+        instances,
+        0,
+        1,
+        allocations,
+        probe,
+        output_hash,
+        abort_output_hash,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn report_dimensions(
+    lane: &str,
+    instances: usize,
+    retained_history: usize,
+    next_epoch: u64,
     allocations: AllocationSnapshot,
     probe: StructuralProbe,
     output_hash: &str,
@@ -141,7 +205,7 @@ fn report(
         .get_or_init(|| Mutex::new(BTreeSet::new()))
         .lock()
         .expect("Gate B report lock");
-    if !reported.insert((lane.to_string(), instances)) {
+    if !reported.insert((lane.to_string(), instances, retained_history, next_epoch)) {
         return;
     }
     drop(reported);
@@ -149,7 +213,7 @@ fn report(
         .map(|hash| format!("\"{hash}\""))
         .unwrap_or_else(|| "null".to_string());
     let line = format!(
-        "GATE_B_SAMPLE {{\"lane\":\"{lane}\",\"instances\":{instances},\"turns\":{EPISODE_LENGTH},\"allocation_count\":{},\"deallocation_count\":{},\"allocated_bytes\":{},\"correctness\":true,\"quantized_state_hash\":\"{output_hash}\",\"candidate_seed_bytes\":{},\"candidate_written_bytes\":{},\"published_buffer_copy_bytes\":{},\"publication_store_count\":{},\"receipt_bytes\":{},\"commit_runtime_call_count\":{},\"legacy_journal_capture_count\":{},\"abort_output_hash\":{abort}}}",
+        "GATE_B_SAMPLE {{\"lane\":\"{lane}\",\"instances\":{instances},\"turns\":{EPISODE_LENGTH},\"retained_history\":{retained_history},\"next_epoch\":{next_epoch},\"allocation_count\":{},\"deallocation_count\":{},\"allocated_bytes\":{},\"correctness\":true,\"quantized_state_hash\":\"{output_hash}\",\"candidate_seed_bytes\":{},\"candidate_written_bytes\":{},\"published_buffer_copy_bytes\":{},\"publication_store_count\":{},\"receipt_bytes\":{},\"commit_runtime_call_count\":{},\"legacy_journal_capture_count\":{},\"dirty_node_count\":{},\"record_preparation_count\":{},\"record_append_count\":{},\"records_retained_before_timing\":{},\"records_appended\":{},\"ledger_records_inspected\":{},\"post_publication_append_infallible\":{},\"abort_output_hash\":{abort}}}",
         allocations.allocations,
         allocations.deallocations,
         allocations.allocated_bytes,
@@ -160,6 +224,13 @@ fn report(
         probe.receipt_bytes,
         probe.commit_runtime_call_count,
         probe.legacy_journal_capture_count,
+        probe.dirty_node_count,
+        probe.record_preparation_count,
+        probe.record_append_count,
+        probe.records_retained_before_timing,
+        probe.records_appended,
+        probe.ledger_records_inspected,
+        probe.post_publication_append_infallible,
     );
     let mut stderr = std::io::stderr().lock();
     stderr
@@ -209,6 +280,19 @@ fn validate_controls() {
     let mut resident_rejected = ResidentKernelFixture::new(1);
     resident_rejected.force_rejected_turn_preserves_publication();
 
+    let mut scheduled = ResidentScheduledFixture::new(1);
+    assert_eq!(
+        scheduled.run_and_validate_every_turn(),
+        REFERENCE_TRAJECTORY_SHA256
+    );
+
+    let mut complete = ResidentTurnFixture::new(1, 0, 1);
+    assert_eq!(
+        complete.run_and_validate_every_turn(),
+        REFERENCE_TRAJECTORY_SHA256
+    );
+    complete.validate_final();
+
     let mut legacy = LegacyEkfFixture::new(1);
     assert_eq!(
         legacy.run_and_validate_every_turn(),
@@ -225,6 +309,9 @@ fn validate_controls() {
     let mut full_resident = ResidentFullWriteFixture::new();
     full_resident.run_episode();
     assert_eq!(buffer_hash(full_resident.published()), full_hash);
+    let mut full_resident_turn = ResidentFullWriteTurnFixture::new();
+    full_resident_turn.run_episode();
+    assert_eq!(buffer_hash(full_resident_turn.published()), full_hash);
     let mut full_rejected = FullWriteEpochFixture::new();
     assert_eq!(
         full_rejected.abort_output_hash(),
@@ -323,6 +410,86 @@ fn resident_kernel(c: &mut Criterion) {
                         instances,
                         allocations,
                         StructuralProbe::default(),
+                        &trajectory_hash,
+                        None,
+                    );
+                }
+                elapsed
+            });
+        });
+    }
+    group.finish();
+}
+
+fn resident_scheduled(c: &mut Criterion) {
+    let mut correctness = ResidentScheduledFixture::new(1);
+    let trajectory_hash = correctness.run_and_validate_every_turn();
+    assert_eq!(trajectory_hash, REFERENCE_TRAJECTORY_SHA256);
+    let mut group = c.benchmark_group("gate_b/mech-resident-scheduled");
+    group.bench_function("1", |benchmark| {
+        benchmark.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let mut fixture = ResidentScheduledFixture::new(1);
+                reset_allocations();
+                let started = Instant::now();
+                fixture.run_episode();
+                elapsed += started.elapsed();
+                let allocations = allocation_snapshot();
+                fixture.validate_final();
+                black_box(fixture.state(0));
+                report(
+                    "mech-resident-scheduled",
+                    1,
+                    allocations,
+                    StructuralProbe {
+                        candidate_written_bytes: 96,
+                        publication_store_count: 1,
+                        dirty_node_count: 15,
+                        ..StructuralProbe::default()
+                    },
+                    &trajectory_hash,
+                    None,
+                );
+            }
+            elapsed
+        });
+    });
+    group.finish();
+}
+
+fn resident_turn(c: &mut Criterion) {
+    let mut correctness = ResidentTurnFixture::new(1, 0, 1);
+    let trajectory_hash = correctness.run_and_validate_every_turn();
+    assert_eq!(trajectory_hash, REFERENCE_TRAJECTORY_SHA256);
+    correctness.validate_final();
+
+    let mut group = c.benchmark_group("gate_b/mech-resident-turn");
+    for (name, history, next_epoch) in [
+        ("history-0-low-epoch", 0, 1),
+        ("history-1000-low-epoch", 1_000, 1),
+        ("history-100000-low-epoch", 100_000, 1),
+        ("history-0-high-epoch", 0, 1_000_000_001),
+    ] {
+        group.bench_function(name, |benchmark| {
+            benchmark.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let mut fixture = ResidentTurnFixture::new(1, history, next_epoch);
+                    reset_allocations();
+                    let started = Instant::now();
+                    fixture.run_episode();
+                    elapsed += started.elapsed();
+                    let allocations = allocation_snapshot();
+                    fixture.validate_final();
+                    black_box(fixture.state(0));
+                    report_dimensions(
+                        "mech-resident-turn",
+                        1,
+                        history,
+                        next_epoch,
+                        allocations,
+                        fixture.probe().into(),
                         &trajectory_hash,
                         None,
                     );
@@ -451,6 +618,32 @@ fn full_write(c: &mut Criterion) {
             elapsed
         });
     });
+    group.bench_function("mech-resident-turn", |benchmark| {
+        benchmark.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let mut fixture = ResidentFullWriteTurnFixture::new();
+                reset_allocations();
+                let started = Instant::now();
+                fixture.run_episode();
+                elapsed += started.elapsed();
+                let allocations = allocation_snapshot();
+                let output_hash = buffer_hash(fixture.published());
+                let mut rejected = ResidentFullWriteTurnFixture::new();
+                let abort_hash = rejected.abort_output_hash_with_rejection();
+                black_box(fixture.published());
+                report(
+                    "mech-resident-turn-full-write",
+                    1,
+                    allocations,
+                    fixture.probe().into(),
+                    &output_hash,
+                    Some(&abort_hash),
+                );
+            }
+            elapsed
+        });
+    });
     group.finish();
 }
 
@@ -481,6 +674,51 @@ fn resident_structural_samples() {
         fixture.probe().into(),
         &output_hash,
         Some(&abort_hash),
+    );
+
+    let mut scheduled = ResidentScheduledFixture::new(1);
+    let scheduled_hash = scheduled.run_and_validate_every_turn();
+    report(
+        "mech-resident-scheduled",
+        1,
+        AllocationSnapshot::default(),
+        StructuralProbe {
+            candidate_written_bytes: 96,
+            publication_store_count: 1,
+            dirty_node_count: 15,
+            ..StructuralProbe::default()
+        },
+        &scheduled_hash,
+        None,
+    );
+
+    for (history, next_epoch) in [(0, 1), (1_000, 1), (100_000, 1), (0, 1_000_000_001)] {
+        let mut complete = ResidentTurnFixture::new(1, history, next_epoch);
+        let complete_hash = complete.run_and_validate_every_turn();
+        report_dimensions(
+            "mech-resident-turn",
+            1,
+            history,
+            next_epoch,
+            AllocationSnapshot::default(),
+            complete.probe().into(),
+            &complete_hash,
+            None,
+        );
+    }
+
+    let mut complete_full = ResidentFullWriteTurnFixture::new();
+    complete_full.run_episode();
+    let complete_full_hash = buffer_hash(complete_full.published());
+    let mut rejected_full = ResidentFullWriteTurnFixture::new();
+    let complete_abort_hash = rejected_full.abort_output_hash_with_rejection();
+    report(
+        "mech-resident-turn-full-write",
+        1,
+        AllocationSnapshot::default(),
+        complete_full.probe().into(),
+        &complete_full_hash,
+        Some(&complete_abort_hash),
     );
 }
 
@@ -541,6 +779,8 @@ fn gate_b_controls(c: &mut Criterion) {
     rust_kernel(c);
     rust_epoch(c);
     resident_kernel(c);
+    resident_scheduled(c);
+    resident_turn(c);
     legacy_atomic(c);
     full_write(c);
 }

--- a/src/runtime/benches/support/gate_b/full_write.rs
+++ b/src/runtime/benches/support/gate_b/full_write.rs
@@ -129,6 +129,8 @@ impl FullWriteEpochFixture {
             working_epoch,
             buffer_hash64(&self.versions[working_index]),
             1,
+            1,
+            1,
         );
         let permit = self.permits[turn].take().expect("unused Gate B admission");
         let prepared = prepare_retained(&mut self.ledger, permit, receipt)

--- a/src/runtime/benches/support/gate_b/full_write.rs
+++ b/src/runtime/benches/support/gate_b/full_write.rs
@@ -1,9 +1,11 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use mech_runtime::__gate_b_recording::{
-    GateBFixedReceipt, LedgerPermit, RecordEstimate, RetainedTurnLedger, prepare_retained,
-    reserve_retained,
+    GateBFixedReceipt, InputSequence, InputSequenceRange, LedgerPermit, OwnedTurnRecord,
+    RecordEstimate, RetainedTurnLedger, TurnId, TurnRecordHeader, TurnRecordStatus,
+    prepare_retained, reserve_retained,
 };
+use mech_runtime::TransactionId;
 use sha2::{Digest, Sha256};
 
 use super::contract::{EPISODE_LENGTH, trace};
@@ -19,6 +21,11 @@ pub struct FullWriteProbe {
     pub published_buffer_copy_bytes: usize,
     pub publication_store_count: usize,
     pub receipt_bytes: usize,
+    pub record_preparation_count: usize,
+    pub record_append_count: usize,
+    pub records_appended: usize,
+    pub ledger_records_inspected: usize,
+    pub post_publication_append_infallible: bool,
 }
 
 pub fn initial_values() -> Vec<f64> {
@@ -66,7 +73,7 @@ pub struct FullWriteEpochFixture {
     coefficient: Box<[f64]>,
     published_epoch: AtomicU64,
     next_epoch: u64,
-    ledger: RetainedTurnLedger<GateBFixedReceipt>,
+    ledger: RetainedTurnLedger<OwnedTurnRecord<GateBFixedReceipt>>,
     permits: Vec<Option<LedgerPermit>>,
 }
 
@@ -124,14 +131,28 @@ impl FullWriteEpochFixture {
             return Err("forced full-write rejection");
         }
 
-        let receipt = GateBFixedReceipt::accepted(
-            base_epoch,
-            working_epoch,
-            buffer_hash64(&self.versions[working_index]),
-            1,
-            1,
-            1,
-        );
+        let identity = u64::try_from(turn + 1).expect("Gate B full-write identity");
+        let input_sequence = InputSequence::new(identity).expect("non-zero Gate B input");
+        let receipt = OwnedTurnRecord {
+            header: TurnRecordHeader {
+                turn_id: TurnId::new(identity).expect("non-zero Gate B turn"),
+                transaction_id: TransactionId::new(u128::from(identity)),
+                input_range: Some(
+                    InputSequenceRange::new(input_sequence, input_sequence)
+                        .expect("one-input Gate B range"),
+                ),
+                status: TurnRecordStatus::Accepted,
+                failure: None,
+            },
+            body: GateBFixedReceipt::accepted(
+                base_epoch,
+                working_epoch,
+                buffer_hash64(&self.versions[working_index]),
+                1,
+                1,
+                1,
+            ),
+        };
         let permit = self.permits[turn].take().expect("unused Gate B admission");
         let prepared = prepare_retained(&mut self.ledger, permit, receipt)
             .expect("Gate B full-write receipt preparation");
@@ -162,6 +183,11 @@ impl FullWriteEpochFixture {
             published_buffer_copy_bytes: 0,
             publication_store_count: 1,
             receipt_bytes: GateBFixedReceipt::RETAINED_BYTES,
+            record_preparation_count: 1,
+            record_append_count: 1,
+            records_appended: EPISODE_LENGTH,
+            ledger_records_inspected: 0,
+            post_publication_append_infallible: true,
         }
     }
 }

--- a/src/runtime/benches/support/gate_b/mod.rs
+++ b/src/runtime/benches/support/gate_b/mod.rs
@@ -4,3 +4,4 @@ pub mod legacy_atomic;
 pub mod raw_epoch;
 pub mod raw_kernel;
 pub mod resident_kernel;
+pub mod resident_turn;

--- a/src/runtime/benches/support/gate_b/raw_epoch.rs
+++ b/src/runtime/benches/support/gate_b/raw_epoch.rs
@@ -110,6 +110,8 @@ impl EpochFixture {
             working_epoch,
             state_hash,
             u16::try_from(self.versions[working_index].len() * 2).expect("Gate B touched count"),
+            u16::try_from(self.versions[working_index].len() * 2).expect("Gate B changed count"),
+            u16::try_from(self.versions[working_index].len() * 15).expect("Gate B dirty count"),
         );
         let permit = self.permits[turn].take().expect("unused Gate B admission");
         let prepared = prepare_retained(&mut self.ledger, permit, receipt)

--- a/src/runtime/benches/support/gate_b/raw_epoch.rs
+++ b/src/runtime/benches/support/gate_b/raw_epoch.rs
@@ -1,9 +1,11 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use mech_runtime::__gate_b_recording::{
-    GateBFixedReceipt, LedgerPermit, RecordEstimate, RetainedTurnLedger, prepare_retained,
-    reserve_retained,
+    GateBFixedReceipt, InputSequence, InputSequenceRange, LedgerPermit, OwnedTurnRecord,
+    RecordEstimate, RetainedTurnLedger, TurnId, TurnRecordHeader, TurnRecordStatus,
+    prepare_retained, reserve_retained,
 };
+use mech_runtime::TransactionId;
 
 use super::contract::{
     EPISODE_LENGTH, EkfState, assert_state_close, quantized_trajectory_hash, reference_trajectory,
@@ -18,13 +20,18 @@ pub struct EpochProbe {
     pub published_buffer_copy_bytes: usize,
     pub publication_store_count: usize,
     pub receipt_bytes: usize,
+    pub record_preparation_count: usize,
+    pub record_append_count: usize,
+    pub records_appended: usize,
+    pub ledger_records_inspected: usize,
+    pub post_publication_append_infallible: bool,
 }
 
 pub struct EpochFixture {
     versions: [Vec<EkfState>; 2],
     published_epoch: AtomicU64,
     next_epoch: u64,
-    ledger: RetainedTurnLedger<GateBFixedReceipt>,
+    ledger: RetainedTurnLedger<OwnedTurnRecord<GateBFixedReceipt>>,
     permits: Vec<Option<LedgerPermit>>,
     probe: EpochProbe,
 }
@@ -58,6 +65,11 @@ impl EpochFixture {
                 published_buffer_copy_bytes: 0,
                 publication_store_count: 1,
                 receipt_bytes: GateBFixedReceipt::RETAINED_BYTES,
+                record_preparation_count: 1,
+                record_append_count: 1,
+                records_appended: EPISODE_LENGTH,
+                ledger_records_inspected: 0,
+                post_publication_append_infallible: true,
             },
         }
     }
@@ -105,14 +117,30 @@ impl EpochFixture {
             state_hash ^= state_hash64(*state);
             state_hash = state_hash.wrapping_mul(0x100000001b3);
         }
-        let receipt = GateBFixedReceipt::accepted(
-            base_epoch,
-            working_epoch,
-            state_hash,
-            u16::try_from(self.versions[working_index].len() * 2).expect("Gate B touched count"),
-            u16::try_from(self.versions[working_index].len() * 2).expect("Gate B changed count"),
-            u16::try_from(self.versions[working_index].len() * 15).expect("Gate B dirty count"),
-        );
+        let identity = u64::try_from(turn + 1).expect("Gate B turn identity");
+        let input_sequence = InputSequence::new(identity).expect("non-zero Gate B input");
+        let receipt = OwnedTurnRecord {
+            header: TurnRecordHeader {
+                turn_id: TurnId::new(identity).expect("non-zero Gate B turn"),
+                transaction_id: TransactionId::new(u128::from(identity)),
+                input_range: Some(
+                    InputSequenceRange::new(input_sequence, input_sequence)
+                        .expect("one-input Gate B range"),
+                ),
+                status: TurnRecordStatus::Accepted,
+                failure: None,
+            },
+            body: GateBFixedReceipt::accepted(
+                base_epoch,
+                working_epoch,
+                state_hash,
+                u16::try_from(self.versions[working_index].len() * 2)
+                    .expect("Gate B touched count"),
+                u16::try_from(self.versions[working_index].len() * 2)
+                    .expect("Gate B changed count"),
+                u16::try_from(self.versions[working_index].len() * 15).expect("Gate B dirty count"),
+            ),
+        };
         let permit = self.permits[turn].take().expect("unused Gate B admission");
         let prepared = prepare_retained(&mut self.ledger, permit, receipt)
             .expect("Gate B exact receipt preparation");

--- a/src/runtime/benches/support/gate_b/resident_turn.rs
+++ b/src/runtime/benches/support/gate_b/resident_turn.rs
@@ -1,0 +1,306 @@
+use mech_engine::__gate_b_resident::{ResidentEkfBatch, ResidentFullWrite};
+use mech_runtime::__gate_b_recording::{GateBFixedReceipt, ResidentTurnRecorder};
+
+use super::{
+    contract::{
+        EPISODE_LENGTH, EkfInput, EkfState, assert_state_close, quantized_trajectory_hash,
+        reference_trajectory, trace,
+    },
+    full_write::{WRITTEN_BYTES, buffer_hash},
+};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ResidentCompleteProbe {
+    pub candidate_seed_bytes: usize,
+    pub candidate_written_bytes: usize,
+    pub published_buffer_copy_bytes: usize,
+    pub publication_store_count: usize,
+    pub receipt_bytes: usize,
+    pub dirty_nodes: usize,
+    pub record_preparation_count: usize,
+    pub record_append_count: usize,
+    pub records_retained_before_timing: usize,
+    pub records_appended: usize,
+    pub ledger_records_inspected: usize,
+}
+
+fn input_array(input: EkfInput) -> [f64; 4] {
+    [
+        input.velocity,
+        input.angular_velocity,
+        input.measured_range,
+        input.measured_bearing,
+    ]
+}
+
+fn state_hash64(state: EkfState) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for value in state.values() {
+        for byte in value.to_bits().to_le_bytes() {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+    }
+    hash
+}
+
+fn batch_state_hash(state: EkfState, instances: usize) -> u64 {
+    let state_hash = state_hash64(state);
+    let mut hash = 0xcbf29ce484222325_u64;
+    for _ in 0..instances {
+        hash ^= state_hash;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+pub struct ResidentScheduledFixture {
+    resident: ResidentEkfBatch,
+}
+
+impl ResidentScheduledFixture {
+    pub fn new(instances: usize) -> Self {
+        Self {
+            resident: ResidentEkfBatch::new(instances),
+        }
+    }
+
+    pub fn run_episode(&mut self) {
+        for input in trace().iter().copied() {
+            self.resident
+                .scheduled_turn(input_array(input))
+                .expect("frozen scheduled resident turn");
+        }
+    }
+
+    pub fn run_and_validate_every_turn(&mut self) -> String {
+        let mut trajectory = Vec::with_capacity(EPISODE_LENGTH);
+        for (turn, (input, expected)) in trace()
+            .iter()
+            .copied()
+            .zip(reference_trajectory().iter().copied())
+            .enumerate()
+        {
+            self.resident
+                .scheduled_turn(input_array(input))
+                .expect("frozen scheduled resident turn");
+            for instance in 0..self.resident.instances() {
+                assert_state_close(self.state(instance), expected, turn + 1);
+            }
+            trajectory.push(self.state(0));
+        }
+        quantized_trajectory_hash(&trajectory)
+    }
+
+    pub fn state(&self, instance: usize) -> EkfState {
+        let state = self.resident.state(instance);
+        EkfState {
+            state: state.state,
+            covariance: state.covariance,
+        }
+    }
+
+    pub fn validate_final(&self) {
+        for instance in 0..self.resident.instances() {
+            assert_state_close(
+                self.state(instance),
+                EkfState::REFERENCE_FINAL,
+                EPISODE_LENGTH,
+            );
+        }
+    }
+}
+
+pub struct ResidentTurnFixture {
+    resident: ResidentEkfBatch,
+    recorder: ResidentTurnRecorder,
+    instances: usize,
+    retained_history: usize,
+}
+
+impl ResidentTurnFixture {
+    pub fn new(instances: usize, retained_history: usize, next_epoch: u64) -> Self {
+        let mut resident = ResidentEkfBatch::new(instances);
+        resident.set_next_epoch_for_gate_b(next_epoch);
+        Self {
+            resident,
+            recorder: ResidentTurnRecorder::new(EPISODE_LENGTH, retained_history)
+                .expect("resident Gate B recorder setup"),
+            instances,
+            retained_history,
+        }
+    }
+
+    #[inline]
+    fn run_turn(&mut self, turn: usize, input: EkfInput) {
+        let permit = self
+            .recorder
+            .take_admission_permit(turn)
+            .expect("pre-reserved resident admission");
+        let prepared = self
+            .resident
+            .prepare_scheduled_turn(input_array(input))
+            .expect("frozen complete resident turn");
+        let commit = self
+            .recorder
+            .prepare_commit(permit, prepared)
+            .expect("exact resident receipt preparation");
+        commit.commit();
+    }
+
+    pub fn run_episode(&mut self) {
+        for (turn, input) in trace().iter().copied().enumerate() {
+            self.run_turn(turn, input);
+        }
+    }
+
+    pub fn run_and_validate_every_turn(&mut self) -> String {
+        let mut trajectory = Vec::with_capacity(EPISODE_LENGTH);
+        for (turn, (input, expected)) in trace()
+            .iter()
+            .copied()
+            .zip(reference_trajectory().iter().copied())
+            .enumerate()
+        {
+            let permit = self
+                .recorder
+                .take_admission_permit(turn)
+                .expect("pre-reserved resident admission");
+            let prepared = self
+                .resident
+                .prepare_scheduled_turn(input_array(input))
+                .expect("frozen complete resident turn");
+            let summary = prepared.summary();
+            assert_eq!(
+                summary.state_hash,
+                batch_state_hash(expected, self.instances)
+            );
+            let commit = self
+                .recorder
+                .prepare_commit(permit, prepared)
+                .expect("exact resident receipt preparation");
+            commit.commit();
+            for instance in 0..self.instances {
+                assert_state_close(self.state(instance), expected, turn + 1);
+            }
+            trajectory.push(self.state(0));
+        }
+        quantized_trajectory_hash(&trajectory)
+    }
+
+    pub fn state(&self, instance: usize) -> EkfState {
+        let state = self.resident.state(instance);
+        EkfState {
+            state: state.state,
+            covariance: state.covariance,
+        }
+    }
+
+    pub fn validate_final(&self) {
+        for instance in 0..self.instances {
+            assert_state_close(
+                self.state(instance),
+                EkfState::REFERENCE_FINAL,
+                EPISODE_LENGTH,
+            );
+        }
+        assert_eq!(
+            self.recorder.recorded_ledger_len(),
+            self.retained_history + EPISODE_LENGTH
+        );
+    }
+
+    pub fn probe(&self) -> ResidentCompleteProbe {
+        ResidentCompleteProbe {
+            candidate_seed_bytes: 0,
+            candidate_written_bytes: self.instances * 96,
+            published_buffer_copy_bytes: 0,
+            publication_store_count: 1,
+            receipt_bytes: GateBFixedReceipt::RETAINED_BYTES,
+            dirty_nodes: self.instances * 15,
+            record_preparation_count: 1,
+            record_append_count: 1,
+            records_retained_before_timing: self.retained_history,
+            records_appended: EPISODE_LENGTH,
+            ledger_records_inspected: self.recorder.records_inspected(),
+        }
+    }
+}
+
+pub struct ResidentFullWriteTurnFixture {
+    resident: ResidentFullWrite,
+    recorder: ResidentTurnRecorder,
+}
+
+impl ResidentFullWriteTurnFixture {
+    pub fn new() -> Self {
+        Self {
+            resident: ResidentFullWrite::new(),
+            recorder: ResidentTurnRecorder::new(EPISODE_LENGTH, 0)
+                .expect("resident full-write recorder setup"),
+        }
+    }
+
+    pub fn run_episode(&mut self) {
+        for (turn, input) in trace().iter().enumerate() {
+            let permit = self
+                .recorder
+                .take_admission_permit(turn)
+                .expect("pre-reserved full-write admission");
+            let prepared = self
+                .resident
+                .prepare_turn(input.velocity)
+                .expect("valid resident full-write candidate");
+            let commit = self
+                .recorder
+                .prepare_full_write_commit(permit, prepared)
+                .expect("exact full-write receipt preparation");
+            commit.commit();
+        }
+    }
+
+    pub fn published(&self) -> &[f64] {
+        self.resident.published()
+    }
+
+    pub fn abort_output_hash_with_rejection(&mut self) -> String {
+        let before_epoch = self.resident.published_epoch();
+        let before_hash = buffer_hash(self.resident.published());
+        let permit = self
+            .recorder
+            .take_admission_permit(0)
+            .expect("pre-reserved rejected full-write admission");
+        self.resident
+            .prepare_turn(1.0)
+            .expect("valid candidate before forced rejection")
+            .abort();
+        self.recorder
+            .prepare_rejected(
+                permit,
+                before_epoch,
+                mech_engine::__gate_b_resident::ResidentExecutionError::NonFiniteState,
+            )
+            .expect("rejected full-write receipt preparation")
+            .append();
+        assert_eq!(self.resident.published_epoch(), before_epoch);
+        assert_eq!(buffer_hash(self.resident.published()), before_hash);
+        assert_eq!(self.recorder.recorded_ledger_len(), 1);
+        before_hash
+    }
+
+    pub fn probe(&self) -> ResidentCompleteProbe {
+        ResidentCompleteProbe {
+            candidate_seed_bytes: 0,
+            candidate_written_bytes: WRITTEN_BYTES,
+            published_buffer_copy_bytes: 0,
+            publication_store_count: 1,
+            receipt_bytes: GateBFixedReceipt::RETAINED_BYTES,
+            dirty_nodes: 1,
+            record_preparation_count: 1,
+            record_append_count: 1,
+            records_retained_before_timing: 0,
+            records_appended: EPISODE_LENGTH,
+            ledger_records_inspected: self.recorder.records_inspected(),
+        }
+    }
+}

--- a/src/runtime/src/ledger/retained.rs
+++ b/src/runtime/src/ledger/retained.rs
@@ -63,6 +63,12 @@ impl<R> RetainedTurnLedger<R> {
             .map(|(sequence, record)| (*sequence, record))
     }
 
+    pub fn last(&self) -> Option<(LedgerSequence, &R)> {
+        self.records
+            .back()
+            .map(|(sequence, record)| (*sequence, record))
+    }
+
     pub fn pop_front(&mut self) -> Option<(LedgerSequence, R)> {
         let entry = self.records.pop_front()?;
         let bytes = self

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -216,7 +216,8 @@ pub mod __gate_b_recording {
         PreparedResidentCommit, ResidentRecordInspection, ResidentTurnRecorder,
     };
     pub use crate::turn_record::{
-        AccountedRecord, GateBFixedReceipt, LedgerSequence, OwnedTurnRecord, TurnFailurePhase,
+        AccountedRecord, GateBFixedReceipt, InputSequence, InputSequenceRange, LedgerSequence,
+        OwnedTurnRecord, TurnFailurePhase, TurnId, TurnRecordHeader, TurnRecordStatus,
     };
 
     use crate::ledger::{PreparedLedgerAppend, TurnLedger};

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -12,6 +12,8 @@ mod ledger;
 pub mod operation;
 #[cfg(feature = "runtime")]
 mod outbox;
+#[cfg(all(feature = "runtime", feature = "runtime_bench_gate_b"))]
+mod resident_gate_b;
 mod resource;
 #[cfg(feature = "runtime")]
 mod snapshot;
@@ -210,7 +212,12 @@ pub mod __gate_b_recording {
     use mech_core::MResult;
 
     pub use crate::ledger::{LedgerPermit, RecordEstimate, RetainedTurnLedger};
-    pub use crate::turn_record::{AccountedRecord, GateBFixedReceipt, LedgerSequence};
+    pub use crate::resident_gate_b::{
+        PreparedResidentCommit, ResidentRecordInspection, ResidentTurnRecorder,
+    };
+    pub use crate::turn_record::{
+        AccountedRecord, GateBFixedReceipt, LedgerSequence, OwnedTurnRecord, TurnFailurePhase,
+    };
 
     use crate::ledger::{PreparedLedgerAppend, TurnLedger};
 

--- a/src/runtime/src/resident_gate_b.rs
+++ b/src/runtime/src/resident_gate_b.rs
@@ -1,0 +1,365 @@
+//! Private complete-turn coordinator for the retained Gate B efficacy proof.
+
+use mech_core::{MResult, MechError, MechErrorKind};
+use mech_engine::__gate_b_resident::{
+    PreparedResidentFullWrite, PreparedResidentTurn, ResidentExecutionError, ResidentTurnSummary,
+};
+
+use crate::{
+    TransactionId,
+    ledger::{LedgerPermit, PreparedLedgerAppend, RecordEstimate, RetainedTurnLedger, TurnLedger},
+    turn_record::{
+        GateBFixedReceipt, InputSequence, InputSequenceRange, LedgerSequence, OwnedTurnRecord,
+        TurnFailurePhase, TurnFailureRecord, TurnId, TurnRecordHeader, TurnRecordStatus,
+    },
+};
+
+pub(crate) type ResidentTurnRecord = OwnedTurnRecord<GateBFixedReceipt>;
+const RESIDENT_RECORD_RESERVATION_BYTES: usize = 256;
+const RESIDENT_RECORD_ESTIMATE: RecordEstimate = RecordEstimate {
+    records: 1,
+    bytes: RESIDENT_RECORD_RESERVATION_BYTES,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResidentRecorderFailure(&'static str);
+
+impl MechErrorKind for ResidentRecorderFailure {
+    fn name(&self) -> &str {
+        "ResidentRecorderFailure"
+    }
+
+    fn message(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+fn error(message: &'static str) -> MechError {
+    MechError::new(ResidentRecorderFailure(message), None)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResidentRecordInspection<'a> {
+    pub sequence: u64,
+    pub turn_id: u64,
+    pub transaction_id: u128,
+    pub input_first: u64,
+    pub input_last: u64,
+    pub accepted: bool,
+    pub failure_phase: Option<TurnFailurePhase>,
+    pub failure_kind: Option<&'a str>,
+    pub body: GateBFixedReceipt,
+}
+
+struct PreparedResidentAppend<'ledger> {
+    ledger: &'ledger mut RetainedTurnLedger<ResidentTurnRecord>,
+    prepared: PreparedLedgerAppend<ResidentTurnRecord>,
+}
+
+impl PreparedResidentAppend<'_> {
+    #[inline]
+    fn append(self) -> LedgerSequence {
+        TurnLedger::append(self.ledger, self.prepared)
+    }
+}
+
+pub struct ResidentTurnRecorder {
+    ledger: RetainedTurnLedger<ResidentTurnRecord>,
+    permits: Box<[Option<LedgerPermit>]>,
+    next_turn: Option<u64>,
+    records_inspected: usize,
+    fail_next_preparation: bool,
+}
+
+impl ResidentTurnRecorder {
+    pub fn new(episode_turns: usize, retained_history: usize) -> MResult<Self> {
+        let capacity = retained_history
+            .checked_add(episode_turns)
+            .ok_or_else(|| error("ledger capacity overflow"))?;
+        let max_bytes = capacity
+            .checked_mul(RESIDENT_RECORD_RESERVATION_BYTES)
+            .ok_or_else(|| error("ledger byte capacity overflow"))?;
+        let mut ledger = RetainedTurnLedger::new(capacity, max_bytes)?;
+        for ordinal in 1..=retained_history {
+            let identity =
+                u64::try_from(ordinal).map_err(|_| error("history identity overflow"))?;
+            let record = accepted_record(
+                identity,
+                ResidentTurnSummary {
+                    before_epoch: identity.saturating_sub(1),
+                    after_epoch: identity,
+                    state_hash: 0,
+                    touched_slots: 0,
+                    changed_slots: 0,
+                    dirty_nodes: 0,
+                },
+            )?;
+            let permit = TurnLedger::reserve(&ledger, RESIDENT_RECORD_ESTIMATE)?;
+            let prepared = TurnLedger::prepare_append(&ledger, permit, record)?;
+            TurnLedger::append(&mut ledger, prepared);
+        }
+
+        let permits = (0..episode_turns)
+            .map(|_| TurnLedger::reserve(&ledger, RESIDENT_RECORD_ESTIMATE).map(Some))
+            .collect::<MResult<Vec<_>>>()?
+            .into_boxed_slice();
+        let next_turn = u64::try_from(retained_history)
+            .ok()
+            .and_then(|history| history.checked_add(1))
+            .ok_or_else(|| error("turn identity overflow"))?;
+        Ok(Self {
+            ledger,
+            permits,
+            next_turn: Some(next_turn),
+            records_inspected: 0,
+            fail_next_preparation: false,
+        })
+    }
+
+    pub fn take_admission_permit(&mut self, turn: usize) -> MResult<LedgerPermit> {
+        self.permits
+            .get_mut(turn)
+            .and_then(Option::take)
+            .ok_or_else(|| error("resident turn has no unused admission permit"))
+    }
+
+    fn prepare_accepted_append(
+        &mut self,
+        permit: LedgerPermit,
+        summary: ResidentTurnSummary,
+    ) -> MResult<PreparedResidentAppend<'_>> {
+        let identity = self.take_turn_identity()?;
+        if core::mem::take(&mut self.fail_next_preparation) {
+            drop(permit);
+            return Err(error("forced resident ledger preparation failure"));
+        }
+        let record = accepted_record(identity, summary)?;
+        let prepared = TurnLedger::prepare_append(&self.ledger, permit, record)?;
+        Ok(PreparedResidentAppend {
+            ledger: &mut self.ledger,
+            prepared,
+        })
+    }
+
+    pub fn prepare_commit<'instance>(
+        &mut self,
+        permit: LedgerPermit,
+        turn: PreparedResidentTurn<'instance>,
+    ) -> MResult<PreparedResidentCommit<'instance, '_>> {
+        let summary = turn.summary();
+        match self.prepare_accepted_append(permit, summary) {
+            Ok(append) => Ok(PreparedResidentCommit {
+                turn: PreparedResidentPublication::Ekf(turn),
+                append,
+            }),
+            Err(error) => {
+                turn.abort();
+                Err(error)
+            }
+        }
+    }
+
+    pub fn prepare_full_write_commit<'instance>(
+        &mut self,
+        permit: LedgerPermit,
+        turn: PreparedResidentFullWrite<'instance>,
+    ) -> MResult<PreparedResidentCommit<'instance, '_>> {
+        let summary = turn.summary();
+        match self.prepare_accepted_append(permit, summary) {
+            Ok(append) => Ok(PreparedResidentCommit {
+                turn: PreparedResidentPublication::FullWrite(turn),
+                append,
+            }),
+            Err(error) => {
+                turn.abort();
+                Err(error)
+            }
+        }
+    }
+
+    pub fn prepare_rejected(
+        &mut self,
+        permit: LedgerPermit,
+        before_epoch: u64,
+        failure: ResidentExecutionError,
+    ) -> MResult<PreparedRejectedAppend<'_>> {
+        let identity = self.take_turn_identity()?;
+        let record = rejected_record(identity, before_epoch, failure)?;
+        let prepared = TurnLedger::prepare_append(&self.ledger, permit, record)?;
+        Ok(PreparedRejectedAppend(PreparedResidentAppend {
+            ledger: &mut self.ledger,
+            prepared,
+        }))
+    }
+
+    pub fn recorded_ledger_len(&self) -> usize {
+        self.ledger.len()
+    }
+
+    pub fn records_inspected(&self) -> usize {
+        self.records_inspected
+    }
+
+    pub fn inspect_last(&mut self) -> Option<ResidentRecordInspection<'_>> {
+        self.records_inspected += 1;
+        let (sequence, record) = self.ledger.last()?;
+        let range = record.header.input_range?;
+        Some(ResidentRecordInspection {
+            sequence: sequence.get(),
+            turn_id: record.header.turn_id.get(),
+            transaction_id: record.header.transaction_id.as_u128(),
+            input_first: range.first().get(),
+            input_last: range.last().get(),
+            accepted: record.header.status == TurnRecordStatus::Accepted,
+            failure_phase: record.header.failure.as_ref().map(|failure| failure.phase),
+            failure_kind: record
+                .header
+                .failure
+                .as_ref()
+                .map(|failure| failure.kind.as_str()),
+            body: record.body,
+        })
+    }
+
+    #[doc(hidden)]
+    pub fn fail_next_preparation_for_test(&mut self) {
+        self.fail_next_preparation = true;
+    }
+
+    #[doc(hidden)]
+    pub fn set_next_turn_identity_for_test(&mut self, next_turn: u64) {
+        assert_ne!(next_turn, 0, "resident turn identities are non-zero");
+        self.next_turn = Some(next_turn);
+    }
+
+    #[doc(hidden)]
+    pub fn reserve_additional_permit_for_test(&self) -> MResult<LedgerPermit> {
+        TurnLedger::reserve(&self.ledger, RESIDENT_RECORD_ESTIMATE)
+    }
+
+    fn take_turn_identity(&mut self) -> MResult<u64> {
+        let identity = self
+            .next_turn
+            .take()
+            .ok_or_else(|| error("turn identity exhausted"))?;
+        self.next_turn = identity.checked_add(1);
+        Ok(identity)
+    }
+}
+
+pub struct PreparedRejectedAppend<'ledger>(PreparedResidentAppend<'ledger>);
+
+impl PreparedRejectedAppend<'_> {
+    pub fn append(self) -> LedgerSequence {
+        self.0.append()
+    }
+}
+
+fn header(
+    identity: u64,
+    status: TurnRecordStatus,
+    failure: Option<TurnFailureRecord>,
+) -> MResult<TurnRecordHeader> {
+    let input =
+        InputSequence::new(identity).ok_or_else(|| error("input identity must be non-zero"))?;
+    Ok(TurnRecordHeader {
+        turn_id: TurnId::new(identity).ok_or_else(|| error("turn identity must be non-zero"))?,
+        transaction_id: TransactionId::new(u128::from(identity)),
+        input_range: Some(InputSequenceRange::new(input, input)?),
+        status,
+        failure,
+    })
+}
+
+fn accepted_record(identity: u64, summary: ResidentTurnSummary) -> MResult<ResidentTurnRecord> {
+    Ok(OwnedTurnRecord {
+        header: header(identity, TurnRecordStatus::Accepted, None)?,
+        body: GateBFixedReceipt::accepted(
+            summary.before_epoch,
+            summary.after_epoch,
+            summary.state_hash,
+            summary.touched_slots,
+            summary.changed_slots,
+            summary.dirty_nodes,
+        ),
+    })
+}
+
+fn rejected_record(
+    identity: u64,
+    before_epoch: u64,
+    failure: ResidentExecutionError,
+) -> MResult<ResidentTurnRecord> {
+    let (phase, kind, message) = match failure {
+        ResidentExecutionError::EpochExhausted => (
+            TurnFailurePhase::Execution,
+            "ResidentEpochExhausted",
+            "resident candidate epoch exhausted",
+        ),
+        ResidentExecutionError::LandmarkDistance => (
+            TurnFailurePhase::Integrity,
+            "ResidentLandmarkDistance",
+            "landmark distance integrity failed",
+        ),
+        ResidentExecutionError::InnovationDeterminant => (
+            TurnFailurePhase::Integrity,
+            "ResidentInnovationDeterminant",
+            "innovation determinant integrity failed",
+        ),
+        ResidentExecutionError::NonFiniteState => (
+            TurnFailurePhase::Integrity,
+            "ResidentNonFiniteState",
+            "resident state contains a non-finite value",
+        ),
+        ResidentExecutionError::CovarianceDiagonal => (
+            TurnFailurePhase::Integrity,
+            "ResidentCovarianceDiagonal",
+            "resident covariance diagonal is invalid",
+        ),
+        ResidentExecutionError::CovarianceSymmetry => (
+            TurnFailurePhase::Integrity,
+            "ResidentCovarianceSymmetry",
+            "resident covariance is not symmetric",
+        ),
+    };
+    Ok(OwnedTurnRecord {
+        header: header(
+            identity,
+            TurnRecordStatus::Rejected,
+            Some(TurnFailureRecord {
+                phase,
+                kind: kind.to_string(),
+                message: message.to_string(),
+            }),
+        )?,
+        body: GateBFixedReceipt::rejected(before_epoch),
+    })
+}
+
+pub struct PreparedResidentCommit<'instance, 'ledger> {
+    turn: PreparedResidentPublication<'instance>,
+    append: PreparedResidentAppend<'ledger>,
+}
+
+enum PreparedResidentPublication<'instance> {
+    Ekf(PreparedResidentTurn<'instance>),
+    FullWrite(PreparedResidentFullWrite<'instance>),
+}
+
+impl PreparedResidentPublication<'_> {
+    #[inline]
+    fn publish(self) {
+        match self {
+            Self::Ekf(turn) => turn.publish(),
+            Self::FullWrite(turn) => turn.publish(),
+        }
+    }
+}
+
+impl PreparedResidentCommit<'_, '_> {
+    #[inline]
+    pub fn commit(self) -> LedgerSequence {
+        self.turn.publish();
+        self.append.append()
+    }
+}

--- a/src/runtime/src/turn_record.rs
+++ b/src/runtime/src/turn_record.rs
@@ -269,18 +269,31 @@ pub struct GateBFixedReceipt {
 impl GateBFixedReceipt {
     pub const RETAINED_BYTES: usize = core::mem::size_of::<Self>();
 
-    pub fn accepted(before_epoch: u64, after_epoch: u64, state_hash: u64, touched: u16) -> Self {
+    pub fn accepted(
+        before_epoch: u64,
+        after_epoch: u64,
+        state_hash: u64,
+        touched: u16,
+        changed: u16,
+        dirty_nodes: u16,
+    ) -> Self {
         Self {
             words: [
                 before_epoch,
                 after_epoch,
                 state_hash,
                 u64::from(touched),
+                u64::from(changed),
+                u64::from(dirty_nodes),
                 1,
                 0,
-                0,
-                0,
             ],
+        }
+    }
+
+    pub fn rejected(before_epoch: u64) -> Self {
+        Self {
+            words: [before_epoch, 0, 0, 0, 0, 0, 2, 0],
         }
     }
 
@@ -290,6 +303,30 @@ impl GateBFixedReceipt {
 
     pub fn after_epoch(&self) -> u64 {
         self.words[1]
+    }
+
+    pub fn state_hash(&self) -> u64 {
+        self.words[2]
+    }
+
+    pub fn touched_slots(&self) -> u16 {
+        self.words[3] as u16
+    }
+
+    pub fn changed_slots(&self) -> u16 {
+        self.words[4] as u16
+    }
+
+    pub fn dirty_nodes(&self) -> u16 {
+        self.words[5] as u16
+    }
+
+    pub fn is_accepted(&self) -> bool {
+        self.words[6] == 1
+    }
+
+    pub fn version(&self) -> u64 {
+        self.words[7]
     }
 }
 

--- a/src/runtime/tests/resident_gate_b_contract.rs
+++ b/src/runtime/tests/resident_gate_b_contract.rs
@@ -1,0 +1,286 @@
+#![cfg(feature = "runtime_bench_gate_b")]
+
+use mech_engine::__gate_b_resident::{
+    PreparedResidentTurn, ResidentEkfBatch, ResidentExecutionError, ResidentFullWrite,
+    ResidentTurnSummary,
+};
+use mech_runtime::__gate_b_recording::{LedgerSequence, ResidentTurnRecorder, TurnFailurePhase};
+
+const INPUT: [f64; 4] = [1.0, 0.1, 24.0, -0.6];
+
+fn commit_prepared(
+    resident: &mut ResidentEkfBatch,
+    recorder: &mut ResidentTurnRecorder,
+    turn: usize,
+    input: [f64; 4],
+) -> (LedgerSequence, ResidentTurnSummary) {
+    let permit = recorder.take_admission_permit(turn).unwrap();
+    let prepared = resident.prepare_scheduled_turn(input).unwrap();
+    let summary = prepared.summary();
+    let sequence = recorder.prepare_commit(permit, prepared).unwrap().commit();
+    (sequence, summary)
+}
+
+fn finish_prepared(
+    prepared: PreparedResidentTurn<'_>,
+    recorder: &mut ResidentTurnRecorder,
+    permit: mech_runtime::__gate_b_recording::LedgerPermit,
+) -> LedgerSequence {
+    recorder.prepare_commit(permit, prepared).unwrap().commit()
+}
+
+#[test]
+fn accepted_commit_is_invisible_until_one_publication_then_retains_owned_receipt() {
+    let mut resident = ResidentEkfBatch::new(1);
+    let mut recorder = ResidentTurnRecorder::new(2, 0).unwrap();
+    let initial = resident.state(0);
+    let permit = recorder.take_admission_permit(0).unwrap();
+    let prepared = resident.prepare_scheduled_turn(INPUT).unwrap();
+    let summary = prepared.summary();
+
+    assert_eq!(prepared.published_epoch(), 0);
+    assert_eq!(prepared.published_state(0), initial);
+    assert_eq!(summary.before_epoch, 0);
+    assert_eq!(summary.after_epoch, 1);
+    assert_eq!(summary.touched_slots, 2);
+    assert_eq!(summary.changed_slots, 2);
+    assert_eq!(summary.dirty_nodes, 15);
+
+    let sequence = finish_prepared(prepared, &mut recorder, permit);
+    assert_eq!(sequence.get(), 1);
+    assert_eq!(resident.published_epoch(), 1);
+    assert_ne!(resident.state(0), initial);
+    assert_eq!(recorder.recorded_ledger_len(), 1);
+
+    let first_body = {
+        let record = recorder.inspect_last().unwrap();
+        assert!(record.accepted);
+        assert_eq!(record.turn_id, 1);
+        assert_eq!(record.transaction_id, 1);
+        assert_eq!(record.input_first, 1);
+        assert_eq!(record.input_last, 1);
+        assert_eq!(record.failure_kind, None);
+        assert_eq!(record.failure_phase, None);
+        assert_eq!(record.body.before_epoch(), 0);
+        assert_eq!(record.body.after_epoch(), 1);
+        assert_eq!(record.body.state_hash(), summary.state_hash);
+        assert_eq!(record.body.touched_slots(), 2);
+        assert_eq!(record.body.changed_slots(), 2);
+        assert_eq!(record.body.dirty_nodes(), 15);
+        assert!(record.body.is_accepted());
+        assert_eq!(record.body.version(), 0);
+        record.body
+    };
+
+    commit_prepared(&mut resident, &mut recorder, 1, INPUT);
+    assert_eq!(first_body.state_hash(), summary.state_hash);
+    let record = recorder.inspect_last().unwrap();
+    assert_eq!(record.sequence, 2);
+    assert_eq!(record.turn_id, 2);
+    assert_eq!(record.transaction_id, 2);
+    assert_eq!(record.input_first, 2);
+}
+
+#[test]
+fn rejected_candidate_records_failure_without_publication_and_epoch_is_not_reused() {
+    let mut resident = ResidentEkfBatch::new(1);
+    let mut recorder = ResidentTurnRecorder::new(2, 0).unwrap();
+    let initial = resident.state(0);
+    let permit = recorder.take_admission_permit(0).unwrap();
+    let mut invalid = INPUT;
+    invalid[2] = f64::NAN;
+    let failure = match resident.prepare_scheduled_turn(invalid) {
+        Ok(prepared) => {
+            prepared.abort();
+            panic!("invalid resident input unexpectedly prepared")
+        }
+        Err(failure) => failure,
+    };
+    let rejected = recorder
+        .prepare_rejected(permit, resident.published_epoch(), failure)
+        .unwrap();
+    assert_eq!(rejected.append().get(), 1);
+
+    assert_eq!(resident.published_epoch(), 0);
+    assert_eq!(resident.state(0), initial);
+    let record = recorder.inspect_last().unwrap();
+    assert!(!record.accepted);
+    assert!(record.failure_kind.is_some());
+    assert!(!record.body.is_accepted());
+    assert_eq!(record.body.after_epoch(), 0);
+
+    let (_, summary) = commit_prepared(&mut resident, &mut recorder, 1, INPUT);
+    assert_eq!(summary.after_epoch, 2);
+    assert_eq!(resident.published_epoch(), 2);
+}
+
+#[test]
+fn record_preparation_failure_automatically_aborts_before_publication() {
+    let mut resident = ResidentEkfBatch::new(1);
+    let mut recorder = ResidentTurnRecorder::new(2, 0).unwrap();
+    let initial = resident.state(0);
+    let permit = recorder.take_admission_permit(0).unwrap();
+    let prepared = resident.prepare_scheduled_turn(INPUT).unwrap();
+    let failed_epoch = prepared.summary().after_epoch;
+    recorder.fail_next_preparation_for_test();
+    assert!(recorder.prepare_commit(permit, prepared).is_err());
+    assert_eq!(resident.published_epoch(), 0);
+    assert_eq!(resident.state(0), initial);
+    assert!(!resident.candidate_epoch_is_active_for_gate_b(failed_epoch));
+    assert_eq!(recorder.recorded_ledger_len(), 0);
+    drop(recorder.reserve_additional_permit_for_test().unwrap());
+
+    let permit = recorder.take_admission_permit(1).unwrap();
+    let prepared = resident.prepare_scheduled_turn(INPUT).unwrap();
+    assert_eq!(prepared.summary().after_epoch, failed_epoch + 1);
+    recorder.prepare_commit(permit, prepared).unwrap().commit();
+    assert_eq!(resident.published_epoch(), failed_epoch + 1);
+    assert_ne!(resident.state(0), initial);
+    assert_eq!(recorder.recorded_ledger_len(), 1);
+}
+
+#[test]
+fn admission_exhaustion_precedes_candidate_execution() {
+    let resident = ResidentEkfBatch::new(1);
+    let mut recorder = ResidentTurnRecorder::new(1, 0).unwrap();
+    drop(recorder.take_admission_permit(0).unwrap());
+    assert!(recorder.take_admission_permit(0).is_err());
+    assert_eq!(resident.published_epoch(), 0);
+    assert_eq!(resident.state(0), ResidentEkfBatch::new(1).state(0));
+}
+
+#[test]
+fn retained_history_does_not_add_turn_work_or_record_iteration() {
+    for history in [0, 1_000, 100_000] {
+        let mut resident = ResidentEkfBatch::new(1);
+        let mut recorder = ResidentTurnRecorder::new(1, history).unwrap();
+        assert_eq!(recorder.records_inspected(), 0);
+        let (sequence, summary) = commit_prepared(&mut resident, &mut recorder, 0, INPUT);
+        assert_eq!(summary.dirty_nodes, 15);
+        assert_eq!(recorder.recorded_ledger_len(), history + 1);
+        assert_eq!(recorder.records_inspected(), 0);
+        assert_eq!(sequence.get() as usize, history + 1);
+        assert_eq!(
+            recorder.inspect_last().unwrap().sequence as usize,
+            history + 1
+        );
+        assert_eq!(recorder.records_inspected(), 1);
+    }
+}
+
+#[test]
+fn high_epoch_executes_the_same_trajectory_and_work() {
+    let mut low = ResidentEkfBatch::new(1);
+    let mut high = ResidentEkfBatch::new(1);
+    high.set_next_epoch_for_gate_b(1_000_000_001);
+    let low_prepared = low.prepare_scheduled_turn(INPUT).unwrap();
+    let high_prepared = high.prepare_scheduled_turn(INPUT).unwrap();
+    let low_summary = low_prepared.summary();
+    let high_summary = high_prepared.summary();
+    assert_eq!(low_summary.state_hash, high_summary.state_hash);
+    assert_eq!(low_summary.touched_slots, high_summary.touched_slots);
+    assert_eq!(low_summary.changed_slots, high_summary.changed_slots);
+    assert_eq!(low_summary.dirty_nodes, high_summary.dirty_nodes);
+    low_prepared.publish();
+    high_prepared.publish();
+    assert_eq!(low.state(0), high.state(0));
+    assert_eq!(low.published_epoch(), 1);
+    assert_eq!(high.published_epoch(), 1_000_000_001);
+}
+
+#[test]
+fn rejection_failure_kinds_and_phases_are_stable_and_bounded() {
+    let failures = [
+        (
+            ResidentExecutionError::EpochExhausted,
+            TurnFailurePhase::Execution,
+            "ResidentEpochExhausted",
+        ),
+        (
+            ResidentExecutionError::LandmarkDistance,
+            TurnFailurePhase::Integrity,
+            "ResidentLandmarkDistance",
+        ),
+        (
+            ResidentExecutionError::InnovationDeterminant,
+            TurnFailurePhase::Integrity,
+            "ResidentInnovationDeterminant",
+        ),
+        (
+            ResidentExecutionError::NonFiniteState,
+            TurnFailurePhase::Integrity,
+            "ResidentNonFiniteState",
+        ),
+        (
+            ResidentExecutionError::CovarianceDiagonal,
+            TurnFailurePhase::Integrity,
+            "ResidentCovarianceDiagonal",
+        ),
+        (
+            ResidentExecutionError::CovarianceSymmetry,
+            TurnFailurePhase::Integrity,
+            "ResidentCovarianceSymmetry",
+        ),
+    ];
+    let mut recorder = ResidentTurnRecorder::new(failures.len(), 0).unwrap();
+    for (turn, (failure, phase, kind)) in failures.into_iter().enumerate() {
+        let permit = recorder.take_admission_permit(turn).unwrap();
+        recorder
+            .prepare_rejected(permit, 0, failure)
+            .unwrap()
+            .append();
+        let record = recorder.inspect_last().unwrap();
+        assert_eq!(record.failure_phase, Some(phase));
+        assert_eq!(record.failure_kind, Some(kind));
+        assert!(!record.body.is_accepted());
+    }
+    assert_eq!(recorder.recorded_ledger_len(), 6);
+}
+
+#[test]
+fn final_turn_identity_is_issued_once_without_wrap_or_reuse() {
+    let mut recorder = ResidentTurnRecorder::new(2, 0).unwrap();
+    recorder.set_next_turn_identity_for_test(u64::MAX);
+
+    let permit = recorder.take_admission_permit(0).unwrap();
+    recorder
+        .prepare_rejected(permit, 0, ResidentExecutionError::EpochExhausted)
+        .unwrap()
+        .append();
+    let record = recorder.inspect_last().unwrap();
+    assert_eq!(record.turn_id, u64::MAX);
+    assert_eq!(record.input_first, u64::MAX);
+    assert_eq!(record.transaction_id, u128::from(u64::MAX));
+
+    let permit = recorder.take_admission_permit(1).unwrap();
+    assert!(
+        recorder
+            .prepare_rejected(permit, 0, ResidentExecutionError::EpochExhausted)
+            .is_err()
+    );
+    assert_eq!(recorder.recorded_ledger_len(), 1);
+}
+
+#[test]
+fn complete_full_write_prepares_receipt_before_one_publication() {
+    let mut resident = ResidentFullWrite::new();
+    let mut recorder = ResidentTurnRecorder::new(1, 0).unwrap();
+    let before_epoch = resident.published_epoch();
+    let permit = recorder.take_admission_permit(0).unwrap();
+    let prepared = resident.prepare_turn(1.0).unwrap();
+    let summary = prepared.summary();
+    assert_eq!(summary.before_epoch, before_epoch);
+    assert_eq!(summary.after_epoch, 1);
+    assert_eq!(summary.touched_slots, 1);
+    assert_eq!(summary.changed_slots, 1);
+    assert_eq!(summary.dirty_nodes, 1);
+    recorder
+        .prepare_full_write_commit(permit, prepared)
+        .unwrap()
+        .commit();
+    assert_eq!(resident.published_epoch(), 1);
+    assert_eq!(recorder.recorded_ledger_len(), 1);
+    let record = recorder.inspect_last().unwrap();
+    assert!(record.accepted);
+    assert_eq!(record.body.state_hash(), summary.state_hash);
+}


### PR DESCRIPTION
## Summary
- separate same-turn from next-turn feedback and execute a dense epoch-marked dirty schedule
- bind each retained receipt to the exact prepared resident candidate and automatically abort that candidate if record preparation fails
- keep the kernel-only full-write lane free of receipt hashing while deriving complete-turn summaries only after execution
- freeze stable rejection phases/kinds, final `u64::MAX` identity behavior, and equivalent raw-epoch record evidence
- enforce history independence at 1k, 100k, and high epoch with a 1.05 ceiling
- record the final same-session Gate B architecture decision

## Controlled evidence
Exact pre-report commit: `bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd`

- Decision: Pass
- Complete resident turn: 292.3632 ns/turn
- Raw epoch: 246.7479 ns/turn
- Legacy atomic: 8682.0186 ns/turn
- Persistent NumPy: 20798.5127 ns/turn
- Legacy gap closure: 0.99459
- Raw epoch ratio: 1.18487
- Executor tax: 202.0938 ns/turn
- History 1k / history 0: 1.00032
- History 100k / history 0: 1.00207
- High epoch / low epoch: 1.00064
- Zero steady-state allocations: yes

Evidence: `benchmarks/runtime/gate-b/b2-resident-turn.json`

## Validation
- `cargo test -p mech-runtime --lib --no-default-features --features source_default`: 660 passed
- `cargo test -p mech-runtime --test resident_gate_b_contract --no-default-features --features source_default,runtime_bench_gate_b`: 9 passed
- `cargo test -p mech-engine --test resident_ekf_contract --features resident-ekf`: 4 passed
- Python runner/checker suites: 33 passed
- Gate B static contract check: passed
- Gate B exact-SHA evidence check: passed
- controlled timed and structural-probe benchmark: passed
- `cargo fmt --check` and `git diff --check`: passed

## Known base validation failure
The engine lib-test feature closure without compiler support compiles compiler-only external-function tests. This is pre-existing on the reviewed B1 base and is not changed or repaired in B2. Focused resident tests and the complete 660-test `source_default` runtime suite pass.
